### PR TITLE
feat(window-manager): click-outside to close task-detail windows

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,7 @@ These settings appear only in App Settings and cannot be overridden per-project:
 - `agent.cliPaths`, `agent.maxConcurrentSessions`, `agent.queueOverflow`, `agent.autoResumeSessionsOnRestart`
 - `terminal.panelHeight`, `terminal.showPreview`
 - `autoFocusIdleSession`
+- `windowLightDismiss`
 - `contextBar.*` (all context bar visibility toggles)
 - `notifications.*` (all notification settings)
 - `agent.idleTimeoutMinutes`
@@ -66,6 +67,7 @@ These settings appear in both App Settings (as defaults) and Project Settings (a
 | `statusBarVisible` | boolean | `true` | Show the status bar at the bottom of the window. Global-only. |
 | `skipDeleteConfirm` | boolean | `false` | Skip confirmation dialog on task delete. Written by the delete dialog's "don't ask again" checkbox. No longer surfaced in the Settings panel. |
 | `autoFocusIdleSession` | boolean | `false` | Auto-switch to session tab when agent goes idle. Idle tabs are always highlighted regardless of this setting. |
+| `windowLightDismiss` | `'off'` \| `'single'` \| `'focused'` \| `'all'` | `'single'` | Click-outside (light-dismiss) policy for modeless task-detail windows. `off` disables; `single` closes a lone floating window; `focused` closes the focused window (any state); `all` closes every window. Closing a window does not kill its session. Global-only. |
 | `restoreWindowPosition` | boolean | `true` | Remember window size and position between launches. Global-only. |
 | `hasCompletedFirstRun` | boolean | `false` | Whether the user has completed first-run onboarding. Auto-set, not shown in UI. |
 | `windowBounds` | object \| null | `null` | Persisted window bounds `{x, y, width, height}`. Auto-saved, not shown in UI. |

--- a/src/renderer/components/OverlayPopover.tsx
+++ b/src/renderer/components/OverlayPopover.tsx
@@ -111,6 +111,9 @@ function OverlayPopoverContent({
       style={{ transformOrigin, ...positionStyle }}
       className={`${className} ${contentClassName}`}
       onAnimationEnd={onAnimationEnd}
+      // Marks this as an open dismissable layer so the click-outside window
+      // dismiss yields to it: an outside click closes the popover, not a window.
+      data-dismissable-layer
       {...domProps}
     >
       {children}

--- a/src/renderer/components/board/ArchivedTaskContextMenu.tsx
+++ b/src/renderer/components/board/ArchivedTaskContextMenu.tsx
@@ -64,6 +64,7 @@ export function ArchivedTaskContextMenu({
       ref={menuRef}
       className="fixed z-50 bg-surface-raised border border-edge rounded-lg shadow-xl py-1 min-w-[180px] overlay-popover-in"
       style={{ ...menuStyle, transformOrigin: 'top left' }}
+      data-dismissable-layer
     >
       <button
         type="button"

--- a/src/renderer/components/board/KanbanBoard.tsx
+++ b/src/renderer/components/board/KanbanBoard.tsx
@@ -354,7 +354,11 @@ export function KanbanBoard() {
   return (
     <div className="relative h-full overflow-x-auto overflow-y-hidden flex flex-col">
       <ConfigWarningBanner />
-      <div className="flex-1 overflow-x-auto overflow-y-hidden p-4">
+      {/* `data-board-background`: the empty-board region the click-outside window
+          dismiss anchors on. Scoped to this scroll container (not the root) so the
+          board-level dialogs rendered after it (NewTaskDialog, BoardDialogs) are
+          siblings, not descendants, and never read as a background click. */}
+      <div className="flex-1 overflow-x-auto overflow-y-hidden p-4" data-board-background>
       <WelcomeOverlay />
       <DndContext
         key={hmrGeneration}

--- a/src/renderer/components/board/TaskContextMenu.tsx
+++ b/src/renderer/components/board/TaskContextMenu.tsx
@@ -69,6 +69,7 @@ export function TaskContextMenu({
       ref={menuRef}
       className="fixed z-50 bg-surface-raised border border-edge rounded-lg shadow-xl py-1 min-w-[180px] overlay-popover-in"
       style={{ ...menuStyle, transformOrigin: 'top left' }}
+      data-dismissable-layer
     >
       <button
         type="button"

--- a/src/renderer/components/dialogs/BaseDialog.tsx
+++ b/src/renderer/components/dialogs/BaseDialog.tsx
@@ -212,6 +212,10 @@ export function BaseDialog({
   return (
     <div
       className={`fixed ${backdropPositionClass} bg-black/60 flex items-center justify-center ${zIndex} ${backdropAnimClass} ${backdropClassName || ''}`}
+      // Marks an open modal as a dismissable layer so a board click while a dialog
+      // is up dismisses the dialog, never a window underneath (BaseDialog renders
+      // inline, so a board-level / card confirm sits inside the board subtree).
+      data-dismissable-layer
       onMouseDown={(e) => { backdropMouseDown.current = e.target === e.currentTarget; }}
       onMouseUp={(e) => {
         if (e.target === e.currentTarget && backdropMouseDown.current) {

--- a/src/renderer/components/dialogs/task-detail/CommandPalettePopover.tsx
+++ b/src/renderer/components/dialogs/task-detail/CommandPalettePopover.tsx
@@ -37,6 +37,10 @@ export function CommandPalettePopover({ triggerRef, cwd, onSelect, onClose }: Co
       ref={popoverRef}
       style={{ ...popoverStyle, transformOrigin: 'top center' }}
       className="fixed w-[280px] max-h-[300px] bg-surface-raised border border-edge-input rounded-md shadow-xl z-[2147483646] flex flex-col overflow-hidden overlay-popover-in"
+      // An open dismissable layer so the click-outside window dismiss yields to
+      // it: a board click while this body-portaled popover is open closes the
+      // popover, not the task-detail window underneath.
+      data-dismissable-layer
       data-testid="command-palette-popover"
     >
       <CommandSearchList cwd={cwd} onSelect={onSelect} onClose={onClose} />

--- a/src/renderer/components/settings/settings-registry.ts
+++ b/src/renderer/components/settings/settings-registry.ts
@@ -86,6 +86,9 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
   { id: 'autoFocusIdleSession', tabId: 'behavior', label: 'Auto-Focus Idle Sessions', description: 'Automatically switch the bottom panel to idle sessions. Idle tabs are always highlighted regardless of this setting.', scope: 'global', keywords: ['switch', 'panel', 'attention'] },
   { id: 'agent.autoResumeSessionsOnRestart', tabId: 'behavior', label: 'Auto-Resume Agents on Restart', description: 'When a project opens, resume any agent sessions that were running at last close. When off, those sessions stay paused until you click Resume on each task. Turn off if resuming many agents at once slows your machine.', scope: 'global', keywords: ['resume', 'restart', 'startup', 'suspend', 'pause', 'stampede', 'auto', 'sessions', 'agents'] },
 
+  // ── Behavior > Task Windows ──
+  { id: 'windowLightDismiss', tabId: 'behavior', label: 'Close on Outside Click', description: 'Click the empty board to dismiss open task windows. Closing keeps the agent running and hands its terminal back to the panel; reopening the task reattaches.', scope: 'global', section: 'Task Windows', keywords: ['dismiss', 'click outside', 'window', 'peek', 'close', 'light dismiss', 'task window'] },
+
   // ── Notifications ──
   { id: 'notifications.onAgentIdle', tabId: 'notifications', label: 'Agent Idle', description: 'When an agent needs attention on a non-visible project', scope: 'global', keywords: ['desktop', 'toast', 'alert'] },
   { id: 'notifications.onPlanComplete', tabId: 'notifications', label: 'Plan Complete', description: 'When a plan finishes and the task auto-moves', scope: 'global', keywords: ['desktop', 'toast', 'alert'] },

--- a/src/renderer/components/settings/tabs/BehaviorTab.tsx
+++ b/src/renderer/components/settings/tabs/BehaviorTab.tsx
@@ -1,4 +1,4 @@
-import type { AppConfig } from '../../../../shared/types';
+import type { AppConfig, WindowLightDismiss } from '../../../../shared/types';
 import { SectionHeader, SettingRow, SettingToggleRow, Select, INPUT_CLASS, useScopedUpdate } from '../shared';
 import { settingProps } from '../settings-registry';
 
@@ -38,6 +38,19 @@ export function BehaviorTab({ globalConfig }: { globalConfig: AppConfig }) {
         checked={globalConfig.agent.autoResumeSessionsOnRestart}
         onChange={(value) => updateGlobal({ agent: { autoResumeSessionsOnRestart: value } })}
       />
+
+      <SectionHeader label="Task Windows" searchIds={['windowLightDismiss']} />
+      <SettingRow {...settingProps('windowLightDismiss')}>
+        <Select
+          value={globalConfig.windowLightDismiss}
+          onChange={(event) => updateGlobal({ windowLightDismiss: event.target.value as WindowLightDismiss })}
+        >
+          <option value="off">Off</option>
+          <option value="single">Single Window</option>
+          <option value="focused">Focused Window</option>
+          <option value="all">All Windows</option>
+        </Select>
+      </SettingRow>
     </>
   );
 }

--- a/src/renderer/window-manager/bridge/useClickOutsideToClose.ts
+++ b/src/renderer/window-manager/bridge/useClickOutsideToClose.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef } from 'react';
+import { useConfigStore } from '../../stores/config-store';
+import { useWindowStore } from '../store/window-store';
+import { resolveLightDismissTargets } from '../light-dismiss/resolve-targets';
+import { requestWindowClose } from '../store/window-close-registry';
+
+/** Pointer travel (px) above which a press is a drag, not a click, so a text
+ *  selection or board pan that releases on empty board never dismisses. Matches
+ *  DRAG_ACTIVATION_PX in dnd/useWindowDrag. */
+const CLEAN_CLICK_MAX_PX = 4;
+
+/** Real interactive controls on the board whose own click must win (the add-task
+ *  button, links, inputs). Deliberately NARROWER than TaskDetailWindow's
+ *  INTERACTIVE_SELECTOR: it omits `[role="button"]` because dnd-kit's useSortable
+ *  stamps `role="button"` on every swimlane column wrapper, so excluding it would
+ *  block the common click on a column's empty body, the very empty-board click
+ *  this feature exists for. Cards are excluded separately via `[data-task-id]`. */
+const BOARD_INTERACTIVE_SELECTOR = 'button, a, input, textarea, select, [contenteditable="true"]';
+
+interface PendingPress {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  /** A dismissable layer (menu / dropdown / modal dialog) was open when the press
+   *  began, so this click belongs to that layer, not the window underneath. */
+  dismissableLayerWasOpen: boolean;
+}
+
+/** True for a clean press on the empty board: within the board background region,
+ *  and not on a card, a window/popover, or an interactive control. */
+function isBoardBackgroundTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  if (target.closest('#window-layer-root')) return false; // a task-detail window frame (portaled popovers exclude themselves via the board-background gate + the layer guard)
+  if (target.closest('[data-task-id]')) return false; // a task card (opens/focuses itself)
+  if (target.closest(BOARD_INTERACTIVE_SELECTOR)) return false; // a real button / input on the board
+  return !!target.closest('[data-board-background]'); // within the board region
+}
+
+/**
+ * Click-outside (light-dismiss) for modeless task-detail windows. Mounted once in
+ * `WindowLayer`. A clean click on the empty board closes open windows per the
+ * user's `windowLightDismiss` policy, routed through each window's unsaved-edits
+ * guard (the close registry). The session/PTY is untouched: closing only releases
+ * the dialog-session claim, so the terminal returns to the bottom panel and
+ * reopening the task reattaches.
+ *
+ * Detection is a `document`-level pointerdown/pointerup pair, not a board-scoped
+ * React handler: cards `stopPropagation` only their synthetic click (not pointer
+ * events), windows live in a body portal, and ancestry classification is robust
+ * regardless. The "a layer was open" signal is read at pointerdown because a menu
+ * self-closes synchronously on its own capture-phase mousedown (React 19 flushes
+ * discrete events), so by pointerup it would already be gone.
+ */
+export function useClickOutsideToClose(): void {
+  const policy = useConfigStore((state) => state.config.windowLightDismiss);
+  const pendingRef = useRef<PendingPress | null>(null);
+
+  useEffect(() => {
+    if (policy === 'off') return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (event.button !== 0 || !isBoardBackgroundTarget(event.target)) {
+        pendingRef.current = null;
+        return;
+      }
+      pendingRef.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        dismissableLayerWasOpen: !!document.querySelector('[data-dismissable-layer]'),
+      };
+    };
+
+    const handlePointerUp = (event: PointerEvent) => {
+      const pending = pendingRef.current;
+      pendingRef.current = null;
+      if (!pending || event.pointerId !== pending.pointerId || pending.dismissableLayerWasOpen) return;
+      if (Math.abs(event.clientX - pending.startX) >= CLEAN_CLICK_MAX_PX) return;
+      if (Math.abs(event.clientY - pending.startY) >= CLEAN_CLICK_MAX_PX) return;
+      if (!isBoardBackgroundTarget(event.target)) return;
+
+      const { windows, focusedWindowId } = useWindowStore.getState();
+      for (const windowId of resolveLightDismissTargets(policy, windows, focusedWindowId)) {
+        requestWindowClose(windowId);
+      }
+    };
+
+    // A cancelled pointer (browser scroll / gesture takeover, capture loss) fires
+    // no pointerup, so clear any pending press to avoid a stale dismiss later.
+    const handlePointerCancel = () => { pendingRef.current = null; };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('pointerup', handlePointerUp);
+    document.addEventListener('pointercancel', handlePointerCancel);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('pointerup', handlePointerUp);
+      document.removeEventListener('pointercancel', handlePointerCancel);
+    };
+  }, [policy]);
+}

--- a/src/renderer/window-manager/components/TaskDetailWindow.tsx
+++ b/src/renderer/window-manager/components/TaskDetailWindow.tsx
@@ -42,6 +42,7 @@ import {
   useTaskActions,
 } from '../../components/dialogs/task-detail';
 import { useWindowStore } from '../store/window-store';
+import { registerWindowCloser, unregisterWindowCloser } from '../store/window-close-registry';
 import { classifySnapZone, nextSnap } from '../dnd/snap-zones';
 import type { SnapDirection } from '../dnd/snap-zones';
 import type { Task, ShortcutConfig } from '../../../shared/types';
@@ -362,6 +363,15 @@ export function TaskDetailWindow({
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [isFocused, closeWithGuard]);
+
+  // Expose this window's guarded close to the central click-outside dismiss hook
+  // (`useClickOutsideToClose`), so a board-background click routes through the
+  // same unsaved-edits guard as Escape and the X. Keyed on `closeWithGuard` so a
+  // re-memo re-registers the fresh closure; mirrors the Escape effect lifecycle.
+  useEffect(() => {
+    registerWindowCloser(windowId, closeWithGuard);
+    return () => unregisterWindowCloser(windowId);
+  }, [windowId, closeWithGuard]);
 
   const onTitleBarPointerDown = useCallback((event: React.PointerEvent) => {
     if (isInteractiveTarget(event)) return;

--- a/src/renderer/window-manager/components/WindowLayer.tsx
+++ b/src/renderer/window-manager/components/WindowLayer.tsx
@@ -25,6 +25,7 @@ import { useWindowSessionClaims } from '../bridge/useWindowSessionClaims';
 import { useWindowAutoCloseOnDone } from '../bridge/useWindowAutoCloseOnDone';
 import { useWindowFocusReconcile } from '../bridge/useWindowFocusReconcile';
 import { useWorkspacePersistence } from '../bridge/useWorkspacePersistence';
+import { useClickOutsideToClose } from '../bridge/useClickOutsideToClose';
 import type { ContainerSize } from '../store/geometry';
 import type { FractionalRect } from '../store/types';
 import { resolveTileLayout } from '../tiling/resolve-layout';
@@ -84,6 +85,9 @@ export function WindowLayer() {
   // Persist the layout (debounced) to the open project's config so it survives a
   // project switch + app restart. Restore is wired into the project-switch effect.
   useWorkspacePersistence();
+  // Light-dismiss: a clean click on the empty board closes open windows per the
+  // user's `windowLightDismiss` policy (off / single / focused / all).
+  useClickOutsideToClose();
 
   const [containerSize, setContainerSize] = useState<ContainerSize>({ width: 0, height: 0 });
   const windows = useWindowStore((state) => state.windows);

--- a/src/renderer/window-manager/light-dismiss/resolve-targets.ts
+++ b/src/renderer/window-manager/light-dismiss/resolve-targets.ts
@@ -1,0 +1,42 @@
+import type { WindowLightDismiss } from '../../../shared/types';
+import type { ManagedWindow } from '../store/types';
+
+/**
+ * Pure policy resolver for click-outside (light-dismiss). Given the dismiss
+ * policy and the current window set, return the ids of the windows a clean
+ * empty-board click should close. The detection hook (`useClickOutsideToClose`)
+ * owns the "was this a clean board-background click" decision; this function
+ * owns only the policy-to-targets mapping, so it stays a pure, total, easily
+ * unit-tested function.
+ *
+ *  - `off`     never closes anything.
+ *  - `single`  closes the window only when exactly one is open AND it is
+ *              `floating` (the peek case). A lone docked window is left alone:
+ *              there is no real "outside" to click, and closing it would still
+ *              surprise.
+ *  - `focused` closes the focused window, regardless of how many are open and
+ *              regardless of its state (the explicit aggressive choice).
+ *  - `all`     closes every open window, regardless of state.
+ */
+export function resolveLightDismissTargets(
+  policy: WindowLightDismiss,
+  windows: Record<string, ManagedWindow>,
+  focusedWindowId: string | null,
+): string[] {
+  const ids = Object.keys(windows);
+  switch (policy) {
+    case 'off':
+      return [];
+    case 'single': {
+      const onlyId = ids[0];
+      const only = onlyId ? windows[onlyId] : undefined;
+      return ids.length === 1 && only?.state === 'floating' ? [only.id] : [];
+    }
+    case 'focused':
+      return focusedWindowId && windows[focusedWindowId] ? [focusedWindowId] : [];
+    case 'all':
+      return ids;
+    default:
+      return [];
+  }
+}

--- a/src/renderer/window-manager/store/window-close-registry.ts
+++ b/src/renderer/window-manager/store/window-close-registry.ts
@@ -1,0 +1,28 @@
+/**
+ * A tiny imperative registry mapping a window id to its guarded close function
+ * (`closeWithGuard` from `TaskDetailWindow`). It lets a central, store-driven
+ * dismiss (the click-outside hook in `useClickOutsideToClose`) route a close
+ * back through the per-window unsaved-edits guard, which lives in component-local
+ * state the window store cannot see.
+ *
+ * The map is module scope so the hook can dispatch without subscribing to it (a
+ * close fn in reactive store state would re-render on every register). It is a
+ * `const` mutated in place; every `TaskDetailWindow` re-runs its register effect
+ * on (re)mount, so an HMR reload that re-evaluates this module with an empty map
+ * self-heals as the windows remount.
+ */
+// hmr-safe: re-populated by each TaskDetailWindow's register effect on remount
+const windowClosers = new Map<string, () => void>();
+
+export function registerWindowCloser(windowId: string, closeWithGuard: () => void): void {
+  windowClosers.set(windowId, closeWithGuard);
+}
+
+export function unregisterWindowCloser(windowId: string): void {
+  windowClosers.delete(windowId);
+}
+
+/** Invoke a window's registered guarded close, if one is registered. */
+export function requestWindowClose(windowId: string): void {
+  windowClosers.get(windowId)?.();
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1087,6 +1087,11 @@ export interface NotificationConfig {
   cooldownSeconds: number;
 }
 
+/** Click-outside (light-dismiss) policy for modeless task-detail windows. `off`
+ *  disables it; `single` closes only a lone floating window (the peek case);
+ *  `focused` closes the focused window in any state; `all` closes every window. */
+export type WindowLightDismiss = 'off' | 'single' | 'focused' | 'all';
+
 export interface AppConfig {
   theme: ThemeMode;
   sidebarVisible: boolean;
@@ -1223,6 +1228,8 @@ export interface AppConfig {
   skipDeleteConfirm: boolean;
   skipBoardConfigConfirm: boolean;
   autoFocusIdleSession: boolean;
+  /** Click-outside dismiss policy for modeless task-detail windows. Default `single`. */
+  windowLightDismiss: WindowLightDismiss;
   /** Task IDs that have already been offered an auto-rename suggestion. Persisted so a
    *  dismissed suggestion does not reappear on the next app launch. Drained on task
    *  delete (TASK_DELETE / TASK_BULK_DELETE handlers in `task-crud.ts`) so the array
@@ -1376,6 +1383,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   skipDeleteConfirm: false,
   skipBoardConfigConfirm: false,
   autoFocusIdleSession: false,
+  windowLightDismiss: 'single',
   autoNameAskedTaskIds: [],
   autoNameRateLimitPerHour: 60,
   restoreWindowPosition: true,

--- a/tests/e2e/window-light-dismiss-pty-survival.spec.ts
+++ b/tests/e2e/window-light-dismiss-pty-survival.spec.ts
@@ -1,0 +1,270 @@
+/**
+ * E2E test: click-outside (light-dismiss) does NOT kill the PTY session.
+ *
+ * When a task-detail window backed by a live PTY session is dismissed with a
+ * clean empty-board click, only the dialog-session claim is released. The
+ * underlying PTY keeps running; reopening the window reattaches the same
+ * session and the scrollback is still present.
+ *
+ * This test is at the E2E tier because it exercises the real PTY lifecycle
+ * (a real `node-pty` process spawned by the mock Claude CLI), real IPC, and
+ * the real Electron window manager. A unit test or headless UI test cannot
+ * prove this: both would use mock sessions with no real PTY.
+ *
+ * High-value invariant:
+ *   - Open a task-detail window backed by a running session.
+ *   - Light-dismiss the window (policy = 'single').
+ *   - The session remains 'running' in sessions.list() after the dismiss.
+ *   - Reopening the task reopens the window; the scrollback marker from the
+ *     original spawn is still present (session was not killed).
+ *
+ * The `resolveLightDismissTargets` resolver and the React-layer detection are
+ * unit/UI tested. This spec is ONLY concerned with "did the PTY die?" and
+ * "does reopening reattach?".
+ */
+import { test, expect } from '@playwright/test';
+import {
+  launchApp,
+  createProject,
+  createTask,
+  createTempProject,
+  cleanupTempProject,
+  getTestDataDir,
+  cleanupTestDataDir,
+  closeApp,
+  mockAgentPath,
+  getTaskIdByTitle,
+  moveTaskIpc,
+} from './helpers';
+import type { ElectronApplication, Page } from '@playwright/test';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const TEST_NAME = 'window-light-dismiss-pty-survival';
+const runId = Date.now();
+const PROJECT_NAME = `PTY Survival ${runId}`;
+
+// ---------------------------------------------------------------------------
+// Helpers shared across the single describe block
+// ---------------------------------------------------------------------------
+
+/** Pre-write config.json so the app uses the mock Claude CLI on startup. */
+function writeTestConfig(dataDir: string): void {
+  fs.writeFileSync(
+    path.join(dataDir, 'config.json'),
+    JSON.stringify({
+      claude: {
+        cliPath: mockAgentPath('claude'),
+        permissionMode: 'default',
+        maxConcurrentSessions: 5,
+        queueOverflow: 'queue',
+      },
+      git: {
+        worktreesEnabled: false,
+      },
+    }),
+  );
+}
+
+/** Get the swimlane ID by name (generic lookup - extends getSwimlaneIds which is
+ *  limited to planning+done). */
+async function getSwimlaneByName(page: Page, name: string): Promise<string> {
+  const swimlaneId = await page.evaluate(async (laneName) => {
+    const swimlanes: Array<{ id: string; name: string }> =
+      await window.electronAPI.swimlanes.list();
+    return swimlanes.find((swimlane) => swimlane.name === laneName)?.id ?? null;
+  }, name);
+  if (!swimlaneId) throw new Error(`Swimlane "${name}" not found`);
+  return swimlaneId;
+}
+
+/**
+ * Poll the scrollback of a SPECIFIC task's running session until the given
+ * marker appears. Keyed by taskId to avoid matching a different session's
+ * scrollback (anti-flake pattern 3 from the test-builder guide).
+ */
+async function waitForTaskScrollback(
+  page: Page,
+  taskId: string,
+  marker: string,
+  timeoutMs = 15000,
+): Promise<string> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const scrollback = await page.evaluate(async (tid) => {
+      const sessions: Array<{ id: string; taskId: string; status: string }> =
+        await window.electronAPI.sessions.list();
+      const session = sessions.find(
+        (sessionEntry) => sessionEntry.taskId === tid && sessionEntry.status === 'running',
+      );
+      if (!session) return '';
+      return window.electronAPI.sessions.getScrollback(session.id);
+    }, taskId);
+
+    if (scrollback.includes(marker)) return scrollback;
+
+    await page.waitForTimeout(400);
+  }
+  throw new Error(
+    `Timed out (${timeoutMs}ms) waiting for task ${taskId.slice(0, 8)} scrollback: ${marker}`,
+  );
+}
+
+/** Open a task-detail window by clicking the task's card on the board.
+ *  Waits until `[data-testid="task-detail-dialog"]` is visible. */
+async function openTaskWindow(page: Page, taskTitle: string): Promise<void> {
+  const card = page.locator(`text=${taskTitle}`).first();
+  await card.click();
+  await page
+    .locator('[data-testid="task-detail-dialog"]')
+    .first()
+    .waitFor({ state: 'visible', timeout: 5000 });
+}
+
+/**
+ * Dispatch a clean board-background click via `dispatchEvent`. Targets the
+ * board-background element directly so `event.target` is that element, not a
+ * dnd-kit swimlane wrapper with `role="button"` that would cause
+ * `isBoardBackgroundTarget` to return false.
+ *
+ * See the corresponding UI-tier spec (window-click-outside-close.spec.ts) for a
+ * full explanation of why `page.mouse` + viewport coordinates fails here.
+ */
+async function clickEmptyBoard(page: Page): Promise<void> {
+  await page.locator('[data-board-background]').waitFor({ state: 'visible', timeout: 5000 });
+  await page.evaluate(() => {
+    const boardBackground = document.querySelector('[data-board-background]');
+    if (!boardBackground) throw new Error('[data-board-background] not found');
+    const init: PointerEventInit = {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      buttons: 1,
+      pointerId: 1,
+      clientX: 300,
+      clientY: 600,
+    };
+    boardBackground.dispatchEvent(new PointerEvent('pointerdown', init));
+    boardBackground.dispatchEvent(new PointerEvent('pointerup', { ...init, buttons: 0 }));
+  });
+}
+
+/** Return the number of visible task-detail windows. */
+async function windowCount(page: Page): Promise<number> {
+  return page.locator('[data-testid="task-detail-dialog"]').count();
+}
+
+/** Set the `windowLightDismiss` policy via the config IPC (real Electron app). */
+async function setLightDismissPolicy(
+  page: Page,
+  policy: 'off' | 'single' | 'focused' | 'all',
+): Promise<void> {
+  await page.evaluate(async (pol) => {
+    await window.electronAPI.config.set({ windowLightDismiss: pol });
+  }, policy);
+}
+
+// ---------------------------------------------------------------------------
+// The test
+// ---------------------------------------------------------------------------
+
+test.describe('Window light-dismiss - PTY survival after dismiss and reopen', () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let tmpDir: string;
+  let dataDir: string;
+
+  test.beforeAll(async () => {
+    tmpDir = createTempProject(TEST_NAME);
+    dataDir = getTestDataDir(TEST_NAME);
+    writeTestConfig(dataDir);
+
+    const result = await launchApp({ dataDir });
+    app = result.app;
+    page = result.page;
+    await createProject(page, PROJECT_NAME, tmpDir);
+  });
+
+  test.afterAll(async () => {
+    await closeApp(app);
+    cleanupTempProject(TEST_NAME);
+    cleanupTestDataDir(TEST_NAME);
+  });
+
+  test('light-dismiss releases the dialog claim without killing the PTY; reopening reattaches', async () => {
+    // Allow extra time: session spawn (~5s) + scrollback wait (~5s) + reopen (~2s).
+    test.slow();
+
+    const taskTitle = `PTY Survival Task ${runId}`;
+    await createTask(page, taskTitle, 'Verify PTY is not killed by light-dismiss');
+
+    // Move the task into an auto-spawn column (Executing) to start a session.
+    const executingId = await getSwimlaneByName(page, 'Executing');
+    const taskId = await getTaskIdByTitle(page, taskTitle);
+    await moveTaskIpc(page, taskId, executingId);
+
+    // Wait for the real PTY session to start.
+    await expect
+      .poll(
+        async () => {
+          return page.evaluate(async (tid) => {
+            const sessions: Array<{ taskId: string; status: string }> =
+              await window.electronAPI.sessions.list();
+            return sessions.some(
+              (sessionEntry) => sessionEntry.taskId === tid && sessionEntry.status === 'running',
+            );
+          }, taskId);
+        },
+        { timeout: 15000, intervals: [300, 500] },
+      )
+      .toBe(true);
+
+    // Wait for the mock Claude CLI to print its SESSION marker in the scrollback.
+    // This confirms the PTY is fully running (not just 'running' in the DB).
+    const scrollbackBeforeDismiss = await waitForTaskScrollback(
+      page,
+      taskId,
+      'MOCK_CLAUDE_SESSION:',
+    );
+    expect(scrollbackBeforeDismiss).toContain('MOCK_CLAUDE_SESSION:');
+
+    // Set policy to 'single' so that one floating window is dismissed.
+    await setLightDismissPolicy(page, 'single');
+
+    // Open the task-detail window by clicking the card.
+    await openTaskWindow(page, taskTitle);
+    expect(await windowCount(page)).toBe(1);
+
+    // Light-dismiss: clean click on the empty board.
+    await clickEmptyBoard(page);
+
+    // The window should close.
+    await expect
+      .poll(() => windowCount(page), { timeout: 3000, intervals: [100, 200] })
+      .toBe(0);
+
+    // CRITICAL: the session must still be 'running'. The light-dismiss only
+    // releases the dialog-session claim; it must NOT suspend or kill the PTY.
+    const sessionStillRunning = await page.evaluate(async (tid) => {
+      const sessions: Array<{ taskId: string; status: string }> =
+        await window.electronAPI.sessions.list();
+      return sessions.some(
+        (sessionEntry) => sessionEntry.taskId === tid && sessionEntry.status === 'running',
+      );
+    }, taskId);
+    expect(sessionStillRunning).toBe(true);
+
+    // Reopen the window by clicking the card again.
+    await openTaskWindow(page, taskTitle);
+    expect(await windowCount(page)).toBe(1);
+
+    // The scrollback from the original spawn must still be present.
+    // This proves the window reattached to the EXISTING session (not a new spawn).
+    const scrollbackAfterReopen = await waitForTaskScrollback(
+      page,
+      taskId,
+      'MOCK_CLAUDE_SESSION:',
+    );
+    expect(scrollbackAfterReopen).toContain('MOCK_CLAUDE_SESSION:');
+  });
+});

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -114,6 +114,7 @@
     skipDeleteConfirm: false,
     skipBoardConfigConfirm: false,
     autoFocusIdleSession: false,
+    windowLightDismiss: 'single',
     autoNameAskedTaskIds: [],
     autoNameRateLimitPerHour: 60,
     restoreWindowPosition: true,

--- a/tests/ui/settings-panel.spec.ts
+++ b/tests/ui/settings-panel.spec.ts
@@ -79,6 +79,8 @@ test.describe('Settings Panel', () => {
     await expect(page.locator('text=When Max Sessions Reached')).toBeVisible();
     await expect(page.locator('text=Auto-Focus Idle Sessions')).toBeVisible();
     await expect(page.locator('text=Auto-Resume Agents on Restart')).toBeVisible();
+    // Task Windows section: close-on-outside-click policy (light-dismiss).
+    await expect(page.locator('text=Close on Outside Click')).toBeVisible();
     await closeSettings();
   });
 

--- a/tests/ui/window-click-outside-close.spec.ts
+++ b/tests/ui/window-click-outside-close.spec.ts
@@ -1,0 +1,539 @@
+/**
+ * UI tests for the click-outside (light-dismiss) feature for modeless
+ * task-detail windows.
+ *
+ * The feature (`useClickOutsideToClose`, mounted once in `WindowLayer`) listens
+ * for a "clean click" on the empty board background - a pointerdown + pointerup
+ * pair whose target satisfies `[data-board-background]`, with no > 4px pointer
+ * travel, no card ancestry, no window/popover ancestry, and no dismissable-layer
+ * open at pointerdown - and then closes windows per the `windowLightDismiss`
+ * policy. Closing routes through each window's unsaved-edits guard
+ * (`closeWithGuard`) without touching the underlying PTY/session.
+ *
+ * Policy values:
+ *  - `off`      never dismisses
+ *  - `single`   dismisses the sole window only when it is `floating` (default)
+ *  - `focused`  dismisses the focused window regardless of how many are open
+ *  - `all`      dismisses every open window
+ *
+ * These tests prove the count-based and detection-based behaviour of the hook.
+ * The pure policy resolver (`resolveLightDismissTargets`) is already exhaustively
+ * unit-tested in `tests/unit/light-dismiss-resolve-targets.test.ts`; we do not
+ * re-test state permutations here.
+ *
+ * Setup mirrors `tests/ui/window-auto-close-on-done.spec.ts`: each describe
+ * block owns its browser/page (no shared state across blocks), and each test
+ * opens windows from a known initial state.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+// ---------------------------------------------------------------------------
+// Shared project / task / session ids (unique per spec run to prevent
+// collisions when multiple UI workers share the Vite server).
+// ---------------------------------------------------------------------------
+const RUN_SUFFIX = Math.random().toString(36).slice(2, 8);
+
+const PROJECT_ID = `proj-light-dismiss-${RUN_SUFFIX}`;
+
+// Task A: has a running session -> opens in VIEW mode (non-edit).
+const TASK_A_ID = `task-ld-a-${RUN_SUFFIX}`;
+const SESSION_A_ID = `sess-ld-a-${RUN_SUFFIX}`;
+
+// Task B: second running task -> second window.
+const TASK_B_ID = `task-ld-b-${RUN_SUFFIX}`;
+const SESSION_B_ID = `sess-ld-b-${RUN_SUFFIX}`;
+
+// Task C: To Do with NO session -> opens in EDIT mode (title input visible).
+const TASK_C_ID = `task-ld-c-${RUN_SUFFIX}`;
+
+/** Build the addInitScript that seeds the mock with project + lanes + tasks. */
+function buildPreConfig(): string {
+  return `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+
+      state.projects.push({
+        id: '${PROJECT_ID}',
+        name: 'Light Dismiss Test',
+        path: '/mock/light-dismiss-test',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+
+      var laneIds = {};
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        var id = 'lane-ld-' + s.name.toLowerCase().replace(/\\s+/g, '-');
+        laneIds[s.name] = id;
+        state.swimlanes.push(Object.assign({}, s, {
+          id: id, position: i, created_at: ts,
+        }));
+      });
+
+      // Expose lane ids so tests can look up 'To Do', 'Executing', etc.
+      window.__ldLaneIds = laneIds;
+
+      // Task A - in Executing, has a running session -> VIEW mode window.
+      state.sessions.push({
+        id: '${SESSION_A_ID}',
+        taskId: '${TASK_A_ID}',
+        projectId: '${PROJECT_ID}',
+        pid: 1001,
+        status: 'running',
+        shell: 'bash',
+        cwd: '/mock/light-dismiss-test',
+        startedAt: ts,
+        exitCode: null,
+      });
+      state.tasks.push({
+        id: '${TASK_A_ID}',
+        display_id: 1,
+        title: 'Task Alpha',
+        description: 'First task for light-dismiss tests',
+        swimlane_id: laneIds['Executing'],
+        position: 0,
+        agent: 'claude',
+        session_id: '${SESSION_A_ID}',
+        worktree_path: null,
+        branch_name: null,
+        pr_number: null,
+        pr_url: null,
+        base_branch: null,
+        archived_at: null,
+        created_at: ts,
+        updated_at: ts,
+      });
+
+      // Task B - in Code Review, has a running session -> VIEW mode window.
+      state.sessions.push({
+        id: '${SESSION_B_ID}',
+        taskId: '${TASK_B_ID}',
+        projectId: '${PROJECT_ID}',
+        pid: 1002,
+        status: 'running',
+        shell: 'bash',
+        cwd: '/mock/light-dismiss-test',
+        startedAt: ts,
+        exitCode: null,
+      });
+      state.tasks.push({
+        id: '${TASK_B_ID}',
+        display_id: 2,
+        title: 'Task Beta',
+        description: 'Second task for light-dismiss tests',
+        swimlane_id: laneIds['Code Review'],
+        position: 0,
+        agent: 'claude',
+        session_id: '${SESSION_B_ID}',
+        worktree_path: null,
+        branch_name: null,
+        pr_number: null,
+        pr_url: null,
+        base_branch: null,
+        archived_at: null,
+        created_at: ts,
+        updated_at: ts,
+      });
+
+      // Task C - in To Do, NO session -> clicking card opens in EDIT mode.
+      state.tasks.push({
+        id: '${TASK_C_ID}',
+        display_id: 3,
+        title: 'Task Gamma',
+        description: 'Third task - To Do, no session, opens in edit mode',
+        swimlane_id: laneIds['To Do'],
+        position: 0,
+        agent: null,
+        session_id: null,
+        worktree_path: null,
+        branch_name: null,
+        pr_number: null,
+        pr_url: null,
+        base_branch: null,
+        archived_at: null,
+        created_at: ts,
+        updated_at: ts,
+      });
+
+      return { currentProjectId: '${PROJECT_ID}' };
+    });
+  `;
+}
+
+/** Launch a fresh headless page with the mock and pre-config seeded. */
+async function launchWithState(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(buildPreConfig());
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+  return { browser, page };
+}
+
+/** Open the task-detail window for a task by clicking its card.
+ *  Waits for the dialog to mount before returning. */
+async function openWindow(page: Page, taskTitle: string): Promise<void> {
+  // Use a broad text locator so we don't depend on a specific swimlane ordering.
+  const card = page.locator(`text=${taskTitle}`).first();
+  await card.click();
+  // Wait for the window to mount so the window-store is populated.
+  const dialog = page.locator('[data-testid="task-detail-dialog"]');
+  await dialog.first().waitFor({ state: 'visible', timeout: 5000 });
+}
+
+/** Close ALL open task-detail windows via Ctrl+Shift+W hotkey so subsequent
+ *  tests start from a clean zero-window state. */
+async function closeAllWindows(page: Page): Promise<void> {
+  // Keep pressing the close-window hotkey until no dialogs are visible.
+  for (let iteration = 0; iteration < 10; iteration++) {
+    const count = await page.locator('[data-testid="task-detail-dialog"]').count();
+    if (count === 0) break;
+    await page.keyboard.press('Control+Shift+W');
+    // Wait a tick for the close animation to settle before checking again.
+    await page.locator('[data-testid="task-detail-dialog"]').first().waitFor({
+      state: 'hidden',
+      timeout: 2000,
+    }).catch(() => { /* count may have already hit 0 */ });
+  }
+}
+
+/** Set the `windowLightDismiss` policy via the config store. */
+async function setPolicy(
+  page: Page,
+  policy: 'off' | 'single' | 'focused' | 'all',
+): Promise<void> {
+  await page.evaluate((pol) => {
+    const stores = (window as unknown as {
+      __zustandStores?: { config: { getState: () => { updateConfig: (patch: Record<string, unknown>) => void } } };
+    }).__zustandStores;
+    stores?.config.getState().updateConfig({ windowLightDismiss: pol });
+  }, policy);
+}
+
+/**
+ * Dispatch a "clean click" onto a swimlane COLUMN body via `dispatchEvent`. This is
+ * the realistic empty-board target: the columns fill the board, so a real user
+ * clicking "empty board" almost always lands on a column body, NOT the thin padding.
+ *
+ * The column wrapper carries dnd-kit's injected `role="button"` (useSortable
+ * `{...attributes}`). `isBoardBackgroundTarget` must still treat a column body as
+ * background: it sits inside `[data-board-background]`, is not a card
+ * (`[data-task-id]`) or window (`#window-layer-root`), and is NOT a real `<button>`.
+ * The hook's board selector deliberately omits `role="button"` precisely so this
+ * common click dismisses - targeting the column here locks that in (re-adding
+ * `role="button"` to the selector turns every occurrence test red).
+ *
+ * Dispatching on the element (rather than `page.mouse` at viewport coordinates)
+ * makes `event.target` deterministic - no dependence on viewport width, column
+ * count, or window position. The hook listens at `document` level, so a dispatched
+ * event that bubbles reaches it. pointerdown + pointerup share a pointerId and
+ * identical clientX/Y (0px travel < the 4px clean-click radius).
+ */
+async function clickEmptyBoard(page: Page): Promise<void> {
+  await page.locator('[data-board-background] [data-swimlane-name]').first().waitFor({ state: 'visible', timeout: 3000 });
+  await page.evaluate(() => {
+    // First column body inside the board background. It has a `role="button"`
+    // sortable-wrapper ancestor (dnd-kit), which is exactly the real-world case.
+    const column = document.querySelector('[data-board-background] [data-swimlane-name]');
+    if (!column) throw new Error('no [data-swimlane-name] column found inside [data-board-background]');
+    const init: PointerEventInit = {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      buttons: 1,
+      pointerId: 1,
+      clientX: 200,
+      clientY: 700,
+    };
+    column.dispatchEvent(new PointerEvent('pointerdown', init));
+    column.dispatchEvent(new PointerEvent('pointerup', { ...init, buttons: 0 }));
+  });
+}
+
+/** Assert that the count of open task-detail windows eventually reaches `expected`.
+ *  Uses expect.poll so it handles async React state updates without fixed waits. */
+async function pollWindowCount(page: Page, expected: number, timeoutMs = 3000): Promise<void> {
+  await expect
+    .poll(
+      () => page.locator('[data-testid="task-detail-dialog"]').count(),
+      { timeout: timeoutMs, intervals: [100, 150, 200, 300] },
+    )
+    .toBe(expected);
+}
+
+// ---------------------------------------------------------------------------
+// Test suite: policies and core detection behaviour
+// ---------------------------------------------------------------------------
+test.describe('window light-dismiss (click-outside-to-close)', () => {
+  let browser: Browser;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    const result = await launchWithState();
+    browser = result.browser;
+    page = result.page;
+    await page.locator('[data-swimlane-name="Executing"]').waitFor({ state: 'visible', timeout: 10000 });
+  });
+
+  test.afterAll(async () => {
+    await browser?.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // Policy: `single` (default)
+  // -------------------------------------------------------------------------
+
+  test('single: one floating window is closed by a clean empty-board click', async () => {
+    await closeAllWindows(page);
+    await setPolicy(page, 'single');
+
+    await openWindow(page, 'Task Alpha');
+    await pollWindowCount(page, 1);
+
+    await clickEmptyBoard(page);
+    await pollWindowCount(page, 0);
+  });
+
+  test('single: two windows open - empty-board click closes NOTHING', async () => {
+    await closeAllWindows(page);
+    await setPolicy(page, 'single');
+
+    await openWindow(page, 'Task Alpha');
+    await pollWindowCount(page, 1);
+    await openWindow(page, 'Task Beta');
+    await pollWindowCount(page, 2);
+
+    await clickEmptyBoard(page);
+
+    // With two windows open, `single` policy returns an empty target list.
+    // Give any latent close a budget, then assert the count is unchanged.
+    // Intentional fixed wait - we cannot poll for non-occurrence.
+    await page.waitForTimeout(600);
+    await pollWindowCount(page, 2);
+  });
+
+  // -------------------------------------------------------------------------
+  // Policy: `off`
+  // -------------------------------------------------------------------------
+
+  test('off: one window open - empty-board click does nothing', async () => {
+    await closeAllWindows(page);
+    await setPolicy(page, 'off');
+
+    await openWindow(page, 'Task Alpha');
+    await pollWindowCount(page, 1);
+
+    await clickEmptyBoard(page);
+
+    // Intentional fixed wait - cannot poll for non-occurrence.
+    await page.waitForTimeout(600);
+    await pollWindowCount(page, 1);
+
+    // Restore to default so later tests are unaffected.
+    await setPolicy(page, 'single');
+  });
+
+  // -------------------------------------------------------------------------
+  // Policy: `focused`
+  // -------------------------------------------------------------------------
+
+  test('focused: two windows open - empty-board click closes the focused one (count 2 -> 1)', async () => {
+    await closeAllWindows(page);
+    await setPolicy(page, 'focused');
+
+    await openWindow(page, 'Task Alpha');
+    await pollWindowCount(page, 1);
+    await openWindow(page, 'Task Beta');
+    await pollWindowCount(page, 2);
+
+    // Task Beta's window was opened last, so it is focused.
+    await clickEmptyBoard(page);
+    // One window should close; the other stays.
+    await pollWindowCount(page, 1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Policy: `all`
+  // -------------------------------------------------------------------------
+
+  test('all: two windows open - empty-board click closes all (count -> 0)', async () => {
+    await closeAllWindows(page);
+    await setPolicy(page, 'all');
+
+    await openWindow(page, 'Task Alpha');
+    await pollWindowCount(page, 1);
+    await openWindow(page, 'Task Beta');
+    await pollWindowCount(page, 2);
+
+    await clickEmptyBoard(page);
+    await pollWindowCount(page, 0);
+
+    await setPolicy(page, 'single');
+  });
+
+  // -------------------------------------------------------------------------
+  // Detection: clicking a card never dismisses
+  // -------------------------------------------------------------------------
+
+  test('clicking a CARD opens a second window and does NOT dismiss the first', async () => {
+    await closeAllWindows(page);
+    await setPolicy(page, 'single');
+
+    // Open window A.
+    await openWindow(page, 'Task Alpha');
+    await pollWindowCount(page, 1);
+
+    // Now click Task Beta's card. The click target is [data-task-id], which the
+    // hook's `isBoardBackgroundTarget` guard rejects - so it is never a dismiss.
+    const betaCard = page.locator('[data-swimlane-name="Code Review"]').locator('text=Task Beta').first();
+    await betaCard.click();
+
+    // A second window opens; the first stays open.
+    await pollWindowCount(page, 2);
+  });
+
+  // -------------------------------------------------------------------------
+  // Detection: dismissable-layer guard (right-click context menu)
+  // -------------------------------------------------------------------------
+
+  test('layer guard: right-click opens TaskContextMenu; empty-board click dismisses menu but NOT the window', async () => {
+    await closeAllWindows(page);
+    await setPolicy(page, 'single');
+
+    await openWindow(page, 'Task Alpha');
+    await pollWindowCount(page, 1);
+
+    // Right-click Task Beta's card to open the TaskContextMenu.
+    // TaskContextMenu has `data-dismissable-layer` on its root div.
+    const betaCard = page.locator('[data-swimlane-name="Code Review"]').locator('text=Task Beta').first();
+    await betaCard.click({ button: 'right' });
+
+    // The context menu should be visible (carries data-dismissable-layer).
+    const contextMenu = page.locator('[data-testid="context-edit-task"]');
+    await contextMenu.waitFor({ state: 'visible', timeout: 3000 });
+
+    // At pointerdown on empty board the hook records layerOpenAtDown = true
+    // (the context menu is visible), so the hook skips the dismiss.
+    // The context menu self-closes via its own capture-phase `mousedown` listener
+    // (see TaskContextMenu.tsx - it listens for `mousedown`, not `pointerdown`).
+    // We dispatch pointerdown (caught by the light-dismiss hook) AND mousedown
+    // (caught by the context-menu close handler) on the board-background element.
+    await page.evaluate(() => {
+      const boardBackground = document.querySelector('[data-board-background]');
+      if (!boardBackground) throw new Error('[data-board-background] not found');
+      const pointerInit: PointerEventInit = {
+        bubbles: true, cancelable: true, button: 0, buttons: 1,
+        pointerId: 1, clientX: 200, clientY: 700,
+      };
+      const mouseInit: MouseEventInit = {
+        bubbles: true, cancelable: true, button: 0, buttons: 1,
+        clientX: 200, clientY: 700,
+      };
+      // pointerdown is captured by the light-dismiss hook.
+      boardBackground.dispatchEvent(new PointerEvent('pointerdown', pointerInit));
+      // mousedown is captured by TaskContextMenu's outside-click handler (capture=true).
+      boardBackground.dispatchEvent(new MouseEvent('mousedown', mouseInit));
+      // pointerup completes the pointer pair for the hook.
+      boardBackground.dispatchEvent(new PointerEvent('pointerup', { ...pointerInit, buttons: 0 }));
+    });
+
+    // The context menu should be gone (self-closed by mousedown outside it).
+    await contextMenu.waitFor({ state: 'hidden', timeout: 3000 });
+
+    // The task-detail window must still be open (the layer guard skipped it).
+    // Intentional fixed wait - cannot poll for non-occurrence.
+    await page.waitForTimeout(400);
+    await pollWindowCount(page, 1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Detection: drag-release is NOT treated as a clean click
+  // -------------------------------------------------------------------------
+
+  test('drag-release on empty board (> 4px) does NOT dismiss the window', async () => {
+    await closeAllWindows(page);
+    await setPolicy(page, 'single');
+
+    await openWindow(page, 'Task Alpha');
+    await pollWindowCount(page, 1);
+
+    // Simulate a drag that starts and ends on the empty board background.
+    // Dispatch directly on board-background (same reason as clickEmptyBoard) so
+    // `event.target` is board-background itself, bypassing the dnd-kit role="button"
+    // wrapper on swimlane columns. Pointerdown at (200, 700), pointerup at (210, 700)
+    // = 10px travel, which exceeds CLEAN_CLICK_MAX_PX (4) and must be ignored.
+    await page.evaluate(() => {
+      const boardBackground = document.querySelector('[data-board-background]');
+      if (!boardBackground) throw new Error('[data-board-background] not found');
+      const downInit: PointerEventInit = {
+        bubbles: true, cancelable: true, button: 0, buttons: 1,
+        pointerId: 1, clientX: 200, clientY: 700,
+      };
+      const upInit: PointerEventInit = {
+        bubbles: true, cancelable: true, button: 0, buttons: 0,
+        pointerId: 1, clientX: 210, clientY: 700,
+      };
+      boardBackground.dispatchEvent(new PointerEvent('pointerdown', downInit));
+      boardBackground.dispatchEvent(new PointerEvent('pointerup', upInit));
+    });
+
+    // Intentional fixed wait - cannot poll for non-occurrence.
+    await page.waitForTimeout(400);
+    await pollWindowCount(page, 1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Unsaved-edits guard (closes via closeWithGuard -> ConfirmDialog instead of
+  // silently, when the edit form is dirty)
+  // -------------------------------------------------------------------------
+
+  test('unsaved-edits guard: dirty edit form triggers ConfirmDialog instead of silently closing', async () => {
+    await closeAllWindows(page);
+    await setPolicy(page, 'single');
+
+    // Task Gamma is in To Do with no session -> opens in EDIT mode.
+    await openWindow(page, 'Task Gamma');
+    await pollWindowCount(page, 1);
+
+    // A To Do task in edit mode shows a title input.
+    const titleInput = page.locator('input[placeholder="Task title"]');
+    await titleInput.waitFor({ state: 'visible', timeout: 3000 });
+
+    // Make the form dirty by typing into the title field.
+    await titleInput.fill('Task Gamma (modified)');
+
+    // Click the empty board. The policy (`single`) selects this window.
+    // `closeWithGuard` sees the dirty form and shows ConfirmDialog instead of closing.
+    await clickEmptyBoard(page);
+
+    // The "Discard unsaved changes?" confirm dialog must appear.
+    const confirmHeading = page.locator('h3:has-text("Discard unsaved changes?")');
+    await confirmHeading.waitFor({ state: 'visible', timeout: 3000 });
+
+    // The task-detail window is still mounted behind the confirm dialog.
+    await pollWindowCount(page, 1);
+
+    // Dismiss the confirm so we leave a clean state.
+    await page.locator('button:has-text("Keep editing")').click();
+    await confirmHeading.waitFor({ state: 'hidden', timeout: 2000 });
+
+    // Close via Ctrl+Shift+W (this will trigger confirm again), then Discard.
+    await page.keyboard.press('Escape');
+    await confirmHeading.waitFor({ state: 'visible', timeout: 2000 });
+    await page.locator('button:has-text("Discard")').click();
+    await pollWindowCount(page, 0);
+  });
+});

--- a/tests/unit/light-dismiss-resolve-targets.test.ts
+++ b/tests/unit/light-dismiss-resolve-targets.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLightDismissTargets } from '../../src/renderer/window-manager/light-dismiss/resolve-targets';
+import type { ManagedWindow, WindowState } from '../../src/renderer/window-manager/store/types';
+
+function makeWindow(id: string, state: WindowState): ManagedWindow {
+  return {
+    id,
+    taskId: `task-${id}`,
+    sessionId: `session-${id}`,
+    geometry: { x: 0.1, y: 0.1, w: 0.4, h: 0.4 },
+    state,
+    zIndex: 1,
+    leafId: state === 'tiled' ? `leaf-${id}` : null,
+    sessionStatus: 'live',
+    restoreGeometry: null,
+    title: `Window ${id}`,
+  };
+}
+
+function windowSet(...entries: Array<[string, WindowState]>): Record<string, ManagedWindow> {
+  const record: Record<string, ManagedWindow> = {};
+  for (const [id, state] of entries) record[id] = makeWindow(id, state);
+  return record;
+}
+
+const ALL_STATES: WindowState[] = ['floating', 'snapped', 'tiled', 'maximized'];
+
+describe('resolveLightDismissTargets', () => {
+  describe('off', () => {
+    it('never returns a target, no matter the window set', () => {
+      expect(resolveLightDismissTargets('off', {}, null)).toEqual([]);
+      expect(resolveLightDismissTargets('off', windowSet(['a', 'floating']), 'a')).toEqual([]);
+      expect(
+        resolveLightDismissTargets('off', windowSet(['a', 'floating'], ['b', 'tiled']), 'a'),
+      ).toEqual([]);
+    });
+  });
+
+  describe('single', () => {
+    it('closes the only window when it is floating', () => {
+      expect(resolveLightDismissTargets('single', windowSet(['a', 'floating']), 'a')).toEqual(['a']);
+    });
+
+    it('does not close a lone window that is docked (snapped/tiled/maximized)', () => {
+      for (const state of ['snapped', 'tiled', 'maximized'] as WindowState[]) {
+        expect(resolveLightDismissTargets('single', windowSet(['a', state]), 'a')).toEqual([]);
+      }
+    });
+
+    it('does not close anything when zero windows are open', () => {
+      expect(resolveLightDismissTargets('single', {}, null)).toEqual([]);
+    });
+
+    it('does not close anything when more than one window is open', () => {
+      expect(
+        resolveLightDismissTargets('single', windowSet(['a', 'floating'], ['b', 'floating']), 'a'),
+      ).toEqual([]);
+    });
+  });
+
+  describe('focused', () => {
+    it('closes the focused window in any state', () => {
+      for (const state of ALL_STATES) {
+        expect(resolveLightDismissTargets('focused', windowSet(['a', state]), 'a')).toEqual(['a']);
+      }
+    });
+
+    it('closes only the focused window when several are open', () => {
+      const windows = windowSet(['a', 'floating'], ['b', 'tiled'], ['c', 'snapped']);
+      expect(resolveLightDismissTargets('focused', windows, 'b')).toEqual(['b']);
+    });
+
+    it('returns nothing when there is no focused window', () => {
+      expect(resolveLightDismissTargets('focused', windowSet(['a', 'floating']), null)).toEqual([]);
+    });
+
+    it('returns nothing when the focused id is stale (no matching window)', () => {
+      expect(
+        resolveLightDismissTargets('focused', windowSet(['a', 'floating']), 'gone'),
+      ).toEqual([]);
+    });
+  });
+
+  describe('all', () => {
+    it('returns every window id regardless of state', () => {
+      const windows = windowSet(['a', 'floating'], ['b', 'tiled'], ['c', 'snapped'], ['d', 'maximized']);
+      expect(resolveLightDismissTargets('all', windows, 'a').sort()).toEqual(['a', 'b', 'c', 'd']);
+    });
+
+    it('returns nothing when no windows are open', () => {
+      expect(resolveLightDismissTargets('all', {}, null)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an optional "click outside to close" (light-dismiss) policy for the modeless task-detail windows (#30 / #246), restoring the muscle memory of the Command Terminal overlay. A clean click on the empty board closes open windows per a new shared/global setting in Settings > Behavior > Task Windows ("Close on Outside Click").

## Impact / behavior

New global setting `windowLightDismiss` (default `single`):

- **Off** - windows persist until closed explicitly (the modeless baseline).
- **Single Window** (default) - closes the window only when exactly one floating window is open (the peek case).
- **Focused Window** - any empty-board click closes the focused window, in any state.
- **All Windows** - any empty-board click closes every open window, in any state.

Details:

- Closes route through each window's existing unsaved-edits guard (`closeWithGuard`), so a dirty task-edit form still prompts to discard. The PTY/session is never killed: closing only releases the dialog-session claim, so the terminal returns to the bottom panel and reopening the task reattaches.
- Detection is a clean pointerdown + pointerup pair on the board background. It ignores drag-release (> 4px travel), non-primary buttons, clicks on cards, clicks on windows, and clicks on real controls.
- An open menu, dropdown, command palette, or modal dialog absorbs the outside click first (dismissable-layer precedence via a `data-dismissable-layer` marker).
- The board interactive-target exclusion deliberately omits `role="button"`, because dnd-kit stamps it on every swimlane column; reusing the window drag selector would have blocked the common click on a column body.

## Test plan

CI checks (lint, typecheck, unit, build, the UI shards, and the Linux Electron E2E shards), plus:

- `tests/unit/light-dismiss-resolve-targets.test.ts` - the pure policy resolver across all 4 policies x window states.
- `tests/ui/window-click-outside-close.spec.ts` - policy variants, card/window/menu precedence, drag-release, and the unsaved-edits guard (the click target is a real swimlane column, locking the board-selector behavior).
- `tests/ui/settings-panel.spec.ts` - asserts the new setting renders in the Behavior tab.
- `tests/e2e/window-light-dismiss-pty-survival.spec.ts` - the PTY stays running across a dismiss and reopening reattaches the session.

Generated with [Claude Code](https://claude.com/claude-code)
