### PR TITLE
fix(hmr): pin board/backlog/project store instances across Fast Refresh

### DIFF
--- a/.claude/rules/hmr-patterns.md
+++ b/.claude/rules/hmr-patterns.md
@@ -2,10 +2,10 @@
 paths:
   - "src/renderer/**"
 ---
-# Rule: HMR dev-mode parity (patterns A-D)
+# Rule: HMR dev-mode parity (patterns A-E)
 
 The team dogfoods Kangentic from `npm start` daily, so a Vite Fast Refresh during a real
-session must be visually and behaviourally indistinguishable from a fresh production boot. Four
+session must be visually and behaviourally indistinguishable from a fresh production boot. Five
 primitives cover every HMR-sensitive surface; mixing them up causes flaky behavior that only
 surfaces in dev, the exact failure mode this project cannot tolerate. Pick the right pattern up
 front rather than reaching for ad-hoc fixes later.
@@ -18,35 +18,48 @@ front rather than reaching for ad-hoc fixes later.
 | **B. Re-sync** | Zustand stores whose truth lives in the main process (IPC-backed) | Add a `load*` / `sync*` call to the `vite:afterUpdate` handler in `App.tsx` | `loadBoard()`, `loadBacklog()`, `loadConfig()`, `loadProjects()`, `syncSessions()` |
 | **C. Re-key remount** | Stateful third-party React subtrees whose subscriptions go stale across Fast Refresh (every `<DndContext>`) | `const hmrGeneration = useHmrGeneration();` then `<DndContext key={hmrGeneration}>` | All 5 `<DndContext>` sites: `KanbanBoard`, `BacklogView`, `PrioritiesPopover`, `ProjectSidebar`, `ShortcutsTab` |
 | **D. Cleanup** | Imperative DOM or global state no React component owns | Add the clear to the top of the `vite:afterUpdate` handler | `.drop-highlight` class removal in `App.tsx` |
+| **E. Pin instance** | A Zustand store whose only runtime export is the non-component hook, so the module is not a Fast Refresh boundary and a re-eval can hand a SECOND store to part of the tree | `const make = () => create<T>(init); export const useX = import.meta.hot?.data?.x ?? make();` plus `import.meta.hot.data.x = useX; import.meta.hot.accept(() => import.meta.hot.invalidate())` | `board-store.ts`, `backlog-store.ts`, `project-store.ts` |
 
 **Decision tree:**
 
 1. New IPC-backed Zustand store, or a new `load*` / `sync*` method on an existing one? Pattern
    B: add a call in `App.tsx`'s `vite:afterUpdate` handler.
-2. New `<DndContext>` or other React component wrapping a third-party library with internal
+2. Is that store's only runtime export the non-component hook (`export const useXStore =
+   create(...)`, no component exports)? Then the module is not a Fast Refresh boundary, so a
+   re-eval (a slice edit, or an edit to a store it imports) can construct a second instance while
+   the mounted view stays subscribed to the first. Pattern E: pin the instance via
+   `import.meta.hot.data` and self-accept with `accept(() => invalidate())`. Pair with Pattern B.
+3. New `<DndContext>` or other React component wrapping a third-party library with internal
    subscription state? Pattern C: pair it with `useHmrGeneration()` and `key={hmrGeneration}`.
-3. New module-scope `let` / `const` mutable state (Maps, Sets, AbortControllers, counters) under
+4. New module-scope `let` / `const` mutable state (Maps, Sets, AbortControllers, counters) under
    `src/renderer/stores/` or `src/renderer/utils/`? Pattern A: preserve via
    `import.meta.hot.data`, or annotate the declaration with `// hmr-safe: <reason>` if
    reset-on-HMR is intentional.
-4. Imperatively setting a class, attribute, or global handle React will not tear down? Pattern
+5. Imperatively setting a class, attribute, or global handle React will not tear down? Pattern
    D: add the clear to the `vite:afterUpdate` handler.
 
