### PR TITLE
fix(clipboard): restore Ctrl+V paste and copy in the first-party renderer

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -308,7 +308,7 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 ### Clipboard (1 channel)
 | Channel | Pattern | Purpose |
 |---------|---------|---------|
-| `clipboard:saveImage` | invoke | Save clipboard image data to a temp file, returns file path |
+| `clipboard:readImage` | invoke | Read the native clipboard image, save it to a temp file, returns file path or null |
 
 ### Browser pane (8 channels)
 | Channel | Pattern | Purpose |

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -24,6 +24,7 @@ import { loadReactDevTools } from './devtools';
 import { syncShutdownCleanup, startHardShutdownFailsafe } from './shutdown';
 import { prRefreshScheduler } from './pr/pr-refresh-scheduler';
 import { restoreShellEnv } from './shell-env';
+import { isFirstPartyPermissionAllowed } from './permission-policy';
 import { MIN_ZOOM, MAX_ZOOM } from '../shared/zoom-steps';
 
 initStartupTimer(PROCESS_START);
@@ -691,18 +692,23 @@ app.whenReady().then(async () => {
     // refused" but the rest of the app stays functional.
   }
 
-  // Grant microphone access for voice-to-text dictation. getUserMedia in the
-  // renderer raises a 'media' permission request; we approve mic access for our
-  // own app origin (the renderer is first-party, not arbitrary web content).
-  // The actual OS-level gate still applies (macOS TCC handled via
-  // systemPreferences in the dictation handler; an OS denial surfaces as a
-  // getUserMedia rejection in the popup).
+  // Grant the first-party renderer the web-platform permissions it actually uses:
+  // 'media' (getUserMedia microphone access for voice-to-text dictation) and the
+  // async Clipboard API ('clipboard-read' / 'clipboard-sanitized-write') that backs
+  // terminal copy/paste and every "copy to clipboard" affordance. The renderer is
+  // our own trusted UI, not arbitrary web content. Without the clipboard grant,
+  // navigator.clipboard.readText()/writeText() throw NotAllowedError and the actions
+  // silently no-op (this broke Ctrl+V text/image paste and the copy buttons). The
+  // policy lives in permission-policy.ts so both handlers stay in lockstep and it is
+  // unit-tested. OS-level gates still apply (macOS TCC for the mic surfaces as a
+  // getUserMedia rejection). The embedded browser webview is untrusted guest content
+  // and keeps its own deny-all handler below; this default-session policy does not
+  // touch it.
   session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
-    // 'media' covers getUserMedia microphone/camera requests.
-    callback(permission === 'media');
+    callback(isFirstPartyPermissionAllowed(permission));
   });
   session.defaultSession.setPermissionCheckHandler((_webContents, permission) => {
-    return permission === 'media';
+    return isFirstPartyPermissionAllowed(permission);
   });
 
   createWindow();

--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
-import { app, ipcMain, Notification, dialog, shell, globalShortcut } from 'electron';
+import { app, ipcMain, Notification, dialog, shell, globalShortcut, clipboard } from 'electron';
 import { IPC } from '../../../shared/ipc-channels';
 import { comboToAccelerator } from '../../../shared/keybindings';
 import { WorktreeManager } from '../../git/worktree-manager';
@@ -523,18 +523,21 @@ export function registerSystemHandlers(context: IpcContext): void {
   });
 
   // === Clipboard ===
