### PR TITLE
fix(renderer): suppress animation replay on project-switch restore

### DIFF
--- a/.claude/agents/test-builder.md
+++ b/.claude/agents/test-builder.md
@@ -97,6 +97,8 @@ These are project rules learned from production incidents. Violating any of them
 
 8. **Build is required for E2E.** `npm run build` must have been run since the last main process change. If you modify `src/main/`, you must rebuild before running E2E tests.
 
+9. **Run Playwright headless and non-interactively. NEVER pass `--debug`, `--ui`, or `--headed`, and never set `PWDEBUG`.** Those flags open the Playwright Inspector GUI and a visible browser, then PAUSE the run waiting for manual step-through. The team dogfoods Kangentic on this same machine, so the popup windows hijack the developer's screen mid-work; the run never exits on its own (it blocks forever); and when it is killed it leaks orphaned `ms-playwright` `chrome.exe` plus the worker `node.exe` that then have to be hunted down. Always run the plain, self-exiting form: `npx playwright test <spec> --project=ui` (or `--project=electron`). To DIAGNOSE a failure, never reach for an interactive pause - use `--reporter=line` (or `list`), `--trace retain-on-failure` and open the saved trace AFTER the run, `console.log` inside the spec, or `page.screenshot(...)`. Keep UI specs launching headless (`chromium.launch({ headless: true })`). The only acceptable way to "watch" a run is the offline trace viewer, never a live inspector.
+
 ## Deriving Expected Behavior (READ FIRST - self-review-bias guard)
 
 You are frequently invoked in the **same session that just wrote the code under test**. That is exactly when a test is most likely to be wrong in a way that hides a bug: if you infer "what the code should do" from the implementation, you encode the implementation's mistakes as the expected result, and the test passes against buggy behavior. This is **self-review bias** - validating what the code *does* instead of what it *should* do. Two non-negotiable rules counter it:
@@ -713,7 +715,7 @@ npm run test:unit
 npm run build
 ```
 
-Remember: every Bash call is exactly ONE command. No chaining.
+Remember: every Bash call is exactly ONE command. No chaining. And per Constraint 9, never append `--debug` / `--ui` / `--headed` (or set `PWDEBUG`) to any of these - they open the Inspector and hang the run. Diagnose with `--trace retain-on-failure` and the offline trace viewer instead.
 
 ## Known Pre-existing Flakes
 

--- a/.claude/rules/restore-no-animation-replay.md
+++ b/.claude/rules/restore-no-animation-replay.md
@@ -1,0 +1,61 @@
+---
+paths:
+  - "src/renderer/**"
+---
+# Rule: a programmatic restore must not replay entrance or change animations
+
+Kangentic re-mounts and re-populates UI on a project switch (and on workspace restore, session
+re-bind, and a hard reload): the destination project's task-detail windows are rebuilt, the
+bottom panel rebinds, and every per-session / per-project metric flips to the new context's
+numbers. None of that is a user-initiated *action* or a *live* change. It is a context reset, and
+it should present a flat, calm canvas. When restore code reuses the same mount path as a fresh
+user open, two distraction classes leak in: entrance animations replay on the restored windows
+(fade + scale + slide), and value-change pulses fire across the status/context bars as their
+numbers jump from project A's session to project B's. The user experiences a flurry of motion on
+what should feel like simply arriving. This rule keeps restore quiet while leaving genuine user
+opens and live ticks fully animated.
+
+## The rule
+
+A programmatic context restore (project switch, workspace restore, session re-bind, hard reload)
+must paint flat. The motion that fires on a real user action or a real live update must NOT fire
+when the same UI is reconstructed or re-pointed by a restore.
+
+- **Restored windows start visible, not entering.** A window rebuilt by `deserializeWorkspace`
+  carries the transient `skipEnterAnimation: true` flag (never persisted); `WindowFrame` forwards
+  it to `useOverlayPhase` as `skipEnter`, which seeds the phase to `'visible'` so the entrance
+  keyframes never run. A fresh `openWindow` leaves the flag unset, so a user-opened window keeps
+  its entrance. Do not remove the flag plumbing, and do not start a restored overlay in
+  `'entering'`.
+- **Value pulses rebaseline on context identity.** Every `useValuePulse(value, ...)` call MUST
+  pass a `resetKey` identifying the context the value belongs to (the project id for a
+  project-scoped aggregate, the session id for a per-session metric). When the `resetKey` changes,
+  the hook rebaselines silently instead of pulsing, so a context switch does not animate; a live
+  in-place change with a stable `resetKey` still pulses. A call that genuinely never re-points
+  across a context boundary may opt out with a `// value-pulse-ok: <reason>` marker on the call
+  line or the line above.
+- **New animated surfaces follow suit.** Any new entrance keyframe, transition, or change-pulse
+  on a surface that can re-mount or re-populate during a project switch / restore must suppress
+  itself on the restore path the same way (a per-instance "restored" flag, or a `resetKey`-style
+  identity gate). Do not add motion that replays on arrival.
+
+## Enforcement (self-maintaining)
+
+- **Test (value pulses):** `tests/unit/restore-no-animation-replay.test.ts` scans `src/renderer/**`
+  and fails if any `useValuePulse(` call site omits `resetKey` and lacks a `// value-pulse-ok:`
+  marker. Runs in CI via `npm run test:unit`.
+- **Test (window restore):** `tests/unit/window-workspace.test.ts` locks that `deserializeWorkspace`
+  stamps `skipEnterAnimation: true` on every rebuilt window and that `serializeWorkspace` never
+  persists it. Runs in CI via `npm run test:unit`. UI-tier coverage of the end-to-end restore
+  (flat paint) lives in `tests/ui/window-no-entrance-animation-on-restore.spec.ts`.
+- **Review (new surfaces):** `/code-review` flags a newly added entrance/transition/pulse that
+  would replay on a project switch or restore. A brand-new keyframe on a brand-new surface is not
+  mechanically detectable (the scans cover only the two known mechanisms above), so this is the
+  judgment backstop and is called out deliberately.
+
+## Scope
+
+Renderer UI under `src/renderer/`. Governs motion that fires on mount or on a value change for
+surfaces reconstructed/re-pointed by a restore. Does not govern ongoing ambient motion
+(`animate-spin`, `animate-pulse-subtle`, the activity `march-border`) or genuinely user-initiated
+open/close animations, which are intentional and stay.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,7 @@ session; rules with one load when you touch matching files. Each rule names its 
 - `activity-state-classification.md` - bucket `ActivityState` idle-vs-active only via `src/shared/activity-state.ts` (`src/renderer/`).
 - `board-completing-task-chokepoint.md` - hide in-flight Done-completing tasks only at KanbanBoard's `tasksPerLane`, never per-lane (`src/renderer/components/board/`).
 - `keybindings-registry.md` - renderer shortcuts declared in `KEYBINDINGS` and bound via `useKeybinding`, not ad-hoc `addEventListener('keydown')` (`src/renderer/`).
