### PR TITLE
fix(pr-linking): drop commit-matched PR whose merge commit is the anchor

### DIFF
--- a/src/main/boards/adapters/github-common/gh-client.ts
+++ b/src/main/boards/adapters/github-common/gh-client.ts
@@ -64,6 +64,14 @@ export interface GhPrListItem {
   baseRefName: string;
   updatedAt: string;
   isCrossRepository?: boolean;
+  /**
+   * The commit the PR landed on its base branch: the merge commit (merge), the
+   * squashed commit (squash), or the new base tip (rebase). Used by commit-based
+   * resolution to reject a PR whose merge product IS the commit being resolved
+   * from - that commit is shared base history, never the task's own work.
+   * Populated from the REST `merge_commit_sha` on the commit-pulls path only.
+   */
+  mergeCommitOid?: string;
 }
 
 /** JSON field set requested from `gh pr list` / `gh pr view`. */
@@ -132,6 +140,7 @@ interface GhCommitPullRaw {
   state: string;          // 'open' | 'closed' (REST does not surface 'merged' here)
   draft?: boolean;
   merged_at?: string | null;
+  merge_commit_sha?: string | null;
   head?: { ref?: string; repo?: { full_name?: string } | null };
   base?: { ref?: string; repo?: { full_name?: string } | null };
   updated_at?: string;
@@ -154,6 +163,7 @@ function normalizeCommitPull(raw: GhCommitPullRaw): GhPrListItem {
     baseRefName: raw.base?.ref ?? '',
     updatedAt: raw.updated_at ?? '',
     isCrossRepository,
+    mergeCommitOid: raw.merge_commit_sha ?? undefined,
   };
 }
 

