### PR TITLE
fix(terminal): restore focus to the terminal on maximize toggle

### DIFF
--- a/src/renderer/components/command-bar/CommandBarOverlay.tsx
+++ b/src/renderer/components/command-bar/CommandBarOverlay.tsx
@@ -200,11 +200,17 @@ export function CommandBarOverlay({ onClose }: CommandBarOverlayProps) {
     }
   }, [phase, fit, focus]);
 
-  // Re-fit terminal when the changes panel toggles or the overlay maximizes
-  // (container dimensions change).
+  // Re-fit terminal when the changes panel toggles (container width changes).
   useEffect(() => {
     if (initialized.current) requestAnimationFrame(() => fit());
-  }, [changesOpen, isMaximized, fit]);
+  }, [changesOpen, fit]);
+
+  // Re-fit AND restore focus on maximize/restore. The toggle (button click,
+  // double-click header, or panel.maximize keybinding) moves DOM focus to the
+  // maximize button; return it to the terminal so the next keystroke lands there.
+  useEffect(() => {
+    if (initialized.current) requestAnimationFrame(() => { fit(); focus(); });
+  }, [isMaximized, fit, focus]);
 
   const defaultBranch = config.git.defaultBaseBranch || 'main';
 

--- a/src/renderer/components/dialogs/TaskDetailDialog.tsx
+++ b/src/renderer/components/dialogs/TaskDetailDialog.tsx
@@ -305,6 +305,20 @@ export function TaskDetailDialog({ task, onClose, initialEdit }: TaskDetailDialo
     return () => clearTimeout(refitTimer);
   }, [isDialogMaximized, hasSessionContext]);
 
+  // After a maximize toggle the header maximize button holds DOM focus; return
+  // focus to the embedded agent terminal so the next keystroke lands there.
+  // Routed through a session-scoped event the nested TerminalTab listens for
+  // (the dialog does not own the terminal's focus()). NOT terminal-panel-resize:
+  // that also fires on sidebar/drag resizes, so it would steal focus then too.
+  const focusSessionId = sessionState.session?.id;
+  useEffect(() => {
+    if (!hasSessionContext || !focusSessionId) return;
+    const focusTimer = setTimeout(() => {
+      window.dispatchEvent(new CustomEvent('terminal-focus-request', { detail: { sessionId: focusSessionId } }));
+    }, 120);
+    return () => clearTimeout(focusTimer);
+  }, [isDialogMaximized, hasSessionContext, focusSessionId]);
+
   // -- Render --
 
   if (actions.confirmSendToBacklog) {

--- a/src/renderer/components/terminal/TerminalTab.tsx
+++ b/src/renderer/components/terminal/TerminalTab.tsx
@@ -198,14 +198,25 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
     const handlePanelResize = () => scheduleRefit(50);
     window.addEventListener('terminal-panel-resize', handlePanelResize);
 
+    // Restore focus to this terminal on request (e.g. after a dialog maximize
+    // toggle moved DOM focus to the maximize button). Session-scoped so an
+    // event meant for another terminal cannot steal focus here.
+    const handleFocusRequest = (event: Event) => {
+      const requestedSessionId = (event as CustomEvent<{ sessionId?: string }>).detail?.sessionId;
+      if (requestedSessionId && requestedSessionId !== sessionId) return;
+      if (initialized.current) requestAnimationFrame(() => focus());
+    };
+    window.addEventListener('terminal-focus-request', handleFocusRequest);
+
     return () => {
       cancelAnimationFrame(initRafId);
       clearTimeout(delayedFitId);
       if (resizeTimer) clearTimeout(resizeTimer);
       observer.disconnect();
       window.removeEventListener('terminal-panel-resize', handlePanelResize);
+      window.removeEventListener('terminal-focus-request', handleFocusRequest);
     };
-  }, [active, fit, focus, scrollbackPending, terminalRef]);
+  }, [active, fit, focus, scrollbackPending, terminalRef, sessionId]);
 
   const fileDrop = useTerminalFileDrop(sessionId, focus, sessionShell);
 