-**Anti-patterns:** do not combine A and C on the same state; do not add a fifth ad-hoc HMR
+**Anti-patterns:** do not combine A and C on the same state; do not add an undocumented ad-hoc HMR
 workaround (surface the gap and extend this catalog deliberately); do not gate Pattern A behind
 `process.env.NODE_ENV` (`import.meta.hot` is `undefined` in production builds, so the guards
 already collapse to no-ops).
 
 ## Enforcement (self-maintaining)
 
-- **Test:** `tests/unit/hmr-resync.test.ts` enforces three things: every IPC-backed store's
+- **Test:** `tests/unit/hmr-resync.test.ts` enforces four things: every IPC-backed store's
   `load*` / `sync*` is called in `App.tsx`'s `vite:afterUpdate` (B); every module-scope mutable
   declaration under the watched dirs has `import.meta.hot.dispose(` or a `// hmr-safe:` opt-out
-  (A); every `<DndContext>` has `key={hmrGeneration}` (C). Runs in CI via `npm run test:unit`.
-- **Review:** the `hmr-parity` agent audits all four patterns; `hmr-integrity` is the narrow
+  (A); every `<DndContext>` has `key={hmrGeneration}` (C); and each instance-pinned store
+  (`board-store.ts`, `backlog-store.ts`, `project-store.ts`) reads and writes its instance in
+  `import.meta.hot.data` and self-accepts (E). Runs in CI via `npm run test:unit`.
+- **Review:** the `hmr-parity` agent audits all five patterns; `hmr-integrity` is the narrow
   Pattern B store-registration check.
 
 ## Scope
 
 Renderer code under `src/renderer/`. Main-process state is not subject to HMR (esbuild does not
 Fast-Refresh the main process).
+
+`config-store.ts` and `session-store.ts` share Pattern E's shape (their only runtime export is the
+non-component hook) and are candidates for the same instance pinning; they currently rely on
+Pattern B re-sync plus Pattern A for their module-scope state. Extend the Pattern E test's store
+list when pinning them.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -600,9 +600,12 @@ export function App() {
 }
 
 // Dev-only: re-sync all IPC-backed Zustand stores after Vite HMR updates.
-// When HMR replaces a store module, its Zustand store reverts to defaults (e.g.
-// config resets to DEFAULT_CONFIG, projects list empties). Re-fetching from the
-// main process restores the correct state.
+// Most store modules revert to defaults when HMR replaces them (e.g. config
+// resets to DEFAULT_CONFIG); re-fetching from the main process restores them.
+// The board/backlog/project stores are instance-pinned across HMR (Pattern E in
+// .claude/rules/hmr-patterns.md), so for them this re-sync RECONCILES the pinned
+// instance with main-process truth rather than restoring it from scratch. Keep
+// the calls either way; the unit test below enforces them.
 //
 // IMPORTANT: If you add a new IPC-backed store, add its load/sync call here.
 // The unit test "hmr-resync.test.ts" will fail if you forget.

