### PR TITLE
fix(terminal): default Claude to fullscreen and fix window-resize sizing

### DIFF
--- a/src/main/agent/adapters/claude/command-builder.ts
+++ b/src/main/agent/adapters/claude/command-builder.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { toForwardSlash, quoteArg, isUnixLikeShell } from '../../../../shared/paths';
 import { resolveBridgeScript } from '../../shared/bridge-utils';
@@ -54,6 +55,27 @@ export class CommandBuilder {
   /** Clear the cached project settings (e.g., when settings files change). */
   clearSettingsCache(): void {
     this.projectSettingsCache.clear();
+  }
+
+  /**
+   * Whether the user has explicitly chosen a Claude TUI renderer in their global
+   * `~/.claude/settings.json` (where Claude's `/tui` command persists the `tui`
+   * setting). When they have, Kangentic must NOT inject its own `tui` default -
+   * `--settings` would override the user's choice. Read fresh each spawn (small
+   * file, infrequent) so a `/tui` change is honored on the next session.
+   */
+  private userHasGlobalTuiPreference(): boolean {
+    try {
+      const globalSettingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+      const parsedGlobalSettings = JSON.parse(fs.readFileSync(globalSettingsPath, 'utf-8')) as Record<string, unknown>;
+      // Treat `tui: null` (a reset sentinel, or a hand-edited file) the same as an
+      // absent key: null is not a renderer choice, so Kangentic should still inject
+      // its fullscreen default rather than leave Claude on the classic renderer.
+      return parsedGlobalSettings.tui !== undefined && parsedGlobalSettings.tui !== null;
+    } catch {
+      // No global settings file, or unreadable/invalid -> user has not chosen.
+      return false;
+    }
   }
 
   buildClaudeCommand(options: CommandOptions): string {
@@ -249,6 +271,20 @@ export class CommandBuilder {
     if (eventsPath) {
       const eventBridge = toForwardSlash(resolveBridgeScript('event-bridge'));
       merged.hooks = buildHooks(eventBridge, eventsPath, baseSettings.hooks || {});
+    }
+
+    // Default Claude's TUI renderer to fullscreen (alt-screen) for the embedded
+    // experience. The classic main-screen renderer re-emits its WHOLE frame into
+    // the normal-buffer scrollback on every resize, which piles up duplicate
+    // banners in an embedded xterm and flickers on resize. The alt-screen renderer
+    // - which Claude's own docs recommend for embedded terminal wrappers - has no
+    // scrollback accumulation and no resize flicker. We only set this when the user
+    // has NOT chosen a renderer themselves: `merged.tui` already carries any
+    // project-level choice, and `userHasGlobalTuiPreference()` covers their global
+    // ~/.claude/settings.json (where `/tui` persists). `--settings` outranks both,
+    // so gating on both keeps Claude's native `/tui` control authoritative.
+    if (merged.tui === undefined && !this.userHasGlobalTuiPreference()) {
+      merged.tui = 'fullscreen';
     }
 
     // Session directory (used for the merged Claude settings file).

--- a/src/renderer/addons/fit-addon.ts
+++ b/src/renderer/addons/fit-addon.ts
@@ -63,7 +63,14 @@ export class FitAddon implements ITerminalAddon {
       return undefined;
     }
 
-    const scrollbarWidth = this._terminal.options.scrollback === 0
+    // Reserve room for the scrollbar so it never overlaps the last column - EXCEPT
+    // when the alternate screen buffer is active (a fullscreen TUI like Claude's
+    // `/tui fullscreen`, vim, or htop). The alt buffer is exactly viewport-sized
+    // and has no scrollbar, so reserving width there just leaves an empty strip on
+    // the right; reclaim it for the grid instead. Re-evaluated on every fit, so the
+    // column count follows the buffer mode on the next resize.
+    const inAltBuffer = this._terminal.buffer?.active?.type === 'alternate';
+    const scrollbarWidth = (this._terminal.options.scrollback === 0 || inAltBuffer)
       ? 0
       : (this._terminal.options.overviewRuler?.width ?? DEFAULT_SCROLLBAR_WIDTH);
 

--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -297,7 +297,7 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
     ),
   );
 
-  const { terminalRef, initTerminal, fit, focus } = useTerminal({
+  const { terminalRef, initTerminal, fit, flushResize, focus } = useTerminal({
     sessionId: effectiveSessionId,
     fontFamily: config.terminal.fontFamily,
     fontSize: config.terminal.fontSize,
@@ -348,11 +348,14 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
   // all that is needed.
   useEffect(() => {
     const onPanelResize = () => {
-      if (initialized.current) fit();
+      // fit() reflows xterm; flushResize() lands the PTY SIGWINCH immediately rather
+      // than 200ms later, so Claude's redraw arrives with the reflow (no resize
+      // flash). Mirrors the task-detail terminal's immediatePanelResize path.
+      if (initialized.current) { fit(); flushResize(); }
     };
     window.addEventListener('terminal-panel-resize', onPanelResize);
     return () => window.removeEventListener('terminal-panel-resize', onPanelResize);
-  }, [fit]);
+  }, [fit, flushResize]);
 
   // Refit when the changes panel toggles (the terminal column width changes).
   useEffect(() => {
@@ -689,8 +692,12 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
 
       {/* Body */}
       <div className="relative flex flex-1 min-h-0">
-        {/* Terminal */}
-        <div className={`${changesOpen ? 'w-1/2' : 'flex-1'} relative`} style={{ backgroundColor: '#18181b' }}>
+        {/* Terminal. min-w-0 lets this flex item shrink below the xterm's content
+            width when the window narrows; without it `min-width: auto` pins the pane
+            to the terminal's column width, so it overflows the window and fit() reads
+            the stale (too-wide) size and never reduces columns. overflow-hidden clips
+            the brief pre-fit overflow. Mirrors the Changes panel sibling. */}
+        <div className={`${changesOpen ? 'w-1/2' : 'flex-1'} relative min-w-0 overflow-hidden`} style={{ backgroundColor: '#18181b' }}>
           {!terminalReady && <LaunchOverlay label="Starting Command Terminal..." />}
           <FileDropOverlay {...fileDrop} />
           <div

--- a/src/renderer/components/terminal/TerminalTab.tsx
+++ b/src/renderer/components/terminal/TerminalTab.tsx
@@ -7,6 +7,7 @@ import { useSessionStore } from '../../stores/session-store';
 import { LaunchOverlay } from '../LaunchOverlay';
 import { getIsHmrReload } from '../../utils/hmr-flag';
 import { useTerminalOverlay } from '../../utils/task-progress';
+import { isManagerResizeInProgress } from '../../window-manager/terminal/manager-resize-gate';
 
 const FIT_DELAY_MS = 100;
 
@@ -60,7 +61,7 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
   // PTY output from accumulating in xterm behind the overlay.
   const [terminalReady, setTerminalReady] = useState(() => hasFirstOutput || hasUsage);
 
-  const { terminalRef, initTerminal, fit, focus, reloadScrollback, scrollbackPending, suppressDataRef } = useTerminal({
+  const { terminalRef, initTerminal, fit, flushResize, focus, reloadScrollback, scrollbackPending, suppressDataRef } = useTerminal({
     sessionId,
     fontFamily: config.terminal.fontFamily,
     fontSize: config.terminal.fontSize,
@@ -209,7 +210,16 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
       // Window-manager terminals defer container-driven fits: the window manager
       // owns sizing and dispatches a single settle-debounced terminal-panel-resize,
       // so rapid snap/maximize/restore resizes the PTY once (one clean SIGWINCH).
-      if (!deferContainerResize) scheduleRefit(200);
+      //
+      // While a window-manager imperative resize gesture is in progress (seam drag,
+      // footprint resize, 8-handle window resize) this observer fires per frame as
+      // the frame's DOM box is rewritten. Refitting per frame would send a SIGWINCH
+      // per frame, and a full-screen TUI re-emits its whole banner on each - stacking
+      // duplicates in scrollback. Suppress the per-frame refit during the gesture; the
+      // store commit on release dispatches a single terminal-panel-resize that refits
+      // once. The gate is OFF for container-only changes (Changes/Browser pane toggle),
+      // so those still refit normally.
+      if (!deferContainerResize && !isManagerResizeInProgress()) scheduleRefit(200);
     });
     observer.observe(el);
 
@@ -227,7 +237,11 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
       // run a redundant second fit afterward.
       if (immediatePanelResize) {
         if (resizeTimer) { clearTimeout(resizeTimer); resizeTimer = null; }
-        if (initialized.current) fit();
+        // Fit synchronously, then flush the PTY resize immediately (don't wait out
+        // the 200ms debounce) so Claude's redraw lands with the reflow instead of
+        // a beat later - minimizes the resize "flash". The manager-resize gate
+        // already guarantees one resize per gesture, so there's nothing to coalesce.
+        if (initialized.current) { fit(); flushResize(); }
         return;
       }
       // Window terminals (deferContainerResize) fit on the next tick; other
@@ -251,7 +265,7 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
       observer.disconnect();
       window.removeEventListener('terminal-panel-resize', handlePanelResize);
     };
-  }, [active, fit, focus, deferContainerResize, immediatePanelResize, reloadScrollback, terminalRef, scrollbackPending]);
+  }, [active, fit, flushResize, focus, deferContainerResize, immediatePanelResize, reloadScrollback, terminalRef, scrollbackPending]);
 
   const fileDrop = useTerminalFileDrop(sessionId, focus, sessionShell);
 

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -348,6 +348,22 @@ export function useTerminal(options: UseTerminalOptions) {
     }
   }, []);
 