--- a/tests/ui/command-terminal.spec.ts
+++ b/tests/ui/command-terminal.spec.ts
@@ -394,10 +394,18 @@ test.describe('Command Terminal', () => {
         await expect(overlay).toHaveClass(/top-10/);
         await expect(overlay).toHaveClass(/bottom-9/);
 
+        // Clicking the maximize button returns focus to the terminal (xterm
+        // keeps keyboard focus on a hidden helper textarea), not the button, so
+        // the next keystroke lands in the terminal. toBeFocused auto-retries,
+        // absorbing the requestAnimationFrame the refocus is scheduled on.
+        await expect(overlay.locator('.xterm-helper-textarea')).toBeFocused();
+
         // Ctrl+Shift+M restores (terminal-safe combo).
         await sharedPage.keyboard.press('Control+Shift+M');
         await expect(maximizeButton).toHaveAttribute('title', /^Maximize/);
         await expect(overlay).toHaveClass(/inset-0/);
+        // Restoring also returns focus to the terminal.
+        await expect(overlay.locator('.xterm-helper-textarea')).toBeFocused();
 
         // Ctrl+Shift+W hides the overlay; the transient session stays alive.
         await sharedPage.keyboard.press('Control+Shift+W');


### PR DESCRIPTION
## Summary

Toggling a terminal between maximized and normal view left DOM focus on the maximize/restore
button, so the next keystroke landed on the button (Space/Enter re-triggered the toggle) instead
of going into the terminal. This restores focus to the terminal after the toggle on both surfaces
that host a live terminal with a maximize control.

- **Command Terminal** (`CommandBarOverlay.tsx`): split the existing refit effect so the maximize
  toggle now refits AND refocuses the terminal, while the changes-panel toggle still only refits
  (refocusing when the user opens the changes panel to read it would be wrong). `focus` was
  already in scope, mirroring the existing `fit()` + `focus()` pairing on overlay open.
- **Task-detail dialog** (`TaskDetailDialog.tsx` + `TerminalTab.tsx`): the dialog does not own the
  embedded terminal's `focus()`, so it dispatches a session-scoped `terminal-focus-request` window
  event on maximize toggle. The nested `TerminalTab` listens for it and refocuses only when the
  event targets its own session. This deliberately does NOT overload `terminal-panel-resize`
  (which also fires on sidebar and drag resizes and would steal focus then) and is session-scoped
  so it cannot focus a different terminal behind the modal.

All three trigger paths are covered (button click, the `panel.maximize` keybinding, and
double-clicking the header), because each effect keys on the maximize state rather than the click.

## Impact / behavior

- Maximizing or restoring a terminal now returns keyboard focus to the terminal, so the next
  keystroke lands where the user expects instead of on the toggle button.
- No change to the changes-panel toggle, IPC, the session store, or types.

## ⚠️ Overlap with #30 (please read before merging)

This PR overlaps with the open #30 (`feat(window-manager): modeless task-detail windows`), which
is a large refactor that **deletes `src/renderer/components/dialogs/TaskDetailDialog.tsx`
entirely** and heavily rewrites `src/renderer/components/terminal/TerminalTab.tsx`. Both files are
part of the **task-detail dialog** fix here (surface 2).

- **Surface 1 (Command Terminal / `CommandBarOverlay.tsx`)** is independent: #30 does not touch
  `CommandBarOverlay.tsx` or `tests/ui/command-terminal.spec.ts`, so that fix and its test stand
  on their own regardless of merge order.
- **Surface 2 (task-detail dialog)** will be redundant or require rework once #30 lands:
  - `TaskDetailDialog.tsx` is removed by #30 and subsumed into `TaskDetailWindow.tsx`, so the
    maximize focus effect added here must be reimplemented against the new window-manager surface
    (its tile/snap/maximize affordances).
  - The `TerminalTab.tsx` `terminal-focus-request` listener added here will conflict with #30's
    changes to the same file, and #30 introduces its own focus model (`auto-focus.ts`,
    `useWindowFocusReconcile`, multi-owner `dialogSessionIds`). A reviewer should check whether
    #30's window manager already restores terminal focus on maximize/tile, in which case surface 2
    is fully subsumed and only the Command Terminal fix needs to carry forward.

Recommended handling: if #30 merges first, expect a conflict on `TerminalTab.tsx` and re-home the
dialog focus logic onto the window manager (or drop it if #30 already covers it). If this merges
first, #30 will need to account for these two files when it reworks them.

## Test plan

- **CI gates:** typecheck, lint (`--max-warnings 0`), unit, UI, and the Linux Electron E2E shards.
- **New UI coverage:** extended the existing maximize test in `tests/ui/command-terminal.spec.ts`
  to assert xterm's hidden `.xterm-helper-textarea` is focused after both the button maximize and
  the Ctrl+Shift+M restore (`toBeFocused()` auto-retries, absorbing the `requestAnimationFrame`).
  Verified green locally scoped to that test.
- **Manual:** verified live in `/preview` that typing immediately after toggling the Command
  Terminal (button, keybinding, and header double-click) lands in the terminal. The dialog path
  shares the same mechanism; covered by manual check given the #30 overlap above.

Generated with [Claude Code](https://claude.com/claude-code)
