### PR TITLE
feat(preview): show task title in header and pre-trust clone workspace

### DIFF
--- a/src/devtools/main/ephemeral-projects.ts
+++ b/src/devtools/main/ephemeral-projects.ts
@@ -31,6 +31,7 @@ import { promisify } from 'node:util';
 import { ipcMain } from 'electron';
 import { IPC } from '../../shared/ipc-channels';
 import { getProjectDb } from '../../main/db/database';
+import { agentRegistry } from '../../main/agent/agent-registry';
 import { DEFAULT_AGENT } from '../../shared/types';
 import type { Project } from '../../shared/types';
 import type { IpcContext } from '../../main/ipc/ipc-context';
@@ -93,6 +94,18 @@ export async function createPreviewClone(context: IpcContext, worktreePath: stri
   const project = context.projectRepo.create({ name: projectName, path: cloneDir, default_agent: DEFAULT_AGENT });
   // Initialize the project DB (tables + default swimlanes) so it shows a real board.
   getProjectDb(project.id);
+  // Pre-seed agent trust for the brand-new clone path BEFORE the board opens and any
+  // agent (or capability-detection probe) runs there. Without this, the clone lives at a
+  // path the agent CLI has never seen, so it treats the workspace as untrusted and ignores
+  // the committed .claude/settings.json permissions.allow entries. Going through the generic
+  // adapter (not a hardcoded Claude helper) keeps this agent-agnostic; each adapter merges into
+  // its own trust store (e.g. Claude's ~/.claude.json) under a serial lock, idempotent with the
+  // spawn-time call.
+  try {
+    await agentRegistry.get(project.default_agent)?.ensureTrust(cloneDir);
+  } catch (trustError) {
+    console.warn(`[DEV] Preview trust seeding failed for ${cloneDir}:`, trustError);
+  }
   // create() prepends at position 0; append so the sidebar keeps creation order.
   const orderedIds = context.projectRepo
     .list()

--- a/src/devtools/main/preview-task-title.ts
+++ b/src/devtools/main/preview-task-title.ts
@@ -1,0 +1,100 @@
+/**
+ * Dev-only: resolve the ORIGINAL task's title for a `/preview` window so the
+ * title bar can identify which task the (otherwise indistinguishable
+ * "Project 1" / "Project 2") preview clones belong to.
+ *
+ * The preview clones run a fresh seeded board DB, so the original task is NOT in
+ * any database the preview process opens. We recover it from the REAL
+ * (non-ephemeral) parent project DB: the worktree path encodes the task UUID
+ * prefix (`<slug>-<shortId>`, where shortId = taskId.slice(0, 8)), and
+ * getPlatformConfigDir() points at the real config dir even when
+ * KANGENTIC_DATA_DIR redirects everything else to the ephemeral data dir.
+ *
+ * Best-effort: any miss (no DB, no matching project/task, locked file) returns
+ * null and the header simply falls back to "Project N".
+ *
+ * Build-excluded from production: imported only behind __KANGENTIC_DEV__ guards
+ * (src/main/index.ts), so esbuild dead-code elimination drops this module from
+ * prod bundles. See `.claude/rules/dev-tooling-build-exclusion.md`.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { getPlatformConfigDir } from '../../main/config/paths';
+import { toForwardSlash } from '../../shared/paths';
+
+const WORKTREE_MARKER = '/.kangentic/worktrees/';
+
+/** True when two paths resolve to the same directory (drive-case / separator safe). */
+function samePath(first: string, second: string): boolean {
+  try {
+    return path.relative(path.resolve(first), path.resolve(second)) === '';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the original task's title for a preview worktree path, or null if it
+ * cannot be determined. Reads the real parent project DB read-only.
+ */
+export function resolvePreviewTaskTitle(worktreePath: string): string | null {
+  try {
+    if (!worktreePath) return null;
+    const normalizedWorktree = toForwardSlash(path.resolve(worktreePath));
+    const markerIndex = normalizedWorktree.indexOf(WORKTREE_MARKER);
+    if (markerIndex === -1) return null;
+
+    const parentRoot = normalizedWorktree.slice(0, markerIndex);
+    const folderName = normalizedWorktree.slice(markerIndex + WORKTREE_MARKER.length).split('/')[0];
+    // Worktree folders are `${slug}-${shortId}`, where shortId = taskId.slice(0, 8).
+    const shortIdMatch = folderName.match(/-([0-9a-f]{8})$/);
+    if (!shortIdMatch) return null;
+    const shortId = shortIdMatch[1];
+
+    const configDir = getPlatformConfigDir();
+    const projectId = findProjectId(path.join(configDir, 'index.db'), parentRoot);
+    if (!projectId) return null;
+
+    return findTaskTitle(path.join(configDir, 'projects', `${projectId}.db`), shortId, worktreePath);
+  } catch {
+    return null;
+  }
+}
+
+/** Look up the parent project's id by its root path in the real global DB. */
+function findProjectId(globalDbPath: string, parentRoot: string): string | null {
+  if (!fs.existsSync(globalDbPath)) return null;
+  const db = new Database(globalDbPath, { readonly: true, fileMustExist: true });
+  try {
+    const rows = db.prepare('SELECT id, path FROM projects').all() as Array<{ id: string; path: string }>;
+    const match = rows.find((row) => samePath(row.path, parentRoot));
+    return match ? match.id : null;
+  } finally {
+    db.close();
+  }
+}
+
+/** Look up the task title by UUID prefix (primary) or stored worktree path (fallback). */
+function findTaskTitle(projectDbPath: string, shortId: string, worktreePath: string): string | null {
+  if (!fs.existsSync(projectDbPath)) return null;
+  const db = new Database(projectDbPath, { readonly: true, fileMustExist: true });
+  try {
+    // shortId is 8 hex chars containing no LIKE metacharacters, so the trailing `%` is the
+    // only wildcard and needs no escaping. A UUIDv4 prefix collision within one project is
+    // astronomically unlikely; LIMIT 1 takes the first match.
+    const taskByIdPrefix = db.prepare('SELECT title FROM tasks WHERE id LIKE ? LIMIT 1').get(`${shortId}%`) as
+      | { title: string }
+      | undefined;
+    if (taskByIdPrefix?.title) return taskByIdPrefix.title;
+
+    const rows = db
+      .prepare('SELECT title, worktree_path FROM tasks WHERE worktree_path IS NOT NULL')
+      .all() as Array<{ title: string; worktree_path: string }>;
+    const match = rows.find((row) => samePath(row.worktree_path, worktreePath));
+    return match ? match.title : null;
+  } finally {
+    db.close();
+  }
+}

--- a/src/main/config/paths.ts
+++ b/src/main/config/paths.ts
@@ -24,7 +24,7 @@ function getDataDirFromArgs(): string | null {
  * its immutable, shared weights survive per-instance data dirs (the ephemeral
  * preview, a relocated data dir) instead of re-downloading.
  */
-function getPlatformConfigDir(): string {
+export function getPlatformConfigDir(): string {
   const platform = process.platform;
   let base: string;
   if (platform === 'win32') {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,6 +7,7 @@ import { registerAllIpc, getSessionManager, getTerminalSubmitScheduler, getBoard
 import { installDiagnostics } from './diagnostics/install';
 // Dev-only (dropped from prod via __KANGENTIC_DEV__ dead-code elimination).
 import { createPreviewClone, fillPreviewClone, registerEphemeralProjectDevIpc } from '../devtools/main/ephemeral-projects';
+import { resolvePreviewTaskTitle } from '../devtools/main/preview-task-title';
 import { registerSeedGitChangesDevIpc } from '../devtools/main/seed-git-changes';
 import { installDevtools } from '../devtools/install';
 import { startMcpHttpServer, type McpHttpServerHandle } from './agent/mcp-http-server';
@@ -177,6 +178,19 @@ const appLaunchTime = Date.now();
 const isEphemeral = process.argv.includes('--ephemeral');
 const isE2ETest = process.env.NODE_ENV === 'test';
 
+// Dev-only: the original task's title for a `/preview` window, resolved once from
+// the real parent project DB (the preview clones never contain it). Surfaced to the
+// renderer via additionalArguments so the title bar can identify the task both clones
+// belong to. Memoized; null outside dev-preview or when resolution misses (graceful).
+let cachedPreviewTaskTitle: string | null | undefined;
+function getPreviewTaskTitle(): string | null {
+  if (cachedPreviewTaskTitle === undefined) {
+    cachedPreviewTaskTitle =
+      __KANGENTIC_DEV__ && isEphemeral ? resolvePreviewTaskTitle(getCwdArg() ?? '') : null;
+  }
+  return cachedPreviewTaskTitle;
+}
+
 // Harden any <webview> tags attached to the renderer (embedded browser pane).
 // `will-attach-webview` fires before the webview is created and lets us
 // strip dangerous webPreferences and validate the initial src. The
@@ -325,6 +339,10 @@ const createWindow = () => {
 
   const savedBounds = resolveWindowBounds();
 
+  // Dev-preview only: resolve once (memoized) so the additionalArguments spread below reads a
+  // single local instead of calling getPreviewTaskTitle() twice (and dropping the non-null `!`).
+  const previewTaskTitle = __KANGENTIC_DEV__ && isEphemeral ? getPreviewTaskTitle() : null;
+
   mainWindow = new BrowserWindow({
     icon: iconImage,
     ...(savedBounds ? savedBounds : { width: 1400, height: 900 }),
@@ -341,10 +359,20 @@ const createWindow = () => {
       // Enable <webview> for the embedded browser side-pane in the task-detail
       // window. Hardened via the will-attach-webview hook below.
       webviewTag: true,
-      // Surface the ephemeral-preview flag to the renderer (read in preload via
-      // process.argv). Set ONLY in dev-preview mode (`--ephemeral`), so the dev
-      // TestHarness stays out of the regular `npm start` dogfood.
-      additionalArguments: __KANGENTIC_DEV__ && isEphemeral ? ['--kangentic-ephemeral'] : [],
+      // Surface the ephemeral-preview flag (and, when resolvable, the original task
+      // title) to the renderer (read in preload via process.argv). Set ONLY in
+      // dev-preview mode (`--ephemeral`), so the dev TestHarness and the preview title
+      // stay out of the regular `npm start` dogfood. The title is base64-encoded so a
+      // value with spaces / `:` / `/` survives command-line round-tripping intact.
+      additionalArguments:
+        __KANGENTIC_DEV__ && isEphemeral
+          ? [
+              '--kangentic-ephemeral',
+              ...(previewTaskTitle
+                ? [`--kangentic-preview-task-title=${Buffer.from(previewTaskTitle, 'utf-8').toString('base64')}`]
+                : []),
+            ]
+          : [],
     },
   });
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -438,10 +438,19 @@ if (__KANGENTIC_DEV__) {
   // BrowserWindow `additionalArguments`) ONLY in dev-preview mode, so this is
   // true for `/preview` and false for the regular `npm start` dogfood.
   const isEphemeralPreview = process.argv.includes('--kangentic-ephemeral');
+  // The original task title (base64-encoded in the BrowserWindow additionalArguments by
+  // main) so the title bar can identify which task the preview clones belong to. Null
+  // when not in preview, or when main could not resolve it.
+  const PREVIEW_TITLE_FLAG = '--kangentic-preview-task-title=';
+  const previewTitleArg = process.argv.find((arg) => arg.startsWith(PREVIEW_TITLE_FLAG));
+  const previewTaskTitle = previewTitleArg
+    ? Buffer.from(previewTitleArg.slice(PREVIEW_TITLE_FLAG.length), 'base64').toString('utf-8')
+    : null;
   api.dev = {
     createEphemeralProject: () => ipcRenderer.invoke(IPC.DEV_CREATE_EPHEMERAL_PROJECT),
     seedGitChanges: (targetPaths: string[]) => ipcRenderer.invoke(IPC.DEV_SEED_GIT_CHANGES, targetPaths),
     isEphemeralPreview,
+    previewTaskTitle,
   };
 }
 

--- a/src/renderer/components/layout/TitleBar.tsx
+++ b/src/renderer/components/layout/TitleBar.tsx
@@ -162,6 +162,23 @@ export function TitleBar({ onQuickSession, onOpenSearch, commandBarOpen, canSpaw
       <div className="flex items-center gap-1.5 flex-shrink-0">
         <img src={logoSrc} alt="Kangentic" className="w-5 h-5" />
         <span className="text-sm font-semibold text-fg-secondary">Kangentic</span>
+        {/*
+          Dev-only (preview): the original task's title after the wordmark, in a muted
+          pill (raised surface + edge border) so it stands out without the low-contrast
+          of a colored fill, so each preview window is identifiable when several are open
+          ("Project N" still tells the two clones apart). Shown in full (no truncation,
+          by request). Surface/edge/fg tokens re-color across all themes. Built out of
+          prod by __KANGENTIC_DEV__; previewTaskTitle is non-null only in `/preview`, so
+          its truthiness gates the render.
+        */}
+        {__KANGENTIC_DEV__ && window.electronAPI.dev?.previewTaskTitle && (
+          <span
+            className="ml-1 px-2.5 py-0.5 rounded-full bg-surface-raised border border-edge text-fg-secondary text-sm font-semibold whitespace-nowrap"
+            title={window.electronAPI.dev.previewTaskTitle}
+          >
+            {window.electronAPI.dev.previewTaskTitle}
+          </span>
+        )}
       </div>
 
       {/* Centered project name */}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2586,6 +2586,12 @@ export interface ElectronAPI {
     seedGitChanges: (targetPaths: string[]) => Promise<DevSeedGitChangesResult>;
     /** True only in dev-preview (`/preview`, `--ephemeral`); false in the regular dogfood. */
     isEphemeralPreview: boolean;
+    /**
+     * The original task's title for a `/preview` window, so the title bar can identify
+     * which task the "Project 1" / "Project 2" clones belong to. Null outside preview, or
+     * when main could not resolve it from the parent project DB.
+     */
+    previewTaskTitle: string | null;
   };
   // Projects
   projects: {

--- a/tests/unit/preview-task-title.test.ts
+++ b/tests/unit/preview-task-title.test.ts
@@ -144,6 +144,17 @@ describe('resolvePreviewTaskTitle', () => {
     expect(resolvePreviewTaskTitle(worktreePath(`improve-preview-dev-${SHORT_ID}`))).toBeNull();
   });
 
+  it('returns null when the global DB exists and a project matches but the project DB is absent', () => {
+    // findProjectId succeeds (global DB present, project row matches), but the per-project
+    // DB file does not exist on disk, so findTaskTitle's fs.existsSync guard fires.
+    mockState.projectsRows = [{ id: PROJECT_ID, path: projectRoot }];
+    mockState.tasksRows = [{ id: TASK_ID, title: 'Improve /preview dev UX', worktree_path: null }];
+    // Touch only the global DB; leave the project DB absent.
+    touchDbFiles(true, false);
+
+    expect(resolvePreviewTaskTitle(worktreePath(`improve-preview-dev-${SHORT_ID}`))).toBeNull();
+  });
+
   it('returns null for an empty worktree path', () => {
     expect(resolvePreviewTaskTitle('')).toBeNull();
   });

--- a/tests/unit/preview-task-title.test.ts
+++ b/tests/unit/preview-task-title.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for resolvePreviewTaskTitle() - recovers the original task's title
+ * for a `/preview` window from the real parent project DB (the preview clones
+ * never contain it).
+ *
+ * better-sqlite3 is compiled for Electron's Node ABI and cannot load under
+ * vitest's system Node (same constraint as task-repository.test.ts), so the
+ * DB is mocked and serves canned rows. The valuable logic under test is the
+ * real resolver's path handling: worktrees-marker detection, the
+ * `<slug>-<shortId>` task-id-prefix extraction, project-root matching, and the
+ * id-prefix vs worktree_path fallback. getPlatformConfigDir() is redirected to
+ * a temp dir whose placeholder DB files make fs.existsSync() pass.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// Hoisted mutable state the mocks read at call time.
+const mockState = vi.hoisted(() => ({
+  configDir: '',
+  projectsRows: [] as Array<{ id: string; path: string }>,
+  tasksRows: [] as Array<{ id: string; title: string; worktree_path: string | null }>,
+}));
+
+vi.mock('../../src/main/config/paths', async () => {
+  const actual = await vi.importActual<typeof import('../../src/main/config/paths')>(
+    '../../src/main/config/paths',
+  );
+  return { ...actual, getPlatformConfigDir: () => mockState.configDir };
+});
+
+// Fake better-sqlite3 Database that routes by SQL to the canned rows.
+vi.mock('better-sqlite3', () => {
+  class FakeStatement {
+    constructor(private readonly sql: string) {}
+    all() {
+      if (this.sql.includes('FROM projects')) return mockState.projectsRows;
+      if (this.sql.includes('FROM tasks')) return mockState.tasksRows.filter((task) => task.worktree_path !== null);
+      return [];
+    }
+    get(boundArg?: unknown) {
+      if (this.sql.includes('FROM tasks') && this.sql.includes('LIKE')) {
+        const prefix = String(boundArg).replace(/%$/, '');
+        return mockState.tasksRows.find((task) => task.id.startsWith(prefix));
+      }
+      return undefined;
+    }
+  }
+  class FakeDatabase {
+    prepare(sql: string) {
+      return new FakeStatement(sql);
+    }
+    close() {}
+  }
+  return { default: FakeDatabase };
+});
+
+import { resolvePreviewTaskTitle } from '../../src/devtools/main/preview-task-title';
+
+const PROJECT_ID = 'project-under-test';
+const TASK_ID = '7f45c661-4380-4499-b44b-963413c63abd';
+const SHORT_ID = TASK_ID.slice(0, 8); // 7f45c661
+
+let projectRoot: string;
+
+/** Touch placeholder DB files so the resolver's fs.existsSync() guards pass. */
+function touchDbFiles(globalDb: boolean, projectDb: boolean): void {
+  if (globalDb) fs.writeFileSync(path.join(mockState.configDir, 'index.db'), '');
+  if (projectDb) {
+    fs.mkdirSync(path.join(mockState.configDir, 'projects'), { recursive: true });
+    fs.writeFileSync(path.join(mockState.configDir, 'projects', `${PROJECT_ID}.db`), '');
+  }
+}
+
+function worktreePath(folderName: string): string {
+  return path.join(projectRoot, '.kangentic', 'worktrees', folderName);
+}
+
+beforeEach(() => {
+  mockState.configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'preview-title-config-'));
+  projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'preview-title-root-'));
+  mockState.projectsRows = [];
+  mockState.tasksRows = [];
+});
+
+afterEach(() => {
+  fs.rmSync(mockState.configDir, { recursive: true, force: true });
+  fs.rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe('resolvePreviewTaskTitle', () => {
+  it('resolves the title by task UUID prefix from the worktree folder', () => {
+    mockState.projectsRows = [{ id: PROJECT_ID, path: projectRoot }];
+    mockState.tasksRows = [{ id: TASK_ID, title: 'Improve /preview dev UX', worktree_path: null }];
+    touchDbFiles(true, true);
+
+    expect(resolvePreviewTaskTitle(worktreePath(`improve-preview-dev-${SHORT_ID}`))).toBe(
+      'Improve /preview dev UX',
+    );
+  });
+
+  it('falls back to matching the stored worktree_path when the id prefix misses', () => {
+    const folder = 'custom-branch-aaaaaaaa'; // shortId "aaaaaaaa" matches no task id
+    mockState.projectsRows = [{ id: PROJECT_ID, path: projectRoot }];
+    mockState.tasksRows = [
+      { id: 'deadbeef-0000-0000-0000-000000000000', title: 'Wrong task', worktree_path: null },
+      { id: 'feedface-1111-1111-1111-111111111111', title: 'Right task', worktree_path: worktreePath(folder) },
+    ];
+    touchDbFiles(true, true);
+
+    expect(resolvePreviewTaskTitle(worktreePath(folder))).toBe('Right task');
+  });
+
+  it('returns null when the path is not inside a worktrees dir', () => {
+    mockState.projectsRows = [{ id: PROJECT_ID, path: projectRoot }];
+    mockState.tasksRows = [{ id: TASK_ID, title: 'Improve /preview dev UX', worktree_path: null }];
+    touchDbFiles(true, true);
+
+    expect(resolvePreviewTaskTitle(path.join(projectRoot, 'not', 'a', 'worktree'))).toBeNull();
+  });
+
+  it('returns null when no project matches the parent root', () => {
+    mockState.projectsRows = [{ id: PROJECT_ID, path: path.join(os.tmpdir(), 'some-other-root') }];
+    mockState.tasksRows = [{ id: TASK_ID, title: 'Improve /preview dev UX', worktree_path: null }];
+    touchDbFiles(true, true);
+
+    expect(resolvePreviewTaskTitle(worktreePath(`improve-preview-dev-${SHORT_ID}`))).toBeNull();
+  });
+
+  it('returns null when no task matches by id prefix or worktree path', () => {
+    mockState.projectsRows = [{ id: PROJECT_ID, path: projectRoot }];
+    mockState.tasksRows = [{ id: 'deadbeef-0000-0000-0000-000000000000', title: 'Wrong task', worktree_path: null }];
+    touchDbFiles(true, true);
+
+    expect(resolvePreviewTaskTitle(worktreePath(`improve-preview-dev-${SHORT_ID}`))).toBeNull();
+  });
+
+  it('returns null on a missing global DB (graceful fallback to "Project N")', () => {
+    mockState.projectsRows = [{ id: PROJECT_ID, path: projectRoot }];
+    mockState.tasksRows = [{ id: TASK_ID, title: 'Improve /preview dev UX', worktree_path: null }];
+    // No DB files touched -> fs.existsSync(index.db) is false.
+
+    expect(resolvePreviewTaskTitle(worktreePath(`improve-preview-dev-${SHORT_ID}`))).toBeNull();
+  });
+
+  it('returns null for an empty worktree path', () => {
+    expect(resolvePreviewTaskTitle('')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Two dev-only `/preview` papercuts, both behind `__KANGENTIC_DEV__` (nothing ships to production):

- **Task title in the preview header.** The original task's title now renders in a muted pill after the "Kangentic" wordmark, so each preview window is identifiable when several are open. The centered "Project N" still distinguishes the two clones.
- **Pre-trust the preview clone workspace.** Each preview clone is now trusted before any agent runs there, so the committed `.claude/settings.json` `permissions.allow` entries are honored.

Affected components: `src/devtools/main/` (new `preview-task-title.ts` resolver, trust seeding in `ephemeral-projects.ts`), `src/main/index.ts` (resolve + forward), `src/preload/preload.ts` (expose), `src/shared/types.ts` (type), `src/main/config/paths.ts` (export `getPlatformConfigDir`), `src/renderer/components/layout/TitleBar.tsx` (render).

## Why

- The preview opens two clones hardcoded as "Project 1" / "Project 2". With multiple previews open it was impossible to tell which window mapped to which task.
- Each clone lives at a brand-new path (`.kangentic/data/preview-projects/project-N`) that Claude Code has never seen, so it treated the workspace as untrusted and **ignored all `permissions.allow` entries** from the committed settings. The agent spawned in a preview then ran without the project allow-list, a real behavioral regression, not just the warning flash.

## How

- **Title:** the clones run a fresh seeded board, so the task is not in the clone DB. It is resolved from the REAL parent project DB: the worktree path encodes the task UUID prefix (`<slug>-<shortId>`), and `getPlatformConfigDir()` reaches the real config dir even though `KANGENTIC_DATA_DIR` redirects everything else to the ephemeral data dir. The resolved title is threaded to the renderer base64-encoded via the BrowserWindow `additionalArguments`, the same channel as `--kangentic-ephemeral`. Resolution is best-effort: any miss falls back to "Project N" exactly as before.
- **Trust:** seeded in `createPreviewClone` via the generic `adapter.ensureTrust(cloneDir)` (not a hardcoded Claude helper, respecting `agent-adapters-boundary.md`). One call covers Project 1, Project 2, and on-demand clones; it is strictly earlier and broader than the existing spawn-time `ensureTrust`, and idempotent with it.
- Both surfaces are gated by `__KANGENTIC_DEV__` (build-time dead-code elimination) and, at runtime, by the preview-only flags, so the normal `npm start` dogfood and production are unchanged.

## Breaking changes

None.

## Tests

- New unit test `tests/unit/preview-task-title.test.ts` (8 cases) for the title resolver: marker detection, `<slug>-<shortId>` extraction, project-root matching, the id-prefix vs `worktree_path` fallback, and graceful `null` returns (mocks `better-sqlite3` per the vitest convention, since it cannot load under system Node).
- Verified locally: `npm run typecheck`, `npm run lint`, and a production `npm run build` confirming the preview code is dead-code-eliminated (0 occurrences in `.vite/build`).
- CI: lint, typecheck, unit, build, UI shards, and the Linux Electron E2E shards.

Generated with [Claude Code](https://claude.com/claude-code)