+  // Flush a pending (debounced) PTY resize immediately, instead of waiting out
+  // PTY_RESIZE_DEBOUNCE_MS. Window-hosted terminals fit synchronously on the
+  // window manager's committed resize, and the manager-resize gate already
+  // coalesces a gesture to a single dimension change, so for them the debounce is
+  // pure latency: it delays Claude's SIGWINCH redraw well past the visual reflow,
+  // which reads as "reflow ... then flash". Calling this right after fit() lands
+  // the PTY resize (and Claude's redraw) in the same beat as the reflow. No-op if
+  // no resize is pending (cols/rows did not change).
+  const flushResize = useCallback(() => {
+    if (!resizeTimerRef.current || !xtermRef.current || !options.sessionId) return;
+    clearTimeout(resizeTimerRef.current);
+    resizeTimerRef.current = null;
+    const { cols, rows } = xtermRef.current;
+    window.electronAPI.sessions.resize(options.sessionId, cols, rows);
+  }, [options.sessionId]);
+
   // Re-fetch scrollback from the PTY and write it to xterm. Called when
   // the loading overlay lifts so that suppressed TUI output is recovered.
   //
@@ -427,6 +443,7 @@ export function useTerminal(options: UseTerminalOptions) {
     terminalRef,
     initTerminal,
     fit,
+    flushResize,
     focus,
     reloadScrollback,
     scrollbackPending: scrollbackPendingRef,

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -340,6 +340,18 @@
   background-color: var(--kng-surface) !important;
 }
 
