### PR TITLE
fix(session-recovery): pause all sessions on restart instead of auto-resuming

### DIFF
--- a/src/main/engine/session-recovery.ts
+++ b/src/main/engine/session-recovery.ts
@@ -148,11 +148,25 @@ export async function recoverSessions(
       continue;
     }
 
-    // Skip user-paused sessions -- they should stay suspended until manually resumed.
+    // Pause everything on restart: users get a clean slate and nothing
+    // auto-resumes until they click Resume. Covers:
+    //   - user-paused (suspended + suspended_by='user')
+    //   - graceful shutdown (also suspended + suspended_by='user' as of
+    //     shutdown.ts; see syncShutdownCleanup)
+    //   - crash-orphaned (status='orphaned') -- upgrade to suspended_by='user'
+    //     in DB so reconcileSessions also leaves them alone.
     // Register a suspended placeholder so the renderer shows "Paused" state
     // and the "Resume session" button. task.session_id stays null (cleared on
     // suspend) so the SESSION_RESUME guard still passes when the user clicks resume.
-    if (record.status === 'suspended' && record.suspended_by === 'user') {
+    if (record.status === 'suspended' || record.status === 'orphaned') {
+      if (record.status === 'orphaned') {
+        sessionRepo.compareAndUpdateStatus(
+          record.id,
+          'orphaned',
+          'suspended',
+          { suspended_by: 'user', suspended_at: now },
+        );
+      }
       sessionManager.registerSuspendedPlaceholder({
         taskId: record.task_id,
         projectId,

--- a/src/main/shutdown.ts
+++ b/src/main/shutdown.ts
@@ -45,6 +45,11 @@ export function syncShutdownCleanup(dependencies: ShutdownDependencies): void {
     // This must happen BEFORE killAll() because killAll sends best-effort exit
     // signals then force-kills. The atomic compareAndUpdateStatus prevents the
     // onExit handler from overwriting 'suspended' back to 'exited'.
+    //
+    // Tag with suspended_by='user' so recoverSessions/reconcileSessions leave
+    // them paused on next launch. Nothing auto-resumes or auto-spawns until
+    // the user explicitly clicks resume. This gives the user a clean slate
+    // on every restart instead of a stampede of recovered/reconciled agents.
     const allSessions = sessionManager.listSessions();
     const sessionsByProject = new Map<string, typeof allSessions>();
     for (const session of allSessions) {
@@ -62,7 +67,7 @@ export function syncShutdownCleanup(dependencies: ShutdownDependencies): void {
         for (const session of sessions) {
           const record = sessionRepo.getLatestForTask(session.taskId);
           if (record && record.status === 'running') {
-            markRecordSuspended(sessionRepo, record.id, 'system');
+            markRecordSuspended(sessionRepo, record.id, 'user');
           } else if (record && record.status === 'queued') {
             // Queued sessions never started Claude CLI - mark as exited
             // (not suspended) since there's nothing to resume.


### PR DESCRIPTION
Pause every Kangentic session on restart instead of auto-resuming.

## Problem

On Kangentic restart, projects with many tasks in auto-spawn columns experience a startup stampede:

1. `recoverSessions` auto-resumes every record marked `suspended_by="system"` (which `syncShutdownCleanup` writes for every running session on graceful quit).
2. `reconcileSessions` then spawns fresh agents for any auto-spawn-column task that does not have a live PTY.

The two passes combined try to spin up dozens of Claude CLI processes within seconds. On a real instance with 19 projects, this produced:

- **23 sessions** marked `running` in DBs after restart
- **Only 1 actual Claude PTY** alive
- **Newly created tasks queued indefinitely** because `SessionQueue.shouldQueue()` saw `getActiveCount() >= maxConcurrent` (default 8)

The phantom `running` rows accumulated because spawn failures or rate limits left DB rows pre-marked `running` while the PTYs never came up. Reconciliation on the next restart compounded the problem.

## Fix

Two minimal changes that make restart a clean slate:

**`src/main/shutdown.ts`** — `syncShutdownCleanup` now marks records `suspended_by="user"` instead of `"system"`. Both `recoverSessions` (line 155) and `getUserPausedTaskIds` already know to leave `"user"`-paused records alone, so this single change neuters the recovery + reconciliation auto-spawn for the graceful-quit path.

**`src/main/engine/session-recovery.ts`** — `recoverSessions` now treats `orphaned` records (the crash-recovery path) the same as user-paused. It upgrades them to `suspended_by="user"` in the DB and registers a suspended placeholder so `reconcileSessions` also skips them.

## Net effect

- Graceful quit → restart: every previously-running task shows as **Paused** with a Resume button. No PTYs spawn until the user clicks Resume.
- Crash → restart: orphaned tasks also show as Paused. No spawn stampede.
- Brand-new tasks created in auto-spawn columns *after* restart still spawn normally — only previously-existing sessions are paused.

## Trade-off

This changes default behavior for users who *want* auto-resume on restart. Open questions for maintainers:
- Should this be opt-in via an `agent.pauseOnRestart` setting in `globalConfig`?
- Or is "pause on restart" universally preferable given the stampede risk?

If a setting is preferred, happy to refactor — current PR is the simplest possible behavior change.

## Test plan

- [ ] Open Kangentic with several tasks in Planning/Executing across multiple projects → all show Paused, no PTYs spawn
- [ ] Click Resume on one task → spawns normally
- [ ] Quit gracefully, reopen → still all Paused
- [ ] Force-kill Kangentic, reopen → orphaned tasks also show Paused (DB updated to `suspended_by="user"`)
- [ ] Existing `tests/unit/session-suspend.test.ts` and friends still pass