### PR TITLE
fix(pr): stop fresh worktrees magnet-linking the last-merged PR

### DIFF
--- a/src/main/git/worktree-head.ts
+++ b/src/main/git/worktree-head.ts
@@ -24,22 +24,27 @@ export async function readWorktreeHead(worktreePath: string): Promise<{ branch: 
 }
 
 /**
- * Whether `sha` is a merge commit (more than one parent). A merge commit is
- * never a task's own work - in particular a base-branch `Merge pull request #N`
- * tip, which a freshly-branched code-review worktree sits on - so the commit-SHA
- * PR anchor must not attribute that commit's originating PR to the task.
+ * Whether `sha` has any commits of its own beyond `baseBranch` - i.e. it is
+ * genuinely a task's work and not a base-branch tip a freshly-branched worktree
+ * sits on. A fresh worktree is branched from the base with zero commits, so its
+ * HEAD equals the base tip, which equals the last-merged PR's commit; the
+ * commit-SHA PR anchor must not run there or it attributes that PR to the task.
  *
- * `rev-list --parents -n 1 <sha>` prints the commit's SHA followed by its parent
- * SHAs on one line, so more than two tokens means two or more parents. The merge
- * commit survives in the object store after the worktree is reclaimed, so this
- * works from the main repo too. Best-effort: returns false on any git error so
- * resolution still proceeds.
+ * `rev-list --count <base>..<sha>` is the number of commits reachable from `sha`
+ * but not from `baseBranch`, which is 0 exactly when `sha` is already contained
+ * in `baseBranch`. Unlike a parent-count merge check this also catches the
+ * single-parent commits that `gh pr merge --rebase` / `--squash` produce (the
+ * team default). The commit survives in the object store after the worktree is
+ * reclaimed, so this works from the main repo too.
+ *
+ * Fails SAFE: on any git error (bad base ref, missing object) returns false so
+ * the caller skips the commit anchor rather than risking a mis-link.
  */
