### PR TITLE
perf(mcp): trim per-agent context tokens injected by the MCP server

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -444,7 +444,7 @@ These **shipped** tools let an agent drive the embedded **Browser pane** of a ta
 
 Targeting: every tool takes an optional `sessionId` or `taskId`; omit both to use the single open pane (errors with candidates when more than one is open). `kangentic_browser_list_panes` lists open panes.
 
-Gating: the global **Agent Browser** settings tab controls the family, read live per call. `browserAutomation.enabled` is the master switch; `allowInteraction` gates click/type/keypress/drag (off = observe-only); `allowNavigation` gates navigate; `allowEval` gates eval (off by default); `restrictNavigationToLocalhost` confines navigation to localhost/private hosts (off by default). Each tool returns an actionable `{ kind, detail }` error when its capability is gated off or no driveable pane exists.
+Gating: the global **Agent Browser** settings tab controls the family, read live per request. `browserAutomation.enabled` is the master switch: when off, the entire `kangentic_browser_*` family is not registered, so the tools never appear in `tools/list` and the instructions omit their guidance section (they would be unusable anyway, and advertising them is wasted context). When `enabled` is on, the sub-capability gates apply: `allowInteraction` gates click/type/keypress/drag (off = observe-only); `allowNavigation` gates navigate; `allowEval` gates eval (off by default); `restrictNavigationToLocalhost` confines navigation to localhost/private hosts (off by default). With `enabled` on, each tool returns an actionable `{ kind, detail }` error when one of those sub-capabilities is gated off or no driveable pane exists.
 
 Tool categories:
 - **Discovery:** `list_panes`

--- a/src/main/agent/mcp-http-server.ts
+++ b/src/main/agent/mcp-http-server.ts
@@ -147,6 +147,50 @@ export function closeMcpHttpServerSafely(httpServer: Pick<Server, 'closeAllConne
   }
 }
 
