### PR TITLE
fix(pr): auto-link PRs created mid-session and discover them on the sweep

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,7 +127,7 @@ All six modes are available in both the global App Settings "Permissions" dropdo
 | `git.copyFiles` | string[] | `[]` | Files to copy from repo root into worktrees |
 | `git.initScript` | string \| null | `null` | Shell script run in each new worktree after creation (and after `node_modules` linking). Runs via the platform shell (cmd.exe on Windows, sh on POSIX). A non-zero exit, timeout (10 min cap), or cancellation fails worktree creation. |
 | `git.linkNodeModules` | boolean | `true` | Symlink the root `node_modules` into each worktree so agents skip a fresh install. Disable to let `git.initScript` install dependencies inside the worktree instead. |
-| `git.prRefreshIntervalMinutes` | number \| null | `5` | Minutes between background PR-state refresh sweeps while the project is open. `null` = off (the on-open sweep still runs) |
+| `git.prRefreshIntervalMinutes` | number \| null | `5` | Minutes between background PR sweeps while the project is open. Each sweep refreshes linked PRs' state and discovers/links a PR for an unlinked task with a live worktree. `null` = off (the on-open sweep still runs) |
 
 ### Shortcuts
 

--- a/src/main/ipc/handlers/sessions.ts
+++ b/src/main/ipc/handlers/sessions.ts
@@ -6,7 +6,7 @@ import { UsageHistoryRepository } from '../../db/repositories/usage-history-repo
 import { TaskRepository } from '../../db/repositories/task-repository';
 import { getProjectDb } from '../../db/database';
 import { getProjectRepos, ensureTaskWorktree, createTransitionEngine, resolveSpawnOverrides } from '../helpers';
-import { linkPR, linkPRForMovedTask } from '../../pr/pr-linking';
+import { linkPR, autoLinkPRForTask } from '../../pr/pr-linking';
 import { resolveProjectContext } from '../helpers/project-repos';
 import { handleTaskMove } from './task-move';
 import { trackEvent } from '../../analytics/analytics';
@@ -378,6 +378,27 @@ export function registerSessionHandlers(context: IpcContext): void {
         }
       }
       context.mainWindow.webContents.send(IPC.SESSION_ACTIVITY, sessionId, state, reason, projectId, taskId, taskTitle);
+
+      // A session going idle (the agent finished its turn) is the catch-all
+      // signal that a PR may have just been created mid-session - the move-time
+      // resolve fired before the PR existed, and the gh-command sniffer
+      // (`pr-candidate`) misses a PR opened any other way. Re-resolve now so the
+      // card links within seconds instead of waiting for the periodic sweep.
+      // NON-force via autoLinkPRForTask, so the 60s per-task throttle coalesces
+      // the repeated idles a long session emits. Skip transient (Command
+      // Terminal) sessions: their synthetic taskId is not a real task row.
+      //
+      // Deliberately the granular 'idle' state only (turn complete), NOT the
+      // idle-vs-active bucket: a 'permission' pause is mid-turn, so it did not
+      // just create a PR. Check the literal first so the per-event getSession
+      // registry lookup is skipped on the far-more-frequent 'thinking' events.
+      // activity-state-ok: granular turn-completion check, not an idle/active bucket.
+      if (state === 'idle' && taskId && projectId) {
+        const session = context.sessionManager.getSession(sessionId);
+        if (session && !session.transient) {
+          autoLinkPRForTask(context, taskId, projectId);
+        }
+      }
     }
   });
 
@@ -652,7 +673,7 @@ export function registerSessionHandlers(context: IpcContext): void {
       }
       console.log(`[plan-exit] Auto-moved "${task.title}" -> "${target.name}"`);
       // Resolve the PR for the new (non-To Do) lane - runs after the move's lock released.
-      linkPRForMovedTask(context, task.id, resolvedProjectId);
+      autoLinkPRForTask(context, task.id, resolvedProjectId);
     } catch (err) {
       console.error('[plan-exit] Auto-move failed:', err);
     }