-  // Matches Claude API vision input: image/jpeg, image/png, image/gif, image/webp
-  const ALLOWED_IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
-
-  ipcMain.handle(IPC.CLIPBOARD_SAVE_IMAGE, (_, data: string, extension: string) => {
-    if (!ALLOWED_IMAGE_EXTENSIONS.includes(extension.toLowerCase())) {
-      throw new Error(`Unsupported image extension: ${extension}`);
-    }
+  // Read the clipboard image natively in the main process rather than via the web
+  // `navigator.clipboard.read()`. The native path avoids the document-focus
+  // requirement (the terminal may not hold document focus when Ctrl+V fires) and
+  // behaves identically on Windows/macOS/Linux, where the web Clipboard API's image
+  // support is inconsistent. Returns the saved PNG file path, or null when the
+  // clipboard holds no image. Always PNG: a NativeImage is a still bitmap, so an
+  // animated GIF copied from a browser is reduced to a single static frame, matching
+  // how OS "copy screenshot" already populates the clipboard.
+  ipcMain.handle(IPC.CLIPBOARD_READ_IMAGE, (): string | null => {
+    const image = clipboard.readImage();
+    if (image.isEmpty()) return null;
     const tempDir = path.join(os.tmpdir(), 'kangentic-clipboard');
     fs.mkdirSync(tempDir, { recursive: true });
-    const filename = `pasted-image-${Date.now()}${extension.toLowerCase()}`;
-    const filePath = path.join(tempDir, filename);
-    fs.writeFileSync(filePath, Buffer.from(data, 'base64'));
+    const filePath = path.join(tempDir, `pasted-image-${Date.now()}.png`);
+    fs.writeFileSync(filePath, image.toPNG());
     return filePath;
   });
 

--- a/src/main/permission-policy.ts
+++ b/src/main/permission-policy.ts
@@ -1,0 +1,35 @@
+/**
+ * Permission policy for the first-party renderer (the Kangentic app window).
+ *
+ * The app window is trusted UI, not arbitrary web content, so it is granted the
+ * handful of web-platform permissions it actually uses:
+ *
+ *  - `media`: getUserMedia microphone access for voice-to-text dictation.
+ *  - `clipboard-read` / `clipboard-sanitized-write`: the async Clipboard API used
+ *    by terminal copy/paste and the various "copy to clipboard" affordances
+ *    (copy task id, copy login command, copy session id, copy file path, ...).
+ *    Without these, `navigator.clipboard.readText()` / `writeText()` throw
+ *    `NotAllowedError` and the actions silently no-op. The permission strings are
+ *    Electron's exact values for both `setPermissionCheckHandler` and
+ *    `setPermissionRequestHandler`.
+ *
+ * Everything else (geolocation, notifications, openExternal, ...) stays denied.
+ *
+ * This policy governs ONLY the default session (the first-party app window). The
+ * embedded browser webview is untrusted guest content and is governed by its own
+ * deny-all handler in `index.ts`; it is not covered here.
+ */
+const ALLOWED_FIRST_PARTY_PERMISSIONS = new Set<string>([
+  'media',
+  'clipboard-read',
+  'clipboard-sanitized-write',
+]);
+
+/**
+ * Returns true when the first-party renderer is allowed to use `permission`.
+ * Used by both the default session's permission check and request handlers so
+ * the two stay in lockstep.
+ */
+export function isFirstPartyPermissionAllowed(permission: string): boolean {
+  return ALLOWED_FIRST_PARTY_PERMISSIONS.has(permission);
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -402,7 +402,7 @@ const api: ElectronAPI = {
   },
 
   clipboard: {
-    saveImage: (data: string, extension: string) => ipcRenderer.invoke(IPC.CLIPBOARD_SAVE_IMAGE, data, extension),
+    readImage: () => ipcRenderer.invoke(IPC.CLIPBOARD_READ_IMAGE),
   },
 
   browser: {

--- a/src/renderer/utils/terminal-clipboard.ts
+++ b/src/renderer/utils/terminal-clipboard.ts
@@ -92,16 +92,6 @@ export function quoteForShell(filePath: string, shellName?: string): string {
   return `"${filePath.replace(/`/g, '``').replace(/\$/g, '`$').replace(/"/g, '\\"')}"`;
 }
 
-/** MIME type to file extension mapping for clipboard images.
- *  Matches the formats supported by the Claude API vision input:
- *  image/jpeg, image/png, image/gif, image/webp */
-const IMAGE_EXTENSION_MAP: Record<string, string> = {
-  'image/png': '.png',
-  'image/jpeg': '.jpg',
-  'image/gif': '.gif',
-  'image/webp': '.webp',
-};
-
 /**
  * Handle Ctrl+V / Cmd+V paste in the terminal.
  *
@@ -126,30 +116,20 @@ async function handlePaste(
     // readText failed or denied - try image below
   }
 
-  // Priority 2: image clipboard (only useful if we can write to PTY)
+  // Priority 2: image clipboard (only useful if we can write to PTY).
+  // Read the image natively in the main process (Electron clipboard), which avoids
+  // the document-focus requirement of the web clipboard API and behaves identically
+  // across platforms, then write the saved file path to the PTY so Claude Code can
+  // pick it up.
   if (!onWrite) return;
 
   try {
-    const items = await navigator.clipboard.read();
-    for (const item of items) {
-      const imageType = item.types.find(type => type.startsWith('image/'));
-      if (!imageType) continue;
-
-      const blob = await item.getType(imageType);
-      const buffer = await blob.arrayBuffer();
-      const base64 = btoa(
-        new Uint8Array(buffer).reduce((accumulated, byte) => accumulated + String.fromCharCode(byte), ''),
-      );
-
-      const extension = IMAGE_EXTENSION_MAP[imageType] || '.png';
-      let filePath = await window.electronAPI.clipboard.saveImage(base64, extension);
-      if (shellName) filePath = convertPathForShell(filePath, shellName);
-      const quoted = quoteForShell(filePath, shellName);
-      onWrite(quoted);
-      return; // only paste the first image
-    }
+    let filePath = await window.electronAPI.clipboard.readImage();
+    if (!filePath) return;
+    if (shellName) filePath = convertPathForShell(filePath, shellName);
+    onWrite(quoteForShell(filePath, shellName));
   } catch {
-    // clipboard.read() not available or denied - silently fail
+    // native clipboard read failed - silently fail
   }
 }
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -225,7 +225,7 @@ export const IPC = {
   BACKLOG_ATTACHMENT_OPEN: 'backlogAttachment:open',
 
   // Clipboard
-  CLIPBOARD_SAVE_IMAGE: 'clipboard:saveImage',
+  CLIPBOARD_READ_IMAGE: 'clipboard:readImage',
 
   // Browser pane: embedded webview capture-and-send
   BROWSER_CAPTURE_SEND: 'browser:captureSend',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2977,7 +2977,7 @@ export interface ElectronAPI {
 
   // Clipboard
   clipboard: {
-    saveImage: (data: string, extension: string) => Promise<string>;
+    readImage: () => Promise<string | null>;
   };
 
   // Browser pane: embedded webview capture-and-send

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -2288,7 +2288,7 @@
     },
 
     clipboard: {
-      saveImage: function (_data, extension) { return Promise.resolve('/tmp/kangentic-clipboard/pasted-image-1234567890' + extension); },
+      readImage: function () { return Promise.resolve('/tmp/kangentic-clipboard/pasted-image-1234567890.png'); },
     },
 
     search: {

--- a/tests/ui/write-batcher-integration.spec.ts
+++ b/tests/ui/write-batcher-integration.spec.ts
@@ -15,7 +15,10 @@
  *
  *   - The clipboard onWrite path (enableTerminalClipboard receives
  *     batcher.schedule) is exercised end-to-end: Ctrl+Enter sends a single
- *     write containing the newline character.
+ *     write containing the newline character; Ctrl+V with clipboard text pastes
+ *     the text through terminal.paste -> onData; and Ctrl+V with a clipboard
+ *     image writes the shell-quoted temp-file path returned by the native
+ *     clipboard.readImage IPC.
  *
  * Coverage of gap 1 (unmount-flush): flush() is called on unmount by the
  * cleanup effect. The synchronous flush() behavior is already unit-tested in
@@ -100,10 +103,13 @@ const deterministicSpawnScript = `
   };
 `;
 
-async function launchWithState(extraScript: string): Promise<{ browser: Browser; page: Page }> {
+async function launchWithState(
+  extraScript: string,
+  permissions?: string[],
+): Promise<{ browser: Browser; page: Page }> {
   await waitForViteReady();
   const browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 }, permissions });
   const page = await context.newPage();
 
   await page.addInitScript({ path: MOCK_SCRIPT });
@@ -273,6 +279,84 @@ test.describe('WriteBatcher - useTerminal IPC wiring', () => {
       const writeCalls = await page.evaluate(() => window.electronAPI.sessions.__writeCalls);
       expect((writeCalls as Array<{ sessionId: string; payload: string }>)[0].sessionId).toBe(TRANSIENT_SESSION_ID);
       expect((writeCalls as Array<{ sessionId: string; payload: string }>)[0].payload).toBe('\n');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('Ctrl+V with clipboard text pastes the text through to the PTY', async () => {
+    // The text-paste path: handlePaste Priority 1 reads navigator.clipboard.readText()
+    // and feeds it to xterm's terminal.paste(), which emits an onData event that the
+    // batcher forwards to sessions.write. The clipboard-read/-write permissions are
+    // granted on the context to simulate the first-party permission grant that the
+    // main-process permission handler now provides (without it, readText() throws
+    // NotAllowedError and the paste silently no-ops - the reported bug).
+    const PASTED_TEXT = 'hello-from-clipboard-42';
+    const { browser, page } = await launchWithState(deterministicSpawnScript, ['clipboard-read', 'clipboard-write']);
+    try {
+      await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+      await page.evaluate(() => {
+        window.electronAPI.sessions.__writeCalls.length = 0;
+      });
+
+      await openCommandBarWithTerminal(page);
+
+      // Seed the clipboard with text (write permission granted on the context).
+      await page.evaluate((text) => navigator.clipboard.writeText(text), PASTED_TEXT);
+
+      // Ctrl+V triggers handlePaste; Priority 1 readText() returns the seeded text.
+      await page.keyboard.press('Control+v');
+
+      // terminal.paste() may or may not be wrapped in bracketed-paste markers
+      // depending on terminal mode, so assert the payload CONTAINS the text.
+      await expect.poll(async () => {
+        return page.evaluate(() =>
+          window.electronAPI.sessions.__writeCalls.map((c: { payload: string }) => c.payload).join(''),
+        );
+      }, { timeout: 3000 }).toContain(PASTED_TEXT);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('Ctrl+V with a clipboard image writes the temp-file path via the onWrite batcher path', async () => {
+    // The image-paste fix: handlePaste's Priority 1 (text) falls through when the
+    // clipboard has no text, then Priority 2 reads the image natively via
+    // window.electronAPI.clipboard.readImage() (the main-process Electron clipboard,
+    // which bypasses the denied web clipboard-read permission). The returned temp
+    // file path is shell-converted, quoted, and written to the PTY through the same
+    // batcher.schedule onWrite callback. This guards the Ctrl+V image regression.
+    // The path has no spaces or special chars, so quoteForShell leaves it unquoted
+    // and the write payload equals the path verbatim on every platform.
+    const IMAGE_PATH = '/tmp/kangentic-clipboard/pasted-image-test.png';
+    const clipboardOverrideScript = `
+      ${deterministicSpawnScript}
+      // Force an empty text clipboard so Priority 1 falls through to the image path,
+      // independent of the headless browser's clipboard-permission state.
+      try { navigator.clipboard.readText = function () { return Promise.resolve(''); }; } catch (e) {}
+      window.electronAPI.clipboard.readImage = function () { return Promise.resolve('${IMAGE_PATH}'); };
+    `;
+    const { browser, page } = await launchWithState(clipboardOverrideScript);
+    try {
+      await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+      await page.evaluate(() => {
+        window.electronAPI.sessions.__writeCalls.length = 0;
+      });
+
+      await openCommandBarWithTerminal(page);
+
+      // Ctrl+V triggers handlePaste in enableTerminalClipboard's custom key handler.
+      await page.keyboard.press('Control+v');
+
+      await expect.poll(async () => {
+        return page.evaluate(() => window.electronAPI.sessions.__writeCalls.length);
+      }, { timeout: 3000 }).toBe(1);
+
+      const writeCalls = await page.evaluate(() => window.electronAPI.sessions.__writeCalls);
+      expect((writeCalls as Array<{ sessionId: string; payload: string }>)[0].sessionId).toBe(TRANSIENT_SESSION_ID);
+      expect((writeCalls as Array<{ sessionId: string; payload: string }>)[0].payload).toBe(IMAGE_PATH);
     } finally {
       await browser.close();
     }

--- a/tests/unit/permission-policy.test.ts
+++ b/tests/unit/permission-policy.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for the first-party renderer permission policy.
+ *
+ * Regression guard for the clipboard bug: the default-session permission handlers
+ * used to allow only 'media', so navigator.clipboard.readText()/writeText() threw
+ * NotAllowedError and Ctrl+V paste plus every "copy to clipboard" button silently
+ * no-op'd. The policy must grant the clipboard permissions while keeping unrelated
+ * permissions (geolocation, notifications, ...) denied.
+ */
+import { describe, it, expect } from 'vitest';
+import { isFirstPartyPermissionAllowed } from '../../src/main/permission-policy';
+
+describe('first-party renderer permission policy', () => {
+  it('allows microphone media access for voice dictation', () => {
+    expect(isFirstPartyPermissionAllowed('media')).toBe(true);
+  });
+
+  it('allows clipboard read and sanitized write for copy/paste', () => {
+    // These are Electron's exact permission strings for the async Clipboard API.
+    expect(isFirstPartyPermissionAllowed('clipboard-read')).toBe(true);
+    expect(isFirstPartyPermissionAllowed('clipboard-sanitized-write')).toBe(true);
+  });
+
+  it('denies every other permission', () => {
+    const deniedPermissions = [
+      'geolocation',
+      'notifications',
+      'midi',
+      'midiSysex',
+      'openExternal',
+      'display-capture',
+      'fullscreen',
+      'idle-detection',
+      'pointerLock',
+      'fileSystem',
+      'usb',
+      'hid',
+      'serial',
+      // clipboard-write (unsanitized) is deliberately NOT granted; only the
+      // sanitized variant (clipboard-sanitized-write) is in the allow-set.
+      'clipboard-write',
+      'unknown',
+    ];
+    for (const permission of deniedPermissions) {
+      expect(isFirstPartyPermissionAllowed(permission)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## What

Restores the web Clipboard API for the first-party app window, fixing Ctrl+V paste (text and
image) in terminals and every "copy to clipboard" affordance across the app.

- `src/main/permission-policy.ts` (new): `isFirstPartyPermissionAllowed()` allow-list (`media`,
  `clipboard-read`, `clipboard-sanitized-write`), shared by both default-session permission
  handlers in `src/main/index.ts`.
- `clipboard:readImage` native IPC replacing the old `clipboard:saveImage`, wired through all
  layers (`ipc-channels.ts`, `types.ts`, `preload.ts`, `system.ts` handler, `mock-electron-api.js`).
- `src/renderer/utils/terminal-clipboard.ts`: terminal image paste now reads the image natively
  via the new IPC; dead `IMAGE_EXTENSION_MAP` + base64 code removed.
- `docs/architecture.md`: updated Clipboard IPC channel row.

## Why

The global permission handler denied every web permission except `'media'`, so
`navigator.clipboard.readText()` / `writeText()` threw `NotAllowedError`. A live probe of the
running app confirmed both reads and writes were denied. This silently broke ALL clipboard
operations: terminal Ctrl+V paste (text and image), terminal copy, and the copy buttons (copy
task id, login command, session id, file path, agent command). The original task assumed only
image paste was broken; in reality text paste and copy were broken too, by the same root cause.

Addresses Kangentic task #300 (Fix Ctrl+V image paste in terminal).

## How

The app window is trusted first-party UI, not arbitrary web content, so it is granted the handful
of permissions it actually uses. The grant is factored into a small pure helper so both the
request and check handlers stay in lockstep and the policy is unit-testable. The embedded browser
webview keeps its own deny-all handler, so untrusted guest content is unaffected.

For terminal image paste specifically, the read happens natively in the main process
(`clipboard.readImage().toPNG()`) rather than via the experimental web `navigator.clipboard.read()`,
which is the one fragile clipboard op (focus/format gating). This is more robust and avoids a
renderer base64 round-trip. The permission strings were verified against the Electron docs.

Verified end-to-end in a worktree preview: after the fix, `readText`, `writeText`, and `read()`
all resolve and the `clipboard-read` permission reports `granted`.

## Breaking changes

None. The `clipboard:saveImage` IPC endpoint is removed, but it had a single internal caller
(the terminal paste path) which now uses `clipboard:readImage`. No public API or user action.

## Tests

- `tests/unit/permission-policy.test.ts` (new): red-green guard for the permission allow-list
  (media + clipboard-read + clipboard-sanitized-write allowed; everything else, including
  unsanitized `clipboard-write`, denied).
- `tests/ui/write-batcher-integration.spec.ts`: added Ctrl+V text paste and Ctrl+V image paste
  cases through the terminal onWrite path.
- typecheck, lint, and the existing image-compression tests pass locally. CI runs the full
  unit / UI / Electron E2E tiers.

Generated with [Claude Code](https://claude.com/claude-code)
