### PR TITLE
fix(preview): check out kangentic.json before DB seed to stop ghost columns

### DIFF
--- a/src/devtools/main/ephemeral-projects.ts
+++ b/src/devtools/main/ephemeral-projects.ts
@@ -47,9 +47,29 @@ function previewProjectsRoot(): string {
 }
 
 /**
+ * Check out the committed team board config (kangentic.json) into the clone's working
+ * tree right after the --no-checkout clone, BEFORE the DB is seeded and the board opens.
+ * Without it, the default-seed columns (random uuids) exist before the team config is on
+ * disk, so the deferred fillPreviewClone applies the config too late and ghosts the
+ * config-id columns that already accumulated tasks. Checking out HEAD (not copying the
+ * possibly-dirty worktree file) keeps the content identical to what fillPreviewClone later
+ * restores, so the post-fill file-watch event is a no-op. Best-effort: a repo with no
+ * committed kangentic.json just falls back to prior behavior.
+ */
+export async function checkoutTeamConfig(cloneDir: string): Promise<void> {
+  try {
+    await execFileAsync('git', ['-C', cloneDir, 'checkout', 'HEAD', '--', 'kangentic.json']);
+  } catch (checkoutError) {
+    console.warn(`[DEV] Preview team-config checkout failed for ${cloneDir}:`, checkoutError);
+  }
+}
+
+/**
  * Clone the worktree into an isolated preview project ("Project N") and register
  * it. FAST: `--no-checkout` copies only the hardlinked .git (~instant), so the
- * working tree is empty until fillPreviewClone() runs. Does NOT open/switch to it.
+ * working tree is empty until fillPreviewClone() runs - except kangentic.json, which
+ * is checked out eagerly so the board reconciles to the committed config at open. Does
+ * NOT open/switch to it.
  */
 export async function createPreviewClone(context: IpcContext, worktreePath: string): Promise<Project> {
   previewProjectIndex += 1;
@@ -65,6 +85,11 @@ export async function createPreviewClone(context: IpcContext, worktreePath: stri
   if (!fs.existsSync(path.join(cloneDir, '.git'))) {
     await execFileAsync('git', ['clone', '--no-checkout', '--local', worktreePath, cloneDir]);
   }
+  // Put the committed team board config on disk BEFORE seeding the DB / opening the board,
+  // so the default-seed columns get cleanly reconciled (deleted/adopted by config id) at
+  // open instead of being ghosted by the late, post-task reconciliation. Runs on the adopt
+  // path too (the pre-clone is also --no-checkout). The slow full-tree checkout stays deferred.
+  await checkoutTeamConfig(cloneDir);
   const project = context.projectRepo.create({ name: projectName, path: cloneDir, default_agent: DEFAULT_AGENT });
   // Initialize the project DB (tables + default swimlanes) so it shows a real board.
   getProjectDb(project.id);

--- a/tests/unit/preview-team-config-checkout.test.ts
+++ b/tests/unit/preview-team-config-checkout.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+// ephemeral-projects.ts pulls in electron's ipcMain and the project DB at import time;
+// neither is exercised by checkoutTeamConfig, so stub them so the module loads under vitest.
+vi.mock('electron', () => ({ ipcMain: { handle: vi.fn() } }));
+vi.mock('../../src/main/db/database', () => ({ getProjectDb: vi.fn() }));
+
+import { checkoutTeamConfig } from '../../src/devtools/main/ephemeral-projects';
+
+const execFileAsync = promisify(execFile);
+
+async function initRepo(repoDir: string): Promise<void> {
+  fs.mkdirSync(repoDir, { recursive: true });
+  await execFileAsync('git', ['-C', repoDir, 'init']);
+  await execFileAsync('git', ['-C', repoDir, 'config', 'user.email', 'dev@example.com']);
+  await execFileAsync('git', ['-C', repoDir, 'config', 'user.name', 'Dev']);
+}
+
+// Regression guard for the preview ghost-column race: the committed team board config must be
+// on disk in the clone BEFORE the DB is seeded and the board opens. Without the eager checkout
+// the default-seed columns (random uuids) exist before kangentic.json lands, and the deferred
+// fillPreviewClone applies the config too late, ghosting the config-id columns. See the module
+// doc on checkoutTeamConfig.
+describe('checkoutTeamConfig (preview team-config eager checkout)', () => {
+  let tempDir: string;
+  let sourceRepo: string;
+  let cloneDir: string;
+  const config = { version: 1, columns: [{ id: 'e6350e8a', name: 'To Do', role: 'todo' }] };
+
+  beforeEach(async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'preview-config-checkout-'));
+    sourceRepo = path.join(tempDir, 'source');
+    cloneDir = path.join(tempDir, 'clone');
+    await initRepo(sourceRepo);
+    fs.writeFileSync(path.join(sourceRepo, 'kangentic.json'), JSON.stringify(config, null, 2));
+    // A second tracked file mirrors a real tree, so we can assert the rest stays deferred.
+    fs.writeFileSync(path.join(sourceRepo, 'README.md'), '# sample\n');
+    await execFileAsync('git', ['-C', sourceRepo, 'add', '.']);
+    await execFileAsync('git', ['-C', sourceRepo, 'commit', '-m', 'init']);
+    await execFileAsync('git', ['clone', '--no-checkout', '--local', sourceRepo, cloneDir]);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('the --no-checkout clone has no working-tree kangentic.json (race precondition)', () => {
+    expect(fs.existsSync(path.join(cloneDir, 'kangentic.json'))).toBe(false);
+  });
+
+  it('checks out the committed kangentic.json into the clone, leaving the rest of the tree deferred', async () => {
+    await checkoutTeamConfig(cloneDir);
+
+    const checkedOut = path.join(cloneDir, 'kangentic.json');
+    expect(fs.existsSync(checkedOut)).toBe(true);
+    // Parse rather than byte-compare so git CRLF normalization can't make this flaky cross-platform.
+    expect(JSON.parse(fs.readFileSync(checkedOut, 'utf-8'))).toEqual(config);
+    // The slow full-tree checkout stays deferred to fillPreviewClone.
+    expect(fs.existsSync(path.join(cloneDir, 'README.md'))).toBe(false);
+  });
+
+  it('is best-effort: a repo with no committed kangentic.json resolves without throwing', async () => {
+    const otherSource = path.join(tempDir, 'other-source');
+    const otherClone = path.join(tempDir, 'other-clone');
+    await initRepo(otherSource);
+    fs.writeFileSync(path.join(otherSource, 'README.md'), '# other\n');
+    await execFileAsync('git', ['-C', otherSource, 'add', '.']);
+    await execFileAsync('git', ['-C', otherSource, 'commit', '-m', 'init']);
+    await execFileAsync('git', ['clone', '--no-checkout', '--local', otherSource, otherClone]);
+
+    await expect(checkoutTeamConfig(otherClone)).resolves.toBeUndefined();
+    expect(fs.existsSync(path.join(otherClone, 'kangentic.json'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Fixes the `/preview` bug where columns holding tasks render as ghost **"Removed from team config"**
columns with a duplicate empty copy beside them (observed on Project 1: To Do and Executing each
appeared twice).

- `src/devtools/main/ephemeral-projects.ts`: new `checkoutTeamConfig(cloneDir)` helper that checks
  out the committed `kangentic.json` (`git checkout HEAD -- kangentic.json`) into the preview clone
  right after the `--no-checkout` clone and before the DB is seeded / the board opens. Best-effort
  (a repo with no committed `kangentic.json` falls back to prior behavior).
- `tests/unit/preview-team-config-checkout.test.ts`: focused regression test against a real temp git
  repo.

Dev-only code (under `src/devtools/`, build-excluded via `__KANGENTIC_DEV__`); no production impact.

## Why

A seed-vs-checkout ordering race unique to preview boot:

1. `createPreviewClone()` runs `git clone --no-checkout` so `kangentic.json` is not on disk yet.
2. `getProjectDb()` runs migrations, seeding the 7 default columns with random `uuidv4()` IDs.
3. The board opens; `applyConfigOnOpen()` finds `kangentic.json` missing, so the config apply is a
   no-op. Tasks land in the random-ID columns.
4. The deferred `fillPreviewClone()` (`git reset --hard HEAD`) finally puts `kangentic.json` on disk.
5. The FileWatcher fires reconciliation, which matches columns by ID only. None of the committed
   config IDs match the random seed IDs, so it creates new config-ID columns and ghosts the
   random-ID ones that have since accumulated tasks: the duplicate ghost columns.

Normal (non-preview) projects never hit this because `kangentic.json` is on disk at open, so the
empty default-seed columns are cleanly reconciled before any task exists.

Closes #275.

## How

Put the committed `kangentic.json` on disk before the DB is seeded and the board opens, so the empty
default-seed columns are cleanly reconciled (deleted/adopted by config ID) at open instead of being
ghosted by the late, post-task reconciliation. The small config file does not reintroduce the
boot-blocking cost the deferral avoids; the slow full source-tree checkout stays deferred.

Using `git checkout HEAD --` (the committed version) rather than copying the possibly-dirty worktree
file is deliberate: the checked-out content is identical to what `fillPreviewClone`'s later
`git reset --hard HEAD` restores, so the post-fill FileWatcher event sees unchanged content and
short-circuits, avoiding a second reconciliation. `kangentic.local.json` is intentionally not
checked out (gitignored, never committed).

The alternative of role/name adoption in `applyBoardConfigToDb` was rejected: it runs for every
project, not just preview, and name/role matching can mis-adopt in legitimate cases (e.g. a renamed
column). This fix is localized to the dev-only preview boot and addresses the actual cause.

## Breaking changes

None.

## Tests

- New unit test `tests/unit/preview-team-config-checkout.test.ts`: asserts the `--no-checkout` clone
  has no `kangentic.json` (the race precondition), that `checkoutTeamConfig` materializes the
  committed config while leaving the rest of the tree deferred, and the best-effort no-throw case.
- Local gate: `npm run typecheck` and `npm run lint` clean; the new test passes (3/3).
- CI runs the full unit, UI, and Electron E2E tiers.

Generated with [Claude Code](https://claude.com/claude-code)
