### PR TITLE
feat(terminal): add 'none' cursor style and restore configurable cursor

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,7 +89,7 @@ These settings appear in both App Settings (as defaults) and Project Settings (a
 | `terminal.panelHeight` | number | `250` | Bottom panel height (px). Global-only. |
 | `terminal.panelCollapsed` | boolean | `false` | Whether the bottom terminal panel is collapsed. Global-only. |
 | `terminal.scrollbackLines` | number | `5000` | Lines kept in the visible xterm scrollback (1000-100000). Full session history is preserved separately by the main-process PTY buffer for replay regardless of this value. |
-| `terminal.cursorStyle` | `'block'` \| `'underline'` \| `'bar'` | `'block'` | Terminal cursor appearance |
+| `terminal.cursorStyle` | `'block'` \| `'underline'` \| `'bar'` \| `'none'` | `'block'` | Terminal cursor appearance. `'none'` hides the cursor entirely (focused and unfocused). |
 
 ### agent.*
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -346,7 +346,7 @@ Choose from 10 themes:
 | Font Size | Terminal text size in pixels |
 | Font Family | CSS font-family for the terminal |
 | Scrollback Lines | Lines kept in the visible scrollback (1000 to 100000, default 5000). Full session history is preserved for replay regardless of this value. |
-| Cursor Style | Terminal cursor appearance (block, underline, or bar) |
+| Cursor Style | Terminal cursor appearance (block, underline, bar, or none - none hides the cursor entirely) |
 
 ### Context Bar
 

--- a/src/renderer/components/settings/settings-registry.ts
+++ b/src/renderer/components/settings/settings-registry.ts
@@ -38,7 +38,7 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
   { id: 'terminal.fontSize', tabId: 'terminal', label: 'Font Size', description: 'Terminal text size in pixels', scope: 'project', keywords: ['px', 'text size'] },
   { id: 'terminal.fontFamily', tabId: 'terminal', label: 'Font Family', description: 'CSS font-family for the terminal', scope: 'project', keywords: ['monospace', 'typeface'] },
   { id: 'terminal.scrollbackLines', tabId: 'terminal', label: 'Scrollback Lines', description: 'Lines kept in the visible scrollback. Full session history is preserved for replay regardless of this value.', scope: 'project', keywords: ['buffer', 'history'] },
-  { id: 'terminal.cursorStyle', tabId: 'terminal', label: 'Cursor Style', description: 'Terminal cursor appearance', scope: 'project', keywords: ['block', 'underline', 'bar'] },
+  { id: 'terminal.cursorStyle', tabId: 'terminal', label: 'Cursor Style', description: 'Terminal cursor appearance', scope: 'project', keywords: ['block', 'underline', 'bar', 'none', 'hidden'] },
 
   // ── Terminal > Context Bar ──
   { id: 'contextBar.showShell', tabId: 'terminal', label: 'Shell', description: 'Detected shell name', scope: 'global', section: 'Context Bar', keywords: ['context bar', 'status'] },

--- a/src/renderer/components/settings/tabs/TerminalTab.tsx
+++ b/src/renderer/components/settings/tabs/TerminalTab.tsx
@@ -1,4 +1,4 @@
-import type { AppConfig } from '../../../../shared/types';
+import type { AppConfig, TerminalCursorStyle } from '../../../../shared/types';
 import { DEFAULT_CONFIG } from '../../../../shared/types';
 import { SectionHeader, SettingRow, Select, CompactToggleList, INPUT_CLASS, useScopedUpdate } from '../shared';
 import { settingProps } from '../settings-registry';
@@ -66,11 +66,12 @@ export function TerminalTab({ config, globalConfig, shells }: {
       <SettingRow {...settingProps('terminal.cursorStyle')}>
         <Select
           value={config.terminal.cursorStyle}
-          onChange={(event) => updateProject({ terminal: { cursorStyle: event.target.value as 'block' | 'underline' | 'bar' } })}
+          onChange={(event) => updateProject({ terminal: { cursorStyle: event.target.value as TerminalCursorStyle } })}
         >
           <option value="block">Block</option>
           <option value="underline">Underline</option>
           <option value="bar">Bar</option>
+          <option value="none">None (hidden)</option>
         </Select>
       </SettingRow>
 

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { Terminal } from '@xterm/xterm';
+import type { TerminalCursorStyle } from '../../shared/types';
 import { FitAddon } from '../addons/fit-addon';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { cleanSelection, enableTerminalClipboard } from '../utils/terminal-clipboard';
@@ -25,11 +26,14 @@ if (import.meta.hot) {
   });
 }
 
-/** Fixed dark terminal theme -- Claude Code's TUI is designed for dark backgrounds. */
+/** Fixed dark terminal theme -- Claude Code's TUI is designed for dark backgrounds.
+ *  `cursor` is the cursor color and `cursorAccent` the color of the glyph under a
+ *  block cursor; they render a visible cursor. The `'none'` cursor style hides it
+ *  by overriding both to the background color (see initTerminal). */
 const TERMINAL_THEME = {
   background: '#18181b',
   foreground: '#e4e4e7',
-  cursor: '#18181b',
+  cursor: '#e4e4e7',
   cursorAccent: '#18181b',
   selectionBackground: 'rgba(58, 130, 246, 0.35)',
   black: '#18181b',
@@ -55,7 +59,7 @@ interface UseTerminalOptions {
   fontFamily?: string;
   fontSize?: number;
   scrollbackLines?: number;
-  cursorStyle?: 'block' | 'underline' | 'bar';
+  cursorStyle?: TerminalCursorStyle;
   shellName?: string;
   /** Let Escape bubble (to close the containing dialog) when the mouse pointer
    *  is outside the terminal. Used by the task detail dialog. */
@@ -99,15 +103,28 @@ export function useTerminal(options: UseTerminalOptions) {
   const initTerminal = useCallback(() => {
     if (!terminalRef.current || xtermRef.current) return;
 
-    const xtermTheme = TERMINAL_THEME;
+    // The `'none'` style hides the cursor by painting it the background color
+    // (xterm's `cursorStyle` has no `'none'`; only `cursorInactiveStyle` does,
+    // so the theme override is what hides the focused cursor too). Any other
+    // style renders a visible cursor with the default theme colors.
+    const hideCursor = options.cursorStyle === 'none';
+    const xtermTheme = hideCursor
+      ? { ...TERMINAL_THEME, cursor: TERMINAL_THEME.background, cursorAccent: TERMINAL_THEME.background }
+      : TERMINAL_THEME;
+    const xtermCursorStyle = options.cursorStyle && options.cursorStyle !== 'none'
+      ? options.cursorStyle
+      : 'block';
 
     const terminal = new Terminal({
       fontFamily: options.fontFamily || 'Menlo, Consolas, "Courier New", monospace',
       fontSize: options.fontSize || 14,
       theme: xtermTheme,
       scrollback: options.scrollbackLines || 5000,
+      // Blink stays off: Claude Code's TUI flickers with a blinking cursor, a
+      // known issue even in the official terminal app.
       cursorBlink: false,
-      cursorStyle: options.cursorStyle || 'block',
+      cursorStyle: xtermCursorStyle,
+      cursorInactiveStyle: hideCursor ? 'none' : 'outline',
       allowProposedApi: true,
     });
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1069,6 +1069,11 @@ export interface NotificationConfig {
   cooldownSeconds: number;
 }
 
+/** Terminal cursor appearance. `'none'` hides the cursor entirely (focused and
+ *  unfocused), for users who find the cursor distracting while a TUI like Claude
+ *  Code redraws. The other three map directly to xterm's focused `cursorStyle`. */
+export type TerminalCursorStyle = 'block' | 'underline' | 'bar' | 'none';
+
 export interface AppConfig {
   theme: ThemeMode;
   sidebarVisible: boolean;
@@ -1087,7 +1092,7 @@ export interface AppConfig {
     panelHeight: number; // persisted terminal panel height in px
     panelCollapsed: boolean; // persisted collapsed state
     scrollbackLines: number;
-    cursorStyle: 'block' | 'underline' | 'bar';
+    cursorStyle: TerminalCursorStyle;
   };
 
   agent: {

--- a/tests/ui/settings-panel.spec.ts
+++ b/tests/ui/settings-panel.spec.ts
@@ -128,6 +128,22 @@ test.describe('Settings Panel', () => {
     await closeSettings();
   });
 
+  test('Terminal tab Cursor Style select includes None (hidden) option', async () => {
+    await openSettings();
+    await page.getByRole('button', { name: 'Terminal', exact: true }).click();
+
+    // Locate the Cursor Style select via its description text, then walk up to
+    // the SettingRow root and find the select within it.
+    const cursorDescription = page.getByText('Terminal cursor appearance');
+    await expect(cursorDescription).toBeVisible();
+    const cursorStyleRow = cursorDescription.locator('..').locator('..').locator('..');
+    const cursorStyleSelect = cursorStyleRow.locator('select');
+    const optionTexts = await cursorStyleSelect.locator('option').allTextContents();
+    expect(optionTexts).toEqual(['Block', 'Underline', 'Bar', 'None (hidden)']);
+
+    await closeSettings();
+  });
+
   test('shows Git tab with worktree and branch settings', async () => {
     await openSettings();
     await page.getByRole('button', { name: 'Git' }).click();


### PR DESCRIPTION
## Summary

PR #13 fixed terminal cursor flicker by hard-coding the xterm cursor to the background color (invisible) and disabling blink. The side effect was that the existing **Settings → Terminal → Cursor Style** option (Block / Underline / Bar) had no visible effect at all, since every style rendered an invisible cursor.

This change removes the hard-coded invisibility and turns "hidden" into an explicit, opt-in choice:

- The base terminal theme now renders a **visible** cursor again (`cursor: '#e4e4e7'`, `cursorAccent: '#18181b'`).
- A new `'none'` cursor style hides the cursor entirely (focused and unfocused). xterm's focused `cursorStyle` has no native `'none'`, so `'none'` is implemented by overriding the theme `cursor`/`cursorAccent` to the background color and setting `cursorInactiveStyle: 'none'` — the same mechanism PR #13 used, but now applied only when the user selects it.
- `cursorBlink` stays `false` (blinking is a known Claude Code TUI flicker issue, called out as acceptable).

The config value space is unified behind a new exported `TerminalCursorStyle` union; the default stays `'block'`, so the out-of-the-box experience is now a visible non-blinking block cursor.

## Impact / behavior

- **Default behavior changes:** users who currently see no cursor will now see a visible non-blinking block cursor (the style they had selected all along now actually renders).
- **Block / Underline / Bar** now visibly differ.
- **None (hidden)** is a new dropdown option that restores the previous invisible-cursor behavior for anyone who prefers it.
- No IPC, store, or migration changes — `cursorStyle` already round-tripped end to end; only its value space and the rendering branch changed.

## Test plan

- CI checks: typecheck, lint, unit, build, UI shards, and the Linux Electron E2E shards.
- Added a UI-tier test (`tests/ui/settings-panel.spec.ts`) asserting the Cursor Style dropdown now offers `Block`, `Underline`, `Bar`, and `None (hidden)`.
- Existing `deep-merge` / `config-overridable-subset` / `project-cache` unit tests already exercise the `cursorStyle` config plumbing and remain valid.
- Manually previewed in a worktree dev server: visible block cursor by default; selecting **None (hidden)** hides it.

Generated with [Claude Code](https://claude.com/claude-code)
