### PR TITLE
fix(window-manager): persist task-detail window layout across restart

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,12 +197,13 @@ All channels defined in `src/shared/ipc-channels.ts`. The preload bridge in `src
 | `session:injectSettings` | invoke | Inject a model/effort change into a live transient session's PTY via slash commands. Session-keyed (no task row, no DB persistence); backs the command-terminal context bar picker. |
 | `session:getPeriodStats` | invoke | Fetch aggregated usage stats (tokens, cost) for a given time period. Sources from the append-only `usage_history` table so totals survive task deletion, bulk-archive, and revert-to-backlog. |
 
-### Config (8 channels)
+### Config (9 channels)
 | Channel | Pattern | Purpose |
 |---------|---------|---------|
 | `config:get` | invoke | Fetch effective AppConfig (global merged with project overrides) |
 | `config:getGlobal` | invoke | Fetch global-only AppConfig (no project overrides) |
 | `config:set` | invoke | Update global config (partial merge) |
+| `config:setSync` | sendSync | Update global config synchronously (blocks the renderer until the fs write completes); used on window close to persist the workspace layout before the renderer tears down |
 | `config:getProject` | invoke | Fetch project-level config overrides |
 | `config:setProject` | invoke | Update project-level overrides |
 | `config:getProjectByPath` | invoke | Fetch project overrides by filesystem path |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,7 +70,7 @@ These settings appear in both App Settings (as defaults) and Project Settings (a
 | `hasCompletedFirstRun` | boolean | `false` | Whether the user has completed first-run onboarding. Auto-set, not shown in UI. |
 | `windowBounds` | object \| null | `null` | Persisted window bounds `{x, y, width, height}`. Auto-saved, not shown in UI. |
 | `windowMaximized` | boolean | `false` | Whether the window was maximized at last close. Auto-saved, not shown in UI. |
-| `workspace` | object \| undefined | `undefined` | In-app window-manager layout: the open task-detail windows, their tiling tree, and fractional geometry. Persisted per-project (survives a project switch and an app restart), restored after sessions resolve, and taskId-anchored so a session respawn never orphans a window. Auto-saved, not shown in UI. |
+| `workspaceByProject` | Record\<string, object\> | `{}` | In-app window-manager layout keyed by project ID: each entry holds the open task-detail windows, their tiling tree, and fractional geometry. Persisted per-project (survives a project switch and an app restart), restored after sessions resolve, and taskId-anchored so a session respawn never orphans a window. Each entry carries a schema `version` and is clamped/validated on restore. Auto-saved, not shown in UI. |
 | `skipBoardConfigConfirm` | boolean | `false` | Auto-apply board config changes without confirmation dialog |
 | `statusBarPeriod` | UsageTimePeriod | `'live'` | Time period for status bar usage stats. Values: `live`, `today`, `week`, `month`, `all`. Global-only. |
 | `lastActiveTaskByProject` | Record\<string, string\> | `{}` | Per-project memory of the last user-clicked task tab in the terminal panel, keyed by project ID. Restored on project switch. Auto-saved, not shown in UI. |
@@ -347,6 +347,7 @@ Config files written by hand (without `id` fields on columns) are treated as add
 | `config:get` | Get effective config (global + project merged) |
 | `config:getGlobal` | Get global config only (no project overrides) |
 | `config:set` | Update global config (partial merge) |
+| `config:setSync` | Update global config synchronously (used on window close to persist the workspace layout) |
 | `config:getProject` | Get project-level overrides for current project |
 | `config:setProject` | Update project-level overrides for current project |
 | `config:getProjectByPath` | Get project-level overrides by project path |

--- a/src/main/config/config-manager.ts
+++ b/src/main/config/config-manager.ts
@@ -9,7 +9,7 @@ import { deepMerge, deepMergeConfig } from '../../shared/object-utils';
  *  These must be REPLACED on partial update so that key deletion works, while
  *  every other typed-struct field gets MERGE semantics. Update this list when
  *  adding a new dictionary-shaped field to AppConfig. */
-const CONFIG_DICTIONARY_PATHS = ['backlog.labelColors', 'agent.cliPaths', 'hotkeyOverrides'] as const;
+const CONFIG_DICTIONARY_PATHS = ['backlog.labelColors', 'agent.cliPaths', 'hotkeyOverrides', 'workspaceByProject'] as const;
 
 /** Drop keys whose value is undefined. Returns undefined when nothing is left,
  *  so callers can skip writing empty nested objects. */

--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -64,6 +64,16 @@ export function registerSystemHandlers(context: IpcContext): void {
     }
   });
 
+  // Synchronous sibling of CONFIG_SET for the renderer's quit/unload flush: an async
+  // invoke() can be dropped if the renderer tears down before the main process drains it,
+  // so the final window-layout write goes through sendSync, which blocks the renderer until
+  // configManager.save() (a synchronous fs write) has persisted it. Intentionally minimal:
+  // no runtime re-apply or detection invalidation, both irrelevant during shutdown.
+  ipcMain.on(IPC.CONFIG_SET_SYNC, (event, config) => {
+    context.configManager.save(config);
+    event.returnValue = true;
+  });
+
   ipcMain.handle(IPC.CONFIG_GET_PROJECT, () => {
     if (!context.currentProjectPath) return null;
     return context.configManager.loadProjectOverrides(context.currentProjectPath);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -220,6 +220,7 @@ const api: ElectronAPI = {
     get: () => ipcRenderer.invoke(IPC.CONFIG_GET),
     getGlobal: () => ipcRenderer.invoke(IPC.CONFIG_GET_GLOBAL),
     set: (config) => ipcRenderer.invoke(IPC.CONFIG_SET, config),
+    setSync: (config) => { ipcRenderer.sendSync(IPC.CONFIG_SET_SYNC, config); },
     getProjectOverrides: () => ipcRenderer.invoke(IPC.CONFIG_GET_PROJECT),
     setProjectOverrides: (overrides) => ipcRenderer.invoke(IPC.CONFIG_SET_PROJECT, overrides),
     getProjectOverridesByPath: (projectPath) => ipcRenderer.invoke(IPC.CONFIG_GET_PROJECT_BY_PATH, projectPath),

--- a/src/renderer/hooks/useProjectSwitchEffect.ts
+++ b/src/renderer/hooks/useProjectSwitchEffect.ts
@@ -160,7 +160,7 @@ export function useProjectSwitchEffect(currentProject: Project | null): void {
         // Restore the persisted window layout. Warm switches keep sessions live,
         // so this resolves synchronously; a cheap setState lets the restored
         // windows appear with the board (no flash) without blocking the swap.
-        restoreWorkspaceForProject();
+        restoreWorkspaceForProject(currentProject.id);
       } else {
         // Cold path: fire the IPC fan-out and reset stale per-project
         // view state. After loads resolve, mark the project as seen so
@@ -236,7 +236,7 @@ export function useProjectSwitchEffect(currentProject: Project | null): void {
           // superseded this one mid-load.
           void coldLoads.then(() => {
             if (previousProjectIdRef.current !== currentProject.id) return;
-            restoreWorkspaceForProject();
+            restoreWorkspaceForProject(currentProject.id);
           });
         });
       }

--- a/src/renderer/hooks/useProjectSwitchEffect.ts
+++ b/src/renderer/hooks/useProjectSwitchEffect.ts
@@ -32,6 +32,7 @@ import {
   getProjectSnapshot,
 } from '../stores/project-cache';
 import { restoreWorkspaceForProject } from '../window-manager/persistence/restore-workspace';
+import { useWindowStore } from '../window-manager/store/window-store';
 
 export function useProjectSwitchEffect(currentProject: Project | null): void {
   // Tracks the project we last rendered so we can snapshot its store
@@ -62,6 +63,19 @@ export function useProjectSwitchEffect(currentProject: Project | null): void {
     // stores. Skip self-switches (same id) and the initial cold mount
     // (no previous project to snapshot).
     if (previousProjectId && previousProjectId !== (currentProject?.id ?? null)) {
+      // Persist the OUTGOING project's window layout FIRST, before snapshotting its
+      // config and before the incoming restore mutates the window store. The
+      // per-window debounced save (useWorkspacePersistence) may not have fired yet -
+      // e.g. a window closed in the last 500ms - so without this, switching away and
+      // back would restore a stale, pre-close layout. Reading the live window store
+      // here, keyed by the explicit outgoing id, keeps the two consistent (never a
+      // cross-project write); doing it before the snapshot means the warm-switch
+      // restore (which sets config from the snapshot) carries the corrected layout.
+      useConfigStore.getState().saveWorkspaceForProject(
+        previousProjectId,
+        useWindowStore.getState().serializeWorkspace(),
+      );
+
       const boardState = useBoardStore.getState();
       const backlogState = useBacklogStore.getState();
       const configState = useConfigStore.getState();

--- a/src/renderer/stores/config-store.ts
+++ b/src/renderer/stores/config-store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { AppConfig, DeepPartial, AgentDetectionInfo } from '../../shared/types';
+import type { AppConfig, DeepPartial, AgentDetectionInfo, SerializedWorkspace } from '../../shared/types';
 import { DEFAULT_CONFIG } from '../../shared/types';
 import { deepMergeConfig } from '../../shared/object-utils';
 import { invalidateAllProjects } from './project-cache';
@@ -30,6 +30,19 @@ interface ConfigStore {
   loading: boolean;
   loadConfig: () => Promise<void>;
   updateConfig: (partial: DeepPartial<AppConfig>) => Promise<void>;
+  /** Persist the in-app window layout for a project into global config, keyed by
+   *  project id and merged in via `config.set` (so it never clobbers other config).
+   *  Decoupled from the Settings panel: the window-manager calls this during normal
+   *  board use. Mirrors `selectActiveSession`'s `lastActiveTaskByProject` write. */
+  saveWorkspaceForProject: (projectId: string, workspace: SerializedWorkspace) => void;
+  /** Synchronous sibling of saveWorkspaceForProject for the quit/unload flush: persists via
+   *  the blocking `config.setSync` so the final layout reaches disk before the renderer tears
+   *  down (an async set() can be dropped mid-teardown). */
+  flushWorkspaceForProject: (projectId: string, workspace: SerializedWorkspace) => void;
+  /** Internal: whether workspaceByProject has been seeded from disk yet. After the first
+   *  config fetch the renderer owns the layout map, so later fetches preserve it instead of
+   *  letting a stale disk read clobber an in-flight save. Resets with the store on HMR. */
+  workspaceSeeded: boolean;
 
   // -- App version --
   appVersion: string | null;
@@ -83,159 +96,210 @@ async function refreshConfigs(): Promise<{ config: AppConfig; globalConfig: AppC
   return { config, globalConfig };
 }
 
-export const useConfigStore = create<ConfigStore>((set, get) => ({
-  config: DEFAULT_CONFIG,
-  globalConfig: DEFAULT_CONFIG,
-  appVersion: null,
-  agentList: [],
-  agentInfo: null,
-  agentVersionNumber: null,
-  gitInfo: null,
-  loading: true,
-  settingsOpen: false,
-  lastSettingsTab: lastSettingsTabHmr,
-  projectSettingsPath: null,
-  projectSettingsProjectName: null,
-  projectSettingsInitialTab: null,
-  projectOverrides: null,
-  loadConfig: async () => {
-    set({ loading: true });
-    const configs = await refreshConfigs();
-    set({ ...configs, loading: false });
-  },
-
-  updateConfig: async (partial) => {
-    await window.electronAPI.config.set(partial);
-    const configs = await refreshConfigs();
-    set(configs);
-    // Global settings can change every project's effective config, so
-    // any cached warm-switch snapshot is now stale. The active project's
-    // live config was just updated above; cached non-current projects
-    // need to be invalidated so a future switch refetches.
-    invalidateAllProjects();
-    // Re-detect agents when CLI path settings change so the UI
-    // updates immediately instead of requiring an app restart.
-    if (partial.agent) {
-      get().detectAgent();
+export const useConfigStore = create<ConfigStore>((set, get) => {
+  /** Overlay freshly-fetched configs, preserving the renderer-authoritative workspaceByProject
+   *  after the first (seeding) fetch so a stale disk read can never revert the live layout. The
+   *  renderer is the SOLE writer of workspaceByProject (saveWorkspaceForProject updates it
+   *  optimistically + persists async, the quit flush persists it synchronously), so once seeded
+   *  from disk its in-memory map is always at least as fresh as disk for every project. The
+   *  `workspaceSeeded` flag lives in store state so it resets with the store on HMR, where the
+   *  post-HMR loadConfig (Pattern B) re-seeds from disk. */
+  const withSeededWorkspace = (
+    fetched: { config: AppConfig; globalConfig: AppConfig },
+  ): { config: AppConfig; globalConfig: AppConfig; workspaceSeeded?: boolean } => {
+    if (!get().workspaceSeeded) {
+      return { ...fetched, workspaceSeeded: true };
     }
-  },
+    const workspaceByProject = get().globalConfig.workspaceByProject ?? {};
+    return {
+      config: { ...fetched.config, workspaceByProject },
+      globalConfig: { ...fetched.globalConfig, workspaceByProject },
+    };
+  };
 
-  loadAppVersion: async () => {
-    const appVersion = await window.electronAPI.app.getVersion();
-    set({ appVersion });
-  },
+  /** Apply an optimistic workspace update to both effective + global config and return the
+   *  merged map, so the IPC write persists exactly what the store now shows. */
+  const applyWorkspaceOptimistic = (
+    projectId: string,
+    workspace: SerializedWorkspace,
+  ): Record<string, SerializedWorkspace> => {
+    const existing = get().globalConfig.workspaceByProject ?? {};
+    const updated = { ...existing, [projectId]: workspace };
+    set((state) => ({
+      config: { ...state.config, workspaceByProject: updated },
+      globalConfig: { ...state.globalConfig, workspaceByProject: updated },
+    }));
+    return updated;
+  };
 
-  detectAgent: async () => {
-    const agentInfo = await window.electronAPI.agent.detect();
-    const version = parseAgentVersion(agentInfo?.version ?? null);
-    set({
-      agentInfo,
-      agentVersionNumber: version,
-    });
-  },
+  return {
+    config: DEFAULT_CONFIG,
+    globalConfig: DEFAULT_CONFIG,
+    appVersion: null,
+    agentList: [],
+    agentInfo: null,
+    agentVersionNumber: null,
+    gitInfo: null,
+    loading: true,
+    workspaceSeeded: false,
+    settingsOpen: false,
+    lastSettingsTab: lastSettingsTabHmr,
+    projectSettingsPath: null,
+    projectSettingsProjectName: null,
+    projectSettingsInitialTab: null,
+    projectOverrides: null,
+    loadConfig: async () => {
+      set({ loading: true });
+      const configs = await refreshConfigs();
+      set({ ...withSeededWorkspace(configs), loading: false });
+    },
 
-  detectGit: async () => {
-    const gitInfo = await window.electronAPI.git.detect();
-    set({ gitInfo });
-  },
-
-  loadAgentList: async (forceRefresh?: boolean) => {
-    const agentList = await window.electronAPI.agents.list(forceRefresh);
-    set({ agentList });
-
-    // Seed the discovered-models cache from `capabilities.models` so every
-    // launch starts with at least the JSONL-walk result merged in. Only writes
-    // when there's actually new material - avoids a config round-trip on every
-    // detection refresh.
-    const current = get().config.discoveredModelsByAgent ?? {};
-    const updates: Record<string, string[]> = {};
-    for (const info of agentList) {
-      const fresh = info.capabilities?.models;
-      if (!fresh || fresh.length === 0) continue;
-      const existing = current[info.name] ?? [];
-      const union = new Set<string>([...existing, ...fresh]);
-      if (union.size > existing.length) {
-        updates[info.name] = Array.from(union).sort((a, b) => a.localeCompare(b));
+    updateConfig: async (partial) => {
+      await window.electronAPI.config.set(partial);
+      const configs = await refreshConfigs();
+      set(withSeededWorkspace(configs));
+      // Global settings can change every project's effective config, so
+      // any cached warm-switch snapshot is now stale. The active project's
+      // live config was just updated above; cached non-current projects
+      // need to be invalidated so a future switch refetches.
+      invalidateAllProjects();
+      // Re-detect agents when CLI path settings change so the UI
+      // updates immediately instead of requiring an app restart.
+      if (partial.agent) {
+        get().detectAgent();
       }
-    }
-    if (Object.keys(updates).length > 0) {
-      get().updateConfig({
-        discoveredModelsByAgent: { ...current, ...updates },
-      });
-    }
-  },
+    },
 
-  rememberDiscoveredModel: (agent, model) => {
-    if (!agent || !model) return;
-    const current = get().config.discoveredModelsByAgent ?? {};
-    const existing = current[agent] ?? [];
-    if (existing.includes(model)) return;
-    const next = [...existing, model].sort((a, b) => a.localeCompare(b));
-    // Fire-and-forget: this is a cache write, not a user-driven setting. If the
-    // persist fails the in-memory effective config will still pick up the new
-    // value via deepMergeConfig on the next refresh.
-    get().updateConfig({
-      discoveredModelsByAgent: { ...current, [agent]: next },
-    }).catch(() => undefined);
-  },
+    saveWorkspaceForProject: (projectId, workspace) => {
+      // Optimistically update the local config (both effective + global) so back-to-back
+      // saves and a follow-on project-switch restore read the value just written rather
+      // than a pre-IPC stale snapshot, then persist async.
+      window.electronAPI.config.set({ workspaceByProject: applyWorkspaceOptimistic(projectId, workspace) });
+    },
 
-  setSettingsOpen: (open) => {
-    if (open) {
-      set({ settingsOpen: true });
-    } else {
+    flushWorkspaceForProject: (projectId, workspace) => {
+      // Quit/unload path: same optimistic update as the async save, but persisted
+      // synchronously so the final layout reaches disk before the renderer tears down.
+      window.electronAPI.config.setSync({ workspaceByProject: applyWorkspaceOptimistic(projectId, workspace) });
+    },
+
+    loadAppVersion: async () => {
+      const appVersion = await window.electronAPI.app.getVersion();
+      set({ appVersion });
+    },
+
+    detectAgent: async () => {
+      const agentInfo = await window.electronAPI.agent.detect();
+      const version = parseAgentVersion(agentInfo?.version ?? null);
       set({
-        settingsOpen: false,
-        projectSettingsPath: null,
-        projectSettingsProjectName: null,
-        projectSettingsInitialTab: null,
-        projectOverrides: null,
+        agentInfo,
+        agentVersionNumber: version,
       });
-      refreshConfigs().then((configs) => set(configs));
-    }
-  },
+    },
 
-  setLastSettingsTab: (tabId) => {
-    lastSettingsTabHmr = tabId;
-    set({ lastSettingsTab: tabId });
-  },
+    detectGit: async () => {
+      const gitInfo = await window.electronAPI.git.detect();
+      set({ gitInfo });
+    },
 
-  // -- Project settings --
-  openProjectSettings: (projectPath, projectName, initialTab) => {
-    const currentPath = get().projectSettingsPath;
-    set({
-      settingsOpen: true,
-      projectSettingsPath: projectPath,
-      projectSettingsProjectName: projectName,
-      projectSettingsInitialTab: initialTab || null,
-      ...(currentPath !== projectPath ? { projectOverrides: null } : {}),
-    });
-    window.electronAPI.config.getProjectOverridesByPath(projectPath).then((overrides) => {
+    loadAgentList: async (forceRefresh?: boolean) => {
+      const agentList = await window.electronAPI.agents.list(forceRefresh);
+      set({ agentList });
+
+      // Seed the discovered-models cache from `capabilities.models` so every
+      // launch starts with at least the JSONL-walk result merged in. Only writes
+      // when there's actually new material - avoids a config round-trip on every
+      // detection refresh.
+      const current = get().config.discoveredModelsByAgent ?? {};
+      const updates: Record<string, string[]> = {};
+      for (const info of agentList) {
+        const fresh = info.capabilities?.models;
+        if (!fresh || fresh.length === 0) continue;
+        const existing = current[info.name] ?? [];
+        const union = new Set<string>([...existing, ...fresh]);
+        if (union.size > existing.length) {
+          updates[info.name] = Array.from(union).sort((a, b) => a.localeCompare(b));
+        }
+      }
+      if (Object.keys(updates).length > 0) {
+        get().updateConfig({
+          discoveredModelsByAgent: { ...current, ...updates },
+        });
+      }
+    },
+
+    rememberDiscoveredModel: (agent, model) => {
+      if (!agent || !model) return;
+      const current = get().config.discoveredModelsByAgent ?? {};
+      const existing = current[agent] ?? [];
+      if (existing.includes(model)) return;
+      const next = [...existing, model].sort((a, b) => a.localeCompare(b));
+      // Fire-and-forget: this is a cache write, not a user-driven setting. If the
+      // persist fails the in-memory effective config will still pick up the new
+      // value via deepMergeConfig on the next refresh.
+      get().updateConfig({
+        discoveredModelsByAgent: { ...current, [agent]: next },
+      }).catch(() => undefined);
+    },
+
+    setSettingsOpen: (open) => {
+      if (open) {
+        set({ settingsOpen: true });
+      } else {
+        set({
+          settingsOpen: false,
+          projectSettingsPath: null,
+          projectSettingsProjectName: null,
+          projectSettingsInitialTab: null,
+          projectOverrides: null,
+        });
+        refreshConfigs().then((configs) => set(withSeededWorkspace(configs)));
+      }
+    },
+
+    setLastSettingsTab: (tabId) => {
+      lastSettingsTabHmr = tabId;
+      set({ lastSettingsTab: tabId });
+    },
+
+    // -- Project settings --
+    openProjectSettings: (projectPath, projectName, initialTab) => {
+      const currentPath = get().projectSettingsPath;
+      set({
+        settingsOpen: true,
+        projectSettingsPath: projectPath,
+        projectSettingsProjectName: projectName,
+        projectSettingsInitialTab: initialTab || null,
+        ...(currentPath !== projectPath ? { projectOverrides: null } : {}),
+      });
+      window.electronAPI.config.getProjectOverridesByPath(projectPath).then((overrides) => {
+        if (get().projectSettingsPath === projectPath) {
+          set({ projectOverrides: overrides });
+        }
+      });
+    },
+
+    loadProjectOverrides: async () => {
+      const projectPath = get().projectSettingsPath;
+      if (!projectPath) return;
+      const overrides = await window.electronAPI.config.getProjectOverridesByPath(projectPath);
       if (get().projectSettingsPath === projectPath) {
         set({ projectOverrides: overrides });
       }
-    });
-  },
+    },
 
-  loadProjectOverrides: async () => {
-    const projectPath = get().projectSettingsPath;
-    if (!projectPath) return;
-    const overrides = await window.electronAPI.config.getProjectOverridesByPath(projectPath);
-    if (get().projectSettingsPath === projectPath) {
-      set({ projectOverrides: overrides });
-    }
-  },
+    updateProjectOverride: async (partial) => {
+      const projectPath = get().projectSettingsPath;
+      if (!projectPath) return;
+      const current = get().projectOverrides || {};
+      const merged = deepMergeConfig(current, partial) as DeepPartial<AppConfig>;
+      await window.electronAPI.config.setProjectOverridesByPath(projectPath, merged);
+      const effective = deepMergeConfig(get().globalConfig, merged);
+      set({ projectOverrides: merged, config: effective });
+    },
 
-  updateProjectOverride: async (partial) => {
-    const projectPath = get().projectSettingsPath;
-    if (!projectPath) return;
-    const current = get().projectOverrides || {};
-    const merged = deepMergeConfig(current, partial) as DeepPartial<AppConfig>;
-    await window.electronAPI.config.setProjectOverridesByPath(projectPath, merged);
-    const effective = deepMergeConfig(get().globalConfig, merged);
-    set({ projectOverrides: merged, config: effective });
-  },
-
-}));
+  };
+});
 
 // Sync resolved theme -> localStorage + <html> class whenever it changes.
 // Runs outside React render so the DOM is always in sync, including for

--- a/src/renderer/window-manager/bridge/useWorkspacePersistence.ts
+++ b/src/renderer/window-manager/bridge/useWorkspacePersistence.ts
@@ -1,37 +1,44 @@
 /**
  * Debounced save of the in-app window layout to the open project's config
- * (`AppConfig.workspace`). Subscribes to the window-store and, ~500ms after the
- * layout settles, serializes it and writes it through the project-override config
- * path. The debounce coalesces rapid changes (drag, focus, tile) into one write
- * and rides out a project-switch transition, so only the settled layout is saved.
+ * (`AppConfig.workspaceByProject`). Subscribes to the window-store and, ~500ms after
+ * the layout settles, serializes it and writes it (keyed by the active project id)
+ * through the global-config `config.set` path. The debounce coalesces rapid changes
+ * (drag, focus, tile) into one write; a `beforeunload` flush persists the current layout
+ * synchronously so the last arrangement made just before quitting is saved even if a
+ * debounced async write is still in flight.
  *
- * Mounted once by WindowLayer; no-ops when no project is open. Restore is the
- * inverse, wired into the project-switch effect (after sessions resolve).
+ * Gated on the ACTIVE project, not the Settings panel, so it persists during normal
+ * board use. Mounted once by WindowLayer; no-ops when no project is open. Restore is
+ * the inverse, wired into the project-switch effect (after sessions resolve). The
+ * debounce/gate/flush state machine itself lives in the pure `workspace-saver` module.
  */
 
 import { useEffect } from 'react';
 import { useWindowStore } from '../store/window-store';
 import { useConfigStore } from '../../stores/config-store';
-
-const WORKSPACE_SAVE_DEBOUNCE_MS = 500;
+import { useProjectStore } from '../../stores/project-store';
+import { createWorkspaceSaver } from '../persistence/workspace-saver';
 
 export function useWorkspacePersistence(): void {
-  const projectSettingsPath = useConfigStore((state) => state.projectSettingsPath);
-  const updateProjectOverride = useConfigStore((state) => state.updateProjectOverride);
+  const saveWorkspaceForProject = useConfigStore((state) => state.saveWorkspaceForProject);
+  const flushWorkspaceForProject = useConfigStore((state) => state.flushWorkspaceForProject);
 
   useEffect(() => {
-    if (!projectSettingsPath) return; // no project open: nothing to persist to
-    let saveTimer: ReturnType<typeof setTimeout> | null = null;
-    const unsubscribe = useWindowStore.subscribe(() => {
-      if (saveTimer) clearTimeout(saveTimer);
-      saveTimer = setTimeout(() => {
-        saveTimer = null;
-        updateProjectOverride({ workspace: useWindowStore.getState().serializeWorkspace() });
-      }, WORKSPACE_SAVE_DEBOUNCE_MS);
+    const saver = createWorkspaceSaver({
+      getProjectId: () => useProjectStore.getState().currentProject?.id ?? null,
+      getWorkspace: () => useWindowStore.getState().serializeWorkspace(),
+      save: saveWorkspaceForProject,
+      saveSync: flushWorkspaceForProject,
     });
+    const unsubscribe = useWindowStore.subscribe(saver.onChange);
+    // Persist synchronously before the renderer tears down, so the very last arrangement
+    // made before quitting reaches disk even if a debounced async save is still in flight.
+    const flushBeforeUnload = (): void => saver.flush();
+    window.addEventListener('beforeunload', flushBeforeUnload);
     return () => {
-      if (saveTimer) clearTimeout(saveTimer);
+      window.removeEventListener('beforeunload', flushBeforeUnload);
       unsubscribe();
+      saver.dispose();
     };
-  }, [projectSettingsPath, updateProjectOverride]);
+  }, [saveWorkspaceForProject, flushWorkspaceForProject]);
 }

--- a/src/renderer/window-manager/persistence/restore-workspace.ts
+++ b/src/renderer/window-manager/persistence/restore-workspace.ts
@@ -1,8 +1,9 @@
 /**
- * Restore the persisted window layout for the just-loaded project. Reads
- * `AppConfig.workspace` and rebuilds the windows via the window-store, re-resolving
- * each window's live session from its durable taskId and dropping windows whose
- * task is no longer on the board. A no-op when no layout was persisted.
+ * Restore the persisted window layout for the just-loaded project. Reads this
+ * project's entry from `AppConfig.workspaceByProject` and rebuilds the windows via the
+ * window-store, re-resolving each window's live session from its durable taskId and
+ * dropping windows whose task is no longer on the board. A no-op when no layout was
+ * persisted for the project.
  *
  * Called from useProjectSwitchEffect (warm + cold paths) AFTER the incoming
  * project's board, config, and sessions have resolved, so session re-binding and
@@ -21,8 +22,8 @@ import { useBoardStore } from '../../stores/board-store';
 import { useSessionStore } from '../../stores/session-store';
 import { useWindowStore } from '../store/window-store';
 
-export function restoreWorkspaceForProject(): void {
-  const workspace = useConfigStore.getState().config.workspace;
+export function restoreWorkspaceForProject(projectId: string): void {
+  const workspace = useConfigStore.getState().config.workspaceByProject?.[projectId];
   if (!workspace) return;
   useWindowStore.getState().applyWorkspace(
     workspace,

--- a/src/renderer/window-manager/persistence/workspace-saver.ts
+++ b/src/renderer/window-manager/persistence/workspace-saver.ts
@@ -1,0 +1,70 @@
+/**
+ * The debounce + gate + serialize + save core for workspace persistence, factored
+ * out of the React hook (`useWorkspacePersistence`) as a pure module so the exact
+ * persistence logic is unit-testable in a tier with no jsdom (the repo pattern for
+ * Zustand + DOM hooks) without dragging React or the stores into the test.
+ *
+ * The project id and the layout are read TOGETHER at persist time, so a save can
+ * never write one project's windows under another's id even if a project switch lands
+ * between the change and the debounce firing.
+ */
+
+import type { SerializedWorkspace } from '../../../shared/types';
+
+/** Default settle delay before a layout change is written. The debounce coalesces a
+ *  drag / resize / tile gesture's rapid updates into a single save. */
+export const WORKSPACE_SAVE_DEBOUNCE_MS = 500;
+
+export interface WorkspaceSaver {
+  /** Schedule a debounced save of the current layout. */
+  onChange: () => void;
+  /** Persist the current layout immediately and SYNCHRONOUSLY (via saveSync), cancelling any
+   *  pending debounce. Always writes, even with nothing pending, so a debounced async save
+   *  still in flight can never be the last word before the renderer tears down on quit.
+   *  No-op only when no project is open. */
+  flush: () => void;
+  /** Cancel any pending save and release the debounce timer. */
+  dispose: () => void;
+}
+
+export function createWorkspaceSaver(deps: {
+  getProjectId: () => string | null;
+  getWorkspace: () => SerializedWorkspace;
+  save: (projectId: string, workspace: SerializedWorkspace) => void;
+  /** Synchronous persist used by flush() (e.g. on app quit) so the final layout is written
+   *  before the renderer tears down. Defaults to `save` when omitted. */
+  saveSync?: (projectId: string, workspace: SerializedWorkspace) => void;
+  debounceMs?: number;
+}): WorkspaceSaver {
+  const { getProjectId, getWorkspace, save } = deps;
+  const saveSync = deps.saveSync ?? save;
+  const debounceMs = deps.debounceMs ?? WORKSPACE_SAVE_DEBOUNCE_MS;
+  let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const persist = (saveFn: (projectId: string, workspace: SerializedWorkspace) => void): void => {
+    const projectId = getProjectId();
+    if (!projectId) return; // no project open: nothing to persist to
+    saveFn(projectId, getWorkspace());
+  };
+
+  return {
+    onChange: () => {
+      if (saveTimer !== null) clearTimeout(saveTimer);
+      saveTimer = setTimeout(() => {
+        saveTimer = null;
+        persist(save);
+      }, debounceMs);
+    },
+    flush: () => {
+      if (saveTimer !== null) {
+        clearTimeout(saveTimer);
+        saveTimer = null;
+      }
+      persist(saveSync);
+    },
+    dispose: () => {
+      if (saveTimer !== null) clearTimeout(saveTimer);
+      saveTimer = null;
+    },
+  };
+}

--- a/src/renderer/window-manager/persistence/workspace.ts
+++ b/src/renderer/window-manager/persistence/workspace.ts
@@ -1,5 +1,5 @@
 /**
- * Serialize / restore the in-app window-manager layout to `AppConfig.workspace`.
+ * Serialize / restore the in-app window-manager layout to `AppConfig.workspaceByProject`.
  *
  * Persisted form is taskId-anchored (a session respawn changes the sessionId but
  * not the task, so the durable anchor is the task) and uses fractional geometry
@@ -7,12 +7,51 @@
  * sessionId from the taskId, regenerates window + tile-node ids, and drops anything
  * whose task no longer exists.
  *
+ * Restore is deliberately TOTAL: the layout is read back from an on-disk config the
+ * app must never trust blindly. A stamped schema `version` gates the whole blob, and
+ * each window's geometry is clamped into the overlay (with a minimum visible size) so
+ * a corrupt or off-overlay entry can never restore an invisible / off-screen window;
+ * a window with malformed geometry or an unknown state is dropped, never thrown on.
+ *
  * Pure module: the store actions supply the id generators + the taskId->session /
  * taskId-exists resolvers (which need live board + session state).
  */
 
-import type { ManagedWindow, TileNode, FractionalRect } from '../store/types';
+import type { ManagedWindow, TileNode, FractionalRect, WindowState } from '../store/types';
 import type { SerializedWorkspace, SerializedTileNode } from '../../../shared/types';
+
+/** Bump when the persisted shape changes; an older / unknown version is ignored on
+ *  restore rather than mis-applied. */
+export const WORKSPACE_SCHEMA_VERSION = 1;
+
+/** Minimum window width/height as a fraction of the overlay, so a clamped or corrupt
+ *  rect always restores to something the user can see and grab. */
+const MIN_WINDOW_FRACTION = 0.05;
+
+const VALID_WINDOW_STATES: ReadonlySet<WindowState> = new Set<WindowState>([
+  'floating',
+  'tiled',
+  'snapped',
+  'maximized',
+]);
+
+const FULL_RECT: FractionalRect = { x: 0, y: 0, w: 1, h: 1 };
+
+/** Clamp a persisted rect into the overlay and enforce a minimum visible size.
+ *  Returns null when the value is not a usable `{x,y,w,h}` of finite numbers, so the
+ *  caller can drop the offending window (geometry) or simply forget it (restoreGeometry). */
+function sanitizeRect(rect: FractionalRect | null | undefined): FractionalRect | null {
+  if (!rect || typeof rect !== 'object') return null;
+  const { x, y, w, h } = rect;
+  if (![x, y, w, h].every((value) => typeof value === 'number' && Number.isFinite(value))) {
+    return null;
+  }
+  const width = Math.min(1, Math.max(MIN_WINDOW_FRACTION, w));
+  const height = Math.min(1, Math.max(MIN_WINDOW_FRACTION, h));
+  const left = Math.min(1 - width, Math.max(0, x));
+  const top = Math.min(1 - height, Math.max(0, y));
+  return { x: left, y: top, w: width, h: height };
+}
 
 /** Snapshot the live window-manager state into the persisted form. */
 export function serializeWorkspace(
@@ -24,6 +63,7 @@ export function serializeWorkspace(
   const windowById = new Map(windows.map((window) => [window.id, window]));
   const focused = focusedWindowId ? windowById.get(focusedWindowId) : undefined;
   return {
+    version: WORKSPACE_SCHEMA_VERSION,
     windows: windows.map((window) => ({
       taskId: window.taskId,
       title: window.title,
@@ -77,7 +117,22 @@ export function deserializeWorkspace(
   serialized: SerializedWorkspace,
   context: RestoreContext,
 ): RestoredWorkspace | null {
-  const surviving = serialized.windows.filter((window) => context.isKnownTask(window.taskId));
+  // Version gate: an unknown / older-shaped blob (or a non-object) is ignored
+  // wholesale rather than partially mis-applied.
+  if (!serialized || serialized.version !== WORKSPACE_SCHEMA_VERSION) return null;
+  if (!Array.isArray(serialized.windows)) return null;
+
+  // Keep only windows whose task still exists AND whose geometry/state survive
+  // sanitization; a malformed entry is dropped, never thrown on. restoreGeometry is
+  // forgotten (set null) when invalid rather than dropping the window.
+  const surviving = serialized.windows
+    .filter((window) => context.isKnownTask(window.taskId))
+    .map((window) => {
+      const geometry = sanitizeRect(window.geometry);
+      if (!geometry || !VALID_WINDOW_STATES.has(window.state)) return null;
+      return { ...window, geometry, restoreGeometry: sanitizeRect(window.restoreGeometry) };
+    })
+    .filter((window): window is NonNullable<typeof window> => window !== null);
   if (surviving.length === 0) return null;
 
   const windowIdByTask = new Map<string, string>();
@@ -132,7 +187,9 @@ export function deserializeWorkspace(
     ? windowIdByTask.get(serialized.focusedTaskId) ?? null
     : null;
 
-  return { windows, order, tileTree, tileTreeRect: { ...serialized.tileTreeRect }, focusedWindowId };
+  const tileTreeRect = sanitizeRect(serialized.tileTreeRect) ?? { ...FULL_RECT };
+
+  return { windows, order, tileTree, tileTreeRect, focusedWindowId };
 }
 
 /** Rebuild a tile subtree with fresh ids; returns null if any leaf's task is gone

--- a/src/renderer/window-manager/store/window-store.ts
+++ b/src/renderer/window-manager/store/window-store.ts
@@ -4,8 +4,9 @@
  * Owns the set of managed windows, their floating z-order, the focused window,
  * and (from P2) the tiling tree. Renderer-only state: there is no IPC truth to
  * re-sync, so this uses HMR Pattern A (preserve the snapshot across Vite Fast
- * Refresh via `import.meta.hot.data`), NOT Pattern B. Persistence to
- * `AppConfig.workspace` lands in P4.
+ * Refresh via `import.meta.hot.data`), NOT Pattern B. The settled layout is
+ * persisted per project to `AppConfig.workspaceByProject` (see
+ * `bridge/useWorkspacePersistence` + `persistence/`).
  */
 
 import { create } from 'zustand';

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -116,6 +116,7 @@ export const IPC = {
   CONFIG_GET: 'config:get',
   CONFIG_GET_GLOBAL: 'config:getGlobal',
   CONFIG_SET: 'config:set',
+  CONFIG_SET_SYNC: 'config:setSync',
   CONFIG_GET_PROJECT: 'config:getProject',
   CONFIG_SET_PROJECT: 'config:setProject',
   CONFIG_GET_PROJECT_BY_PATH: 'config:getProjectByPath',

--- a/src/shared/object-utils.ts
+++ b/src/shared/object-utils.ts
@@ -110,10 +110,14 @@ function deepMergeInternal<T extends object>(target: T, source: Partial<T>, opti
 /** Typed deep-merge for config overlay (global + project overrides).
  *  Disables flat-map replacement so partial overrides preserve unmentioned keys. */
 export function deepMergeConfig<T extends object>(base: T, overrides: Partial<T> | Record<string, unknown>): T {
-  // `workspace` is a wholesale window-layout snapshot: REPLACE it (a changed tile
-  // tree must not deep-merge into the old one). Other keys still merge so partial
-  // overrides preserve unmentioned settings.
-  return deepMerge(base, overrides as Partial<T>, { replaceFlatMaps: false, dictionaryPaths: ['workspace'] });
+  // `workspaceByProject` holds wholesale per-project window-layout snapshots: REPLACE
+  // the map (a changed tile tree must not deep-merge into the old one). Other keys
+  // still merge so partial overrides preserve unmentioned settings. This is a
+  // deliberately NARROWER set than config-manager's CONFIG_DICTIONARY_PATHS: that list
+  // also wholesale-replaces labelColors/cliPaths/hotkeyOverrides on a partial SAVE so
+  // deletion works, but on this overlay/read path those must still merge so a project
+  // inherits global settings. Keep the two lists separate; do not unify them.
+  return deepMerge(base, overrides as Partial<T>, { replaceFlatMaps: false, dictionaryPaths: ['workspaceByProject'] });
 }
 
 /** Simple deep equality check for plain values, arrays, and objects. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1154,13 +1154,6 @@ export interface AppConfig {
     defaultUrl?: string;
   };
 
-  /** In-app window-manager layout, persisted per project so the open task windows +
-   *  their tiling survive a project switch and an app restart. taskId-anchored (so a
-   *  session respawn does not orphan a window) and fractional (so a viewport resize
-   *  re-projects cleanly). Restored AFTER sessions resolve. See
-   *  src/renderer/window-manager/persistence/. */
-  workspace?: SerializedWorkspace;
-
   /**
    * Developer / debug toggles. Global-only - the debug overlay is a
    * per-machine dev affordance, not something that varies per project.
@@ -1227,6 +1220,12 @@ export interface AppConfig {
   /** Per-project memory of the last user-selected task tab in the terminal panel.
    *  Keyed by project ID, value is the task ID. Restored on project switch. */
   lastActiveTaskByProject: Record<string, string>;
+  /** Per-project in-app window-manager layout: the open task-detail windows + their
+   *  tiling, so the full arrangement survives a project switch and an app restart.
+   *  Keyed by project ID. Global (per-machine) state, written merge-safely via
+   *  `config.set` and restored AFTER sessions resolve. See
+   *  src/renderer/window-manager/persistence/. */
+  workspaceByProject: Record<string, SerializedWorkspace>;
   /** Persisted union of every model ID we've ever seen for each agent: the
    *  result of the static/JSONL `discoverCapabilities()` walk, plus any model
    *  that has appeared on a live session's usage stream (Claude reports model
@@ -1241,9 +1240,13 @@ export interface AppConfig {
   hotkeyOverrides: Record<string, string>;
 }
 
-/** A persisted in-app window-manager layout (`AppConfig.workspace`). taskId-anchored
- *  and fractional, so it survives session respawns and viewport resizes. */
+/** A persisted in-app window-manager layout (one entry per project in
+ *  `AppConfig.workspaceByProject`). taskId-anchored and fractional, so it survives
+ *  session respawns and viewport resizes. */
 export interface SerializedWorkspace {
+  /** Schema version of this persisted layout. Stamped on save and checked on
+   *  restore so an older / unknown-shaped blob is ignored rather than mis-applied. */
+  version: number;
   windows: Array<{
     taskId: string;
     title: string;
@@ -1362,6 +1365,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   windowMaximized: false,
   statusBarPeriod: 'live',
   lastActiveTaskByProject: {},
+  workspaceByProject: {},
   discoveredModelsByAgent: {},
   hotkeyOverrides: {},
 };
@@ -2410,6 +2414,10 @@ export interface ElectronAPI {
     get: () => Promise<AppConfig>;
     getGlobal: () => Promise<AppConfig>;
     set: (config: DeepPartial<AppConfig>) => Promise<void>;
+    /** Synchronous, blocking persist of a config partial. Used only on the quit/unload
+     *  path so the final state reaches disk before the renderer tears down (an async
+     *  set() can be dropped mid-teardown). Same merge semantics as set(). */
+    setSync: (config: DeepPartial<AppConfig>) => void;
     getProjectOverrides: () => Promise<DeepPartial<AppConfig> | null>;
     setProjectOverrides: (overrides: DeepPartial<AppConfig>) => Promise<void>;
     getProjectOverridesByPath: (projectPath: string) => Promise<DeepPartial<AppConfig> | null>;

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -109,6 +109,7 @@
       labelColors: {},
     },
     hotkeyOverrides: {},
+    workspaceByProject: {},
     hasCompletedFirstRun: true,
     skipDeleteConfirm: false,
     skipBoardConfigConfirm: false,
@@ -1449,6 +1450,23 @@
         // key-by-key, so mirror the replace semantics here.
         if (partial && Object.prototype.hasOwnProperty.call(partial, 'hotkeyOverrides')) {
           config.hotkeyOverrides = Object.assign({}, partial.hotkeyOverrides);
+        }
+        // workspaceByProject is likewise a dictionary-style map (CONFIG_DICTIONARY_PATHS):
+        // the real save REPLACES the per-project map wholesale so a changed tile tree
+        // never deep-merges into the old one. Mirror the replace semantics here.
+        if (partial && Object.prototype.hasOwnProperty.call(partial, 'workspaceByProject')) {
+          config.workspaceByProject = Object.assign({}, partial.workspaceByProject);
+        }
+      },
+      // Synchronous sibling of set() for the quit/unload flush. Mirrors the real
+      // configManager.save dictionary-path replace semantics (hotkeyOverrides + workspaceByProject).
+      setSync: function (partial) {
+        config = deepMerge(config, partial);
+        if (partial && Object.prototype.hasOwnProperty.call(partial, 'hotkeyOverrides')) {
+          config.hotkeyOverrides = Object.assign({}, partial.hotkeyOverrides);
+        }
+        if (partial && Object.prototype.hasOwnProperty.call(partial, 'workspaceByProject')) {
+          config.workspaceByProject = Object.assign({}, partial.workspaceByProject);
         }
       },
       getProjectOverrides: async function () {

--- a/tests/unit/config-handler-wiring.test.ts
+++ b/tests/unit/config-handler-wiring.test.ts
@@ -25,6 +25,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // ---------------------------------------------------------------------------
 
 const capturedHandlers = new Map<string, (...args: unknown[]) => unknown>();
+const capturedOnHandlers = new Map<string, (...args: unknown[]) => unknown>();
 
 vi.mock('electron', () => ({
   app: { getVersion: vi.fn(() => '0.0.0'), getPath: vi.fn(() => '/tmp') },
@@ -32,7 +33,9 @@ vi.mock('electron', () => ({
     handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
       capturedHandlers.set(channel, handler);
     }),
-    on: vi.fn(),
+    on: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      capturedOnHandlers.set(channel, handler);
+    }),
   },
   Notification: { isSupported: vi.fn(() => false) },
   dialog: { showOpenDialog: vi.fn() },
@@ -162,6 +165,12 @@ function invokeHandler(channel: string, ...args: unknown[]): unknown {
   return handler(undefined, ...args);
 }
 
+function invokeOnHandler(channel: string, event: Record<string, unknown>, ...args: unknown[]): void {
+  const handler = capturedOnHandlers.get(channel);
+  if (!handler) throw new Error(`On-handler not registered for channel: ${channel}`);
+  handler(event, ...args);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -169,6 +178,7 @@ function invokeHandler(channel: string, ...args: unknown[]): unknown {
 describe('CONFIG_SET IPC handler - applyRuntimeConfig wiring', () => {
   beforeEach(() => {
     capturedHandlers.clear();
+    capturedOnHandlers.clear();
     applyRuntimeConfigSpy.mockClear();
   });
 
@@ -204,6 +214,7 @@ describe('CONFIG_SET IPC handler - applyRuntimeConfig wiring', () => {
 describe('CONFIG_SET_PROJECT IPC handler - applyRuntimeConfig wiring', () => {
   beforeEach(() => {
     capturedHandlers.clear();
+    capturedOnHandlers.clear();
     applyRuntimeConfigSpy.mockClear();
   });
 
@@ -233,6 +244,7 @@ describe('CONFIG_SET_PROJECT IPC handler - applyRuntimeConfig wiring', () => {
 describe('CONFIG_SET_PROJECT_BY_PATH IPC handler - applyRuntimeConfig wiring', () => {
   beforeEach(() => {
     capturedHandlers.clear();
+    capturedOnHandlers.clear();
     applyRuntimeConfigSpy.mockClear();
   });
 
@@ -282,6 +294,7 @@ describe('CONFIG_SET_PROJECT_BY_PATH IPC handler - applyRuntimeConfig wiring', (
 describe('CONFIG_SET_PROJECT_BY_PATH IPC handler - prRefreshScheduler wiring', () => {
   beforeEach(() => {
     capturedHandlers.clear();
+    capturedOnHandlers.clear();
     applyRuntimeConfigSpy.mockClear();
     startForProjectSpy.mockClear();
   });
@@ -344,6 +357,7 @@ describe('CONFIG_SET_PROJECT_BY_PATH IPC handler - prRefreshScheduler wiring', (
 describe('CONFIG_SYNC_DEFAULT_TO_PROJECTS IPC handler - applyRuntimeConfig wiring', () => {
   beforeEach(() => {
     capturedHandlers.clear();
+    capturedOnHandlers.clear();
     applyRuntimeConfigSpy.mockClear();
   });
 
@@ -387,5 +401,51 @@ describe('CONFIG_SYNC_DEFAULT_TO_PROJECTS IPC handler - applyRuntimeConfig wirin
     const result = invokeHandler('config:syncDefaultToProjects', { agent: { maxConcurrentSessions: 2 } });
 
     expect(result).toBe(3);
+  });
+});
+
+describe('CONFIG_SET_SYNC IPC handler - synchronous quit-flush wiring', () => {
+  // Regression guard for the intentionally-minimal design of the sync flush handler:
+  // it must persist the layout to disk AND set event.returnValue (so sendSync unblocks
+  // the renderer), but must NOT call applyRuntimeConfig (irrelevant during shutdown and
+  // would run synchronously at an unsafe time). If someone copies the CONFIG_SET body
+  // and adds applyRuntimeConfig here, this test catches it.
+  beforeEach(() => {
+    capturedHandlers.clear();
+    capturedOnHandlers.clear();
+    applyRuntimeConfigSpy.mockClear();
+  });
+
+  it('saves the config to disk synchronously and sets event.returnValue to true', () => {
+    const context = makeContext({ currentProjectPath: '/repo/main' });
+    registerSystemHandlers(context as Parameters<typeof registerSystemHandlers>[0]);
+
+    const fakeEvent: Record<string, unknown> = {};
+    const payload = { workspaceByProject: { 'proj-a': { version: 1, windows: [], tileTree: null, tileTreeRect: { x: 0, y: 0, w: 1, h: 1 }, focusedTaskId: null } } };
+    invokeOnHandler('config:setSync', fakeEvent, payload);
+
+    expect(context.configManager.save).toHaveBeenCalledTimes(1);
+    expect(context.configManager.save).toHaveBeenCalledWith(payload);
+    expect(fakeEvent.returnValue).toBe(true);
+  });
+
+  it('does NOT call applyRuntimeConfig (intentionally minimal - shutdown path)', () => {
+    const context = makeContext({ currentProjectPath: '/repo/main' });
+    registerSystemHandlers(context as Parameters<typeof registerSystemHandlers>[0]);
+
+    const fakeEvent: Record<string, unknown> = {};
+    invokeOnHandler('config:setSync', fakeEvent, { workspaceByProject: {} });
+
+    expect(applyRuntimeConfigSpy).not.toHaveBeenCalled();
+  });
+
+  it('is registered as a synchronous on-handler (not an async handle), so it is present in capturedOnHandlers', () => {
+    const context = makeContext();
+    registerSystemHandlers(context as Parameters<typeof registerSystemHandlers>[0]);
+
+    // Confirm it is NOT in the async handler map (which sendSync cannot reach).
+    expect(capturedHandlers.has('config:setSync')).toBe(false);
+    // Confirm it IS in the sync on-handler map.
+    expect(capturedOnHandlers.has('config:setSync')).toBe(true);
   });
 });

--- a/tests/unit/config-store-workspace.test.ts
+++ b/tests/unit/config-store-workspace.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Coverage for the config-store `saveWorkspaceForProject` action: the actual
+ * persistence write for the in-app window layout. Proves it is decoupled from the
+ * Settings panel (no `projectSettingsPath` involved) and that it merges the layout
+ * under the project id via `config.set` WITHOUT clobbering other projects' entries -
+ * the exact data-loss hazard that ruled out the project-override write path.
+ *
+ * The store reads `window.electronAPI.config.set` at call time, stubbed here (the
+ * unit tier has no jsdom); changing only `workspaceByProject` never trips the store's
+ * theme / animations subscriptions, so no DOM access occurs.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useConfigStore } from '../../src/renderer/stores/config-store';
+import { DEFAULT_CONFIG, type SerializedWorkspace } from '../../src/shared/types';
+
+function makeWorkspace(taskId: string): SerializedWorkspace {
+  return {
+    version: 1,
+    windows: [
+      { taskId, title: taskId, geometry: { x: 0.1, y: 0.1, w: 0.4, h: 0.5 }, restoreGeometry: null, state: 'floating' },
+    ],
+    tileTree: null,
+    tileTreeRect: { x: 0, y: 0, w: 1, h: 1 },
+    focusedTaskId: taskId,
+  };
+}
+
+describe('config-store workspace persistence', () => {
+  let configSet: ReturnType<typeof vi.fn>;
+  let configSetSync: ReturnType<typeof vi.fn>;
+  let configGet: ReturnType<typeof vi.fn>;
+  let configGetGlobal: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    configSet = vi.fn();
+    configSetSync = vi.fn();
+    configGet = vi.fn().mockResolvedValue({ ...DEFAULT_CONFIG });
+    configGetGlobal = vi.fn().mockResolvedValue({ ...DEFAULT_CONFIG });
+    vi.stubGlobal('window', {
+      electronAPI: {
+        config: { set: configSet, setSync: configSetSync, get: configGet, getGlobal: configGetGlobal },
+      },
+    });
+    useConfigStore.setState({
+      config: { ...DEFAULT_CONFIG },
+      globalConfig: { ...DEFAULT_CONFIG },
+      workspaceSeeded: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('merges the layout under the project id without clobbering other projects, writing via config.set', () => {
+    const layoutA = makeWorkspace('task-a');
+    const layoutB = makeWorkspace('task-b');
+    // Seed an existing entry for another project.
+    useConfigStore.setState((state) => ({
+      config: { ...state.config, workspaceByProject: { 'proj-b': layoutB } },
+      globalConfig: { ...state.globalConfig, workspaceByProject: { 'proj-b': layoutB } },
+    }));
+
+    useConfigStore.getState().saveWorkspaceForProject('proj-a', layoutA);
+
+    const map = useConfigStore.getState().config.workspaceByProject;
+    expect(map['proj-a']).toBe(layoutA);
+    expect(map['proj-b']).toBe(layoutB); // untouched: no clobber
+    expect(configSet).toHaveBeenCalledTimes(1);
+    expect(configSet).toHaveBeenCalledWith({ workspaceByProject: { 'proj-b': layoutB, 'proj-a': layoutA } });
+  });
+
+  it('updates both the effective and global config optimistically', () => {
+    const layoutA = makeWorkspace('task-a');
+    useConfigStore.getState().saveWorkspaceForProject('proj-a', layoutA);
+    expect(useConfigStore.getState().config.workspaceByProject['proj-a']).toBe(layoutA);
+    expect(useConfigStore.getState().globalConfig.workspaceByProject['proj-a']).toBe(layoutA);
+  });
+
+  it('flushWorkspaceForProject persists synchronously via config.setSync with the merged map', () => {
+    const layoutA = makeWorkspace('task-a');
+    useConfigStore.getState().flushWorkspaceForProject('proj-a', layoutA);
+    expect(configSetSync).toHaveBeenCalledTimes(1);
+    expect(configSetSync).toHaveBeenCalledWith({ workspaceByProject: { 'proj-a': layoutA } });
+    // Same optimistic update as the async save, but through the blocking sync write.
+    expect(useConfigStore.getState().config.workspaceByProject['proj-a']).toBe(layoutA);
+    expect(useConfigStore.getState().globalConfig.workspaceByProject['proj-a']).toBe(layoutA);
+    expect(configSet).not.toHaveBeenCalled();
+  });
+
+  it('seeds workspaceByProject from disk on the first config fetch', async () => {
+    const layoutA = makeWorkspace('task-a');
+    const diskConfig = { ...DEFAULT_CONFIG, workspaceByProject: { 'proj-a': layoutA } };
+    configGet.mockResolvedValue(diskConfig);
+    configGetGlobal.mockResolvedValue(diskConfig);
+    await useConfigStore.getState().loadConfig();
+    expect(useConfigStore.getState().config.workspaceByProject['proj-a']).toEqual(layoutA);
+    expect(useConfigStore.getState().workspaceSeeded).toBe(true);
+  });
+
+  it('does not let a later config fetch clobber an in-flight optimistic save (renderer is authoritative)', async () => {
+    const layoutA = makeWorkspace('task-a');
+    // First load seeds workspaceByProject from disk (empty here).
+    await useConfigStore.getState().loadConfig();
+    expect(useConfigStore.getState().workspaceSeeded).toBe(true);
+    // User saves a layout: the store updates optimistically, but the async persist has not
+    // yet reached our stale disk stub (still empty).
+    useConfigStore.getState().saveWorkspaceForProject('proj-a', layoutA);
+    expect(useConfigStore.getState().config.workspaceByProject['proj-a']).toBe(layoutA);
+    // A second fetch resolves with the STALE disk (no proj-a). It must NOT revert the store.
+    await useConfigStore.getState().loadConfig();
+    expect(useConfigStore.getState().config.workspaceByProject['proj-a']).toBe(layoutA);
+    expect(useConfigStore.getState().globalConfig.workspaceByProject['proj-a']).toBe(layoutA);
+  });
+});

--- a/tests/unit/deep-merge.test.ts
+++ b/tests/unit/deep-merge.test.ts
@@ -225,5 +225,30 @@ describe('deepMerge', () => {
       expect(result.terminal.shell).toBe('powershell');
       expect(result.terminal.cursorStyle).toBe('block');
     });
+
+    it('deepMergeConfig replaces the workspaceByProject map wholesale, not entry-by-entry', () => {
+      // Regression guard for the workspace -> workspaceByProject rename: the layout
+      // map is a dictionaryPath, so a changed entry replaces wholesale (a shrunk
+      // window list / restructured tile tree never deep-merges into the old blob).
+      // If dictionaryPaths reverted to the old ['workspace'], this would deep-merge
+      // and the assertions below would fail.
+      const base = {
+        workspaceByProject: {
+          'proj-a': { version: 1, windows: [{ taskId: 't1' }, { taskId: 't2' }], tileTree: { kind: 'split' } },
+          'proj-b': { version: 1, windows: [{ taskId: 't9' }], tileTree: null },
+        },
+      };
+      const overrides = {
+        workspaceByProject: {
+          'proj-a': { version: 1, windows: [{ taskId: 't1' }], tileTree: null },
+        },
+      };
+      const result = deepMergeConfig(base, overrides);
+      // The whole map is the override's map: proj-a is the new value (no merge of the
+      // old windows array or the old non-null tileTree), and the absent proj-b is gone.
+      expect(result.workspaceByProject).toEqual({
+        'proj-a': { version: 1, windows: [{ taskId: 't1' }], tileTree: null },
+      });
+    });
   });
 });

--- a/tests/unit/window-workspace.test.ts
+++ b/tests/unit/window-workspace.test.ts
@@ -1,9 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   serializeWorkspace,
   deserializeWorkspace,
+  WORKSPACE_SCHEMA_VERSION,
   type RestoreContext,
 } from '../../src/renderer/window-manager/persistence/workspace';
+import { createWorkspaceSaver } from '../../src/renderer/window-manager/persistence/workspace-saver';
+import type { SerializedWorkspace } from '../../src/shared/types';
 import type { ManagedWindow, TileNode, FractionalRect, WindowState } from '../../src/renderer/window-manager/store/types';
 
 function makeWindow(
@@ -136,5 +139,251 @@ describe('workspace serialize / deserialize', () => {
     const windows = [makeWindow('win-1', 'task-gone', 'floating', HALF_LEFT)];
     const serialized = serializeWorkspace(windows, null, FULL, null);
     expect(deserializeWorkspace(serialized, makeContext([]))).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Restore hardening: a layout read back from an on-disk config is never trusted.
+// ---------------------------------------------------------------------------
+
+/** Build a raw serialized workspace whose window entries can hold deliberately
+ *  invalid values (out-of-range / malformed geometry, unknown state) so the
+ *  sanitizing restore path can be exercised. */
+function serializedWith(windows: Array<Record<string, unknown>>): SerializedWorkspace {
+  return {
+    version: WORKSPACE_SCHEMA_VERSION,
+    windows: windows as SerializedWorkspace['windows'],
+    tileTree: null,
+    tileTreeRect: { ...FULL },
+    focusedTaskId: null,
+  };
+}
+
+const VALID_PERSISTED = {
+  taskId: 'task-a',
+  title: 'Task task-a',
+  geometry: { x: 0.1, y: 0.1, w: 0.4, h: 0.5 },
+  restoreGeometry: null,
+  state: 'floating',
+};
+
+describe('deserializeWorkspace hardening', () => {
+  it('ignores a workspace stamped with an unknown schema version', () => {
+    const serialized = serializeWorkspace(
+      [makeWindow('win-1', 'task-a', 'floating', HALF_LEFT)],
+      null,
+      FULL,
+      null,
+    );
+    const fromFuture = { ...serialized, version: serialized.version + 1 };
+    expect(deserializeWorkspace(fromFuture, makeContext(['task-a']))).toBeNull();
+  });
+
+  it('clamps out-of-range geometry back into the overlay', () => {
+    const serialized = serializedWith([
+      { ...VALID_PERSISTED, geometry: { x: -0.5, y: 2, w: 5, h: 0.4 } },
+    ]);
+    const restored = deserializeWorkspace(serialized, makeContext(['task-a']))!;
+    const window = Object.values(restored.windows)[0];
+    // w clamped to 1, x pinned so the (now full-width) window stays on the overlay,
+    // y pinned so its bottom edge stays visible.
+    expect(window.geometry).toEqual({ x: 0, y: 0.6, w: 1, h: 0.4 });
+  });
+
+  it('raises a below-minimum window size to the minimum visible size', () => {
+    const serialized = serializedWith([
+      { ...VALID_PERSISTED, geometry: { x: 0.1, y: 0.1, w: 0.001, h: 0 } },
+    ]);
+    const restored = deserializeWorkspace(serialized, makeContext(['task-a']))!;
+    const window = Object.values(restored.windows)[0];
+    expect(window.geometry).toEqual({ x: 0.1, y: 0.1, w: 0.05, h: 0.05 });
+  });
+
+  it('drops a window with malformed geometry instead of throwing, keeping the valid ones', () => {
+    const serialized = serializedWith([
+      VALID_PERSISTED,
+      { taskId: 'task-bad', title: 'bad', geometry: { x: Number.NaN, y: 0, w: 0.4, h: 0.5 }, restoreGeometry: null, state: 'floating' },
+    ]);
+    const restored = deserializeWorkspace(serialized, makeContext(['task-a', 'task-bad']))!;
+    expect(Object.values(restored.windows).map((window) => window.taskId)).toEqual(['task-a']);
+  });
+
+  it('drops a window with an unknown state', () => {
+    const serialized = serializedWith([
+      VALID_PERSISTED,
+      { ...VALID_PERSISTED, taskId: 'task-weird', state: 'bogus' },
+    ]);
+    const restored = deserializeWorkspace(serialized, makeContext(['task-a', 'task-weird']))!;
+    expect(Object.values(restored.windows).map((window) => window.taskId)).toEqual(['task-a']);
+  });
+
+  it('returns null when windows is not an array', () => {
+    const hostile = {
+      version: WORKSPACE_SCHEMA_VERSION,
+      windows: null,
+      tileTree: null,
+      tileTreeRect: { ...FULL },
+      focusedTaskId: null,
+    };
+    expect(deserializeWorkspace(hostile as unknown as SerializedWorkspace, makeContext(['task-a']))).toBeNull();
+  });
+
+  it('returns null when the blob itself is null or undefined', () => {
+    expect(deserializeWorkspace(null as unknown as SerializedWorkspace, makeContext([]))).toBeNull();
+    expect(deserializeWorkspace(undefined as unknown as SerializedWorkspace, makeContext([]))).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The save trigger: the regression guard for the bug. Pure debounce/gate/flush
+// state machine, exercised with fake timers (no jsdom, no stores).
+// ---------------------------------------------------------------------------
+
+const EMPTY_WORKSPACE = serializeWorkspace([], null, FULL, null);
+
+describe('createWorkspaceSaver', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('saves the active project\'s layout after the debounce while a project is open (Settings irrelevant)', () => {
+    const save = vi.fn();
+    const saver = createWorkspaceSaver({
+      getProjectId: () => 'proj-1',
+      getWorkspace: () => EMPTY_WORKSPACE,
+      save,
+      debounceMs: 500,
+    });
+    saver.onChange();
+    expect(save).not.toHaveBeenCalled(); // not yet: still settling
+    vi.advanceTimersByTime(500);
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith('proj-1', EMPTY_WORKSPACE);
+  });
+
+  it('does not save when no project is open', () => {
+    const save = vi.fn();
+    const saver = createWorkspaceSaver({
+      getProjectId: () => null,
+      getWorkspace: () => EMPTY_WORKSPACE,
+      save,
+      debounceMs: 500,
+    });
+    saver.onChange();
+    vi.advanceTimersByTime(500);
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('coalesces rapid changes into a single save', () => {
+    const save = vi.fn();
+    const saver = createWorkspaceSaver({
+      getProjectId: () => 'proj-1',
+      getWorkspace: () => EMPTY_WORKSPACE,
+      save,
+      debounceMs: 500,
+    });
+    saver.onChange();
+    vi.advanceTimersByTime(200);
+    saver.onChange();
+    vi.advanceTimersByTime(200);
+    saver.onChange();
+    vi.advanceTimersByTime(500);
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it('flush persists a pending layout immediately via saveSync, and does not double-save afterward', () => {
+    const save = vi.fn();
+    const saveSync = vi.fn();
+    const saver = createWorkspaceSaver({
+      getProjectId: () => 'proj-1',
+      getWorkspace: () => EMPTY_WORKSPACE,
+      save,
+      saveSync,
+      debounceMs: 500,
+    });
+    saver.onChange();
+    saver.flush();
+    expect(saveSync).toHaveBeenCalledTimes(1);
+    expect(saveSync).toHaveBeenCalledWith('proj-1', EMPTY_WORKSPACE);
+    expect(save).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(500);
+    expect(saveSync).toHaveBeenCalledTimes(1); // the pending timer was cleared
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('flush persists the current layout even when nothing is pending (covers an in-flight async save)', () => {
+    const save = vi.fn();
+    const saveSync = vi.fn();
+    const saver = createWorkspaceSaver({
+      getProjectId: () => 'proj-1',
+      getWorkspace: () => EMPTY_WORKSPACE,
+      save,
+      saveSync,
+    });
+    // A debounced async save fired and cleared its timer; before it lands the user quits.
+    saver.flush();
+    expect(saveSync).toHaveBeenCalledTimes(1);
+    expect(saveSync).toHaveBeenCalledWith('proj-1', EMPTY_WORKSPACE);
+  });
+
+  it('flush falls back to the async save when no saveSync is provided', () => {
+    const save = vi.fn();
+    const saver = createWorkspaceSaver({
+      getProjectId: () => 'proj-1',
+      getWorkspace: () => EMPTY_WORKSPACE,
+      save,
+    });
+    saver.flush();
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it('flush is a no-op when no project is open', () => {
+    const saveSync = vi.fn();
+    const saver = createWorkspaceSaver({
+      getProjectId: () => null,
+      getWorkspace: () => EMPTY_WORKSPACE,
+      save: vi.fn(),
+      saveSync,
+    });
+    saver.flush();
+    expect(saveSync).not.toHaveBeenCalled();
+  });
+
+  it('reads the project id and workspace together at persist time (consistent, never cross-contaminated)', () => {
+    const save = vi.fn();
+    let projectId: string | null = 'proj-a';
+    let workspace = EMPTY_WORKSPACE;
+    const otherWorkspace = serializeWorkspace([], null, HALF_LEFT, null);
+    const saver = createWorkspaceSaver({
+      getProjectId: () => projectId,
+      getWorkspace: () => workspace,
+      save,
+      debounceMs: 500,
+    });
+    saver.onChange();
+    // A project switch lands before the debounce fires: both reads must reflect the
+    // new project, so the save can never write one project's windows under another's id.
+    projectId = 'proj-b';
+    workspace = otherWorkspace;
+    vi.advanceTimersByTime(500);
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith('proj-b', otherWorkspace);
+  });
+
+  it('disposing cancels a pending save', () => {
+    const save = vi.fn();
+    const saver = createWorkspaceSaver({
+      getProjectId: () => 'proj-1',
+      getWorkspace: () => EMPTY_WORKSPACE,
+      save,
+      debounceMs: 500,
+    });
+    saver.onChange();
+    saver.dispose();
+    vi.advanceTimersByTime(500);
+    expect(save).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Modeless task-detail windows (shipped in #30) have a full serialize/restore pipeline, but the layout was **never written to disk during normal board use**, so a restart restored nothing. The agent session still resumed (session recovery is a separate mechanism), which is why the window came back empty/misplaced while the conversation returned.

Root cause: the only saver subscribed to the window-store only while `projectSettingsPath` was truthy, i.e. only while the **Settings panel** was open (and that overlay covers the board, so a window can never be dragged then). Its write path also routed through `updateProjectOverride` / `setProjectOverridesByPath`, which **overwrites the whole** `<project>/.kangentic/config.json` and would have clobbered other project overrides.

The fix moves window-layout persistence onto the same rails as `lastActiveTaskByProject`: a per-project entry in **global** config, written merge-safely, gated on the active project rather than the Settings panel.

## Impact / behavior

- **Window geometry now survives a restart.** Open one or more task-detail windows, arrange them (move, resize, snap, tile), restart Kangentic, and the full per-project arrangement is restored: every window, its floating/snapped/maximized/tiled state, the tiling tree with pane sizes, and which window was focused.
- **Per project.** Each project keeps its own independent layout (`workspaceByProject`, keyed by project id). Switching projects restores each one's own windows.
- **Captures the last arrangement before quit.** A synchronous `config.setSync` flush on `beforeunload` drains the pending debounced layout, so an arrangement made within the 500ms settle window before quitting still reaches disk.
- **Robust restore.** A stamped schema `version` gates the persisted blob; geometry is clamped into the overlay with a minimum visible size (no off-screen / zero-size windows); a malformed or unknown-state window is dropped rather than throwing on the project-switch critical path.
- **No data-loss / clobber.** Persisted via `config.set` (top-level merge), not the project-override overwrite path. The renderer is the sole writer of `workspaceByProject`, so a later stale config refetch never reverts an in-flight optimistic save.

## Implementation notes

- `workspaceByProject: Record<string, SerializedWorkspace>` replaces the unused `workspace?` field on `AppConfig`; `SerializedWorkspace` gains a `version` field. It is a wholesale-replace dictionary path in `deepMergeConfig` and `config-manager`'s `CONFIG_DICTIONARY_PATHS` (a changed tile tree must not deep-merge into the old one; map replacement also lets a removed project drop out).
- New `config:setSync` IPC channel (`sendSync` -> `ipcMain.on`) wired through all 7 layers (channel, type, preload, handler, store, mock) for the synchronous quit flush.
- The debounce/gate/flush state machine is a pure `workspace-saver` module so it is unit-testable without jsdom.

## Test plan

CI runs the full gate (lint, typecheck, unit, build, the UI shards, and the Linux Electron E2E shards). New/updated unit coverage added with the change:
- `tests/unit/window-workspace.test.ts` - restore hardening (version guard, geometry clamp, drop malformed/unknown-state) and `createWorkspaceSaver` (debounce, gate-on-active-project, flush, dispose, no cross-project contamination).
- `tests/unit/config-store-workspace.test.ts` - `saveWorkspaceForProject` merge-without-clobber + optimistic update, `flushWorkspaceForProject` synchronous write, disk seeding, and no-clobber-on-stale-refetch.
- `tests/unit/deep-merge.test.ts` - `deepMergeConfig` replaces the `workspaceByProject` map wholesale.

Manual: open task-detail windows, arrange them, fully restart, confirm the layout returns and a `workspaceByProject` entry exists in the global `config.json`.

Generated with [Claude Code](https://claude.com/claude-code)