--- a/src/main/pr/adapters/github/github-connector.ts
+++ b/src/main/pr/adapters/github/github-connector.ts
@@ -196,9 +196,19 @@ export const gitHubPRConnector: PRConnector = {
   async resolveByCommit(repoCwd: string, commitSha: string, branchHint?: string): Promise<ResolvedPR | null> {
     return viaGh(async () => {
       const items = await ghImporter.resolvePRByCommit(repoCwd, commitSha);
-      // The commit can belong to several PRs (shared/squashed commits); the
+      // Drop any PR whose merge product IS the commit we resolved from. A fresh
+      // worktree branched from base sits on base's tip, which is the last-merged
+      // PR's merge/squash/rebase commit - that commit is shared base history, not
+      // this task's work, and `gh api commits/{sha}/pulls` would otherwise magnet
+      // the task onto a sibling's merged PR. (An open PR's `merge_commit_sha` is a
+      // synthetic test-merge that can never equal a real authored commit, so a
+      // task's own PR is never dropped here.) This backstops the linker's
+      // commits-ahead-of-base guard, which misfires when the task's base branch is
+      // wrong or unknown.
+      const candidates = items.filter((item) => item.mergeCommitOid !== commitSha);
+      // The commit can still belong to several PRs (shared/squashed commits); the
       // branch hint ties it back to this task and ambiguous matches return null.
-      const best = disambiguate(items, { branchHint });
+      const best = disambiguate(candidates, { branchHint });
       return best ? toResolvedPR(best) : null;
     });
   },

--- a/tests/unit/branch-pr-resolver.test.ts
+++ b/tests/unit/branch-pr-resolver.test.ts
@@ -223,7 +223,7 @@ describe('GitHubImporter.resolvePRByCommit (REST normalization)', () => {
   it('queries the commits/{sha}/pulls endpoint and normalizes REST -> GhPrListItem', async () => {
     const sameRepo = { full_name: 'owner/repo' };
     state.ghStdout = JSON.stringify([
-      { number: 1, html_url: 'u-merged', state: 'closed', draft: false, merged_at: '2026-02-01T00:00:00Z', head: { ref: 'feat', repo: sameRepo }, base: { ref: 'main', repo: sameRepo }, updated_at: '2026-02-01T00:00:00Z' },
+      { number: 1, html_url: 'u-merged', state: 'closed', draft: false, merged_at: '2026-02-01T00:00:00Z', merge_commit_sha: 'merge-sha-1', head: { ref: 'feat', repo: sameRepo }, base: { ref: 'main', repo: sameRepo }, updated_at: '2026-02-01T00:00:00Z' },
       { number: 2, html_url: 'u-open', state: 'open', draft: false, merged_at: null, head: { ref: 'feat', repo: sameRepo }, base: { ref: 'main', repo: sameRepo }, updated_at: '2026-01-01T00:00:00Z' },
       { number: 3, html_url: 'u-closed', state: 'closed', draft: false, merged_at: null, head: { ref: 'feat', repo: sameRepo }, base: { ref: 'main', repo: sameRepo }, updated_at: '2026-01-01T00:00:00Z' },
       { number: 4, html_url: 'u-draft', state: 'open', draft: true, merged_at: null, head: { ref: 'feat', repo: sameRepo }, base: { ref: 'main', repo: sameRepo }, updated_at: '2026-01-01T00:00:00Z' },
@@ -240,6 +240,8 @@ describe('GitHubImporter.resolvePRByCommit (REST normalization)', () => {
     ]);
     expect(result[0].url).toBe('u-merged');
     expect(result[0].headRefName).toBe('feat');
+    expect(result[0].mergeCommitOid).toBe('merge-sha-1');     // merge_commit_sha -> mergeCommitOid
+    expect(result[1].mergeCommitOid).toBeUndefined();         // absent in raw -> undefined
     expect(result.every((item) => item.isCrossRepository === false)).toBe(true);
   });
 
@@ -337,6 +339,42 @@ describe('connector resolveByNumber / resolveByCommit + error translation', () =
     // PR by commit) is prevented upstream by the linker's commits-ahead-of-base guard, which never
     // reaches this resolver for a branchless worktree - not by rejecting a single non-matching PR here.
     expect((await gitHubPRConnector.resolveByCommit!('/r', 'sha', 'stale-slug'))?.number).toBe(5);
+  });
+
+  it('resolveByCommit drops a candidate whose merge commit IS the resolved-from commit (base-tip magnet)', async () => {
+    // The #77 magnet: a fresh worktree branched from develop sits on develop's tip,
+    // which is the merge commit of the last-merged PR (716). resolveByCommit must not
+    // link that sibling PR even though it is the only candidate, because the commit is
+    // shared base history, not this task's own work.
+    vi.spyOn(GitHubImporter.prototype, 'resolvePRByCommit').mockResolvedValue([
+      pr({ number: 716, headRefName: 'chore/715-claude-rules-and-hooks', mergeCommitOid: '5d503751' }),
+    ]);
+    expect(await gitHubPRConnector.resolveByCommit!('/r', '5d503751', 'ci-release-tickets-s-a66f2e5c')).toBeNull();
+  });
+
+  it('resolveByCommit keeps a candidate whose merge commit differs from the resolved-from commit (own work)', async () => {
+    // A task's authored HEAD is never its own PR's merge product, so a real
+    // commit-based discovery still resolves.
+    vi.spyOn(GitHubImporter.prototype, 'resolvePRByCommit').mockResolvedValue([
+      pr({ number: 500, headRefName: 'feat', mergeCommitOid: 'other-sha' }),
+    ]);
+    expect((await gitHubPRConnector.resolveByCommit!('/r', 'head-sha', 'feat'))?.number).toBe(500);
+  });
+
+  it('resolveByCommit - multi-candidate: drops base-tip magnet that would win by recency, keeps the real PR', async () => {
+    // Multi-candidate, no branchHint - the "base branch wrong or unknown" path.
+    // Candidate #716 is the base-tip magnet: its mergeCommitOid equals the commit
+    // being resolved from AND it is the more-recently-updated MERGED PR, so without
+    // the filter disambiguate would return it by recency. The filter drops it and
+    // #500 (the task's own PR, older updatedAt) survives.
+    const resolvedFromSha = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+    const ownPrMergeCommitSha = '0000111122223333444455556666777788889999';
+    vi.spyOn(GitHubImporter.prototype, 'resolvePRByCommit').mockResolvedValue([
+      pr({ number: 716, state: 'MERGED', updatedAt: '2026-05-01T00:00:00Z', headRefName: 'chore/last-merged', mergeCommitOid: resolvedFromSha }),
+      pr({ number: 500, state: 'MERGED', updatedAt: '2026-01-01T00:00:00Z', headRefName: 'feat', mergeCommitOid: ownPrMergeCommitSha }),
+    ]);
+    const result = await gitHubPRConnector.resolveByCommit!('/r', resolvedFromSha);
+    expect(result?.number).toBe(500);
   });
 
   it('registry resolvePRByNumber / resolvePRByCommit delegate to the connector', async () => {


### PR DESCRIPTION
## What

The GitHub PR connector's commit-based resolver (`resolveByCommit`) now drops any candidate PR whose merge commit IS the commit being resolved from, before disambiguation. `GhPrListItem` gains a `mergeCommitOid`, populated from the REST `merge_commit_sha` on the `commits/{sha}/pulls` path.

- `src/main/pr/adapters/github/github-connector.ts`
- `src/main/boards/adapters/github-common/gh-client.ts`

## Why

A board task could be stamped with a sibling task's PR and render it as "merged". A fresh worktree branched from the integration branch sits on that branch's tip, which is the last-merged PR's merge commit. Tier-3 commit resolution then queried `gh api commits/<sha>/pulls`, found that sibling PR, and linked it, because the upstream commits-ahead-of-base guard misfired: it measured against the wrong base (`base_branch` is unset, so it defaults to `main`) while the project's real integration branch was `develop`, so a worktree on `develop`'s tip looked ahead of base and the magnet ran.

Confirmed empirically on TWC-Website task #77, which showed PR #716 (a sibling task's PR, head `chore/715-...`, base `develop`) as merged. Tracks Kangentic board task #283.

## How

A PR's merge commit is shared base-branch history, never a task's own authored work, so it is a base-branch-agnostic signal: dropping a commit-resolved candidate whose merge commit equals the resolved-from commit kills the magnet without needing a correct `base_branch`. It preserves the intentional single-PR fallthrough (the renamed-branch Done discovery, guarded by an existing test): a task's authored HEAD is never its own PR's merge product, and an open PR's synthetic test-merge SHA can never equal a real authored commit, so a legitimate own-PR match is never dropped.

This complements (does not replace) the existing `hasCommitsAheadOfBase` guard. Out of scope: populating `base_branch` correctly at worktree creation would make that guard correct too.

## Breaking changes

None. `mergeCommitOid` is transient resolution data and is never persisted (no schema change).

## Tests

`tests/unit/branch-pr-resolver.test.ts` (red-green verified, runs in the CI unit tier):

- Drops the base-tip magnet (the #77 instance): a single PR whose merge commit equals the resolved-from commit resolves to `null`.
- Keeps a real own-work PR whose merge commit differs.
- Multi-candidate: the magnet would win by recency, but the filter drops it and the real PR survives.
- `merge_commit_sha` normalizes to `mergeCommitOid` (and an absent field maps to `undefined`).

Existing tests, including the intentional single-PR fallthrough, stay green. CI runs the full unit, UI, and Electron E2E tiers.

Generated with [Claude Code](https://claude.com/claude-code)
