### PR TITLE
fix(pr): keep fork PR state on by-number lookup

### DIFF
--- a/src/main/pr/adapters/github/github-connector.ts
+++ b/src/main/pr/adapters/github/github-connector.ts
@@ -70,9 +70,11 @@ function toResolvedPR(item: GhPrListItem): ResolvedPR {
 }
 
 /**
- * Pick the best PR from a candidate list, guarding against mislinks:
- *   - drop fork (cross-repository) PRs - they can share a branch name or contain
- *     the same commit but are never this task's PR,
+ * Pick the best PR from a candidate list for inferred (branch- or commit-based)
+ * resolution, guarding against mislinks:
+ *   - drop fork (cross-repository) PRs - an inferred match on a shared branch name
+ *     or commit is never reliably this task's PR (resolveByNumber bypasses this
+ *     guard, since an explicit number is unambiguous),
  *   - when a `branchHint` is given, restrict to PRs whose head ref matches it;
  *     if none match and the list is ambiguous (>1), return null rather than guess,
  *   - then prefer open/draft over merged/closed, then a matching base branch,
@@ -183,8 +185,11 @@ export const gitHubPRConnector: PRConnector = {
   async resolveByNumber(repoCwd: string, prNumber: number): Promise<ResolvedPR | null> {
     return viaGh(async () => {
       const item = await ghImporter.resolvePRByNumber(repoCwd, prNumber);
-      // Explicit number lookup: trust it, but never link a fork PR.
-      return item && !item.isCrossRepository ? toResolvedPR(item) : null;
+      // Explicit number lookup is unambiguous: a PR number is unique within the repo,
+      // so there is no cross-repo collision risk. Unlike resolveForBranch/resolveByCommit
+      // (which drop fork PRs because a fork can share a branch name or commit), trusting a
+      // fork PR here is safe - the caller already named the exact PR.
+      return item ? toResolvedPR(item) : null;
     });
   },
 

--- a/tests/unit/branch-pr-resolver.test.ts
+++ b/tests/unit/branch-pr-resolver.test.ts
@@ -276,6 +276,14 @@ describe('connector resolveByNumber / resolveByCommit + error translation', () =
     expect(result).toMatchObject({ number: 42, state: 'merged' });
   });
 
+  it('resolveByNumber keeps a fork (cross-repository) PR - an explicit number is unambiguous', async () => {
+    vi.spyOn(GitHubImporter.prototype, 'resolvePRByNumber').mockResolvedValue(
+      pr({ number: 31, state: 'OPEN', isCrossRepository: true }),
+    );
+    const result = await gitHubPRConnector.resolveByNumber!('/r', 31);
+    expect(result).toMatchObject({ number: 31, state: 'open' });
+  });
+
   it('resolveByCommit disambiguates the associated PRs', async () => {
     vi.spyOn(GitHubImporter.prototype, 'resolvePRByCommit').mockResolvedValue([
       pr({ number: 1, state: 'MERGED', updatedAt: '2026-05-01T00:00:00Z' }),


### PR DESCRIPTION
## Summary

The by-number PR resolver rejected cross-repository (fork) PRs with the same guard the
branch- and commit-based resolvers use. Code-review tasks linked to external-contributor PRs
(from a fork) showed the PR number and GitHub link but no status badge: `resolveByNumber`
returned `null`, so the ladder in `pr-linking.ts` fell back to `{ url, number, state: null }`,
and `prStatePresentation` renders nothing for a `null` state. The state re-resolved to `null`
on every refresh sweep.

A lookup by explicit PR number is unambiguous: there is exactly one PR #N in the base repo, so
a fork PR found that way is an external contribution, not a mislink. This drops the
cross-repository check on the by-number path only.

## Impact / behavior

- External-contributor (fork) PRs linked by number now resolve to a real state, so the Code
  Review cards render their status badge ("open", "merged", etc.) after a refresh sweep
  (project open / periodic timer) or a manual kebab refresh.
- The fork guards in `resolveForBranch` and `resolveByCommit` (via the `disambiguate` helper)
  are deliberately left intact: a fork can genuinely share a branch name or a commit and
  mislink, so inferred resolution still drops cross-repository candidates.
- `item.url` from `gh pr view` is the canonical base-repo PR URL, so there is no URL drift.
  `toResolvedPR` / `mapState` already map `OPEN/CLOSED/MERGED` + `isDraft`, and `gh-client.ts`
  already requests `isCrossRepository`, so no other change was needed.

## Test plan

- New unit test in `tests/unit/branch-pr-resolver.test.ts`: a by-number lookup returning
  `isCrossRepository: true` (state OPEN) yields a `ResolvedPR` with `state: 'open'`, not `null`.
- The existing `resolveForBranch filters out fork (cross-repository) PRs even when they are
  open` test stays green, confirming the branch path still drops forks (no assertion inverted).
- Local gate: `npm run typecheck` and `npm run lint` clean.
- The unit, UI, and Electron E2E tiers run as the CI checks on this PR.

Generated with [Claude Code](https://claude.com/claude-code)