--- a/src/main/ipc/handlers/task-move.ts
+++ b/src/main/ipc/handlers/task-move.ts
@@ -18,7 +18,7 @@ import {
   spawnAgent,
   buildAutoCommandVars,
 } from '../helpers';
-import { linkPRForMovedTask } from '../../pr/pr-linking';
+import { autoLinkPRForTask } from '../../pr/pr-linking';
 import { resolveProjectContext } from '../helpers/project-repos';
 import { interpolateTemplate } from '../../agent/shared';
 import { trackEvent } from '../../analytics/analytics';
@@ -919,7 +919,7 @@ export function registerTaskMoveHandlers(context: IpcContext): void {
       // After the move's task lock has released, resolve the PR for the new lane
       // (gated on a branch + non-To Do lane inside the helper). Fire-and-forget so
       // a slow gh query never blocks the move response.
-      linkPRForMovedTask(context, input.taskId, resolvedProjectId ?? context.currentProjectId);
+      autoLinkPRForTask(context, input.taskId, resolvedProjectId ?? context.currentProjectId);
       return result;
     } catch (error) {
       // Shutdown closes the DB synchronously; any handler that crossed an

--- a/src/main/pr/pr-linking.ts
+++ b/src/main/pr/pr-linking.ts
@@ -312,10 +312,15 @@ export async function linkPR(context: IpcContext, options: LinkPROptions): Promi
  * Fire-and-forget best-effort auto-resolve of a task's PR, gated on the task
  * being in a post-To Do lane (To Do resets the task, so there is no PR to link
  * there). Keeps platform logic in the connector; here we only gate on having a
- * branch/worktree and a non-To Do lane. Called AFTER `handleTaskMove` returns so
- * it runs outside the move's task lock.
+ * branch/worktree and a non-To Do lane.
+ *
+ * The shared auto-link entry point for every implicit trigger: a task-move
+ * (called AFTER `handleTaskMove` returns, outside the move's task lock), the
+ * plan-exit auto-move, and a session going idle (a PR was likely just created).
+ * All run NON-force, so the per-task 60s throttle in `linkPRForTask` coalesces
+ * them.
  */
-export function linkPRForMovedTask(context: IpcContext, taskId: string, projectId: string | null): void {
+export function autoLinkPRForTask(context: IpcContext, taskId: string, projectId: string | null): void {
   try {
     const { tasks, swimlanes } = getProjectRepos(context, projectId);
     const task = tasks.getById(taskId);

--- a/src/main/pr/pr-refresh.ts
+++ b/src/main/pr/pr-refresh.ts
@@ -1,8 +1,11 @@
 /**
- * Background PR-state refresh sweep. Re-resolves the PR state of every eligible
- * task in a project so a PR merged/closed externally on the host (off-app) is
- * reflected on the board. Runs fire-and-forget on project open/switch and on a
- * periodic timer (see pr-refresh-scheduler.ts).
+ * Background PR refresh-and-discover sweep. For each eligible task it re-resolves
+ * the PR via the `linkPR` backbone, which both refreshes an already-linked PR's
+ * state (so a PR merged/closed off-app is reflected on the board) AND discovers a
+ * PR for a still-unlinked task that has a live worktree (e.g. an agent created
+ * the PR mid-session on a renamed branch and no other trigger caught it). Runs
+ * fire-and-forget on project open/switch and on a periodic timer (see
+ * pr-refresh-scheduler.ts).
  *
  * Reuses the `linkPR` backbone unchanged and NON-FORCE on purpose: non-force
  * re-resolves open/draft/null PRs (so open -> merged is caught), skips terminal
@@ -16,15 +19,24 @@ import type { Task } from '../../shared/types';
 import type { IpcContext } from '../ipc/ipc-context';
 
 /**
- * A task is worth a background refresh when it has a non-terminal linked PR (or a
- * PR URL anchor in its description) - i.e. a state that can still change off-app.
- * Terminal merged/closed PRs never change, and tasks with no PR anchor have
- * nothing to resolve, so both are skipped to bound the `gh` load. (`tasks.list()`
- * already excludes archived tasks.)
+ * A task is worth a background sweep when its PR can still change or be found:
+ *   - a non-terminal linked PR (`pr_number`) - state can change off-app;
+ *   - a live worktree (`worktree_path`) - an actively-worked task whose PR may
+ *     have been created but not yet linked (the discovery case); the worktree's
+ *     live HEAD branch resolves the PR even after the agent renamed the branch.
+ *     Only active tasks have a worktree (To Do clears it, Done reclaims it), so
+ *     this stays a small bounded set, further bounded by the per-task 60s TTL and
+ *     the global `gh` concurrency cap;
+ *   - a PR URL anchor in the description.
+ * Terminal merged/closed PRs never change and are skipped first. A task with none
+ * of these has nothing to resolve. (`tasks.list()` already excludes archived
+ * tasks.) `head_sha` is deliberately NOT an anchor here: nearly every historical
+ * task carries one, so it would make the sweep unbounded.
  */
 function isEligibleForRefresh(task: Task): boolean {
   if (task.pr_state === 'merged' || task.pr_state === 'closed') return false;
   if (task.pr_number != null) return true;
+  if (task.worktree_path != null) return true;
   return detectCanonicalPR(task.description ?? '') != null;
 }
 

--- a/tests/unit/abort-task-move.test.ts
+++ b/tests/unit/abort-task-move.test.ts
@@ -121,7 +121,7 @@ vi.mock('../../src/main/ipc/helpers/index', () => ({
   autoSpawnForTask: vi.fn(async () => {}),
 }));
 vi.mock('../../src/main/pr/pr-linking', () => ({
-  linkPRForMovedTask: vi.fn(),
+  autoLinkPRForTask: vi.fn(),
 }));
 
 const mockGetProjectRepos = vi.fn();

--- a/tests/unit/pr-link-ladder.test.ts
+++ b/tests/unit/pr-link-ladder.test.ts
@@ -26,6 +26,9 @@ const conn = vi.hoisted(() => ({
   detect: null as unknown,
   canonical: null as unknown,
   calls: [] as string[],
+  // Args the last call to each resolver received, so a test can assert which
+  // branch/commit was queried (e.g. the live HEAD branch, not the stored slug).
+  lastArgs: {} as Record<string, unknown[]>,
 }));
 
 vi.mock('simple-git', () => ({
@@ -46,8 +49,9 @@ vi.mock('../../src/main/pr/pr-registry', () => {
   class PRResolverTransientError extends Error {
     constructor(message: string) { super(message); this.name = 'PRResolverTransientError'; }
   }
-  const make = (key: 'byNumber' | 'byBranch' | 'byCommit') => async () => {
+  const make = (key: 'byNumber' | 'byBranch' | 'byCommit') => async (...args: unknown[]) => {
     conn.calls.push(key);
+    conn.lastArgs[key] = args;
     const value = conn[key];
     if (value instanceof Error) throw value;
     return value ?? null;
@@ -92,7 +96,7 @@ function depsFor(task: Task, opts: { updateSpy?: ReturnType<typeof vi.fn>; force
 const resolved = (number: number, state = 'open') => ({ url: `u${number}`, number, state });
 
 beforeEach(() => {
-  conn.byNumber = null; conn.byBranch = null; conn.byCommit = null; conn.detect = null; conn.canonical = null; conn.calls = [];
+  conn.byNumber = null; conn.byBranch = null; conn.byCommit = null; conn.detect = null; conn.canonical = null; conn.calls = []; conn.lastArgs = {};
   git.branch = 'real-branch'; git.sha = 'sha-current'; git.aheadCount = '1';
 });
 
@@ -113,6 +117,21 @@ describe('linkPRForTask confidence ladder', () => {
     const result = await linkPRForTask(task.id, depsFor(task));
     expect(result.task?.pr_number).toBe(20);
     expect(conn.calls).toEqual(['byBranch']);
+  });
+
+  it('tier 2: branch rename - resolves by the live HEAD branch, not the stored slug', async () => {
+    // The agent renamed the worktree branch after creation (team branch
+    // conventions): tasks.branch_name is the old slug, but the worktree's live
+    // HEAD is the renamed branch, and the PR exists only for the renamed branch.
+    // Tier 2 must query the live HEAD, never the stored slug.
+    git.branch = 'renamed-branch';
+    conn.byBranch = resolved(123, 'open');
+    const task = makeTask({ branch_name: 'old-slug', worktree_path: '/wt', pr_number: null });
+    const result = await linkPRForTask(task.id, depsFor(task));
+    expect(result.task?.pr_number).toBe(123);
+    expect(conn.calls).toEqual(['byBranch']);
+    // The load-bearing assertion: the renamed branch was queried, not the slug.
+    expect(conn.lastArgs.byBranch?.[1]).toBe('renamed-branch');
   });
 
   it('tier 3: no worktree but head_sha set resolves by commit', async () => {

--- a/tests/unit/pr-refresh-sweep.test.ts
+++ b/tests/unit/pr-refresh-sweep.test.ts
@@ -1,7 +1,9 @@
 /**
  * Unit tests for the background PR-refresh sweep (refreshProjectPRs): which tasks
- * are eligible (non-terminal linked PR or a description PR anchor) and that the
- * backbone is invoked NON-FORCE exactly once per eligible task.
+ * are eligible (non-terminal linked PR, a live worktree, or a description PR
+ * anchor) and that the backbone is invoked NON-FORCE exactly once per eligible
+ * task. The live-worktree case is the discovery path - an unlinked task whose PR
+ * was created mid-session is found on the next sweep.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -53,7 +55,8 @@ describe('refreshProjectPRs eligibility', () => {
     const merged = makeTask({ id: 'merged', pr_number: 4, pr_state: 'merged' });
     const closed = makeTask({ id: 'closed', pr_number: 5, pr_state: 'closed' });
     const descAnchored = makeTask({ id: 'desc', pr_number: null, pr_state: null, description: 'see https://github.com/o/r/pull/7' });
-    const noAnchor = makeTask({ id: 'none', pr_number: null, pr_state: null, description: 'no pr here' });
+    // No pr_number, no description anchor, AND no worktree -> genuinely no anchor.
+    const noAnchor = makeTask({ id: 'none', pr_number: null, pr_state: null, description: 'no pr here', worktree_path: null });
     withTasks([open, draft, unknownState, merged, closed, descAnchored, noAnchor]);
 
     await refreshProjectPRs({} as never, 'proj-1');
@@ -76,14 +79,31 @@ describe('refreshProjectPRs eligibility', () => {
   });
 
   it('does nothing when no task is eligible', async () => {
+    // worktree_path: null keeps these out of the discovery path (the makeTask
+    // default sets a worktree, which would make the second task eligible).
     withTasks([
-      makeTask({ pr_number: 4, pr_state: 'merged' }),
-      makeTask({ pr_number: null, pr_state: null, description: '' }),
+      makeTask({ pr_number: 4, pr_state: 'merged', worktree_path: null }),
+      makeTask({ pr_number: null, pr_state: null, description: '', worktree_path: null }),
     ]);
 
     await refreshProjectPRs({} as never, 'proj-1');
 
     expect(linkPR).not.toHaveBeenCalled();
+  });
+
+  it('discovers an unlinked task with a live worktree (no pr_number, no description anchor)', async () => {
+    const wtOnly = makeTask({ id: 'wt-only', pr_number: null, pr_state: null, description: '', worktree_path: '/mock/worktrees/wt' });
+    const bare = makeTask({ id: 'bare', pr_number: null, pr_state: null, description: '', worktree_path: null, branch_name: null });
+    // Terminal guard runs before the worktree check: a merged PR is never swept,
+    // even with a live worktree.
+    const mergedWt = makeTask({ id: 'merged-wt', pr_number: 9, pr_state: 'merged', worktree_path: '/mock/worktrees/wt' });
+    withTasks([wtOnly, bare, mergedWt]);
+
+    await refreshProjectPRs({} as never, 'proj-1');
+
+    expect(linkedTaskIds()).toEqual(['wt-only']);
+    expect(linkedTaskIds()).not.toContain('bare');
+    expect(linkedTaskIds()).not.toContain('merged-wt');
   });
 
   it('swallows a per-task failure and continues the sweep', async () => {

--- a/tests/unit/session-idle-pr-link.test.ts
+++ b/tests/unit/session-idle-pr-link.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for the session-idle PR auto-link trigger in registerSessionHandlers.
+ *
+ * When an agent finishes its turn the session transitions to ActivityState
+ * 'idle'. That is the catch-all signal that a PR may have just been created
+ * mid-session (the move-time resolve fired before the PR existed, and the
+ * gh-command sniffer misses a PR opened any other way). The 'activity' listener
+ * fires `autoLinkPRForTask` for the session's task on 'idle' so the card links
+ * within seconds instead of waiting for the periodic sweep.
+ *
+ * These tests verify the listener:
+ *   - calls autoLinkPRForTask(context, taskId, projectId) on 'idle' for a real,
+ *     non-transient session;
+ *   - does NOT call it on 'thinking' (the agent is still working);
+ *   - does NOT call it when the session has no task (taskId undefined);
+ *   - does NOT call it for a transient (Command Terminal) session, whose
+ *     synthetic taskId is not a real task row.
+ *
+ * Mock strategy mirrors session-idle-timeout.test.ts: electron/ipcMain, the DB
+ * helpers, repositories, and the transition-engine chain are stubbed so
+ * registerSessionHandlers can run headless; sessionManager.on is captured into a
+ * Map; and pr-linking is mocked so autoLinkPRForTask is a spy.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks (must be declared before any imports of the mocked modules)
+// ---------------------------------------------------------------------------
+
+const capturedSessionEventHandlers = new Map<string, (...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/main/db/database', () => ({
+  getProjectDb: vi.fn(() => ({})),
+}));
+
+vi.mock('../../src/main/db/repositories/session-repository', () => ({
+  SessionRepository: class {
+    getLatestForTask = vi.fn(() => null);
+    compareAndUpdateStatus = vi.fn(() => true);
+    updateMetrics = vi.fn();
+    insert = vi.fn();
+    updateStatus = vi.fn();
+    updateGitStats = vi.fn();
+  },
+}));
+
+vi.mock('../../src/main/db/repositories/usage-history-repository', () => ({
+  UsageHistoryRepository: class {
+    insert = vi.fn();
+    aggregate = vi.fn(() => []);
+  },
+}));
+
+vi.mock('../../src/main/db/repositories/task-repository', () => ({
+  TaskRepository: class {
+    getById = vi.fn(() => null);
+  },
+}));
+
+vi.mock('../../src/main/transition-engine/session-lifecycle', () => ({
+  markRecordExited: vi.fn(),
+  markRecordSuspended: vi.fn(),
+  promoteRecord: vi.fn(),
+  recoverStaleSessionId: vi.fn(),
+}));
+
+vi.mock('../../src/main/analytics/analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('../../src/main/ipc/handlers/session-metrics', () => ({
+  captureSessionMetrics: vi.fn(),
+}));
+
+vi.mock('../../src/main/agent/shared', () => ({
+  interpolateTemplate: vi.fn((template: string) => template),
+}));
+
+vi.mock('../../src/main/ipc/handlers/task-move', () => ({ handleTaskMove: vi.fn(async () => {}) }));
+
+vi.mock('../../src/main/ipc/handlers/session-reconcile', () => ({
+  applySuspendDbWrites: vi.fn(),
+  reconcileTaskSessionRef: vi.fn(),
+}));
+
+vi.mock('../../src/main/ipc/helpers', () => ({
+  getProjectRepos: vi.fn(() => ({})),
+  ensureTaskWorktree: vi.fn(async () => {}),
+  createTransitionEngine: vi.fn(() => ({})),
+  resolveSpawnOverrides: vi.fn(() => ({})),
+}));
+
+vi.mock('../../src/main/ipc/helpers/project-repos', () => ({
+  resolveProjectContext: vi.fn(() => ({ projectId: 'proj-1', projectPath: '/mock/project' })),
+}));
+
+// The unit under test: autoLinkPRForTask is a spy so we assert it fires on idle.
+vi.mock('../../src/main/pr/pr-linking', () => ({
+  linkPR: vi.fn(async () => ({ status: 'unchanged', task: null })),
+  autoLinkPRForTask: vi.fn(),
+}));
+
+// Import under test AFTER all mocks are registered.
+import { registerSessionHandlers } from '../../src/main/ipc/handlers/sessions';
+import { autoLinkPRForTask } from '../../src/main/pr/pr-linking';
+
+// ---------------------------------------------------------------------------
+// Shared fixture factory
+// ---------------------------------------------------------------------------
+
+function createMockContext() {
+  return {
+    currentProjectId: 'proj-1',
+    currentProjectPath: '/mock/project',
+    mainWindow: {
+      isDestroyed: vi.fn(() => false),
+      webContents: { send: vi.fn() },
+    },
+    sessionManager: {
+      getSession: vi.fn(() => ({ transient: false })),
+      getSessionTaskId: vi.fn(() => 'task-1' as string | null | undefined),
+      getSessionProjectId: vi.fn(() => 'proj-1' as string | null | undefined),
+      getSessionAgentName: vi.fn(() => 'claude'),
+      getFocusedSessions: vi.fn(() => new Set<string>()),
+      on: vi.fn((event: string, handler: (...args: unknown[]) => unknown) => {
+        capturedSessionEventHandlers.set(event, handler);
+      }),
+      off: vi.fn(),
+    },
+    configManager: {
+      getEffectiveConfig: vi.fn(() => ({ git: { defaultBaseBranch: 'main' } })),
+    },
+    projectRepo: {
+      getById: vi.fn(() => ({ default_agent: 'claude', path: '/mock/project' })),
+    },
+  };
+}
+
+function fireActivity(context: ReturnType<typeof createMockContext>, sessionId: string, state: string): void {
+  const handler = capturedSessionEventHandlers.get('activity');
+  if (!handler) throw new Error('activity handler was not registered');
+  handler(sessionId, state, undefined);
+}
+
+describe('session-idle PR auto-link trigger', () => {
+  let context: ReturnType<typeof createMockContext>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedSessionEventHandlers.clear();
+    context = createMockContext();
+    registerSessionHandlers(context as never);
+  });
+
+  it('fires autoLinkPRForTask on idle for a real, non-transient session', () => {
+    fireActivity(context, 'sess-1', 'idle');
+
+    expect(autoLinkPRForTask).toHaveBeenCalledTimes(1);
+    expect(autoLinkPRForTask).toHaveBeenCalledWith(context, 'task-1', 'proj-1');
+  });
+
+  it('does NOT fire on thinking (the agent is still working)', () => {
+    fireActivity(context, 'sess-1', 'thinking');
+
+    expect(autoLinkPRForTask).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire on idle when the session has no task', () => {
+    context.sessionManager.getSessionTaskId.mockReturnValue(undefined);
+
+    fireActivity(context, 'sess-1', 'idle');
+
+    expect(autoLinkPRForTask).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire for a transient (Command Terminal) session on idle', () => {
+    context.sessionManager.getSession.mockReturnValue({ transient: true });
+
+    fireActivity(context, 'sess-transient', 'idle');
+
+    expect(autoLinkPRForTask).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/session-shutdown-exit-suspend.test.ts
+++ b/tests/unit/session-shutdown-exit-suspend.test.ts
@@ -94,7 +94,7 @@ vi.mock('../../src/main/ipc/helpers', () => ({
 }));
 vi.mock('../../src/main/pr/pr-linking', () => ({
   linkPR: vi.fn(async () => {}),
-  linkPRForMovedTask: vi.fn(),
+  autoLinkPRForTask: vi.fn(),
 }));
 vi.mock('../../src/main/ipc/handlers/task-move', () => ({ handleTaskMove: vi.fn(async () => {}) }));
 vi.mock('../../src/main/ipc/handlers/session-reconcile', () => ({

--- a/tests/unit/task-move-isolation-switch.test.ts
+++ b/tests/unit/task-move-isolation-switch.test.ts
@@ -114,7 +114,7 @@ vi.mock('../../src/main/ipc/helpers/index', () => ({
   autoSpawnForTask: vi.fn(async () => {}),
 }));
 vi.mock('../../src/main/pr/pr-linking', () => ({
-  linkPRForMovedTask: vi.fn(),
+  autoLinkPRForTask: vi.fn(),
 }));
 
 import { handleTaskMove } from '../../src/main/ipc/handlers/task-move';

--- a/tests/unit/task-move-settings-restart.test.ts
+++ b/tests/unit/task-move-settings-restart.test.ts
@@ -126,7 +126,7 @@ vi.mock('../../src/main/ipc/helpers/index', () => ({
   autoSpawnForTask: vi.fn(async () => {}),
 }));
 vi.mock('../../src/main/pr/pr-linking', () => ({
-  linkPRForMovedTask: vi.fn(),
+  autoLinkPRForTask: vi.fn(),
 }));
 
 import { handleTaskMove } from '../../src/main/ipc/handlers/task-move';


### PR DESCRIPTION
## What

Auto-link a pull request that an agent opens mid-session to its task card, and let the background sweep discover such PRs.

- New session-idle trigger in `src/main/ipc/handlers/sessions.ts`.
- Broadened sweep eligibility in `src/main/pr/pr-refresh.ts`.
- Rename `linkPRForMovedTask` to `autoLinkPRForTask` (it now serves the task-move, plan-exit, and session-idle triggers).

## Why

When an agent created a PR partway through a session (often after renaming the worktree branch to a team convention), the task card stayed blank until a manual "Link PR". The move-time resolve fired before the PR existed, the `gh`-command sniffer is fragile, and the periodic sweep only refreshed already-linked tasks, so nothing re-resolved the task. A PR could be green and open but invisible on the card, which undermines the PR-based board workflow.

Kangentic task #262.

## How

The confidence ladder already resolves by the live worktree HEAD, so a renamed branch resolves correctly; the gap was purely a missing re-resolve trigger.

- **Resolve on session idle:** when a session goes idle (the agent finished its turn) fire `autoLinkPRForTask` for its task, the catch-all signal that a PR may have just been created. It is non-force, so the existing 60s per-task throttle coalesces the repeated idles a long session emits. Transient Command Terminal sessions are skipped (their synthetic taskId is not a real task row).
- **Sweep discovery:** `isEligibleForRefresh` now also includes a task with a live worktree, so the periodic and project-open sweeps discover an unlinked PR on a renamed branch as a restart and missed-idle backstop. Only active tasks have a worktree, and the per-task 60s TTL plus the global `gh` concurrency cap keep it bounded. `head_sha` was deliberately not added (nearly every historical task carries one, which would make the sweep unbounded). Terminal merged/closed PRs are still excluded first.

No change to the resolution ladder itself, the 60s throttle, or the existing `pr-candidate` path.

## Breaking changes

None.

## Tests

- `pr-link-ladder.test.ts`: branch-rename regression asserting the live renamed HEAD branch is queried, not the stored slug.
- `pr-refresh-sweep.test.ts`: worktree-only discovery, plus negative cases (a bare no-anchor task, and a merged task with a worktree to lock terminal-guard-first).
- `session-idle-pr-link.test.ts` (new): fires `autoLinkPRForTask` on idle, and not on thinking, no-task, or a transient session.
- CI checks: lint, typecheck, unit, build, the UI shards, and the Linux Electron E2E shards.

Generated with [Claude Code](https://claude.com/claude-code)
