### PR TITLE
refactor(mcp): clean up MCP Server settings tab

### DIFF
--- a/.claude/rules/mcp-tool-list-parity.md
+++ b/.claude/rules/mcp-tool-list-parity.md
@@ -1,0 +1,63 @@
+---
+paths:
+  - "src/main/agent/mcp-http/**"
+  - "src/shared/mcp-tool-manifest.ts"
+  - "src/renderer/components/settings/tabs/McpServerTab.tsx"
+  - "docs/mcp-server.md"
+---
+# Rule: MCP tool-list parity (panel + docs track the registrations)
+
+The Kangentic MCP server registers its tools across the `*-tools.ts` files in
+`src/main/agent/mcp-http/`. Two human-facing surfaces enumerate those tools: the Settings -> MCP
+Server "Available Tools" list (`McpServerTab.tsx`) and `docs/mcp-server.md`. Nothing forced either
+to track the registrations, so both drifted: the panel hardcoded 10 of 46 registered tools, missing
+the entire browser and backlog families, `list_projects`, `search_everything`, and move/delete task.
+A user reading the panel had no idea most of the agent's board, browser, and session capabilities
+existed.
+
+The fix is one source of truth, `src/shared/mcp-tool-manifest.ts` (`MCP_TOOL_MANIFEST`), that both
+the panel renders from and the parity test checks. Drift becomes a failing build.
+
+## The rule
+
+When you add, rename, or remove a tool registered via `server.registerTool('kangentic_...', ...)`
+under `src/main/agent/mcp-http/*-tools.ts`, keep its user-facing surfaces in sync:
+
+1. **Manifest:** add / rename / remove the matching entry in `MCP_TOOL_MANIFEST`
+   (`src/shared/mcp-tool-manifest.ts`). The entry's `name` MUST equal the registered tool name.
+   Give it a `label`, a one-line `blurb`, and a `category`.
+2. **Panel:** `McpServerTab.tsx` renders every manifest entry as a pill, grouped by category.
+   You do not edit the panel for a new tool - listing it in the manifest is enough.
+3. **Docs:** document the tool in `docs/mcp-server.md` (the exhaustive reference). This couples to
+   [[docs-stay-in-sync]]: the MCP tool list is a doc anchor.
+4. **Diagnostics group:** the dev-leaning diagnostics tools (and the read-only `kangentic_query_db`)
+   carry `category: 'diagnostics'`, so they render last under their own header. They are listed in
+   full like every other tool - there is no hidden flag. Do not drop a tool from the manifest to keep
+   it out of the panel; every registered tool belongs in the list.
+
+The dev-only `kangentic_devtools_*` tools live under `src/devtools/`, outside the scanned glob, and
+are intentionally not part of this surface.
+
+## Enforcement (self-maintaining)
+
+- **Test (mechanical, CI):** `tests/unit/mcp-tool-list-parity.test.ts` parses every
+  `registerTool('<name>', ...)` literal under `src/main/agent/mcp-http/*-tools.ts` (it globs by the
+  `-tools.ts` suffix, so a brand-new registration file is auto-covered) and asserts (a) every
+  registered tool has a manifest entry; (b) every manifest entry names a real registered tool
+  (catches a rename/removal); (c) every manifest tool appears in
+  `docs/mcp-server.md`. Runs in CI via `npm run test:unit`. Because the rule is path-scoped, a
+  brand-new `*-tools.ts` file does not pre-load this rule (the read-trigger gap); the CI test is the
+  real guarantee.
+- **Review:** `/code-review` flags a new `registerTool` call site without a matching manifest entry,
+  and the `doc-auditor` agent reports a tool missing from `docs/mcp-server.md`.
+
+Do not weaken these by deleting a manifest entry to silence the test - that reintroduces the exact
+drift the rule prevents.
+
+## Scope
+
+Tools registered under `src/main/agent/mcp-http/*-tools.ts` and the two surfaces that enumerate them
+for humans (the settings panel via `MCP_TOOL_MANIFEST`, and `docs/mcp-server.md`). The dev-only
+`kangentic_devtools_*` tools under `src/devtools/` are out of scope. The tools' own server-facing
+`description` strings (sent to agents) are authored independently of the manifest's short UI copy;
+this rule governs name parity, not description wording.

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -259,7 +259,7 @@ Each entry has a one-line rationale so future edits know what the entry was prot
   WHY: shared agent helpers (auto-name.ts, prompt-xml.ts, agent-detector.ts, bridge-utils.ts, hook-utils.ts, exec-version.ts) back multiple feature docs (configuration.md, agent-integration.md, cross-platform.md). Small directory; safe to glob.
 
 - `src/main/agent/mcp-http/**`
-  WHY: MCP tool registrations (task-tools.ts, session-tools.ts, search-tools.ts, project-tools.ts) are enumerated in mcp-server.md. Adding a new tool is a docs-affecting event.
+  WHY: MCP tool registrations (task-tools.ts, session-tools.ts, search-tools.ts, project-tools.ts, diagnostics-tools.ts, browser-tools.ts) are enumerated in mcp-server.md. Adding a new tool is a docs-affecting event. The settings panel renders the same tools from `src/shared/mcp-tool-manifest.ts` (`MCP_TOOL_MANIFEST`); `tests/unit/mcp-tool-list-parity.test.ts` asserts every registered tool is in both the manifest and mcp-server.md (see `.claude/rules/mcp-tool-list-parity.md`).
 
 - `src/main/agent/commands/**`
   WHY: MCP command implementations (column-resolver.ts, handoff-commands.ts, task-commands.ts, backlog-commands.ts, search-commands.ts, etc.) are cited in mcp-server.md component table and architecture.md board-integration section. Adding or renaming a command file is a docs-affecting event. Small directory (13 files); safe to glob.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,7 @@ session; rules with one load when you touch matching files. Each rule names its 
 - `restore-no-animation-replay.md` - a project switch / restore paints flat: restored windows skip the entrance animation (`skipEnterAnimation`) and `useValuePulse` rebaselines on a `resetKey` instead of pulsing (`src/renderer/`).
 - `cross-platform-parity.md` - code and tests must behave identically on Windows/macOS/Linux/CI; no OS-specific paths, no cross-test state leakage or pixel-exact assertions (`tests/`, `src/main/` pty/agent/git).
 - `browser-automation-driver.md` - the shipped CDP driver is singular and ships; every `kangentic_browser_*` tool routes through `withGuest`; no `src/devtools/` import from shipped code (`src/main/browser/`).