--- a/src/renderer/stores/backlog-store.ts
+++ b/src/renderer/stores/backlog-store.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand';
+import { create, type StateCreator } from 'zustand';
 import type {
   BacklogTask,
   BacklogTaskCreateInput,
@@ -69,7 +69,7 @@ interface BacklogState {
   setScrollToBacklogId: (id: string | null) => void;
 }
 
-export const useBacklogStore = create<BacklogState>((set, get) => ({
+const backlogStoreInitializer: StateCreator<BacklogState> = (set, get) => ({
   items: [],
   loading: false,
   hydrated: false,
@@ -249,4 +249,26 @@ export const useBacklogStore = create<BacklogState>((set, get) => ({
   setPendingBulkDelete: (pending) => set({ pendingBulkDelete: pending }),
   setImportSource: (source) => set({ importSource: source }),
   setScrollToBacklogId: (id) => set({ scrollToBacklogId: id }),
-}));
+});
+
+const createBacklogStore = () => create<BacklogState>(backlogStoreInitializer);
+
+// HMR instance pinning (Pattern E, see .claude/rules/hmr-patterns.md): this
+// module's only runtime export is the non-component `useBacklogStore`, so it is
+// not a React Fast Refresh boundary. Pin the instance in `import.meta.hot.data`
+// so a Fast Refresh that re-evaluates this module cannot strand a second store
+// instance while the mounted backlog view stays subscribed to the first.
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+const preservedBacklogStore: ReturnType<typeof createBacklogStore> | undefined = import.meta.hot?.data?.backlogStore;
+
+export const useBacklogStore = preservedBacklogStore ?? createBacklogStore();
+
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+if (import.meta.hot) {
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.data.backlogStore = useBacklogStore;
+  // Editing this module's OWN code would leave the pinned instance running stale
+  // closures; force a clean full reload instead (rare; prod drops this block).
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.accept(() => import.meta.hot.invalidate());
+}

--- a/src/renderer/stores/board-store.ts
+++ b/src/renderer/stores/board-store.ts
@@ -24,21 +24,47 @@ import { createBoardFilterSlice } from './board-store/board-filter-slice';
  * pattern in App.tsx.
  *
  * HMR re-sync: the `vite:afterUpdate` handler in App.tsx calls
- * `loadBoard()` and `loadShortcuts()` after hot reload. The
- * hmr-resync.test.ts unit test enforces that every `load*` / `sync*`
- * method on this store is referenced in that handler - do not rename
- * or remove without updating both.
+ * `loadBoard()` and `loadShortcuts()` after hot reload to reconcile with
+ * main-process truth. The hmr-resync.test.ts unit test enforces that every
+ * `load*` / `sync*` method on this store is referenced in that handler - do
+ * not rename or remove without updating both.
+ *
+ * HMR instance pinning (Pattern E, see .claude/rules/hmr-patterns.md): this
+ * module's only runtime export is the non-component `useBoardStore`, so it is
+ * not a React Fast Refresh boundary. A Fast Refresh that re-evaluates this
+ * module (a slice edit, or an edit to a store it imports) would otherwise
+ * construct a SECOND store instance while the mounted board stays subscribed to
+ * the first, stranding agent/MCP-created tasks until a full reload. Pinning the
+ * instance in `import.meta.hot.data` guarantees a single store across HMR cycles.
  */
-export const useBoardStore = create<BoardStore>((...args) => ({
-  ...createTaskSlice(...args),
-  ...createSwimlaneSlice(...args),
-  ...createArchivedTasksSlice(...args),
-  ...createTaskCompletionSlice(...args),
-  ...createBoardConfigSlice(...args),
-  ...createBoardHydrationSlice(...args),
-  ...createTaskMoveConfirmSlice(...args),
-  ...createDoneDropConfirmSlice(...args),
-  ...createActiveViewSlice(...args),
-  ...createBoardManagerSlice(...args),
-  ...createBoardFilterSlice(...args),
-}));
+export function createBoardStore() {
+  return create<BoardStore>((...args) => ({
+    ...createTaskSlice(...args),
+    ...createSwimlaneSlice(...args),
+    ...createArchivedTasksSlice(...args),
+    ...createTaskCompletionSlice(...args),
+    ...createBoardConfigSlice(...args),
+    ...createBoardHydrationSlice(...args),
+    ...createTaskMoveConfirmSlice(...args),
+    ...createDoneDropConfirmSlice(...args),
+    ...createActiveViewSlice(...args),
+    ...createBoardManagerSlice(...args),
+    ...createBoardFilterSlice(...args),
+  }));
+}
+
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+const preservedBoardStore: ReturnType<typeof createBoardStore> | undefined = import.meta.hot?.data?.boardStore;
+
+export const useBoardStore = preservedBoardStore ?? createBoardStore();
+
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+if (import.meta.hot) {
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.data.boardStore = useBoardStore;
+  // Editing this module's OWN code would leave the pinned instance running stale
+  // slice closures; force a clean full reload instead. Rare; prod is unaffected
+  // (import.meta.hot is undefined there, so this whole block is dropped).
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.accept(() => import.meta.hot.invalidate());
+}

--- a/src/renderer/stores/project-store.ts
+++ b/src/renderer/stores/project-store.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand';
+import { create, type StateCreator } from 'zustand';
 import type { Project, ProjectCreateInput, ProjectGroup, ProjectGroupCreateInput, ProjectRelocateOptions, ProjectRelocateResult } from '../../shared/types';
 import { PROJECT_PATH_MISSING_PREFIX } from '../../shared/ipc-channels';
 import { useSessionStore } from './session-store';
@@ -7,8 +7,9 @@ import { dropProject as dropProjectCache } from './project-cache';
 
 // Hydration gate: tracks whether both loadProjects() and loadCurrent() have
 // resolved at least once. Module-scoped so they don't pollute the store
-// interface. On HMR, the module re-evaluates and both reset to false, but the
-// vite:afterUpdate handler in App.tsx immediately re-calls both methods.
+// interface. The store instance is pinned across HMR (Pattern E, below), and the
+// vite:afterUpdate handler in App.tsx re-calls both methods after every reload,
+// so these gates stay correct for the pinned instance's closures.
 let projectsReady = false;
 let currentReady = false;
 
@@ -42,7 +43,7 @@ interface ProjectStore {
   toggleGroupCollapsed: (id: string) => Promise<void>;
 }
 
-export const useProjectStore = create<ProjectStore>((set, get) => ({
+const projectStoreInitializer: StateCreator<ProjectStore> = (set, get) => ({
   projects: [],
   groups: [],
   currentProject: null,
@@ -272,4 +273,26 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
       await get().loadGroups();
     }
   },
-}));
+});
+
+const createProjectStore = () => create<ProjectStore>(projectStoreInitializer);
+
+// HMR instance pinning (Pattern E, see .claude/rules/hmr-patterns.md): this
+// module's only runtime export is the non-component `useProjectStore`, so it is
+// not a React Fast Refresh boundary. Pin the instance in `import.meta.hot.data`
+// so a Fast Refresh that re-evaluates this module cannot strand a second store
+// instance while the mounted sidebar stays subscribed to the first.
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+const preservedProjectStore: ReturnType<typeof createProjectStore> | undefined = import.meta.hot?.data?.projectStore;
+
+export const useProjectStore = preservedProjectStore ?? createProjectStore();
+
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+if (import.meta.hot) {
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.data.projectStore = useProjectStore;
+  // Editing this module's OWN code would leave the pinned instance running stale
+  // closures; force a clean full reload instead (rare; prod drops this block).
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.accept(() => import.meta.hot.invalidate());
+}

--- a/tests/ui/agent-driven-invalidation.spec.ts
+++ b/tests/ui/agent-driven-invalidation.spec.ts
@@ -567,3 +567,55 @@ test.describe('Cross-project shortcuts isolation via warm cache', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Test: a current-project agent create renders the new card in its lane
+//
+// Regression guard for the HMR board-store split-brain (bug #277/#278): an
+// agent/MCP-created task lands in the board store, but the mounted KanbanBoard
+// must actually re-render to show the card. This exercises the full
+// agent-create -> useAgentDrivenInvalidation -> scheduleBoardReload ->
+// loadBoard -> lane render path (the tests above only assert the cache/IPC side
+// effects, not that the card renders). Pattern E instance pinning of the board
+// store keeps a single store instance across HMR so this re-render lands on the
+// mounted board.
+// ---------------------------------------------------------------------------
+
+test.describe('useAgentDrivenInvalidation - current project create renders the card', () => {
+  test('tasks.onCreatedByAgent for the current project renders the new card in its lane', async () => {
+    const { browser, page } = await launch();
+
+    try {
+      // Alpha is current; wait for its board (To Do lane = inv-lane-0).
+      const todoLane = page.locator('[data-swimlane-name="To Do"]');
+      await todoLane.waitFor({ state: 'visible', timeout: 15000 });
+
+      const NEW_TASK_TITLE = 'Agent Created To Do Card';
+
+      // The card must not exist before the agent create.
+      await expect(todoLane.getByText(NEW_TASK_TITLE)).toHaveCount(0);
+
+      // Simulate the backend create (the main process wrote it to the DB), then
+      // the TASK_CREATED_BY_AGENT push the renderer reacts to. The debounced
+      // loadBoard re-fetches tasks.list, which now includes the seeded task.
+      const newTaskId = await page.evaluate(async (currentProjectId) => {
+        const created = await window.electronAPI.tasks.create({
+          title: 'Agent Created To Do Card',
+          description: '',
+          swimlane_id: 'inv-lane-0',
+        });
+        (window as unknown as {
+          __mockFireTaskCreatedByAgent: (taskId: string, title: string, column: string, projectId: string) => void;
+        }).__mockFireTaskCreatedByAgent(created.id, created.title, 'To Do', currentProjectId);
+        return created.id;
+      }, PROJECT_A_ID);
+
+      // toBeVisible polls until the debounced reload (250ms) lands the card; no
+      // fixed wait, so this is stable across Windows/CI timing.
+      await expect(todoLane.getByText(NEW_TASK_TITLE)).toBeVisible({ timeout: 5000 });
+      await expect(todoLane.locator(`[data-task-id="${newTaskId}"]`)).toBeVisible({ timeout: 5000 });
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/unit/board-store-hmr.test.ts
+++ b/tests/unit/board-store-hmr.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for HMR instance pinning in src/renderer/stores/board-store.ts
+ * (Pattern E, see .claude/rules/hmr-patterns.md).
+ *
+ * board-store's only runtime export is the non-component `useBoardStore`, so the
+ * module is not a React Fast Refresh boundary. Without pinning, a Fast Refresh
+ * that re-evaluates this module (a slice edit, or an edit to a store it imports)
+ * constructs a SECOND store instance while the mounted KanbanBoard stays
+ * subscribed to the first - the agent/MCP-created-task split-brain (the card
+ * lands in the store via getState() but the board never re-renders until a full
+ * reload). The fix pins the instance in `import.meta.hot.data`:
+ *
+ *   export const useBoardStore = import.meta.hot?.data?.boardStore ?? createBoardStore();
+ *   import.meta.hot.data.boardStore = useBoardStore;
+ *   import.meta.hot.accept(() => import.meta.hot.invalidate());
+ *
+ * In vitest node mode `import.meta.hot` is undefined, so:
+ *   - the cold path always runs: `useBoardStore` is a fresh `createBoardStore()`;
+ *   - the `if (import.meta.hot)` pin block is skipped (production-like behavior).
+ * We therefore verify (1) cold-init defaults, (2) `createBoardStore()` is a real
+ * factory that yields independent instances (the property that makes pinning
+ * meaningful), and (3) the preservation contract by simulating the HMR
+ * round-trip against the same expression the module uses.
+ *
+ * The fine-grained pin/self-accept lines are guarded mechanically by the
+ * "Pattern E" check in tests/unit/hmr-resync.test.ts. This file locks the
+ * factory's behavior and the resolve contract.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { useBoardStore, createBoardStore } from '../../src/renderer/stores/board-store';
+
+describe('board-store HMR instance pinning (Pattern E)', () => {
+  it('cold-init: the module exports a working store with empty board defaults', () => {
+    const state = useBoardStore.getState();
+    expect(Array.isArray(state.tasks)).toBe(true);
+    expect(state.tasks).toHaveLength(0);
+    expect(Array.isArray(state.swimlanes)).toBe(true);
+    expect(state.swimlanes).toHaveLength(0);
+    expect(state.hydrated).toBe(false);
+    expect(typeof state.loadBoard).toBe('function');
+  });
+
+  it('createBoardStore() yields independent instances (a real factory)', () => {
+    const storeA = createBoardStore();
+    const storeB = createBoardStore();
+    expect(storeA).not.toBe(storeB);
+
+    // Mutating one must not affect the other - proves they do not share state.
+    storeA.setState({ hydrated: true });
+    expect(storeA.getState().hydrated).toBe(true);
+    expect(storeB.getState().hydrated).toBe(false);
+
+    // And neither is the module singleton.
+    expect(storeA).not.toBe(useBoardStore);
+  });
+
+  it('preservation contract: the pin round-trips the SAME instance across HMR', () => {
+    // Simulate the module's pin: stash the live instance into hot.data...
+    const hotData: Record<string, unknown> = {};
+    hotData.boardStore = useBoardStore;
+
+    // ...then the next module evaluation resolves it back via the same
+    // expression the module uses: `import.meta.hot?.data?.boardStore ?? createBoardStore()`.
+    const preserved = hotData.boardStore as typeof useBoardStore | undefined;
+    const resolved = preserved ?? createBoardStore();
+
+    // The pinned instance is reused, never replaced - the guarantee that kills
+    // the split-brain. A bare `createBoardStore()` would return a new object.
+    expect(resolved).toBe(useBoardStore);
+  });
+
+  it('cold path (no preserved instance) constructs a fresh store', () => {
+    const hotData: Record<string, unknown> = {};
+    const preserved = hotData.boardStore as typeof useBoardStore | undefined;
+    const resolved = preserved ?? createBoardStore();
+    expect(resolved).not.toBe(useBoardStore);
+    expect(typeof resolved.getState().loadBoard).toBe('function');
+  });
+});

--- a/tests/unit/hmr-resync.test.ts
+++ b/tests/unit/hmr-resync.test.ts
@@ -238,4 +238,38 @@ describe('HMR store re-sync', () => {
       violations.map((v) => `  - ${v}`).join('\n'),
     ).toHaveLength(0);
   });
+
+  // Pattern E (single-instance store boundary). A Zustand store whose only
+  // runtime export is the non-component hook is not a React Fast Refresh
+  // boundary: a re-eval (a slice edit, or an edit to a store it imports) can
+  // construct a SECOND store instance while a mounted view stays subscribed to
+  // the first. That is the agent/MCP-created-task split-brain (the card lands in
+  // the store but the board never re-renders until a full reload). Each such
+  // store must pin its instance - read it from import.meta.hot.data, write it
+  // back, and self-accept so editing the store's own code forces a clean reload
+  // instead of running stale closures. See .claude/rules/hmr-patterns.md.
+  it('instance-pinned stores read, write, and self-accept across HMR (Pattern E)', () => {
+    const PATTERN_E_STORES = ['board-store.ts', 'backlog-store.ts', 'project-store.ts'];
+    const violations: string[] = [];
+    for (const fileName of PATTERN_E_STORES) {
+      const source = fs.readFileSync(path.join(STORES_DIR, fileName), 'utf-8');
+      const readsPreserved = /import\.meta\.hot\?\.data\?\.\w+/.test(source);
+      const writesPreserved = /import\.meta\.hot\.data\.\w+\s*=/.test(source);
+      const selfAccepts = /import\.meta\.hot\.accept\s*\(/.test(source);
+      if (!readsPreserved || !writesPreserved || !selfAccepts) {
+        violations.push(
+          `${fileName} -> reads:${readsPreserved} writes:${writesPreserved} accepts:${selfAccepts}`,
+        );
+      }
+    }
+
+    expect(
+      violations,
+      `Pattern E stores must pin their Zustand instance across HMR.\n` +
+      `Each must read import.meta.hot?.data?.<key>, assign import.meta.hot.data.<key> = useXStore,\n` +
+      `and call import.meta.hot.accept(() => import.meta.hot.invalidate()).\n` +
+      `See .claude/rules/hmr-patterns.md (Pattern E):\n` +
+      violations.map((v) => `  - ${v}`).join('\n'),
+    ).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## What

Fixes a Vite HMR "split-brain" where an agent/MCP-created task landed in the board Zustand store
(`useBoardStore.getState().tasks` had it) but the mounted `KanbanBoard` never re-rendered to show
the card until a full renderer reload. Switching projects did not help; it was column-agnostic
(reproduced for To Do and Planning).

Affected components:
- `src/renderer/stores/board-store.ts`, `backlog-store.ts`, `project-store.ts` - instance pinning
- `src/renderer/App.tsx` - reconcile-vs-restore comment on the `vite:afterUpdate` re-sync
- `.claude/rules/hmr-patterns.md` - new Pattern E catalog entry + enforcement

## Why

A Zustand store whose only runtime export is the non-component hook is not a React Fast Refresh
boundary. When the store file, one of its slices, or a store it imports (e.g. `config-store`) is
edited during a dogfooding session, Fast Refresh re-evaluates the module and constructs a SECOND
store instance. The mounted board stays subscribed to the first instance, while the agent-push path
(`useAgentDrivenInvalidation` -> `scheduleBoardReload` -> `loadBoard`), the `vite:afterUpdate`
re-sync, and the `__zustandStores` devtools bridge all resolve the new instance. Mutations land on
the new instance; the board renders from the old one, so the card never appears.

Pattern B (`loadBoard()` re-sync in `vite:afterUpdate`) was already present yet the bug persisted -
which is itself the proof it is a dual-instance problem, not a single-instance state reset (Pattern
B can only repair the latter). Kangentic task #278.

## How

Pin each store instance across HMR (a new "Pattern E"):

- Read the preserved instance from `import.meta.hot.data` and reuse it, or construct one via a
  `createXStore()` factory on cold init.
- Write the instance back into `import.meta.hot.data` so the next module evaluation reuses it.
- Self-accept with `import.meta.hot.accept(() => import.meta.hot.invalidate())` so editing the
  store's OWN code forces a clean full reload (no stale slice closures) while an unrelated re-eval
  keeps the single pinned instance.

`import.meta.hot` is `undefined` in production builds, so the whole block is a no-op there. The
existing Pattern B re-sync stays and now reliably reconciles the one pinned instance. The
`task-slice.ts` `moveGeneration` Pattern A preservation is left untouched (orthogonal). Pattern E is
documented in `.claude/rules/hmr-patterns.md`; `config-store`/`session-store` share the shape and
are noted as a follow-up.

## Breaking changes

None. Dev-only HMR behavior; production is unaffected (`import.meta.hot` is undefined). Editing a
store's own slice code now triggers a clean full reload in dev instead of a silent HMR swap, which
is the intended trade-off.

## Tests

- `tests/unit/hmr-resync.test.ts` - new mechanical "Pattern E" guard: each pinned store reads +
  writes `import.meta.hot.data` and self-accepts. Red-green verified (removing the pin write fails
  the test).
- `tests/unit/board-store-hmr.test.ts` (new) - cold-init defaults, `createBoardStore()` factory
  independence, and the preservation/resolve contract.
- `tests/ui/agent-driven-invalidation.spec.ts` - new test asserting an agent-driven create renders
  the new card in its lane (the full create -> reload -> render path).
- Local gate: `npm run typecheck` and `npm run lint` clean. The unit/UI/E2E tiers run as CI checks.

Generated with [Claude Code](https://claude.com/claude-code)
