### PR TITLE
feat(board): add opt-in ticket numbers to task cards

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,7 @@ Both panels use a VS Code-style layout: a sidebar with tab navigation on the lef
 These settings appear only in App Settings and cannot be overridden per-project:
 
 - `sidebarVisible`, `boardLayout`, `sidebar.width`
-- `cardDensity`, `columnWidth`, `terminalPanelVisible`, `animationsEnabled`, `statusBarVisible`, `diffViewMode`
+- `cardDensity`, `columnWidth`, `showTaskNumbers`, `terminalPanelVisible`, `animationsEnabled`, `statusBarVisible`, `diffViewMode`
 - `diffDefaultScope`, `diffIgnoreWhitespace`, `diffCollapseUnchanged`, `diffFileSort`, `diffFlatList`
 - `restoreWindowPosition`
 - `agent.cliPaths`, `agent.maxConcurrentSessions`, `agent.queueOverflow`, `agent.autoResumeSessionsOnRestart`
@@ -66,6 +66,7 @@ These settings appear in both App Settings (as defaults) and Project Settings (a
 | `boardLayout` | `'horizontal'` \| `'vertical'` | `'horizontal'` | Board scroll direction. Global-only. |
 | `cardDensity` | `'compact'` \| `'default'` \| `'comfortable'` | `'default'` | Amount of detail shown on task cards. Global-only. |
 | `columnWidth` | `'narrow'` \| `'default'` \| `'wide'` | `'default'` | Width of board columns. Global-only. |
+| `showTaskNumbers` | boolean | `false` | Show each task's `#N` (`display_id`) as a muted badge in the board card header. Opt-in; matches the number shown in the task detail header. Global-only. |
 | `terminalPanelVisible` | boolean | `true` | Show the terminal panel below the board. Global-only. |
 | `animationsEnabled` | boolean | `true` | Enable CSS keyframe animations (idle pulse, dialog fades, status bar pulses). Global-only. |
 | `statusBarVisible` | boolean | `true` | Show the status bar at the bottom of the window. Global-only. |

--- a/src/renderer/components/board/TaskCard.tsx
+++ b/src/renderer/components/board/TaskCard.tsx
@@ -146,6 +146,19 @@ const TaskCardInner = function TaskCard({ task, isDragOverlay, compact, onDelete
   const labelColors = useConfigStore((state) => state.config.backlog?.labelColors) ?? {};
   const taskLabels = task.labels ?? [];
   const cardDensity = useConfigStore((state) => state.config.cardDensity);
+  const showTaskNumbers = useConfigStore((state) => state.config.showTaskNumbers);
+
+  // Subtle, muted `#N` (display_id) matching the task-detail header format. Right-aligned
+  // and shrink-0 so a long title truncates before the number; rendered only when the
+  // board's Ticket Numbers setting is on.
+  const displayIdBadge = showTaskNumbers ? (
+    <span
+      className="shrink-0 font-mono text-xs text-fg-muted"
+      data-testid="task-card-display-id"
+    >
+      #{task.display_id}
+    </span>
+  ) : null;
 
   const handleContextDelete = async (dontAskAgain: boolean) => {
     if (dontAskAgain) useConfigStore.getState().updateConfig({ skipDeleteConfirm: true });
@@ -174,6 +187,7 @@ const TaskCardInner = function TaskCard({ task, isDragOverlay, compact, onDelete
         >
           <div className="flex items-center gap-2">
             <span className="text-sm text-fg-tertiary truncate flex-1" data-testid="compact-title">{task.title}</span>
+            {displayIdBadge}
             {onDelete && (
               <button
                 type="button"
@@ -271,7 +285,8 @@ const TaskCardInner = function TaskCard({ task, isDragOverlay, compact, onDelete
               {activityReason && <title>{formatActivityReasonText(activityReason)}</title>}
             </Loader2>
           )}
-          <div className="text-sm text-fg font-medium truncate">{task.title}</div>
+          <div className="text-sm text-fg font-medium truncate flex-1 min-w-0">{task.title}</div>
+          {displayIdBadge}
         </div>
 
         {!isCompactDensity && task.pr_url && (

--- a/src/renderer/components/settings/settings-registry.ts
+++ b/src/renderer/components/settings/settings-registry.ts
@@ -28,6 +28,7 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
   // ── Layout ──
   { id: 'cardDensity', tabId: 'layout', label: 'Card Density', description: 'Amount of detail shown on task cards', scope: 'global', keywords: ['compact', 'comfortable', 'minimal', 'detailed'] },
   { id: 'columnWidth', tabId: 'layout', label: 'Column Width', description: 'Width of board columns', scope: 'global', keywords: ['narrow', 'wide', 'size'] },
+  { id: 'showTaskNumbers', tabId: 'layout', label: 'Ticket Numbers', description: "Show each task's #N number on its card", scope: 'global', keywords: ['ticket', 'number', 'id', 'display', 'card', 'display_id', 'hash'] },
   { id: 'terminalPanelVisible', tabId: 'layout', label: 'Terminal Panel', description: 'Show the terminal panel below the board', scope: 'global', keywords: ['bottom', 'panel', 'hide', 'terminal', 'visible'] },
   { id: 'statusBarVisible', tabId: 'layout', label: 'Status Bar', description: 'Show the status bar at the bottom of the window', scope: 'global', keywords: ['bottom', 'bar', 'hide', 'visible'] },
   { id: 'restoreWindowPosition', tabId: 'layout', label: 'Restore Window Position', description: 'Remember window size and position between launches', scope: 'global', keywords: ['size', 'bounds', 'remember'] },

--- a/src/renderer/components/settings/tabs/LayoutTab.tsx
+++ b/src/renderer/components/settings/tabs/LayoutTab.tsx
@@ -27,6 +27,11 @@ export function LayoutTab({ globalConfig }: { globalConfig: AppConfig }) {
         </Select>
       </SettingRow>
       <SettingToggleRow
+        {...settingProps('showTaskNumbers')}
+        checked={globalConfig.showTaskNumbers}
+        onChange={(value) => updateGlobal({ showTaskNumbers: value })}
+      />
+      <SettingToggleRow
         {...settingProps('terminalPanelVisible')}
         checked={globalConfig.terminalPanelVisible !== false}
         onChange={(value) => updateGlobal({ terminalPanelVisible: value })}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1310,6 +1310,7 @@ export interface AppConfig {
   boardLayout: 'horizontal' | 'vertical';
   cardDensity: 'compact' | 'default' | 'comfortable';
   columnWidth: 'narrow' | 'default' | 'wide';
+  showTaskNumbers: boolean; // show each task's #N (display_id) on its board card
   terminalPanelVisible: boolean;
   animationsEnabled: boolean;
   statusBarVisible: boolean;
@@ -1594,6 +1595,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   boardLayout: 'horizontal',
   cardDensity: 'default',
   columnWidth: 'default',
+  showTaskNumbers: false,
   terminalPanelVisible: true,
   animationsEnabled: true,
   statusBarVisible: true,

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -46,6 +46,7 @@
     boardLayout: 'horizontal',
     cardDensity: 'default',
     columnWidth: 'default',
+    showTaskNumbers: false,
     terminalPanelVisible: true,
     animationsEnabled: true,
     statusBarVisible: true,

--- a/tests/ui/settings-panel.spec.ts
+++ b/tests/ui/settings-panel.spec.ts
@@ -90,6 +90,9 @@ test.describe('Settings Panel', () => {
     await page.getByRole('button', { name: 'Layout' }).click();
     await expect(page.locator('text=Card Density')).toBeVisible();
     await expect(page.locator('text=Column Width')).toBeVisible();
+    // Ticket Numbers toggle row (showTaskNumbers) - goes RED if SettingToggleRow is
+    // removed from LayoutTab.tsx, while leaving all other assertions green.
+    await expect(page.locator('text=Ticket Numbers')).toBeVisible();
     await expect(page.getByText('Terminal Panel', { exact: true })).toBeVisible();
     await expect(page.getByText('Status Bar', { exact: true })).toBeVisible();
     await expect(page.locator('text=Restore Window Position')).toBeVisible();

--- a/tests/ui/task-card-display-id.spec.ts
+++ b/tests/ui/task-card-display-id.spec.ts
@@ -56,7 +56,7 @@ const COMPACT_DISPLAY_ID = 99;
 
 const preConfig = `
   window.__mockPreConfigure(function (state) {
-    var ts = new Date().toISOString();
+    var timestamp = new Date().toISOString();
 
     state.projects.push({
       id: '${PROJECT_ID}',
@@ -64,15 +64,15 @@ const preConfig = `
       path: '/mock/display-id-test',
       github_url: null,
       default_agent: 'claude',
-      last_opened: ts,
-      created_at: ts,
+      last_opened: timestamp,
+      created_at: timestamp,
     });
 
     var laneIds = {};
     state.DEFAULT_SWIMLANES.forEach(function (s, i) {
       var id = 'lane-tcdi-' + s.name.toLowerCase().replace(/\\s+/g, '-');
       laneIds[s.name] = id;
-      state.swimlanes.push(Object.assign({}, s, { id: id, position: i, created_at: ts }));
+      state.swimlanes.push(Object.assign({}, s, { id: id, position: i, created_at: timestamp }));
     });
 
     state.tasks.push({
@@ -90,8 +90,8 @@ const preConfig = `
       pr_url: null,
       base_branch: null,
       archived_at: null,
-      created_at: ts,
-      updated_at: ts,
+      created_at: timestamp,
+      updated_at: timestamp,
     });
 
     // Seed an archived task so the DoneSwimlane renders it via compact={true}.
@@ -112,9 +112,9 @@ const preConfig = `
       pr_number: null,
       pr_url: null,
       base_branch: null,
-      archived_at: ts,
-      created_at: ts,
-      updated_at: ts,
+      archived_at: timestamp,
+      created_at: timestamp,
+      updated_at: timestamp,
     });
 
     return { currentProjectId: '${PROJECT_ID}' };

--- a/tests/ui/task-card-display-id.spec.ts
+++ b/tests/ui/task-card-display-id.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * UI tests for the opt-in `showTaskNumbers` board setting.
+ *
+ * Intent: when `showTaskNumbers` is on, every board task card renders its
+ * `#N` (`display_id`) as a subtle, muted badge in the card header
+ * (`data-testid="task-card-display-id"`). The setting is global and defaults
+ * to OFF, so a fresh board shows no numbers until the user opts in via the
+ * Layout settings tab.
+ *
+ * The card reads `useConfigStore(state => state.config.showTaskNumbers)`; the
+ * Layout tab toggle writes the same key via `updateConfig({ showTaskNumbers })`.
+ * These tests drive that exact write path through the dev-only config store
+ * handle (`__zustandStores.config`) and assert the card read path, rather than
+ * walking the settings UI, so they stay robust.
+ *
+ * Tests:
+ *   1. Default OFF: the seeded card shows no `#N` badge.
+ *   2. After enabling: the badge appears and its text matches the seeded
+ *      `display_id` (the same number shown in the task detail header).
+ *   3. Compact (archived) card branch: an archived task renders as compact={true}
+ *      in DoneSwimlane's "Completed" section. Asserts {displayIdBadge} in THAT
+ *      branch is also correctly gated - removing it from the compact branch only
+ *      (while leaving the normal branch intact) makes this test go RED while
+ *      keeping tests 1 and 2 green.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+async function launchWithState(preConfigScript: string): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(preConfigScript);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+  return { browser, page };
+}
+
+const PROJECT_ID = 'proj-display-id';
+const TASK_ID = 'task-display-id';
+const DISPLAY_ID = 42;
+/** Seeded as an archived task so it renders via the compact={true} branch in DoneSwimlane. */
+const COMPACT_TASK_ID = 'task-display-id-compact';
+const COMPACT_DISPLAY_ID = 99;
+
+const preConfig = `
+  window.__mockPreConfigure(function (state) {
+    var ts = new Date().toISOString();
+
+    state.projects.push({
+      id: '${PROJECT_ID}',
+      name: 'Display ID Test',
+      path: '/mock/display-id-test',
+      github_url: null,
+      default_agent: 'claude',
+      last_opened: ts,
+      created_at: ts,
+    });
+
+    var laneIds = {};
+    state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+      var id = 'lane-tcdi-' + s.name.toLowerCase().replace(/\\s+/g, '-');
+      laneIds[s.name] = id;
+      state.swimlanes.push(Object.assign({}, s, { id: id, position: i, created_at: ts }));
+    });
+
+    state.tasks.push({
+      id: '${TASK_ID}',
+      display_id: ${DISPLAY_ID},
+      title: 'Card Display ID Task',
+      description: 'Task used to test the opt-in ticket-number badge',
+      swimlane_id: laneIds['To Do'],
+      position: 0,
+      agent: null,
+      session_id: null,
+      worktree_path: null,
+      branch_name: null,
+      pr_number: null,
+      pr_url: null,
+      base_branch: null,
+      archived_at: null,
+      created_at: ts,
+      updated_at: ts,
+    });
+
+    // Seed an archived task so the DoneSwimlane renders it via compact={true}.
+    // This is the only path through the compact branch that is reachable from
+    // the board (BacklogView does not use compact). The archived task shows up
+    // in DoneSwimlane's scrollable "Completed" preview list.
+    state.archivedTasks.push({
+      id: '${COMPACT_TASK_ID}',
+      display_id: ${COMPACT_DISPLAY_ID},
+      title: 'Compact Badge Task',
+      description: null,
+      swimlane_id: laneIds['Done'],
+      position: 0,
+      agent: null,
+      session_id: null,
+      worktree_path: null,
+      branch_name: null,
+      pr_number: null,
+      pr_url: null,
+      base_branch: null,
+      archived_at: ts,
+      created_at: ts,
+      updated_at: ts,
+    });
+
+    return { currentProjectId: '${PROJECT_ID}' };
+  });
+`;
+
+/** Flip the global showTaskNumbers config through the real write path the Layout toggle uses. */
+async function setShowTaskNumbers(page: Page, value: boolean): Promise<void> {
+  await page.evaluate((newValue) => {
+    const stores = (window as unknown as {
+      __zustandStores?: { config: { getState: () => { updateConfig: (partial: { showTaskNumbers: boolean }) => Promise<void> } } };
+    }).__zustandStores;
+    return stores?.config.getState().updateConfig({ showTaskNumbers: newValue });
+  }, value);
+}
+
+let browser: Browser;
+let page: Page;
+
+test.beforeAll(async () => {
+  const result = await launchWithState(preConfig);
+  browser = result.browser;
+  page = result.page;
+  await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+});
+
+test.afterAll(async () => {
+  await browser?.close();
+});
+
+test.describe('showTaskNumbers: card ticket-number badge', () => {
+  test('is hidden by default (opt-in)', async () => {
+    const card = page.locator(`[data-task-id="${TASK_ID}"]`);
+    await expect(card).toBeVisible();
+    // Default is OFF, so the #N badge must not render.
+    await expect(card.locator('[data-testid="task-card-display-id"]')).toHaveCount(0);
+  });
+
+  test('renders #N matching display_id once enabled', async () => {
+    await setShowTaskNumbers(page, true);
+
+    const card = page.locator(`[data-task-id="${TASK_ID}"]`);
+    const badge = card.locator('[data-testid="task-card-display-id"]');
+    await expect(badge).toBeVisible({ timeout: 5000 });
+    await expect(badge).toHaveText(`#${DISPLAY_ID}`);
+
+    // Turning it back off hides the badge again (read path is reactive).
+    await setShowTaskNumbers(page, false);
+    await expect(card.locator('[data-testid="task-card-display-id"]')).toHaveCount(0);
+  });
+
+  test('compact (archived) card badge is hidden by default and shown once enabled', async () => {
+    // Coverage target: the `{displayIdBadge}` placed inside the `if (compact)` branch
+    // of TaskCard.tsx (rendered for archived tasks in DoneSwimlane's "Completed" list).
+    // Removing that single JSX expression from the compact branch -- while leaving the
+    // normal-branch badge intact -- makes this assertion time out (RED) while tests 1
+    // and 2 remain green. data-testid="compact-title" is only rendered by the compact
+    // branch, confirming we are exercising that code path.
+    const doneSwimlane = page.locator('[data-swimlane-name="Done"]');
+    await expect(doneSwimlane).toBeVisible({ timeout: 10000 });
+
+    const compactCard = page.locator(`[data-task-id="${COMPACT_TASK_ID}"]`);
+    // Verify we are in the compact branch: compact-title is a unique testid on line 189
+    // of TaskCard.tsx, present only inside `if (compact) { ... }`.
+    await expect(compactCard.locator('[data-testid="compact-title"]')).toBeVisible({ timeout: 5000 });
+
+    // Default is OFF: no badge.
+    await expect(compactCard.locator('[data-testid="task-card-display-id"]')).toHaveCount(0);
+
+    // Enable ticket numbers: compact badge appears with the correct display_id.
+    await setShowTaskNumbers(page, true);
+    const compactBadge = compactCard.locator('[data-testid="task-card-display-id"]');
+    await expect(compactBadge).toBeVisible({ timeout: 5000 });
+    await expect(compactBadge).toHaveText(`#${COMPACT_DISPLAY_ID}`);
+
+    // Disable again: badge gone.
+    await setShowTaskNumbers(page, false);
+    await expect(compactCard.locator('[data-testid="task-card-display-id"]')).toHaveCount(0);
+  });
+});

--- a/tests/unit/project-cache.test.ts
+++ b/tests/unit/project-cache.test.ts
@@ -57,6 +57,7 @@ function makeMinimalConfig(): AppConfig {
     boardLayout: 'horizontal',
     cardDensity: 'default',
     columnWidth: 'default',
+    showTaskNumbers: false,
     terminalPanelVisible: true,
     animationsEnabled: true,
     statusBarVisible: true,


### PR DESCRIPTION
## What

Adds an opt-in board setting that shows each task's ticket number (the `#N`
`display_id`) on its card.

- New global `AppConfig.showTaskNumbers` boolean (default `false`), surfaced as
  a "Ticket Numbers" toggle in the Layout settings tab.
- `TaskCard` renders `#N` as a muted monospace badge in the card header, in
  both the density-driven main path and the `compact`-prop path (archived cards
  in the Done lane preview).
- The badge matches the format and styling of the number already shown in the
  task detail header.

Affected: `src/shared/types.ts`, `src/renderer/components/board/TaskCard.tsx`,
`src/renderer/components/settings/settings-registry.ts`,
`src/renderer/components/settings/tabs/LayoutTab.tsx`, plus the headless mock,
docs, and tests.

## Why

Kangentic board task #8. Tickets can be referenced quickly from the board
without opening the detail dialog. The number is the stable `display_id`, the
same `#N` shown in the task detail view. It is opt-in (default off) so existing
boards are unchanged until a user turns it on.

## How

- `showTaskNumbers` rides the existing config get/set IPC path (no new channel,
  no migration, no board-config wiring; deep-merge over `DEFAULT_CONFIG` means
  old config files default to `false`).
- The card reads `state.config.showTaskNumbers` and renders a shared
  `displayIdBadge` in both render branches. The title gets `flex-1 min-w-0` so a
  long title truncates while the badge stays `shrink-0`, keeping the header
  clean.
- Styling mirrors the detail header (`font-mono text-xs text-fg-muted`).

## Breaking changes

None. New field defaults to `false`; behavior is unchanged unless enabled.

## Tests

- `tests/ui/task-card-display-id.spec.ts` (new): badge hidden by default, shows
  `#N` matching `display_id` when enabled, hides again when toggled off, across
  both the normal and the compact (archived) card render paths.
- `tests/ui/settings-panel.spec.ts`: asserts the "Ticket Numbers" toggle renders
  in the Layout tab.
- `tests/unit/project-cache.test.ts`: config helper includes the new field.
- `docs/configuration.md` updated; the doc-anchor audit confirmed AppConfig and
  the settings registry are fully enumerated.

Local typecheck and lint pass; the unit, UI, and Electron E2E tiers run as the
CI checks on this PR.

Generated with [Claude Code](https://claude.com/claude-code)
