### PR TITLE
fix(board): warn on move-to-Done only when the move destroys work

### DIFF
--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -759,13 +759,13 @@ Two PTY regex anchors plus a filesystem fallback:
 
 1. **Welcome banner**: `Session: <uuid>` printed in the cyan startup box (interactive and `--print`).
 2. **Print-mode exit**: `To resume this session: kimi -r <uuid>` written to stderr at session end.
-3. **Filesystem fallback**: `runtime.sessionId.fromFilesystem` scans `~/.kimi/sessions/*\/<uuid>/` for directories whose mtime is within ±30s of the spawn time.
+3. **Filesystem fallback**: `runtime.sessionId.fromFilesystem` scans this spawn's own work_dir directory - `~/.kimi/sessions/<md5(cwd)>/` (and its `<kaos>_<md5(cwd)>` variant) - for UUID directories whose mtime is within ±30s of the spawn time, returning the newest. Scoping to the spawn's own work_dir hash (rather than globbing every hash dir) keeps a concurrent Kimi session in another work_dir, or a `-w`-less probe's stray session, from winning the recency race and poisoning the captured id.
 
 ### Session History
 
 `src/main/agent/adapters/kimi/session-history-parser.ts` + `wire-parser.ts`
 
-Kimi writes `wire.jsonl` to `~/.kimi/sessions/<work_dir_hash>/<sessionId>/` on every spawn (interactive or `--print`). The work_dir hash is opaque - the locator globs across all hash dirs and matches on session UUID.
+Kimi writes `wire.jsonl` to `~/.kimi/sessions/<work_dir_hash>/<sessionId>/` on every spawn (interactive or `--print`). The work_dir hash is `md5(absolute work_dir)`. The history locator (`locate()`, given a known session UUID) globs across all hash dirs and matches on the UUID, so it is robust to the same directory opened under different paths. This differs from the capture fallback above, which has no known UUID and so is scoped to the spawn's own work_dir hash to avoid mis-attributing another work_dir's session.
 
 The file is append-only (resume via `-r <uuid>` appends new `TurnBegin` / `TurnEnd` lines). Format:
 

