### PR TITLE
fix(header): cap title reserve at a 50ch floor so quick-action pills can show

### DIFF
--- a/src/devtools/renderer/TestHarness.tsx
+++ b/src/devtools/renderer/TestHarness.tsx
@@ -50,8 +50,19 @@ function capitalize(text: string): string {
   return text.charAt(0).toUpperCase() + text.slice(1);
 }
 
+// Long by default: build past ~260 chars so the title overflows the header at any
+// window size - even maximized (~1920px is ~240 chars wide) - and ALWAYS truncates.
+// That is the common mode the header's title-floor / pill-overflow behavior is built
+// for, so a seeded task exercises it without hand-crafting a long title each time.
 function loremTitle(): string {
-  return capitalize(loremWords(randomInt(3, 6)));
+  const words: string[] = [];
+  let length = 0;
+  while (length < 260) {
+    const word = LOREM_WORDS[randomInt(0, LOREM_WORDS.length - 1)];
+    words.push(word);
+    length += word.length + 1;
+  }
+  return capitalize(words.join(' '));
 }
 
 // A short-circuit directive appended to every seeded description. Without it the

--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -140,8 +140,9 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
   // The branch picker can fold into the kebab; this drives the kebab-anchored
   // fallback dropdown ("Switch branch").
   const [branchMenuOpen, setBranchMenuOpen] = useState(false);
-  // Refs for the measured "priority-plus" header overflow (title wins; pills fold
-  // into the kebab as the window narrows). Mirrors the task-detail header.
+  // Refs for the measured "priority-plus" header overflow (the title keeps a ~50ch
+  // floor; pills reclaim the space above it and fold into the kebab as the window
+  // narrows). Mirrors the task-detail header.
   const headerRef = useRef<HTMLDivElement>(null);
   const leadingRef = useRef<HTMLDivElement>(null);
   const trailingRef = useRef<HTMLDivElement>(null);
@@ -454,8 +455,9 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden" data-testid="command-terminal-window">
-      {/* Header. Priority-plus layout: the title wins the space fight; the pills
-          fold into the kebab as the window narrows (useHeaderPillOverflow). */}
+      {/* Header. Priority-plus layout: the title keeps a ~50ch floor; the pills
+          reclaim the space above it and fold into the kebab as the window narrows
+          (useHeaderPillOverflow). */}
       <div ref={headerRef} className="flex items-center gap-3 px-4 py-2.5 border-b border-edge flex-shrink-0 select-none min-w-0">
         {/* Leading cluster: Stop (protected, measured as one unit). */}
         <div ref={leadingRef} className="flex items-center flex-shrink-0">
@@ -472,15 +474,17 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
           </button>
         </div>
 
-        {/* Title - reserves its full natural width so pills fold first; it is also
-            the drag handle (double-click toggles maximize). */}
+        {/* Title - the overflow calc reserves only a ~50ch floor (not the full
+            width), so pills reclaim the space above it; this is also the drag
+            handle (double-click toggles maximize). */}
         <div
           className="flex-1 min-w-[64px] truncate cursor-grab active:cursor-grabbing"
           onPointerDown={titleBarPointerDown}
           onDoubleClick={handleToggleMaximized}
         >
           {/* Inline span so its scrollWidth measures the TEXT width (not the
-              flex-grown div), which useHeaderPillOverflow reserves for the title. */}
+              flex-grown div); useHeaderPillOverflow reserves up to a ~50ch floor
+              of that width for the title and lets the pills reclaim the rest. */}
           <span
             ref={titleSpanRef}
             className="text-base font-semibold text-fg truncate"

