### PR TITLE
refactor(renderer): extract shared panel drag-resize gesture into one helper

### DIFF
--- a/src/renderer/hooks/panel-drag.ts
+++ b/src/renderer/hooks/panel-drag.ts
@@ -1,0 +1,44 @@
+import type { MouseEvent as ReactMouseEvent } from 'react';
+
+export interface PanelDragOptions {
+  /**
+   * Body cursor for the duration of the drag, set immediately at mousedown.
+   * Omit when the caller sets the cursor itself (the sidebar sets it lazily
+   * after a dead zone). The cursor is always reset to '' on release regardless.
+   */
+  cursor?: 'col-resize' | 'row-resize';
+  /** Fires on every mousemove with the live event. The caller does its own math. */
+  onMove: (event: MouseEvent) => void;
+  /** Fires once on release, after the listeners are removed and body styles reset. */
+  onRelease: () => void;
+}
+
+/**
+ * Shared pointer-drag gesture for the app-shell panel resizers (sidebar, bottom
+ * terminal panel, task-detail divider). Owns the boilerplate that all three share:
+ * preventDefault, the body userSelect lock, document mousemove/mouseup wiring, and
+ * resetting body cursor + userSelect on release. Callers keep their own per-frame
+ * math, clamping, persistence, and `terminal-panel-resize` dispatch in onMove /
+ * onRelease.
+ *
+ * Imperative (no React state) by design, so callers invoke it from inside their own
+ * onResizeStart useCallback without it entering a dependency array.
+ */
+export function startPanelDrag(event: ReactMouseEvent, options: PanelDragOptions): void {
+  event.preventDefault();
+  document.body.style.userSelect = 'none';
+  if (options.cursor) document.body.style.cursor = options.cursor;
+
+  const handleMove = options.onMove;
+
+  const handleUp = () => {
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+    document.removeEventListener('mousemove', handleMove);
+    document.removeEventListener('mouseup', handleUp);
+    options.onRelease();
+  };
+
+  document.addEventListener('mousemove', handleMove);
+  document.addEventListener('mouseup', handleUp);
+}

--- a/src/renderer/hooks/useSidebarResize.ts
+++ b/src/renderer/hooks/useSidebarResize.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import type { AppConfig } from '../../shared/types';
+import { startPanelDrag } from './panel-drag';
 
 const MIN_WIDTH = 200;
 const MAX_WIDTH = 400;
@@ -14,7 +15,7 @@ export interface SidebarResizeState {
   isResizing: boolean;
   ready: boolean;
   toggle: () => void;
-  onResizeStart: (e: React.MouseEvent) => void;
+  onResizeStart: (event: React.MouseEvent) => void;
 }
 
 export function useSidebarResize(config: AppConfig): SidebarResizeState {
@@ -55,80 +56,73 @@ export function useSidebarResize(config: AppConfig): SidebarResizeState {
   }, []);
   toggleRef.current = toggle;
 
-  const onResizeStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    document.body.style.userSelect = 'none';
-
-    const startX = e.clientX;
+  const onResizeStart = useCallback((event: React.MouseEvent) => {
+    const startX = event.clientX;
     const wasClosed = !openRef.current;
     const startWidth = wasClosed ? 0 : latestWidthRef.current;
     let isDragging = false;
     let didCollapse = false;
 
-    const onMouseMove = (e: MouseEvent) => {
-      const delta = Math.abs(e.clientX - startX);
+    startPanelDrag(event, {
+      // Cursor is set lazily below, only once the drag clears the dead zone, so a
+      // pure click never changes the cursor.
+      onMove: (moveEvent) => {
+        const delta = Math.abs(moveEvent.clientX - startX);
 
-      // Don't start dragging until past the dead zone
-      if (!isDragging) {
-        if (delta < DRAG_DEAD_ZONE) return;
-        isDragging = true;
-        setIsResizing(true);
-        document.body.style.cursor = 'col-resize';
-      }
+        // Don't start dragging until past the dead zone
+        if (!isDragging) {
+          if (delta < DRAG_DEAD_ZONE) return;
+          isDragging = true;
+          setIsResizing(true);
+          document.body.style.cursor = 'col-resize';
+        }
 
-      const rawWidth = startWidth + (e.clientX - startX);
+        const rawWidth = startWidth + (moveEvent.clientX - startX);
 
-      if (rawWidth < COLLAPSE_THRESHOLD) {
-        // Hold at min width during drag; collapse animates on mouseUp
-        setWidth(MIN_WIDTH);
-        didCollapse = true;
-      } else {
-        const newWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, rawWidth));
-        setWidth(newWidth);
-        latestWidthRef.current = newWidth;
-        didCollapse = false;
-        if (!openRef.current) setOpen(true);
-      }
-    };
+        if (rawWidth < COLLAPSE_THRESHOLD) {
+          // Hold at min width during drag; collapse animates on mouseUp
+          setWidth(MIN_WIDTH);
+          didCollapse = true;
+        } else {
+          const newWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, rawWidth));
+          setWidth(newWidth);
+          latestWidthRef.current = newWidth;
+          didCollapse = false;
+          if (!openRef.current) setOpen(true);
+        }
+      },
 