--- a/src/main/agent/adapters/kimi/project-relocation.ts
+++ b/src/main/agent/adapters/kimi/project-relocation.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import * as crypto from 'node:crypto';
+import { kimiWorkDirHash } from './work-dir-hash';
 import { replacePathPrefix } from '../../../../shared/paths';
 import {
   collectRelocationPairs,
@@ -46,11 +46,6 @@ interface WorkDirEntry {
 
 const kimiJsonPath = (): string => path.join(os.homedir(), '.kimi', 'kimi.json');
 const sessionsRoot = (): string => path.join(os.homedir(), '.kimi', 'sessions');
-
-/** md5 hex of the literal absolute path string (kimi-cli `metadata.py`). */
-function kimiWorkDirHash(literalPath: string): string {
-  return crypto.createHash('md5').update(literalPath, 'utf8').digest('hex');
-}
 
 function migrateKimiProjectDataSync(oldProjectPath: string, newProjectPath: string): void {
   const oldResolved = path.resolve(oldProjectPath);

--- a/src/main/agent/adapters/kimi/session-history-parser.ts
+++ b/src/main/agent/adapters/kimi/session-history-parser.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { parseWireJsonl } from './wire-parser';
+import { kimiWorkDirHash, kimiSessionsRoot } from './work-dir-hash';
 import type { SessionHistoryParseResult } from '../../../../shared/types';
 
 /**
@@ -45,7 +45,7 @@ export class KimiSessionHistoryParser {
     cwd: string;
   }): Promise<string | null> {
     const { agentSessionId } = options;
-    const sessionsRoot = path.join(os.homedir(), '.kimi', 'sessions');
+    const sessionsRoot = kimiSessionsRoot();
     const maxAttempts = 10;
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -61,9 +61,16 @@ export class KimiSessionHistoryParser {
    * when the PTY output capture missed the welcome banner. Mirrors
    * Codex's filesystem fallback path.
    *
-   * Strategy: scan `~/.kimi/sessions/*` for session UUID directories
-   * created within ±30s of the spawn. Returns the most recently
-   * created match, or null if none.
+   * Strategy: scan ONLY this work_dir's session directory
+   * (`~/.kimi/sessions/<md5(cwd)>/`, plus its `<kaos>_<md5(cwd)>` variant)
+   * for session UUID directories created within ±30s of the spawn, and
+   * return the most recently created match, or null if none.
+   *
+   * Scoping to the spawn's own work_dir hash is load-bearing, not an
+   * optimization: a global newest-across-all-hashes scan attributes the wrong
+   * session whenever another Kimi session exists in the window under a
+   * different work_dir - a concurrent spawn in another project, or a `-w`-less
+   * probe's stray session - which would poison `--resume` with a foreign id.
    *
    * This is best-effort. The primary capture path is the PTY regex
    * scrape on the welcome banner ("Session: <uuid>"); this fallback
@@ -78,12 +85,15 @@ export class KimiSessionHistoryParser {
     const spawnedAtMs = options.spawnedAt.getTime();
     const floorMs = spawnedAtMs - 30_000;
     const ceilMs = spawnedAtMs + 30_000;
-    const sessionsRoot = path.join(os.homedir(), '.kimi', 'sessions');
+    const sessionsRoot = kimiSessionsRoot();
+    // Hash of the spawn's own work_dir; only sessions under this hash (and its
+    // non-local-kaos `<kaos>_<hash>` variant) belong to this spawn.
+    const workDirHash = kimiWorkDirHash(path.resolve(options.cwd));
     const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
     const maxAttempts = options.maxAttempts ?? 20;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const candidates = collectFreshSessionDirs(sessionsRoot, uuidPattern, floorMs, ceilMs);
+      const candidates = collectFreshSessionDirs(sessionsRoot, workDirHash, uuidPattern, floorMs, ceilMs);
       if (candidates.length > 0) {
         candidates.sort((a, b) => b.createdAtMs - a.createdAtMs);
         return candidates[0].uuid;
@@ -136,18 +146,20 @@ export function findSessionWireFile(sessionsRoot: string, sessionUuid: string): 
 }
 
 /**
- * Collect every session UUID directory under
- * `~/.kimi/sessions/*\/<uuid>/` whose directory mtime falls between
- * `floorMs` and `ceilMs`. Used as the filesystem fallback for session
- * ID capture when PTY scraping fails.
+ * Collect every session UUID directory under this work_dir's hash directory
+ * (`~/.kimi/sessions/<workDirHash>/<uuid>/`, plus any `<kaos>_<workDirHash>`
+ * variant) whose directory mtime falls between `floorMs` and `ceilMs`. Used as
+ * the filesystem fallback for session ID capture when PTY scraping fails.
  *
- * Two-level scan: first the hash directories, then the UUID
- * directories beneath each. Filters by uuidPattern so any
- * future non-UUID files Kimi might add to the sessions root are
- * ignored.
+ * Restricting to `workDirHash` is what keeps a concurrent session under a
+ * different work_dir (or a `-w`-less probe stray) from winning the recency
+ * sort. Two-level scan: the matching hash directories, then the UUID
+ * directories beneath each. Filters by uuidPattern so any future non-UUID
+ * files Kimi might add are ignored.
  */
 function collectFreshSessionDirs(
   sessionsRoot: string,
+  workDirHash: string,
   uuidPattern: RegExp,
   floorMs: number,
   ceilMs: number,
@@ -161,6 +173,9 @@ function collectFreshSessionDirs(
 
   const results: Array<{ uuid: string; createdAtMs: number }> = [];
   for (const hash of hashEntries) {
+    // Only this work_dir's hash dir (and its non-local-kaos `<kaos>_<hash>`
+    // variant); every other hash belongs to a different work_dir.
+    if (hash !== workDirHash && !hash.endsWith(`_${workDirHash}`)) continue;
     let sessionEntries: string[];
     try {
       sessionEntries = fs.readdirSync(path.join(sessionsRoot, hash));

--- a/src/main/agent/adapters/kimi/work-dir-hash.ts
+++ b/src/main/agent/adapters/kimi/work-dir-hash.ts
@@ -1,0 +1,29 @@
+import crypto from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Canonical Kimi work-dir -> sessions-directory hash.
+ *
+ * Kimi keys sessions to the absolute work-dir path:
+ *   ~/.kimi/sessions/<md5(work_dir)>/<uuid>/...
+ * where the directory name is the md5 hex of the literal absolute work-dir
+ * string (verified empirically and against kimi-cli's `metadata.py`). Kangentic
+ * spawns Kimi with a forward-slashed `-w`, but Kimi normalizes it to the native
+ * separator before hashing, and `path.resolve` yields that native form, so
+ * callers should hash `path.resolve(cwd)` to land on the same on-disk digest.
+ *
+ * Single source of truth shared by `project-relocation.ts` (which renames these
+ * directories on a project move) and `session-history-parser.ts` (which scopes
+ * the filesystem session-id capture to this directory). Keeping one definition
+ * prevents the two from drifting, which would silently break capture or
+ * relocation.
+ */
+export function kimiWorkDirHash(literalPath: string): string {
+  return crypto.createHash('md5').update(literalPath, 'utf8').digest('hex');
+}
+
+/** Absolute path to `~/.kimi/sessions`. */
+export function kimiSessionsRoot(): string {
+  return path.join(os.homedir(), '.kimi', 'sessions');
+}

--- a/src/main/git/local-only-commits.ts
+++ b/src/main/git/local-only-commits.ts
@@ -1,0 +1,113 @@
+import simpleGit from 'simple-git';
+import { resolvePRByNumber } from '../pr/pr-registry';
+import type { PRState } from '../../shared/types';
+
+/** PR context for the merged-state signal (squash-merge, which patch-id cannot detect). */
+export interface PrMergeContext {
+  prNumber?: number | null;
+  prState?: PRState | null;
+}
+
+/** Time budget for the best-effort `gh` merged-state lookup; matches the probe's fetch ceiling. */
+const PR_LOOKUP_TIMEOUT_MS = 5_000;
+
+/**
+ * Count commits whose work exists ONLY on this local branch and nowhere
+ * recoverable - the commits a worktree/branch deletion would actually destroy.
+ * A commit is NOT counted when it is:
+ *   - reachable from any remote ref (pushed, so recoverable from the remote), or
+ *   - already present in the base branch by patch-id - a rebase, merge-commit,
+ *     or cherry-pick re-creates the commit under a new SHA, so it is unreachable
+ *     from the remote by SHA yet its work is on the base branch, or
+ *   - part of a merged PR - a squash-merge collapses N commits into a single
+ *     commit whose patch-id matches none of them, so patch-id alone cannot see
+ *     it; the linked PR's merged state is the only robust signal.
+ *
+ * Best-effort: every failure path returns a count no smaller than the
+ * provably-local set, so the result can only drop false positives, never hide
+ * genuinely at-risk work.
+ */
+export async function countLocalOnlyCommits(checkPath: string, pr?: PrMergeContext): Promise<number> {
+  const git = simpleGit(checkPath);
+
+  // Commits on HEAD reachable from no remote ref (by SHA). Anything pushed is
+  // recoverable from the remote and excluded here.
+  const localOnly = (await git.raw(['rev-list', 'HEAD', '--not', '--remotes']))
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (localOnly.length === 0) return 0;
+
+  // Drop commits already present in the base branch by CONTENT (patch-id). This
+  // is what makes a rebase-merged branch read clean: the rebased copies live on
+  // origin/<base> under new SHAs, and `git cherry` marks the originals '-'.
+  const contentMerged = await contentMergedShas(git);
+  const remaining = localOnly.filter((sha) => !contentMerged.has(sha));
+  if (remaining.length === 0) return 0;
+
+  // Patch-id cannot prove a squash-merge; fall back to the linked PR's merged
+  // state. A stored 'merged' is trusted directly (no network); otherwise a
+  // bounded fresh lookup catches "merged just now, stored state not refreshed".
+  if (await isPrMerged(checkPath, pr)) return 0;
+
+  return remaining.length;
+}
+
+/** SHAs reachable from HEAD whose patch-id already exists in the base branch. */
+async function contentMergedShas(git: ReturnType<typeof simpleGit>): Promise<Set<string>> {
+  const base = await resolveBaseBranch(git);
+  // `origin/<base>` first (current after the probe's fetch), then local `<base>`.
+  for (const upstream of [`origin/${base}`, base]) {
+    try {
+      const output = await git.raw(['cherry', '-v', upstream, 'HEAD']);
+      const merged = new Set<string>();
+      for (const line of output.split('\n')) {
+        const trimmed = line.trim();
+        // `git cherry` prints '+ <sha> <subject>' (absent upstream) or
+        // '- <sha> <subject>' (present upstream by patch-id).
+        if (!trimmed.startsWith('-')) continue;
+        const sha = trimmed.split(/\s+/)[1];
+        if (sha) merged.add(sha);
+      }
+      return merged;
+    } catch {
+      continue; // Upstream ref missing - try the next, else give up (no false negative).
+    }
+  }
+  return new Set();
+}
+
+/** The base branch the worktree forked from, recorded at creation; falls back to 'main'. */
+async function resolveBaseBranch(git: ReturnType<typeof simpleGit>): Promise<string> {
+  try {
+    const configured = (await git.raw(['config', 'kangentic.baseBranch'])).trim();
+    if (configured) return configured;
+  } catch {
+    // Not set (older worktree, or branched outside Kangentic).
+  }
+  return 'main';
+}
+
+/** Whether the task's linked PR is merged (covers squash and any merge strategy). */
+async function isPrMerged(checkPath: string, pr?: PrMergeContext): Promise<boolean> {
+  if (!pr) return false;
+  if (pr.prState === 'merged') return true;
+  if (pr.prNumber == null) return false;
+  try {
+    const resolved = await withTimeout(resolvePRByNumber(checkPath, pr.prNumber), PR_LOOKUP_TIMEOUT_MS);
+    return resolved?.state === 'merged';
+  } catch {
+    return false; // gh missing / unauthenticated / offline / timeout - keep the warning.
+  }
+}
+
+/** Resolve `promise`, or reject after `timeoutMs`, so a hung `gh` cannot stall the Done dialog. */
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('pr-lookup-timeout')), timeoutMs);
+    promise.then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (error) => { clearTimeout(timer); reject(error); },
+    );
+  });
+}

--- a/src/main/ipc/handlers/git-diff.ts
+++ b/src/main/ipc/handlers/git-diff.ts
@@ -4,8 +4,20 @@ import { IPC } from '../../../shared/ipc-channels';
 import { DiffService } from '../../git/diff-service';
 import { readWorktreeHead } from '../../git/worktree-head';
 import { fetchAllRemotesIfStale } from '../../git/fetch-throttle';
-import type { GitDiffFilesInput, GitFileContentInput, GitPendingChangesInput, GitPendingChangesResult } from '../../../shared/types';
+import { countLocalOnlyCommits } from '../../git/local-only-commits';
+import type { GitDiffFilesInput, GitFileContentInput, GitPendingChangesInput, GitPendingChangesResult, PRState } from '../../../shared/types';
 import type { IpcContext } from '../ipc-context';
+
+/**
+ * Policy inputs that shape what the Done move would actually destroy. `autoCleanup`
+ * decides whether the move force-deletes the branch (only then are only-local
+ * commits at risk); `prNumber` / `prState` let the count detect a squash-merge.
+ */
+export interface ProbeOptions {
+  autoCleanup?: boolean;
+  prNumber?: number | null;
+  prState?: PRState | null;
+}
 
 /**
  * Probe a worktree (or project) directory for work that the Done move would
@@ -13,18 +25,27 @@ import type { IpcContext } from '../ipc-context';
  * that exist on no remote. Also reports the live HEAD branch so the dialog can
  * name the branch the work actually lives on rather than a stale stored slug.
  *
- * The unpushed count is gated on the repo having at least one remote: with no
+ * The commit count is gated on the repo having at least one remote: with no
  * remotes, `rev-list --not --remotes` matches nothing and would count the
- * entire history, scaring the user with a number that is not unpushed work.
+ * entire history, scaring the user with a number that is not at-risk work.
  * When a remote exists we first refresh remote-tracking refs
  * (fetchAllRemotesIfStale) so the count reflects current remote state rather
  * than stale local refs, which previously made already-pushed commits look
  * local-only.
  *
+ * The count reports only commits the move would actually destroy:
+ * `countLocalOnlyCommits` excludes anything recoverable (pushed, merged by
+ * content, or in a merged PR), and the result counts only when `autoCleanup`
+ * will force-delete the branch - with the branch kept, even unmerged commits
+ * survive on its ref and are not at risk.
+ *
  * On any git failure it returns a safe default (`hasPendingChanges: true`) so
  * a corrupted or missing worktree still routes through the confirm dialog.
  */
-export async function probePendingChanges(checkPath: string): Promise<GitPendingChangesResult> {
+export async function probePendingChanges(checkPath: string, opts?: ProbeOptions): Promise<GitPendingChangesResult> {
+  // Default to true (conservative): a caller that omits it is treated as if the
+  // branch will be deleted, so only-local commits are surfaced rather than hidden.
+  const autoCleanup = opts?.autoCleanup ?? true;
   try {
     const git = simpleGit(checkPath);
     const status = await git.status();
@@ -34,7 +55,14 @@ export async function probePendingChanges(checkPath: string): Promise<GitPending
 
     let unpushedCommitCount = 0;
     const remotes = await git.getRemotes();
-    if (remotes.length > 0) {
+    // The count matters only when the move force-deletes the branch (autoCleanup):
+    // only then are only-local commits genuinely at risk. With the branch kept
+    // they stay reachable on its ref and the worktree is recreatable, so the count
+    // is 0 and the (potentially expensive: a remote fetch, git cherry, and a `gh`
+    // PR lookup) work below is skipped entirely rather than computed and discarded.
+    // The count is also gated on having a remote: with none, `rev-list --not
+    // --remotes` matches nothing and would count all of history.
+    if (remotes.length > 0 && autoCleanup) {
       // Refresh remote-tracking refs first: stale local refs make rev-list
       // report already-pushed commits as local-only. Never rejects; on failure
       // the count falls back to existing (possibly stale) refs, the pre-fix
@@ -42,10 +70,9 @@ export async function probePendingChanges(checkPath: string): Promise<GitPending
       // the outer catch (safe default) rather than yielding a false 0 count.
       await fetchAllRemotesIfStale(checkPath);
       try {
-        const countOutput = (await git.raw(['rev-list', 'HEAD', '--not', '--remotes', '--count'])).trim();
-        unpushedCommitCount = parseInt(countOutput, 10) || 0;
+        unpushedCommitCount = await countLocalOnlyCommits(checkPath, { prNumber: opts?.prNumber, prState: opts?.prState });
       } catch {
-        // Detached HEAD or unborn branch - treat as 0 unpushed.
+        // Detached HEAD or unborn branch - treat as 0.
       }
     }
 
@@ -96,7 +123,11 @@ export function registerGitDiffHandlers(context: IpcContext): void {
   });
 
   ipcMain.handle(IPC.GIT_CHECK_PENDING_CHANGES, (_, input: GitPendingChangesInput): Promise<GitPendingChangesResult> => {
-    return probePendingChanges(input.checkPath);
+    return probePendingChanges(input.checkPath, {
+      autoCleanup: input.autoCleanup,
+      prNumber: input.prNumber,
+      prState: input.prState,
+    });
   });
 
   ipcMain.on(IPC.GIT_DIFF_UNSUBSCRIBE, (_, worktreePath: string) => {

--- a/src/renderer/components/board/BoardDialogs.tsx
+++ b/src/renderer/components/board/BoardDialogs.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { Check } from 'lucide-react';
+import { Check, Trash2 } from 'lucide-react';
 import { ConfirmDialog } from '../dialogs/ConfirmDialog';
 import { BoardManagerDialog } from '../dialogs/BoardManagerDialog';
 import { useBoardStore } from '../../stores/board-store';
@@ -126,7 +126,7 @@ export function BoardDialogs() {
       )}
 
       {pendingDoneConfirm && (() => {
-        const { hasPendingChanges, uncommittedFileCount, unpushedCommitCount } = pendingDoneConfirm;
+        const { hasPendingChanges, uncommittedFileCount, unpushedCommitCount, autoCleanup } = pendingDoneConfirm;
         // Prefer the worktree's live HEAD branch over the stored slug: agents
         // rename branches inside the worktree, so the slug can be stale.
         const displayBranch = pendingDoneConfirm.currentBranch ?? pendingDoneConfirm.task.branch_name;
@@ -150,8 +150,8 @@ export function BoardDialogs() {
                   "{pendingDoneConfirm.task.title}"
                 </p>
                 {/* Red is reserved for data the move genuinely destroys:
-                    uncommitted files (and the probe-failure fallback, where the
-                    worktree is suspect). */}
+                    uncommitted files, at-risk local-only commits (below), and the
+                    probe-failure fallback where the worktree is suspect. */}
                 {uncommittedFileCount > 0 && (
                   <ul className="list-disc list-inside text-red-400 font-medium" data-testid="done-confirm-uncommitted">
                     <li>
@@ -167,13 +167,18 @@ export function BoardDialogs() {
                     Unable to verify pending changes. There may be unsaved work.
                   </p>
                 )}
-                {/* Unpushed commits are NOT lost on Done: the branch is
-                    preserved. Amber, not red, and worded to say so. */}
-                {unpushedCommitCount > 0 && (
-                  <ul className="list-disc list-inside text-yellow-400 font-medium" data-testid="done-confirm-unpushed">
+                {/* The count is non-zero only when the move force-deletes the
+                    branch (autoCleanup) AND the commits exist nowhere
+                    recoverable, so this is genuine loss: red, worded to say so.
+                    Merged or pushed commits are already excluded upstream. The
+                    `autoCleanup` guard is redundant with the probe (which zeroes
+                    the count when the branch is kept) but keeps the dialog
+                    self-consistent: no "will be lost when the branch is deleted"
+                    line while the branch is being kept. */}
+                {autoCleanup && unpushedCommitCount > 0 && (
+                  <ul className="list-disc list-inside text-red-400 font-medium" data-testid="done-confirm-unpushed">
                     <li>
-                      {unpushedCommitCount} commit{unpushedCommitCount !== 1 ? 's' : ''} remain{unpushedCommitCount !== 1 ? '' : 's'} only on the local branch
-                      {branchCode && <> (kept on branch {branchCode})</>}
+                      {unpushedCommitCount} commit{unpushedCommitCount !== 1 ? 's' : ''} exist{unpushedCommitCount !== 1 ? '' : 's'} only on {branchCode ? <>branch {branchCode}</> : 'the local branch'} and will be lost when the branch is deleted
                     </li>
                   </ul>
                 )}
@@ -183,21 +188,34 @@ export function BoardDialogs() {
                     <span>Local worktree will be deleted</span>
                   </li>
                   {displayBranch && (
-                    <li className="flex items-start gap-2">
-                      <Check size={14} className="text-emerald-500 mt-0.5 shrink-0" aria-hidden />
-                      <span>
-                        Branch {branchCode} will be unaffected
-                      </span>
-                    </li>
+                    autoCleanup ? (
+                      // Branch is force-deleted on this move; state it plainly
+                      // rather than the old (false) "will be unaffected".
+                      <li className="flex items-start gap-2" data-testid="done-confirm-branch-fate">
+                        <Trash2 size={14} className="text-fg-muted mt-0.5 shrink-0" aria-hidden />
+                        <span>
+                          Branch {branchCode} will be deleted
+                        </span>
+                      </li>
+                    ) : (
+                      <li className="flex items-start gap-2" data-testid="done-confirm-branch-fate">
+                        <Check size={14} className="text-emerald-500 mt-0.5 shrink-0" aria-hidden />
+                        <span>
+                          Branch {branchCode} will be kept
+                        </span>
+                      </li>
+                    )
                   )}
                   <li className="flex items-start gap-2">
                     <Check size={14} className="text-emerald-500 mt-0.5 shrink-0" aria-hidden />
                     <span>Session history will be kept</span>
                   </li>
                 </ul>
-                <p className="text-fg-muted">
-                  If this task is resumed, the worktree will be recreated from the branch's last commit.
-                </p>
+                {!autoCleanup && (
+                  <p className="text-fg-muted">
+                    If this task is resumed, the worktree will be recreated from the branch's last commit.
+                  </p>
+                )}
               </div>
             }
             onConfirm={() => void confirmPendingDone()}

--- a/src/renderer/hooks/useBoardDragDrop.ts
+++ b/src/renderer/hooks/useBoardDragDrop.ts
@@ -23,6 +23,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { useBoardStore } from '../stores/board-store';
 import { useToastStore } from '../stores/toast-store';
 import { useProjectStore } from '../stores/project-store';
+import { useConfigStore } from '../stores/config-store';
 import { beginBoardDrag, endBoardDrag } from '../lib/session-update-coalescer';
 import type { Task, Swimlane as SwimlaneType } from '../../shared/types';
 
@@ -519,13 +520,23 @@ export function useBoardDragDrop({ swimlanes, tasks, archivedTasks }: UseBoardDr
       // the user confirms the dialog). The no-rect fallback can't animate, so it
       // awaits the probe before deciding, as before.
       const worktreePath = task.worktree_path;
+      // Captured at drop time (interaction-time correct): whether the Done move
+      // will force-delete the branch, plus the linked PR so the probe can tell
+      // merged-and-safe commits from genuinely at-risk ones.
+      const autoCleanup = useConfigStore.getState().config.git.autoCleanup;
       const probe = async () => {
         try {
-          return await window.electronAPI.git.checkPendingChanges({ checkPath: worktreePath });
+          const result = await window.electronAPI.git.checkPendingChanges({
+            checkPath: worktreePath,
+            autoCleanup,
+            prNumber: task.pr_number,
+            prState: task.pr_state,
+          });
+          return { ...result, autoCleanup };
         } catch {
           // Treat git failures as "potentially has changes" - safer to ask
           // than to silently destroy. Mirrors the To Do path in task-slice.ts.
-          return { uncommittedFileCount: 0, unpushedCommitCount: 0, hasPendingChanges: true, currentBranch: null };
+          return { uncommittedFileCount: 0, unpushedCommitCount: 0, hasPendingChanges: true, currentBranch: null, autoCleanup };
         }
       };
 

--- a/src/renderer/stores/board-store/done-drop-confirm-slice.ts
+++ b/src/renderer/stores/board-store/done-drop-confirm-slice.ts
@@ -3,7 +3,10 @@ import type { GitPendingChangesResult, Task, TaskMoveInput } from '../../../shar
 import { useProjectStore } from '../project-store';
 import type { BoardStore, CompletingTask, PendingDoneConfirm } from './types';
 
-export type PendingChangesInfo = Pick<GitPendingChangesResult, 'hasPendingChanges' | 'uncommittedFileCount' | 'unpushedCommitCount' | 'currentBranch'>;
+export type PendingChangesInfo = Pick<GitPendingChangesResult, 'hasPendingChanges' | 'uncommittedFileCount' | 'unpushedCommitCount' | 'currentBranch'> & {
+  /** Captured at drop time so the dialog can state whether the branch is kept or force-deleted. */
+  autoCleanup: boolean;
+};
 
 export interface DoneDropConfirmSlice {
   pendingDoneConfirm: PendingDoneConfirm | null;
@@ -48,6 +51,7 @@ export const createDoneDropConfirmSlice: StateCreator<BoardStore, [], [], DoneDr
         uncommittedFileCount: pendingChanges.uncommittedFileCount,
         unpushedCommitCount: pendingChanges.unpushedCommitCount,
         currentBranch: pendingChanges.currentBranch,
+        autoCleanup: pendingChanges.autoCleanup,
       });
     },
 
@@ -60,6 +64,7 @@ export const createDoneDropConfirmSlice: StateCreator<BoardStore, [], [], DoneDr
         uncommittedFileCount: pendingChanges.uncommittedFileCount,
         unpushedCommitCount: pendingChanges.unpushedCommitCount,
         currentBranch: pendingChanges.currentBranch,
+        autoCleanup: pendingChanges.autoCleanup,
       });
     },
 

--- a/src/renderer/stores/board-store/types.ts
+++ b/src/renderer/stores/board-store/types.ts
@@ -48,7 +48,9 @@ export type { CompletionGate } from './completion-gate';
  * counts to report) can still lock the dialog into its danger styling.
  * `currentBranch` is the worktree's live HEAD branch (null on detached HEAD or
  * probe failure); the dialog prefers it over the stored slug, which agents
- * rename inside the worktree.
+ * rename inside the worktree. `autoCleanup` is captured at drop time so the
+ * dialog can state the branch's real fate: kept (recreatable) when off,
+ * force-deleted when on.
  */
 export type PendingDoneConfirm =
   | {
@@ -59,6 +61,7 @@ export type PendingDoneConfirm =
       uncommittedFileCount: number;
       unpushedCommitCount: number;
       currentBranch: string | null;
+      autoCleanup: boolean;
     }
   | {
       kind: 'direct';
@@ -68,6 +71,7 @@ export type PendingDoneConfirm =
       uncommittedFileCount: number;
       unpushedCommitCount: number;
       currentBranch: string | null;
+      autoCleanup: boolean;
     };
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -933,11 +933,29 @@ export interface GitDiffFileEntry {
 export interface GitPendingChangesInput {
   /** Path to check - worktree path or project path */
   checkPath: string;
+  /**
+   * Whether the move that follows will force-delete the branch (git autoCleanup).
+   * Only-local commits are at risk of loss only when the branch is deleted; with
+   * the branch kept they stay reachable on its ref and must not warn. Defaults to
+   * true (conservative) when omitted.
+   */
+  autoCleanup?: boolean;
+  /** Linked PR number, used to detect a squash-merge that patch-id cannot see. */
+  prNumber?: number | null;
+  /** Last-known linked PR state; a stored 'merged' avoids a fresh `gh` lookup. */
+  prState?: PRState | null;
 }
 
 export interface GitPendingChangesResult {
   hasPendingChanges: boolean;
   uncommittedFileCount: number;
+  /**
+   * Commits that exist only on this local branch and nowhere recoverable (not
+   * pushed, not merged by content, not in a merged PR), AND that the pending
+   * move would actually destroy by force-deleting the branch. Zero when the
+   * branch will be kept, since the commits then survive on its ref. Despite the
+   * legacy name, this is "at-risk local-only commits," not merely "unpushed."
+   */
   unpushedCommitCount: number;
   /**
    * The worktree's live HEAD branch, or null on a detached HEAD or probe

--- a/tests/ui/move-to-done-confirm.spec.ts
+++ b/tests/ui/move-to-done-confirm.spec.ts
@@ -41,7 +41,16 @@ function makePreConfig(options: {
   // Pass null to simulate a task that was created without a branch (edge case
   // tested by the null-displayBranch + unpushed-commits scenario).
   branchName?: string | null;
+  // When false, a project-config override turns git.autoCleanup off so the Done
+  // move keeps the branch. The dialog then states the branch is kept and never
+  // warns about only-local commits. Defaults to the mock global (true).
+  autoCleanup?: boolean;
 } = {}): string {
+  // Project-config override applied via projectConfigs so config.get() (which
+  // merges the current project's overrides) returns the desired autoCleanup.
+  const autoCleanupOverride = options.autoCleanup === false
+    ? `state.projectConfigs['/mock/done-confirm-test'] = { git: { autoCleanup: false } };`
+    : '';
   const pendingChanges = options.pendingChanges;
   const currentBranchLiteral = pendingChanges && pendingChanges.currentBranch !== undefined
     ? JSON.stringify(pendingChanges.currentBranch)
@@ -117,6 +126,7 @@ function makePreConfig(options: {
       });
 
       ${pendingChangesOverride}
+      ${autoCleanupOverride}
 
       return { currentProjectId: '${PROJECT_ID}' };
     });
@@ -189,17 +199,44 @@ test.describe('Move to Done - Delete Worktree Confirmation', () => {
       const dialog = page.locator('text=Move to Done?');
       await expect(dialog).toBeVisible({ timeout: 3000 });
 
-      // Dialog enumerates the trade-off as bullets: worktree deleted,
-      // branch unaffected (with concrete branch name shown), session kept.
-      // Plus a closing line about resume restoring both.
+      // Dialog enumerates the trade-off as bullets: worktree deleted, branch
+      // force-deleted (autoCleanup default on, with the branch name shown),
+      // session kept. The "recreated from the branch" line is absent because the
+      // branch is gone.
       await expect(page.locator('text=Local worktree will be deleted')).toBeVisible();
-      await expect(page.locator('text=will be unaffected')).toBeVisible();
+      await expect(page.locator('[data-testid="done-confirm-branch-fate"]')).toContainText('will be deleted');
       await expect(page.locator('text=ready-to-ship-abcd1234')).toBeVisible();
       await expect(page.locator('text=Session history will be kept')).toBeVisible();
-      await expect(page.locator("text=the worktree will be recreated from the branch's last commit")).toBeVisible();
+      await expect(page.locator("text=the worktree will be recreated from the branch's last commit")).toHaveCount(0);
 
       await expect(page.locator('button:has-text("Move")').first()).toBeVisible();
       await expect(page.locator('button:has-text("Cancel")')).toBeVisible();
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('keeps the branch and omits the commit-loss warning when autoCleanup is off', async () => {
+    // With autoCleanup off the Done move keeps the branch, so only-local commits
+    // are recoverable and must not warn; the dialog states the branch is kept and
+    // offers worktree recreation. The dialog still opens for the uncommitted file.
+    const { browser, page } = await launchWithState(
+      makePreConfig({
+        autoCleanup: false,
+        pendingChanges: { uncommittedFileCount: 1, unpushedCommitCount: 0 },
+      }),
+    );
+
+    try {
+      await page.locator('[data-swimlane-name="Done"]').waitFor({ state: 'visible', timeout: 15000 });
+
+      await dragTaskToColumn(page, 'Ready To Ship', 'Done');
+
+      await expect(page.locator('text=Move to Done?')).toBeVisible({ timeout: 3000 });
+      await expect(page.locator('[data-testid="done-confirm-branch-fate"]')).toContainText('will be kept');
+      await expect(page.locator("text=the worktree will be recreated from the branch's last commit")).toBeVisible();
+      // No commit-loss warning when the branch survives.
+      await expect(page.locator('[data-testid="done-confirm-unpushed"]')).toHaveCount(0);
     } finally {
       await browser.close();
     }
@@ -324,8 +361,12 @@ test.describe('Move to Done - Delete Worktree Confirmation', () => {
       await dragTaskToColumn(page, 'Ready To Ship', 'Done');
 
       await expect(page.locator('text=Move to Done?')).toBeVisible({ timeout: 3000 });
-      // Unpushed commits are kept (branch preserved), so the copy says "remain".
-      await expect(page.locator('text=2 commits remain only on the local branch')).toBeVisible();
+      // autoCleanup is on (mock default), so the branch is deleted and only-local
+      // commits are genuine loss. Use the testid because the branch name renders
+      // in a nested <code>, splitting the text node.
+      const unpushed = page.locator('[data-testid="done-confirm-unpushed"]');
+      await expect(unpushed).toContainText('2 commits exist only on');
+      await expect(unpushed).toContainText('will be lost when the branch is deleted');
     } finally {
       await browser.close();
     }
@@ -389,7 +430,7 @@ test.describe('Move to Done - Delete Worktree Confirmation', () => {
                 requestDoneConfirmDirect: (
                   task: { id: string; title: string; branch_name: string; worktree_path: string },
                   input: { taskId: string; targetSwimlaneId: string; targetPosition: number },
-                  pendingChanges: { hasPendingChanges: boolean; uncommittedFileCount: number; unpushedCommitCount: number; currentBranch: string | null },
+                  pendingChanges: { hasPendingChanges: boolean; uncommittedFileCount: number; unpushedCommitCount: number; currentBranch: string | null; autoCleanup: boolean },
                 ) => void;
               };
             };
@@ -407,15 +448,17 @@ test.describe('Move to Done - Delete Worktree Confirmation', () => {
             targetSwimlaneId: 'lane-done',
             targetPosition: 0,
           },
-          { hasPendingChanges: true, uncommittedFileCount: 2, unpushedCommitCount: 1, currentBranch: null },
+          { hasPendingChanges: true, uncommittedFileCount: 2, unpushedCommitCount: 1, currentBranch: null, autoCleanup: true },
         );
       });
 
       // The dialog should appear with the correct content.
       await expect(page.locator('text=Move to Done?')).toBeVisible({ timeout: 3000 });
       await expect(page.locator('text=2 uncommitted files will be lost')).toBeVisible();
-      // Singular "remains" for a single unpushed commit (kept on the branch).
-      await expect(page.locator('text=1 commit remains only on the local branch')).toBeVisible();
+      // Singular "exists" for a single at-risk commit (branch force-deleted).
+      const unpushed = page.locator('[data-testid="done-confirm-unpushed"]');
+      await expect(unpushed).toContainText('1 commit exists only on');
+      await expect(unpushed).toContainText('will be lost when the branch is deleted');
     } finally {
       await browser.close();
     }
@@ -553,9 +596,9 @@ test.describe('Move to Done - Delete Worktree Confirmation', () => {
     }
   });
 
-  test('styles uncommitted files as danger and unpushed commits as a warning', async () => {
-    // Red is reserved for genuinely destroyed data (uncommitted files). Unpushed
-    // commits are kept on the preserved branch, so they render amber, not red.
+  test('styles both uncommitted files and at-risk commits as danger', async () => {
+    // With autoCleanup on (mock default) the branch is force-deleted, so both
+    // uncommitted files and only-local commits are genuinely destroyed: both red.
     const { browser, page } = await launchWithState(
       makePreConfig({
         pendingChanges: { uncommittedFileCount: 2, unpushedCommitCount: 3 },
@@ -574,7 +617,7 @@ test.describe('Move to Done - Delete Worktree Confirmation', () => {
       await expect(uncommitted).toBeVisible();
       await expect(unpushed).toBeVisible();
       await expect(uncommitted).toHaveClass(/text-red-400/);
-      await expect(unpushed).toHaveClass(/text-yellow-400/);
+      await expect(unpushed).toHaveClass(/text-red-400/);
     } finally {
       await browser.close();
     }
@@ -584,10 +627,10 @@ test.describe('Move to Done - Delete Worktree Confirmation', () => {
   // Null displayBranch + unpushed commits: edge case in BoardDialogs.tsx
   //
   // When BOTH task.branch_name and currentBranch are null, displayBranch is null.
-  // The template branches on `branchCode && ...` (null -> falsy) so the unpushed
-  // bullet must omit the "(kept on branch X)" clause, and the "Branch ... will
-  // be unaffected" green bullet must be absent entirely. This guards the
-  // `{displayBranch && (...)}` conditional in BoardDialogs.tsx.
+  // The commit-loss bullet falls back to the generic "the local branch" wording,
+  // and the branch-fate bullet (kept/deleted) is absent entirely because there is
+  // no branch name to surface. This guards the `{displayBranch && (...)}` and
+  // `branchCode ? ... : 'the local branch'` conditionals in BoardDialogs.tsx.
   // ---------------------------------------------------------------------------
   test('null displayBranch with unpushed commits omits branch clauses', async () => {
     // Seed a task with no branch_name AND a probe that returns currentBranch: null
@@ -606,20 +649,15 @@ test.describe('Move to Done - Delete Worktree Confirmation', () => {
 
       await expect(page.locator('text=Move to Done?')).toBeVisible({ timeout: 3000 });
 
-      // The unpushed-commit bullet must be visible (this is a pending-changes dialog).
+      // The commit-loss bullet must be visible (this is a pending-changes dialog).
       const unpushedBullet = page.locator('[data-testid="done-confirm-unpushed"]');
       await expect(unpushedBullet).toBeVisible();
 
-      // The bullet text must say "remain only on the local branch" (the generic
-      // copy that does not mention a specific branch name).
-      await expect(unpushedBullet).toContainText('remain only on the local branch');
+      // The bullet uses the generic "the local branch" wording (no branch name).
+      await expect(unpushedBullet).toContainText('exist only on the local branch');
 
-      // The "(kept on branch X)" parenthetical must NOT appear anywhere.
-      await expect(page.locator('text=(kept on branch')).toHaveCount(0);
-
-      // The green "Branch ... will be unaffected" bullet must be absent because
-      // displayBranch is null (there is no branch name to surface).
-      await expect(page.locator('text=will be unaffected')).toHaveCount(0);
+      // No branch-fate bullet (kept/deleted) renders without a branch name.
+      await expect(page.locator('[data-testid="done-confirm-branch-fate"]')).toHaveCount(0);
     } finally {
       await browser.close();
     }

--- a/tests/unit/git-pending-changes.test.ts
+++ b/tests/unit/git-pending-changes.test.ts
@@ -1,12 +1,14 @@
 /**
  * Unit tests for probePendingChanges -- the Done-move probe that reports
- * uncommitted files, unpushed commits (gated on the repo having a remote), and
- * the worktree's live HEAD branch.
+ * uncommitted files, at-risk local-only commits (gated on the repo having a
+ * remote AND on the move force-deleting the branch), and the worktree's live
+ * HEAD branch. The merge/remote-aware commit count itself lives in
+ * countLocalOnlyCommits (covered by local-only-commits.test.ts) and is mocked
+ * here so the probe's policy is tested in isolation.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// The probe builds a simple-git instance and calls status() / getRemotes() /
-// raw(). One shared mock object so each test configures the responses.
+// The probe builds a simple-git instance and calls status() / getRemotes().
 const mockGit = {
   status: vi.fn<() => Promise<{ files: unknown[] }>>(),
   getRemotes: vi.fn<() => Promise<unknown[]>>(),
@@ -24,12 +26,18 @@ vi.mock('../../src/main/git/worktree-head', () => ({
   readWorktreeHead: (path: string) => mockReadWorktreeHead(path),
 }));
 
-// The probe refreshes remote-tracking refs before counting unpushed commits.
-// Mock it so the unit tests don't spawn a real fetch; behavior of the helper
-// itself is covered in fetch-throttle.test.ts.
+// The probe refreshes remote-tracking refs before counting. Mock it so the unit
+// tests don't spawn a real fetch (the helper is covered in fetch-throttle.test.ts).
 const mockFetchAllRemotesIfStale = vi.fn<(checkPath: string) => Promise<void>>();
 vi.mock('../../src/main/git/fetch-throttle', () => ({
   fetchAllRemotesIfStale: (checkPath: string) => mockFetchAllRemotesIfStale(checkPath),
+}));
+
+// The merge/remote-aware count is mocked so the probe's autoCleanup policy is
+// tested in isolation (the count's own logic is in local-only-commits.test.ts).
+const mockCountLocalOnlyCommits = vi.fn<(checkPath: string, pr?: PrMergeContext) => Promise<number>>();
+vi.mock('../../src/main/git/local-only-commits', () => ({
+  countLocalOnlyCommits: (checkPath: string, pr?: PrMergeContext) => mockCountLocalOnlyCommits(checkPath, pr),
 }));
 
 // git-diff.ts imports these at module scope; stub them so the import resolves
@@ -39,15 +47,16 @@ vi.mock('../../src/main/git/diff-service', () => ({ DiffService: class {} }));
 vi.mock('../../src/main/git/diff-watcher', () => ({ DiffWatcher: class {} }));
 
 import { probePendingChanges } from '../../src/main/ipc/handlers/git-diff';
+import type { PrMergeContext } from '../../src/main/git/local-only-commits';
 
 describe('probePendingChanges', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGit.status.mockResolvedValue({ files: [] });
     mockGit.getRemotes.mockResolvedValue([]);
-    mockGit.raw.mockResolvedValue('0');
     mockReadWorktreeHead.mockResolvedValue({ branch: 'feat/work', sha: 'abc123' });
     mockFetchAllRemotesIfStale.mockResolvedValue(undefined);
+    mockCountLocalOnlyCommits.mockResolvedValue(0);
   });
 
   it('counts uncommitted files from git status', async () => {
@@ -75,48 +84,87 @@ describe('probePendingChanges', () => {
     expect(result.currentBranch).toBeNull();
   });
 
-  it('skips the unpushed count entirely when the repo has no remotes', async () => {
+  it('skips the commit count entirely when the repo has no remotes', async () => {
     mockGit.getRemotes.mockResolvedValue([]);
 
     const result = await probePendingChanges('/mock/worktree');
 
-    // rev-list must never run with no remotes (it would count all of history).
-    expect(mockGit.raw).not.toHaveBeenCalled();
+    // The count must never run with no remotes (rev-list would count all history).
+    expect(mockCountLocalOnlyCommits).not.toHaveBeenCalled();
     // With no remote there is nothing to refresh, so no fetch is attempted.
     expect(mockFetchAllRemotesIfStale).not.toHaveBeenCalled();
     expect(result.unpushedCommitCount).toBe(0);
   });
 
-  it('counts unpushed commits when at least one remote exists', async () => {
+  it('counts at-risk commits when a remote exists and the branch will be deleted', async () => {
     mockGit.getRemotes.mockResolvedValue([{ name: 'origin' }]);
-    mockGit.raw.mockResolvedValue('4\n');
+    mockCountLocalOnlyCommits.mockResolvedValue(4);
 
-    const result = await probePendingChanges('/mock/worktree');
+    const result = await probePendingChanges('/mock/worktree', { autoCleanup: true });
 
-    expect(mockGit.raw).toHaveBeenCalledWith(['rev-list', 'HEAD', '--not', '--remotes', '--count']);
     expect(result.unpushedCommitCount).toBe(4);
     expect(result.hasPendingChanges).toBe(true);
   });
 
-  it('refreshes remote-tracking refs before counting unpushed commits', async () => {
+  it('defaults to the conservative (branch-deleted) policy when autoCleanup is omitted', async () => {
     mockGit.getRemotes.mockResolvedValue([{ name: 'origin' }]);
-    mockGit.raw.mockResolvedValue('0\n');
-
-    await probePendingChanges('/mock/worktree');
-
-    expect(mockFetchAllRemotesIfStale).toHaveBeenCalledWith('/mock/worktree');
-    // The fetch must complete before rev-list, otherwise the count still reads
-    // stale refs. invocationCallOrder is monotonic across all mocks.
-    const fetchOrder = mockFetchAllRemotesIfStale.mock.invocationCallOrder[0];
-    const revListOrder = mockGit.raw.mock.invocationCallOrder[0];
-    expect(fetchOrder).toBeLessThan(revListOrder);
-  });
-
-  it('treats a rev-list failure (unborn / detached) as zero unpushed', async () => {
-    mockGit.getRemotes.mockResolvedValue([{ name: 'origin' }]);
-    mockGit.raw.mockRejectedValue(new Error('unknown revision HEAD'));
+    mockCountLocalOnlyCommits.mockResolvedValue(2);
 
     const result = await probePendingChanges('/mock/worktree');
+
+    expect(result.unpushedCommitCount).toBe(2);
+    expect(result.hasPendingChanges).toBe(true);
+  });
+
+  it('does not warn about local-only commits when the branch will be kept (autoCleanup off)', async () => {
+    mockGit.getRemotes.mockResolvedValue([{ name: 'origin' }]);
+    mockCountLocalOnlyCommits.mockResolvedValue(5);
+
+    const result = await probePendingChanges('/mock/worktree', { autoCleanup: false });
+
+    // The branch survives, so the commits are recoverable and not at risk.
+    expect(result.unpushedCommitCount).toBe(0);
+    expect(result.hasPendingChanges).toBe(false);
+  });
+
+  it('still warns about uncommitted files even when the branch will be kept', async () => {
+    mockGit.status.mockResolvedValue({ files: [{}] });
+    mockGit.getRemotes.mockResolvedValue([{ name: 'origin' }]);
+    mockCountLocalOnlyCommits.mockResolvedValue(3);
+
+    const result = await probePendingChanges('/mock/worktree', { autoCleanup: false });
+
+    expect(result.uncommittedFileCount).toBe(1);
+    expect(result.unpushedCommitCount).toBe(0);
+    expect(result.hasPendingChanges).toBe(true);
+  });
+
+  it('forwards autoCleanup / prNumber / prState into the count', async () => {
+    mockGit.getRemotes.mockResolvedValue([{ name: 'origin' }]);
+
+    await probePendingChanges('/mock/worktree', { autoCleanup: true, prNumber: 7, prState: 'open' });
+
+    expect(mockCountLocalOnlyCommits).toHaveBeenCalledWith('/mock/worktree', { prNumber: 7, prState: 'open' });
+  });
+
+  it('refreshes remote-tracking refs before counting', async () => {
+    mockGit.getRemotes.mockResolvedValue([{ name: 'origin' }]);
+
+    await probePendingChanges('/mock/worktree', { autoCleanup: true });
+
+    expect(mockFetchAllRemotesIfStale).toHaveBeenCalledWith('/mock/worktree');
+    // The fetch must complete before the count, otherwise it still reads stale
+    // refs. invocationCallOrder is monotonic across all mocks.
+    const fetchOrder = mockFetchAllRemotesIfStale.mock.invocationCallOrder[0];
+    const countOrder = mockCountLocalOnlyCommits.mock.invocationCallOrder[0];
+    expect(fetchOrder).toBeLessThan(countOrder);
+  });
+
+  it('treats a count failure (unborn / detached) as zero', async () => {
+    mockGit.getRemotes.mockResolvedValue([{ name: 'origin' }]);
+    mockCountLocalOnlyCommits.mockRejectedValue(new Error('unknown revision HEAD'));
+
+    const result = await probePendingChanges('/mock/worktree', { autoCleanup: true });
 
     expect(result.unpushedCommitCount).toBe(0);
   });
@@ -156,8 +204,6 @@ describe('probePendingChanges', () => {
   // -------------------------------------------------------------------------
 
   it('returns a safe default when getRemotes() rejects after status() succeeds', async () => {
-    // status() succeeds; getRemotes() throws (network / corrupted repo config).
-    // The outer catch must return the all-null safe default.
     mockGit.status.mockResolvedValue({ files: [{}] });
     mockGit.getRemotes.mockRejectedValue(new Error('could not read git config'));
 
@@ -173,13 +219,13 @@ describe('probePendingChanges', () => {
 
   it('returns the safe default if the freshness fetch rejects unexpectedly', async () => {
     // fetchAllRemotesIfStale is contracted to never reject, but the call site
-    // sits outside the inner rev-list try so that if it ever did, the outer
-    // catch (safe default) fires rather than a false 0 unpushed count. This
-    // locks that placement against future refactors.
+    // sits outside the inner count try so that if it ever did, the outer catch
+    // (safe default) fires rather than a false 0 count. This locks that
+    // placement against future refactors.
     mockGit.getRemotes.mockResolvedValue([{ name: 'origin' }]);
     mockFetchAllRemotesIfStale.mockRejectedValue(new Error('unexpected fetch failure'));
 
-    const result = await probePendingChanges('/mock/worktree');
+    const result = await probePendingChanges('/mock/worktree', { autoCleanup: true });
 
     expect(result).toEqual({
       hasPendingChanges: true,
@@ -190,9 +236,6 @@ describe('probePendingChanges', () => {
   });
 
   it('returns a safe default when readWorktreeHead rejects after status() succeeds', async () => {
-    // status() succeeds; readWorktreeHead throws (unexpected error from the
-    // helper -- normally it swallows its own errors, but if a future change
-    // causes it to propagate, the outer catch must still protect the caller).
     mockGit.status.mockResolvedValue({ files: [] });
     mockReadWorktreeHead.mockRejectedValue(new Error('unexpected read failure'));
 

--- a/tests/unit/kimi-session-history-parser.test.ts
+++ b/tests/unit/kimi-session-history-parser.test.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import os from 'node:os';
 import path from 'node:path';
+import { kimiWorkDirHash } from '../../src/main/agent/adapters/kimi/work-dir-hash';
 
 // ── Mutable mock state ────────────────────────────────────────────────────────
 
@@ -182,6 +183,14 @@ describe('KimiSessionHistoryParser.locate()', () => {
 // ── captureSessionIdFromFilesystem() ─────────────────────────────────────────
 
 describe('KimiSessionHistoryParser.captureSessionIdFromFilesystem()', () => {
+  // The capture is scoped to the spawn's OWN work_dir hash, so the mocked
+  // sessions live under md5(resolve(cwd)) - the same digest the real Kimi CLI
+  // (and mock-kimi) writes under. A session under any other hash belongs to a
+  // different work_dir and must be ignored.
+  const CWD = '/projects/foo';
+  const WORK_DIR_HASH = kimiWorkDirHash(path.resolve(CWD));
+  const FOREIGN_HASH = kimiWorkDirHash(path.resolve('/projects/other'));
+
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -195,15 +204,15 @@ describe('KimiSessionHistoryParser.captureSessionIdFromFilesystem()', () => {
     const inWindowMtime = spawnedAt.getTime(); // exactly at spawn time - always in window
 
     mockReaddirSync = (filePath: string) => {
-      if (filePath === SESSIONS_ROOT) return ['hash00000001'];
-      if (filePath.includes('hash00000001')) return [SESSION_UUID];
+      if (filePath === SESSIONS_ROOT) return [WORK_DIR_HASH];
+      if (filePath.includes(WORK_DIR_HASH)) return [SESSION_UUID];
       return [];
     };
     mockStatSync = () => ({ mtimeMs: inWindowMtime });
 
     const resultPromise = KimiSessionHistoryParser.captureSessionIdFromFilesystem({
       spawnedAt,
-      cwd: '/projects/foo',
+      cwd: CWD,
       maxAttempts: 5,
     });
     await vi.runAllTimersAsync();
@@ -217,7 +226,7 @@ describe('KimiSessionHistoryParser.captureSessionIdFromFilesystem()', () => {
 
     const resultPromise = KimiSessionHistoryParser.captureSessionIdFromFilesystem({
       spawnedAt: new Date(),
-      cwd: '/projects/foo',
+      cwd: CWD,
       maxAttempts: 3,
     });
     await vi.runAllTimersAsync();
@@ -236,16 +245,16 @@ describe('KimiSessionHistoryParser.captureSessionIdFromFilesystem()', () => {
       if (filePath === SESSIONS_ROOT) {
         pollCount++;
         // Dir only exists starting from poll 3.
-        return pollCount >= 3 ? ['hashAppears'] : [];
+        return pollCount >= 3 ? [WORK_DIR_HASH] : [];
       }
-      if (filePath.includes('hashAppears')) return [SESSION_UUID];
+      if (filePath.includes(WORK_DIR_HASH)) return [SESSION_UUID];
       return [];
     };
     mockStatSync = () => ({ mtimeMs: inWindowMtime });
 
     const resultPromise = KimiSessionHistoryParser.captureSessionIdFromFilesystem({
       spawnedAt,
-      cwd: '/projects/foo',
+      cwd: CWD,
       maxAttempts: 10,
     });
     await vi.runAllTimersAsync();
@@ -263,15 +272,15 @@ describe('KimiSessionHistoryParser.captureSessionIdFromFilesystem()', () => {
     const staleUuid = '51a1e000-0000-0000-0000-000000000000';
 
     mockReaddirSync = (filePath: string) => {
-      if (filePath === SESSIONS_ROOT) return ['hashStale'];
-      if (filePath.includes('hashStale')) return [staleUuid];
+      if (filePath === SESSIONS_ROOT) return [WORK_DIR_HASH];
+      if (filePath.includes(WORK_DIR_HASH)) return [staleUuid];
       return [];
     };
     mockStatSync = () => ({ mtimeMs: staleMs });
 
     const resultPromise = KimiSessionHistoryParser.captureSessionIdFromFilesystem({
       spawnedAt,
-      cwd: '/projects/foo',
+      cwd: CWD,
       maxAttempts: 2,
     });
     await vi.runAllTimersAsync();
@@ -289,15 +298,15 @@ describe('KimiSessionHistoryParser.captureSessionIdFromFilesystem()', () => {
     const futureUuid = 'f00001ee-0000-0000-0000-000000000000';
 
     mockReaddirSync = (filePath: string) => {
-      if (filePath === SESSIONS_ROOT) return ['hashFuture'];
-      if (filePath.includes('hashFuture')) return [futureUuid];
+      if (filePath === SESSIONS_ROOT) return [WORK_DIR_HASH];
+      if (filePath.includes(WORK_DIR_HASH)) return [futureUuid];
       return [];
     };
     mockStatSync = () => ({ mtimeMs: futureMs });
 
     const resultPromise = KimiSessionHistoryParser.captureSessionIdFromFilesystem({
       spawnedAt,
-      cwd: '/projects/foo',
+      cwd: CWD,
       maxAttempts: 2,
     });
     await vi.runAllTimersAsync();
@@ -314,15 +323,15 @@ describe('KimiSessionHistoryParser.captureSessionIdFromFilesystem()', () => {
     const targetUuid = 'aa110000-0000-0000-0000-000000000001';
 
     mockReaddirSync = (filePath: string) => {
-      if (filePath === SESSIONS_ROOT) return ['hashTarget'];
-      if (filePath.includes('hashTarget')) return [targetUuid];
+      if (filePath === SESSIONS_ROOT) return [WORK_DIR_HASH];
+      if (filePath.includes(WORK_DIR_HASH)) return [targetUuid];
       return [];
     };
     mockStatSync = () => ({ mtimeMs: inWindowMtime });
 
     const resultPromise = KimiSessionHistoryParser.captureSessionIdFromFilesystem({
       spawnedAt,
-      cwd: '/projects/foo',
+      cwd: CWD,
       maxAttempts: 2,
     });
     await vi.runAllTimersAsync();
@@ -342,8 +351,8 @@ describe('KimiSessionHistoryParser.captureSessionIdFromFilesystem()', () => {
     const newerMtime = spawnedAt.getTime() + 20_000;
 
     mockReaddirSync = (filePath: string) => {
-      if (filePath === SESSIONS_ROOT) return ['hashBoth'];
-      if (filePath.includes('hashBoth')) return [olderUuid, newerUuid];
+      if (filePath === SESSIONS_ROOT) return [WORK_DIR_HASH];
+      if (filePath.includes(WORK_DIR_HASH)) return [olderUuid, newerUuid];
       return [];
     };
     mockStatSync = (filePath: string) => ({
@@ -352,7 +361,7 @@ describe('KimiSessionHistoryParser.captureSessionIdFromFilesystem()', () => {
 
     const resultPromise = KimiSessionHistoryParser.captureSessionIdFromFilesystem({
       spawnedAt,
-      cwd: '/projects/foo',
+      cwd: CWD,
       maxAttempts: 2,
     });
     await vi.runAllTimersAsync();
@@ -370,8 +379,8 @@ describe('KimiSessionHistoryParser.captureSessionIdFromFilesystem()', () => {
     const goodUuid = 'cccccccc-1234-5678-abcd-ffffffffffff';
 
     mockReaddirSync = (filePath: string) => {
-      if (filePath === SESSIONS_ROOT) return ['hashMixed'];
-      if (filePath.includes('hashMixed')) return ['metadata.json', goodUuid, '.DS_Store'];
+      if (filePath === SESSIONS_ROOT) return [WORK_DIR_HASH];
+      if (filePath.includes(WORK_DIR_HASH)) return ['metadata.json', goodUuid, '.DS_Store'];
       return [];
     };
 
@@ -379,12 +388,12 @@ describe('KimiSessionHistoryParser.captureSessionIdFromFilesystem()', () => {
     // are filtered BEFORE statSync is called (cheaper than statting every
     // entry just to throw it away). This produces clearer failure messages
     // than a defensive throw inside the mock.
-    const statSyncSpy = vi.fn((filePath: string) => ({ mtimeMs: inWindowMtime }));
+    const statSyncSpy = vi.fn((_filePath: string) => ({ mtimeMs: inWindowMtime }));
     mockStatSync = statSyncSpy;
 
     const resultPromise = KimiSessionHistoryParser.captureSessionIdFromFilesystem({
       spawnedAt,
-      cwd: '/projects/foo',
+      cwd: CWD,
       maxAttempts: 2,
     });
     await vi.runAllTimersAsync();
@@ -399,5 +408,87 @@ describe('KimiSessionHistoryParser.captureSessionIdFromFilesystem()', () => {
     // Negative assertions: non-UUID entries were filtered out before statSync.
     expect(calledPaths.some((filePath) => filePath.includes('metadata.json'))).toBe(false);
     expect(calledPaths.some((filePath) => filePath.includes('.DS_Store'))).toBe(false);
+  });
+
+  // --- work_dir scoping (the stray-session race regression guard) ------------
+
+  it('ignores a newer in-window session under a different work_dir hash', async () => {
+    // The exact contamination this fix prevents: a concurrent Kimi spawn (or a
+    // -w-less probe) plants a NEWER session under a DIFFERENT work_dir hash.
+    // A global newest-across-all-hashes scan would return the foreign UUID and
+    // poison --resume. The scoped scan must return only this work_dir's session.
+    const spawnedAt = new Date(7_000_000_000_000);
+
+    const ownUuid = '0117c0de-0000-0000-0000-000000000001';
+    const foreignUuid = 'f04e1011-0000-0000-0000-000000000002';
+
+    const ownMtime = spawnedAt.getTime() + 2_000;
+    const foreignMtime = spawnedAt.getTime() + 20_000; // newer, also in window
+
+    mockReaddirSync = (filePath: string) => {
+      if (filePath === SESSIONS_ROOT) return [WORK_DIR_HASH, FOREIGN_HASH];
+      if (filePath.includes(WORK_DIR_HASH)) return [ownUuid];
+      if (filePath.includes(FOREIGN_HASH)) return [foreignUuid];
+      return [];
+    };
+    mockStatSync = (filePath: string) => ({
+      mtimeMs: filePath.includes(foreignUuid) ? foreignMtime : ownMtime,
+    });
+
+    const resultPromise = KimiSessionHistoryParser.captureSessionIdFromFilesystem({
+      spawnedAt,
+      cwd: CWD,
+      maxAttempts: 2,
+    });
+    await vi.runAllTimersAsync();
+
+    const result = await resultPromise;
+    expect(result).toBe(ownUuid);
+    expect(result).not.toBe(foreignUuid);
+  });
+
+  it('returns null when only a different work_dir hash has a fresh session', async () => {
+    const spawnedAt = new Date(8_000_000_000_000);
+    const foreignUuid = 'f04e1011-0000-0000-0000-000000000003';
+
+    mockReaddirSync = (filePath: string) => {
+      if (filePath === SESSIONS_ROOT) return [FOREIGN_HASH];
+      if (filePath.includes(FOREIGN_HASH)) return [foreignUuid];
+      return [];
+    };
+    mockStatSync = () => ({ mtimeMs: spawnedAt.getTime() });
+
+    const resultPromise = KimiSessionHistoryParser.captureSessionIdFromFilesystem({
+      spawnedAt,
+      cwd: CWD,
+      maxAttempts: 2,
+    });
+    await vi.runAllTimersAsync();
+
+    const result = await resultPromise;
+    expect(result).toBeNull();
+  });
+
+  it('matches the non-local-kaos <kaos>_<hash> variant directory', async () => {
+    const spawnedAt = new Date(9_000_000_000_000);
+    const kaosUuid = 'aa05aa05-0000-0000-0000-000000000004';
+    const kaosHashDir = `kaos_${WORK_DIR_HASH}`;
+
+    mockReaddirSync = (filePath: string) => {
+      if (filePath === SESSIONS_ROOT) return [kaosHashDir];
+      if (filePath.includes(kaosHashDir)) return [kaosUuid];
+      return [];
+    };
+    mockStatSync = () => ({ mtimeMs: spawnedAt.getTime() });
+
+    const resultPromise = KimiSessionHistoryParser.captureSessionIdFromFilesystem({
+      spawnedAt,
+      cwd: CWD,
+      maxAttempts: 2,
+    });
+    await vi.runAllTimersAsync();
+
+    const result = await resultPromise;
+    expect(result).toBe(kaosUuid);
   });
 });

--- a/tests/unit/local-only-commits.test.ts
+++ b/tests/unit/local-only-commits.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Unit tests for countLocalOnlyCommits -- the merge/remote-aware count behind
+ * the Done-move probe. It reports only commits the move would actually destroy:
+ * commits that exist solely on this local branch and nowhere recoverable (not
+ * pushed, not merged into the base by content, not in a merged PR).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The helper builds a simple-git instance and drives everything through raw().
+const mockGit = {
+  raw: vi.fn<(args: string[]) => Promise<string>>(),
+};
+
+vi.mock('simple-git', () => ({
+  default: vi.fn(() => mockGit),
+}));
+
+// The squash signal calls the PR connector registry; mock it so no `gh` spawns.
+const mockResolvePRByNumber = vi.fn<(repoCwd: string, prNumber: number) => Promise<{ state: string } | null>>();
+vi.mock('../../src/main/pr/pr-registry', () => ({
+  resolvePRByNumber: (repoCwd: string, prNumber: number) => mockResolvePRByNumber(repoCwd, prNumber),
+}));
+
+import { countLocalOnlyCommits } from '../../src/main/git/local-only-commits';
+
+/**
+ * Wire git.raw responses by subcommand. `cherry` may be a string (returned for
+ * any upstream) or a map keyed by the upstream ref (for the ladder test); an
+ * Error value (or a missing key) makes that `git cherry` invocation throw.
+ */
+function setGit(options: {
+  revList: string;
+  base?: string | Error;
+  cherry?: string | Error | Record<string, string | Error>;
+}): void {
+  mockGit.raw.mockImplementation(async (args: string[]) => {
+    const subcommand = args[0];
+    if (subcommand === 'rev-list') return options.revList;
+    if (subcommand === 'config') {
+      if (options.base instanceof Error || options.base === undefined) throw new Error('key not set');
+      return options.base;
+    }
+    if (subcommand === 'cherry') {
+      const upstream = args[2];
+      let value: string | Error | undefined = options.cherry as string | Error | undefined;
+      if (options.cherry && typeof options.cherry === 'object' && !(options.cherry instanceof Error)) {
+        value = options.cherry[upstream];
+      }
+      if (value === undefined || value instanceof Error) throw new Error(`no upstream ${upstream}`);
+      return value;
+    }
+    throw new Error(`unexpected git args: ${args.join(' ')}`);
+  });
+}
+
+/** Build `git cherry -v` output lines: '-' = present upstream by patch-id, '+' = absent. */
+function cherryLines(entries: Array<{ sign: '+' | '-'; sha: string }>): string {
+  return entries.map((entry) => `${entry.sign} ${entry.sha} some subject`).join('\n');
+}
+
+describe('countLocalOnlyCommits', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolvePRByNumber.mockResolvedValue(null);
+  });
+
+  it('returns 0 for a rebase-merged branch (commits present upstream by patch-id)', async () => {
+    // The repro: the pre-rebase commits are unreachable from the remote by SHA,
+    // but their rebased copies live on origin/main, so `git cherry` marks them -.
+    setGit({
+      revList: 'sha1\nsha2\nsha3',
+      base: 'main',
+      cherry: cherryLines([
+        { sign: '-', sha: 'sha1' },
+        { sign: '-', sha: 'sha2' },
+        { sign: '-', sha: 'sha3' },
+      ]),
+    });
+
+    const count = await countLocalOnlyCommits('/mock/worktree');
+
+    expect(count).toBe(0);
+    expect(mockResolvePRByNumber).not.toHaveBeenCalled();
+  });
+
+  it('counts genuinely unmerged local commits (all absent upstream)', async () => {
+    setGit({
+      revList: 'sha1\nsha2',
+      base: 'main',
+      cherry: cherryLines([
+        { sign: '+', sha: 'sha1' },
+        { sign: '+', sha: 'sha2' },
+      ]),
+    });
+
+    expect(await countLocalOnlyCommits('/mock/worktree')).toBe(2);
+  });
+
+  it('counts only the commits absent upstream in a mixed branch', async () => {
+    setGit({
+      revList: 'sha1\nsha2\nsha3',
+      base: 'main',
+      cherry: cherryLines([
+        { sign: '-', sha: 'sha1' },
+        { sign: '+', sha: 'sha2' },
+        { sign: '+', sha: 'sha3' },
+      ]),
+    });
+
+    expect(await countLocalOnlyCommits('/mock/worktree')).toBe(2);
+  });
+
+  it('returns 0 and never runs git cherry when nothing is local-only', async () => {
+    setGit({ revList: '', base: 'main' });
+
+    expect(await countLocalOnlyCommits('/mock/worktree')).toBe(0);
+    const cherryCalls = mockGit.raw.mock.calls.filter((call) => call[0][0] === 'cherry');
+    expect(cherryCalls).toHaveLength(0);
+  });
+
+  it('falls back to the base ladder when origin/<base> is missing', async () => {
+    setGit({
+      revList: 'sha1',
+      base: 'main',
+      cherry: {
+        'origin/main': new Error('no such ref'),
+        main: cherryLines([{ sign: '-', sha: 'sha1' }]),
+      },
+    });
+
+    expect(await countLocalOnlyCommits('/mock/worktree')).toBe(0);
+  });
+
+  it('defaults the base to main when kangentic.baseBranch is unset', async () => {
+    setGit({
+      revList: 'sha1',
+      base: new Error('unset'),
+      cherry: {
+        'origin/main': cherryLines([{ sign: '-', sha: 'sha1' }]),
+      },
+    });
+
+    expect(await countLocalOnlyCommits('/mock/worktree')).toBe(0);
+  });
+
+  it('treats a squash-merge as clean when the stored PR state is merged (no gh call)', async () => {
+    // Squash collapses the commits into one whose patch-id matches none of them,
+    // so cherry still marks them +; the linked PR's merged state is the signal.
+    setGit({
+      revList: 'sha1\nsha2',
+      base: 'main',
+      cherry: cherryLines([
+        { sign: '+', sha: 'sha1' },
+        { sign: '+', sha: 'sha2' },
+      ]),
+    });
+
+    const count = await countLocalOnlyCommits('/mock/worktree', { prNumber: 42, prState: 'merged' });
+
+    expect(count).toBe(0);
+    expect(mockResolvePRByNumber).not.toHaveBeenCalled();
+  });
+
+  it('resolves a fresh PR state when the stored state is stale (merged just now)', async () => {
+    setGit({
+      revList: 'sha1\nsha2',
+      base: 'main',
+      cherry: cherryLines([
+        { sign: '+', sha: 'sha1' },
+        { sign: '+', sha: 'sha2' },
+      ]),
+    });
+    mockResolvePRByNumber.mockResolvedValue({ state: 'merged' });
+
+    const count = await countLocalOnlyCommits('/mock/worktree', { prNumber: 42, prState: 'open' });
+
+    expect(count).toBe(0);
+    expect(mockResolvePRByNumber).toHaveBeenCalledWith('/mock/worktree', 42);
+  });
+
+  it('keeps the count when the linked PR is open / not merged', async () => {
+    setGit({
+      revList: 'sha1\nsha2',
+      base: 'main',
+      cherry: cherryLines([
+        { sign: '+', sha: 'sha1' },
+        { sign: '+', sha: 'sha2' },
+      ]),
+    });
+    mockResolvePRByNumber.mockResolvedValue({ state: 'open' });
+
+    expect(await countLocalOnlyCommits('/mock/worktree', { prNumber: 42, prState: 'open' })).toBe(2);
+  });
+
+  it('falls back to the local-only count when git cherry fails entirely', async () => {
+    // No content filtering possible -> never hide work: count all local-only.
+    setGit({
+      revList: 'sha1\nsha2',
+      base: 'main',
+      cherry: new Error('cherry blew up'),
+    });
+
+    expect(await countLocalOnlyCommits('/mock/worktree')).toBe(2);
+  });
+
+  it('keeps the count when the fresh PR lookup throws (gh missing / offline)', async () => {
+    setGit({
+      revList: 'sha1',
+      base: 'main',
+      cherry: cherryLines([{ sign: '+', sha: 'sha1' }]),
+    });
+    mockResolvePRByNumber.mockRejectedValue(new Error('gh not found'));
+
+    expect(await countLocalOnlyCommits('/mock/worktree', { prNumber: 9, prState: 'open' })).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the move-to-Done false-positive "N commits remain on the local branch" warning (task #266).
The probe counted at-risk commits by SHA reachability (`git rev-list HEAD --not --remotes`), so any
SHA-rewriting merge (rebase-merge is the documented repro; squash-merge is the same class) made
already-merged commits look local-only and fired a "loss of data" warning for work the move cannot
lose. The dialog also claimed "branch will be unaffected" while, under the default `autoCleanup`, it
was force-deleting the branch.

The warning is now **impact-gated**: it fires only when the move will actually destroy the user's
changes, across any git workflow.

## Impact / behavior

What the Done move can destroy, and when it now warns:

- **Uncommitted working-tree files** are lost with the worktree directory -> always warn (red).
- **Committed commits** live in the object store and survive on the branch ref. They are at risk
  only when `autoCleanup` force-deletes the branch (`git branch -D`, default on) AND the commits
  exist nowhere recoverable. A new `countLocalOnlyCommits` helper excludes commits that are:
  - pushed (`git rev-list HEAD --not --remotes`),
  - merged into the base by content (`git cherry` / patch-id - rebase, merge-commit, cherry-pick),
  - in a merged PR (stored `pr_state`, else a bounded fresh `gh` lookup - covers squash, which
    patch-id cannot detect).
  With `autoCleanup` off the branch is kept, so only-local commits are recoverable and never warn.
- The dialog now states the branch's real fate (kept vs deleted) and labels at-risk commits as
  genuine loss ("will be lost when the branch is deleted"), replacing the old, often-false copy.

Net result: a rebase- or squash-merged branch moves to Done with no warning; genuinely-only-local
unmerged commits (when the branch is deleted) and uncommitted files still warn. Every failure path
falls back to the conservative count, so the change only removes false positives and never hides
at-risk work.

Sole documented residual: a squash-merge with no linked PR on an advanced base cannot be proven
merged by git alone, so it may still warn (safe, non-destructive).

## Test plan

CI checks (lint, typecheck, unit, build, UI shards, Linux Electron E2E shards), plus:

- New `tests/unit/local-only-commits.test.ts` (11 cases): rebase-merge -> 0, genuinely-unmerged,
  mixed, clean fast-path, base ladder, base default, squash via stored state, squash via fresh PR,
  open PR, and the `git cherry` / `gh` failure fallbacks.
- Reworked `tests/unit/git-pending-changes.test.ts`: the `autoCleanup` gate (on/off/omitted),
  uncommitted-always-warns, `prNumber`/`prState` passthrough, fetch-before-count ordering,
  count-failure -> 0, and the safe-default catch branches.
- Updated `tests/ui/move-to-done-confirm.spec.ts`: new loss copy, a `done-confirm-branch-fate`
  testid asserting "will be deleted" vs "will be kept", an `autoCleanup: false` branch-kept case,
  null-branch wording, and danger styling.

Generated with [Claude Code](https://claude.com/claude-code)
