### PR TITLE
fix(changes): silence benign Monaco DiffEditor disposal console error

### DIFF
--- a/src/renderer/components/dialogs/task-detail/changes/DiffViewer.tsx
+++ b/src/renderer/components/dialogs/task-detail/changes/DiffViewer.tsx
@@ -485,13 +485,16 @@ export function DiffViewer({
         ) : (
           // On unmount (panel close, Changes<->Browser switch, file deselect),
           // @monaco-editor/react disposes this DiffEditor's two TextModels
-          // before the widget, so monaco logs a self-healing BugIndicatingError
+          // before the widget, so a disposal listener throws a BugIndicatingError
           // ("TextModel got disposed before DiffEditorWidget model got reset")
-          // and resets its own model. It is benign and does not leak (both
+          // and monaco resets its own model. It is benign and does not leak (both
           // models are disposed regardless of order); no stable release fixes
           // the order, and taking over disposal here would only add leak
-          // surface. The test harness filters this known message; do not
-          // "fix" it by adding keepCurrent*Model + manual disposal.
+          // surface. Do not "fix" it by adding keepCurrent*Model + manual
+          // disposal. The thrown message is swallowed at monaco's error funnel
+          // (monacoConfig.ts wraps errorHandler.unexpectedErrorHandler; pattern
+          // list in src/shared/benign-renderer-errors.ts) so it no longer renders
+          // red in the console, and the test harness filters the same message.
           // Upstream: https://github.com/suren-atoyan/monaco-react/issues/647
           <DiffEditor
             height="100%"

--- a/src/renderer/monacoConfig.ts
+++ b/src/renderer/monacoConfig.ts
@@ -1,10 +1,12 @@
 import { loader } from '@monaco-editor/react';
 import * as monaco from 'monaco-editor';
+import { errorHandler } from 'monaco-editor/esm/vs/base/common/errors';
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
 import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker';
 import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker';
 import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
+import { isBenignRendererError } from '../shared/benign-renderer-errors';
 
 self.MonacoEnvironment = {
   getWorker(_: string, label: string) {
@@ -17,6 +19,36 @@ self.MonacoEnvironment = {
 };
 
 loader.config({ monaco });
+
+// Silence one known-benign error at monaco's source. On DiffEditor unmount,
+// @monaco-editor/react disposes the two TextModels before the widget resets its
+// model, so a disposal listener throws "TextModel got disposed before
+// DiffEditorWidget model got reset". monaco's Emitter catches that throw and
+// funnels it through errorHandler.unexpectedErrorHandler, whose default re-throws
+// it on a timer, surfacing it as a red uncaught error (and a Vite overlay) on a
+// routine panel close. It is benign and does not leak (both models are disposed
+// regardless of order; see DiffViewer.tsx). Wrap the funnel: swallow exactly that
+// message and delegate every other unexpected error to monaco's real default, so
+// no genuine error is masked. This monaco build has no setUnexpectedErrorHandler
+// export, so we reassign the singleton's handler field directly.
+// Upstream: https://github.com/suren-atoyan/monaco-react/issues/647
+const defaultUnexpectedErrorHandler = errorHandler.unexpectedErrorHandler;
+errorHandler.unexpectedErrorHandler = (error: unknown) => {
+  if (isBenignRendererError(error)) return;
+  defaultUnexpectedErrorHandler(error);
+};
+
+// Restore the original handler on HMR dispose so re-executing this module (an
+// edit to monacoConfig.ts, or to benign-renderer-errors.ts which it imports)
+// rewraps the real default rather than stacking another layer on the already-
+// wrapped handler. Pattern D cleanup; see .claude/rules/hmr-patterns.md.
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+if (import.meta.hot) {
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.dispose(() => {
+    errorHandler.unexpectedErrorHandler = defaultUnexpectedErrorHandler;
+  });
+}
 
 // Dev-only: expose the monaco instance for UI test automation (Playwright
 // page.evaluate), e.g. asserting `editor.getModels()` returns to baseline after

--- a/src/shared/benign-renderer-errors.ts
+++ b/src/shared/benign-renderer-errors.ts
@@ -1,0 +1,31 @@
+/**
+ * Renderer errors that are known-benign and outside the app's control. The
+ * single source of truth for both the runtime suppressor (the monaco
+ * error-funnel wrapper in src/renderer/monacoConfig.ts, which reassigns
+ * errorHandler.unexpectedErrorHandler) and the test collector (collectPageErrors
+ * in tests/ui/helpers.ts).
+ *
+ * - The monaco DiffEditor disposal-order quirk. On unmount, @monaco-editor/react
+ *   disposes a DiffEditor's two TextModels before the widget, so monaco throws a
+ *   self-healing BugIndicatingError and resets its own model. Non-fatal and does
+ *   not leak (both models are disposed regardless of order); no stable
+ *   @monaco-editor/react (4.7.0) / monaco-editor (0.55.1) release fixes the order.
+ *   Upstream: https://github.com/suren-atoyan/monaco-react/issues/647
+ */
+export const BENIGN_RENDERER_ERRORS: RegExp[] = [
+  /TextModel got disposed before DiffEditorWidget model got reset/,
+];
+
+/**
+ * Returns true when `error` matches one of the known-benign renderer error
+ * patterns and should be silently suppressed. Returns false for any genuine
+ * unexpected error that must reach the default handler.
+ *
+ * Accepts both Error objects and raw strings so it can be used both in the
+ * runtime error funnel (monaco throws arbitrary values) and in test collectors
+ * (Playwright pageerror events and raw message strings alike).
+ */
+export function isBenignRendererError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return BENIGN_RENDERER_ERRORS.some((pattern) => pattern.test(message));
+}

--- a/src/types/monaco-internal.d.ts
+++ b/src/types/monaco-internal.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Minimal typings for the monaco-editor deep-internal error module. monaco only
+ * ships public API types (monaco.d.ts); the unexpected-error funnel lives in this
+ * internal module, which we reach to suppress one benign disposal-order message
+ * on DiffEditor unmount. See src/renderer/monacoConfig.ts and
+ * src/shared/benign-renderer-errors.ts.
+ */
+declare module 'monaco-editor/esm/vs/base/common/errors' {
+  /**
+   * The process-wide error handler singleton. Its `unexpectedErrorHandler` field
+   * is the function monaco routes every unexpected (BugIndicating) error through;
+   * reassigning it installs a custom handler (this monaco build has no
+   * `setUnexpectedErrorHandler` export).
+   */
+  export const errorHandler: {
+    unexpectedErrorHandler: (error: unknown) => void;
+  };
+}

--- a/tests/ui/changes-panel-diff-disposal.spec.ts
+++ b/tests/ui/changes-panel-diff-disposal.spec.ts
@@ -4,18 +4,23 @@
  * Background:
  * The task-detail Changes panel mounts a @monaco-editor/react DiffEditor and
  * unmounts it instantly when toggled closed. On unmount the library disposes
- * the DiffEditor's two TextModels before the widget, so monaco logs a
+ * the DiffEditor's two TextModels before the widget, so monaco throws a
  * self-healing BugIndicatingError ("TextModel got disposed before
  * DiffEditorWidget model got reset"). It is benign and does not leak: both
  * models are disposed regardless of order, so `editor.getModels()` returns to
  * baseline. See src/renderer/components/dialogs/task-detail/changes/DiffViewer.tsx
  * and https://github.com/suren-atoyan/monaco-react/issues/647
  *
- * This spec locks two properties under rapid open/close:
+ * This spec locks three properties under rapid open/close:
  *   1. No NON-benign renderer errors (the known monaco message is filtered by
  *      the shared collector; anything else fails).
  *   2. No model leak - rapid open/close does not accumulate TextModels; the
  *      registry returns to its baseline count once the panel is closed.
+ *   3. The benign monaco message no longer surfaces as an uncaught pageerror at
+ *      all: monacoConfig.ts wraps monaco's error funnel
+ *      (errorHandler.unexpectedErrorHandler) to swallow it at the source before
+ *      monaco re-throws it to the window, so it stops rendering red in the
+ *      console. A regression that dropped that wrapper would let it fire again.
  *
  * Tier: UI (headless Chromium). A diff fixture is seeded via the mock's
  * __mockGitDiff hook so a real DiffEditor mounts; no PTY or real git needed.
@@ -23,7 +28,7 @@
 import { test, expect } from '@playwright/test';
 import { chromium, type Browser, type Page } from '@playwright/test';
 import path from 'node:path';
-import { waitForViteReady, collectPageErrors } from './helpers';
+import { waitForViteReady, collectPageErrors, isBenignRendererError } from './helpers';
 
 const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
 const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
@@ -189,6 +194,13 @@ test.describe('Changes panel - Monaco DiffEditor disposal', () => {
     // filtered; anything else fails the assertion below.
     const getPageErrors = collectPageErrors(page);
 
+    // A second, RAW collector that keeps every pageerror unfiltered. Used to
+    // assert the benign monaco message no longer reaches the page at all
+    // (monacoConfig.ts suppresses it at monaco's error funnel before it is
+    // re-thrown to the window).
+    const rawPageErrors: string[] = [];
+    page.on('pageerror', (error) => rawPageErrors.push(error.message));
+
     // Open the task dialog (view mode, since the session is suspended). The
     // suspended body branch renders the Changes panel once Changes is toggled on.
     const card = page.locator(`[data-task-id="${TASK_ID}"]`);
@@ -225,5 +237,12 @@ test.describe('Changes panel - Monaco DiffEditor disposal', () => {
     // No non-benign renderer errors across all the teardowns. The monaco
     // disposal-order message is expected and filtered by collectPageErrors.
     expect(getPageErrors()).toHaveLength(0);
+
+    // The benign monaco message must not have surfaced as an uncaught pageerror
+    // at all: monacoConfig.ts swallows it at monaco's error funnel before it is
+    // re-thrown to the window, so it stops rendering red in the console. Before
+    // that wrapper this raw collector would have caught it on every teardown.
+    const benignThatLeaked = rawPageErrors.filter((message) => isBenignRendererError(message));
+    expect(benignThatLeaked).toHaveLength(0);
   });
 });

--- a/tests/ui/helpers.ts
+++ b/tests/ui/helpers.ts
@@ -4,20 +4,14 @@ import path from 'node:path';
 const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
 const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
 
-/**
- * Renderer errors that are known-benign and outside the app's control, so a
- * spec asserting "no uncaught errors" should ignore them.
- *
- * - The monaco DiffEditor disposal-order quirk. On unmount, @monaco-editor/react
- *   disposes a DiffEditor's two TextModels before the widget, so monaco logs a
- *   self-healing BugIndicatingError and immediately resets its own model. It is
- *   non-fatal and does not leak (both models are disposed regardless of order),
- *   and no stable @monaco-editor/react (4.7.0) or monaco-editor (0.55.1) release
- *   fixes it. Upstream: https://github.com/suren-atoyan/monaco-react/issues/647
- */
-export const BENIGN_RENDERER_ERRORS: RegExp[] = [
-  /TextModel got disposed before DiffEditorWidget model got reset/,
-];
+// Single source of truth for known-benign renderer errors, shared with the
+// renderer's runtime suppressor (the monaco error-funnel wrapper in
+// src/renderer/monacoConfig.ts, which reassigns errorHandler.unexpectedErrorHandler).
+// monacoConfig.ts swallows these before they reach the page, so collectPageErrors
+// rarely sees them, but the filter stays as a belt-and-suspenders for any path
+// that reaches window despite the funnel wrapper.
+import { BENIGN_RENDERER_ERRORS, isBenignRendererError } from '../../src/shared/benign-renderer-errors';
+export { BENIGN_RENDERER_ERRORS, isBenignRendererError };
 
 /**
  * Attach a `pageerror` collector that drops messages matching
@@ -29,7 +23,7 @@ export const BENIGN_RENDERER_ERRORS: RegExp[] = [
 export function collectPageErrors(page: Page): () => string[] {
   const errors: string[] = [];
   page.on('pageerror', (error) => {
-    if (BENIGN_RENDERER_ERRORS.some((pattern) => pattern.test(error.message))) return;
+    if (isBenignRendererError(error)) return;
     errors.push(error.message);
   });
   return () => errors.slice();

--- a/tests/unit/benign-renderer-errors.test.ts
+++ b/tests/unit/benign-renderer-errors.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for isBenignRendererError and the BENIGN_RENDERER_ERRORS registry.
+ *
+ * The key coverage gap these tests close is the PASSTHROUGH branch of the monaco
+ * error-funnel wrapper in src/renderer/monacoConfig.ts:
+ *
+ *   errorHandler.unexpectedErrorHandler = (error: unknown) => {
+ *     if (isBenignRendererError(error)) return;  // swallow
+ *     defaultUnexpectedErrorHandler(error);       // <-- THIS branch was untested
+ *   };
+ *
+ * A test that only covers the swallow path cannot catch a future broadening of
+ * the regex (or a logic inversion) that silently masks genuine errors. The
+ * passthrough assertions below (returns false for non-benign inputs) fail
+ * precisely when the predicate would mistakenly swallow a real error.
+ *
+ * isBenignRendererError is extracted from the inline logic that was previously
+ * duplicated across monacoConfig.ts (with Error/string coercion) and the
+ * collectPageErrors helper in tests/ui/helpers.ts. All three call sites now use
+ * this single predicate, so this test covers the shared logic for all of them.
+ */
+import { describe, it, expect } from 'vitest';
+import { isBenignRendererError, BENIGN_RENDERER_ERRORS } from '../../src/shared/benign-renderer-errors';
+
+describe('isBenignRendererError', () => {
+  describe('BENIGN branch - known disposable monaco message', () => {
+    it('returns true for the known DiffEditor disposal Error object', () => {
+      const error = new Error(
+        'TextModel got disposed before DiffEditorWidget model got reset',
+      );
+      expect(isBenignRendererError(error)).toBe(true);
+    });
+
+    it('returns true for the known DiffEditor disposal message as a raw string', () => {
+      // Covers the String(error) coercion path when monaco throws a non-Error value.
+      expect(
+        isBenignRendererError(
+          'TextModel got disposed before DiffEditorWidget model got reset',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns true when the known message appears as a substring', () => {
+      // Monaco may prepend extra context; the regex is not anchored.
+      const error = new Error(
+        'BugIndicatingError: TextModel got disposed before DiffEditorWidget model got reset',
+      );
+      expect(isBenignRendererError(error)).toBe(true);
+    });
+  });
+
+  describe('PASSTHROUGH branch - non-benign errors must not be swallowed', () => {
+    it('returns false for a generic TypeError (Error object)', () => {
+      // This is the load-bearing assertion for the coverage hole: a real error
+      // must return false so the funnel delegates to defaultUnexpectedErrorHandler.
+      const error = new Error(
+        'TypeError: cannot read properties of undefined (reading "value")',
+      );
+      expect(isBenignRendererError(error)).toBe(false);
+    });
+
+    it('returns false for a ReferenceError (Error object)', () => {
+      const error = new ReferenceError('window is not defined');
+      expect(isBenignRendererError(error)).toBe(false);
+    });
+
+    it('returns false for an empty message Error', () => {
+      expect(isBenignRendererError(new Error(''))).toBe(false);
+    });
+
+    it('returns false for an unrelated string', () => {
+      expect(isBenignRendererError('Uncaught SyntaxError: Unexpected token')).toBe(false);
+    });
+
+    it('returns false for null coerced to string', () => {
+      // String(null) === 'null' - must not match any pattern
+      expect(isBenignRendererError(null)).toBe(false);
+    });
+
+    it('returns false for undefined coerced to string', () => {
+      // String(undefined) === 'undefined' - must not match any pattern
+      expect(isBenignRendererError(undefined)).toBe(false);
+    });
+  });
+
+  describe('BENIGN_RENDERER_ERRORS registry shape', () => {
+    it('is a non-empty array of RegExp instances', () => {
+      expect(Array.isArray(BENIGN_RENDERER_ERRORS)).toBe(true);
+      expect(BENIGN_RENDERER_ERRORS.length).toBeGreaterThan(0);
+      for (const pattern of BENIGN_RENDERER_ERRORS) {
+        expect(pattern).toBeInstanceOf(RegExp);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What

Silences the benign Monaco `DiffEditor` console error that appeared on every routine
task-detail Changes-panel teardown (panel close, Changes <-> Browser switch, file deselect,
dialog close):

```
Uncaught Error: TextModel got disposed before DiffEditorWidget model got reset
```

- New `src/shared/benign-renderer-errors.ts`: single source of truth for the benign-error
  pattern list and an `isBenignRendererError(error)` predicate.
- `src/renderer/monacoConfig.ts`: wraps monaco's error funnel
  (`errorHandler.unexpectedErrorHandler`) to swallow exactly that message and delegate every
  other unexpected error to monaco's real default (restored on HMR dispose so wrappers do not
  stack).
- `src/types/monaco-internal.d.ts`: minimal ambient typing for the monaco-internal `errors`
  module (this build has no `setUnexpectedErrorHandler` export).
- Test wiring: `tests/ui/helpers.ts` and the disposal spec consume the shared predicate; a new
  `tests/unit/benign-renderer-errors.test.ts` covers it.

## Why

The red uncaught error was alarming on a routine UI interaction. It is benign and self-healing:
both `TextModel`s are disposed regardless of order, so there is no leak and no broken diff state.
The disposal-order quirk is a known upstream `@monaco-editor/react` imperfection
(https://github.com/suren-atoyan/monaco-react/issues/647) with no stable release that fixes it,
so the right move is to silence the alarm at the source rather than open a new upstream PR.

Closes #296.

## How

The error does not actually propagate through React's commit phase as first assumed. monaco's
`Emitter._deliver` catches the disposal listener throw and re-dispatches it through
`errorHandler.unexpectedErrorHandler`, whose default re-throws it on a timer, surfacing it as a
window uncaught error (and a Vite dev overlay). Intercepting at that funnel is the only layer
that prevents the error from ever reaching the window: a React `createRoot` `onUncaughtError`
filter was tried first and empirically did not catch it (the error fired 4 pageerrors in the UI
spec). The wrapper captures the original handler and delegates all non-benign errors to it, so
no genuine error is masked. This monaco build exposes the `errorHandler` singleton but no
`setUnexpectedErrorHandler` setter, so the handler field is reassigned directly.

## Breaking changes

None.

## Tests

- `tests/unit/benign-renderer-errors.test.ts` - `isBenignRendererError` swallow branch,
  passthrough branch (the load-bearing "real errors must not be swallowed" assertions), and
  registry shape (10 cases, green locally).
- `tests/ui/changes-panel-diff-disposal.spec.ts` - existing no-leak (model count returns to 0
  across 5 rapid open/close cycles) and no-non-benign-error assertions, plus a new raw-pageerror
  assertion that the benign message no longer surfaces as an uncaught error (red-green: it fired
  before the fix, is absent after). Verified locally; the WebServer log is now clean of the
  monaco `[Unhandled error]` lines.
- Local gate: `npm run typecheck` and `npm run lint` pass. Full unit/UI/E2E tiers run on CI.

Generated with [Claude Code](https://claude.com/claude-code)