-    const onMouseUp = () => {
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
+      onRelease: () => {
+        if (!isDragging) {
+          // Pure click - toggle sidebar
+          toggleRef.current();
+          return;
+        }
 
-      if (!isDragging) {
-        // Pure click -- toggle sidebar
-        toggleRef.current();
-        return;
-      }
+        // End resize state first so CSS transition re-enables
+        setIsResizing(false);
 
-      // End resize state first so CSS transition re-enables
-      setIsResizing(false);
-
-      if (didCollapse) {
-        collapsedByDragRef.current = true;
-        window.electronAPI.config.set({ sidebarVisible: false });
-        // Animate closed: transition is now active, so setting width to 0
-        // triggers the CSS transition from MIN_WIDTH → 0
+        if (didCollapse) {
+          collapsedByDragRef.current = true;
+          window.electronAPI.config.set({ sidebarVisible: false });
+          // Animate closed: transition is now active, so setting width to 0
+          // triggers the CSS transition from MIN_WIDTH → 0
+          requestAnimationFrame(() => {
+            setWidth(0);
+            setOpen(false);
+          });
+        } else {
+          setOpen(true);
+          window.electronAPI.config.set({
+            sidebar: { width: latestWidthRef.current },
+            sidebarVisible: true,
+          });
+        }
         requestAnimationFrame(() => {
-          setWidth(0);
-          setOpen(false);
+          window.dispatchEvent(new CustomEvent('terminal-panel-resize'));
         });
-      } else {
-        setOpen(true);
-        window.electronAPI.config.set({
-          sidebar: { width: latestWidthRef.current },
-          sidebarVisible: true,
-        });
-      }
-      requestAnimationFrame(() => {
-        window.dispatchEvent(new CustomEvent('terminal-panel-resize'));
-      });
-    };
-
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
+      },
+    });
   }, []);
 
   return { open, width, isResizing, ready, toggle, onResizeStart };

--- a/src/renderer/hooks/useTaskSplitResize.ts
+++ b/src/renderer/hooks/useTaskSplitResize.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect, type RefObject } from 'react';
 import { useSessionStore } from '../stores/session-store';
+import { startPanelDrag } from './panel-drag';
 
 const MIN_RATIO = 0.25;
 const MAX_RATIO = 0.75;