+- `mcp-tool-list-parity.md` - every MCP tool registered under `src/main/agent/mcp-http/*-tools.ts` stays in sync with `MCP_TOOL_MANIFEST` (the settings panel's source) and `docs/mcp-server.md` (`src/main/agent/mcp-http/`, `src/shared/mcp-tool-manifest.ts`).
 
 **Local overrides:** there is no per-rule local file. Put machine-specific instruction
 overrides in a gitignored `CLAUDE.local.md` at the project root.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,7 +165,6 @@ IPC channels for shortcuts are in the Board Config group: `boardConfig:getShortc
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `mcpServer.enabled` | boolean | `true` | Allow agents to create and query tasks via MCP tools. When disabled, no kangentic MCP server is injected into sessions. See [MCP Server](mcp-server.md). |
-| `mcpServer.maxTaskCreateCount` | number | `50` | Maximum tasks an agent may create via `kangentic_create_task` per app launch before the tool returns a rate-limit error. Read live (a change applies without restart); the accumulated count resets when Kangentic restarts. Configurable in Settings -> MCP Server. |
 
 ### notifications.*
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -94,7 +94,7 @@ If the target column has `auto_spawn` enabled, creating a task there will also s
 
 **Cross-project routing guard:** when `project` is omitted (so the task would default to the active project) but the title or description names a *different* registered project, the tool refuses with a routing-check error instead of creating the task. No task is created and no rate-limit slot is consumed. Re-run with `project: "<that project>"` to file it there, or with `project: "<active project>"` to confirm the active project. This catches the common cross-project triage case (filing a bug about one project from another) when the routing cue is only implied by the task text.
 
-Rate limit: capped at the Settings -> MCP Server "Max Tasks Per Session" value (`mcpServer.maxTaskCreateCount`, default 50) per app launch, shared across board and backlog. Exceeding the cap returns a clear error and creates nothing. The value is read live, so a change applies without restarting; the accumulated count resets on restart.
+Runaway-loop safeguard: a single Kangentic launch can create at most 500 tasks via this tool (a high internal circuit breaker against a misbehaving agent, shared across board and backlog, not a user-tunable setting). Hitting it returns a clear error and creates nothing; the accumulated count resets when Kangentic restarts.
 
 ### kangentic_list_columns
 
@@ -446,12 +446,12 @@ Targeting: every tool takes an optional `sessionId` or `taskId`; omit both to us
 
 Gating: the global **Agent Browser** settings tab controls the family, read live per request. `browserAutomation.enabled` is the master switch: when off, the entire `kangentic_browser_*` family is not registered, so the tools never appear in `tools/list` and the instructions omit their guidance section (they would be unusable anyway, and advertising them is wasted context). When `enabled` is on, the sub-capability gates apply: `allowInteraction` gates click/type/keypress/drag (off = observe-only); `allowNavigation` gates navigate; `allowEval` gates eval (off by default); `restrictNavigationToLocalhost` confines navigation to localhost/private hosts (off by default). With `enabled` on, each tool returns an actionable `{ kind, detail }` error when one of those sub-capabilities is gated off or no driveable pane exists.
 
-Tool categories:
-- **Discovery:** `list_panes`
-- **Navigate:** `navigate` - point the pane at an http(s) URL
-- **Observe:** `screenshot`, `screenshot_element`, `query_dom`, `query_all`, `bounding_box`, `console`, `wait`
-- **Interact:** `click`, `type`, `keypress`, `drag`
-- **Eval:** `eval` - evaluate a JavaScript expression in the loaded page; gated by `browserAutomation.allowEval`
+Tool categories (14 tools):
+- **Discovery:** `kangentic_browser_list_panes` - list open Browser panes and their URLs
+- **Navigate:** `kangentic_browser_navigate` - point the pane at an http(s) URL
+- **Observe:** `kangentic_browser_screenshot`, `kangentic_browser_screenshot_element`, `kangentic_browser_query_dom`, `kangentic_browser_query_all`, `kangentic_browser_bounding_box`, `kangentic_browser_console`, `kangentic_browser_wait`
+- **Interact:** `kangentic_browser_click`, `kangentic_browser_type`, `kangentic_browser_keypress`, `kangentic_browser_drag`
+- **Eval:** `kangentic_browser_eval` - evaluate a JavaScript expression in the loaded page; gated by `browserAutomation.allowEval`
 
 Cookie isolation is per worktree (`persist:kngbrowser-<hash(worktreePath)>`) so concurrent worktrees' dev environments never share a `localhost` cookie jar. See [embedded-browser.md](embedded-browser.md).
 
@@ -497,7 +497,7 @@ The `.claude/settings.json` file includes a wildcard permission entry (`mcp__kan
 - **Per-launch token** - every Kangentic launch generates a fresh 32-byte random `X-Kangentic-Token`. Clients without the token get `401`. Comparison is constant-time (`timingSafeEqual`) so a local timing oracle cannot byte-by-byte recover the token.
 - **DNS rebinding protection** - the Streamable HTTP transport enforces a host allowlist (`127.0.0.1`, `localhost`, `[::1]`) on top of the loopback bind.
 - **Project routing via URL path** - the URL embeds the project ID (`/mcp/<projectId>`). A stale `mcp.json` for a different project cannot be reused against the current launch.
-- **Rate limiting** - task creations are capped per app launch at the configurable Settings -> MCP Server "Max Tasks Per Session" value (`mcpServer.maxTaskCreateCount`, default 50), enforced atomically by the shared `TaskCounter`.
+- **Runaway-loop safeguard** - task creations are capped at a fixed 500 per app launch, enforced atomically by the shared `TaskCounter`. This is an internal circuit breaker against a looping agent, not a user-tunable knob; the count resets on restart.
 - **Input validation** - Zod schemas enforce title (200 chars) and description (10000 chars) limits at the protocol level; the command handlers validate again.
 - **Column safety** - `kangentic_create_task` defaults to the To Do column; creating in an auto_spawn column intentionally triggers agent spawn.
 - **Destructive operations are explicit** - `kangentic_delete_task`, `kangentic_delete_backlog_item`, and `kangentic_move_task` mutate the board. Agents must invoke them by name; there is no implicit fallback.

--- a/src/main/agent/mcp-http-server.ts
+++ b/src/main/agent/mcp-http-server.ts
@@ -67,11 +67,10 @@ export interface McpHttpServerHandle {
 export async function startMcpHttpServer(
   buildContext: ProjectContextFactory,
   getBrowserAutomationConfig: AutomationConfigReader,
-  getMaxTaskCreateCount: () => number,
 ): Promise<McpHttpServerHandle> {
   const token = randomBytes(32).toString('hex');
   const expectedTokenBuffer = Buffer.from(token, 'utf-8');
-  const taskCounter = makeTaskCounter(getMaxTaskCreateCount);
+  const taskCounter = makeTaskCounter();
 
   const httpServer: Server = createServer((req, res) => {
     handleHttpRequest(req, res, expectedTokenBuffer, buildContext, taskCounter, getBrowserAutomationConfig)

--- a/src/main/agent/mcp-http/handler-helpers.ts
+++ b/src/main/agent/mcp-http/handler-helpers.ts
@@ -31,32 +31,40 @@ export const PROJECT_SELECTOR_DESCRIPTION =
   'Optional project name (case-insensitive exact) or UUID to target a different project than the active one. Set it whenever the user\'s request names another registered project; omit for the active project. See the server instructions ("PROJECT ROUTING RULE") for how mentions are phrased, and kangentic_list_projects for valid names.';
 
 /**
+ * Internal runaway-loop safeguard: the maximum number of tasks one MCP
+ * server launch will create before `kangentic_create_task` starts refusing.
+ * This is a circuit breaker against a misbehaving agent looping on task
+ * creation, NOT a user-tunable quota. It is intentionally high (a heavy
+ * dogfooding day stays well under it) and resets on app restart.
+ */
+const MAX_TASK_CREATE_PER_LAUNCH = 500;
+
+/**
  * Atomic create_task rate-limit counter shared across all requests served
  * by one server-launch. Encapsulated as a getter+mutator pair so the
  * check-and-increment is impossible to race in the JS event loop.
  */
 export interface TaskCounter {
-  /** Reserve one slot. Returns false if the rate-limit ceiling is reached. */
+  /** Reserve one slot. Returns false if the runaway-loop ceiling is reached. */
   tryReserve(): boolean;
-  /** Current configured ceiling, read live. Used to build the rate-limit error message. */
+  /** The fixed ceiling. Used to build the limit-reached error message. */
   limit(): number;
 }
 
 /**
- * Build an in-memory TaskCounter enforcing a per-launch ceiling. The ceiling
- * is read live through `getMaxTaskCreateCount` on every reservation, so a
- * settings change to the cap takes effect without restarting the app (the
- * accumulated count still persists for the app launch and resets on restart).
+ * Build an in-memory TaskCounter enforcing the `MAX_TASK_CREATE_PER_LAUNCH`
+ * runaway-loop safeguard. The accumulated count persists for the app launch
+ * and resets on restart.
  */
-export function makeTaskCounter(getMaxTaskCreateCount: () => number): TaskCounter {
+export function makeTaskCounter(): TaskCounter {
   let count = 0;
   return {
     tryReserve: () => {
-      if (count >= getMaxTaskCreateCount()) return false;
+      if (count >= MAX_TASK_CREATE_PER_LAUNCH) return false;
       count++;
       return true;
     },
-    limit: () => getMaxTaskCreateCount(),
+    limit: () => MAX_TASK_CREATE_PER_LAUNCH,
   };
 }
 

--- a/src/main/agent/mcp-http/task-tools.ts
+++ b/src/main/agent/mcp-http/task-tools.ts
@@ -95,7 +95,7 @@ export function registerTaskTools(
       // No await between the check and the increment, so this can't race.
       if (!taskCounter.tryReserve()) {
         return Promise.resolve({
-          content: [{ type: 'text' as const, text: `Rate limit reached: maximum ${taskCounter.limit()} tasks per session.` }],
+          content: [{ type: 'text' as const, text: `Task-creation limit reached: this Kangentic MCP server already created its maximum of ${taskCounter.limit()} tasks since the app launched (a runaway-loop safeguard). Restart Kangentic to reset.` }],
           isError: true,
         });
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -732,7 +732,6 @@ app.whenReady().then(async () => {
         return createRequestResolver(ctx, projectId);
       },
       () => readBrowserAutomationConfig(getOptionalIpcContext()?.configManager ?? windowConfigManager),
-      () => Math.max(1, (getOptionalIpcContext()?.configManager ?? windowConfigManager).load().mcpServer.maxTaskCreateCount || 50),
     );
   } catch (err) {
     console.error('[APP] Failed to start MCP HTTP server:', err);

--- a/src/renderer/components/settings/settings-registry.ts
+++ b/src/renderer/components/settings/settings-registry.ts
@@ -94,7 +94,6 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
 
   // ── MCP Server ──
   { id: 'mcpServer.enabled', tabId: 'mcpServer', label: 'Kangentic MCP Server', description: 'Give agents tools to interact with your board', scope: 'global', keywords: ['mcp', 'tools', 'create task', 'agent', 'board', 'query', 'session', 'stats'] },
-  { id: 'mcpServer.maxTaskCreateCount', tabId: 'mcpServer', label: 'Max Tasks Per Session', description: 'Cap how many tasks an agent can create through MCP before it must stop. Resets when Kangentic restarts.', scope: 'global', keywords: ['rate limit', 'cap', 'flood', 'create task', 'mcp', 'max'] },
 
   // ── Behavior > Session Limits ──
   { id: 'agent.maxConcurrentSessions', tabId: 'behavior', label: 'Max Concurrent Sessions', description: 'Limit how many agents can run at the same time', scope: 'global', section: 'Session Limits', keywords: ['parallel', 'limit'] },

--- a/src/renderer/components/settings/tabs/McpServerTab.tsx
+++ b/src/renderer/components/settings/tabs/McpServerTab.tsx
@@ -1,7 +1,7 @@
 import { Plug } from 'lucide-react';
 import type { AppConfig } from '../../../../shared/types';
-import { DEFAULT_CONFIG } from '../../../../shared/types';
-import { INPUT_CLASS, SectionHeader, SettingRow, SettingToggleRow, useScopedUpdate } from '../shared';
+import { MCP_TOOL_CATEGORIES, MCP_TOOL_MANIFEST } from '../../../../shared/mcp-tool-manifest';
+import { SectionHeader, SettingToggleRow, useScopedUpdate } from '../shared';
 import { settingProps } from '../settings-registry';
 
 export function McpServerTab({ globalConfig }: { globalConfig: AppConfig }) {
@@ -17,35 +17,28 @@ export function McpServerTab({ globalConfig }: { globalConfig: AppConfig }) {
       />
 
       <div className={enabled ? '' : 'opacity-40 pointer-events-none'}>
-        <SettingRow {...settingProps('mcpServer.maxTaskCreateCount')}>
-          <input
-            type="number"
-            value={globalConfig.mcpServer?.maxTaskCreateCount ?? DEFAULT_CONFIG.mcpServer.maxTaskCreateCount}
-            onChange={(event) => {
-              if (event.target.value === '') return;
-              const value = Number(event.target.value);
-              if (Number.isNaN(value)) return;
-              updateGlobal({ mcpServer: { maxTaskCreateCount: Math.max(1, Math.min(500, Math.floor(value))) } });
-            }}
-            min={1}
-            max={500}
-            className={INPUT_CLASS}
-          />
-        </SettingRow>
-
         <SectionHeader label="Available Tools" searchIds={['mcpServer.enabled']} />
-        <ul className="list-disc list-inside text-sm text-fg-muted space-y-1 ml-1">
-          <li><strong className="text-fg-secondary">Create Task</strong> - add tasks to any column from within an agent session</li>
-          <li><strong className="text-fg-secondary">Update Task</strong> - edit title and description of existing tasks</li>
-          <li><strong className="text-fg-secondary">List Columns</strong> - see all board columns with task counts</li>
-          <li><strong className="text-fg-secondary">List Tasks</strong> - browse tasks, optionally filtered by column</li>
-          <li><strong className="text-fg-secondary">Search Tasks</strong> - find tasks by keyword across titles and descriptions</li>
-          <li><strong className="text-fg-secondary">Find Task</strong> - look up tasks by branch name, title, or PR number</li>
-          <li><strong className="text-fg-secondary">Board Summary</strong> - overview of task counts, active sessions, and costs</li>
-          <li><strong className="text-fg-secondary">Task Stats</strong> - token usage, cost, and duration for individual or all tasks</li>
-          <li><strong className="text-fg-secondary">Session History</strong> - timeline of sessions for a task</li>
-          <li><strong className="text-fg-secondary">Column Detail</strong> - automation settings, permission mode, and configuration</li>
-        </ul>
+        {MCP_TOOL_CATEGORIES.map((category) => {
+          const tools = MCP_TOOL_MANIFEST.filter((tool) => tool.category === category.id);
+          if (tools.length === 0) return null;
+          return (
+            <div key={category.id} className="mt-3 first:mt-1">
+              <h4 className="text-[11px] font-semibold uppercase tracking-wider text-fg-faint mb-1">{category.label}</h4>
+              <ul className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-1.5 ml-1">
+                {tools.map((tool) => (
+                  <li
+                    key={tool.name}
+                    data-testid="mcp-tool-pill"
+                    title={`${tool.label} - ${tool.blurb}`}
+                    className="truncate rounded-md border border-edge/50 bg-surface-hover/30 px-2.5 py-1 text-xs text-fg-secondary"
+                  >
+                    {tool.label}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
 
         <SectionHeader label="How It Works" searchIds={['mcpServer.enabled']} />
         <p className="text-sm text-fg-muted leading-relaxed">

--- a/src/shared/mcp-tool-manifest.ts
+++ b/src/shared/mcp-tool-manifest.ts
@@ -1,0 +1,102 @@
+/**
+ * Single source of truth for the user-facing MCP tool catalogue.
+ *
+ * The Kangentic MCP server registers tools across the `*-tools.ts` files in
+ * `src/main/agent/mcp-http/`. Two surfaces enumerate those tools for humans:
+ * the Settings -> MCP Server "Available Tools" list (`McpServerTab.tsx`) and
+ * `docs/mcp-server.md`. Before this manifest existed both hardcoded their own
+ * copies and drifted: the panel listed 10 of 46 registered tools.
+ *
+ * This manifest is the one list both the panel and the parity test read, so
+ * the catalogue cannot silently drift from the registrations again. Every
+ * registered tool MUST have an entry here, and every entry MUST name a real
+ * registered tool. `tests/unit/mcp-tool-list-parity.test.ts` enforces both
+ * directions plus presence in `docs/mcp-server.md`; the convention is
+ * documented in `.claude/rules/mcp-tool-list-parity.md`.
+ *
+ * The panel renders every entry as a pill, grouped by `category` in
+ * `MCP_TOOL_CATEGORIES` order, so the complete tool catalogue is visible
+ * (the dev-leaning diagnostics group sorts last under its own header). The
+ * array below is ordered to mirror that grouping; `category`, not array
+ * position, is what drives the panel grouping.
+ */
+
+export type McpToolCategoryId = 'tasks' | 'board' | 'sessions' | 'browser' | 'diagnostics';
+
+export interface McpToolManifestEntry {
+  /** Registered tool name. MUST match a registerTool('...') literal under src/main/agent/mcp-http/*-tools.ts. */
+  name: string;
+  /** User-facing label shown in the settings panel, e.g. 'Create Task'. */
+  label: string;
+  /** One-line user-facing blurb. */
+  blurb: string;
+  /** Grouping for the panel and docs. */
+  category: McpToolCategoryId;
+}
+
+/** Categories in panel render order. The diagnostics group sorts last under its own header. */
+export const MCP_TOOL_CATEGORIES: { id: McpToolCategoryId; label: string }[] = [
+  { id: 'tasks', label: 'Tasks' },
+  { id: 'board', label: 'Board' },
+  { id: 'sessions', label: 'Sessions' },
+  { id: 'browser', label: 'Browser Automation' },
+  { id: 'diagnostics', label: 'Diagnostics' },
+];
+
+export const MCP_TOOL_MANIFEST: McpToolManifestEntry[] = [
+  // ── Tasks (task-tools.ts) - operations on individual tasks ──
+  { name: 'kangentic_create_task', label: 'Create Task', blurb: 'add a task to any board column or the backlog', category: 'tasks' },
+  { name: 'kangentic_list_tasks', label: 'List Tasks', blurb: 'browse tasks, optionally filtered by column', category: 'tasks' },
+  { name: 'kangentic_search_tasks', label: 'Search Tasks', blurb: 'keyword search across board and backlog tasks', category: 'tasks' },
+  { name: 'kangentic_find_task', label: 'Find Task', blurb: 'look up a task by ID, branch, title, or PR number', category: 'tasks' },
+  { name: 'kangentic_get_current_task', label: 'Current Task', blurb: 'resolve the task for the current directory or branch', category: 'tasks' },
+  { name: 'kangentic_get_task_stats', label: 'Task Stats', blurb: 'token usage, cost, duration, and lines changed per task', category: 'tasks' },
+  { name: 'kangentic_update_task', label: 'Update Task', blurb: 'edit title, description, PR info, agent, priority, labels, base branch, and worktree', category: 'tasks' },
+  { name: 'kangentic_move_task', label: 'Move Task', blurb: 'move a task between columns, running the same lifecycle as a drag', category: 'tasks' },
+  { name: 'kangentic_link_pr', label: 'Link PR', blurb: 'resolve and attach a task pull request via the gh CLI', category: 'tasks' },
+  { name: 'kangentic_delete_task', label: 'Delete Task', blurb: 'permanently remove a task, its attachments, and session records', category: 'tasks' },
+
+  // ── Board (columns from task-tools.ts, backlog from session-tools.ts, projects/search from project-tools.ts + search-tools.ts) ──
+  { name: 'kangentic_list_columns', label: 'List Columns', blurb: 'see every board column with its task counts', category: 'board' },
+  { name: 'kangentic_get_column_detail', label: 'Column Detail', blurb: 'automation, permission mode, and config for a column', category: 'board' },
+  { name: 'kangentic_update_column', label: 'Update Column', blurb: 'rename, recolor, and configure a column automation', category: 'board' },
+  { name: 'kangentic_board_summary', label: 'Board Summary', blurb: 'counts, active sessions, and aggregate cost across the board', category: 'board' },
+  { name: 'kangentic_list_backlog', label: 'List Backlog', blurb: 'see items staged in the backlog', category: 'board' },
+  { name: 'kangentic_promote_backlog', label: 'Promote Backlog', blurb: 'move backlog items onto the board as tasks', category: 'board' },
+  { name: 'kangentic_update_backlog_item', label: 'Update Backlog Item', blurb: 'edit a backlog item title, description, priority, or labels', category: 'board' },
+  { name: 'kangentic_delete_backlog_item', label: 'Delete Backlog Item', blurb: 'permanently remove a backlog item and its attachments', category: 'board' },
+  { name: 'kangentic_list_projects', label: 'List Projects', blurb: 'every Kangentic project registered on this machine', category: 'board' },
+  { name: 'kangentic_search_everything', label: 'Search Everything', blurb: 'unified search across tasks, backlog, sessions, and projects', category: 'board' },
+
+  // ── Sessions (session-tools.ts) - per-task session history, transcripts, and handoff ──
+  { name: 'kangentic_list_sessions', label: 'List Sessions', blurb: 'session records for a task with timings, cost, and exit info', category: 'sessions' },
+  { name: 'kangentic_get_session_history', label: 'Session History', blurb: 'read the native agent session transcript file for a task', category: 'sessions' },
+  { name: 'kangentic_get_session_files', label: 'Session Files', blurb: 'absolute paths to a session activity, status, and history files', category: 'sessions' },
+  { name: 'kangentic_get_session_events', label: 'Session Events', blurb: 'parsed activity events from a session log', category: 'sessions' },
+  { name: 'kangentic_get_handoff_context', label: 'Handoff Context', blurb: 'the most recent cross-agent handoff record for a task', category: 'sessions' },
+  { name: 'kangentic_get_transcript', label: 'Get Transcript', blurb: 'read what the agent on another task or project said', category: 'sessions' },
+
+  // ── Browser Automation (browser-tools.ts) ──
+  { name: 'kangentic_browser_list_panes', label: 'List Browser Panes', blurb: 'open embedded Browser panes and their URLs', category: 'browser' },
+  { name: 'kangentic_browser_navigate', label: 'Navigate', blurb: 'point a task Browser pane at a URL', category: 'browser' },
+  { name: 'kangentic_browser_screenshot', label: 'Screenshot', blurb: 'capture the Browser pane as an image', category: 'browser' },
+  { name: 'kangentic_browser_screenshot_element', label: 'Screenshot Element', blurb: 'capture a single element in the Browser pane', category: 'browser' },
+  { name: 'kangentic_browser_query_dom', label: 'Query DOM', blurb: 'get the HTML and box of an element', category: 'browser' },
+  { name: 'kangentic_browser_query_all', label: 'Query All', blurb: 'measure every element matching a selector', category: 'browser' },
+  { name: 'kangentic_browser_bounding_box', label: 'Bounding Box', blurb: 'the CDP box model of an element', category: 'browser' },
+  { name: 'kangentic_browser_console', label: 'Browser Console', blurb: 'read recent console messages from the pane', category: 'browser' },
+  { name: 'kangentic_browser_wait', label: 'Wait', blurb: 'wait for an element or text to appear', category: 'browser' },
+  { name: 'kangentic_browser_click', label: 'Click', blurb: 'click an element or a point in the pane', category: 'browser' },
+  { name: 'kangentic_browser_type', label: 'Type', blurb: 'type text into the Browser pane', category: 'browser' },
+  { name: 'kangentic_browser_keypress', label: 'Keypress', blurb: 'send a key or chord to the pane', category: 'browser' },
+  { name: 'kangentic_browser_drag', label: 'Drag', blurb: 'drag from one element to another', category: 'browser' },
+  { name: 'kangentic_browser_eval', label: 'Eval', blurb: 'evaluate JavaScript in the page (off by default)', category: 'browser' },
+
+  // ── Diagnostics (diagnostics-tools.ts; query_db from session-tools.ts) - dev-leaning, rendered last ──
+  { name: 'kangentic_query_db', label: 'Query Database', blurb: 'run a read-only SQL query against the project database', category: 'diagnostics' },
+  { name: 'kangentic_tail_logs', label: 'Tail Logs', blurb: 'read recent lines from the Kangentic console log', category: 'diagnostics' },
+  { name: 'kangentic_get_recent_crashes', label: 'Recent Crashes', blurb: 'list recent crash records with source-mapped stacks', category: 'diagnostics' },
+  { name: 'kangentic_get_process_metrics', label: 'Process Metrics', blurb: 'memory and CPU per Electron process', category: 'diagnostics' },
+  { name: 'kangentic_get_ipc_log', label: 'IPC Log', blurb: 'recent IPC traffic with timings and errors', category: 'diagnostics' },
+  { name: 'kangentic_list_worktrees', label: 'List Worktrees', blurb: 'enumerate worktrees with branch and dirty state', category: 'diagnostics' },
+];

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1418,8 +1418,6 @@ export interface AppConfig {
 
   mcpServer: {
     enabled: boolean;
-    /** Max tasks an agent may create via MCP before it must stop, per app launch. Resets on restart. */
-    maxTaskCreateCount: number;
   };
 
   contextBar: {
@@ -1698,7 +1696,6 @@ export const DEFAULT_CONFIG: AppConfig = {
   },
   mcpServer: {
     enabled: true,
-    maxTaskCreateCount: 50,
   },
   contextBar: {
     showShell: true,

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -87,7 +87,6 @@
     },
     mcpServer: {
       enabled: true,
-      maxTaskCreateCount: 50,
     },
     contextBar: {
       showShell: true,

--- a/tests/ui/settings-panel.spec.ts
+++ b/tests/ui/settings-panel.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
-import { launchPage, waitForBoard, createProject } from './helpers';
+import { launchPage, createProject } from './helpers';
 import type { Browser, Page } from '@playwright/test';
+import { MCP_TOOL_MANIFEST } from '../../src/shared/mcp-tool-manifest';
 
 let browser: Browser;
 let page: Page;
@@ -279,7 +280,7 @@ test.describe('Settings Panel', () => {
     await closeSettings();
   });
 
-  test('shows MCP Server tab with toggle, tools list, and how it works', async () => {
+  test('shows MCP Server tab with toggle, grouped tools list, and how it works', async () => {
     await openSettings();
     await page.getByRole('button', { name: 'MCP Server' }).click();
 
@@ -287,85 +288,41 @@ test.describe('Settings Panel', () => {
     await expect(page.getByText('Kangentic MCP Server')).toBeVisible();
     await expect(page.getByText('Give agents tools to interact with your board')).toBeVisible();
 
-    // Settings-driven task-creation cap, defaulting to 50
-    await expect(page.getByText('Max Tasks Per Session')).toBeVisible();
-    await expect(
-      page.getByTestId('setting-row-mcpServer.maxTaskCreateCount').locator('input[type="number"]'),
-    ).toHaveValue('50');
+    // No user-tunable task-creation cap anymore (it is now a fixed internal backstop).
+    await expect(page.getByText('Max Tasks Per Session')).toHaveCount(0);
 
-    // Tools list should be visible (spot-check a few)
-    await expect(page.getByRole('list').getByText('Create Task')).toBeVisible();
-    await expect(page.getByText('Board Summary')).toBeVisible();
+    // The tools list renders from MCP_TOOL_MANIFEST, grouped by category as pills.
+    // Spot-check each section header by its heading role (short labels like "Board"
+    // are substrings of tool names AND collide with the board view-toggle button
+    // behind the panel) plus a representative tool from each group. Backlog tools
+    // and Search Everything live under Board; sessions under Sessions.
+    await expect(page.getByRole('heading', { name: 'Tasks', exact: true })).toBeVisible();
+    await expect(page.getByText('Create Task')).toBeVisible();
+    await expect(page.getByText('Move Task')).toBeVisible();
+    await expect(page.getByText('Delete Task')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Board', exact: true })).toBeVisible();
+    await expect(page.getByText('List Backlog')).toBeVisible();
+    await expect(page.getByText('Search Everything')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Sessions', exact: true })).toBeVisible();
     await expect(page.getByText('Session History')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Browser Automation', exact: true })).toBeVisible();
+    await expect(page.getByText('Bounding Box')).toBeVisible();
+
+    // The complete catalogue (including the dev-leaning diagnostics group) is now
+    // rendered as pills, one per manifest entry. Pinning the pill count to the
+    // manifest length is the red-green anchor: dropping a tool, or a category that
+    // fails to render, fails here, and a newly-added tool is covered for free.
+    await expect(page.getByTestId('mcp-tool-pill')).toHaveCount(MCP_TOOL_MANIFEST.length);
+    // The diagnostics tools that the panel used to omit now appear under their header.
+    await expect(page.getByRole('heading', { name: 'Diagnostics', exact: true })).toBeVisible();
+    await expect(page.getByText('Tail Logs', { exact: true })).toBeVisible();
+    await expect(page.getByText('Query Database', { exact: true })).toBeVisible();
+    await expect(page.getByText('List Worktrees', { exact: true })).toBeVisible();
 
     // How It Works section
     await expect(page.getByText('How It Works')).toBeVisible();
 
     await closeSettings();
-  });
-
-  test.describe('MCP Server tab - maxTaskCreateCount clamp', () => {
-    // Helper: open Settings and navigate to the MCP Server tab from scratch.
-    // Each test owns its setup to avoid cross-test state leakage (cross-platform-parity rule).
-    async function openMcpServerTab() {
-      await openSettings();
-      await page.getByRole('button', { name: 'MCP Server' }).click();
-    }
-
-    test('valid in-range value 25 persists and the input reflects it', async () => {
-      await openMcpServerTab();
-      const input = page.getByTestId('setting-row-mcpServer.maxTaskCreateCount').locator('input[type="number"]');
-      await input.waitFor({ state: 'visible', timeout: 3000 });
-      try {
-        await input.fill('25');
-        // onChange: Math.max(1, Math.min(500, Math.floor(25))) = 25.
-        // updateGlobal fires config.set, which deep-merges and re-fetches; Zustand
-        // updates globalConfig; React re-renders the controlled input to 25.
-        // toHaveValue retries until the controlled value settles.
-        await expect(input).toHaveValue('25');
-      } finally {
-        // Reset to default so later tests start from a known state.
-        await input.fill('50');
-        await expect(input).toHaveValue('50');
-        await closeSettings();
-      }
-    });
-
-    test('over-max value 5000 clamps to 500', async () => {
-      await openMcpServerTab();
-      const input = page.getByTestId('setting-row-mcpServer.maxTaskCreateCount').locator('input[type="number"]');
-      await input.waitFor({ state: 'visible', timeout: 3000 });
-      try {
-        await input.fill('5000');
-        // onChange: Math.max(1, Math.min(500, Math.floor(5000))) = 500.
-        // Red-green: reverting the onChange to omit Math.min(500, ...) would let 5000
-        // persist in the config, and the controlled input would re-render with 5000,
-        // causing toHaveValue('500') to fail.
-        await expect(input).toHaveValue('500');
-      } finally {
-        await input.fill('50');
-        await expect(input).toHaveValue('50');
-        await closeSettings();
-      }
-    });
-
-    test('value 0 clamps to minimum 1', async () => {
-      await openMcpServerTab();
-      const input = page.getByTestId('setting-row-mcpServer.maxTaskCreateCount').locator('input[type="number"]');
-      await input.waitFor({ state: 'visible', timeout: 3000 });
-      try {
-        await input.fill('0');
-        // onChange: Math.max(1, Math.min(500, Math.floor(0))) = 1.
-        // Red-green: reverting the onChange to omit Math.max(1, ...) would let 0
-        // persist in the config, and the controlled input would re-render with 0,
-        // causing toHaveValue('1') to fail.
-        await expect(input).toHaveValue('1');
-      } finally {
-        await input.fill('50');
-        await expect(input).toHaveValue('50');
-        await closeSettings();
-      }
-    });
   });
 
   test('reopens to the last viewed tab after closing', async () => {

--- a/tests/unit/mcp-task-counter.test.ts
+++ b/tests/unit/mcp-task-counter.test.ts
@@ -9,39 +9,32 @@ vi.mock('../../src/main/agent/commands', () => ({ commandHandlers: {} }));
 
 import { makeTaskCounter } from '../../src/main/agent/mcp-http/handler-helpers';
 
-describe('makeTaskCounter (settings-driven, live ceiling)', () => {
-  it('enforces the ceiling and reads it fresh on every reservation', () => {
-    let max = 2;
-    const counter = makeTaskCounter(() => max);
-
-    expect(counter.tryReserve()).toBe(true);  // 1
-    expect(counter.tryReserve()).toBe(true);  // 2
-    expect(counter.tryReserve()).toBe(false); // 3 - at ceiling
-
-    // Raising the configured ceiling lets more reservations through WITHOUT
-    // resetting the accumulated count: the thunk is read live on each call, so a
-    // settings change takes effect mid-launch.
-    max = 4;
-    expect(counter.tryReserve()).toBe(true);  // 3
-    expect(counter.tryReserve()).toBe(true);  // 4
-    expect(counter.tryReserve()).toBe(false); // 5 - at the new ceiling
+// The runaway-loop ceiling is a fixed internal constant (MAX_TASK_CREATE_PER_LAUNCH
+// in handler-helpers.ts), not a user-tunable setting. limit() reports it.
+describe('makeTaskCounter (fixed runaway-loop ceiling)', () => {
+  it('reports a high fixed ceiling via limit()', () => {
+    const counter = makeTaskCounter();
+    expect(counter.limit()).toBeGreaterThanOrEqual(500);
   });
 
-  it('blocks further reservations when the ceiling is lowered below the current count', () => {
-    let max = 5;
-    const counter = makeTaskCounter(() => max);
-    expect(counter.tryReserve()).toBe(true); // 1
-    expect(counter.tryReserve()).toBe(true); // 2
+  it('reserves up to the ceiling, then refuses', () => {
+    const counter = makeTaskCounter();
+    const ceiling = counter.limit();
 
-    max = 1; // now below the accumulated count of 2
+    for (let reserved = 0; reserved < ceiling; reserved++) {
+      expect(counter.tryReserve()).toBe(true);
+    }
+    // The ceiling is reached: the next reservation is refused.
+    expect(counter.tryReserve()).toBe(false);
+    // And stays refused (the count does not roll over).
     expect(counter.tryReserve()).toBe(false);
   });
 
-  it('exposes the current ceiling live via limit()', () => {
-    let max = 7;
-    const counter = makeTaskCounter(() => max);
-    expect(counter.limit()).toBe(7);
-    max = 9;
-    expect(counter.limit()).toBe(9);
+  it('each counter accumulates independently of others', () => {
+    const first = makeTaskCounter();
+    const second = makeTaskCounter();
+    expect(first.tryReserve()).toBe(true);
+    // A reservation on one counter does not advance the other.
+    expect(second.tryReserve()).toBe(true);
   });
 });

--- a/tests/unit/mcp-task-session-tools.test.ts
+++ b/tests/unit/mcp-task-session-tools.test.ts
@@ -73,15 +73,20 @@ vi.mock('../../src/main/agent/mcp-http/handler-helpers', () => ({
   // Identity stub: the real sanitizer is unit-tested elsewhere; here we
   // only need the routing-check message to embed names verbatim.
   sanitizeProjectName: (name: string) => name,
-  makeTaskCounter: (getMaxTaskCreateCount: () => number) => {
+  makeTaskCounter: () => {
     let count = 0;
+    // Arbitrary high ceiling so the routing tests' creations are never throttled.
+    // It mirrors MAX_TASK_CREATE_PER_LAUNCH in handler-helpers.ts but need not stay
+    // in lockstep: the exhaustion tests below use their own decoupled counters, and
+    // the real ceiling is verified in mcp-task-counter.test.ts.
+    const ceiling = 500;
     return {
       tryReserve: vi.fn(() => {
-        if (count >= getMaxTaskCreateCount()) return false;
+        if (count >= ceiling) return false;
         count++;
         return true;
       }),
-      limit: () => getMaxTaskCreateCount(),
+      limit: () => ceiling,
     };
   },
   PROJECT_SELECTOR_DESCRIPTION: 'optional project selector',
@@ -205,7 +210,7 @@ describe('create_task rate-limit wiring', () => {
     const result = await server.getHandler('kangentic_create_task')({ title: 'One too many' });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('Rate limit reached');
+    expect(result.content[0].text).toContain('Task-creation limit reached');
     expect(result.content[0].text).toContain(String(MAX_TASKS));
     // callHandler must NOT be called after a failed tryReserve.
     expect(mockCallHandler).not.toHaveBeenCalled();
@@ -216,7 +221,7 @@ describe('create_task rate-limit wiring', () => {
     // REPORTED_LIMIT=7 - deliberately mismatched values. If task-tools.ts were
     // changed to interpolate a captured constant (e.g. the accumulated count at
     // exhaustion time, or any frozen number) instead of calling taskCounter.limit()
-    // live, the error text would say "maximum 3 tasks per session" and the
+    // live, the error text would say "maximum of 3 tasks" and the
     // toContain('7') assertion below would fail.
     //
     // Red-green: temporarily change the rate-limit error string in task-tools.ts
@@ -244,12 +249,12 @@ describe('create_task rate-limit wiring', () => {
     const result = await decoupledServer.getHandler('kangentic_create_task')({ title: 'Overflow' });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('Rate limit reached');
+    expect(result.content[0].text).toContain('Task-creation limit reached');
     // Must contain the live limit() value ('7'), not the exhaustion count ('3').
     expect(result.content[0].text).toContain(String(REPORTED_LIMIT));
     // Defensive: '3' must NOT appear; if it does, the code read the count at
     // exhaustion instead of calling limit() live. (Message is
-    // "Rate limit reached: maximum 7 tasks per session." which contains no '3'.)
+    // "...maximum of 7 tasks since the app launched..." which contains no '3'.)
     expect(result.content[0].text).not.toContain(String(EXHAUST_AT));
   });
 });

--- a/tests/unit/mcp-tool-list-parity.test.ts
+++ b/tests/unit/mcp-tool-list-parity.test.ts
@@ -1,0 +1,101 @@
+/**
+ * MCP tool-list parity guard (see .claude/rules/mcp-tool-list-parity.md).
+ *
+ * The Kangentic MCP server registers its tools across the `*-tools.ts` files in
+ * src/main/agent/mcp-http/. Two human-facing surfaces enumerate those tools:
+ * the Settings -> MCP Server "Available Tools" list (McpServerTab.tsx) and
+ * docs/mcp-server.md. Both used to hardcode their own copy and drifted - the
+ * panel listed 10 of 46 registered tools, missing the whole browser and backlog
+ * families.
+ *
+ * src/shared/mcp-tool-manifest.ts is now the one list both surfaces read. This
+ * test (pure source analysis, runs in CI) makes drift unmergeable by asserting:
+ *   (a) every registered tool has a manifest entry (a new tool fails until listed);
+ *   (b) every manifest entry names a real registered tool (a renamed/removed
+ *       tool fails until the manifest is updated);
+ *   (c) every manifest tool is documented in docs/mcp-server.md, which is the
+ *       exhaustive reference.
+ *
+ * The dev-only kangentic_devtools_* tools live under src/devtools/, OUTSIDE the
+ * scanned glob, so they are intentionally not in scope. Within scope, every
+ * registered tool is enumerated in the panel and the docs; the diagnostics group
+ * (diagnostics + query_db) simply renders last under its own header.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { MCP_TOOL_MANIFEST } from '../../src/shared/mcp-tool-manifest';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const MCP_HTTP_DIR = path.join(REPO_ROOT, 'src/main/agent/mcp-http');
+const DOCS_PATH = path.join(REPO_ROOT, 'docs/mcp-server.md');
+
+/** The shipped registration files. Glob by suffix so a brand-new `<x>-tools.ts` is auto-covered. */
+function collectToolFiles(): string[] {
+  return fs
+    .readdirSync(MCP_HTTP_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('-tools.ts'))
+    .map((entry) => path.join(MCP_HTTP_DIR, entry.name));
+}
+
+/**
+ * Collect every registerTool('<name>', ...) literal. The name literal sits on
+ * the line AFTER `registerTool(`, so we scan whole-file content (JS `\s`
+ * matches the newline) rather than line-by-line.
+ */
+function collectRegisteredToolNames(): Set<string> {
+  const names = new Set<string>();
+  const pattern = /registerTool\(\s*(['"])([^'"]+)\1/g;
+  for (const filePath of collectToolFiles()) {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    for (const match of content.matchAll(pattern)) {
+      names.add(match[2]);
+    }
+  }
+  return names;
+}
+
+const registeredNames = collectRegisteredToolNames();
+const manifestNames = new Set(MCP_TOOL_MANIFEST.map((entry) => entry.name));
+
+describe('mcp tool-list parity', () => {
+  it('finds the registered tools (glob did not silently miss the files)', () => {
+    expect(registeredNames.size).toBeGreaterThan(0);
+  });
+
+  it('the manifest has no duplicate tool names', () => {
+    expect(manifestNames.size).toBe(MCP_TOOL_MANIFEST.length);
+  });
+
+  it('every registered tool has a manifest entry', () => {
+    const missing = [...registeredNames].filter((name) => !manifestNames.has(name)).sort();
+    expect(
+      missing,
+      `These tools are registered under src/main/agent/mcp-http/*-tools.ts but missing from `
+        + `MCP_TOOL_MANIFEST (src/shared/mcp-tool-manifest.ts). Add an entry with a label, blurb, `
+        + `and category:\n${missing.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('every manifest entry names a real registered tool', () => {
+    const phantom = [...manifestNames].filter((name) => !registeredNames.has(name)).sort();
+    expect(
+      phantom,
+      `These MCP_TOOL_MANIFEST entries name no registered tool (renamed or removed?). Remove or `
+        + `fix them in src/shared/mcp-tool-manifest.ts:\n${phantom.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('every manifest tool is documented in docs/mcp-server.md', () => {
+    const docContent = fs.readFileSync(DOCS_PATH, 'utf-8');
+    const undocumented = MCP_TOOL_MANIFEST.map((entry) => entry.name)
+      .filter((name) => !docContent.includes(name))
+      .sort();
+    expect(
+      undocumented,
+      `These tools are not documented in docs/mcp-server.md (the exhaustive reference). Add a `
+        + `description for each:\n${undocumented.join('\n')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Cleans up the **Settings -> MCP Server** tab, in three parts:

1. **Removes the `maxTaskCreateCount` setting.** The number input, its `settings-registry` entry, the `AppConfig`/`DEFAULT_CONFIG` field, and the mock are gone. The cap is now a fixed internal constant `MAX_TASK_CREATE_PER_LAUNCH = 500` in `handler-helpers.ts`, and the `kangentic_create_task` error message no longer says "per session".
2. **Rebuilds the "Available Tools" list** from a new single source of truth, `src/shared/mcp-tool-manifest.ts` (`MCP_TOOL_MANIFEST`, all 46 registered tools). `McpServerTab.tsx` renders every tool as a pill grouped by category (Tasks, Board, Sessions, Browser Automation, Diagnostics). The old hardcoded list showed only 10.
3. **Adds a parity rule + CI test** so the list can never drift again.

Affected: `src/main/agent/mcp-http/handler-helpers.ts`, `mcp-http-server.ts`, `task-tools.ts`, `src/main/index.ts`, `src/shared/types.ts`, `src/shared/mcp-tool-manifest.ts` (new), `src/renderer/components/settings/{tabs/McpServerTab.tsx,settings-registry.ts}`, `docs/{configuration,mcp-server}.md`, `.claude/rules/mcp-tool-list-parity.md` (new), and the tests.

## Why

The counter was created once per app launch and shared across every request, agent, and project. So the "Max Tasks Per Session" label and the "per session" error were both wrong (it was one app-wide budget), and once any mix of agents created 50 tasks since launch, `kangentic_create_task` was silently blocked app-wide until restart. A cap like that should be an invisible runaway-loop circuit breaker, not a user-tunable knob.

Separately, the hardcoded tools list had gone badly stale: it listed 10 of the 46 registered tools, omitting the entire browser and backlog families, move/delete task, `list_projects`, and `search_everything`. Nothing forced it to track the registrations.

## How

The cap reuses the existing `TaskCounter` interface and `makeTaskCounter` factory, just dropping the live-read argument in favor of the internal constant. Removing the config key is safe for a user currently sitting on an exhausted counter: a stale `maxTaskCreateCount` left in `config.json` is ignored once the key is dropped from the type.

The manifest is the one list both the panel and the parity test read. `tests/unit/mcp-tool-list-parity.test.ts` statically parses the `registerTool('kangentic_...', ...)` literals under `src/main/agent/mcp-http/*-tools.ts` and asserts the registered set equals the manifest set (both directions) and that every manifest tool appears in `docs/mcp-server.md`. The dev-only `kangentic_devtools_*` tools live under `src/devtools/`, outside the scanned glob, so they are intentionally out of scope. This mirrors the existing `external-scripts-parity` / `board-config-parity` tests and ties into `docs-stay-in-sync`.

## Breaking changes

None requiring user action. `mcpServer.maxTaskCreateCount` is removed from the config schema; any leftover value in an existing `config.json` is silently ignored.

## Tests

- New `tests/unit/mcp-tool-list-parity.test.ts` (red-green verified: removing a manifest entry fails the test naming the tool).
- Rewrote `tests/unit/mcp-task-counter.test.ts` for the fixed-ceiling counter and updated `tests/unit/mcp-task-session-tools.test.ts` for the no-arg `makeTaskCounter`.
- Updated `tests/ui/settings-panel.spec.ts`: the cap input is gone; the grouped pill list (including diagnostics) is asserted, pinned to `MCP_TOOL_MANIFEST.length`.
- Local gate before push: `npm run typecheck` and `npm run lint` clean; scoped unit + the MCP Server UI spec pass. The full unit/UI/Electron-E2E tiers run as the CI checks on this PR.

Generated with [Claude Code](https://claude.com/claude-code)