--- a/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
+++ b/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
@@ -195,9 +195,9 @@ export function TaskDetailHeader({
   const browserCombo = useFormattedCombo('taskDetail.toggleBrowser');
   const changesCombo = useFormattedCombo('taskDetail.toggleChanges');
 
-  // Quick-access pills, highest priority collapses LAST. The title wins the space
-  // fight first (useHeaderPillOverflow reserves its full width); these compete for
-  // whatever is left. Among the built-in defaults the order is Browser -> PR ->
+  // Quick-access pills, highest priority collapses LAST. The title is reserved only
+  // up to a ~50ch floor (useHeaderPillOverflow); these compete for whatever is left
+  // above the floor. Among the built-in defaults the order is Browser -> PR ->
   // Changes -> Project -> Commands (Browser drops first). Custom header shortcuts
   // rank LOWEST (priority 10), so they fold BEFORE any built-in default - an
   // unbounded number of shortcuts can never bury the defaults. A folded header
@@ -283,11 +283,13 @@ export function TaskDetailHeader({
       <PriorityBadge priority={task.priority ?? 0} />
       </div>
 
-      {/* Title - wins the space fight: the overflow calc reserves its FULL natural
-          width (so pills fold first), and it only truncates once every pill has
-          folded. The hard min-w-[64px] keeps it from fully vanishing in a tiny
-          tiled pane. The inner span is content-sized, so its scrollWidth is the
-          title's natural width (read by useHeaderPillOverflow). */}
+      {/* Title - the overflow calc reserves only a ~50ch floor (not the full
+          width), so quick-action pills reclaim the space above the floor. Because
+          this h2 is flex-1, on a wide window the title shows in FULL and only
+          truncates toward the floor once the pills need the room. The hard
+          min-w-[64px] keeps it from fully vanishing in a tiny tiled pane. The
+          inner span is content-sized, so its scrollWidth is the title's natural
+          width (read by useHeaderPillOverflow). */}
       <h2
         className="text-base font-semibold text-fg truncate flex-1 min-w-[64px] flex items-center gap-2"
         title={task.title}

--- a/src/renderer/components/dialogs/task-detail/useHeaderPillOverflow.ts
+++ b/src/renderer/components/dialogs/task-detail/useHeaderPillOverflow.ts
@@ -1,20 +1,26 @@
 /**
  * Measured "priority-plus" overflow for the task-detail header quick-access pills.
  *
- * The title wins. As the window narrows, the header protects the leading cluster
- * (pause / id / priority), the trailing controls (overflow / expand / close), and
- * the TITLE's full natural width - then fills whatever is left with the quick
- * access pills in DESCENDING priority, so the lowest-priority pills surrender
- * first. The title only starts truncating once every pill has folded. Dropped
- * pills are not lost: the `...` overflow menu mirrors every built-in pill, and a
- * header-only shortcut is folded back into the menu by the caller.
+ * The title is reserved only up to a FLOOR (~50 chars), not its full natural
+ * width. As the window narrows, the header protects the leading cluster (pause /
+ * id / priority), the trailing controls (overflow / expand / close), and that
+ * title floor - then fills whatever is left with the quick access pills in
+ * DESCENDING priority, so the lowest-priority pills surrender first. Because the
+ * title element is `flex-1`, on a large window it reclaims all leftover space and
+ * shows in FULL (well past the floor); it only truncates toward the floor when the
+ * pills genuinely need the room. The resulting priority is: title up to ~50ch >
+ * quick-action pills > title beyond ~50ch. Dropped pills are not lost: the `...`
+ * overflow menu mirrors every built-in pill, and a header-only shortcut is folded
+ * back into the menu by the caller.
  *
  * The title's natural width is read from the inner title `<span>`'s `scrollWidth`.
  * Because that span is content-sized (not flex-grown), its `scrollWidth` is the
  * full untruncated text width whether or not it is currently ellipsized - so no
- * canvas/offscreen measurement is needed. Pill widths are cached per id from the
- * live DOM, so a folded pill still contributes its last-measured width when
- * deciding whether it fits again as the window grows.
+ * canvas/offscreen measurement is needed. The floor's pixel size is derived from
+ * the same span (`scrollWidth / textContent.length` gives a live average char
+ * width), so "~50 chars" stays accurate across themes and font changes. Pill
+ * widths are cached per id from the live DOM, so a folded pill still contributes
+ * its last-measured width when deciding whether it fits again as the window grows.
  */
 
 import { useLayoutEffect, useRef, useState, type RefObject } from 'react';
@@ -33,11 +39,76 @@ const HEADER_PADDING_X_PX = 32;
 const OUTER_GAP_TOTAL_PX = GAP_PX * 3;
 /** A little breathing room past the title text before a pill may sit next to it. */
 const TITLE_RESERVE_BUFFER_PX = 8;
+/**
+ * Title floor: reserve at most this many characters of the title before pills may
+ * compete for the remaining width. Tuned to keep a legible leading portion of the
+ * title visible while letting the quick actions reclaim the rest of a wide header.
+ */
+const TITLE_FLOOR_CHARS = 50;
 
 function sameSet(first: Set<string>, second: Set<string>): boolean {
   if (first.size !== second.size) return false;
   for (const value of first) if (!second.has(value)) return false;
   return true;
+}
+
+/** Header geometry the overflow calc needs: measured from the live DOM by the hook,
+ *  and supplied synthetically by unit tests. */
+export interface HeaderOverflowMeasurements {
+  /** Header content-box width (`clientWidth`). */
+  headerWidth: number;
+  /** Protected leading cluster width (pause / id / priority). */
+  leadingWidth: number;
+  /** Protected trailing controls width (overflow / expand / close). */
+  trailingWidth: number;
+  /** The title's full untruncated text width (the inner span's `scrollWidth`). */
+  titleNaturalWidth: number;
+  /** The title's character count in code points (so an emoji counts once). */
+  titleCharCount: number;
+  /** Last-measured pill widths by id; an id absent from the map is unmeasured. */
+  pillWidths: Map<string, number>;
+}
+
+/**
+ * Pure "priority-plus" overflow math: given the measured header, decide which pills
+ * must fold into the kebab. The title is reserved only up to a ~50ch FLOOR (not its
+ * full natural width), so pills reclaim any width above the floor and fold in
+ * ASCENDING priority (lowest first) once the leftover runs out. The floor's pixel
+ * size is the live average char width (natural width / char count), so "~50 chars"
+ * tracks the current font, and it is clamped to the natural width so a short title
+ * reserves only what it needs. Extracted from the hook so the floor-vs-pills decision
+ * is unit-testable without a DOM or ResizeObserver.
+ */
+export function computeHiddenPills(
+  pills: HeaderPillSpec[],
+  measurements: HeaderOverflowMeasurements,
+): Set<string> {
+  const averageCharWidth = measurements.titleNaturalWidth / Math.max(measurements.titleCharCount, 1);
+  const titleFloor = Math.min(measurements.titleNaturalWidth, TITLE_FLOOR_CHARS * averageCharWidth);
+  const titleReserve = titleFloor + TITLE_RESERVE_BUFFER_PX;
+  const available =
+    measurements.headerWidth
+    - HEADER_PADDING_X_PX
+    - measurements.leadingWidth
+    - measurements.trailingWidth
+    - titleReserve
+    - OUTER_GAP_TOTAL_PX;
+
+  // Keep the highest-priority pills that fit in the leftover space.
+  const ordered = [...pills].sort((first, second) => second.priority - first.priority);
+  const keep = new Set<string>();
+  let used = 0;
+  for (const pill of ordered) {
+    const width = measurements.pillWidths.get(pill.id);
+    // An as-yet-unmeasured pill is shown so it can measure on the next pass.
+    if (width == null) { keep.add(pill.id); continue; }
+    const projected = used + width + (keep.size > 0 ? GAP_PX : 0);
+    if (projected <= available) { keep.add(pill.id); used = projected; }
+  }
+
+  const hidden = new Set<string>();
+  for (const pill of pills) if (!keep.has(pill.id)) hidden.add(pill.id);
+  return hidden;
 }
 
 export function useHeaderPillOverflow(
@@ -66,31 +137,18 @@ export function useHeaderPillOverflow(
         if (id) widthCacheRef.current.set(id, (child as HTMLElement).offsetWidth);
       }
 
-      // The title's full text width gets reserved first, so pills only ever take
-      // space the title does not need (and fold to give it back when squeezed).
-      const titleReserve = title.scrollWidth + TITLE_RESERVE_BUFFER_PX;
-      const available =
-        header.clientWidth
-        - HEADER_PADDING_X_PX
-        - leading.offsetWidth
-        - trailing.offsetWidth
-        - titleReserve
-        - OUTER_GAP_TOTAL_PX;
-
-      // Keep the highest-priority pills that fit in the leftover space.
-      const ordered = [...pills].sort((first, second) => second.priority - first.priority);
-      const keep = new Set<string>();
-      let used = 0;
-      for (const pill of ordered) {
-        const width = widthCacheRef.current.get(pill.id);
-        // An as-yet-unmeasured pill is shown so it can measure on the next pass.
-        if (width == null) { keep.add(pill.id); continue; }
-        const projected = used + width + (keep.size > 0 ? GAP_PX : 0);
-        if (projected <= available) { keep.add(pill.id); used = projected; }
-      }
-
-      const nextHidden = new Set<string>();
-      for (const pill of pills) if (!keep.has(pill.id)) nextHidden.add(pill.id);
+      const nextHidden = computeHiddenPills(pills, {
+        headerWidth: header.clientWidth,
+        leadingWidth: leading.offsetWidth,
+        trailingWidth: trailing.offsetWidth,
+        // scrollWidth is the full untruncated text width even when ellipsized,
+        // because the inner title span is content-sized (not flex-grown).
+        titleNaturalWidth: title.scrollWidth,
+        // Count code points (spread), not UTF-16 units, so a surrogate-pair glyph
+        // (e.g. an emoji) counts as one character and does not deflate the average.
+        titleCharCount: [...(title.textContent ?? '')].length,
+        pillWidths: widthCacheRef.current,
+      });
       setHiddenIds((previous) => (sameSet(previous, nextHidden) ? previous : nextHidden));
     };
 

--- a/tests/ui/task-detail-header-overflow.spec.ts
+++ b/tests/ui/task-detail-header-overflow.spec.ts
@@ -1,17 +1,25 @@
 /**
  * UI tests for the task-detail header pill overflow (useHeaderPillOverflow).
  *
- * Two behaviors:
- * - Title wins. The header reserves the title's full width first, so a long title
- *   keeps the row and the quick-access pills fold into the `...` kebab (even the
- *   highest-priority default). The title ellipsizes only once the pills have gone.
- * - Custom shortcuts fold before the built-in defaults. When a short title leaves
- *   room for some pills, the built-in defaults (Commands, Worktree, Changes,
- *   Browser) outrank custom header shortcuts (priority 10), so an unbounded number
- *   of custom shortcuts can never bury a default.
+ * The header reserves only a ~50ch FLOOR of the title, not its full width, so the
+ * quick-access pills reclaim the space above the floor and appear in priority order
+ * (title up to 50ch > pills > title beyond 50ch). The title element is flex-1, so it
+ * shows in FULL on a wide window and only truncates toward the floor when the pills
+ * genuinely need the room. A title long enough that even a maximized window cannot
+ * show it (lorem ipsum below) therefore truncates at every width, while the pills
+ * appear or fold purely as a function of the window's width:
  *
- * Assertions use visibility and a truncation check (auto-retried), not pixel-exact
- * widths, so they are robust on headless-Linux CI.
+ * - Narrow window (near the min): the floor reserve leaves no room, every pill folds
+ *   into the `...` kebab and the title takes the whole row.
+ * - Wide / maximized window: the pills are visible AND the title still truncates, but
+ *   the rendered title keeps at least the floor's worth of characters.
+ * - Short title: floor === natural width, so behavior is unchanged - all pills show
+ *   and the lowest-priority custom shortcuts fold before any built-in default.
+ *
+ * The window width is driven through the window-manager store (exposed at
+ * window.__zustandStores in dev mode), not the browser viewport, so each case is
+ * deterministic. Assertions use visibility and a font-relative truncation check
+ * (auto-retried), not pixel-exact widths, so they are robust on headless-Linux CI.
  */
 import { test, expect } from '@playwright/test';
 import { chromium, type Browser, type Page } from '@playwright/test';
@@ -19,6 +27,7 @@ import { chromium, type Browser, type Page } from '@playwright/test';
 test.describe.configure({ mode: 'parallel' });
 import path from 'node:path';
 import { waitForViteReady } from './helpers';
+import type { FractionalRect } from '../../src/renderer/window-manager/store/types';
 
 const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
 const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
@@ -29,10 +38,12 @@ const LONG_SESSION_ID = 'sess-header-overflow-long';
 const SHORT_TASK_ID = 'task-header-overflow-short';
 const SHORT_SESSION_ID = 'sess-header-overflow-short';
 
-// Long enough that its natural width exceeds the floating window, so the title
-// wins the whole row and every quick-access pill folds.
+// Long enough that its natural width exceeds even a maximized window, so the title
+// truncates at every width from the min up to maximized. A unique opening substring
+// (used to click the card) keeps the locator off the full 250+ char string.
+const LONG_TITLE_PREFIX = 'Lorem ipsum dolor sit amet';
 const LONG_TITLE =
-  'Bug: agent/MCP-created task is in the board store but absent from the rendered board until a full reload (HMR board-store subscription split-brain)';
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit';
 // Short enough to leave room for some pills, so the default-vs-shortcut fold order
 // is observable.
 const SHORT_TITLE = 'Quick task';
@@ -131,13 +142,66 @@ const preConfigScript = `
   });
 `;
 
-async function openTaskDialog(page: Page, titleText: string) {
-  const card = page.locator('[data-swimlane-name="Code Review"]').locator(`text=${titleText}`).first();
+/** The slice of the dev-only window.__zustandStores surface these tests drive. */
+type WindowStores = {
+  window: {
+    getState: () => {
+      windows: Record<string, { id: string; anchor: string }>;
+      setGeometry: (id: string, geometry: FractionalRect) => void;
+      maximizeWindow: (id: string) => void;
+    };
+  };
+};
+
+async function openTaskDialog(page: Page, cardText: string) {
+  const card = page.locator('[data-swimlane-name="Code Review"]').locator(`text=${cardText}`).first();
   await card.click();
   await page.locator('[data-testid="task-detail-dialog"]').waitFor({ state: 'visible', timeout: 5000 });
 }
 
-test.describe('Task detail header pill overflow (title wins)', () => {
+/** Find the managed window hosting `taskId` and run `apply` against the window store. */
+async function driveTaskWindow(
+  page: Page,
+  taskId: string,
+  action: 'setGeometry' | 'maximizeWindow',
+  rect?: FractionalRect,
+) {
+  await page.evaluate(
+    ({ taskId, action, rect }) => {
+      const stores = (window as unknown as { __zustandStores?: WindowStores }).__zustandStores;
+      if (!stores) throw new Error('window.__zustandStores not exposed');
+      const state = stores.window.getState();
+      const managed = Object.values(state.windows).find((candidate) => candidate.anchor === taskId);
+      if (!managed) throw new Error(`no managed window for task ${taskId}`);
+      if (action === 'maximizeWindow') {
+        state.maximizeWindow(managed.id);
+      } else if (rect) {
+        state.setGeometry(managed.id, rect);
+      }
+    },
+    { taskId, action, rect },
+  );
+}
+
+/** Set the task-detail window to a fixed-fraction floating size. */
+function resizeTaskWindow(page: Page, taskId: string, rect: FractionalRect) {
+  return driveTaskWindow(page, taskId, 'setGeometry', rect);
+}
+
+/** Maximize the task-detail window (fills the whole overlay). */
+function maximizeTaskWindow(page: Page, taskId: string) {
+  return driveTaskWindow(page, taskId, 'maximizeWindow');
+}
+
+// ~31% of the 1920px overlay (~595px), at the narrow end of the float range. Both
+// the ~50ch floor reserve AND a quick-action pill's width scale with the CI font's
+// char metrics, but at this width the protected clusters plus the floor consume the
+// row across the plausible font range, so every pill folds. Driving it this narrow
+// (below the interactive 650px resize floor) is a valid programmatic geometry: the
+// store only clamps to MIN_FRACTION (0.12), not to DEFAULT_MIN_WIDTH_PX.
+const NARROW_RECT: FractionalRect = { x: 0.3, y: 0.15, w: 0.31, h: 0.6 };
+
+test.describe('Task detail header pill overflow (title floor)', () => {
   let browser: Browser;
   let page: Page;
 
@@ -162,11 +226,12 @@ test.describe('Task detail header pill overflow (title wins)', () => {
     await page.locator('[data-swimlane-name="Code Review"]').waitFor({ state: 'visible', timeout: 10000 });
   });
 
-  test('a long title wins the row and folds the quick actions into the kebab', async () => {
-    await openTaskDialog(page, LONG_TITLE);
+  test('a long title at a narrow window folds every quick action into the kebab', async () => {
+    await openTaskDialog(page, LONG_TITLE_PREFIX);
+    await resizeTaskWindow(page, LONG_TASK_ID, NARROW_RECT);
 
-    // The title takes the whole row, so even the highest-priority default pill
-    // (Commands) folds into the kebab - which proves every pill folded.
+    // At the min-width end the floor reserve leaves no room, so even the
+    // highest-priority default (Commands) folds - which proves every pill folded.
     await expect(page.locator('[data-testid="commands-button"]')).toBeHidden();
     await expect(page.locator('[data-testid="browser-toggle"]')).toBeHidden();
 
@@ -177,6 +242,31 @@ test.describe('Task detail header pill overflow (title wins)', () => {
         page
           .locator('[data-testid="task-title-text"]')
           .evaluate((element) => element.scrollWidth > element.clientWidth),
+      )
+      .toBe(true);
+  });
+
+  test('a long title at a wide window shows the quick actions and still truncates to the floor', async () => {
+    await openTaskDialog(page, LONG_TITLE_PREFIX);
+    await maximizeTaskWindow(page, LONG_TASK_ID);
+
+    // Maximized leaves plenty of room above the floor, so the pills reclaim it: the
+    // highest-priority default is visible. This inverts the old behavior where a long
+    // title reserved its full width and hid every pill.
+    await expect(page.locator('[data-testid="commands-button"]')).toBeVisible();
+
+    // The title still truncates (its natural width exceeds even a maximized window),
+    // and the rendered title keeps at least the ~50ch floor's worth of characters.
+    // averageCharWidth is read from the live span (scrollWidth / length), so the check
+    // is font-relative, not pixel-exact; the 45 vs 50 margin absorbs sub-pixel rounding.
+    await expect
+      .poll(async () =>
+        page.locator('[data-testid="task-title-text"]').evaluate((element) => {
+          const textLength = (element.textContent ?? '').length || 1;
+          const averageCharWidth = element.scrollWidth / textLength;
+          const renderedChars = element.clientWidth / averageCharWidth;
+          return element.scrollWidth > element.clientWidth && renderedChars >= 45;
+        }),
       )
       .toBe(true);
   });

--- a/tests/unit/header-pill-overflow.test.ts
+++ b/tests/unit/header-pill-overflow.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit coverage for the task-detail / command-terminal header overflow math
+ * (`computeHiddenPills`), the pure core extracted from `useHeaderPillOverflow`.
+ *
+ * This is the robust, font-independent companion to the UI spec
+ * (`tests/ui/task-detail-header-overflow.spec.ts`). The UI spec can prove the
+ * extreme cases (a screen-wide title always truncates; a maximized window shows the
+ * pills), but the floor's defining behavior - reserving only ~50ch of the title so
+ * pills reclaim the rest, instead of reserving the title's FULL natural width - only
+ * flips a pill's visibility inside a narrow, font-sensitive width band that a DOM
+ * test cannot pin without flaking. Driving the pure function with synthetic
+ * measurements pins exactly that behavior with zero DOM or font dependence.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeHiddenPills,
+  type HeaderOverflowMeasurements,
+  type HeaderPillSpec,
+} from '../../src/renderer/components/dialogs/task-detail/useHeaderPillOverflow';
+
+/** A measurement base with no pills folded; tests override the interesting fields. */
+function measurements(overrides: Partial<HeaderOverflowMeasurements>): HeaderOverflowMeasurements {
+  return {
+    headerWidth: 1000,
+    leadingWidth: 100,
+    trailingWidth: 100,
+    titleNaturalWidth: 100,
+    titleCharCount: 10,
+    pillWidths: new Map(),
+    ...overrides,
+  };
+}
+
+describe('computeHiddenPills', () => {
+  it('reserves only the ~50ch floor, so a long title does NOT bury the pills', () => {
+    const pills: HeaderPillSpec[] = [
+      { id: 'a', priority: 50 },
+      { id: 'b', priority: 40 },
+    ];
+    // A title far wider than the header: natural width 5000px, 500 chars -> average
+    // char width 10px, so the floor is 50 * 10 = 500px (clamped under 5000). The old
+    // behavior reserved the FULL 5000px, which would push `available` deeply negative
+    // and fold BOTH pills. With the 500px floor there is room for both.
+    const hidden = computeHiddenPills(
+      pills,
+      measurements({
+        headerWidth: 1000,
+        titleNaturalWidth: 5000,
+        titleCharCount: 500,
+        pillWidths: new Map([
+          ['a', 80],
+          ['b', 80],
+        ]),
+      }),
+    );
+    // Reverting the floor to a full-natural-width reserve makes this go red.
+    expect(hidden).toEqual(new Set());
+  });
+
+  it('folds the lowest-priority pill first when the leftover runs out', () => {
+    const pills: HeaderPillSpec[] = [
+      { id: 'high', priority: 50 },
+      { id: 'mid', priority: 30 },
+      { id: 'low', priority: 10 },
+    ];
+    // Tuned so exactly two of three 100px pills fit: the two highest priorities stay,
+    // the lowest folds. (available ~= 250px: 100 + 100+12 fits, the third 324 does not.)
+    const hidden = computeHiddenPills(
+      pills,
+      measurements({
+        headerWidth: 646,
+        leadingWidth: 100,
+        trailingWidth: 100,
+        titleNaturalWidth: 120,
+        titleCharCount: 12,
+        pillWidths: new Map([
+          ['high', 100],
+          ['mid', 100],
+          ['low', 100],
+        ]),
+      }),
+    );
+    expect(hidden).toEqual(new Set(['low']));
+  });
+
+  it('keeps an as-yet-unmeasured pill so it can measure on the next pass', () => {
+    const pills: HeaderPillSpec[] = [
+      { id: 'measured', priority: 50 },
+      { id: 'unmeasured', priority: 10 },
+    ];
+    // No room for anything (huge title floor), but the unmeasured pill (absent from
+    // pillWidths) is shown regardless so it can report its width next pass.
+    const hidden = computeHiddenPills(
+      pills,
+      measurements({
+        headerWidth: 500,
+        titleNaturalWidth: 5000,
+        titleCharCount: 250,
+        pillWidths: new Map([['measured', 100]]),
+      }),
+    );
+    expect(hidden.has('measured')).toBe(true);
+    expect(hidden.has('unmeasured')).toBe(false);
+  });
+
+  it('clamps the floor to the natural width for a short title', () => {
+    const pills: HeaderPillSpec[] = [{ id: 'a', priority: 50 }];
+    // Short title: natural 80px, 8 chars -> average char 10px. An unclamped floor
+    // would reserve 50 * 10 = 500px and fold the pill; the Math.min clamp reserves
+    // only the 80px the title needs, leaving room for the 100px pill.
+    const hidden = computeHiddenPills(
+      pills,
+      measurements({
+        headerWidth: 400,
+        leadingWidth: 50,
+        trailingWidth: 50,
+        titleNaturalWidth: 80,
+        titleCharCount: 8,
+        pillWidths: new Map([['a', 100]]),
+      }),
+    );
+    expect(hidden).toEqual(new Set());
+  });
+
+  it('is safe for an empty title (no NaN from a zero char count)', () => {
+    const pills: HeaderPillSpec[] = [{ id: 'a', priority: 50 }];
+    const compute = () =>
+      computeHiddenPills(
+        pills,
+        measurements({
+          headerWidth: 1000,
+          titleNaturalWidth: 0,
+          titleCharCount: 0,
+          pillWidths: new Map([['a', 100]]),
+        }),
+      );
+    expect(compute).not.toThrow();
+    // Zero floor + a wide header leaves ample room, so the pill stays.
+    expect(compute()).toEqual(new Set());
+  });
+});


### PR DESCRIPTION
## What

Both window headers (task-detail and Command Terminal) share `useHeaderPillOverflow`. It used to reserve the title's FULL natural width before any quick-action pill could compete, so a long title pushed every pill (Commands, Worktree/Project, PR, Changes, Browser) into the `...` kebab while the title showed far more width than it needed.

This reserves only a ~50ch title FLOOR instead. Pills reclaim the space above the floor and appear in descending priority. Because the title is `flex-1` it still shows in full on a wide window and only truncates toward the floor when the pills genuinely need the room. Resulting priority: title up to ~50ch > quick-action pills > title beyond ~50ch.

Affected: `useHeaderPillOverflow.ts` (the change), `TaskDetailHeader.tsx` + `CommandTerminalWindow.tsx` (comment-only), and the dev `TestHarness.tsx` (seeds long titles by default).

## Why

A realistic task title buried every pill, which is the opposite of the intent: a short title showed everything, a long title showed nothing. The floor keeps a legible leading portion of the title while letting the quick actions stay reachable. One shared hook, so both headers benefit from a single edit.

## How

The floor's pixel size is the live average char width (`titleNaturalWidth / titleCharCount`, counted in code points so an emoji counts once), so "50 chars" tracks the current font/theme with no offscreen or canvas measurement, reusing the content-sized inner span the hook already reads. The floor is `Math.min(naturalWidth, 50 * averageCharWidth)`, clamped to the natural width so a short title behaves exactly as before.

The floor-vs-pills decision is extracted into a pure, exported `computeHiddenPills(pills, measurements)`. The hook now just measures the live DOM (header/leading/trailing widths, the title span's `scrollWidth` and char count, cached pill widths) and delegates, so the math is unit-testable with no DOM or ResizeObserver.

Trade-off worth a look: the window min width is 650px, where only ~38-40 chars physically fit alongside the leading/trailing clusters, so the 50ch floor becomes fully reachable around ~720-760px and degrades gracefully below that. The floor count is a single tuning constant (`TITLE_FLOOR_CHARS`).

## Breaking changes

None. Short titles are unchanged (floor clamps to the natural width).

## Tests

- `tests/unit/header-pill-overflow.test.ts` drives the pure `computeHiddenPills` with synthetic measurements (font-independent): the floor does not bury pills, the lowest-priority pill folds first, an unmeasured pill is kept for the next pass, the short-title clamp, and empty-title safety (no NaN).
- `tests/ui/task-detail-header-overflow.spec.ts` rewritten to drive the task-detail window width through the window-manager store (not the viewport): a long title at a narrow window folds every pill into the kebab; a long title at a maximized window shows the pills AND still truncates to the floor; the short-title default-vs-shortcut fold order is unchanged.
- Verified locally: typecheck, lint, the scoped unit file (5 passed), and the scoped UI spec (3 passed). CI runs the full unit, UI, and Electron E2E tiers.

Generated with [Claude Code](https://claude.com/claude-code)