@@ -17,10 +18,10 @@ export interface TaskSplitResizeState {
 }
 
 /**
- * Drag-to-resize for the task-detail terminal / right-panel split. Mirrors the
- * col-resize pattern in `useSidebarResize`: document-level mousemove/mouseup
- * listeners, body cursor + userSelect overrides, and a `terminal-panel-resize`
- * dispatch on release so the embedded xterm refits to its new width.
+ * Drag-to-resize for the task-detail terminal / right-panel split. Drives the
+ * gesture through the shared `startPanelDrag` helper (document mousemove/mouseup
+ * wiring + body cursor/userSelect lock) and dispatches `terminal-panel-resize` on
+ * release so the embedded xterm refits to its new width.
  *
  * The ratio is one shared value per task (keyed by `taskId` in the session
  * store), so the divider position is identical whether the Browser or Changes
@@ -47,36 +48,28 @@ export function useTaskSplitResize(
   }, [storedRatio, isResizing]);
 
   const onResizeStart = useCallback((event: React.MouseEvent) => {
-    event.preventDefault();
     const container = containerRef.current;
     if (!container) return;
 
     setIsResizing(true);
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
 
-    const onMouseMove = (moveEvent: MouseEvent) => {
-      const rect = container.getBoundingClientRect();
-      if (rect.width === 0) return;
-      const nextRatio = clampRatio((moveEvent.clientX - rect.left) / rect.width);
-      setRatio(nextRatio);
-      latestRatioRef.current = nextRatio;
-    };
-
-    const onMouseUp = () => {
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-      setIsResizing(false);
-      setDividerRatio(taskId, latestRatioRef.current);
-      requestAnimationFrame(() => {
-        window.dispatchEvent(new CustomEvent('terminal-panel-resize'));
-      });
-    };
-
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
+    startPanelDrag(event, {
+      cursor: 'col-resize',
+      onMove: (moveEvent) => {
+        const rect = container.getBoundingClientRect();
+        if (rect.width === 0) return;
+        const nextRatio = clampRatio((moveEvent.clientX - rect.left) / rect.width);
+        setRatio(nextRatio);
+        latestRatioRef.current = nextRatio;
+      },
+      onRelease: () => {
+        setIsResizing(false);
+        setDividerRatio(taskId, latestRatioRef.current);
+        requestAnimationFrame(() => {
+          window.dispatchEvent(new CustomEvent('terminal-panel-resize'));
+        });
+      },
+    });
   }, [containerRef, setDividerRatio, taskId]);
 
   return { ratio, isResizing, onResizeStart };

--- a/src/renderer/hooks/useTerminalResize.ts
+++ b/src/renderer/hooks/useTerminalResize.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import type { AppConfig } from '../../shared/types';
+import { startPanelDrag } from './panel-drag';
 
 const MIN_HEIGHT = 100;
 export const COLLAPSED_HEIGHT = 36;
@@ -51,7 +52,7 @@ export interface TerminalResizeState {
   suppressTransition: boolean;
   contentColRef: React.RefObject<HTMLDivElement | null>;
   onToggleCollapse: () => void;
-  onResizeStart: (e: React.MouseEvent) => void;
+  onResizeStart: (event: React.MouseEvent) => void;
   handleTransitionEnd: () => void;
 }
 
@@ -218,38 +219,30 @@ export function useTerminalResize(
     }
   }, []);
 
-  const onResizeStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
+  const onResizeStart = useCallback((event: React.MouseEvent) => {
     setIsResizing(true);
-    document.body.style.cursor = 'row-resize';
-    document.body.style.userSelect = 'none';
 
-    const startY = e.clientY;
+    const startY = event.clientY;
     const startHeight = height;
 
-    const onMouseMove = (e: MouseEvent) => {
-      const delta = startY - e.clientY;
-      const newHeight = clampHeight(startHeight + delta);
-      setHeight(newHeight);
-      latestHeightRef.current = newHeight;
-    };
-
-    const onMouseUp = () => {
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-      window.electronAPI.config.set({
-        terminal: { ...config.terminal, panelHeight: latestHeightRef.current },
-      });
-      setIsResizing(false);
-      // Explicit refit signal. The debounced ResizeObserver also handles this,
-      // but the explicit event gives a faster 50ms response.
-      window.dispatchEvent(new CustomEvent('terminal-panel-resize'));
-    };
-
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
+    startPanelDrag(event, {
+      cursor: 'row-resize',
+      onMove: (moveEvent) => {
+        const delta = startY - moveEvent.clientY;
+        const newHeight = clampHeight(startHeight + delta);
+        setHeight(newHeight);
+        latestHeightRef.current = newHeight;
+      },
+      onRelease: () => {
+        window.electronAPI.config.set({
+          terminal: { ...config.terminal, panelHeight: latestHeightRef.current },
+        });
+        setIsResizing(false);
+        // Explicit refit signal. The debounced ResizeObserver also handles this,
+        // but the explicit event gives a faster 50ms response.
+        window.dispatchEvent(new CustomEvent('terminal-panel-resize'));
+      },
+    });
   }, [height, config.terminal, clampHeight]);
 
   return { height, collapsed: effectiveCollapsed, isResizing, showContent, ready, suppressTransition, contentColRef, onToggleCollapse, onResizeStart, handleTransitionEnd };


### PR DESCRIPTION
## What

Extracts the shared low-level pointer-drag gesture out of the three app-shell resize hooks into one helper. No behavior change.

- New `src/renderer/hooks/panel-drag.ts` - `startPanelDrag(event, { cursor?, onMove, onRelease })`. Owns the boilerplate all three hooks shared: `preventDefault`, the body `userSelect` lock, document `mousemove`/`mouseup` wiring, and resetting body `cursor` + `userSelect` + removing both listeners on release. Imperative (no React state), so callers invoke it from inside their own `onResizeStart` `useCallback` without it entering a dependency array.
- `useSidebarResize.ts`, `useTerminalResize.ts`, `useTaskSplitResize.ts` - each now calls `startPanelDrag` and keeps its own distinct logic on top: the sidebar's dead-zone + collapse-to-strip + click-to-toggle, the terminal panel's inverted-delta half-viewport clamp + ResizeObserver re-clamp, and the task-detail divider's per-task container-rect ratio. Each keeps its own `terminal-panel-resize` dispatch on release (sidebar and task-split wrap it in `requestAnimationFrame`; the terminal panel dispatches synchronously for the faster 50ms refit).

## Why

The three hooks each hand-rolled the same ~15-line mouse-drag skeleton, and the duplication was already acknowledged in-code (`useTaskSplitResize`'s doc comment: "Mirrors the col-resize pattern in `useSidebarResize`"). A leaked listener or a forgotten body-style reset is a real bug class, so centralizing the gesture plumbing in one place removes the copy-paste while leaving each hook's behavior untouched.

This is deliberately the only consolidation in scope. The window-manager resizers (`TileSplitter`, `useWindowResize` / `FootprintResizer`) stay untouched: they use the opposite no-re-render imperative strategy and are terminal-fit-aware, so folding the app-shell panels onto them was explicitly ruled out.

## How

The helper is a plain module-level function rather than a `use*` hook, since it holds no React state. That keeps it out of every consumer's `useCallback` dependency array, so none of the three dependency lists change (no `react-hooks/exhaustive-deps` churn under `--max-warnings 0`). It passes the raw `MouseEvent` to `onMove` (task-split needs absolute `clientX` vs its container rect, not a delta) and treats `cursor` as optional (the sidebar sets its cursor lazily after a dead zone, so a pure click never changes the cursor).

One invisible micro-difference: in `useTaskSplitResize`, the `if (!container) return` guard now sits just before `startPanelDrag`, so on a (practically impossible) null-`containerRef` mousedown, `preventDefault` is skipped where it previously fired first. The ref is always attached during a real divider mousedown.

## Breaking changes

None. Hook return shapes are unchanged; the window-manager resizers and the consumers (`AppLayout`, `TaskDetailBody`) are untouched.

## Tests

No new tests - this is a behavior-preserving extraction with no new branch or public contract, and a `test-builder` coverage pass confirmed existing coverage is adequate. The behavior is already exercised end-to-end by `tests/ui/collapsed-rail.spec.ts` (sidebar collapse-to-strip), `tests/ui/task-detail-split-divider.spec.ts` (real divider drags + the `terminal-panel-resize` dispatch on mouseup), and `tests/unit/use-task-split-resize.test.ts` (the pure ratio/resync logic). Local gate green (typecheck + lint zero-warnings); CI runs the unit, UI, and Electron E2E tiers.

Generated with [Claude Code](https://claude.com/claude-code)
