### PR TITLE
docs: align contributing guidelines with the real workflow

### DIFF
--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -194,10 +194,15 @@ fails because someone else pushed to the branch, report it and stop - never bare
 1. **Determine PR title:** the first line of the most recent commit. If there are several commits
    since the source branch, combine them into one concise title.
 2. **Determine PR body:** write a rich, reviewer-facing body and save it to `.kangentic/PR_BODY.tmp`
-   with the Write tool (avoids shell escaping). Include:
-   - `## Summary` - what changed and why.
-   - `## Impact / behavior` - user-visible behavior, features, and bug fixes.
-   - `## Test plan` - how it is verified (the CI checks plus any tests added in Step 3.5).
+   with the Write tool (avoids shell escaping). Mirror the section order of
+   `.github/pull_request_template.md` so skill-created PRs match UI-created ones:
+   - `## What` - what changed and the affected components.
+   - `## Why` - the motivation or problem. Link any related issue with a closing keyword
+     (e.g. `Closes #123`).
+   - `## How` - the approach and any trade-offs worth a reviewer's attention.
+   - `## Breaking changes` - any API, config, or behavioral change that requires user action, with
+     migration notes; otherwise `None`.
+   - `## Tests` - how it is verified (the CI checks plus any tests added in Step 3.5).
    - Footer: `Generated with [Claude Code](https://claude.com/claude-code)`
 3. Run: `gh pr create --base <sourceBranch> --head <branch> --title "<title>" --body-file .kangentic/PR_BODY.tmp`
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,11 @@ See CONTRIBUTING.md for conventions, the CI gate, and what to expect.
 
 <!-- The approach. Call out anything reviewers should look at closely or any trade-offs. -->
 
+## Breaking changes
+
+<!-- Any API, config, or behavioral changes that require user action? If yes, use a `!` in your
+commit type (e.g. feat!:) and describe the migration. If none, write "None". -->
+
 ## Tests
 
 <!-- How you verified this: tests added/updated and what you ran locally. Screenshot or clip for UI changes. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+<!--