-export async function isMergeCommit(repoCwd: string, sha: string): Promise<boolean> {
+export async function hasCommitsAheadOfBase(repoCwd: string, baseBranch: string, sha: string): Promise<boolean> {
   try {
     const git = simpleGit(repoCwd);
-    const line = (await git.raw(['rev-list', '--parents', '-n', '1', sha])).trim();
-    return line.split(/\s+/).length > 2;
+    const commitCountOutput = (await git.raw(['rev-list', '--count', `${baseBranch}..${sha}`])).trim();
+    return Number.parseInt(commitCountOutput, 10) > 0;
   } catch {
     return false;
   }

--- a/src/main/pr/pr-linking.ts
+++ b/src/main/pr/pr-linking.ts
@@ -1,6 +1,6 @@
 import { IPC } from '../../shared/ipc-channels';
 import { withTaskLock } from '../ipc/task-lifecycle-lock';
-import { readWorktreeHead, isMergeCommit } from '../git/worktree-head';
+import { readWorktreeHead, hasCommitsAheadOfBase } from '../git/worktree-head';
 import { getProjectRepos } from '../ipc/helpers/project-repos';
 import {
   resolvePRForBranch,
@@ -38,6 +38,12 @@ export interface PRLinkDeps {
   tasks: TaskRepository;
   /** Repo root used as the resolver `cwd` when the task has no worktree of its own. */
   projectPath: string | null;
+  /**
+   * Project default base branch (from config), used to resolve the task's base
+   * for the Tier-3 commits-ahead-of-base guard when `task.base_branch` is unset.
+   * Falls back to 'main' when absent.
+   */
+  defaultBaseBranch?: string;
   /** Notify the renderer that the task changed (e.g. send TASK_UPDATED_BY_AGENT). */
   onLinked: (task: Task) => void;
   /** Optional raw PTY scrollback for the degradation fallback when the resolver is unavailable. */
@@ -73,9 +79,10 @@ async function resolvePRViaLadder(args: {
   projectPath: string | null;
   branch: string | null;
   effectiveSha: string | null;
+  baseBranch: string;
   descriptionPR: DetectedPR | null;
 }): Promise<LinkedPR | null> {
-  const { task, cwd, projectPath, branch, effectiveSha, descriptionPR } = args;
+  const { task, cwd, projectPath, branch, effectiveSha, baseBranch, descriptionPR } = args;
 
   // Tier 0: a single PR URL written into the task description is authoritative.
   // A code-review worktree is branched from the base branch with no commits of
@@ -98,12 +105,15 @@ async function resolvePRViaLadder(args: {
     const byBranch = await resolvePRForBranch(cwd, branch, task.base_branch ?? undefined);
     if (byBranch) return byBranch;
   }
-  if (effectiveSha && !(await isMergeCommit(projectPath ?? cwd, effectiveSha))) {
+  if (effectiveSha && (await hasCommitsAheadOfBase(projectPath ?? cwd, baseBranch, effectiveSha))) {
     // Run from the main repo (projectPath) so it works even when the worktree is
     // gone. Pass the known branch as a hint so a commit shared by several PRs
     // ties back to this task (ambiguous matches resolve to null, not a guess).
-    // Skip merge commits: a `Merge pull request #N` base-branch tip (which a
-    // freshly-branched worktree sits on) is never this task's own work.
+    // Only run when the commit has work of its own beyond base: a fresh worktree
+    // branched from base sits on base's tip (== the last-merged PR's commit), and
+    // that PR is never this task's work. This also catches the single-parent
+    // commits `gh pr merge --rebase`/`--squash` produce, which a parent-count
+    // merge check misses.
     const byCommit = await resolvePRByCommit(projectPath ?? cwd, effectiveSha, branch ?? undefined);
     if (byCommit) return byCommit;
   }
@@ -152,6 +162,7 @@ export async function linkPRForTask(taskId: string, deps: PRLinkDeps): Promise<P
     }
     const branch = worktreeBranch ?? task.branch_name;
     const effectiveSha = freshSha ?? task.head_sha;
+    const baseBranch = task.base_branch ?? deps.defaultBaseBranch ?? 'main';
 
     // Nothing to resolve from at all. A PR URL in the description is itself an
     // anchor (Tier 0), so a task with no git state still resolves from it.
@@ -172,7 +183,7 @@ export async function linkPRForTask(taskId: string, deps: PRLinkDeps): Promise<P
     let degradeMessage: string | undefined;
 
     try {
-      const resolved = await resolvePRViaLadder({ task, cwd, projectPath: deps.projectPath, branch, effectiveSha, descriptionPR });
+      const resolved = await resolvePRViaLadder({ task, cwd, projectPath: deps.projectPath, branch, effectiveSha, baseBranch, descriptionPR });
       if (resolved) next = { url: resolved.url, number: resolved.number, state: resolved.state };
     } catch (error) {
       if (error instanceof PRResolverUnavailableError || error instanceof PRResolverTransientError) {
@@ -202,15 +213,30 @@ export async function linkPRForTask(taskId: string, deps: PRLinkDeps): Promise<P
       patch.pr_number = next.number;
       patch.pr_state = next.state;
     }
+    // Confident not-found: the resolver ran cleanly (no transient / unavailable
+    // degrade) and matched no PR, yet the task still carries a link. Clear it so
+    // a stale `merged` (or any orphaned link) never lingers - pr_number, pr_url,
+    // and pr_state always agree, written atomically in the same update below. A
+    // degraded resolve never clears (the link is preserved, as before).
+    const hadLink = task.pr_number != null || task.pr_url != null || task.pr_state != null;
+    const prCleared = next == null && !degradeStatus && hadLink;
+    if (prCleared) {
+      patch.pr_url = null;
+      patch.pr_number = null;
+      patch.pr_state = null;
+    }
     const shaChanged = freshSha != null && freshSha !== task.head_sha;
     if (shaChanged) patch.head_sha = freshSha;
 
     let updatedTask = task;
-    if (prChanged || shaChanged) {
+    if (prChanged || prCleared || shaChanged) {
       updatedTask = deps.tasks.update(patch);
     }
     if (prChanged && next) {
       console.log(`[pr-linking] Linked PR #${next.number} (${next.state ?? 'unknown'}) to "${task.title}": ${next.url}`);
+      deps.onLinked(updatedTask);
+    } else if (prCleared) {
+      console.log(`[pr-linking] Cleared stale PR link from "${task.title}" (no PR resolves for its branch)`);
       deps.onLinked(updatedTask);
     }
 
@@ -261,10 +287,17 @@ export async function linkPR(context: IpcContext, options: LinkPROptions): Promi
   if (!task) return { status: 'no-anchor', task: null };
 
   const projectPath = context.projectRepo.getById(projectId)?.path ?? null;
+  let defaultBaseBranch: string | undefined;
+  try {
+    defaultBaseBranch = projectPath ? context.configManager.getEffectiveConfig(projectPath).git.defaultBaseBranch : undefined;
+  } catch {
+    defaultBaseBranch = undefined;
+  }
 
   return linkPRForTask(task.id, {
     tasks,
     projectPath,
+    defaultBaseBranch,
     force: options.force,
     getScrollback: options.scrollback != null ? () => options.scrollback : undefined,
     onLinked: (linked) => {

--- a/tests/unit/branch-pr-resolver.test.ts
+++ b/tests/unit/branch-pr-resolver.test.ts
@@ -325,6 +325,9 @@ describe('connector resolveByNumber / resolveByCommit + error translation', () =
       pr({ number: 5, headRefName: 'renamed-real-branch' }),
     ]);
     // Done-task case: stored slug != real branch, but a single PR for the commit is unambiguous.
+    // This is intentional and must stay: the magnet bug (a fresh worktree linking the last-merged
+    // PR by commit) is prevented upstream by the linker's commits-ahead-of-base guard, which never
+    // reaches this resolver for a branchless worktree - not by rejecting a single non-matching PR here.
     expect((await gitHubPRConnector.resolveByCommit!('/r', 'sha', 'stale-slug'))?.number).toBe(5);
   });
 

--- a/tests/unit/pr-link-ladder.test.ts
+++ b/tests/unit/pr-link-ladder.test.ts
@@ -14,9 +14,10 @@ import type { Task } from '../../src/shared/types';
 const git = vi.hoisted(() => ({
   branch: 'real-branch' as string | null,
   sha: 'sha-current' as string | null,
-  // `rev-list --parents -n 1` output: commit SHA + parent SHAs. Two tokens = a
-  // normal (single-parent) commit; isMergeCommit treats >2 tokens as a merge.
-  parents: 'commit-sha parent-sha',
+  // `rev-list --count <base>..<sha>` output: commits the head has of its own
+  // beyond base. '0' = a branchless worktree on base's tip (Tier 3 skipped);
+  // '1'+ = the task's own work (Tier 3 runs).
+  aheadCount: '1',
 }));
 const conn = vi.hoisted(() => ({
   byNumber: null as unknown,
@@ -30,7 +31,7 @@ const conn = vi.hoisted(() => ({
 vi.mock('simple-git', () => ({
   simpleGit: () => ({
     revparse: async (args: string[]) => (args.includes('--abbrev-ref') ? (git.branch ?? 'HEAD') : git.sha),
-    raw: async () => git.parents,
+    raw: async () => git.aheadCount,
   }),
 }));
 
@@ -92,7 +93,7 @@ const resolved = (number: number, state = 'open') => ({ url: `u${number}`, numbe
 
 beforeEach(() => {
   conn.byNumber = null; conn.byBranch = null; conn.byCommit = null; conn.detect = null; conn.canonical = null; conn.calls = [];
-  git.branch = 'real-branch'; git.sha = 'sha-current'; git.parents = 'commit-sha parent-sha';
+  git.branch = 'real-branch'; git.sha = 'sha-current'; git.aheadCount = '1';
 });
 
 describe('linkPRForTask confidence ladder', () => {
@@ -131,13 +132,43 @@ describe('linkPRForTask confidence ladder', () => {
     expect(conn.calls).toContain('byBranch');
   });
 
-  it('tier 3: skips the commit anchor when HEAD is a merge commit (base-branch tip)', async () => {
-    git.parents = 'merge-sha parent-1 parent-2'; // a `Merge pull request #N` commit has two parents
-    conn.byCommit = resolved(702, 'merged'); // the PR that merge commit closed - not this task's PR
-    const task = makeTask({ worktree_path: null, branch_name: null, head_sha: 'develop-tip-merge' });
+  it('tier 3: skips the commit anchor when the commit has no commits ahead of base', async () => {
+    // HEAD is base's tip - a branchless worktree, or a single-parent rebase/squash
+    // merge tip that a parent-count check would have missed. Not this task's work.
+    git.aheadCount = '0';
+    conn.byCommit = resolved(702, 'merged'); // the PR that owns base's tip - not this task's PR
+    const task = makeTask({ worktree_path: null, branch_name: null, head_sha: 'base-tip' });
     const result = await linkPRForTask(task.id, depsFor(task));
     expect(conn.calls).not.toContain('byCommit');
     expect(result.status).toBe('not-found');
+  });
+
+  it('regression: a fresh worktree on base tip does not link the just-merged PR (magnet bug)', async () => {
+    // A newly created task's worktree is branched from base with zero commits, so
+    // its HEAD == base's tip == the last-merged PR's rebased commit. With 0 commits
+    // ahead of base the commit anchor must not run and magnet onto that PR.
+    git.aheadCount = '0';
+    conn.byBranch = null; // no PR exists for this brand-new branch yet
+    conn.byCommit = resolved(36, 'merged'); // the last-merged PR the commit would magnet onto
+    const task = makeTask(); // worktree present, real HEAD branch, no pr_number
+    const result = await linkPRForTask(task.id, depsFor(task));
+    expect(conn.calls).not.toContain('byCommit');
+    expect(result.status).toBe('not-found');
+    expect(result.task?.pr_number).toBeNull();
+  });
+
+  it('clears a stale link when the resolver cleanly finds no PR (never leaves a stale merged)', async () => {
+    // The PR vanished (branch/PR deleted): every tier returns null with no degrade.
+    // The stale link - including a stale `merged` - must be cleared atomically.
+    conn.byNumber = null; // pr_number no longer resolves
+    const updateSpy = vi.fn((patch: Partial<Task>) => patch as Task);
+    const task = makeTask({ pr_number: 99, pr_url: 'u99', pr_state: 'merged', worktree_path: null, head_sha: null, branch_name: null });
+    const deps = depsFor(task, { updateSpy });
+    const result = await linkPRForTask(task.id, deps);
+    expect(result.status).toBe('not-found');
+    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ pr_number: null, pr_url: null, pr_state: null }));
+    expect(deps.onLinked).toHaveBeenCalledWith(expect.objectContaining({ pr_number: null }));
+    expect(result.task?.pr_number).toBeNull();
   });
 
   it('write-only-on-change: returns unchanged and does not write when the PR is already current', async () => {

--- a/tests/unit/worktree-head.test.ts
+++ b/tests/unit/worktree-head.test.ts
@@ -26,7 +26,7 @@ vi.mock('simple-git', () => ({
   simpleGit: vi.fn(() => mockGit),
 }));
 
-import { readWorktreeHead, isMergeCommit } from '../../src/main/git/worktree-head';
+import { readWorktreeHead, hasCommitsAheadOfBase } from '../../src/main/git/worktree-head';
 
 describe('readWorktreeHead', () => {
   beforeEach(() => {
@@ -120,45 +120,43 @@ describe('readWorktreeHead', () => {
 });
 
 /**
- * isMergeCommit is the merge-commit guard that keeps the PR confidence ladder
- * from attributing a base-branch `Merge pull request #N` tip (which a freshly
- * branched review worktree sits on) to the task. `rev-list --parents -n 1 <sha>`
- * prints the commit SHA followed by its parent SHAs on one line: 1 token = root
- * commit, 2 = a normal single-parent commit, >2 = a merge commit.
+ * hasCommitsAheadOfBase is the Tier-3 guard that keeps the PR confidence ladder
+ * from attributing a base-branch tip (which a freshly-branched worktree sits on)
+ * to the task. `rev-list --count <base>..<sha>` is the number of commits
+ * reachable from <sha> but not from <base>: 0 means the commit is already
+ * contained in base (a branchless worktree, or any rebase/squash/merge tip), so
+ * the commit anchor must be skipped; >0 means the commit is the task's own work.
  */
-describe('isMergeCommit', () => {
+describe('hasCommitsAheadOfBase', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('returns false for a single-parent commit (two tokens)', async () => {
-    mockGit.raw.mockResolvedValue('abc123 parent1');
-    expect(await isMergeCommit('/mock/repo', 'abc123')).toBe(false);
+  it('returns true when the commit has commits of its own ahead of base (count > 0)', async () => {
+    mockGit.raw.mockResolvedValue('3');
+    expect(await hasCommitsAheadOfBase('/mock/repo', 'main', 'abc123')).toBe(true);
   });
 
-  it('returns true for a merge commit (more than two tokens)', async () => {
-    mockGit.raw.mockResolvedValue('mergesha parent1 parent2');
-    expect(await isMergeCommit('/mock/repo', 'mergesha')).toBe(true);
-  });
-
-  it('returns false for a root commit with no parents (one token)', async () => {
-    mockGit.raw.mockResolvedValue('rootsha');
-    expect(await isMergeCommit('/mock/repo', 'rootsha')).toBe(false);
+  it('returns false when the commit is already contained in base (count 0)', async () => {
+    // A fresh worktree sits on base's tip: 0 commits ahead -> skip the anchor so
+    // the last-merged PR is never attributed to the task.
+    mockGit.raw.mockResolvedValue('0');
+    expect(await hasCommitsAheadOfBase('/mock/repo', 'main', 'base-tip')).toBe(false);
   });
 
   it('tolerates surrounding whitespace and a trailing newline', async () => {
-    mockGit.raw.mockResolvedValue('  mergesha parent1 parent2\n');
-    expect(await isMergeCommit('/mock/repo', 'mergesha')).toBe(true);
+    mockGit.raw.mockResolvedValue('  2\n');
+    expect(await hasCommitsAheadOfBase('/mock/repo', 'main', 'abc123')).toBe(true);
   });
 
-  it('returns false when git throws (best-effort degrade, never propagates)', async () => {
-    mockGit.raw.mockRejectedValue(new Error('fatal: bad object missing'));
-    expect(await isMergeCommit('/mock/repo', 'missing')).toBe(false);
+  it('returns false when git throws (fails safe -> skip the anchor, never fails open)', async () => {
+    mockGit.raw.mockRejectedValue(new Error('fatal: bad revision main..missing'));
+    expect(await hasCommitsAheadOfBase('/mock/repo', 'main', 'missing')).toBe(false);
   });
 
-  it('queries rev-list --parents for the given SHA', async () => {
-    mockGit.raw.mockResolvedValue('abc123 parent1');
-    await isMergeCommit('/mock/repo', 'abc123');
-    expect(mockGit.raw).toHaveBeenCalledWith(['rev-list', '--parents', '-n', '1', 'abc123']);
+  it('queries rev-list --count for <base>..<sha>', async () => {
+    mockGit.raw.mockResolvedValue('1');
+    await hasCommitsAheadOfBase('/mock/repo', 'develop', 'abc123');
+    expect(mockGit.raw).toHaveBeenCalledWith(['rev-list', '--count', 'develop..abc123']);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the PR-linking "magnet" bug (task #271): newly created tasks were auto-linked to an
unrelated, already-merged PR and shown with a "merged" badge within seconds of creation, before
any PR existed.

Root cause: Tier 3 of the PR confidence ladder (commit-SHA resolution) ran on fresh, branchless
worktrees. A new worktree is branched from `main` with zero commits of its own, so its HEAD SHA
equals `main`'s tip, which equals the last-merged PR's rebased commit. Tier 3 asked GitHub "which
PR owns this commit?" (`gh api .../commits/<sha>/pulls`), got the just-merged PR, and linked it
(and its `merged` state) to the task. The old `isMergeCommit` (parent-count) guard missed this
because the team rebase-merges (`gh pr merge --rebase`/`--squash`), which produce single-parent
merge commits.

## Impact / behavior

- Creating a task right after a merge no longer magnet-links the just-merged PR. A branchless
  worktree never reaches the commit resolver.
- The Tier-3 guard now also fails **safe** on a git error (skip the commit anchor) instead of
  failing open and resolving anyway.
- A refresh that cleanly resolves no PR for a task now clears `pr_number` / `pr_url` / `pr_state`
  together, so a stale `merged` (or any orphaned link) can no longer linger or silently disagree.
  A degraded resolve (transient / resolver-unavailable) still preserves the existing link.

## Changes

- `src/main/git/worktree-head.ts`: replace `isMergeCommit` with
  `hasCommitsAheadOfBase(repoCwd, baseBranch, sha)` (`git rev-list --count <base>..<sha>` > 0).
  Strictly stronger than parent-count (catches rebase/squash/merge tips and branchless
  worktrees); fails safe to `false` on any git error.
- `src/main/pr/pr-linking.ts`: gate Tier 3 on `hasCommitsAheadOfBase`; resolve the base as
  `task.base_branch ?? deps.defaultBaseBranch ?? 'main'` (the `linkPR` IPC wrapper now reads the
  project default from config); clear stale PR fields atomically on a confident not-found.
- `disambiguate` is intentionally left unchanged. Returning a single unambiguous PR for a commit
  is the deliberate fallback for Done tasks whose branch was renamed away from the stored slug;
  the commits-ahead guard prevents the magnet bug upstream, so that fallback is never reached for
  a branchless worktree. A clarifying comment was added to its test.

## Test plan

- CI checks: lint, typecheck, unit, build, the UI shards, and the Linux Electron E2E shards.
- Unit coverage (all changed tiers, run scoped locally):
  - `tests/unit/worktree-head.test.ts`: `hasCommitsAheadOfBase` (count > 0 / 0, whitespace, git
    error fails safe, `rev-list --count <base>..<sha>` arg shape).
  - `tests/unit/pr-link-ladder.test.ts`: Tier 3 skipped when 0 commits ahead of base; magnet-bug
    regression (fresh worktree on base tip does not link the merged PR); clear-on-confident-not-found.
  - `tests/unit/branch-pr-resolver.test.ts`: the intentional single-PR-for-a-commit fallback is
    preserved.
- Red-green verified: with the new guard disabled, the magnet regression test fails by linking the
  merged PR; restored, it passes. Full scoped run is 60 passing.

Generated with [Claude Code](https://claude.com/claude-code)
