### PR TITLE
feat(agent): add Ollama adapter for local LLMs

### DIFF
--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -1,6 +1,6 @@
 # Agent Integration
 
-Kangentic supports eleven AI coding agents: Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cursor CLI, GitHub Copilot CLI, OpenCode, Aider, Oz CLI (Warp), Kimi Code, and Droid. Each agent is wrapped behind a common `AgentAdapter` interface that handles CLI detection, command building, permission mapping, session lifecycle hooks, and cross-agent handoff. This doc covers the adapter system, agent-specific details, and shared infrastructure.
+Kangentic supports twelve AI coding agents: Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cursor CLI, GitHub Copilot CLI, OpenCode, Aider, Oz CLI (Warp), Kimi Code, Droid, and Ollama. Each agent is wrapped behind a common `AgentAdapter` interface that handles CLI detection, command building, permission mapping, session lifecycle hooks, and cross-agent handoff. This doc covers the adapter system, agent-specific details, and shared infrastructure.
 
 ## Agent Adapter Interface
 
@@ -27,7 +27,7 @@ Every agent implements the `AgentAdapter` interface. Each adapter lives in `src/
 
 | Property | Type | Purpose |
 |----------|------|---------|
-| `name` | `string` | Unique identifier (`'claude'`, `'codex'`, `'gemini'`, `'qwen'`, `'cursor'`, `'copilot'`, `'opencode'`, `'aider'`, `'warp'`, `'kimi'`, `'droid'`) |
+| `name` | `string` | Unique identifier (`'claude'`, `'codex'`, `'gemini'`, `'qwen'`, `'cursor'`, `'copilot'`, `'opencode'`, `'aider'`, `'warp'`, `'kimi'`, `'droid'`, `'ollama'`) |
 | `displayName` | `string` | Human-readable product name |
 | `sessionType` | `SessionRecord['session_type']` | Value stored in the sessions DB table |
 | `supportsCallerSessionId` | `boolean` | True when the CLI accepts a caller-supplied session ID via `--session-id` (Claude). When false, Kangentic captures the agent's own ID via `runtime.sessionId` for `--resume`. |
@@ -45,9 +45,9 @@ Every agent implements the `AgentAdapter` interface. Each adapter lives in `src/
 | `buildEnv?(options)` | `(SpawnCommandOptions) => Record<string, string> \| null` | Adapter-specific environment variables to inject into the PTY spawn. Used by adapters whose CLI has no flag-based MCP wiring and must deliver the Kangentic MCP server config via env (e.g. OpenCode's `OPENCODE_CONFIG_CONTENT`). |
 | `getExitSequence?()` | `() => string[]` | Sequence of strings to write to the PTY for a graceful exit. Default is `['\x03']` (Ctrl+C only). Claude overrides with `['\x03', '/exit\r']` to flush conversation state. |
 | `attachSession?(context)` | `(SessionContext) => SessionAttachment \| void` | Per-session lifecycle hook for adapters that need work outside the declarative `runtime` strategy (out-of-band CLI queries, file watchers, etc.). The returned `dispose` is called on session end. |
-| `summarize?(prompt, cliPath, cwd)` | `(string, string, string) => Promise<string>` | One-shot summarization for the auto-name-tasks-from-prompt feature. Spawns the CLI in non-interactive `--print` mode. Adapters without a clean headless mode (Aider, Warp) omit this. |
-| `parseTranscript?(agentSessionId, cwd)` | `(string, string) => Promise<ParsedTranscript>` | Parse the agent's native session history into agent-agnostic `TranscriptEntry[]` for the MCP `get_transcript` structured format. The adapter owns all format/location knowledge (JSONL file, chat JSONL, SQLite DB), so `handleGetTranscript` never branches on agent name. Must not throw; returns `{ entries: [], sourcePath }` on missing/corrupt history. Implemented by Claude, Droid, Codex, Gemini, Qwen, Kimi, and OpenCode; Aider/Warp/Cursor/Copilot omit it (raw format only). See [MCP server - get_transcript](mcp-server.md#kangentic_get_transcript). |
-| `onProjectRelocated?(oldPath, newPath)` | `(string, string) => Promise<void>` | Migrate per-cwd data the agent keeps OUTSIDE the working directory, keyed by the absolute path, when that path changes. Invoked for two relocations with the same (oldPath, newPath) contract: a whole-project move (the `project:relocate` IPC handler, reached via Locate Folder / Change or the one-step "Move..." flow), and a single worktree-cwd rename on the first resume after a task's worktree was recreated at a new path (`migrateResumeCwdIfRenamed` in `src/main/transition-engine/resume-cwd-migration.ts`, which passes one worktree's old/new path so only that cwd's data moves). Called best-effort after the stored paths are settled and the new location exists. Implemented by Claude, Codex, Gemini, Qwen, Copilot, OpenCode, Kimi, and Droid (per-agent details in [Project relocation](#project-relocation) below); the shared mechanics (path-pair collection, directory rename/merge, backup + atomic write, serial lock) live in `src/main/agent/shared/relocation-utils.ts`. Implementations must be non-destructive and never block the caller. Aider, Cursor, and Warp omit this (their resumable state is in-project or absent). |
+| `summarize?(prompt, cliPath, cwd)` | `(string, string, string) => Promise<string>` | One-shot summarization for the auto-name-tasks-from-prompt feature. Spawns the CLI in non-interactive `--print` mode. Adapters without a clean headless mode (Aider, Warp) omit this, as does Ollama (its headless mode is not yet wired). |
+| `parseTranscript?(agentSessionId, cwd)` | `(string, string) => Promise<ParsedTranscript>` | Parse the agent's native session history into agent-agnostic `TranscriptEntry[]` for the MCP `get_transcript` structured format. The adapter owns all format/location knowledge (JSONL file, chat JSONL, SQLite DB), so `handleGetTranscript` never branches on agent name. Must not throw; returns `{ entries: [], sourcePath }` on missing/corrupt history. Implemented by Claude, Droid, Codex, Gemini, Qwen, Kimi, and OpenCode; Aider/Warp/Cursor/Copilot/Ollama omit it (raw format only). See [MCP server - get_transcript](mcp-server.md#kangentic_get_transcript). |
+| `onProjectRelocated?(oldPath, newPath)` | `(string, string) => Promise<void>` | Migrate per-cwd data the agent keeps OUTSIDE the working directory, keyed by the absolute path, when that path changes. Invoked for two relocations with the same (oldPath, newPath) contract: a whole-project move (the `project:relocate` IPC handler, reached via Locate Folder / Change or the one-step "Move..." flow), and a single worktree-cwd rename on the first resume after a task's worktree was recreated at a new path (`migrateResumeCwdIfRenamed` in `src/main/transition-engine/resume-cwd-migration.ts`, which passes one worktree's old/new path so only that cwd's data moves). Called best-effort after the stored paths are settled and the new location exists. Implemented by Claude, Codex, Gemini, Qwen, Copilot, OpenCode, Kimi, and Droid (per-agent details in [Project relocation](#project-relocation) below); the shared mechanics (path-pair collection, directory rename/merge, backup + atomic write, serial lock) live in `src/main/agent/shared/relocation-utils.ts`. Implementations must be non-destructive and never block the caller. Aider, Cursor, Warp, and Ollama omit this (their resumable state is in-project or absent). |
 | `probeAuth?()` | `() => Promise<boolean \| null>` | See the methods table above. |
 | `discoverCapabilities?(cliPath)` | `(string) => Promise<AgentCapabilities>` | Probe the live CLI for adapter-specific knobs (e.g. parsing `--help` for valid effort levels and the presence of a `--model` flag). Result is attached to `AgentDetectionInfo.capabilities` and read by the renderer to gate optional UI controls (Model and Effort dropdowns on `EditColumnDialog`). Implementations must never throw - return an empty object on parse failure so the rest of detection still succeeds. |
 | `getInjectionSequence?(spec)` | `(SettingsChangeSpec) => string[]` | Translate a column-level settings change (model / effort) into the writes the `TerminalSubmitScheduler` should push onto the live PTY. Sibling of `getExitSequence` - both return `string[]` of writes. Claude returns `['/model X', '/effort Y']` for changed fields. Adapters with no live-swap slash return `[]` and the caller falls back to suspend+respawn. |
@@ -124,6 +124,7 @@ Omit `sessionId` entirely for agents that use caller-owned IDs (Claude via `--se
 | Kimi Code | `kimi-adapter.ts` | `kimi` | `--session <uuid>` (caller-owned) | Yes (`wire.jsonl`) | No | No |
 | Droid | `droid-adapter.ts` | `droid` | `--resume <uuid>` | No (PTY-only) | No (use Droid's TUI: `/model` + Ctrl+D, shift+tab; MCP via manual `droid mcp add`) | No |
 | OpenCode | `opencode-adapter.ts` | `opencode` | Plugin/PTY-captured `ses_<id>` (auto-generated) | Yes (plugin JSONL via `tool.execute.before/after` + `event` `session.*`) | No (`opencode.json` + `OPENCODE_CONFIG_CONTENT` env) | No (auth via `opencode auth login` -> `~/.local/share/opencode/auth.json`) |
+| Ollama | `ollama-adapter.ts` | `ollama` | No | No | No | No |
 
 ## Agent Resolution
 
@@ -157,6 +158,7 @@ Each adapter implements `detectFirstOutput(data)` to signal when the agent's TUI
 | Kimi Code | `\x1b[?25l` (cursor hide) | TUI hides cursor when its alternate-screen buffer takes over (verified empirically with kimi v1.37.0) |
 | Droid | `\x1b[?25l` (cursor hide) | Ink-based TUI, same pattern as Claude (verified empirically) |
 | OpenCode | `\x1b[?25l` (cursor hide) | Full-screen TUI initializes alternate screen buffer with cursor hide on first frame |
+| Ollama | `data.length > 0` | Ollama streams output immediately (no alternate screen buffer) |
 
 The `\x1b[?25l` (ANSI cursor hide) sequence fires after the shell prompt noise but before the TUI draws its startup banner. This keeps the shell command hidden behind the shimmer overlay.
 
@@ -177,6 +179,7 @@ Graceful exit sequences written to the PTY during `SessionManager.suspend()`:
 | Kimi Code | `Ctrl+C`, `/exit` | Conventional TUI quit; flushes context.jsonl / wire.jsonl |
 | Droid | `Ctrl+C`, `/quit` | Triggers clean shutdown of the Ink TUI |
 | OpenCode | `Ctrl+C` | Verified 2026-04-28: PTY exits in ~1s. `/exit` and `/quit` are not recognized slash commands. |
+| Ollama | `Ctrl+C`, `/bye` | `/bye` exits the interactive REPL; harmless after a one-shot run has already exited |
 
 ## Session History File Location
 
@@ -195,10 +198,11 @@ During cross-agent handoff, each adapter's `locateSessionHistoryFile()` finds th
 | Kimi Code | `~/.kimi/sessions/<work_dir_hash>/<sessionId>/wire.jsonl` | Glob across all hash dirs (work_dir hash is opaque) and match on session UUID |
 | OpenCode | `~/.local/share/opencode/opencode.db` (SQLite `session` table) | Read-only WAL handle; match `directory == cwd` and `time_created` within spawn window |
 | Droid | N/A | Returns null (no native session history file; activity flows through PTY-only detection) |
+| Ollama | N/A | Returns null (no CLI-accessible session history) |
 
 ## Auto-Name (Summarize)
 
-Always-on feature that suggests a task title from the task description, via each adapter's optional `summarize?(prompt, cliPath, cwd)` method. Adapters without a clean plain-text headless mode (Aider, Warp) omit `summarize` and are gated out automatically: the renderer hides the button and never schedules the rename toast.
+Always-on feature that suggests a task title from the task description, via each adapter's optional `summarize?(prompt, cliPath, cwd)` method. Adapters that omit `summarize` are gated out automatically (Aider and Warp lack a clean plain-text headless mode; Ollama's is not yet wired): the renderer hides the button and never schedules the rename toast.
 
 ### Surfaces
 
@@ -221,6 +225,7 @@ Implementations live next to each adapter and call the shared `runCliPrintSummar
 | Droid | `droid exec -o text "<prompt>"` | positional arg |
 | Copilot | `copilot --silent -p "<prompt>"` | positional arg |
 | Aider, Warp | (no clean plain-text headless mode yet) | n/a |
+| Ollama | (summarize not yet wired) | n/a |
 
 ### Configuration knobs
 
@@ -942,6 +947,7 @@ same caveat the Claude adapter documents).
 | Aider | None. | History (`.aider.chat.history.md`) lives inside the project folder and moves with it. |
 | Cursor | None. | No cwd-keyed external session store Kangentic depends on. |
 | Oz (Warp) | None. | No resumable on-disk session state. |
+| Ollama | None. | No resumable external session state; `onProjectRelocated` omitted. |
 
 ## Prompt Templates
 

--- a/src/main/agent/adapters/ollama/capability-discovery.ts
+++ b/src/main/agent/adapters/ollama/capability-discovery.ts
@@ -1,0 +1,88 @@
+/**
+ * Ollama capability discovery: enumerate locally installed models via
+ * `ollama list` so the renderer can populate the model-picker dropdown.
+ *
+ * `ollama run` always accepts a positional model argument, so model override
+ * is always supported. The discovered list is the set of already-pulled
+ * models; the user can still type any model name (Ollama auto-pulls on run),
+ * which is why the renderer falls back to a free-form text input when the
+ * list is empty.
+ */
+import { exec, execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { AgentCapabilities } from '../../../../shared/types';
+
+const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+const LIST_TIMEOUT_MS = 5000;
+
+/**
+ * Run `<cliPath> list` and capture stdout.
+ * On Windows, use a shell invocation (handles `.cmd` / `.exe` shims); on
+ * Unix, use direct execFile.
+ */
+async function readModelListOutput(cliPath: string): Promise<string> {
+  if (process.platform === 'win32') {
+    const { stdout } = await execAsync(`"${cliPath}" list`, {
+      timeout: LIST_TIMEOUT_MS,
+      windowsHide: true,
+      maxBuffer: 1024 * 1024,
+    });
+    return stdout;
+  }
+  const { stdout } = await execFileAsync(cliPath, ['list'], {
+    timeout: LIST_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+  });
+  return stdout;
+}
+
+/**
+ * Parse `ollama list` table output into a sorted list of model names.
+ *
+ * Output format:
+ *   NAME               ID              SIZE      MODIFIED
+ *   llama3.2:latest    a80c4f17acd5    2.0 GB    2 days ago
+ *   qwen2.5-coder:7b   2b0496514337    4.7 GB    1 week ago
+ *
+ * Takes the first whitespace-delimited column of each row, skipping the
+ * header. Pure and side-effect-free so it can be unit-tested directly.
+ */
+export function parseOllamaModelList(stdout: string): string[] {
+  const models = new Set<string>();
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    const firstColumn = trimmed.split(/\s+/)[0];
+    // Skip the header row (always emitted as uppercase "NAME") and any stray
+    // separator lines. Exact-match so a model literally named "name" is kept.
+    if (!firstColumn || firstColumn === 'NAME') continue;
+    models.add(firstColumn);
+  }
+  // Ascending alphabetical, matching the other adapters' model ordering.
+  return Array.from(models).sort();
+}
+
+/**
+ * Discover Ollama capabilities: model override is always supported, and the
+ * model list comes from `ollama list`.
+ *
+ * Best-effort: never throws. On any failure (daemon down, CLI missing,
+ * unparseable output) it returns `{ supportsModelOverride: true }` with no
+ * model list, so the renderer falls back to a free-form model text input.
+ */
+export async function discoverOllamaCapabilities(cliPath: string): Promise<AgentCapabilities> {
+  let models: string[] = [];
+  try {
+    models = parseOllamaModelList(await readModelListOutput(cliPath));
+  } catch {
+    // `ollama list` failed - fall back to free-form model input.
+  }
+  return {
+    supportsModelOverride: true,
+    models: models.length > 0 ? models : undefined,
+    // Ollama has no effort / reasoning levels.
+    effortLevels: [],
+  };
+}

--- a/src/main/agent/adapters/ollama/index.ts
+++ b/src/main/agent/adapters/ollama/index.ts
@@ -1,0 +1,2 @@
+export { OllamaAdapter, DEFAULT_OLLAMA_MODEL } from './ollama-adapter';
+export { discoverOllamaCapabilities, parseOllamaModelList } from './capability-discovery';

--- a/src/main/agent/adapters/ollama/ollama-adapter.ts
+++ b/src/main/agent/adapters/ollama/ollama-adapter.ts
@@ -102,7 +102,12 @@ export class OllamaAdapter implements AgentAdapter {
       const safePrompt = needsDoubleQuoteReplacement
         ? options.prompt.replace(/"/g, "'")
         : options.prompt;
-      parts.push(quoteArg(safePrompt, shell, { multiline: true }));
+      // `ollama run` is a cobra/pflag CLI with flag parsing on, so a prompt
+      // beginning with a dash (a markdown bullet, a dashed list item) would be
+      // misread as a flag. Push the `--` end-of-options marker first so the
+      // prompt is always taken as the positional argument (matches the Warp
+      // adapter).
+      parts.push('--', quoteArg(safePrompt, shell, { multiline: true }));
     }
 
     return parts.join(' ');

--- a/src/main/agent/adapters/ollama/ollama-adapter.ts
+++ b/src/main/agent/adapters/ollama/ollama-adapter.ts
@@ -1,0 +1,160 @@
+import { AgentDetector } from '../../shared/agent-detector';
+import { standardUnixFallbackPaths } from '../../shared/fallback-paths';
+import { interpolateTemplate } from '../../shared/template-utils';
+import { quoteArg, isUnixLikeShell } from '../../../../shared/paths';
+import { discoverOllamaCapabilities } from './capability-discovery';
+import type { AgentAdapter, AgentInfo, SpawnCommandOptions } from '../../agent-adapter';
+import type {
+  AgentPermissionEntry,
+  PermissionMode,
+  AdapterRuntimeStrategy,
+  AgentCapabilities,
+  SubmissionContextType,
+  SubmissionVerifier,
+} from '../../../../shared/types';
+import { ActivityDetection } from '../../../../shared/types';
+
+/**
+ * Default model used when no per-column / per-task model override is set.
+ *
+ * `ollama run` REQUIRES a model argument (it has no built-in default and no
+ * interactive picker), so the adapter must always supply one. Users normally
+ * pick a specific installed model via the model dropdown, which is populated
+ * from `ollama list` (see capability-discovery.ts). Ollama auto-pulls a
+ * missing model on first run, so this fallback is always runnable.
+ */
+export const DEFAULT_OLLAMA_MODEL = 'llama3.2';
+
+/**
+ * Ollama CLI adapter - drives a local LLM via the `ollama` CLI
+ * (https://ollama.com) behind the generic AgentAdapter interface.
+ *
+ * Ollama is a local-inference tool, not an agentic coder: `ollama run` opens
+ * a chat with a local model and cannot edit files or call tools on its own.
+ * It is modeled on the Warp adapter (a one-shot run that streams output then
+ * exits), NOT on the agentic CLIs: `ollama run <model> "<prompt>"` prints the
+ * answer and the process exits, so each spawn is a single turn. Free-form
+ * multi-turn chat is available by running `ollama run <model>` directly in a
+ * Command Terminal.
+ *
+ * No session resume (Ollama has no CLI-level session IDs), no hooks, no trust
+ * mechanism, no MCP wiring. The one Kangentic-managed knob is the model
+ * argument, which is mandatory for `ollama run` and therefore a documented
+ * exception to cli-features-over-custom-layers.md.
+ */
+export class OllamaAdapter implements AgentAdapter {
+  readonly name = 'ollama';
+  readonly displayName = 'Ollama';
+  readonly sessionType = 'ollama_agent';
+  readonly supportsCallerSessionId = false;
+  // Ollama has no autonomy / permission concept - it is a plain chat REPL.
+  // Per cli-features-over-custom-layers.md, expose a single informational
+  // entry and inject no permission flags in buildCommand().
+  readonly permissions: AgentPermissionEntry[] = [
+    { mode: 'default', label: 'Chat' },
+  ];
+  readonly defaultPermission: PermissionMode = 'default';
+
+  // Shared AgentDetector via composition (like Aider). `ollama --version`
+  // prints `ollama version is X.Y.Z`.
+  private readonly detector = new AgentDetector({
+    binaryName: 'ollama',
+    fallbackPaths: standardUnixFallbackPaths('ollama'),
+    parseVersion: (raw) => raw.replace(/^ollama version is\s+/i, '').trim() || null,
+  });
+
+  async detect(overridePath?: string | null): Promise<AgentInfo> {
+    return this.detector.detect(overridePath);
+  }
+
+  invalidateDetectionCache(): void {
+    this.detector.invalidateCache();
+  }
+
+  /**
+   * Discover installed models via `ollama list` so the renderer can populate
+   * the model picker. Never throws (returns model-override support with no
+   * list on failure, which the renderer renders as a free-form text input).
+   */
+  async discoverCapabilities(cliPath: string): Promise<AgentCapabilities> {
+    return discoverOllamaCapabilities(cliPath);
+  }
+
+  // Ollama has no trust mechanism - no-op
+  async ensureTrust(_workingDirectory: string): Promise<void> {}
+
+  buildCommand(options: SpawnCommandOptions): string {
+    const { shell } = options;
+
+    // `ollama run` requires a model. Use the per-column / per-task override
+    // when set, else fall back to a common default (Ollama auto-pulls it if
+    // it is not already installed).
+    const model = options.model?.trim() || DEFAULT_OLLAMA_MODEL;
+    const parts: string[] = [quoteArg(options.agentPath, shell), 'run', quoteArg(model, shell)];
+
+    // Initial prompt delivered as a single positional argument (one-shot
+    // run). When absent (a no-prompt spawn), `ollama run <model>` drops into
+    // an interactive REPL the user types into.
+    if (options.prompt) {
+      const needsDoubleQuoteReplacement = shell
+        ? !isUnixLikeShell(shell)
+        : process.platform === 'win32';
+      const safePrompt = needsDoubleQuoteReplacement
+        ? options.prompt.replace(/"/g, "'")
+        : options.prompt;
+      parts.push(quoteArg(safePrompt, shell, { multiline: true }));
+    }
+
+    return parts.join(' ');
+  }
+
+  interpolateTemplate(template: string, variables: Record<string, string>): string {
+    return interpolateTemplate(template, variables);
+  }
+
+  /**
+   * Runtime strategy: Ollama has no hooks and no native session IDs.
+   *
+   * - Activity: PTY-only. A one-shot `ollama run` streams output then exits,
+   *   so the PTY silence timer drives the idle transition. The detectIdle
+   *   callback additionally catches the interactive REPL prompt (`>>> `) for
+   *   an instant idle when a no-prompt spawn drops into the REPL.
+   * - Session ID / history: omitted - Ollama has no CLI-level resume and no
+   *   session history files for `ollama run`.
+   */
+  readonly runtime: AdapterRuntimeStrategy = {
+    activity: ActivityDetection.pty((data: string) => {
+      const clean = data.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
+      return /(?:^|\n)>>>\s*$/.test(clean);
+    }),
+  };
+
+  // Ollama does not use hooks - no-op
+  removeHooks(_directory: string): void {}
+
+  // Ollama has no merged settings - no-op
+  clearSettingsCache(): void {}
+
+  getExitSequence(): string[] {
+    // Ctrl+C interrupts generation; /bye cleanly exits an interactive REPL.
+    // Harmless when the one-shot process has already exited.
+    return ['\x03', '/bye\r'];
+  }
+
+  detectFirstOutput(data: string): boolean {
+    // Ollama writes immediately (no alternate screen buffer). Any non-empty
+    // data means the agent is ready.
+    return data.length > 0;
+  }
+
+  async locateSessionHistoryFile(_agentSessionId: string, _cwd: string): Promise<string | null> {
+    // Ollama has no native session history files for `ollama run`.
+    return null;
+  }
+
+  getSubmissionVerifier(_contextType: SubmissionContextType): SubmissionVerifier | null {
+    // Ollama has no hooks or structured verification signals.
+    // Callers fall back to time-based settle.
+    return null;
+  }
+}

--- a/src/main/agent/agent-registry.ts
+++ b/src/main/agent/agent-registry.ts
@@ -10,6 +10,7 @@ import { OpenCodeAdapter } from './adapters/opencode';
 import { QwenAdapter } from './adapters/qwen-code';
 import { KimiAdapter } from './adapters/kimi';
 import { DroidAdapter } from './adapters/droid';
+import { OllamaAdapter } from './adapters/ollama';
 
 class AgentRegistry {
   private adapters = new Map<string, AgentAdapter>();
@@ -63,3 +64,4 @@ agentRegistry.register(new OpenCodeAdapter());
 agentRegistry.register(new QwenAdapter());
 agentRegistry.register(new KimiAdapter());
 agentRegistry.register(new DroidAdapter());
+agentRegistry.register(new OllamaAdapter());

--- a/src/renderer/utils/agent-display-name.ts
+++ b/src/renderer/utils/agent-display-name.ts
@@ -72,6 +72,11 @@ const AGENT_META: Record<string, AgentMeta> = {
     short: 'Droid',
     installUrl: 'https://docs.factory.ai/cli/getting-started/overview',
   },
+  ollama: {
+    display: 'Ollama',
+    short: 'Ollama',
+    installUrl: 'https://ollama.com/download',
+  },
 };
 
 /** Full product name for an agent identifier (e.g. 'claude' -> 'Claude Code'). */

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -1809,6 +1809,14 @@
                 'Tracked upstream: Factory-AI/factory (see docs/agent-integration.md).',
             },
           },
+          {
+            name: 'ollama', displayName: 'Ollama', found: false, path: null, version: null,
+            // KEEP IN SYNC with OllamaAdapter.permissions in src/main/agent/adapters/ollama/ollama-adapter.ts
+            permissions: [
+              { mode: 'default', label: 'Chat' },
+            ],
+            defaultPermission: 'default',
+          },
         ];
         return defaults.map(function (agent) {
           var override = overrides[agent.name];

--- a/tests/unit/adapter-multiline-prompt.test.ts
+++ b/tests/unit/adapter-multiline-prompt.test.ts
@@ -9,7 +9,7 @@
  * to multiline mode. Dropping the option from any adapter regresses prompt
  * delivery for tasks with multi-line descriptions.
  *
- * Coverage: codex, aider, opencode, kimi, droid, warp.
+ * Coverage: codex, aider, opencode, kimi, droid, warp, ollama.
  * (claude, gemini, copilot, qwen-code are covered in their own test files.)
  *
  * Strategy: build the command with `shell: 'bash'` and a multi-line XML
@@ -56,6 +56,7 @@ import { OpenCodeCommandBuilder } from '../../src/main/agent/adapters/opencode';
 import { KimiCommandBuilder } from '../../src/main/agent/adapters/kimi';
 import { DroidCommandBuilder } from '../../src/main/agent/adapters/droid';
 import { WarpAdapter } from '../../src/main/agent/adapters/warp';
+import { OllamaAdapter } from '../../src/main/agent/adapters/ollama';
 
 // ---------------------------------------------------------------------------
 // Shared test data
@@ -146,6 +147,19 @@ describe('Adapter multiline prompt - regression guard for { multiline: true }', 
     const adapter = new WarpAdapter();
     const command = adapter.buildCommand({
       agentPath: '/usr/bin/oz',
+      taskId: 'task-1',
+      cwd: '/project',
+      permissionMode: 'default',
+      shell: 'bash',
+      prompt: MULTILINE_XML,
+    });
+    expect(command).toContain(EXPECTED_FRAGMENT);
+  });
+
+  it('OllamaAdapter.buildCommand preserves newlines in prompt under bash', () => {
+    const adapter = new OllamaAdapter();
+    const command = adapter.buildCommand({
+      agentPath: '/usr/bin/ollama',
       taskId: 'task-1',
       cwd: '/project',
       permissionMode: 'default',

--- a/tests/unit/agent-login-command.test.ts
+++ b/tests/unit/agent-login-command.test.ts
@@ -45,6 +45,10 @@ describe('agentLoginCommand', () => {
     expect(agentLoginCommand('droid')).toBeUndefined();
   });
 
+  it('returns undefined for ollama (local inference tool, no auth UX)', () => {
+    expect(agentLoginCommand('ollama')).toBeUndefined();
+  });
+
   it('returns undefined for an unknown agent identifier', () => {
     expect(agentLoginCommand('unknown-agent-xyz')).toBeUndefined();
   });

--- a/tests/unit/agent-submission-verifier-shape.test.ts
+++ b/tests/unit/agent-submission-verifier-shape.test.ts
@@ -20,6 +20,7 @@ const ADAPTER_CLASSES = [
   { name: 'droid',     importPath: '../../src/main/agent/adapters/droid/droid-adapter',        className: 'DroidAdapter' },
   { name: 'kimi',      importPath: '../../src/main/agent/adapters/kimi/kimi-adapter',          className: 'KimiAdapter' },
   { name: 'warp',      importPath: '../../src/main/agent/adapters/warp/warp-adapter',          className: 'WarpAdapter' },
+  { name: 'ollama',    importPath: '../../src/main/agent/adapters/ollama/ollama-adapter',      className: 'OllamaAdapter' },
 ] as const;
 
 describe('Adapter getSubmissionVerifier implementation', () => {

--- a/tests/unit/ollama-adapter.test.ts
+++ b/tests/unit/ollama-adapter.test.ts
@@ -1,0 +1,512 @@
+/**
+ * Unit tests for OllamaAdapter - detection, command building, capability
+ * discovery, and registry integration.
+ *
+ * These tests exercise pure logic without any Electron, DOM, or IPC
+ * dependencies. Ollama is modeled on the Warp adapter (a one-shot
+ * `ollama run <model> "<prompt>"` that streams output then exits).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { quoteArg } from '../../src/shared/paths';
+import type { SpawnCommandOptions } from '../../src/main/agent/agent-adapter';
+import type { PermissionMode } from '../../src/shared/types';
+import {
+  agentDisplayName,
+  agentShortName,
+  agentInstallUrl,
+} from '../../src/renderer/utils/agent-display-name';
+
+// ── Mocks (set up before importing the adapter) ───────────────────────────────
+
+// Detection: AgentDetector calls which() + the shared exec-version helper.
+let mockWhichResult: string | Error = '/usr/bin/ollama';
+let mockExecVersionStdout = 'ollama version is 0.5.7\n';
+let mockExecVersionShouldFail = false;
+let mockExistsSyncReturnValue = true;
+let execVersionCallCount = 0;
+
+// Capability discovery: `ollama list` via node:child_process.
+let mockListStdout = '';
+let mockListShouldFail = false;
+// Records which node:child_process function capability-discovery.ts last invoked.
+// Lets platform-routing tests distinguish exec (win32 shell path) from execFile
+// (non-win32 direct path) without spawning a real process.
+let lastChildProcessCall: 'exec' | 'execFile' | null = null;
+
+vi.mock('which', () => ({
+  default: async () => {
+    if (mockWhichResult instanceof Error) throw mockWhichResult;
+    return mockWhichResult;
+  },
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...original,
+    default: {
+      ...original,
+      existsSync: () => mockExistsSyncReturnValue,
+    },
+  };
+});
+
+vi.mock('../../src/main/agent/shared/exec-version', () => ({
+  execVersion: async () => {
+    execVersionCallCount++;
+    if (mockExecVersionShouldFail) {
+      throw new Error('command not found');
+    }
+    return { stdout: mockExecVersionStdout, stderr: '' };
+  },
+}));
+
+// Mock node:child_process so capability discovery never spawns a real
+// process. Attaching the promisify-custom symbol makes `promisify(exec)`
+// return our async function directly (avoids the callback convention).
+vi.mock('node:child_process', () => {
+  const promisifyCustom = Symbol.for('nodejs.util.promisify.custom');
+  const makeExec = (callType: 'exec' | 'execFile') => {
+    const execStub = (): void => {};
+    (execStub as unknown as Record<symbol, unknown>)[promisifyCustom] = async () => {
+      lastChildProcessCall = callType;
+      if (mockListShouldFail) throw new Error('ollama list failed');
+      return { stdout: mockListStdout, stderr: '' };
+    };
+    return execStub;
+  };
+  return { exec: makeExec('exec'), execFile: makeExec('execFile') };
+});
+
+// Import after mocks are set up
+const { OllamaAdapter, DEFAULT_OLLAMA_MODEL, parseOllamaModelList } = await import(
+  '../../src/main/agent/adapters/ollama'
+);
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build minimal SpawnCommandOptions with sensible defaults. */
+function makeOptions(overrides: Partial<SpawnCommandOptions> = {}): SpawnCommandOptions {
+  return {
+    agentPath: '/usr/bin/ollama',
+    taskId: 'task-1',
+    cwd: '/projects/my-app',
+    permissionMode: 'default',
+    ...overrides,
+  };
+}
+
+// ── OllamaAdapter ──────────────────────────────────────────────────────────────
+
+describe('OllamaAdapter', () => {
+  let adapter: InstanceType<typeof OllamaAdapter>;
+
+  beforeEach(() => {
+    adapter = new OllamaAdapter();
+    mockWhichResult = '/usr/bin/ollama';
+    mockExecVersionStdout = 'ollama version is 0.5.7\n';
+    mockExecVersionShouldFail = false;
+    mockExistsSyncReturnValue = true;
+    execVersionCallCount = 0;
+    mockListStdout = '';
+    mockListShouldFail = false;
+    lastChildProcessCall = null;
+  });
+
+  // ── Identity ─────────────────────────────────────────────────────────────
+
+  it('has name "ollama"', () => {
+    expect(adapter.name).toBe('ollama');
+  });
+
+  it('has displayName "Ollama"', () => {
+    expect(adapter.displayName).toBe('Ollama');
+  });
+
+  it('has sessionType "ollama_agent"', () => {
+    expect(adapter.sessionType).toBe('ollama_agent');
+  });
+
+  it('does not support caller session IDs', () => {
+    expect(adapter.supportsCallerSessionId).toBe(false);
+  });
+
+  it('exposes a single "default" permission entry (no autonomy concept)', () => {
+    expect(adapter.permissions).toHaveLength(1);
+    expect(adapter.permissions[0].mode).toBe('default');
+    expect(adapter.defaultPermission).toBe('default');
+  });
+
+  // ── Detection ────────────────────────────────────────────────────────────
+
+  describe('detect', () => {
+    it('returns found: true with override path and parsed version', async () => {
+      const result = await adapter.detect('/custom/ollama');
+      expect(result.found).toBe(true);
+      expect(result.path).toBe('/custom/ollama');
+      // parseVersion strips the "ollama version is " prefix
+      expect(result.version).toBe('0.5.7');
+    });
+
+    it('falls back to which when no override path', async () => {
+      const result = await adapter.detect();
+      expect(result.found).toBe(true);
+      expect(result.path).toBe('/usr/bin/ollama');
+    });
+
+    it('returns found: false when which fails and no fallback path exists', async () => {
+      mockWhichResult = new Error('not found');
+      mockExistsSyncReturnValue = false;
+      const result = await adapter.detect();
+      expect(result.found).toBe(false);
+      expect(result.path).toBeNull();
+      expect(result.version).toBeNull();
+    });
+
+    it('caches detection result', async () => {
+      const first = await adapter.detect('/custom/ollama');
+      const second = await adapter.detect('/custom/ollama');
+      expect(first).toBe(second);
+      expect(execVersionCallCount).toBe(1);
+    });
+
+    it('invalidateDetectionCache clears cache', async () => {
+      await adapter.detect('/custom/ollama');
+      adapter.invalidateDetectionCache();
+      await adapter.detect('/custom/ollama');
+      expect(execVersionCallCount).toBe(2);
+    });
+  });
+
+  // ── buildCommand ─────────────────────────────────────────────────────────
+
+  describe('buildCommand', () => {
+    it('builds command starting with "ollama run <model>"', () => {
+      const command = adapter.buildCommand(makeOptions({ shell: 'bash' }));
+      const expected = `${quoteArg('/usr/bin/ollama', 'bash')} run ${quoteArg(DEFAULT_OLLAMA_MODEL, 'bash')}`;
+      expect(command.startsWith(expected)).toBe(true);
+    });
+
+    it('uses the per-column/task model override when provided', () => {
+      const command = adapter.buildCommand(makeOptions({ model: 'qwen2.5-coder:7b' }));
+      expect(command).toContain('qwen2.5-coder:7b');
+      expect(command).not.toContain(DEFAULT_OLLAMA_MODEL);
+    });
+
+    it('falls back to DEFAULT_OLLAMA_MODEL when the model is blank/whitespace', () => {
+      const command = adapter.buildCommand(makeOptions({ model: '   ' }));
+      expect(command).toContain(DEFAULT_OLLAMA_MODEL);
+    });
+
+    it('appends the prompt as a positional argument when provided', () => {
+      const command = adapter.buildCommand(makeOptions({ prompt: 'Explain closures', shell: 'bash' }));
+      expect(command).toContain('Explain closures');
+    });
+
+    it('omits the prompt argument when no prompt is provided', () => {
+      const command = adapter.buildCommand(makeOptions({ shell: 'bash' }));
+      const expected = `${quoteArg('/usr/bin/ollama', 'bash')} run ${quoteArg(DEFAULT_OLLAMA_MODEL, 'bash')}`;
+      expect(command).toBe(expected);
+    });
+
+    it('ignores resume flag (Ollama has no session resume)', () => {
+      const command = adapter.buildCommand(makeOptions({ sessionId: 'session-123', resume: true }));
+      expect(command).not.toContain('--resume');
+      expect(command).not.toContain('--session');
+      expect(command).not.toContain('session-123');
+    });
+
+    // ── Shell quoting ────────────────────────────────────────────────────
+
+    describe('shell quoting', () => {
+      it('replaces double quotes with single quotes for non-unix shells', () => {
+        const command = adapter.buildCommand(makeOptions({
+          prompt: 'Fix the "broken" test',
+          shell: 'powershell',
+        }));
+        expect(command).not.toContain('"broken"');
+        expect(command).toContain("'broken'");
+      });
+
+      it('preserves double quotes for unix-like shells', () => {
+        const command = adapter.buildCommand(makeOptions({
+          prompt: 'Fix the "broken" test',
+          shell: 'bash',
+        }));
+        expect(command).toContain('"broken"');
+      });
+
+      // ── process.platform fallback (no shell provided) ─────────────────
+      // buildCommand falls back to `process.platform === 'win32'` when no
+      // shell is supplied. The two tests below cover the unreached arm on CI
+      // (Linux) and the symmetrical arm on the team's Windows machines. Both
+      // are needed to ensure the branch is correct in both directions.
+      describe('process.platform fallback when no shell is specified', () => {
+        let savedPlatformDescriptor: PropertyDescriptor | undefined;
+
+        beforeEach(() => {
+          savedPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+        });
+
+        afterEach(() => {
+          if (savedPlatformDescriptor !== undefined) {
+            Object.defineProperty(process, 'platform', savedPlatformDescriptor);
+          }
+        });
+
+        it('replaces double quotes with single quotes on win32 when no shell is given', () => {
+          Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+          const command = adapter.buildCommand(makeOptions({ prompt: 'Fix the "broken" test' }));
+          expect(command).not.toContain('"broken"');
+          expect(command).toContain("'broken'");
+        });
+
+        it('preserves double quotes on non-win32 platforms when no shell is given', () => {
+          Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+          const command = adapter.buildCommand(makeOptions({ prompt: 'Fix the "broken" test' }));
+          expect(command).toContain('"broken"');
+        });
+      });
+    });
+  });
+
+  // ── Capability discovery ───────────────────────────────────────────────────
+
+  describe('discoverCapabilities', () => {
+    it('always reports model-override support', async () => {
+      mockListStdout = 'NAME    ID    SIZE    MODIFIED\n';
+      const capabilities = await adapter.discoverCapabilities('/usr/bin/ollama');
+      expect(capabilities.supportsModelOverride).toBe(true);
+      expect(capabilities.effortLevels).toEqual([]);
+    });
+
+    it('returns installed models parsed from `ollama list`', async () => {
+      mockListStdout = [
+        'NAME               ID              SIZE      MODIFIED',
+        'llama3.2:latest    a80c4f17acd5    2.0 GB    2 days ago',
+        'qwen2.5-coder:7b   2b0496514337    4.7 GB    1 week ago',
+      ].join('\n');
+      const capabilities = await adapter.discoverCapabilities('/usr/bin/ollama');
+      expect(capabilities.models).toEqual(['llama3.2:latest', 'qwen2.5-coder:7b']);
+    });
+
+    it('never throws and falls back to undefined models when `ollama list` fails', async () => {
+      mockListShouldFail = true;
+      const capabilities = await adapter.discoverCapabilities('/usr/bin/ollama');
+      expect(capabilities.supportsModelOverride).toBe(true);
+      expect(capabilities.models).toBeUndefined();
+    });
+
+    // ── Platform-specific exec routing ───────────────────────────────────
+    // capability-discovery.ts:readModelListOutput uses exec (shell invocation)
+    // on win32 so that .cmd/.exe shims are resolved by the shell, and execFile
+    // (direct invocation) on every other platform. These tests cover both arms
+    // by stubbing process.platform, which is read at call time (not module load
+    // time), so the stub is safe even though execAsync/execFileAsync are bound
+    // at module evaluation.
+    describe('platform-specific exec routing in readModelListOutput', () => {
+      let savedPlatformDescriptor: PropertyDescriptor | undefined;
+
+      beforeEach(() => {
+        savedPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+        lastChildProcessCall = null;
+      });
+
+      afterEach(() => {
+        if (savedPlatformDescriptor !== undefined) {
+          Object.defineProperty(process, 'platform', savedPlatformDescriptor);
+        }
+      });
+
+      it('uses shell exec on win32 so .cmd and .exe shims are resolved', async () => {
+        Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+        await adapter.discoverCapabilities('/usr/bin/ollama');
+        expect(lastChildProcessCall).toBe('exec');
+      });
+
+      it('uses execFile on non-win32 platforms for direct process invocation', async () => {
+        Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+        await adapter.discoverCapabilities('/usr/bin/ollama');
+        expect(lastChildProcessCall).toBe('execFile');
+      });
+    });
+  });
+
+  // ── parseOllamaModelList (pure) ────────────────────────────────────────────
+
+  describe('parseOllamaModelList', () => {
+    it('skips the header row and extracts the first column, sorted', () => {
+      const stdout = [
+        'NAME               ID              SIZE      MODIFIED',
+        'qwen2.5-coder:7b   2b0496514337    4.7 GB    1 week ago',
+        'llama3.2:latest    a80c4f17acd5    2.0 GB    2 days ago',
+      ].join('\n');
+      expect(parseOllamaModelList(stdout)).toEqual(['llama3.2:latest', 'qwen2.5-coder:7b']);
+    });
+
+    it('returns an empty list for empty or header-only output', () => {
+      expect(parseOllamaModelList('')).toEqual([]);
+      expect(parseOllamaModelList('NAME    ID    SIZE    MODIFIED\n')).toEqual([]);
+    });
+
+    it('deduplicates repeated model names', () => {
+      const stdout = 'gemma3:1b  aaa  1 GB  now\ngemma3:1b  aaa  1 GB  now\n';
+      expect(parseOllamaModelList(stdout)).toEqual(['gemma3:1b']);
+    });
+  });
+
+  // ── runtime strategy ───────────────────────────────────────────────────────
+
+  describe('runtime', () => {
+    it('uses PTY activity detection', () => {
+      expect(adapter.runtime.activity.kind).toBe('pty');
+    });
+
+    it('detects the interactive REPL prompt as idle', () => {
+      const activity = adapter.runtime.activity;
+      expect(activity.kind).toBe('pty');
+      if (activity.kind === 'pty') {
+        expect(activity.detectIdle?.('thinking through the answer\n>>> ')).toBe(true);
+        expect(activity.detectIdle?.('still generating output...')).toBe(false);
+      }
+    });
+
+    it('strips ANSI escape codes before the idle prompt pattern check', () => {
+      const activity = adapter.runtime.activity;
+      expect(activity.kind).toBe('pty');
+      if (activity.kind === 'pty') {
+        // A CSI reset sequence immediately before the prompt must be stripped so
+        // the pattern still matches. Removing the strip would cause this to return
+        // false (the regex sees '\x1b' not '>' at the start-of-string anchor).
+        expect(activity.detectIdle?.('\x1b[0m>>> ')).toBe(true);
+        // ANSI colour codes wrapping non-prompt content must not produce a false
+        // positive (no '>>>' anywhere after stripping).
+        expect(activity.detectIdle?.('\x1b[32mstill working\x1b[0m')).toBe(false);
+      }
+    });
+
+    it('declares no session history (no resume)', () => {
+      expect(adapter.runtime.sessionHistory).toBeUndefined();
+    });
+  });
+
+  // ── No-op methods ──────────────────────────────────────────────────────────
+
+  describe('no-op methods', () => {
+    it('ensureTrust resolves without error', async () => {
+      await expect(adapter.ensureTrust('/some/dir')).resolves.toBeUndefined();
+    });
+
+    it('removeHooks does not throw', () => {
+      expect(() => adapter.removeHooks('/some/dir')).not.toThrow();
+    });
+
+    it('clearSettingsCache does not throw', () => {
+      expect(() => adapter.clearSettingsCache()).not.toThrow();
+    });
+
+    it('locateSessionHistoryFile returns null', async () => {
+      const result = await adapter.locateSessionHistoryFile('session-1', '/some/dir');
+      expect(result).toBeNull();
+    });
+
+    it('getSubmissionVerifier returns null', () => {
+      expect(adapter.getSubmissionVerifier('paste')).toBeNull();
+      expect(adapter.getSubmissionVerifier('command-injection')).toBeNull();
+    });
+  });
+
+  // ── detectFirstOutput ────────────────────────────────────────────────────
+
+  describe('detectFirstOutput', () => {
+    it('returns true for any non-empty data', () => {
+      expect(adapter.detectFirstOutput('Hello')).toBe(true);
+    });
+
+    it('returns false for empty string', () => {
+      expect(adapter.detectFirstOutput('')).toBe(false);
+    });
+  });
+
+  // ── getExitSequence ────────────────────────────────────────────────────────
+
+  it('exit sequence is Ctrl+C then /bye', () => {
+    expect(adapter.getExitSequence()).toEqual(['\x03', '/bye\r']);
+  });
+
+  // ── interpolateTemplate ────────────────────────────────────────────────────
+
+  describe('interpolateTemplate', () => {
+    it('replaces {{key}} placeholders', () => {
+      const result = adapter.interpolateTemplate(
+        'Fix {{issue}} in {{file}}',
+        { issue: 'bug-123', file: 'main.ts' },
+      );
+      expect(result).toBe('Fix bug-123 in main.ts');
+    });
+
+    it('leaves unmatched placeholders unchanged', () => {
+      const result = adapter.interpolateTemplate('{{name}} - {{unknown}}', { name: 'test' });
+      expect(result).toBe('test - {{unknown}}');
+    });
+  });
+
+  // ── permission mode mapping ──────────────────────────────────────────────
+
+  describe('permission mode mapping', () => {
+    const allModes: PermissionMode[] = ['default', 'plan', 'dontAsk', 'acceptEdits', 'auto', 'bypassPermissions'];
+
+    for (const mode of allModes) {
+      it(`adds no permission flags for ${mode} (Ollama has no autonomy controls)`, () => {
+        const command = adapter.buildCommand(makeOptions({ permissionMode: mode }));
+        expect(command).not.toContain('--yes');
+        expect(command).not.toContain('--permission');
+        expect(command).not.toContain('--approval');
+      });
+    }
+  });
+});
+
+// ── Registry integration ─────────────────────────────────────────────────────
+
+describe('Agent Registry', () => {
+  it('has ollama adapter registered', async () => {
+    const { agentRegistry } = await import('../../src/main/agent/agent-registry');
+    expect(agentRegistry.has('ollama')).toBe(true);
+  });
+
+  it('getOrThrow returns OllamaAdapter instance', async () => {
+    const { agentRegistry } = await import('../../src/main/agent/agent-registry');
+    const adapter = agentRegistry.getOrThrow('ollama');
+    expect(adapter.name).toBe('ollama');
+    expect(adapter.sessionType).toBe('ollama_agent');
+  });
+
+  it('lists ollama among registered adapters', async () => {
+    const { agentRegistry } = await import('../../src/main/agent/agent-registry');
+    expect(agentRegistry.list()).toContain('ollama');
+  });
+
+  it('getBySessionType finds ollama adapter', async () => {
+    const { agentRegistry } = await import('../../src/main/agent/agent-registry');
+    const adapter = agentRegistry.getBySessionType('ollama_agent');
+    expect(adapter).toBeDefined();
+    expect(adapter!.name).toBe('ollama');
+  });
+});
+
+// ── agent-display-name - ollama entry ─────────────────────────────────────────
+
+describe('agent-display-name - ollama entry', () => {
+  it('agentDisplayName returns "Ollama" for "ollama"', () => {
+    expect(agentDisplayName('ollama')).toBe('Ollama');
+  });
+
+  it('agentShortName returns "Ollama" for "ollama"', () => {
+    expect(agentShortName('ollama')).toBe('Ollama');
+  });
+
+  it('agentInstallUrl returns the Ollama download URL for "ollama"', () => {
+    expect(agentInstallUrl('ollama')).toBe('https://ollama.com/download');
+  });
+});

--- a/tests/unit/ollama-adapter.test.ts
+++ b/tests/unit/ollama-adapter.test.ts
@@ -216,6 +216,15 @@ describe('OllamaAdapter', () => {
       expect(command).not.toContain('session-123');
     });
 
+    it('inserts a "--" end-of-options guard before a dash-prefixed prompt so it is not parsed as a flag', () => {
+      const command = adapter.buildCommand(makeOptions({ prompt: '- fix the bug', shell: 'bash' }));
+      // The guard token must appear after the model and immediately before the
+      // prompt positional: `... run <model> -- <prompt>`.
+      expect(command).toMatch(/ run \S+ -- /);
+      const guardIndex = command.indexOf(' -- ');
+      expect(command.indexOf('- fix the bug')).toBeGreaterThan(guardIndex);
+    });
+
     // ── Shell quoting ────────────────────────────────────────────────────
 
     describe('shell quoting', () => {


### PR DESCRIPTION
## What

Adds an **Ollama** agent adapter so users can drive a local LLM from the board. Ollama becomes the twelfth supported agent.

- New adapter under `src/main/agent/adapters/ollama/` (`OllamaAdapter`, `capability-discovery.ts`, barrel `index.ts`).
- Registered in `agent-registry.ts`; display metadata in `agent-display-name.ts`.
- `docs/agent-integration.md` anchors updated (agent count, `name` list, and the Supported Agents / First-Output / Exit Sequences / Session History / Auto-Name / Project relocation tables).

## Why

Task #11: support running a local Ollama model as a board agent for free, offline Q&A and brainstorming. Confirmed scope: a standalone chat agent (not a backend for another agent), with model discovery via `ollama list`.

## How

Ollama is a local-inference REPL, not an agentic coder, so it is modeled on the **Warp** adapter (a one-shot run that streams output then exits) rather than the agentic CLIs. The load-bearing constraint: Kangentic delivers the initial task prompt only on the command line, and `ollama run <model> "<prompt>"` is one-shot, so each spawn is a single turn. (Free-form multi-turn chat is still available by running `ollama run <model>` directly in a Command Terminal.)

- `buildCommand` emits `ollama run <model> [prompt]`. `ollama run` has no default model and no interactive picker, so a model argument is mandatory; the adapter injects the per-column/task model override or a sensible `DEFAULT_OLLAMA_MODEL`. This is the documented exception to `cli-features-over-custom-layers` (the rule defers to a CLI's own picker, but Ollama has none).
- `discoverCapabilities` runs `ollama list` to populate Kangentic's existing model picker via the pure, never-throwing `parseOllamaModelList`.
- Activity via the PTY silence timer plus a `>>>` REPL idle detector; a single `Chat` permission; exit sequence `Ctrl+C` then `/bye`; no resume, hooks, trust, MCP wiring, or session history.

## Breaking changes

None. New adapter only. `session_type` is a free-form string (no migration), and all UI reads the registry and `AgentCapabilities` generically, so the agent and its model picker surface automatically.

## Tests

- New `tests/unit/ollama-adapter.test.ts`: identity, detection (override / PATH / not-found / cache), command building (model override, default fallback, prompt present and absent, resume ignored, shell quoting), capability discovery (success + failure) and `parseOllamaModelList`, runtime activity + `>>>` idle, no-ops, exit sequence, registry, and display-name.
- Ollama added to the `adapter-multiline-prompt`, `agent-submission-verifier-shape`, and `agent-login-command` guards, and to the UI `mock-electron-api`.
- Verified locally against a real Ollama 0.30.7 install (`ollama --version` parse and `ollama list` model parsing).
- CI runs the full unit, UI, and Linux Electron E2E tiers.

Generated with [Claude Code](https://claude.com/claude-code)