+/**
+ * Build a fully-configured per-request McpServer: instructions + every tool
+ * family registered. Exported so the registration and policy gating are
+ * unit-testable without booting the HTTP server.
+ *
+ * The kangentic_browser_* family is registered (and its instructions section
+ * emitted) ONLY when browser automation is enabled in settings. When it is off,
+ * every CDP-driving browser tool is already blocked by the withGuest capability
+ * gate, and the one non-gated tool (kangentic_browser_list_panes) could only
+ * report panes the agent cannot act on, so advertising the ~14 unusable tools
+ * would just inject ~3.6k tokens of dead schema into every agent's context. The
+ * policy is read once here, per request, so a Settings toggle takes effect on
+ * the next agent session.
+ */
+export function buildConfiguredMcpServer(
+  resolver: RequestResolver,
+  taskCounter: TaskCounter,
+  getBrowserAutomationConfig: AutomationConfigReader,
+): McpServer {
+  const browserAutomationEnabled = getBrowserAutomationConfig().enabled;
+  const instructions = buildServerInstructions(resolver, browserAutomationEnabled);
+  const mcpServer = new McpServer(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    { instructions },
+  );
+  registerTaskTools(mcpServer, resolver, taskCounter);
+  registerSessionTools(mcpServer, resolver);
+  registerProjectTools(mcpServer, resolver);
+  registerSearchTools(mcpServer, resolver);
+  registerDiagnosticsTools(mcpServer, resolver);
+  if (browserAutomationEnabled) {
+    registerBrowserTools(mcpServer, getBrowserAutomationConfig);
+  }
+
+  // Dev-only: register the kangentic_devtools_* tools that drive the localhost
+  // inspection bridge. Production builds drop both the import (top of file) and
+  // this call via `__KANGENTIC_DEV__` dead-code elimination.
+  if (__KANGENTIC_DEV__) {
+    registerDevtoolsMcpTools(mcpServer);
+  }
+
+  return mcpServer;
+}
+
 /** Validates the URL path and token, then dispatches to a per-request McpServer. */
 async function handleHttpRequest(
   req: IncomingMessage,
@@ -194,35 +238,13 @@ async function handleHttpRequest(
     return;
   }
 
-  // Per-request McpServer + transport. Stateless mode, plain JSON
-  // responses (no SSE), built-in DNS rebinding protection on top of the
-  // 127.0.0.1 bind for belt-and-suspenders.
-  //
-  // `instructions` is surfaced to the agent at initialize time (Claude
-  // Code renders it as `## kangentic` in its system prompt). We build it
-  // per-request so the active-project name and registered-project list
-  // reflect the current DB state, not whatever was true at launch.
-  const instructions = buildServerInstructions(resolver);
-  const mcpServer = new McpServer(
-    { name: SERVER_NAME, version: SERVER_VERSION },
-    { instructions },
-  );
-  registerTaskTools(mcpServer, resolver, taskCounter);
-  registerSessionTools(mcpServer, resolver);
-  registerProjectTools(mcpServer, resolver);
-  registerSearchTools(mcpServer, resolver);
-  registerDiagnosticsTools(mcpServer, resolver);
-  // Shipped: the user-facing kangentic_browser_* family that drives the
-  // embedded Browser pane in-process. Registered unconditionally (NOT gated
-  // by __KANGENTIC_DEV__) - this targets the user's own dev server.
-  registerBrowserTools(mcpServer, getBrowserAutomationConfig);
-
-  // Dev-only: register the kangentic_devtools_* tools that drive the
-  // localhost inspection bridge. Production builds drop both the import
-  // (above) and this call via `__KANGENTIC_DEV__` dead-code elimination.
-  if (__KANGENTIC_DEV__) {
-    registerDevtoolsMcpTools(mcpServer);
-  }
+  // Per-request McpServer + transport. Stateless mode, plain JSON responses
+  // (no SSE), built-in DNS rebinding protection on top of the 127.0.0.1 bind
+  // for belt-and-suspenders. The server is rebuilt per request so the
+  // instructions (active-project name, registered-project list) and the
+  // browser-tool gating reflect current DB / settings state (see
+  // buildConfiguredMcpServer).
+  const mcpServer = buildConfiguredMcpServer(resolver, taskCounter, getBrowserAutomationConfig);
 
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: undefined,

--- a/src/main/agent/mcp-http/handler-helpers.ts
+++ b/src/main/agent/mcp-http/handler-helpers.ts
@@ -20,8 +20,15 @@ export interface McpToolResult {
  * cross-project-aware MCP tool accepts. Lives here so task-tools and
  * session-tools import one source of truth.
  */
+// Kept deliberately concise: the full cross-project routing rule (including
+// how project mentions are phrased) lives once in the server `instructions`
+// string (server-instructions.ts, "PROJECT ROUTING RULE"), which is in every
+// agent's system prompt, and create_task carries its own routing guidance plus
+// a runtime guardrail. Repeating the full paragraph on all ~28 project-aware
+// tools added ~4.5k tokens of duplicated context to every spawned agent; this
+// pointer keeps the behavioral trigger while shedding the duplication.
 export const PROJECT_SELECTOR_DESCRIPTION =
-  'Optional project selector. Pass a project name (case-insensitive exact) or project UUID to route this call to a different project than the one the MCP client is bound to. If the user\'s request names another Kangentic project, pass that name here instead of omitting - do not rely on the active default when the prompt specifies a different target. The name counts however it is phrased, not just the explicit "create a task in X" form: treat "in X", "in the X board", "on X\'s board", "the X to do", "X\'s backlog", and "add it to X" as all targeting project X. Use kangentic_list_projects to discover valid selectors. Omit to target the active project.';
+  'Optional project name (case-insensitive exact) or UUID to target a different project than the active one. Set it whenever the user\'s request names another registered project; omit for the active project. See the server instructions ("PROJECT ROUTING RULE") for how mentions are phrased, and kangentic_list_projects for valid names.';
 
 /**
  * Atomic create_task rate-limit counter shared across all requests served

--- a/src/main/agent/mcp-http/server-instructions.ts
+++ b/src/main/agent/mcp-http/server-instructions.ts
@@ -60,7 +60,18 @@ function buildBrowserSection(activeProjectId: string | null): string[] {
   return lines;
 }
 
-export function buildServerInstructions(resolver: RequestResolver): string {
+/**
+ * @param browserAutomationEnabled When false, the BROWSER VERIFICATION section
+ *   is omitted because the `kangentic_browser_*` tools are not registered (the
+ *   global policy blocks them). Keeps the instructions consistent with the
+ *   advertised tool set and sheds the section's tokens for opt-out users.
+ *   Defaults to true so callers that do not gate on the policy (e.g. tests) get
+ *   the section as before.
+ */
+export function buildServerInstructions(
+  resolver: RequestResolver,
+  browserAutomationEnabled = true,
+): string {
   const projects = resolver.listProjects();
   const active = projects.find((project) => project.isActive);
   // Normalise every embedded name through the same sanitizer used by the
@@ -84,7 +95,9 @@ export function buildServerInstructions(resolver: RequestResolver): string {
     'When a kangentic_create_task or kangentic_update_task call carries both a long description (roughly 1KB or more) and labels, the labels can be dropped before they reach the server. To make labels stick, set them in a separate labels-only kangentic_update_task call after creating or updating the task with the long description.',
   ];
 
-  lines.push('', ...buildBrowserSection(active?.id ?? null));
+  if (browserAutomationEnabled) {
+    lines.push('', ...buildBrowserSection(active?.id ?? null));
+  }
 
   if (projects.length > 0) {
     lines.push('', 'Registered projects (use any name or id below as the `project` argument):');

--- a/tests/unit/mcp-server-config-gating.test.ts
+++ b/tests/unit/mcp-server-config-gating.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Guards two MCP context-weight optimizations that trim the fixed token cost
+ * every spawned agent pays (tool schemas + instructions live in the agent's
+ * system prompt):
+ *
+ *   1. The kangentic_browser_* family (~14 tools, ~3.6k tokens) is registered
+ *      ONLY when browser automation is enabled. When it is off, every
+ *      CDP-driving tool is already blocked by the withGuest capability gate (and
+ *      the one non-gated tool, list_panes, could only report panes the agent
+ *      cannot act on), so advertising them is dead context. Red-green: on the
+ *      old unconditional path the disabled server still exposes browser tools;
+ *      on the gated path it does not.
+ *   2. The per-tool `project` selector description is a concise pointer, not the
+ *      full routing paragraph repeated on ~28 tools (~4.5k tokens of dup). The
+ *      full rule lives once in the server instructions. Red-green: the old
+ *      paragraph repeated the phrasing examples per tool; the new one defers
+ *      them to the instructions.
+ *
+ * Heavy leaf modules are stubbed so mcp-http-server imports under node.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  webContents: { fromId: () => null },
+  app: { getPath: () => '/tmp', isPackaged: false },
+}));
+vi.mock('../../src/main/agent/commands', () => ({ commandHandlers: {} }));
+vi.mock('../../src/main/agent/mcp-project-context', () => ({
+  buildCommandContextForProject: vi.fn(() => null),
+}));
+vi.mock('../../src/main/search/search-core', () => ({ runSearchEverything: vi.fn() }));
+vi.mock('../../src/main/diagnostics/process-metrics', () => ({ getProcessMetrics: vi.fn() }));
+vi.mock('../../src/main/git/worktree-list', () => ({ enumerateWorktrees: vi.fn() }));
+vi.mock('../../src/main/browser/browser-pane-driver', () => ({
+  withGuest: vi.fn(),
+  validateNavigationUrl: vi.fn(),
+}));
+vi.mock('../../src/main/browser/browser-pane-registry', () => ({
+  browserPaneRegistry: { list: () => [] },
+}));
+vi.mock('../../src/main/browser/cdp/cdp', () => ({
+  clickAtCenterOfSelector: vi.fn(),
+  dispatchMouseEvent: vi.fn(),
+  dispatchKeyEvent: vi.fn(),
+  dispatchKeypress: vi.fn(),
+  dragFromTo: vi.fn(),
+  getOuterHtml: vi.fn(),
+  getBoundingBox: vi.fn(),
+  getConsoleEntries: vi.fn(),
+  getLayoutMetrics: vi.fn(),
+  queryAllElements: vi.fn(),
+  runtimeEvaluate: vi.fn(),
+  typeText: vi.fn(),
+}));
+vi.mock('../../src/main/browser/cdp/screenshot', () => ({
+  captureScreenshotWithBudget: vi.fn(),
+  captureElementClip: vi.fn(),
+}));
+vi.mock('../../src/devtools/mcp/register', () => ({ registerDevtoolsMcpTools: vi.fn() }));
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { buildConfiguredMcpServer } from '../../src/main/agent/mcp-http-server';
+import { buildServerInstructions } from '../../src/main/agent/mcp-http/server-instructions';
+import { PROJECT_SELECTOR_DESCRIPTION, type TaskCounter } from '../../src/main/agent/mcp-http/handler-helpers';
+import type { RequestResolver } from '../../src/main/agent/mcp-http/project-resolver';
+import type { ResolvedBrowserAutomationConfig } from '../../src/main/browser/browser-automation-config';
+
+function makeResolver(): RequestResolver {
+  return {
+    listProjects: () => [
+      { id: 'p1', name: 'Alpha', path: '/p1', lastOpened: '2026-01-01T00:00:00.000Z', isActive: true },
+    ],
+    resolveProject: () => ({ error: 'unused in this test' }),
+  } as unknown as RequestResolver;
+}
+
+const fakeTaskCounter: TaskCounter = { tryReserve: () => true, limit: () => 100 };
+
+function configReader(enabled: boolean): () => ResolvedBrowserAutomationConfig {
+  return () => ({
+    enabled,
+    allowInteraction: true,
+    allowNavigation: true,
+    allowEval: false,
+    restrictNavigationToLocalhost: false,
+  });
+}
+
+/** Build a configured server and read its advertised tool names via the public client API. */
+async function listToolNames(browserEnabled: boolean): Promise<string[]> {
+  const server = buildConfiguredMcpServer(
+    makeResolver(),
+    fakeTaskCounter,
+    configReader(browserEnabled),
+  );
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'guard', version: '1.0.0' });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  const { tools } = await client.listTools();
+  await client.close();
+  await server.close();
+  return tools.map((tool) => tool.name);
+}
+
+describe('buildConfiguredMcpServer - browser tool gating', () => {
+  it('registers the kangentic_browser_* family when browser automation is enabled', async () => {
+    const names = await listToolNames(true);
+    expect(names.some((name) => name.startsWith('kangentic_browser_'))).toBe(true);
+    // Core tools are always present.
+    expect(names).toContain('kangentic_create_task');
+  });
+
+  it('omits the kangentic_browser_* family when browser automation is disabled', async () => {
+    const enabled = await listToolNames(true);
+    const disabled = await listToolNames(false);
+
+    expect(disabled.some((name) => name.startsWith('kangentic_browser_'))).toBe(false);
+    // Disabling browser automation drops ONLY the browser family - nothing else.
+    expect(disabled).toContain('kangentic_create_task');
+    const browserCount = enabled.filter((name) => name.startsWith('kangentic_browser_')).length;
+    expect(browserCount).toBeGreaterThan(0);
+    expect(enabled.length - disabled.length).toBe(browserCount);
+  });
+});
+
+describe('project-selector description dedup', () => {
+  it('is a concise pointer and defers the phrasing examples to the server instructions', () => {
+    // The repeated routing paragraph (with "X's backlog" et al.) must NOT be
+    // duplicated onto every project-aware tool.
+    expect(PROJECT_SELECTOR_DESCRIPTION).not.toContain("X's backlog");
+    expect(PROJECT_SELECTOR_DESCRIPTION.length).toBeLessThan(420);
+    // ...but the full routing rule (examples included) must still exist exactly
+    // once, in the server instructions that ride in every agent's system prompt.
+    const instructions = buildServerInstructions(makeResolver());
+    expect(instructions).toContain('PROJECT ROUTING RULE');
+    expect(instructions).toContain("X's backlog");
+  });
+});

