### PR TITLE
fix(terminal): make xterm cursor transparent to prevent flickering

### DIFF
--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -14,7 +14,8 @@ const PTY_RESIZE_DEBOUNCE_MS = 200;
 const TERMINAL_THEME = {
   background: '#18181b',
   foreground: '#e4e4e7',
-  cursor: '#e4e4e7',
+  cursor: '#18181b',
+  cursorAccent: '#18181b',
   selectionBackground: 'rgba(58, 130, 246, 0.35)',
   black: '#18181b',
   red: '#ef4444',
@@ -67,7 +68,7 @@ export function useTerminal(options: UseTerminalOptions) {
       fontSize: options.fontSize || 14,
       theme: xtermTheme,
       scrollback: options.scrollbackLines || 5000,
-      cursorBlink: true,
+      cursorBlink: false,
       cursorStyle: options.cursorStyle || 'block',
       allowProposedApi: true,
     });


### PR DESCRIPTION
## Summary

- Set xterm cursor and cursorAccent colors to match terminal background (`#18181b`), making the cursor effectively invisible
- Disable cursor blink to eliminate flickering while Claude Code is working

## Test plan

- [ ] `npm start` and open a task with an active terminal session
- [ ] Verify cursor is no longer visible or flickering while Claude is working
- [ ] Verify terminal text rendering is unaffected

Generated with [Claude Code](https://claude.com/claude-code)