+/* Terminal scrollbar visibility: the global thumb color (--kng-edge, #3f3f46) is
+   nearly invisible against the dark terminal background (#18181b), so the scrollbar
+   reads as missing. Use a brighter translucent thumb so it is discoverable. Width is
+   left at the global 8px so the fit-addon's DEFAULT_SCROLLBAR_WIDTH assumption holds. */
+.xterm .xterm-viewport::-webkit-scrollbar-thumb {
+  background: rgba(228, 228, 231, 0.28);
+  border-radius: 4px;
+}
+.xterm .xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background: rgba(228, 228, 231, 0.5);
+}
+
 /* Terminal panel resize handle */
 .resize-handle {
   cursor: ns-resize;

--- a/src/renderer/window-manager/components/FootprintResizer.tsx
+++ b/src/renderer/window-manager/components/FootprintResizer.tsx
@@ -15,13 +15,14 @@
  * no per-frame terminal fit). The footprint is committed once on release.
  */
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { RefObject } from 'react';
 import { useLayerStore, useWindowManager } from '../context';
 import { clamp } from '../store/geometry';
 import type { ContainerSize, PixelRect } from '../store/geometry';
 import type { FractionalRect, TileNode } from '../store/types';
 import { resolveTileLayout } from '../tiling/resolve-layout';
+import { beginManagerResize, endManagerResize } from '../terminal/manager-resize-gate';
 
 export type FootprintEdge = 'left' | 'right' | 'top' | 'bottom';
 