--- a/tests/unit/mcp-server-instructions-browser.test.ts
+++ b/tests/unit/mcp-server-instructions-browser.test.ts
@@ -132,6 +132,25 @@ describe('buildServerInstructions - browser section', () => {
     expect(instructions).toContain('Browser pill in the task header');
   });
 
+  it('omits the entire BROWSER VERIFICATION section when browser automation is disabled', () => {
+    // When the policy is off, the kangentic_browser_* tools are not registered,
+    // so the section must not advertise tools the agent cannot call (and its
+    // tokens are shed). The rest of the instructions are unaffected.
+    fakeList.mockReturnValue([makePane({ taskId: 'task-abc' })]);
+    const instructions = buildServerInstructions(ACTIVE_RESOLVER, false);
+
+    expect(instructions).not.toContain('BROWSER VERIFICATION');
+    expect(instructions).not.toContain('kangentic_browser_list_panes');
+    expect(instructions).not.toContain('A Browser pane is currently open');
+    // Non-browser content survives.
+    expect(instructions).toContain('PROJECT ROUTING RULE');
+  });
+
+  it('includes the BROWSER VERIFICATION section when browser automation is enabled', () => {
+    const instructions = buildServerInstructions(ACTIVE_RESOLVER, true);
+    expect(instructions).toContain('BROWSER VERIFICATION (kangentic_browser_* tools):');
+  });
+
   it('adds no pane advertisement when the registry is empty', () => {
     const instructions = buildServerInstructions(ACTIVE_RESOLVER);
 


### PR DESCRIPTION
## What

Trims the fixed context the in-process MCP HTTP server injects into every spawned agent's system prompt (the tool definitions + instructions). Two behavior-preserving reductions:

- **Dedup `PROJECT_SELECTOR_DESCRIPTION`** (`mcp-http/handler-helpers.ts`): the 163-token cross-project routing paragraph was repeated on 28 project-aware tools (~4.5k tokens of duplication). Shortened to a concise pointer. The full routing rule already lives once in the server `instructions` (`PROJECT ROUTING RULE`), plus `create_task`'s own description and the runtime guardrail.
- **Gate the `kangentic_browser_*` family on `browserAutomation.enabled`** (`mcp-http-server.ts`, `mcp-http/server-instructions.ts`): when browser automation is off, `capabilityGate` already blocks every browser tool, so the 14 tools (~3.6k tokens) and their instructions section were dead context. They are now registered only when enabled (the default). Extracted `buildConfiguredMcpServer` so the registration/gating is unit-testable.

## Why

`kangentic_*` MCP calls were observed to "sometimes take a while." Measurement showed the per-request server reconstruction (the original target) is only **~3ms** (imperceptible) and `buildServerInstructions` is 0.002ms - not worth optimizing. The real, measurable lever is the **~18.8k tokens** of fixed context each spawned agent processes every turn and re-prefills on every spawn. (Perceived latency beyond that is model inference and git-bound worktree work, which are config/inherent, not server code.)

## How

Pure context-weight reduction with no change to the tool set or any tool's behavior. Measured token impact (46 tools): tools/list JSON **18,169 -> 15,762 tokens** (~2.4k saved for every agent), and a further ~3.6k for users who disable browser automation. The browser gate is read per request, so a Settings toggle takes effect on the next agent session.

## Breaking changes

None. When browser automation is enabled (the default) the advertised tool set and instructions are unchanged. When disabled, the browser tools were already non-functional (blocked by `capabilityGate`), so removing them from the advertised set is zero functional loss.

## Tests

- `npm run typecheck`, `npm run lint`, and `npm run build` pass locally (CI is the authoritative gate).
- New `tests/unit/mcp-server-config-gating.test.ts`: red-green guards that the `kangentic_browser_*` family is present when enabled and absent when disabled (dropping only that family), and that `PROJECT_SELECTOR_DESCRIPTION` is a concise pointer while the full routing rule still exists once in the instructions.
- `tests/unit/mcp-server-instructions-browser.test.ts`: added cases that the browser-verification section is omitted when disabled and present when enabled.

Generated with [Claude Code](https://claude.com/claude-code)