+Thanks for contributing to Kangentic! Please fill out the sections below.
+See CONTRIBUTING.md for conventions, the CI gate, and what to expect.
+-->
+
+## What
+
+<!-- What does this PR change? A short summary. -->
+
+## Why
+
+<!-- The problem this solves or the motivation. Link any related issue (e.g. Closes #123). -->
+
+## How
+
+<!-- The approach. Call out anything reviewers should look at closely or any trade-offs. -->
+
+## Tests
+
+<!-- How you verified this: tests added/updated and what you ran locally. Screenshot or clip for UI changes. -->
+
+## Checklist
+
+- [ ] PR title follows Conventional Commits (`type(scope): subject`)
+- [ ] No em-dashes or `--` used as punctuation
+- [ ] Tests added or updated for this change
+- [ ] Docs updated if anchor source changed (types, IPC channels, migrations, adapters, settings)
+- [ ] Ran `npm run lint`, `npm run typecheck`, and the relevant tests locally
+- [ ] Screenshot or clip included (UI changes)
+- [ ] CLA signed (or will sign on first PR)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,13 @@ The CLA is modeled after the [Apache Individual Contributor License Agreement](h
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) 20+
+- [Node.js](https://nodejs.org/) 22+ (building from source; CI runs on Node 22)
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and on PATH
-- Git
+- Git 2.25+
+
+Native modules (`better-sqlite3`) are compiled on install, so you also need a C/C++ toolchain:
+Visual Studio Build Tools on Windows, Xcode Command Line Tools on macOS, or `build-essential` and
+`python3` on Linux. See [docs/developer-guide.md](docs/developer-guide.md) for the full setup.
 
 ### Setup
 
@@ -35,20 +39,29 @@ The CLA is modeled after the [Apache Individual Contributor License Agreement](h
 git clone https://github.com/Kangentic/kangentic.git
 cd kangentic
 npm install
-npm run dev
+npm start
 ```
+
+### Where the conventions live
+
+The authoritative conventions for this codebase are [CLAUDE.md](CLAUDE.md) and the focused rule files
+in [.claude/rules/](.claude/rules/). Each rule names how it is enforced (a CI test, an ESLint rule,
+or code review). The sections below distill the human-relevant subset so you do not have to read all
+of them before your first PR, but those files are the source of truth if anything here is ambiguous.
 
 ### Project Structure
 
 ```
 src/
   main/           # Electron main process
+  preload/        # Context bridge (preload.ts)
   renderer/       # React UI (React 19, Zustand, Tailwind CSS 4)
   shared/         # Types and IPC channel constants
 tests/
-  ui/             # Headless Playwright tests (fast, no Electron)
+  unit/           # Vitest unit tests (fast, pure logic)
+  ui/             # Headless Playwright tests (no Electron)
   e2e/            # Real Electron tests (opens windows)
-  unit/           # Vitest unit tests
+docs/             # Architecture, developer guide, subsystem docs
 ```
 
 ## Making Changes
@@ -60,50 +73,111 @@ Use descriptive branch names:
 - `feature/multi-agent-support`
 - `docs/update-architecture`
 
-### Code Style
+### Conventions
 
-- TypeScript strict mode
-- No `any` types -- use proper types from `src/shared/types.ts`, `unknown` with type guards, or generic constraints
-- No shorthand variable names -- use `currentIndex` not `curIdx`, `previousValue` not `prev`
-- Icons use Lucide React -- no inline SVGs
-- Use `data-testid` attributes for test selectors
+These are the conventions that most often need a maintainer follow-up when missed. Each notes how it
+is enforced. The full set lives in [.claude/rules/](.claude/rules/).
+
+- **Text formatting.** No em-dashes (U+2014) and no `--` used as punctuation in anything you author
+  (code, comments, tests, docs, commit messages). Use a single dash for inline separators or
+  restructure with a period. Em-dashes render as garbled characters on Windows consoles.
+  (Enforced by a CI unit test plus review.)
+- **TypeScript style.** Strict mode, no `any` types (use proper types from `src/shared/types.ts`,
+  `unknown` with type guards, or generics), and full descriptive names (`currentIndex` not `curIdx`,
+  `session` not `sess`). (Enforced by ESLint `no-explicit-any` and `tsc`; names by review.)
+- **UI conventions.** Use the shared primitives (`Select`, not a raw `<select>`; `CountBadge`;
+  `ConfirmDialog`) and Lucide React icons (no inline SVGs). Respect the font floor (default
+  `text-xs`, never below `text-[11px]`). Avoid hover-only controls. Use theme-adaptive semantic
+  tokens, not hardcoded colors, so the UI re-colors across all themes. Prefer visual subtraction
+  over addition. Add `data-testid` attributes for test selectors. (Enforced by review.)
+- **Cross-platform parity.** Code and tests must behave identically on Windows, macOS, and Linux.
+  No hardcoded OS paths (use `path.join` and runtime-derived directories), pass `{ force: true }` to
+  `fs.rmSync`/`fs.rm` (Windows file locking), have tests write only under `os.tmpdir()`, and avoid
+  pixel-exact or bare-timeout assertions. (Enforced by a CI unit test, the Linux CI run, and review.)
+- **No personal info.** The repo is public. Never hardcode usernames, emails, or home-directory
+  paths; use generic placeholders like `C:\Users\dev` in tests and examples. (Enforced by review.)
+- **Reuse before reimplement (DRY).** Search for an existing utility before adding a new one, and
+  extract duplicated logic into a shared module instead of copying it. (Enforced by review.)
+- **Bounded IPC payloads.** Cap large captured buffers (for example child-process stdout/stderr)
+  before they cross IPC. Do not let an Error carry tens of megabytes; use a sensible per-stream cap.
+  (Enforced by review.)
+- **Docs stay in sync.** When you change an anchor source file (union types, IPC channels, DB
+  migrations, adapter capabilities, or settings), update the matching docs under `docs/`.
+  (Enforced by an automated doc-anchor check when the PR is opened and merged.)
 
 ### Testing
 
-Run the UI tests before submitting a PR:
+Tests run in three tiers. See [docs/developer-guide.md](docs/developer-guide.md) for the full
+description of each tier and the headless mock.
+
+- **Unit** (`tests/unit/`, Vitest, sub-second, pure logic): `npm run test:unit`
+- **UI** (`tests/ui/`, headless Playwright, no Electron): `npx playwright test --project=ui`
+- **E2E** (`tests/e2e/`, real Electron, opens windows): `npm run build` then
+  `npx playwright test --project=electron`
+
+Stay scoped to what you changed while iterating (run only the tests you added or touched). Before you
+open a PR, the quick local pass is:
 
 ```bash
+npm run lint
+npm run typecheck
+npm run test:unit
 npx playwright test --project=ui
 ```
 
-For changes that affect the Electron main process, also run the E2E tests:
-
-```bash
-npm run build
-npx playwright test --project=electron
-```
+CI is the authoritative full gate (see "What to expect" below), so you do not need to run every tier
+locally, especially the E2E tier.
 
 ### Commit Messages
 
-Write clear, concise commit messages that explain *why* the change was made:
+Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/): a
+`commit-msg` git hook runs commitlint with `@commitlint/config-conventional` and rejects messages
+that do not conform. The format is:
 
-- `Fix session resume failing when worktree branch is deleted`
-- `Add keyboard shortcut for moving tasks between columns`
-- `Update transition engine to support webhook actions`
+```
+type(scope): subject
+```
+
+Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`,
+`revert`. The scope is optional. Keep the subject short and in the imperative mood. Examples:
+
+- `fix(session): resume when worktree branch is deleted`
+- `feat(board): add keyboard shortcut for moving tasks between columns`
+- `docs: clarify the E2E test setup`
 
 ## Pull Requests
 
 1. Fork the repo and create a branch from `main`
-2. Make your changes and ensure all tests pass
-3. Sign the CLA when prompted on your first PR
-4. Write a clear PR description explaining what changed and why
-5. Link any related issues
+2. Make your changes and add or update tests for them
+3. Run the quick local pass above (`lint`, `typecheck`, unit, UI)
+4. Sign the CLA when prompted on your first PR
+5. Open the PR. The template prompts you for What / Why / How / Tests and a short checklist
+6. Link any related issues
 
-### What to Expect
+### What to expect
 
-- PRs are reviewed as time permits -- this is a small project
-- Small, focused PRs are easier to review and more likely to be merged quickly
-- If your PR includes new UI, consider adding a screenshot
+- Your PR must be green on all of the CI checks before it can merge: **Lint (ESLint)**,
+  **Type check (tsc)**, **Unit tests (Vitest)**, **Build (production bundle)**, **UI tests
+  (Playwright)**, and **E2E tests (Electron)**. The lint check runs with `--max-warnings 0`, so any
+  warning fails it.
+- A maintainer may push follow-up commits to your branch for design polish or hardening before
+  merging. This is normal and not a reflection on your work; it is how we keep the bar consistent.
+- Small, focused PRs are easier to review and merge faster.
+
+### UI contributions
+
+UI changes get a maintainer design review against the UI conventions above (shared primitives, font
+floor, theme-adaptive colors, no hover-only controls, visual subtraction over addition). Including a
+screenshot or short clip in the PR makes that review much faster and is always appreciated.
+
+### How maintainers land your PR
+
+You do not need to run any of this; it is just so the flow is not a mystery. Maintainers drive a PR
+to green and merge it through an internal Kanban board: a Tests column runs `/pull-request` (which
+pushes the branch and drives the CI checks to green, auto-fixing and de-flaking along the way), and a
+Ship It column runs `/merge-pull-request` (which merges the green PR). The internal board mechanics,
+git worktrees, and agent skills are documented in [CLAUDE.md](CLAUDE.md) and are not something a
+contributor is expected to set up.
 
 ## Finding Work
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ Get started at [kangentic.com/getting-started](https://www.kangentic.com/getting
 
 ## Development
 
+Building from source requires Node.js 22+ (the npx floor above is for end users running the
+launcher).
+
 ```bash
 git clone https://github.com/Kangentic/kangentic.git
 cd kangentic
@@ -115,7 +118,7 @@ npm install
 npm start
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for project structure, testing, and code style.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for project structure, testing, and conventions.
 
 ## Contributing
 


### PR DESCRIPTION
## What

Aligns the contributor-facing documentation with how Kangentic is actually built.

- **`CONTRIBUTING.md` rewritten:** Conventional Commits (replacing prose examples the commitlint
  `commit-msg` hook rejects), a distilled Conventions section (text formatting, TypeScript style,
  UI conventions, cross-platform parity, no personal info, reuse-before-reimplement, bounded IPC
  payloads, docs-stay-in-sync, each tagged CI-enforced vs review), the three test tiers, the six CI
  gates, the UI design-review expectation, a brief "how maintainers land your PR" note, and fixed
  setup details (Node 22+, `npm start`, native-build toolchain, source-of-truth pointer to
  `CLAUDE.md` and `.claude/rules/`).
- **`.github/pull_request_template.md` added:** What / Why / How / Breaking changes / Tests plus a
  checklist (conventional title, no em-dash / `--`, tests, docs synced, lint + typecheck, screenshot
  for UI, CLA).
- **`/pull-request` skill aligned:** Step 5 now generates a PR body matching the template's section
  order.
- **`README.md`:** notes that building from source needs Node 22+, preserving the distinct npx
  end-user floor.

## Why

Two recent external PRs each needed a maintainer follow-up pass (design rework, DRY extraction, IPC
payload hardening, added tests, house-style fixes) because the real conventions live in `CLAUDE.md`
and `.claude/rules/`, which external contributors never see, while `CONTRIBUTING.md` duplicated only
a thin, partly-stale slice and showed prose commit examples that the commitlint hook rejects. This
repo's `CONTRIBUTING.md` is now the single source of truth the website's public copy will derive
from.

## How

Distilled the human-relevant subset of the internal rules into `CONTRIBUTING.md` rather than
duplicating each rule file, and pointed contributors at `CLAUDE.md` and `.claude/rules/` as
authoritative. The PR template uses HTML-comment guidance and a closing-keyword issue prompt per
GitHub's recommended structure. The Breaking changes section ties into the project's Conventional
Commits `!` convention.

## Breaking changes

None. Documentation, a new PR template, and a skill-instruction update only.

## Tests

- Docs/skill-only change; no test tier is affected (lint, typecheck, unit, build, UI, and E2E all
  cover `src/`, not markdown), so the CI checks confirm nothing was inadvertently broken.
- Verified every command named in `CONTRIBUTING.md` matches `package.json` scripts.
- Verified the documented conventional-commit types match `@commitlint/config-conventional`.
- Scanned the edited files for em-dashes and `--` punctuation (none; remaining `--` are CLI flags).
- Each commit passed the repo's commitlint `commit-msg` hook.

Generated with [Claude Code](https://claude.com/claude-code)
