### PR TITLE
fix(devtools): gate the dev TestHarness to preview mode only

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -315,9 +315,13 @@ const createWindow = () => {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
-      // Enable <webview> for the embedded browser side-pane in
-      // TaskDetailDialog. Hardened via the will-attach-webview hook below.
+      // Enable <webview> for the embedded browser side-pane in the task-detail
+      // window. Hardened via the will-attach-webview hook below.
       webviewTag: true,
+      // Surface the ephemeral-preview flag to the renderer (read in preload via
+      // process.argv). Set ONLY in dev-preview mode (`--ephemeral`), so the dev
+      // TestHarness stays out of the regular `npm start` dogfood.
+      additionalArguments: __KANGENTIC_DEV__ && isEphemeral ? ['--kangentic-ephemeral'] : [],
     },
   });
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -400,7 +400,14 @@ const api: ElectronAPI = {
 // Dev-only: expose the preview's ephemeral-project creator behind the same
 // __KANGENTIC_DEV__ guard as the inspection hooks above, so production drops it.
 if (__KANGENTIC_DEV__) {
-  api.dev = { createEphemeralProject: () => ipcRenderer.invoke(IPC.DEV_CREATE_EPHEMERAL_PROJECT) };
+  // `--kangentic-ephemeral` is appended to the renderer process argv (via the
+  // BrowserWindow `additionalArguments`) ONLY in dev-preview mode, so this is
+  // true for `/preview` and false for the regular `npm start` dogfood.
+  const isEphemeralPreview = process.argv.includes('--kangentic-ephemeral');
+  api.dev = {
+    createEphemeralProject: () => ipcRenderer.invoke(IPC.DEV_CREATE_EPHEMERAL_PROJECT),
+    isEphemeralPreview,
+  };
 }
 
 contextBridge.exposeInMainWorld('electronAPI', api);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -590,10 +590,11 @@ export function App() {
       */}
       {__KANGENTIC_DEV__ && <DevtoolsBootstrap />}
       {/*
-        Dev-only preview test harness (floating "Create Task" toolbar). Same
-        dead-code-elimination guard as DevtoolsBootstrap; never ships to prod.
+        Dev-only preview test harness (floating "Create Task" toolbar). Built out
+        of prod by the `__KANGENTIC_DEV__` dead-code guard, AND gated at runtime on
+        `isEphemeralPreview` so it shows only in `/preview`, not the `npm start` dogfood.
       */}
-      {__KANGENTIC_DEV__ && <TestHarness />}
+      {__KANGENTIC_DEV__ && window.electronAPI.dev?.isEphemeralPreview && <TestHarness />}
     </>
   );
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2221,6 +2221,8 @@ export interface ElectronAPI {
   dev?: {
     /** Create + return a synthetic ephemeral project for the preview. */
     createEphemeralProject: () => Promise<Project>;
+    /** True only in dev-preview (`/preview`, `--ephemeral`); false in the regular dogfood. */
+    isEphemeralPreview: boolean;
   };
   // Projects
   projects: {


### PR DESCRIPTION
## Summary

The dev `TestHarness` (the floating Create Task / Create Project toolbar from the 2-project ephemeral preview) was gated only on the `__KANGENTIC_DEV__` build flag, so it rendered in the regular `npm start` dogfood and in the UI-test DOM, not just in `/preview`.

## Impact / behavior

- The harness now appears ONLY in `/preview` (dev-ephemeral mode), not the regular `npm start` dogfood.
- It also stays out of the UI-test DOM, which removes the `Create Task` / `Create Project` button collisions that UI specs previously had to scope around (those scopings are now belt-and-suspenders).
- Mechanism: the main process already knows `isEphemeral` (`--ephemeral`); this surfaces it to the renderer via the BrowserWindow `additionalArguments`, then preload (`api.dev.isEphemeralPreview`), and ANDs it into the `App.tsx` gate. Production is unaffected (the whole branch is dropped by `__KANGENTIC_DEV__` dead-code elimination).

## Test plan

- CI: typecheck, lint, unit, the UI shards, and the Linux Electron E2E shards. The UI and E2E shards confirm nothing regresses with the harness removed from the test DOM.
- Manual: after an `npm start` restart, the harness is absent in the regular dogfood and present in a fresh `/preview`.

Generated with [Claude Code](https://claude.com/claude-code)
