### PR TITLE
refactor(activity-colors): tokenize indicators and soften the idle color

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,8 @@ won't be found.
   Both behaviors live in the shared engine, so task-detail windows get them too. The title-bar terminal button is context-aware: it opens the layer when
   closed, and spawns another terminal (up to the cap) when open. The title-bar glyph is a custom
   SVG (`CommandTerminalIcon` in `TitleBar.tsx`): its stroke color is the aggregate activity of the
-  project's terminals (emerald working / amber needs-you / muted rest) and the working border
+  project's terminals (active-green working / attention-amber needs-you / muted rest, via the
+  central `--kng-active` / `--kng-attention` tokens) and the working border
   MARCHES (`@keyframes march-border` + a `pathLength`-normalized stroke-dash). The `+` add
   affordance lives in the CENTER of the glyph (replacing the shell prompt) when the layer is open
   and below the cap, not a corner badge, so it never clashes with the activity color. This replaces

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -527,7 +527,7 @@ Sessions paused manually by the user (via the pause button in the task detail di
 
 The Command Terminal provides quick, ephemeral access to Claude Code without creating a task on the board. Useful for one-off actions like creating releases, running queries, or any ad-hoc interaction.
 
-**Opening:** Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS), or click the terminal icon in the title bar (next to the settings gear). The terminal icon's border reflects activity across your open terminals: it marches in emerald while an agent is working, holds a solid amber when one needs your input, and stays plain when idle.
+**Opening:** Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS), or click the terminal icon in the title bar (next to the settings gear). The terminal icon's border reflects activity across your open terminals: it marches in green while an agent is working, holds a steady warm amber when one needs your input, and stays plain when idle.
 
 **Behavior:**
 - Spawns Claude Code at the project root on the configured default base branch

--- a/src/renderer/components/board/ActivityReasonTooltip.tsx
+++ b/src/renderer/components/board/ActivityReasonTooltip.tsx
@@ -45,14 +45,14 @@ export function ActivityReasonTooltip({ reason }: { reason: ActivityReason }): R
     case 'idle':
       return (
         <span className="inline-flex items-center gap-1.5 text-xs text-fg-faint">
-          <Mail size={12} className="text-amber-400" />
+          <Mail size={12} className="text-attention" />
           <span>Idle</span>
         </span>
       );
     case 'permission':
       return (
         <span className="inline-flex items-center gap-1.5 text-xs text-fg-faint">
-          <Lock size={12} className="text-amber-400" />
+          <Lock size={12} className="text-attention" />
           <span>Awaiting permission</span>
         </span>
       );