+- `restore-no-animation-replay.md` - a project switch / restore paints flat: restored windows skip the entrance animation (`skipEnterAnimation`) and `useValuePulse` rebaselines on a `resetKey` instead of pulsing (`src/renderer/`).
 - `cross-platform-parity.md` - code and tests must behave identically on Windows/macOS/Linux/CI; no OS-specific paths, no cross-test state leakage or pixel-exact assertions (`tests/`, `src/main/` pty/agent/git).
 
 **Local overrides:** there is no per-rule local file. Put machine-specific instruction

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -16,6 +16,7 @@ import { resolveAutoFocusTarget } from './utils/auto-focus';
 import { requiresUserInteraction } from '../shared/activity-state';
 import { bumpHmrGeneration } from './utils/hmr-generation';
 import { clearSnapPreviewDom } from './window-manager';
+import { useWindowStore } from './window-manager/store/window-store';
 import {
   autoNameTimers,
   scheduleAutoNameSuggestion,
@@ -672,5 +673,6 @@ if (import.meta.env.DEV) {
     config: useConfigStore,
     project: useProjectStore,
     session: useSessionStore,
+    window: useWindowStore,
   };
 }

--- a/src/renderer/components/layout/StatusBar.tsx
+++ b/src/renderer/components/layout/StatusBar.tsx
@@ -121,8 +121,12 @@ export function StatusBar() {
 
   // Pulse hooks - always called unconditionally (hooks rules)
   const tokenKey = `${displayInput}-${displayOutput}`;
-  const tokenPulseRef = useValuePulse(tokenKey);
-  const costPulseRef = useValuePulse(displayCost);
+  // Rebaseline the pulse on a project or period switch: that flips the displayed
+  // totals to a different context, which is not a live tick and must not animate
+  // (.claude/rules/restore-no-animation-replay.md).
+  const pulseResetKey = `${currentProject?.id ?? ''}:${selectedPeriod}`;
+  const tokenPulseRef = useValuePulse(tokenKey, { resetKey: pulseResetKey });
+  const costPulseRef = useValuePulse(displayCost, { resetKey: pulseResetKey });
 
   function handlePeriodSelect(period: UsageTimePeriod) {
     setSelectedPeriod(period);

--- a/src/renderer/components/terminal/ContextBar.tsx
+++ b/src/renderer/components/terminal/ContextBar.tsx
@@ -159,19 +159,23 @@ export function ContextBar({ sessionId, agentFallback = null }: ContextBarProps)
     (s) => s.agentList.find((a) => a.name === taskAgent)?.reportsRateLimits ?? false
   );
 
-  // Pulse hooks -- always called unconditionally (hooks rules)
-  const costRef = useValuePulse(usage?.cost.totalCostUsd);
-  const toolCallRef = useValuePulse(usage?.toolCallCount);
+  // Pulse hooks - always called unconditionally (hooks rules). Every pulse
+  // rebaselines on `sessionId`: switching the bar to a different session (a
+  // project/task switch swaps it) flips all these metrics to another context's
+  // numbers, which is not a live tick and must not animate
+  // (.claude/rules/restore-no-animation-replay.md).
+  const costRef = useValuePulse(usage?.cost.totalCostUsd, { resetKey: sessionId });
+  const toolCallRef = useValuePulse(usage?.toolCallCount, { resetKey: sessionId });
   const inputTokens = usage?.contextWindow.totalInputTokens;
   const outputTokens = usage?.contextWindow.totalOutputTokens;
   const tokenKey = `${inputTokens}-${outputTokens}`;
-  const tokenRef = useValuePulse(tokenKey);
-  const pctRef = useValuePulse(usage ? Math.round(usage.contextWindow.usedPercentage) : 0);
-  const fractionRef = useValuePulse(usage?.contextWindow.usedTokens);
+  const tokenRef = useValuePulse(tokenKey, { resetKey: sessionId });
+  const pctRef = useValuePulse(usage ? Math.round(usage.contextWindow.usedPercentage) : 0, { resetKey: sessionId });
+  const fractionRef = useValuePulse(usage?.contextWindow.usedTokens, { resetKey: sessionId });
   const rateLimitsKey = latestRateLimits
     ? latestRateLimits.rateLimits.map((limitWindow) => `${limitWindow.id}:${Math.round(limitWindow.usedPercentage)}`).join('|')
     : '';
-  const rateLimitsRef = useValuePulse(rateLimitsKey);
+  const rateLimitsRef = useValuePulse(rateLimitsKey, { resetKey: sessionId });
 
   // Tool-call breakdown popover. This pill lives directly in ContextBar, so it
   // owns its own open state (unlike the model/effort popovers, which live in the

--- a/src/renderer/hooks/useOverlayPhase.ts
+++ b/src/renderer/hooks/useOverlayPhase.ts
@@ -27,6 +27,12 @@ interface UseOverlayPhaseOptions {
    * overlays that can remount on HMR (command bar, search) opt in.
    */
   skipEnterOnHmr?: boolean;
+  /**
+   * Start already-visible this mount (unconditionally), skipping the entrance
+   * animation. For content remounted in a state that should not animate in
+   * (e.g. a window rebuilt by a workspace restore on project switch).
+   */
+  skipEnter?: boolean;
 }
 
 export interface OverlayPhaseApi {
@@ -66,10 +72,10 @@ export function useOverlayPhase(
   onClose: () => void,
   options: UseOverlayPhaseOptions = {},
 ): OverlayPhaseApi {
-  const { variant = 'dialog', skipEnterOnHmr = false } = options;
+  const { variant = 'dialog', skipEnterOnHmr = false, skipEnter = false } = options;
 
   const [phase, setPhase] = useState<OverlayPhaseName>(() =>
-    skipEnterOnHmr && getIsHmrReload() ? 'visible' : 'entering',
+    skipEnter || (skipEnterOnHmr && getIsHmrReload()) ? 'visible' : 'entering',
   );
 
   const requestClose = useCallback(() => {

--- a/src/renderer/hooks/useValuePulse.ts
+++ b/src/renderer/hooks/useValuePulse.ts
@@ -1,13 +1,30 @@
 import { useRef, useEffect, useCallback } from 'react';
 
+interface UseValuePulseOptions {
+  /**
+   * Identity of the CONTEXT the value belongs to (e.g. the current project id, or
+   * the session id a metric is reporting for). When it changes - a project switch,
+   * a session re-bind, any programmatic context reset - the pulse is rebaselined
+   * silently instead of firing: the value flipping from one context's number to
+   * another's is not a live change and must not animate. See
+   * `.claude/rules/restore-no-animation-replay.md`.
+   */
+  resetKey?: unknown;
+  className?: string;
+  durationMs?: number;
+}
+
 /**
- * Tracks a value and applies a transient CSS class when it changes.
- * Skips the initial mount so the pulse only fires on updates.
+ * Tracks a value and applies a transient CSS class when it changes IN PLACE.
+ * Skips the initial mount, and skips a change that coincides with a `resetKey`
+ * change (a context switch), so the pulse only fires on genuine live updates.
  * Returns a ref callback to attach to the target element.
  */
-export function useValuePulse<T>(value: T, className = 'animate-value-update', durationMs = 350) {
+export function useValuePulse<T>(value: T, options: UseValuePulseOptions = {}) {
+  const { resetKey, className = 'animate-value-update', durationMs = 350 } = options;
   const elRef = useRef<HTMLElement | null>(null);
   const prevRef = useRef<T>(value);
+  const resetKeyRef = useRef<unknown>(resetKey);
   const mountedRef = useRef(false);
   const rafRef = useRef<number>(0);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -17,6 +34,19 @@ export function useValuePulse<T>(value: T, className = 'animate-value-update', d
       mountedRef.current = true;
       return;
     }
+
+    // Context reset (project switch, session re-bind, any programmatic restore):
+    // rebaseline silently. The value moving from one context's number to another's
+    // is not a live tick and must not pulse.
+    if (resetKey !== resetKeyRef.current) {
+      resetKeyRef.current = resetKey;
+      prevRef.current = value;
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      elRef.current?.classList.remove(className);
+      return;
+    }
+
     if (value === prevRef.current) return;
     prevRef.current = value;
 
@@ -32,7 +62,7 @@ export function useValuePulse<T>(value: T, className = 'animate-value-update', d
       el.classList.add(className);
       timerRef.current = setTimeout(() => el.classList.remove(className), durationMs);
     });
-  }, [value, className, durationMs]);
+  }, [value, resetKey, className, durationMs]);
 
   // Cleanup on unmount
   useEffect(() => () => {

--- a/src/renderer/window-manager/components/WindowFrame.tsx
+++ b/src/renderer/window-manager/components/WindowFrame.tsx
@@ -41,7 +41,7 @@ export function WindowFrame({ managedWindow, containerSize, overlayRef, tiledRec
 
   const { requestClose, contentClassName, onAnimationEnd, isExiting } = useOverlayPhase(
     () => closeWindow(managedWindow.id),
-    { variant: 'dialog', skipEnterOnHmr: true },
+    { variant: 'dialog', skipEnterOnHmr: true, skipEnter: managedWindow.skipEnterAnimation ?? false },
   );
 
   // Fallback: if the exit animation's `animationend` never fires (animations

--- a/src/renderer/window-manager/persistence/workspace.ts
+++ b/src/renderer/window-manager/persistence/workspace.ts
@@ -162,6 +162,7 @@ export function deserializeWorkspace(
       sessionStatus: 'live',
       restoreGeometry: persisted.restoreGeometry ? { ...persisted.restoreGeometry } : null,
       title: persisted.title,
+      skipEnterAnimation: true,
     };
   }
 

--- a/src/renderer/window-manager/store/types.ts
+++ b/src/renderer/window-manager/store/types.ts
@@ -67,6 +67,10 @@ export interface ManagedWindow {
    *  (not a component ref) so it survives the content remount the Done "fly" causes
    *  when the task briefly leaves `tasks`. */
   openedDone?: boolean;
+  /** Transient, never persisted: set true on windows rebuilt by a workspace
+   *  restore (project switch) so they paint flat with NO entrance animation,
+   *  unlike a fresh user-opened window. Re-derived on every restore. */
+  skipEnterAnimation?: boolean;
 }
 
 /**

--- a/tests/ui/use-value-pulse-reset-key.spec.ts
+++ b/tests/ui/use-value-pulse-reset-key.spec.ts
@@ -1,0 +1,415 @@
+/**
+ * UI-tier tests for the `resetKey` behavior introduced in `useValuePulse.ts`.
+ *
+ * ## Why UI tier (not unit)
+ *
+ * `useValuePulse` is DOM-coupled: it applies a CSS class via `element.classList`,
+ * queues the class-add via `requestAnimationFrame`, and schedules removal via
+ * `setTimeout`. The vitest config has NO jsdom environment and NO
+ * @testing-library/react dependency (deliberate team decision - see
+ * `tests/unit/use-browser-url-logic.test.ts`). A pure-logic replica would not
+ * produce a genuine red-green test: reverting the production `resetKey` branch
+ * would leave the replica green (the replica doesn't use the real hook). A
+ * genuine red-green test MUST import and exercise the real exported `useValuePulse`
+ * inside a real DOM where `requestAnimationFrame` runs.
+ *
+ * Headless Chromium (the `--project=ui` tier) is the ONLY existing environment
+ * where both the real React hook and rAF run without new dependencies.
+ *
+ * ## What we test
+ *
+ * The hook is exercised through its real consumer: `StatusBar` in the running Vite
+ * app. StatusBar renders `[data-testid="aggregate-cost"]` when there is live usage
+ * data, and that element is the ref target of `costPulseRef = useValuePulse(displayCost,
+ * { resetKey: pulseResetKey })`. We manipulate the Zustand stores (exposed on
+ * `window.__zustandStores` in DEV mode) to trigger value and resetKey changes, then
+ * observe whether `animate-value-update` appears on the DOM element.
+ *
+ * ## Behavior contract
+ *
+ * (a) When `resetKey` CHANGES, the hook rebaselines SILENTLY - it must NOT add the
+ *     pulse class `animate-value-update`.
+ * (b) When `resetKey` is STABLE and `value` changes, it DOES pulse.
+ * (c) Initial mount never pulses.
+ *
+ * ## Red-green anchoring
+ *
+ * Reverting the `resetKey` effect branch (lines ~41-48 in `useValuePulse.ts`) makes
+ * test (a) fail: without the early return on `resetKey` change, the hook would not
+ * suppress the class and would instead fall through to the normal pulse path,
+ * applying `animate-value-update`. The poll in test (a) has a tight window (500ms)
+ * and a deliberate fixed-wait negative assertion after it.
+ */
+
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-pulse-test';
+const SESSION_ID = 'sess-pulse-test';
+const SWIMLANE_ID = 'lane-pulse-0';
+
+/** Initial cost value seeded via getUsage mock. Must be non-zero so StatusBar renders usage. */
+const INITIAL_COST = 0.0042;
+/** A different cost that causes a value-change effect run. */
+const UPDATED_COST = 0.0099;
+
+/**
+ * Pre-configure script: one project with one running session. The `getUsage` mock
+ * is overridden to return real usage so StatusBar renders `[data-testid="aggregate-tokens"]`
+ * and `[data-testid="aggregate-cost"]`.
+ */
+const PRE_CONFIGURE = `
+  window.__mockPreConfigure(function (state) {
+    var ts = new Date().toISOString();
+
+    state.projects.push({
+      id: '${PROJECT_ID}',
+      name: 'Pulse Test Project',
+      path: '/mock/pulse-test',
+      github_url: null,
+      default_agent: 'claude',
+      last_opened: ts,
+      created_at: ts,
+    });
+
+    state.DEFAULT_SWIMLANES.forEach(function (lane, index) {
+      state.swimlanes.push({
+        id: index === 0 ? '${SWIMLANE_ID}' : 'lane-pulse-' + index,
+        name: lane.name,
+        role: lane.role,
+        color: lane.color,
+        icon: lane.icon,
+        is_archived: lane.is_archived,
+        permission_strategy: lane.permission_strategy || null,
+        auto_spawn: lane.auto_spawn || false,
+        position: index,
+        created_at: ts,
+      });
+    });
+
+    state.sessions.push({
+      id: '${SESSION_ID}',
+      taskId: 'task-pulse-test',
+      projectId: '${PROJECT_ID}',
+      pid: 7777,
+      status: 'running',
+      shell: 'bash',
+      cwd: '/mock/pulse-test',
+      startedAt: ts,
+      exitCode: null,
+    });
+
+    state.activityCache['${SESSION_ID}'] = 'idle';
+
+    state.tasks.push({
+      id: 'task-pulse-test',
+      title: 'Pulse Test Task',
+      description: '',
+      swimlane_id: '${SWIMLANE_ID}',
+      position: 0,
+      agent: null,
+      session_id: '${SESSION_ID}',
+      worktree_path: null,
+      branch_name: null,
+      pr_number: null,
+      pr_url: null,
+      base_branch: null,
+      archived_at: null,
+      created_at: ts,
+      updated_at: ts,
+    });
+
+    return { currentProjectId: '${PROJECT_ID}' };
+  });
+
+  // Override getUsage so StatusBar sees real usage data for SESSION_ID.
+  // The initial cost is ${INITIAL_COST} - non-zero so the status bar renders the cost span.
+  window.electronAPI.sessions.getUsage = async function () {
+    var result = {};
+    result['${SESSION_ID}'] = {
+      model: { id: 'claude-sonnet', displayName: 'Claude Sonnet' },
+      contextWindow: {
+        usedPercentage: 10,
+        usedTokens: 800,
+        cacheTokens: 0,
+        totalInputTokens: 600,
+        totalOutputTokens: 200,
+        contextWindowSize: 200000,
+      },
+      cost: { totalCostUsd: ${INITIAL_COST}, totalDurationMs: 1000 },
+    };
+    return result;
+  };
+`;
+
+async function launchPulsePage(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(PRE_CONFIGURE);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+  return { browser, page };
+}
+
+/**
+ * Wait for the StatusBar's cost element to be visible AND carrying the initial
+ * usage value (confirming the getUsage mock was consumed and the store is hydrated).
+ */
+async function waitForUsageVisible(page: Page): Promise<void> {
+  await page.locator('[data-testid="aggregate-cost"]').waitFor({ state: 'visible', timeout: 10000 });
+}
+
+/**
+ * Inject new usage data into the session store's `sessionUsage` map for SESSION_ID.
+ * `projectId` in the session list stays the same as PROJECT_ID, so `pulseResetKey`
+ * (`"${projectId}:live"`) is unchanged - this is a pure VALUE change with STABLE reset key.
+ */
+async function injectUsageUpdate(page: Page, newCostUsd: number): Promise<void> {
+  await page.evaluate(
+    ({ sessionId, newCost }: { sessionId: string; newCost: number }) => {
+      type SessionStoreHandle = {
+        getState: () => {
+          sessionUsage: Record<
+            string,
+            {
+              model: { id: string; displayName: string };
+              contextWindow: {
+                usedPercentage: number;
+                usedTokens: number;
+                cacheTokens: number;
+                totalInputTokens: number;
+                totalOutputTokens: number;
+                contextWindowSize: number;
+              };
+              cost: { totalCostUsd: number; totalDurationMs: number };
+            }
+          >;
+        };
+        setState: (partial: Record<string, unknown>) => void;
+      };
+
+      const stores = (
+        window as unknown as { __zustandStores?: { session: SessionStoreHandle } }
+      ).__zustandStores;
+      if (!stores) throw new Error('window.__zustandStores not exposed');
+
+      const currentUsage = stores.session.getState().sessionUsage;
+      const existing = currentUsage[sessionId];
+      if (!existing) throw new Error(`No usage entry for session ${sessionId}`);
+
+      stores.session.setState({
+        sessionUsage: {
+          ...currentUsage,
+          [sessionId]: {
+            ...existing,
+            cost: { totalCostUsd: newCost, totalDurationMs: existing.cost.totalDurationMs + 100 },
+          },
+        },
+      });
+    },
+    { sessionId: SESSION_ID, newCost: newCostUsd },
+  );
+}
+
+/**
+ * Inject new usage data AND simultaneously change the selected period from 'live'
+ * to 'today'. Both writes go into one synchronous `setState` call on the session
+ * store, so React 18 batches them into one render. The single resulting effect run
+ * sees `resetKey` changed (from `"<projectId>:live"` to `"<projectId>:today"`) AND
+ * `value` changed (cost ticked up), so:
+ *
+ * - WITH the resetKey branch: the early return fires, no class is added.
+ * - WITHOUT the resetKey branch: `value !== prevRef.current` is true, so the class
+ *   IS added. That is what the red run verifies.
+ *
+ * Using `selectedPeriod` (not project id) for the resetKey change preserves the
+ * session-project relationship: `projectSessions` still matches, `liveUsage.count`
+ * stays > 0, `hasUsage` remains true, so `[data-testid="aggregate-cost"]` stays
+ * mounted throughout the test. This makes the element observable when the class
+ * would be wrongly added, giving genuine red-green discrimination.
+ */
+async function injectResetKeyChange(page: Page, newCostUsd: number): Promise<void> {
+  await page.evaluate(
+    ({ sessionId, newCost }: { sessionId: string; newCost: number }) => {
+      type SessionStoreHandle = {
+        getState: () => {
+          sessionUsage: Record<
+            string,
+            {
+              model: { id: string; displayName: string };
+              contextWindow: {
+                usedPercentage: number;
+                usedTokens: number;
+                cacheTokens: number;
+                totalInputTokens: number;
+                totalOutputTokens: number;
+                contextWindowSize: number;
+              };
+              cost: { totalCostUsd: number; totalDurationMs: number };
+            }
+          >;
+        };
+        setState: (partial: Record<string, unknown>) => void;
+      };
+
+      const stores = (
+        window as unknown as { __zustandStores?: { session: SessionStoreHandle } }
+      ).__zustandStores;
+      if (!stores) throw new Error('window.__zustandStores not exposed');
+
+      const currentUsage = stores.session.getState().sessionUsage;
+      const existing = currentUsage[sessionId];
+      if (!existing) throw new Error(`No usage entry for session ${sessionId}`);
+
+      // Single setState call changes both selectedPeriod (which changes the resetKey
+      // component from 'live' to 'today') and sessionUsage (which changes the cost value).
+      // React 18 batches this into one render with one effect run.
+      // The reset branch in useValuePulse fires on resetKey change and returns early.
+      stores.session.setState({
+        selectedPeriod: 'today',
+        sessionUsage: {
+          ...currentUsage,
+          [sessionId]: {
+            ...existing,
+            cost: { totalCostUsd: newCost, totalDurationMs: existing.cost.totalDurationMs + 100 },
+          },
+        },
+      });
+    },
+    { sessionId: SESSION_ID, newCost: newCostUsd },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('useValuePulse resetKey behavior (via StatusBar)', () => {
+  // Tests use separate browser instances for isolation - no shared state.
+
+  test('(c) initial mount never pulses - animate-value-update is absent on first load', async () => {
+    const { browser, page } = await launchPulsePage();
+    try {
+      await waitForUsageVisible(page);
+
+      // On initial mount, mountedRef.current is false so the effect returns early.
+      // The class must never appear at all - not even for a frame.
+      await expect(page.locator('[data-testid="aggregate-cost"]')).not.toHaveClass(
+        /animate-value-update/,
+      );
+      await expect(page.locator('[data-testid="aggregate-tokens"]')).not.toHaveClass(
+        /animate-value-update/,
+      );
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('(b) stable resetKey + value change = pulse class is applied then removed', async () => {
+    const { browser, page } = await launchPulsePage();
+    try {
+      await waitForUsageVisible(page);
+
+      // Confirm no class before the mutation.
+      await expect(page.locator('[data-testid="aggregate-cost"]')).not.toHaveClass(
+        /animate-value-update/,
+      );
+
+      // Inject a cost update with the same project/period = stable pulseResetKey.
+      await injectUsageUpdate(page, UPDATED_COST);
+
+      // The hook queues the class-add via requestAnimationFrame. Poll for it.
+      // Timeout 2000ms is generous but deterministic - rAF fires within one vsync frame
+      // (~16ms). The poll interval 50ms keeps the check tight without busy-looping.
+      await expect
+        .poll(
+          () =>
+            page.evaluate(() => {
+              const element = document.querySelector('[data-testid="aggregate-cost"]');
+              return element?.classList.contains('animate-value-update') ?? false;
+            }),
+          { timeout: 2000, intervals: [50, 50, 100, 100, 100] },
+        )
+        .toBe(true);
+
+      // After durationMs (350ms default) the class is removed. Wait 600ms total to be safe.
+      await expect
+        .poll(
+          () =>
+            page.evaluate(() => {
+              const element = document.querySelector('[data-testid="aggregate-cost"]');
+              return element?.classList.contains('animate-value-update') ?? false;
+            }),
+          { timeout: 1500, intervals: [100, 200, 300, 300] },
+        )
+        .toBe(false);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('(a) resetKey change suppresses pulse - animate-value-update must NOT appear', async () => {
+    const { browser, page } = await launchPulsePage();
+    try {
+      await waitForUsageVisible(page);
+
+      // Confirm no class before the mutation.
+      await expect(page.locator('[data-testid="aggregate-cost"]')).not.toHaveClass(
+        /animate-value-update/,
+      );
+
+      // Inject cost change AND selectedPeriod change simultaneously (one setState call,
+      // one React render, one effect run). The effect sees resetKey changed (period
+      // changed from 'live' to 'today', so pulseResetKey flips), so with the correct
+      // implementation it rebaselines silently and never adds the class.
+      //
+      // Without the resetKey branch: value changed (INITIAL_COST -> UPDATED_COST+0.005),
+      // so the hook falls through to the pulse logic and adds the class via rAF.
+      await injectResetKeyChange(page, UPDATED_COST + 0.005);
+
+      // Red-green observation window: sample the DOM every 100ms for 600ms.
+      // requestAnimationFrame fires within ~16ms of the state update. If the resetKey
+      // branch is absent, the class appears in the first 100ms window and
+      // classObservedDuringWindow becomes true -> the expect below fails (RED).
+      // With the correct implementation the class never appears -> expect passes (GREEN).
+      //
+      // We do NOT use expect.poll(toBe(false)) here - that is anti-pattern 6
+      // (polling for non-occurrence exits immediately). Instead we actively scan the
+      // window before drawing a conclusion.
+      let classObservedDuringWindow = false;
+      for (let iteration = 0; iteration < 6; iteration++) {
+        // intentional fixed wait - scanning for non-occurrence requires a time budget
+        await page.waitForTimeout(100);
+        const classPresent = await page.evaluate(() => {
+          const element = document.querySelector('[data-testid="aggregate-cost"]');
+          return element?.classList.contains('animate-value-update') ?? false;
+        });
+        if (classPresent) {
+          classObservedDuringWindow = true;
+          break;
+        }
+      }
+
+      expect(
+        classObservedDuringWindow,
+        'animate-value-update must NOT appear when resetKey changes: a context switch is ' +
+          'not a live value tick and must not pulse (useValuePulse.ts resetKey branch)',
+      ).toBe(false);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/ui/window-no-entrance-animation-on-restore.spec.ts
+++ b/tests/ui/window-no-entrance-animation-on-restore.spec.ts
@@ -1,0 +1,241 @@
+/**
+ * UI tests proving that a task-detail window rebuilt by a workspace restore (project switch)
+ * paints flat with NO entrance animation, while a freshly user-opened window is left to play
+ * the normal entrance animation.
+ *
+ * The feature under test:
+ *   - `deserializeWorkspace` stamps `skipEnterAnimation: true` on every rebuilt window.
+ *   - `WindowFrame` passes `skipEnter: managedWindow.skipEnterAnimation ?? false` to
+ *     `useOverlayPhase`, which initialises phase to 'visible' (no enter class) instead of
+ *     'entering' (which carries the class `overlay-content-in`).
+ *   - `openWindow` (the fresh user-open path) leaves `skipEnterAnimation` unset, so its window
+ *     keeps the default entrance.
+ *
+ * Determinism (per .claude/rules/cross-platform-parity.md - assert programmatic state, never
+ * sub-frame pixels or animation timing):
+ *   - The load-bearing assertion is the programmatic `skipEnterAnimation` flag on the rebuilt
+ *     `ManagedWindow`, read straight from the window store. It has no timing dependence at all.
+ *   - The restore test additionally asserts the rendered frame never carries `overlay-content-in`.
+ *     Absence is stable: a restored window starts in phase='visible' on its very first render, so
+ *     the class is never applied (unlike a fresh open, where it appears then disappears after the
+ *     ~200ms animation - which is exactly the race this test avoids asserting on).
+ *
+ * Restore mechanics: the test calls `useWindowStore.getState().applyWorkspace(...)` directly -
+ * the same function the real project-switch path (`restore-workspace.ts`) calls, with the same
+ * `isKnownAnchor` (board contains the task) and `resolveSession` (null in UI tests) semantics.
+ * `applyWorkspace` -> `deserializeWorkspace` is what stamps the flag.
+ *
+ * App.tsx change: `useWindowStore` is added to the dev-only `window.__zustandStores` block so the
+ * test can drive `applyWorkspace` and read the window list without module-path gymnastics.
+ */
+
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+// Fixed IDs - no personal info, no machine paths.
+const PROJECT_ID = 'proj-win-anim-test';
+const TASK_ID = 'task-win-anim-test';
+const TASK_TITLE = 'Animation Test Task';
+
+/** A valid v1 workspace blob with a single floating detail window for our task. */
+const WORKSPACE_BLOB = {
+  version: 1,
+  windows: [
+    {
+      taskId: TASK_ID,
+      title: TASK_TITLE,
+      geometry: { x: 0.1, y: 0.1, w: 0.5, h: 0.5 },
+      restoreGeometry: null,
+      state: 'floating',
+    },
+  ],
+  tileTree: null,
+  tileTreeRect: { x: 0, y: 0, w: 1, h: 1 },
+  focusedTaskId: TASK_ID,
+};
+
+/** Pre-configure the mock: one project, board open, one task in the first swimlane. */
+const PRE_CONFIGURE_SCRIPT = `
+  window.__mockPreConfigure(function (state) {
+    var ts = new Date().toISOString();
+    state.projects.push({
+      id: '${PROJECT_ID}',
+      name: 'Animation Test Project',
+      path: '/mock/${PROJECT_ID}',
+      github_url: null,
+      default_agent: 'claude',
+      last_opened: ts,
+      created_at: ts,
+    });
+
+    state.DEFAULT_SWIMLANES.forEach(function (lane, i) {
+      state.swimlanes.push(Object.assign({}, lane, {
+        id: 'lane-anim-' + i,
+        position: i,
+        created_at: ts,
+      }));
+    });
+
+    return { currentProjectId: '${PROJECT_ID}' };
+  });
+`;
+
+async function launch(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(PRE_CONFIGURE_SCRIPT);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+  return { browser, page };
+}
+
+type ZustandStores = {
+  board: {
+    getState: () => { tasks: Array<{ id: string }> };
+    setState: (partial: object) => void;
+  };
+  session: {
+    getState: () => { setDetailTaskId: (id: string | null, options?: { initialEdit?: boolean }) => void };
+  };
+  window: {
+    getState: () => {
+      applyWorkspace: (
+        workspace: unknown,
+        resolveSession: (anchor: string) => string | null,
+        isKnownAnchor: (anchor: string) => boolean,
+      ) => void;
+      windows: Record<string, { skipEnterAnimation?: boolean }>;
+    };
+  };
+};
+
+/** Seed the board store so `isKnownAnchor` returns true for TASK_ID during restore and so the
+ *  detail bridge can find the task on open. Idempotent. */
+async function seedBoardStoreTask(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ taskId, taskTitle, projectId }) => {
+      const stores = (window as unknown as { __zustandStores?: ZustandStores }).__zustandStores;
+      if (!stores) throw new Error('window.__zustandStores not exposed');
+      const existing = stores.board.getState().tasks;
+      if (existing.some((task) => task.id === taskId)) return;
+      const now = new Date().toISOString();
+      stores.board.setState({
+        tasks: [
+          ...existing,
+          {
+            id: taskId,
+            display_id: 1,
+            title: taskTitle,
+            description: '',
+            swimlane_id: 'lane-anim-0',
+            position: 0,
+            agent: null,
+            session_id: null,
+            worktree_path: null,
+            branch_name: null,
+            pr_number: null,
+            pr_url: null,
+            pr_state: null,
+            base_branch: null,
+            use_worktree: null,
+            labels: [],
+            priority: 0,
+            model_override: null,
+            effort_override: null,
+            agent_override: null,
+            attachment_count: 0,
+            archived_at: null,
+            created_at: now,
+            updated_at: now,
+            projectId,
+          },
+        ],
+        hydrated: true,
+        loading: false,
+      });
+    },
+    { taskId: TASK_ID, taskTitle: TASK_TITLE, projectId: PROJECT_ID },
+  );
+}
+
+/** Run the real restore entry point with the workspace blob (mirrors restore-workspace.ts). */
+async function applyWorkspaceRestore(page: Page): Promise<void> {
+  await page.evaluate((workspace) => {
+    const stores = (window as unknown as { __zustandStores?: ZustandStores }).__zustandStores;
+    if (!stores) throw new Error('window.__zustandStores not exposed');
+    const boardTasks = stores.board.getState().tasks;
+    stores.window.getState().applyWorkspace(
+      workspace,
+      () => null, // resolveSession: no live PTY in UI tests; the window still mounts.
+      (anchor: string) => boardTasks.some((task) => task.id === anchor), // isKnownAnchor
+    );
+  }, WORKSPACE_BLOB);
+}
+
+/** Read each managed window's skip-enter flag, normalised to a strict boolean (undefined -> false,
+ *  which is how it travels over the CDP bridge anyway). */
+async function readSkipEnterFlags(page: Page): Promise<boolean[]> {
+  return page.evaluate(() => {
+    const stores = (window as unknown as { __zustandStores?: ZustandStores }).__zustandStores;
+    if (!stores) throw new Error('window.__zustandStores not exposed');
+    return Object.values(stores.window.getState().windows).map((managed) => managed.skipEnterAnimation === true);
+  });
+}
+
+test.describe('task-detail window entrance animation suppression on restore', () => {
+  test('a restored window carries the skip-enter flag and paints flat (no overlay-content-in)', async () => {
+    const { browser, page } = await launch();
+    try {
+      await seedBoardStoreTask(page);
+      await applyWorkspaceRestore(page);
+
+      const restoredFrame = page.locator('[data-testid^="window-frame-"]').first();
+      await restoredFrame.waitFor({ state: 'attached', timeout: 5000 });
+
+      // Programmatic state: deserializeWorkspace stamped the flag on the rebuilt window.
+      await expect.poll(() => readSkipEnterFlags(page), { timeout: 5000 }).toEqual([true]);
+
+      // Rendered effect: phase started 'visible', so the frame never gets the entrance class.
+      await expect(restoredFrame).not.toHaveClass(/overlay-content-in/);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('a freshly opened window is left without the skip-enter flag (keeps its entrance)', async () => {
+    const { browser, page } = await launch();
+    try {
+      await seedBoardStoreTask(page);
+
+      // Card-click path: setDetailTaskId -> useTaskDetailWindowBridge -> openWindow, which does
+      // NOT set skipEnterAnimation.
+      await page.evaluate((taskId) => {
+        const stores = (window as unknown as { __zustandStores?: ZustandStores }).__zustandStores;
+        if (!stores) throw new Error('window.__zustandStores not exposed');
+        stores.session.getState().setDetailTaskId(taskId);
+      }, TASK_ID);
+
+      const freshFrame = page.locator('[data-testid^="window-frame-"]').first();
+      await freshFrame.waitFor({ state: 'attached', timeout: 5000 });
+
+      // Programmatic state: the open path leaves the flag unset, so the window animates in
+      // (the suppression is scoped to restored windows only).
+      await expect.poll(() => readSkipEnterFlags(page), { timeout: 5000 }).toEqual([false]);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/unit/restore-no-animation-replay.test.ts
+++ b/tests/unit/restore-no-animation-replay.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Enforces .claude/rules/restore-no-animation-replay.md (the value-pulse arm). A project
+// switch / restore re-points the status and context bars to a different context's numbers;
+// that flip is not a live tick and must not pulse. The guard: every `useValuePulse(...)` call
+// must pass a `resetKey` identifying the context the value belongs to (project id, session id),
+// so the hook rebaselines silently on a context switch instead of animating.
+//
+// (The window-restore arm of the same rule is locked by window-workspace.test.ts:
+// deserializeWorkspace stamps skipEnterAnimation and serializeWorkspace never persists it.)
+//
+// Escape hatch: a call that genuinely never re-points across a context boundary may carry a
+// `// value-pulse-ok: <reason>` marker on the call line or the line above.
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const SCAN_DIR = 'src/renderer';
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);
+const OK_MARKER = /value-pulse-ok/;
+
+// The hook's own definition lives here; it is not a call site.
+const DEFINITION_FILE = 'src/renderer/hooks/useValuePulse.ts';
+
+function collectSourceFiles(directory: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath));
+    } else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function toPosix(relativePath: string): string {
+  return relativePath.replace(/\\/g, '/');
+}
+
+/** Extract the balanced-paren argument list of the call starting at `openParenIndex`
+ *  (the index of the '(' right after `useValuePulse`). Returns the substring between the
+ *  parentheses. Naive paren counting is sufficient for these simple call sites. */
+function extractCallArgs(text: string, openParenIndex: number): string {
+  let depth = 0;
+  for (let i = openParenIndex; i < text.length; i++) {
+    if (text[i] === '(') depth++;
+    else if (text[i] === ')') {
+      depth--;
+      if (depth === 0) return text.slice(openParenIndex + 1, i);
+    }
+  }
+  return text.slice(openParenIndex + 1); // unbalanced (should not happen in valid source)
+}
+
+function lineNumberAt(text: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index; i++) if (text[i] === '\n') line++;
+  return line;
+}
+
+describe('every useValuePulse call rebaselines on a context change (resetKey)', () => {
+  it('no useValuePulse call site in src/renderer omits resetKey', () => {
+    const offenders: string[] = [];
+    const absoluteDir = path.join(REPO_ROOT, SCAN_DIR);
+    const callPattern = /useValuePulse\s*\(/g;
+
+    for (const filePath of collectSourceFiles(absoluteDir)) {
+      const relative = toPosix(path.relative(REPO_ROOT, filePath));
+      if (relative === DEFINITION_FILE) continue;
+      const text = fs.readFileSync(filePath, 'utf-8');
+      const lines = text.split('\n');
+
+      for (const match of text.matchAll(callPattern)) {
+        const openParenIndex = match.index + match[0].length - 1;
+        const args = extractCallArgs(text, openParenIndex);
+        if (/resetKey/.test(args)) continue;
+
+        const callLine = lineNumberAt(text, match.index); // 1-based
+        const lineIndex = callLine - 1;
+        if (OK_MARKER.test(lines[lineIndex])) continue;
+        let previousIndex = lineIndex - 1;
+        while (previousIndex >= 0 && lines[previousIndex].trim() === '') previousIndex--;
+        if (previousIndex >= 0 && OK_MARKER.test(lines[previousIndex])) continue;
+
+        offenders.push(`${relative}:${callLine}`);
+      }
+    }
+
+    expect(
+      offenders,
+      `Every useValuePulse(...) must pass a resetKey identifying the value's context (project id, ` +
+        `session id, ...) so a project/session switch rebaselines silently instead of pulsing. ` +
+        `See .claude/rules/restore-no-animation-replay.md. For a call that never re-points across a ` +
+        `context boundary, add // value-pulse-ok: <reason>.\nOffenders:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/window-manager.test.ts
+++ b/tests/unit/window-manager.test.ts
@@ -107,6 +107,13 @@ describe('window-store actions', () => {
     expect(state.order).toEqual([id]);
   });
 
+  it('leaves a freshly opened window without the skip-enter flag, so it plays the entrance animation', () => {
+    // Only a workspace restore (deserializeWorkspace) sets skipEnterAnimation; a user-opened
+    // window must keep the normal entrance, so the flag stays unset here.
+    const id = useWindowStore.getState().openWindow({ anchor: 'task-a', sessionId: 'sess-a', title: 'A' });
+    expect(useWindowStore.getState().windows[id].skipEnterAnimation).toBeUndefined();
+  });
+
   it('focuses the existing window when re-opening the same task (one window per task)', () => {
     const first = useWindowStore.getState().openWindow({ anchor: 'task-a', sessionId: 'sess-a', title: 'A' });
     const second = useWindowStore.getState().openWindow({ anchor: 'task-a', sessionId: 'sess-a', title: 'A again' });

--- a/tests/unit/window-workspace.test.ts
+++ b/tests/unit/window-workspace.test.ts
@@ -71,6 +71,23 @@ describe('workspace serialize / deserialize', () => {
     expect(restored.tileTree).toBeNull();
   });
 
+  it('marks every restored window to skip the entrance animation, and never persists the flag', () => {
+    // A restored window must paint flat (no project-switch entrance replay), so deserialize
+    // stamps the transient flag. It is presentation-only and must not survive a serialize.
+    const restoredWindow = makeWindow('win-1', 'task-a', 'floating', HALF_LEFT);
+    restoredWindow.skipEnterAnimation = true; // as a window already rebuilt by a prior restore carries
+    const serialized = serializeWorkspace([restoredWindow], null, FULL, 'win-1');
+    expect(serialized.windows[0]).not.toHaveProperty('skipEnterAnimation');
+
+    const windows = [
+      makeWindow('win-1', 'task-a', 'floating', { x: 0.1, y: 0.1, w: 0.4, h: 0.5 }),
+      makeWindow('win-2', 'task-b', 'maximized', { x: 0.2, y: 0.2, w: 0.4, h: 0.5 }),
+    ];
+    const fresh = serializeWorkspace(windows, null, FULL, 'win-1');
+    const restored = deserializeWorkspace(fresh, makeContext(['task-a', 'task-b']))!;
+    expect(Object.values(restored.windows).every((window) => window.skipEnterAnimation === true)).toBe(true);
+  });
+
   it('round-trips a 2-up tile tree, re-anchoring leaves by taskId then back to fresh window ids', () => {
     const tree: TileNode = {
       kind: 'split',
@@ -99,6 +116,8 @@ describe('workspace serialize / deserialize', () => {
     const tiled = Object.values(restored.windows).filter((window) => window.state === 'tiled');
     expect(tiled).toHaveLength(2);
     expect(tiled.every((window) => window.leafId)).toBe(true);
+    // The skip-enter flag rides the tiled-window spread too (restored tiles paint flat).
+    expect(tiled.every((window) => window.skipEnterAnimation === true)).toBe(true);
     // The tree's leaves reference exactly the restored windows' new ids.
     expect(new Set(leafWindowIds(restored.tileTree!))).toEqual(new Set(Object.keys(restored.windows)));
   });


### PR DESCRIPTION
## What

Makes a project switch / workspace restore paint flat, with no animation replay. Two distinct
distractions are suppressed:

- **Task-detail window entrance animation.** A window rebuilt by `deserializeWorkspace` on a
  project switch no longer replays the dialog entrance (fade + scale + slide). It carries a
  transient, never-persisted `skipEnterAnimation` flag; `WindowFrame` forwards it to
  `useOverlayPhase` as a new `skipEnter` option that seeds the phase to `'visible'`. A fresh
  user-opened window leaves the flag unset and animates as before.
- **Status / context bar value-pulse flurry.** `useValuePulse` now takes a `resetKey`; when the
  context identity changes (project switch, session re-bind) it rebaselines silently instead of
  firing the 350ms highlight. `StatusBar` keys on `currentProject.id` + selected period;
  `ContextBar` keys on `sessionId`. Genuine live in-session ticks still pulse.

Also adds `.claude/rules/restore-no-animation-replay.md` codifying the principle, and a
`test-builder` agent constraint forbidding Playwright's interactive debug/inspector modes (they
open the Inspector GUI and hang a run).

## Why

Project switching is already a jarring context change. Returning to a project that has an open
task-detail window (with a live terminal) should present a calm, flat canvas, not re-animate the
window in and flash a burst of value highlights across the bars. Both were false positives: a
context *reset* being treated as a fresh *open* or a *live* change.

## How

The restore path (`useProjectSwitchEffect` -> `restoreWorkspaceForProject` ->
`applyWorkspace` -> `deserializeWorkspace`) is the single place restored windows are rebuilt, so
the flag is stamped there and consumed at the one mount site (`WindowFrame`). It is deliberately
kept out of `serializeWorkspace`, so it is naturally never persisted and is re-derived on every
restore. The pulse fix is symmetric: the hook's existing initial-mount skip is generalized to also
skip a change that coincides with a `resetKey` change.

The window store is exposed on the dev-only `__zustandStores` block so the UI tier can drive
`applyWorkspace` and read the rebuilt window list.

## Breaking changes

None.

## Tests

- `tests/unit/restore-no-animation-replay.test.ts` (new) - static scan: every `useValuePulse`
  call must pass a `resetKey` (or an explicit opt-out marker). Red-green verified.
- `tests/unit/window-workspace.test.ts` - asserts `deserializeWorkspace` stamps
  `skipEnterAnimation` on every rebuilt window (floating / maximized / tiled) and that
  `serializeWorkspace` never persists it.
- `tests/unit/window-manager.test.ts` - asserts `openWindow` leaves the flag unset (fresh opens
  animate).
- `tests/ui/window-no-entrance-animation-on-restore.spec.ts` (new) - restored window carries the
  flag and its frame never gets `overlay-content-in`.
- `tests/ui/use-value-pulse-reset-key.spec.ts` (new) - resetKey change suppresses the pulse;
  stable resetKey + value change still pulses; initial mount never pulses.
- Local: typecheck + lint clean; both new UI specs pass headless; the rest run on CI.

Generated with [Claude Code](https://claude.com/claude-code)