@@ -90,6 +91,16 @@ export function FootprintResizer({ edge, tileTree, tileTreeRect, containerSize, 
   const dragRef = useRef<FootprintDrag | null>(null);
   const [dragging, setDragging] = useState(false);
 
+  // Balance the manager-resize gate if this resizer unmounts mid-drag (the overlay
+  // is torn down while a pointer is held - e.g. a keyboard shortcut hides the layer
+  // or closes the dialog). React removes the pointer handlers on unmount, so
+  // onPointerUp's endManagerResize() would never fire; without this the module-level
+  // gate stays open and suppresses refits in terminals on OTHER layers (the bottom
+  // panel, the command bar) until a reload.
+  useEffect(() => () => {
+    if (dragRef.current) { endManagerResize(); dragRef.current = null; }
+  }, []);
+
   const isVerticalBar = edge === 'left' || edge === 'right';
   const origin = { left: tileTreeRect.x * containerSize.width, top: tileTreeRect.y * containerSize.height };
   const footprintSize = { width: tileTreeRect.w * containerSize.width, height: tileTreeRect.h * containerSize.height };
@@ -97,6 +108,10 @@ export function FootprintResizer({ edge, tileTree, tileTreeRect, containerSize, 
 
   const onPointerDown = (event: React.PointerEvent) => {
     if (event.button !== 0) return;
+    // Re-entry guard: a second pointer-down while a drag is live would overwrite
+    // dragRef (abandoning the first gesture's capture) and open the gate a second
+    // time, which a single matching pointer-up cannot fully close. Ignore it.
+    if (dragRef.current) return;
     const overlay = overlayRef.current;
     if (!overlay) return;
     const overlayRect = overlay.getBoundingClientRect();
@@ -138,6 +153,9 @@ export function FootprintResizer({ edge, tileTree, tileTreeRect, containerSize, 
       minFootprint,
     };
     setDragging(true);
+    // Open the manager-resize gate so window terminals suppress per-frame refits
+    // (one SIGWINCH on commit instead of one per drag frame). Closed in onPointerUp.
+    beginManagerResize();
     (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
     event.stopPropagation();
   };
@@ -181,6 +199,10 @@ export function FootprintResizer({ edge, tileTree, tileTreeRect, containerSize, 
     setDragging(false);
     const drag = dragRef.current;
     dragRef.current = null;
+    // Close the gate this gesture opened (balanced on `drag`, nulled above so a
+    // second up/cancel cannot double-close). Runs before the pointerId guard so
+    // the gate is never left stuck open.
+    if (drag) endManagerResize();
     if (!drag || event.pointerId !== drag.pointerId) return;
     const element = event.currentTarget as HTMLElement;
     if (element.hasPointerCapture(drag.pointerId)) element.releasePointerCapture(drag.pointerId);

--- a/src/renderer/window-manager/components/TileSplitter.tsx
+++ b/src/renderer/window-manager/components/TileSplitter.tsx
@@ -12,7 +12,7 @@
  * writes. Sits in the gap BETWEEN panes, so it never overlaps a live terminal.
  */
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { RefObject } from 'react';
 import { useLayerStore, useWindowManager } from '../context';
 import type { ContainerSize } from '../store/geometry';
@@ -20,6 +20,7 @@ import type { TileNode } from '../store/types';
 import { resolveTileLayout } from '../tiling/resolve-layout';
 import type { TileSeam } from '../tiling/resolve-layout';
 import { clampTileRatio, setSeamRatio as resizeSeamInTree } from '../tiling/tree-ops';
+import { beginManagerResize, endManagerResize } from '../terminal/manager-resize-gate';
 
 interface TileSplitterProps {
   seam: TileSeam;
@@ -67,8 +68,22 @@ export function TileSplitter({ seam, tileTree, treeSize, treeOrigin, gapPx, seam
   // the captured pointer travels off the thin overlay).
   const [dragging, setDragging] = useState(false);
 
+  // Balance the manager-resize gate if this splitter unmounts mid-drag (the overlay
+  // is torn down while a pointer is held - e.g. a keyboard shortcut hides the layer
+  // or closes the dialog). React removes the pointer handlers on unmount, so
+  // onPointerUp's endManagerResize() would never fire; without this the module-level
+  // gate stays open and suppresses refits in terminals on OTHER layers (the bottom
+  // panel, the command bar) until a reload.
+  useEffect(() => () => {
+    if (dragRef.current) { endManagerResize(); dragRef.current = null; }
+  }, []);
+
   const onPointerDown = (event: React.PointerEvent) => {
     if (event.button !== 0) return;
+    // Re-entry guard: a second pointer-down while a drag is live would overwrite
+    // dragRef (abandoning the first gesture's capture) and open the gate a second
+    // time, which a single matching pointer-up cannot fully close. Ignore it.
+    if (dragRef.current) return;
     const overlay = overlayRef.current;
     if (!overlay) return;
     const overlayRect = overlay.getBoundingClientRect();
@@ -93,6 +108,9 @@ export function TileSplitter({ seam, tileTree, treeSize, treeOrigin, gapPx, seam
       ratio: 0,
     };
     setDragging(true);
+    // Open the manager-resize gate so window terminals suppress per-frame refits
+    // (one SIGWINCH on commit instead of one per drag frame). Closed in onPointerUp.
+    beginManagerResize();
     (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
     // Don't let the pointer-down fall through to focus/raise a window under the seam.
     event.stopPropagation();
@@ -131,6 +149,10 @@ export function TileSplitter({ seam, tileTree, treeSize, treeOrigin, gapPx, seam
     setDragging(false);
     const drag = dragRef.current;
     dragRef.current = null;
+    // Close the gate this gesture opened (the begin/end pair is balanced on `drag`,
+    // nulled above so a second up/cancel cannot double-close). Runs before the
+    // pointerId guard so the gate is never left stuck open.
+    if (drag) endManagerResize();
     if (!drag || event.pointerId !== drag.pointerId) return;
     const element = event.currentTarget as HTMLElement;
     if (element.hasPointerCapture(drag.pointerId)) element.releasePointerCapture(drag.pointerId);

--- a/src/renderer/window-manager/dnd/useWindowResize.ts
+++ b/src/renderer/window-manager/dnd/useWindowResize.ts
@@ -13,11 +13,12 @@
  * WindowFrame wires the frame's move/up to call back here.
  */
 
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import type { RefObject } from 'react';
 import { clamp, pixelsToFractional } from '../store/geometry';
 import type { PixelRect } from '../store/geometry';
 import { useWindowManager } from '../context';
+import { beginManagerResize, endManagerResize } from '../terminal/manager-resize-gate';
 
 export type ResizeDirection = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
 
@@ -109,6 +110,16 @@ export function useWindowResize({ windowId, frameRef, overlayRef }: UseWindowRes
   const minHeight = layer.minSize.height;
   const resizeRef = useRef<ResizeSession | null>(null);
 
+  // Balance the manager-resize gate if the frame unmounts mid-drag (the window or
+  // its overlay is torn down while a pointer is held - e.g. a keyboard shortcut
+  // closes the window). React removes the move/up handlers on unmount, so endResize's
+  // endManagerResize() would never fire; without this the module-level gate stays
+  // open and suppresses refits in terminals on OTHER layers until a reload. Gated on
+  // `captured`, the same condition that opened the gate.
+  useEffect(() => () => {
+    if (resizeRef.current?.captured) endManagerResize();
+  }, []);
+
   const handlePointerDown = (direction: ResizeDirection) => (event: React.PointerEvent) => {
     if (event.button !== 0) return;
     const frame = frameRef.current;
@@ -158,6 +169,11 @@ export function useWindowResize({ windowId, frameRef, overlayRef }: UseWindowRes
         // ignore: capture not available for this pointer
       }
       resize.captured = true;
+      // Open the manager-resize gate now that a real drag has started (gated on
+      // `captured`, so a no-move click never opens it). Window terminals suppress
+      // their per-frame refit until endResize closes the gate, so the PTY resizes
+      // once on commit instead of once per drag frame. Closed in endResize.
+      beginManagerResize();
     }
     // Remember the last good pointer position; the commit reads it instead of the
     // pointerup/cancel coords (which can be a bogus (0,0) on a captured release).
@@ -176,6 +192,10 @@ export function useWindowResize({ windowId, frameRef, overlayRef }: UseWindowRes
     resizeRef.current = null;
     // Always restore text selection, even on the guard return below.
     document.body.style.userSelect = '';
+    // Close the gate this gesture opened. Gated on `captured` (the same condition
+    // that opened it) and independent of the frame/pointerId guards below, so a
+    // captured drag always closes its gate and never leaves it stuck open.
+    if (resize?.captured) endManagerResize();
     if (!resize || !frame || event.pointerId !== resize.pointerId) return;
     if (frame.hasPointerCapture(event.pointerId)) frame.releasePointerCapture(event.pointerId);
     // Commit from the LAST tracked move position, never the end event's coords: a

--- a/src/renderer/window-manager/terminal/manager-resize-gate.ts
+++ b/src/renderer/window-manager/terminal/manager-resize-gate.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared "manager-resize in progress" gate.
+ *
+ * The window manager's imperative resizers (TileSplitter seam-drag,
+ * FootprintResizer, useWindowResize 8-handle) resize the tiled frames' DOM boxes
+ * on every pointermove WITHOUT a store write, so a window-hosted terminal's
+ * ResizeObserver fires per frame. Refitting per frame sends a SIGWINCH per frame,
+ * and a full-screen TUI (Claude Code) re-emits its whole banner + transcript frame
+ * on each SIGWINCH - stacking duplicate banners in the PTY scrollback.
+ *
+ * A resizer marks "a manager drag is in progress" for the duration of its gesture.
+ * While the gate is open the terminal suppresses its per-frame ResizeObserver
+ * refit (see `TerminalTab`); the PTY is then resized exactly once, from the single
+ * `terminal-panel-resize` the store commit already dispatches on release. The gate
+ * does NOT itself dispatch - the existing commit path owns the one settle-resize.
+ *
+ * Balance invariant: every `beginManagerResize()` is matched by exactly one
+ * `endManagerResize()`. The counter is floored at 0, and each resizer's end runs
+ * only when that gesture opened the gate, with its drag ref nulled first - so a
+ * pathological multi-pointer race can only close the gate EARLY (degrading to the
+ * pre-gate behavior), never leave it stuck open.
+ */
+
+// A transient gesture counter: how many imperative manager-resize drags are open.
+// hmr-safe: a reset on HMR can only drop an in-flight drag's gate, which the next pointerdown re-establishes.
+let activeGestureCount = 0;
+
+export function beginManagerResize(): void {
+  activeGestureCount += 1;
+}
+
+export function endManagerResize(): void {
+  activeGestureCount = Math.max(0, activeGestureCount - 1);
+}
+
+export function isManagerResizeInProgress(): boolean {
+  return activeGestureCount > 0;
+}

--- a/tests/unit/command-builder.test.ts
+++ b/tests/unit/command-builder.test.ts
@@ -4,14 +4,13 @@
  *
  * Migrated from tests/e2e/command-builder.spec.ts -- pure logic, no Electron needed.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { execFileSync, execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import {
   quoteArg,
-  isUnixLikeShell,
   isCmdShell,
   adaptCommandForShell,
   convertWindowsExePath,
@@ -1179,6 +1178,109 @@ describe('Merged Settings -- Local Settings Merge', () => {
     // Worktree "always allow" grants should be merged in
     expect(merged.permissions.allow).toContain('Bash(npm test:*)');
     expect(merged.permissions.allow).toContain('Edit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TUI Fullscreen Default
+// Tests for the `merged.tui = 'fullscreen'` injection in createMergedSettings.
+// userHasGlobalTuiPreference() reads os.homedir()/.claude/settings.json, so
+// we spy on os.homedir() to redirect reads to a controlled temp directory that
+// we populate per-case. This makes all four cases hermetic regardless of what
+// any developer's real ~/.claude/settings.json contains.
+// ---------------------------------------------------------------------------
+
+describe('Merged Settings -- TUI Fullscreen Default', () => {
+  let tmpDir: string;
+  let tempHome: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kangentic-tui-'));
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'kangentic-home-'));
+    // Project .claude/settings.json starts empty so there is no tui key.
+    fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, '.claude', 'settings.json'), JSON.stringify({}));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  /**
+   * Spy on os.homedir() to return tempHome, then build and return the written
+   * merged settings. Callers set up project settings and/or tempHome/.claude/
+   * before invoking this helper.
+   */
+  function buildAndReadMerged(): Record<string, unknown> {
+    vi.spyOn(os, 'homedir').mockReturnValue(tempHome);
+    const builder = new CommandBuilder();
+    const statusOutput = path.join(tmpDir, '.kangentic', 'sessions', 'tui-test', 'status.json');
+    fs.mkdirSync(path.dirname(statusOutput), { recursive: true });
+    builder.buildClaudeCommand({
+      cliPath: '/usr/bin/claude',
+      taskId: 'tui-task',
+      cwd: tmpDir,
+      permissionMode: 'default',
+      sessionId: 'tui-test',
+      statusOutputPath: statusOutput,
+    });
+    const mergedPath = path.join(tmpDir, '.kangentic', 'sessions', 'tui-test', 'settings.json');
+    return JSON.parse(fs.readFileSync(mergedPath, 'utf-8'));
+  }
+
+  it('A: injects tui=fullscreen when no global preference and project settings has no tui key', () => {
+    // tempHome has no .claude/ directory -> userHasGlobalTuiPreference() returns false.
+    // project settings.json is {} -> no tui key.
+    // Expected: Kangentic injects fullscreen default.
+    // RED: removing `merged.tui = 'fullscreen'` makes merged.tui undefined, failing this.
+    const merged = buildAndReadMerged();
+    expect(merged.tui).toBe('fullscreen');
+  });
+
+  it('B: preserves project-level tui when project settings.json already specifies tui=auto', () => {
+    // A project with { tui: 'auto' } in .claude/settings.json wins: merged.tui starts
+    // as 'auto' from baseSettings, the guard sees merged.tui !== undefined, and skips
+    // the fullscreen injection.
+    // RED: removing the `merged.tui === undefined` guard would overwrite 'auto' to 'fullscreen'.
+    fs.writeFileSync(
+      path.join(tmpDir, '.claude', 'settings.json'),
+      JSON.stringify({ tui: 'auto' }),
+    );
+    // tempHome has no .claude/ -> global preference absent.
+    const merged = buildAndReadMerged();
+    expect(merged.tui).toBe('auto');
+  });
+
+  it('C: suppresses the fullscreen default when global ~/.claude/settings.json sets tui=auto', () => {
+    // userHasGlobalTuiPreference() reads tempHome/.claude/settings.json and finds
+    // tui: 'auto', so it returns true. The injection condition is false and tui is
+    // NOT set to 'fullscreen' (it stays undefined in the merged output).
+    // RED: removing the `!this.userHasGlobalTuiPreference()` guard makes merged.tui
+    //      'fullscreen' even though the user explicitly chose 'auto'.
+    fs.mkdirSync(path.join(tempHome, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempHome, '.claude', 'settings.json'),
+      JSON.stringify({ tui: 'auto' }),
+    );
+    const merged = buildAndReadMerged();
+    expect(merged.tui).not.toBe('fullscreen');
+  });
+
+  it('D: treats global tui=null as no preference and injects the fullscreen default', () => {
+    // `tui: null` is the reset sentinel (e.g. a hand-edited file). The code gates
+    // on `parsedGlobalSettings.tui !== null`, so null -> userHasGlobalTuiPreference()
+    // returns false -> Kangentic still injects its fullscreen default.
+    // RED: removing the null check makes null treated as a real preference, returning
+    //      true from userHasGlobalTuiPreference(), and merged.tui stays undefined.
+    fs.mkdirSync(path.join(tempHome, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempHome, '.claude', 'settings.json'),
+      JSON.stringify({ tui: null }),
+    );
+    const merged = buildAndReadMerged();
+    expect(merged.tui).toBe('fullscreen');
   });
 });
 

--- a/tests/unit/fit-addon.test.ts
+++ b/tests/unit/fit-addon.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit coverage for FitAddon.proposeDimensions() -- alt-buffer scrollbar reclaim.
+ *
+ * proposeDimensions() touches:
+ *   _terminal.element / .parentElement  (plain objects stubbed below)
+ *   _terminal.options.scrollback / overviewRuler?.width
+ *   _terminal.buffer?.active?.type  ('normal' | 'alternate')
+ *   _terminal._core._renderService.dimensions.css.cell  (private xterm API, plain object)
+ *   window.getComputedStyle  (mocked via vi.stubGlobal; jsdom not required)
+ *
+ * No DOM environment needed: every dependency is a plain-object stub or a
+ * vi.stubGlobal('window', ...) mock. All three cases are fully deterministic.
+ *
+ * Geometry used across all cases:
+ *   parentWidth = 800, parentHeight = 600, padding = 0 on terminal element
+ *   cellWidth = 8, cellHeight = 16
+ *   DEFAULT_SCROLLBAR_WIDTH = 14  (matches the constant in fit-addon.ts)
+ *
+ * Column derivation:
+ *   scrollbarWidth = 0  -> cols = floor(800 / 8) = 100
+ *   scrollbarWidth = 14 -> cols = floor((800 - 14) / 8) = floor(786 / 8) = 98
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Terminal } from '@xterm/xterm';
+import { FitAddon } from '../../src/renderer/addons/fit-addon';
+
+// ---------------------------------------------------------------------------
+// Minimal stubs
+// ---------------------------------------------------------------------------
+
+/** Pair of parent/element objects that satisfy proposeDimensions()'s early-exit
+ *  checks without any real DOM. parentElement is non-null (truthy), so the
+ *  guard `!_terminal.element.parentElement` passes. */
+function makeElements() {
+  const parentEl = {};
+  const elementEl = { parentElement: parentEl };
+  return { parentEl, elementEl };
+}
+
+/** Build a minimal Terminal-shaped stub. The private _core path uses `as any`
+ *  in the source, so a plain object satisfies it without type gymnastics. */
+function makeTerminalStub(
+  elementEl: { parentElement: object },
+  bufferType: 'normal' | 'alternate',
+  scrollback: number,
+): Terminal {
+  return {
+    element: elementEl,
+    options: { scrollback },
+    buffer: { active: { type: bufferType } },
+    _core: {
+      _renderService: {
+        dimensions: { css: { cell: { width: 8, height: 16 } } },
+      },
+    },
+  } as unknown as Terminal;
+}
+
+// ---------------------------------------------------------------------------
+// Shared mock-window setup -- returns controlled geometry for both the parent
+// element (800x600) and the terminal element (zero padding).
+// ---------------------------------------------------------------------------
+
+function makeWindowStub(parentEl: object) {
+  return {
+    getComputedStyle: (element: unknown) => ({
+      getPropertyValue: (prop: string): string => {
+        if (element === parentEl) {
+          if (prop === 'width') return '800';
+          if (prop === 'height') return '600';
+        }
+        // terminal element -- all padding values are 0
+        return '0';
+      },
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('FitAddon.proposeDimensions -- alt-buffer scrollbar reclaim', () => {
+  let fitAddon: FitAddon;
+  const { parentEl, elementEl } = makeElements();
+
+  beforeEach(() => {
+    fitAddon = new FitAddon();
+    vi.stubGlobal('window', makeWindowStub(parentEl));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('normal buffer with scrollback reserves the scrollbar column (baseline behavior)', () => {
+    // scrollback > 0 and type === 'normal': scrollbarWidth = DEFAULT_SCROLLBAR_WIDTH (14).
+    // availableWidth = 800 - 14 = 786 -> cols = floor(786 / 8) = 98.
+    // Verifies pre-existing behavior is not disturbed by the alt-buffer change.
+    const terminal = makeTerminalStub(elementEl, 'normal', 1000);
+    fitAddon.activate(terminal);
+    const dims = fitAddon.proposeDimensions();
+    expect(dims).toBeDefined();
+    expect(dims!.cols).toBe(98);
+  });
+
+  it('alternate buffer reclaims the scrollbar column regardless of scrollback', () => {
+    // buffer.active.type === 'alternate': inAltBuffer = true -> scrollbarWidth = 0.
+    // availableWidth = 800 -> cols = floor(800 / 8) = 100.
+    // RED: reverting `|| inAltBuffer` from the condition makes scrollbarWidth = 14,
+    //      so cols = 98 and this assertion fails, pinning the fix.
+    const terminal = makeTerminalStub(elementEl, 'alternate', 1000);
+    fitAddon.activate(terminal);
+    const dims = fitAddon.proposeDimensions();
+    expect(dims).toBeDefined();
+    expect(dims!.cols).toBe(100);
+  });
+
+  it('normal buffer with scrollback=0 also reclaims the scrollbar (prior behavior unchanged)', () => {
+    // The scrollback === 0 branch pre-dated the alt-buffer change. Verify it still gives
+    // scrollbarWidth = 0 -> cols = 100 after our edit.
+    const terminal = makeTerminalStub(elementEl, 'normal', 0);
+    fitAddon.activate(terminal);
+    const dims = fitAddon.proposeDimensions();
+    expect(dims).toBeDefined();
+    expect(dims!.cols).toBe(100);
+  });
+});

--- a/tests/unit/manager-resize-gate.test.ts
+++ b/tests/unit/manager-resize-gate.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit coverage for the manager-resize gate primitive.
+ *
+ * The gate is a module-level singleton that the window manager's imperative
+ * resizers open for the duration of a drag, so a window-hosted terminal suppresses
+ * its per-frame ResizeObserver refit and the PTY is resized once on commit instead
+ * of once per drag frame (which would stack duplicate Claude banners in scrollback).
+ *
+ * The functions are pure counter logic with no DOM dependency, so we exercise the
+ * real exported module directly. The end-to-end SIGWINCH/scrollback behavior is
+ * verified empirically via the dev getScrollback IPC, not here.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  beginManagerResize,
+  endManagerResize,
+  isManagerResizeInProgress,
+} from '../../src/renderer/window-manager/terminal/manager-resize-gate';
+
+describe('manager-resize-gate', () => {
+  // The gate is a module singleton; drain it to a known-closed state before each
+  // test so state does not leak between cases.
+  beforeEach(() => {
+    while (isManagerResizeInProgress()) endManagerResize();
+  });
+
+  it('starts closed', () => {
+    expect(isManagerResizeInProgress()).toBe(false);
+  });
+
+  it('opens on begin and closes on the matching end', () => {
+    beginManagerResize();
+    expect(isManagerResizeInProgress()).toBe(true);
+    endManagerResize();
+    expect(isManagerResizeInProgress()).toBe(false);
+  });
+
+  it('stays open across nested gestures until every begin is matched', () => {
+    beginManagerResize();
+    beginManagerResize();
+    expect(isManagerResizeInProgress()).toBe(true);
+    endManagerResize();
+    // One gesture still open: the gate must stay closed-suppressing, i.e. in progress.
+    expect(isManagerResizeInProgress()).toBe(true);
+    endManagerResize();
+    expect(isManagerResizeInProgress()).toBe(false);
+  });
+
+  it('floors at zero so an unmatched end cannot drive the counter negative', () => {
+    // A spurious end (e.g. a multi-pointer race) must not leave the gate "owing"
+    // ends, which would wedge a later real begin as a no-op.
+    endManagerResize();
+    endManagerResize();
+    expect(isManagerResizeInProgress()).toBe(false);
+    // A subsequent real gesture still opens the gate normally.
+    beginManagerResize();
+    expect(isManagerResizeInProgress()).toBe(true);
+    endManagerResize();
+    expect(isManagerResizeInProgress()).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Fixes terminal resize behavior for Claude Code sessions and the in-app window manager:

- Default Claude sessions to fullscreen (alternate-screen) rendering.
- Add a manager-resize gate so a tiled / window drag fires one PTY resize on commit instead of one per frame.
- Fix the terminal not re-fitting when a command-terminal window shrinks.
- Flush the PTY resize immediately on a window-manager commit (less resize flash).
- Reclaim the reserved scrollbar width when a fullscreen TUI is active.
- Make the classic-renderer scrollbar visible.

Affected: `src/main/agent/adapters/claude/command-builder.ts`, `src/renderer/window-manager/*` (new `terminal/manager-resize-gate.ts`, the three resizers), `src/renderer/components/terminal/TerminalTab.tsx`, `src/renderer/hooks/useTerminal.ts`, `src/renderer/addons/fit-addon.ts`, `src/renderer/components/command-bar/CommandTerminalWindow.tsx`, `src/renderer/index.css`.

## Why

Claude Code's classic (main-screen) renderer re-emits its full frame into the terminal's normal-buffer scrollback on every SIGWINCH. In an embedded xterm.js terminal, resizing therefore stacks duplicate banner + transcript copies in the scrollback and flickers on resize. Separately, several window-manager resize paths sent a SIGWINCH per drag frame, a command-terminal pane could not shrink below its content width (so it stayed full-width when the window narrowed), and a fullscreen TUI was left a wasted scrollbar gutter.

## How

The real cure for the duplication and flicker is Claude's own fullscreen (alt-screen) renderer, which its docs recommend specifically for embedded terminal wrappers like Kangentic. Spawned Claude sessions now default to it: the command builder writes `tui: fullscreen` into the per-session settings, but only when the user has not chosen a renderer themselves. It checks both project settings and the user's global `~/.claude/settings.json` (where `/tui` persists), and since `--settings` outranks both, gating on them keeps Claude's native `/tui` control authoritative (`tui: null` is treated as no choice). This is the only Claude-specific change and it lives in the Claude adapter.

The remaining fixes harden the classic / non-fullscreen path and the layout, so the terminal behaves for every agent and both renderers, and none of them branch on agent name:

- **Manager-resize gate** (new `manager-resize-gate.ts`): the imperative resizers (TileSplitter seam drag, FootprintResizer, 8-handle `useWindowResize`) open a gate on grab and close it on commit; while it is open, a window terminal's per-frame ResizeObserver refit is suppressed, so a gesture fires one SIGWINCH on release instead of one per frame.
- **Shrink-fit**: the command-terminal pane was a bare `flex-1`; adding `min-w-0 overflow-hidden` lets the flex item shrink below the xterm content width so the grid re-fits when the window narrows.
- **flushResize**: a window-hosted terminal flushes the PTY resize immediately on the window manager's committed resize instead of waiting out the 200 ms debounce, so Claude's redraw lands with the reflow.
- **fit-addon**: reserve no scrollbar width while the alternate buffer is active (a fullscreen TUI has no scrollbar), reclaiming that width for the grid.
- **Scrollbar visibility**: the classic-renderer xterm thumb was near-invisible against the dark terminal; it now uses a brighter translucent thumb.

## Breaking changes

None requiring action. Behavior change: Claude sessions spawned through Kangentic now start in fullscreen rendering by default. A user who prefers the classic renderer sets it once with Claude's own `/tui default` (or a `tui` key in their settings), which Kangentic respects. Other agents are unchanged.

## Tests

- `tests/unit/manager-resize-gate.test.ts` - gate open/close, nesting, floor-at-zero.
- `tests/unit/command-builder.test.ts` - TUI fullscreen default: inject when unset, preserve a project-level `tui`, suppress on a global `tui` choice, and treat `tui: null` as no choice (home dir spied for hermetic cases).
- `tests/unit/fit-addon.test.ts` - fit logic including the alternate-buffer scrollbar reclaim.
- CI runs the unit, UI, and Linux Electron E2E tiers. The CSS / layout and `flushResize` changes were verified live in the dev preview (shrink-fit re-fits, one banner per gesture, reclaimed fullscreen width, visible classic scrollbar).

Generated with [Claude Code](https://claude.com/claude-code)