@@ -75,7 +75,7 @@ export function ActivityReasonTooltip({ reason }: { reason: ActivityReason }): R
     case 'background-shell':
       return (
         <span className="inline-flex items-center gap-1.5 text-xs text-fg-faint">
-          <Terminal size={12} className="text-emerald-400" />
+          <Terminal size={12} className="text-active" />
           <span>
             {reason.count} background shell{reason.count === 1 ? '' : 's'}
             {reason.ids.length > 0 ? ` (${reason.ids.join(', ')})` : ''}
@@ -85,7 +85,7 @@ export function ActivityReasonTooltip({ reason }: { reason: ActivityReason }): R
     case 'turn-active':
       return (
         <span className="inline-flex items-center gap-1.5 text-xs text-fg-faint">
-          <Loader2 size={12} className="text-green-400 animate-spin" />
+          <Loader2 size={12} className="text-active animate-spin" />
           <span>Thinking</span>
         </span>
       );

--- a/src/renderer/components/board/TaskCard.tsx
+++ b/src/renderer/components/board/TaskCard.tsx
@@ -256,7 +256,7 @@ const TaskCardInner = function TaskCard({ task, isDragOverlay, compact, onDelete
           {isIdle && (
             <Mail
               size={14}
-              className="text-amber-400 shrink-0"
+              className="text-attention shrink-0"
               aria-label={activityReason ? formatActivityReasonText(activityReason) : 'Idle'}
             >
               {activityReason && <title>{formatActivityReasonText(activityReason)}</title>}
@@ -265,7 +265,7 @@ const TaskCardInner = function TaskCard({ task, isDragOverlay, compact, onDelete
           {isThinking && (
             <Loader2
               size={14}
-              className="text-emerald-400 animate-spin shrink-0"
+              className="text-active animate-spin shrink-0"
               aria-label={activityReason ? formatActivityReasonText(activityReason) : 'Thinking'}
             >
               {activityReason && <title>{formatActivityReasonText(activityReason)}</title>}

--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -72,24 +72,24 @@ function StopSquare({ colorClass }: { colorClass: string }): ReactNode {
  * folds into its pause button (`PauseButtonIcon`), but with a STOP square centered
  * instead of pause bars - the command terminal stops (kills the PTY); it never
  * pauses. Activity is encoded by the surrounding ring:
- *   - thinking (agent working): a spinning emerald ring around the stop square.
- *   - idle/permission (needs you): a static amber ring around the stop square.
+ *   - thinking (agent working): a spinning active ring around the stop square.
+ *   - idle/permission (needs you): a static attention ring around the stop square.
  *   - not yet running / no activity: the plain red CircleStop (rest state).
  */
 function StopButtonIcon({ isThinking, isIdle }: { isThinking: boolean; isIdle: boolean }): ReactNode {
   if (isThinking) {
     return (
       <span className="grid place-items-center">
-        <Circle size={20} className="col-start-1 row-start-1 text-emerald-400 animate-spin [stroke-dasharray:47_16]" />
-        <StopSquare colorClass="bg-emerald-400" />
+        <Circle size={20} className="col-start-1 row-start-1 text-active animate-spin [stroke-dasharray:47_16]" />
+        <StopSquare colorClass="bg-active" />
       </span>
     );
   }
   if (isIdle) {
     return (
       <span className="grid place-items-center">
-        <Circle size={20} className="col-start-1 row-start-1 text-amber-400" />
-        <StopSquare colorClass="bg-amber-400" />
+        <Circle size={20} className="col-start-1 row-start-1 text-attention" />
+        <StopSquare colorClass="bg-attention" />
       </span>
     );
   }

--- a/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
+++ b/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
@@ -26,7 +26,7 @@ import { WindowLayoutMenu } from '../WindowLayoutMenu';
  * Drawn as solid `bg-*` bars (not the stroked lucide `Pause`, which renders
  * ragged at this size) and sized to match the CirclePause proportions, so the
  * bars stay crisp and the icon reads cleanly at ~20px. `colorClass` is a
- * `bg-*` utility matching the ring (amber for idle, emerald for active).
+ * `bg-*` utility matching the ring (attention for idle, active for working).
  */
 function PauseBars({ colorClass }: { colorClass: string }): ReactNode {
   return (
@@ -42,12 +42,12 @@ function PauseBars({ colorClass }: { colorClass: string }): ReactNode {
  * running session; activity is encoded by the surrounding ring (the button
  * itself never changes its icon on hover). Branches in evaluation order:
  *   - toggling: a muted grey spinner (brief, sub-5s).
- *   - active (thinking): a spinning emerald ring around the pause.
- *   - idle/permission:   a static amber ring around the pause.
+ *   - active (thinking): a spinning active ring around the pause.
+ *   - idle/permission:   a static attention ring around the pause.
  *   - queued: the clock.
  *   - launching (preparing/initializing): a muted grey spinner (matching the
- *     board card) - the agent has not started yet, so it is NOT green; it flips
- *     to the emerald active ring once the session is running.
+ *     board card) - the agent has not started yet, so it is NOT active-green; it flips
+ *     to the active ring once the session is running.
  *   - suspended: the resume control.
  */
 function PauseButtonIcon({
@@ -66,35 +66,35 @@ function PauseButtonIcon({
   if (toggling) return <Loader2 size={18} className="animate-spin" />;
 
   // Active: the SAME Circle as idle (identical radius/size - lucide's Loader2 is
-  // radius 9 vs Circle's 10, which rendered ~10% smaller) but emerald, spinning,
+  // radius 9 vs Circle's 10, which rendered ~10% smaller) but active-green, spinning,
   // and dashed so the spin reads as a loading arc. The pause shares the grid cell
   // (place-items-center) so it sits dead-center in the 20px ring.
   if (isThinking) {
     return (
       <span className="grid place-items-center">
-        <Circle size={20} className="col-start-1 row-start-1 text-emerald-400 animate-spin [stroke-dasharray:47_16]" />
-        <PauseBars colorClass="bg-emerald-400" />
+        <Circle size={20} className="col-start-1 row-start-1 text-active animate-spin [stroke-dasharray:47_16]" />
+        <PauseBars colorClass="bg-active" />
       </span>
     );
   }
 
-  // Idle/permission: the same ring + pause as active, but an amber static ring
+  // Idle/permission: the same ring + pause as active, but an attention static ring
   // (a full circle, no spin) so the two states share one visual language and
   // differ only by color and motion.
   if (isIdle) {
     return (
       <span className="grid place-items-center">
-        <Circle size={20} className="col-start-1 row-start-1 text-amber-400" />
-        <PauseBars colorClass="bg-amber-400" />
+        <Circle size={20} className="col-start-1 row-start-1 text-attention" />
+        <PauseBars colorClass="bg-attention" />
       </span>
     );
   }
 
   if (isQueued) return <Clock size={18} />;
   // Launching (preparing/initializing): a muted grey spinner matching the board
-  // card's loading indicator. The agent has not started yet, so it is NOT green;
+  // card's loading indicator. The agent has not started yet, so it is NOT active-green;
   // once the session is running the engine seeds 'thinking' and this flips to the
-  // emerald active ring. Suspended -> the resume control.
+  // active ring. Suspended -> the resume control.
   if (isSessionActive) {
     return <Loader2 size={18} className="animate-spin text-fg-muted" />;
   }
@@ -109,9 +109,9 @@ interface TaskDetailHeaderProps {
   canToggle: boolean;
   isSessionActive: boolean;
   isQueued: boolean;
-  /** Running and the agent is working on its own - emerald spinner rest face. */
+  /** Running and the agent is working on its own - active spinner rest face. */
   isThinking: boolean;
-  /** Running and the agent needs the user - amber envelope rest face. */
+  /** Running and the agent needs the user - attention envelope rest face. */
   isIdle: boolean;
   isArchived: boolean;
   isIsolated: boolean;
@@ -249,7 +249,7 @@ export function TaskDetailHeader({
               : isQueued
                 ? 'text-fg-muted hover:bg-surface-hover'
                 : isSessionActive
-                  ? 'text-green-400 hover:bg-surface-hover'
+                  ? 'text-active hover:bg-surface-hover'
                   : 'text-fg-faint hover:bg-surface-hover hover:text-fg-tertiary'
           }`}
           title={toggling ? 'Working...' : isQueued ? 'Queued (click to pause)' : isSessionActive ? 'Pause session' : 'Resume session'}

--- a/src/renderer/components/layout/StatusBar.tsx
+++ b/src/renderer/components/layout/StatusBar.tsx
@@ -138,8 +138,8 @@ export function StatusBar() {
       {currentProject && (
         <div className="flex items-center gap-4">
           <span className="flex items-center gap-1.5" data-testid="session-count">
-            <SquareTerminal size={14} className={activeSessions > 0 ? 'text-green-400' : 'text-fg-faint'} />
-            <span className={activeSessions > 0 ? 'text-green-400' : ''}>
+            <SquareTerminal size={14} className={activeSessions > 0 ? 'text-active' : 'text-fg-faint'} />
+            <span className={activeSessions > 0 ? 'text-active' : ''}>
               {activeSessions} agents
             </span>
             {queued > 0 && <span className="text-fg-faint">{queued} queued</span>}

--- a/src/renderer/components/layout/TitleBar.tsx
+++ b/src/renderer/components/layout/TitleBar.tsx
@@ -25,8 +25,9 @@ interface TitleBarProps {
 /**
  * The title-bar Command Terminal glyph: a custom terminal icon whose state lives
  * IN the glyph rather than in a separate corner badge. The stroke color is the
- * aggregate activity of the project's terminals (emerald working / amber needs-you
- * / muted rest), and the working border MARCHES (a dash flows around the
+ * aggregate activity of the project's terminals (green while working / warm amber
+ * when one needs you / muted rest, via the --kng-active / --kng-attention tokens),
+ * and the working border MARCHES (a dash flows around the
  * perimeter). The center morphs from the shell prompt to a `+` when the layer is
  * open and another terminal can be spawned, so the add affordance reads as part of
  * the icon (no clashing blue corner dot). 24 viewBox at strokeWidth 2 to match the
@@ -44,7 +45,7 @@ function CommandTerminalIcon({
   // tone was computed, so these are per-tone affordances, not a hand-rolled ActivityState bucket.
   const isWorking = tone === 'thinking'; // activity-state-ok: presentational tone, not an ActivityState
   const needsAttention = tone === 'idle'; // activity-state-ok: presentational tone, not an ActivityState
-  const colorClass = isWorking ? 'text-emerald-400' : needsAttention ? 'text-amber-400' : '';
+  const colorClass = isWorking ? 'text-active' : needsAttention ? 'text-attention' : '';
   return (
     <svg
       viewBox="0 0 24 24"
@@ -98,8 +99,8 @@ export function TitleBar({ onQuickSession, onOpenSearch, commandBarOpen, canSpaw
 
   // Aggregate activity across THIS project's Command Terminal sessions, surfaced
   // as the title-bar terminal icon's COLOR (the same active/idle language as the
-  // task-detail / per-terminal controls, no separate dot). WORKING (emerald) wins:
-  // if any terminal is active the icon is emerald, else amber if any needs you,
+  // task-detail / per-terminal controls, no separate dot). WORKING (active) wins:
+  // if any terminal is active the icon is active-green, else attention-amber if any needs you,
   // else rest. Classified only via the shared helpers (activity-state rule).
   const transientActivityTone = useSessionStore((state) => {
     const ids = selectCurrentProjectTransientSessionIds(state.transientSessions, currentProject?.id ?? null);

--- a/src/renderer/components/sidebar/project-sidebar/SidebarActivityCounts.tsx
+++ b/src/renderer/components/sidebar/project-sidebar/SidebarActivityCounts.tsx
@@ -18,7 +18,10 @@ export const SidebarActivityCounts = React.memo(function SidebarActivityCounts({
   const hasIdle = idleCount > 0;
   if (!hasThinking && !hasIdle) return null;
 
-  const iconSize = size === 'group' ? 11 : 12;
+  // Match the row's sibling icons (project name text, kebab) and the task-card
+  // indicator at 14px: the lucide Mail/Loader2 glyphs smear at 11-12px because the
+  // 2px stroke scales down to a sub-pixel hairline.
+  const iconSize = size === 'group' ? 12 : 14;
   const labelParts: string[] = [];
   if (hasIdle) labelParts.push(`${idleCount} idle`);
   if (hasThinking) labelParts.push(`${thinkingCount} thinking`);
@@ -32,9 +35,9 @@ export const SidebarActivityCounts = React.memo(function SidebarActivityCounts({
     >
       {hasIdle && (
         <span className="flex items-center gap-1" aria-hidden>
-          <Mail size={iconSize} className="text-amber-400 flex-shrink-0" />
+          <Mail size={iconSize} className="text-attention flex-shrink-0" />
           <span
-            className="flex items-center justify-center min-w-[1ch] font-semibold text-amber-400"
+            className="flex items-center justify-center min-w-[1ch] font-semibold text-attention"
             style={countBoxStyle}
           >
             {idleCount}
@@ -43,9 +46,9 @@ export const SidebarActivityCounts = React.memo(function SidebarActivityCounts({
       )}
       {hasThinking && (
         <span className="flex items-center gap-1" aria-hidden>
-          <Loader2 size={iconSize} className="text-green-400 animate-spin flex-shrink-0" />
+          <Loader2 size={iconSize} className="text-active animate-spin flex-shrink-0" />
           <span
-            className="flex items-center justify-center min-w-[1ch] font-semibold text-green-400"
+            className="flex items-center justify-center min-w-[1ch] font-semibold text-active"
             style={countBoxStyle}
           >
             {thinkingCount}

--- a/src/renderer/components/terminal/TerminalPanel.tsx
+++ b/src/renderer/components/terminal/TerminalPanel.tsx
@@ -164,14 +164,14 @@ export function TerminalPanel({ collapsed = false, showContent = true, onToggleC
                 }`}
               >
                 {session.status === 'running' && isActive(sessionActivity[session.id]) ? (
-                  <Loader2 size={8} className="text-green-400 animate-spin" />
+                  <Loader2 size={8} className="text-active animate-spin" />
                 ) : session.status === 'running' && requiresUserInteraction(sessionActivity[session.id]) ? (
-                  <div className={`w-1.5 h-1.5 rounded-full bg-amber-400${
+                  <div className={`w-1.5 h-1.5 rounded-full bg-attention${
                     effectiveActiveId !== session.id && !seenIdleSessions[session.id] ? ' animate-pulse' : ''
                   }`} />
                 ) : (
                   <div className={`w-1.5 h-1.5 rounded-full ${
-                    session.status === 'running' ? 'bg-green-400' : 'bg-fg-faint'
+                    session.status === 'running' ? 'bg-active' : 'bg-fg-faint'
                   }`} />
                 )}
                 {label}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -27,6 +27,10 @@
   --kng-accent-emphasis: #2563eb;
   --kng-accent-fg: #60a5fa;
   --kng-accent-on: #ffffff;
+
+  /* Activity indicators (identical across all themes) */
+  --kng-active: #34d399;      /* working / thinking (emerald-400) */
+  --kng-attention: #e3b341;   /* needs-you / idle / permission (soft honey) */
 }
 
 .theme-light {
@@ -241,6 +245,9 @@
   --color-accent-emphasis: var(--kng-accent-emphasis);
   --color-accent-fg: var(--kng-accent-fg);
   --color-accent-on: var(--kng-accent-on);
+
+  --color-active: var(--kng-active);
+  --color-attention: var(--kng-attention);
 }
 
 /* Custom scrollbar */

--- a/tests/ui/collapsed-rail.spec.ts
+++ b/tests/ui/collapsed-rail.spec.ts
@@ -228,8 +228,8 @@ test.describe('CollapsedRail - distinct projects (no sessions)', () => {
     const alphaButton = page.locator(`[data-testid="rail-project-${PROJECT_A_ID}"]`);
     await alphaButton.waitFor({ state: 'attached', timeout: 5000 });
 
-    await expect(alphaButton.locator('svg.text-amber-400')).toHaveCount(0);
-    await expect(alphaButton.locator('svg.text-green-400')).toHaveCount(0);
+    await expect(alphaButton.locator('svg.text-attention')).toHaveCount(0);
+    await expect(alphaButton.locator('svg.text-active')).toHaveCount(0);
   });
 
   test('expand button re-opens the full sidebar', async () => {
@@ -333,8 +333,8 @@ test.describe('CollapsedRail - idle session, no activity icon', () => {
     const alphaButton = page.locator(`[data-testid="rail-project-${PROJECT_A_ID}"]`);
     await alphaButton.waitFor({ state: 'attached', timeout: 5000 });
 
-    await expect(alphaButton.locator('svg.text-amber-400')).toHaveCount(0);
-    await expect(alphaButton.locator('svg.text-green-400')).toHaveCount(0);
+    await expect(alphaButton.locator('svg.text-attention')).toHaveCount(0);
+    await expect(alphaButton.locator('svg.text-active')).toHaveCount(0);
   });
 });
 
@@ -365,8 +365,8 @@ test.describe('CollapsedRail - thinking session, no icon and plain title', () =>
     const alphaButton = page.locator(`[data-testid="rail-project-${PROJECT_A_ID}"]`);
     await alphaButton.waitFor({ state: 'attached', timeout: 5000 });
 
-    await expect(alphaButton.locator('svg.text-amber-400')).toHaveCount(0);
-    await expect(alphaButton.locator('svg.text-green-400')).toHaveCount(0);
+    await expect(alphaButton.locator('svg.text-attention')).toHaveCount(0);
+    await expect(alphaButton.locator('svg.text-active')).toHaveCount(0);
   });
 
   test('title is plain project name even when a thinking session is active', async () => {

--- a/tests/ui/command-terminal.spec.ts
+++ b/tests/ui/command-terminal.spec.ts
@@ -1367,8 +1367,8 @@ test.describe('Command Terminal', () => {
   // Stop activity ring - the Stop button in CommandTerminalWindow carries the
   // same ring affordance as the task-detail pause button, but with a stop square
   // instead of pause bars. Three ring states:
-  //   thinking (isActive)          -> spinning emerald Circle + emerald stop-square
-  //   idle/permission (requiresUI) -> static amber Circle + amber stop-square
+  //   thinking (isActive)          -> spinning active Circle + active stop-square
+  //   idle/permission (requiresUI) -> static attention Circle + attention stop-square
   //   no session / not running     -> plain CircleStop, no stop-square
   //
   // Each test uses a deterministic spawnTransient override (known session id) so
@@ -1457,10 +1457,10 @@ test.describe('Command Terminal', () => {
       // We assert the activity-specific state in each individual test instead.
     }
 
-    test('thinking activity shows spinning emerald ring and emerald stop-square', async () => {
+    test('thinking activity shows spinning active ring and active stop-square', async () => {
       // Derives expected behavior from the contract in CommandTerminalWindow.tsx:
       //   isThinking = sessionRunning && isActive(activity)
-      //   -> spinning Circle with text-emerald-400 animate-spin, plus StopSquare bg-emerald-400
+      //   -> spinning Circle with text-active animate-spin, plus StopSquare bg-active
       const { browser, page } = await launchWithState(
         ringBasePreConfig() + deterministicSpawn
       );
@@ -1484,15 +1484,15 @@ test.describe('Command Terminal', () => {
         // stop-square must be present (the StopSquare inner span inside the ring)
         await expect(stopButton.getByTestId('stop-square')).toBeVisible({ timeout: 3000 });
 
-        // The stop-square inner span carries bg-emerald-400 for thinking
+        // The stop-square inner span carries bg-active for thinking
         const squareInner = stopButton.getByTestId('stop-square').locator('span');
-        await expect(squareInner).toHaveClass(/bg-emerald-400/);
+        await expect(squareInner).toHaveClass(/bg-active/);
 
-        // The animated emerald ring (Circle svg) must also be present
+        // The animated active ring (Circle svg) must also be present
         // lucide-circle is the CSS class Lucide attaches to the Circle component
         await expect(stopButton.locator('.lucide-circle')).toBeVisible();
         const ringCircle = stopButton.locator('.lucide-circle');
-        await expect(ringCircle).toHaveClass(/text-emerald-400/);
+        await expect(ringCircle).toHaveClass(/text-active/);
         await expect(ringCircle).toHaveClass(/animate-spin/);
 
         // The plain rest-state icon (CircleStop) must NOT be present when thinking
@@ -1502,11 +1502,11 @@ test.describe('Command Terminal', () => {
       }
     });
 
-    test('idle activity shows static amber ring and amber stop-square', async () => {
+    test('idle activity shows static attention ring and attention stop-square', async () => {
       // Derives expected behavior from the contract in CommandTerminalWindow.tsx:
       //   isIdle = sessionRunning && requiresUserInteraction(activity)
       //   requiresUserInteraction('idle') = true (ACTIVITY_DISPOSITION idle -> 'idle')
-      //   -> static Circle with text-amber-400 (no animate-spin), plus StopSquare bg-amber-400
+      //   -> static Circle with text-attention (no animate-spin), plus StopSquare bg-attention
       const { browser, page } = await launchWithState(
         ringBasePreConfig() + deterministicSpawn
       );
@@ -1530,14 +1530,14 @@ test.describe('Command Terminal', () => {
         // stop-square must be present for idle state
         await expect(stopButton.getByTestId('stop-square')).toBeVisible({ timeout: 3000 });
 
-        // The stop-square inner span carries bg-amber-400 for idle
+        // The stop-square inner span carries bg-attention for idle
         const squareInner = stopButton.getByTestId('stop-square').locator('span');
-        await expect(squareInner).toHaveClass(/bg-amber-400/);
+        await expect(squareInner).toHaveClass(/bg-attention/);
 
-        // The static amber ring (Circle svg) must be present and NOT spinning
+        // The static attention ring (Circle svg) must be present and NOT spinning
         await expect(stopButton.locator('.lucide-circle')).toBeVisible();
         const ringCircle = stopButton.locator('.lucide-circle');
-        await expect(ringCircle).toHaveClass(/text-amber-400/);
+        await expect(ringCircle).toHaveClass(/text-attention/);
         // Idle ring is static: no animate-spin class
         const ringClass = await ringCircle.getAttribute('class');
         expect(ringClass).not.toContain('animate-spin');
@@ -1549,11 +1549,11 @@ test.describe('Command Terminal', () => {
       }
     });
 
-    test('permission activity shows static amber ring (same as idle)', async () => {
+    test('permission activity shows static attention ring (same as idle)', async () => {
       // requiresUserInteraction('permission') = true (ACTIVITY_DISPOSITION maps
       // 'permission' -> 'idle'). The ring is identical to the idle ring.
       // This pins the activity-state-classification contract in the UI layer:
-      // 'permission' must be treated as "needs user" (amber) not "working" (emerald).
+      // 'permission' must be treated as "needs user" (attention) not "working" (active).
       const { browser, page } = await launchWithState(
         ringBasePreConfig() + deterministicSpawn
       );
@@ -1577,14 +1577,14 @@ test.describe('Command Terminal', () => {
         // stop-square must be present for permission state
         await expect(stopButton.getByTestId('stop-square')).toBeVisible({ timeout: 3000 });
 
-        // The stop-square inner span carries bg-amber-400 for permission (same as idle)
+        // The stop-square inner span carries bg-attention for permission (same as idle)
         const squareInner = stopButton.getByTestId('stop-square').locator('span');
-        await expect(squareInner).toHaveClass(/bg-amber-400/);
+        await expect(squareInner).toHaveClass(/bg-attention/);
 
-        // Static amber ring (no spin) - permission maps to idle disposition
+        // Static attention ring (no spin) - permission maps to idle disposition
         await expect(stopButton.locator('.lucide-circle')).toBeVisible();
         const ringClass = await stopButton.locator('.lucide-circle').getAttribute('class');
-        expect(ringClass).toContain('text-amber-400');
+        expect(ringClass).toContain('text-attention');
         expect(ringClass).not.toContain('animate-spin');
 
         // No plain CircleStop for permission state

--- a/tests/ui/project-session-scope.spec.ts
+++ b/tests/ui/project-session-scope.spec.ts
@@ -243,16 +243,16 @@ test.describe('Project Session Scope', () => {
 
       // Project Alpha (active) should show the amber idle mail icon
       const alphaRow = page.locator('[role="button"]:has-text("Project Alpha")');
-      await expect(alphaRow.locator('svg.text-amber-400').first()).toBeVisible();
+      await expect(alphaRow.locator('svg.text-attention').first()).toBeVisible();
       await expect(alphaRow).toHaveAttribute('title', /1 thinking, 1 idle|0 thinking, 1 idle/);
 
       // Project Beta (non-active) should also show the amber idle mail icon
       const betaRow = page.locator('[role="button"]:has-text("Project Beta")');
-      await expect(betaRow.locator('svg.text-amber-400').first()).toBeVisible();
+      await expect(betaRow.locator('svg.text-attention').first()).toBeVisible();
 
       // Neither should show a green thinking spinner (only one indicator per row; idle uses amber)
-      await expect(alphaRow.locator('svg.text-green-400')).toHaveCount(0);
-      await expect(betaRow.locator('svg.text-green-400')).toHaveCount(0);
+      await expect(alphaRow.locator('svg.text-active')).toHaveCount(0);
+      await expect(betaRow.locator('svg.text-active')).toHaveCount(0);
     } finally {
       await browser.close();
     }
@@ -272,13 +272,13 @@ test.describe('Project Session Scope', () => {
 
       // Project Alpha should show a green thinking spinner (no amber)
       const alphaRow = page.locator('[role="button"]:has-text("Project Alpha")');
-      await expect(alphaRow.locator('svg.text-green-400').first()).toBeVisible();
-      await expect(alphaRow.locator('svg.text-amber-400')).toHaveCount(0);
+      await expect(alphaRow.locator('svg.text-active').first()).toBeVisible();
+      await expect(alphaRow.locator('svg.text-attention')).toHaveCount(0);
 
       // Project Beta still idle -- amber mail icon, no green
       const betaRow = page.locator('[role="button"]:has-text("Project Beta")');
-      await expect(betaRow.locator('svg.text-amber-400').first()).toBeVisible();
-      await expect(betaRow.locator('svg.text-green-400')).toHaveCount(0);
+      await expect(betaRow.locator('svg.text-attention').first()).toBeVisible();
+      await expect(betaRow.locator('svg.text-active')).toHaveCount(0);
     } finally {
       await browser.close();
     }
@@ -308,8 +308,8 @@ test.describe('Project Session Scope', () => {
       // Project Gamma has no sessions -- no activity indicator icon renders
       const gammaRow = page.locator('[role="button"]:has-text("Project Gamma")');
       await expect(gammaRow).toBeVisible();
-      await expect(gammaRow.locator('svg.text-amber-400')).toHaveCount(0);
-      await expect(gammaRow.locator('svg.text-green-400')).toHaveCount(0);
+      await expect(gammaRow.locator('svg.text-attention')).toHaveCount(0);
+      await expect(gammaRow.locator('svg.text-active')).toHaveCount(0);
     } finally {
       await browser.close();
     }
@@ -359,8 +359,8 @@ test.describe('Project Session Scope', () => {
       // Project Alpha shows both idle and thinking indicators with their counts;
       // the row title surfaces both counts for screen-reader parity.
       const alphaRow = page.locator('[role="button"]:has-text("Project Alpha")');
-      await expect(alphaRow.locator('svg.text-green-400').first()).toBeVisible();
-      await expect(alphaRow.locator('svg.text-amber-400').first()).toBeVisible();
+      await expect(alphaRow.locator('svg.text-active').first()).toBeVisible();
+      await expect(alphaRow.locator('svg.text-attention').first()).toBeVisible();
       await expect(alphaRow).toHaveAttribute('title', /1 thinking, 1 idle/);
     } finally {
       await browser.close();
@@ -370,7 +370,7 @@ test.describe('Project Session Scope', () => {
   test('count digits render next to icon for each activity type', async () => {
     // Project Alpha: 2 idle sessions + 3 thinking sessions.
     // Verifies that the numeric count span rendered by SidebarActivityCounts
-    // contains the correct digit and is coloured with the matching amber/green class.
+    // contains the correct digit and is coloured with the matching attention/active class.
     const preConfig = twoProjectPreConfig() + `
       window.__mockPreConfigure(function (state) {
         var ts = new Date().toISOString();
@@ -414,20 +414,20 @@ test.describe('Project Session Scope', () => {
       const alphaRow = page.locator('[role="button"]:has-text("Project Alpha")');
 
       // Amber idle pair: icon present + count span shows "2"
-      const idlePair = alphaRow.locator('svg.text-amber-400').first().locator('..');
+      const idlePair = alphaRow.locator('svg.text-attention').first().locator('..');
       await expect(idlePair).toBeVisible();
-      const idleCountSpan = alphaRow.locator('span.text-amber-400');
+      const idleCountSpan = alphaRow.locator('span.text-attention');
       await expect(idleCountSpan).toBeVisible();
       await expect(idleCountSpan).toContainText('2');
 
       // Green thinking pair: icon present + count span shows "3"
-      const thinkingCountSpan = alphaRow.locator('span.text-green-400');
+      const thinkingCountSpan = alphaRow.locator('span.text-active');
       await expect(thinkingCountSpan).toBeVisible();
       await expect(thinkingCountSpan).toContainText('3');
 
       // Project Beta still has 1 idle only -- count span shows "1"
       const betaRow = page.locator('[role="button"]:has-text("Project Beta")');
-      const betaIdleCountSpan = betaRow.locator('span.text-amber-400');
+      const betaIdleCountSpan = betaRow.locator('span.text-attention');
       await expect(betaIdleCountSpan).toBeVisible();
       await expect(betaIdleCountSpan).toContainText('1');
     } finally {
@@ -466,12 +466,12 @@ test.describe('Project Session Scope', () => {
       const alphaRow = page.locator('[role="button"]:has-text("Project Alpha")');
 
       // Amber idle span counts both the base idle session and the permission one.
-      const idleCountSpan = alphaRow.locator('span.text-amber-400');
+      const idleCountSpan = alphaRow.locator('span.text-attention');
       await expect(idleCountSpan).toBeVisible();
       await expect(idleCountSpan).toContainText('2');
 
       // The permission session must NOT be counted as active -- no green span.
-      await expect(alphaRow.locator('span.text-green-400')).toHaveCount(0);
+      await expect(alphaRow.locator('span.text-active')).toHaveCount(0);
     } finally {
       await browser.close();
     }
@@ -507,12 +507,12 @@ test.describe('Project Session Scope', () => {
       // 1 transient idle session added above. Only the non-transient one should
       // be counted, so the amber count span must show "1", not "2".
       const alphaRow = page.locator('[role="button"]:has-text("Project Alpha")');
-      const idleCountSpan = alphaRow.locator('span.text-amber-400');
+      const idleCountSpan = alphaRow.locator('span.text-attention');
       await expect(idleCountSpan).toBeVisible();
       await expect(idleCountSpan).toContainText('1');
 
       // No thinking count should appear for Project Alpha
-      await expect(alphaRow.locator('span.text-green-400')).toHaveCount(0);
+      await expect(alphaRow.locator('span.text-active')).toHaveCount(0);
     } finally {
       await browser.close();
     }
@@ -546,12 +546,12 @@ test.describe('Project Session Scope', () => {
       // Project Alpha has 1 running idle session (from base config) plus 1
       // suspended idle session. Only the running one counts; amber span = "1".
       const alphaRow = page.locator('[role="button"]:has-text("Project Alpha")');
-      const idleCountSpan = alphaRow.locator('span.text-amber-400');
+      const idleCountSpan = alphaRow.locator('span.text-attention');
       await expect(idleCountSpan).toBeVisible();
       await expect(idleCountSpan).toContainText('1');
 
       // No thinking count should appear
-      await expect(alphaRow.locator('span.text-green-400')).toHaveCount(0);
+      await expect(alphaRow.locator('span.text-active')).toHaveCount(0);
     } finally {
       await browser.close();
     }


### PR DESCRIPTION
## What

Centralizes the two activity-indicator colors into semantic tokens and softens the "needs-you" color.

- Adds `--kng-active: #34d399` (working green) and `--kng-attention: #e3b341` (soft honey) to `:root` in `src/renderer/index.css`, mapped in the `@theme inline` block to the Tailwind utilities `text-active` / `bg-active` and `text-attention` / `bg-attention` (alpha modifiers included).
- Routes every activity indicator through those tokens: the title-bar Command Terminal glyph, the command-terminal and task-detail stop/pause rings, task cards, sidebar idle/thinking counts, terminal tab dots, and the status-bar active-session count. Stray `green-400` "active" sites are unified onto the single working green.
- Bumps the sidebar idle/thinking icons from 12px to 14px so they match the task card and the row's sibling icons (the lucide envelope smeared at 12px as the 2px stroke scaled to a sub-pixel hairline).

## Why

The old "needs-you" color was hardcoded `amber-400` (`#fbbf24`) scattered across ~8 files; it read as alarming and out-shouted the green, and the active green was itself inconsistent (`emerald-400` in some places, `green-400` in others). Tokenizing both colors gives one place to tune or swap either, and the soft-honey amber pairs with the green as a sibling rather than an alarm. The sidebar envelope was also noticeably muddy at its smaller size.

## How

Tokens are defined once in `:root` (not per-theme), so they cascade identically across all themes, matching today's behavior. `@theme inline` generates the utilities, so the swap is a one-line edit to either token value going forward. The color hex for "soft honey" was picked live in `/preview` by A/B-ing the candidates against the green on dark and light surfaces.

Out of scope and deliberately left as-is: the decorative per-session badge palette and log highlights in `ActivityLog.tsx`, the build-excluded `ActivityDebugOverlay`, and all non-activity uses of amber/green (auth warnings, git-diff markers, toasts, PR-state badge, search highlight, success checks).

## Breaking changes

None.

## Tests

- Typecheck and lint clean.
- The three UI specs that assert on indicator colors (`tests/ui/command-terminal.spec.ts`, `tests/ui/collapsed-rail.spec.ts`, `tests/ui/project-session-scope.spec.ts`) were updated to the new token class names and pass locally; CI re-runs the unit, UI, and Linux Electron E2E tiers.
- Step 3.5 coverage audit returned a no-op: a CSS token rename is fully covered by those updated specs, and an exact icon-size assertion is excluded by the cross-platform pixel-tolerance rule.

Generated with [Claude Code](https://claude.com/claude-code)
