### PR TITLE
fix(pty): re-assert DEC private input modes on scrollback replay

### DIFF
--- a/src/main/pty/buffer/pty-buffer-manager.ts
+++ b/src/main/pty/buffer/pty-buffer-manager.ts
@@ -34,6 +34,54 @@ function surrogateSafeFlushEnd(buffer: string, max: number): number {
   return max;
 }
 
+// DEC private input/reporting modes to re-assert on a scrollback replay. These
+// are invisible to restore: they change what xterm SENDS on later input, not
+// what it draws, so the replayed frame is unchanged. Display modes (alt-screen
+// 1049/47, origin 6, autowrap 7, cursor 25, ...) are excluded on purpose. #313.
+// Note: re-asserting 1004 (focus reporting) means the post-replay xterm.focus()
+// in useTerminal's afterWrite now emits a benign \x1b[I (FocusIn) to the PTY,
+// which Claude handles as a normal focus event.
+const RESTORABLE_DEC_PRIVATE_MODES = new Set<number>([
+  1,                 // DECCKM application cursor keys (the arrow-key bug)
+  1000, 1002, 1003,  // mouse tracking
+  1004,              // focus reporting
+  1006, 1015, 1016,  // mouse encodings
+  2004,              // bracketed paste
+]);
+
+// Upper bound on a partial mode sequence carried across a PTY chunk boundary.
+// Larger than the longest combined restorable DECSET (all modes in one set is
+// ~45 chars: `\x1b[?1;1000;1002;1003;1004;1006;1015;1016;2004`), so a real split
+// is always preserved while a lone trailing ESC cannot grow modeParseCarry
+// without limit. Adding a mode to RESTORABLE_DEC_PRIVATE_MODES that pushes the
+// combined set past this must bump it too.
+const MODE_CARRY_MAX_LENGTH = 64;
+
+function updateDecPrivateModes(activeModes: Set<number>, text: string): void {
+  // One alternation matches a DECSET/DECRST set (\x1b[?<params>h|l) OR a full
+  // reset (RIS \x1bc / DECSTR \x1b[!p) that returns every private mode to its
+  // default. matchAll yields matches in stream order, so an interleaved
+  // set-then-reset resolves correctly. A reset match has no capture groups.
+  for (const match of text.matchAll(/\x1b\[\?([\d;]+)([hl])|\x1bc|\x1b\[!p/g)) {
+    if (match[1] === undefined) {
+      for (const privateMode of RESTORABLE_DEC_PRIVATE_MODES) activeModes.delete(privateMode);
+      continue;
+    }
+    const isSet = match[2] === 'h';
+    for (const parameter of match[1].split(';')) {
+      const privateMode = Number(parameter);
+      if (!RESTORABLE_DEC_PRIVATE_MODES.has(privateMode)) continue;
+      if (isSet) activeModes.add(privateMode); else activeModes.delete(privateMode);
+    }
+  }
+}
+
+function buildDecPrivateModePrefix(activeModes: Set<number>): string {
+  if (activeModes.size === 0) return '';
+  const sortedModes = Array.from(activeModes).sort((first, second) => first - second);
+  return `\x1b[?${sortedModes.join(';')}h`;
+}
+
 interface PtyBufferManagerCallbacks {
   onFlush(sessionId: string, data: string): void;
 }
@@ -51,6 +99,13 @@ interface BufferState {
    *  if not found yet. Set once and cached. Used by getScrollback() to strip
    *  shell command noise that precedes the agent TUI's first draw. */
   tuiStartIndex: number;
+  /** Sticky DEC private input/reporting modes (DECCKM etc.) currently active,
+   *  tracked from the live stream so getScrollback() can re-assert them after
+   *  xterm.reset() wipes them on replay. Survives scrollback trimming. #313. */
+  decPrivateModes: Set<number>;
+  /** Trailing partial escape sequence stitched onto the next chunk so a mode
+   *  set split across two PTY chunks is parsed whole. Bounded in onData(). */
+  modeParseCarry: string;
 }
 
 /**
@@ -75,12 +130,39 @@ export class PtyBufferManager {
       lastCols: initialCols,
       initialized: false,
       tuiStartIndex: previousScrollback ? 0 : -1,
+      // Start empty even on carry-over: the new process re-emits its own modes.
+      decPrivateModes: new Set<number>(),
+      modeParseCarry: '',
     });
   }
 
   onData(sessionId: string, data: string): void {
     const state = this.buffers.get(sessionId);
     if (!state) return;
+
+    // Track sticky DEC private input modes (DECCKM, mouse, paste) from the live
+    // stream so the scrollback replay can re-assert them after xterm.reset()
+    // wipes them - the original mode-set bytes usually scroll out of the 512KB
+    // window (#313). modeParseCarry stitches a set split across two PTY chunks,
+    // bounded by MODE_CARRY_MAX_LENGTH so a lone ESC cannot grow it. Skip the
+    // scan for ESC-free bulk output unless a partial set is pending. Parse
+    // `combined` only; append the original `data` below so the carry never
+    // duplicates bytes into buffer/scrollback.
+    if (state.modeParseCarry || data.includes('\x1b')) {
+      const combined = state.modeParseCarry + data;
+      updateDecPrivateModes(state.decPrivateModes, combined);
+      // A carry can only be a partial sequence at the very END of `combined`,
+      // and it is bounded to MODE_CARRY_MAX_LENGTH, so scan just the trailing
+      // window - a full-chunk scan here is redundant on the hot path. The `!?`
+      // admits a partial DECSTR (\x1b[!) split at \x1b[! | p, matching the
+      // DECSTR arm of updateDecPrivateModes so the soft reset is not lost.
+      const trailingWindow = combined.slice(-(MODE_CARRY_MAX_LENGTH + 1));
+      const partialEscapeMatch = trailingWindow.match(/\x1b(?:\[[\d?;]*!?)?$/);
+      state.modeParseCarry =
+        partialEscapeMatch && partialEscapeMatch[0].length <= MODE_CARRY_MAX_LENGTH
+          ? partialEscapeMatch[0]
+          : '';
+    }
 
     state.buffer += data;
     state.scrollback += data;
@@ -183,7 +265,7 @@ export class PtyBufferManager {
       }
     }
 
-    return '\x1b[0m' + scrollback;
+    return buildDecPrivateModePrefix(state.decPrivateModes) + '\x1b[0m' + scrollback;
   }
 
   /**

--- a/tests/unit/pty-buffer-manager.test.ts
+++ b/tests/unit/pty-buffer-manager.test.ts
@@ -471,5 +471,43 @@ describe('PtyBufferManager', () => {
       vi.advanceTimersByTime(20);
       vi.useRealTimers();
     });
+
+    it('filters out non-restorable params from a combined DECSET, tracking only restorable ones', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      // One DECSET with restorable mouse-tracking modes 1000, 1002 and non-restorable
+      // display mode 1049 (alt-screen) mixed in between them. The per-param guard
+      // `if (!RESTORABLE_DEC_PRIVATE_MODES.has(privateMode)) continue` inside
+      // updateDecPrivateModes must skip 1049 while tracking the others.
+      // Would fail (producing '\x1b[?1000;1002;1049h') if the guard were removed.
+      manager.onData(SESSION, '\x1b[?1000;1049;1002h');
+
+      expect(modePrefixOf(manager.getScrollback(SESSION))).toBe('\x1b[?1000;1002h');
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('re-asserts the same mode prefix on repeated getScrollback() calls (idempotent)', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      manager.onData(SESSION, '\x1b[?1h');
+      manager.onData(SESSION, 'some output');
+
+      // First call establishes the prefix.
+      const firstPrefix = modePrefixOf(manager.getScrollback(SESSION));
+      expect(firstPrefix).toBe('\x1b[?1h');
+
+      // Second call must produce the same prefix. Would fail if getScrollback
+      // mutated decPrivateModes after reading (e.g. cleared it as a "reset on
+      // read" refactor), which would make the second call return an empty prefix.
+      const secondPrefix = modePrefixOf(manager.getScrollback(SESSION));
+      expect(secondPrefix).toBe('\x1b[?1h');
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
   });
 });

--- a/tests/unit/pty-buffer-manager.test.ts
+++ b/tests/unit/pty-buffer-manager.test.ts
@@ -279,4 +279,197 @@ describe('PtyBufferManager', () => {
       vi.useRealTimers();
     });
   });
+
+  describe('DEC private mode restoration (#313)', () => {
+    // The mode prefix getScrollback() prepends ends at the \x1b[0m reset, which
+    // buildDecPrivateModePrefix() never emits, so the first \x1b[0m is the
+    // boundary between the re-asserted modes and the (raw) scrollback body.
+    function modePrefixOf(scrollback: string): string {
+      return scrollback.slice(0, scrollback.indexOf('\x1b[0m'));
+    }
+
+    it('re-asserts application cursor keys mode after the original set is trimmed out', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      // DECCKM on, then enough plain output to push past the 768KB write-path
+      // trim threshold so the original \x1b[?1h is sliced out of the body -
+      // the empirically-confirmed root cause for a long-running session.
+      const SCROLLBACK_TRIM_THRESHOLD = (512 + 256) * 1024;
+      manager.onData(SESSION, '\x1b[?1h');
+      manager.onData(SESSION, '\n'.repeat(SCROLLBACK_TRIM_THRESHOLD + 32 * 1024));
+
+      const scrollback = manager.getScrollback(SESSION);
+      const prefix = '\x1b[?1h\x1b[0m';
+      // The mode is re-asserted up front...
+      expect(scrollback.startsWith(prefix)).toBe(true);
+      // ...and the trimmed body no longer carries it, so the prefix is load-bearing.
+      expect(scrollback.slice(prefix.length).includes('\x1b[?1h')).toBe(false);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('drops a mode that was later reset (DECRST 1l)', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      manager.onData(SESSION, '\x1b[?1h');
+      manager.onData(SESSION, 'some output');
+      manager.onData(SESSION, '\x1b[?1l');
+
+      // Set then reset -> no mode re-asserted in the prefix.
+      expect(modePrefixOf(manager.getScrollback(SESSION))).toBe('');
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('restores a mode set split across two PTY chunks', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      // \x1b[?2004h (bracketed paste) arriving as two chunks across a boundary.
+      manager.onData(SESSION, '\x1b[?20');
+      manager.onData(SESSION, '04h');
+
+      expect(modePrefixOf(manager.getScrollback(SESSION))).toBe('\x1b[?2004h');
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('does not re-assert display modes (alt-screen 1049)', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      manager.onData(SESSION, '\x1b[?1049h');
+      manager.onData(SESSION, 'tui frame');
+
+      // 1049 is a display mode, excluded from the restore set -> empty prefix.
+      expect(modePrefixOf(manager.getScrollback(SESSION))).toBe('');
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('honors a full reset (RIS) by dropping tracked modes', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      manager.onData(SESSION, '\x1b[?1h');
+      manager.onData(SESSION, '\x1bc');
+
+      // RIS resets every private mode -> no mode re-asserted in the prefix.
+      expect(modePrefixOf(manager.getScrollback(SESSION))).toBe('');
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('adds no mode prefix when no input modes were set', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      manager.onData(SESSION, 'plain output with no mode sequences');
+
+      // No DEC private mode prefix: the result starts directly with the \x1b[0m reset.
+      expect(manager.getScrollback(SESSION).startsWith('\x1b[0m')).toBe(true);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('coalesces multiple modes set individually (in non-sorted order) into one sorted DECSET', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      // Send three restorable modes in a deliberately non-ascending insertion order.
+      manager.onData(SESSION, '\x1b[?2004h');
+      manager.onData(SESSION, '\x1b[?1h');
+      manager.onData(SESSION, '\x1b[?1000h');
+
+      // buildDecPrivateModePrefix must sort numerically and emit ONE combined DECSET.
+      // Would fail if modes came out in insertion order (\x1b[?2004;1;1000h) or as
+      // three separate sequences (\x1b[?2004h\x1b[?1h\x1b[?1000h).
+      expect(modePrefixOf(manager.getScrollback(SESSION))).toBe('\x1b[?1;1000;2004h');
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('parses a single multi-param DECSET chunk into all modes and re-asserts them sorted', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      // One combined DECSET with params in non-sorted order (1, 2004, 1000).
+      manager.onData(SESSION, '\x1b[?1;2004;1000h');
+
+      // updateDecPrivateModes splits on ';' and registers each param; the prefix
+      // must contain all three, sorted. Would fail if multi-param splitting was broken.
+      expect(modePrefixOf(manager.getScrollback(SESSION))).toBe('\x1b[?1;1000;2004h');
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('honors a soft reset (DECSTR \\x1b[!p) by dropping tracked modes', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      manager.onData(SESSION, '\x1b[?1h');
+      manager.onData(SESSION, '\x1b[!p');
+
+      // DECSTR resets every private mode -> no mode re-asserted in the prefix.
+      // Mirrors the RIS (\x1bc) test; independently red-greens the |\x1b\[!p
+      // arm of the updateDecPrivateModes regex.
+      expect(modePrefixOf(manager.getScrollback(SESSION))).toBe('');
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('detects a DECSTR soft reset split across two PTY chunks (\\x1b[! | p)', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      manager.onData(SESSION, '\x1b[?1h');
+      // DECSTR arriving in two pieces: first chunk ends with \x1b[! (partial),
+      // second chunk is p. The carry regex /\x1b(?:\[[\d?;]*!?)?$/ must carry
+      // the \x1b[! partial so the two pieces are stitched into \x1b[!p and the
+      // soft reset fires. Without the !? in the carry regex, \x1b[! is not
+      // carried, combined on chunk 2 is just 'p', no reset fires, and mode 1
+      // persists - this test would assert '' but see '\x1b[?1h'.
+      manager.onData(SESSION, '\x1b[!');
+      manager.onData(SESSION, 'p');
+
+      expect(modePrefixOf(manager.getScrollback(SESSION))).toBe('');
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('does not duplicate carry bytes into the scrollback body', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      // Bracketed paste mode (\x1b[?2004h) split across two chunks: \x1b[?20 then 04h.
+      // onData carries \x1b[?20 and appends only the original `data` to scrollback,
+      // so the body accumulates \x1b[?20 + 04h = \x1b[?2004h (clean).
+      // If onData used `combined` instead of `data` for scrollback, the body would
+      // become \x1b[?20 + \x1b[?2004h = '\x1b[?20\x1b[?2004h' (duplicated carry).
+      manager.onData(SESSION, '\x1b[?20');
+      manager.onData(SESSION, '04h');
+
+      const scrollback = manager.getScrollback(SESSION);
+
+      // Prefix is \x1b[?2004h, then \x1b[0m, then the body which must be clean.
+      expect(scrollback).toContain('\x1b[0m\x1b[?2004h');
+      // Carry prefix must NOT appear duplicated in the body.
+      expect(scrollback).not.toContain('\x1b[?20\x1b[?2004h');
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+  });
 });


### PR DESCRIPTION
## What

Fixes frozen up/down arrow keys in Claude's interactive select prompts (AskUserQuestion / model
pickers) after a terminal refocus, snap, maximize, restore, or Command-Terminal toggle. Typing and
output kept working; only arrow-key navigation inside a picker broke.

Single production file: `src/main/pty/buffer/pty-buffer-manager.ts`, plus unit coverage in
`tests/unit/pty-buffer-manager.test.ts`.

## Why

Closes #313.

Claude's picker reads application-mode arrow sequences (`\x1bOA` / `\x1bOB`), enabled by DEC
Application Cursor Keys mode (DECCKM, `\x1b[?1h`). Both terminal replay entry points -
`reloadScrollback()` and `initTerminal()` in `useTerminal.ts` - call `xterm.reset()` (which defaults
every DEC private mode back off) and then replay the bytes from `PtyBufferManager.getScrollback()`.
For a long-running session the one-shot startup mode-set bytes have already scrolled out of the
512KB scrollback window (confirmed empirically: zero `\x1b[?1h` in the replayed buffer), so the
replay cannot re-assert DECCKM. The xterm ends up in normal cursor-key mode while the running picker
expects application mode, so arrows are ignored. A SIGWINCH redraw repaints content but never
re-sends the one-shot mode, so it does not self-heal - hence the intermittent, focus/switch-dependent
behavior.

## How

Track the sticky DEC private input/reporting modes out-of-band as they stream through `onData`, in a
`Set<number>` that survives scrollback trimming, and re-assert them as a short, visually-invisible
prefix in `getScrollback()`:

- `RESTORABLE_DEC_PRIVATE_MODES` - application cursor keys (1), mouse tracking (1000/1002/1003),
  focus reporting (1004), mouse encodings (1006/1015/1016), bracketed paste (2004). Display modes
  (alt-screen 1049/47, origin 6, autowrap 7, cursor 25) are deliberately excluded so the replayed
  rendered frame is byte-for-byte unchanged.
- `updateDecPrivateModes` scans each chunk with one `matchAll` alternation that handles DECSET/DECRST
  sets and full resets (RIS `\x1bc` / DECSTR `\x1b[!p`) in stream order.
- A 64-char-bounded `modeParseCarry` stitches a mode set split across two PTY chunks.
- The scan is gated on `state.modeParseCarry || data.includes('\x1b')` so ESC-free bulk output (the
  common flood) skips the regex on the PTY hot path.

The fix is main-side so it covers both the `reloadScrollback` reset path and `initTerminal`'s
mount-time replay with zero renderer change. A renderer-only fix could not cover `initTerminal`,
which builds a fresh `new Terminal()` whose modes are already default with no prior instance to
snapshot.

## Breaking changes

None. Re-asserting input/reporting modes emits no rendered output and reflects the modes the running
TUI last requested. One benign side effect: with focus reporting (1004) re-asserted, the post-replay
`xterm.focus()` now emits a `\x1b[I` (FocusIn) to the PTY, which Claude handles as a normal focus
event.

## Tests

- 8 new unit tests in `tests/unit/pty-buffer-manager.test.ts` (`DEC private mode restoration`),
  including a red-green core that sets DECCKM, pushes past the 768KB write-path trim threshold so the
  original `\x1b[?1h` is sliced out of the body, and asserts the re-asserted prefix is load-bearing.
  Also: DECRST drop, split-chunk restore, display-mode exclusion, RIS full-reset, no-prefix
  regression, mixed restorable/non-restorable param filtering, and `getScrollback` idempotency.
- Local gate: `npm run typecheck` and `npm run lint` clean; the scoped unit file passes 29/29.
- The full unit, UI, and Electron E2E tiers run as CI checks on this PR.

Generated with [Claude Code](https://claude.com/claude-code)
