### PR TITLE
fix(pty): show the live model on background task cards

### DIFF
--- a/src/main/agent/adapters/claude/command-builder.ts
+++ b/src/main/agent/adapters/claude/command-builder.ts
@@ -8,9 +8,24 @@ import { buildHooks } from './hook-manager';
 import type { ClaudeHookEntry } from './hook-manager';
 import type { CommandOptions } from '../../agent-adapter';
 
+/**
+ * Coarse seconds for the statusLine `refreshInterval`. Claude only runs the
+ * statusLine command on event-driven triggers (after an assistant message,
+ * /compact, permission-mode change, vim toggle - never at session start), so a
+ * background / idle session can go a long time without writing status.json and
+ * the board card never learns the live model + context %. `refreshInterval`
+ * re-runs the command on a fixed timer regardless, which keeps status.json
+ * flowing for unopened cards. Kept coarse (not the 1s minimum) on purpose: the
+ * card already shows a correct model/agent placeholder instantly (see
+ * TaskCard), so this only backfills the slow-moving live numbers; one node
+ * bridge spawn per session per interval is plenty. Docs:
+ * https://code.claude.com/docs/en/statusline (units are seconds, min 1).
+ */
+const STATUS_LINE_REFRESH_INTERVAL_SECONDS = 10;
+
 /** Subset of Claude Code settings.json that we read/write. */
 interface ClaudeSettings {
-  statusLine?: { type: string; command: string };
+  statusLine?: { type: string; command: string; refreshInterval?: number };
   hooks?: Record<string, ClaudeHookEntry[]>;
   [key: string]: unknown; // preserve unknown keys from user's settings
 }
@@ -263,6 +278,7 @@ export class CommandBuilder {
       statusLine: {
         type: 'command',
         command: `node "${statusBridge}" "${statusPath}"`,
+        refreshInterval: STATUS_LINE_REFRESH_INTERVAL_SECONDS,
       },
     };
 

--- a/src/main/pty/lifecycle/session-spawn-flow.ts
+++ b/src/main/pty/lifecycle/session-spawn-flow.ts
@@ -22,6 +22,17 @@ import { isShuttingDown } from '../../shutdown-state';
 import { adaptCommandForShell } from '../../../shared/paths';
 
 /**
+ * Default PTY dimensions a session is spawned at, before any renderer-driven
+ * resize. Exported so the statusline-repaint kick in SessionManager has a
+ * fallback size for a background session that has not been resized yet: the
+ * kick nudges relative to the PTY's current size (resize to rows-1 then back
+ * forces a SIGWINCH without changing the ending dimensions), and for a
+ * never-resized session that current size is exactly this spawn default.
+ */
+export const DEFAULT_PTY_COLS = 120;
+export const DEFAULT_PTY_ROWS = 30;
+
+/**
  * Collaborators that the spawn flow reads and mutates. Grouped into a
  * single object so the signature stays readable as new modules get
  * wired into the lifecycle.
@@ -151,8 +162,8 @@ export async function performSpawn(
   try {
     ptyProcess = pty.spawn(shellExe, shellArgs, {
       name: 'xterm-256color',
-      cols: 120,
-      rows: 30,
+      cols: DEFAULT_PTY_COLS,
+      rows: DEFAULT_PTY_ROWS,
       cwd: effectiveCwd,
       env: cleanEnv,
     });

--- a/src/main/pty/session-manager.ts
+++ b/src/main/pty/session-manager.ts
@@ -16,7 +16,7 @@ import { ResizeManager } from './lifecycle/resize-manager';
 import { FirstOutputTracker } from './lifecycle/first-output-tracker';
 import { disposeAdapterAttachment, removeAdapterHooks } from './lifecycle/adapter-lifecycle';
 import { safeKillPty } from './lifecycle/pty-kill';
-import { performSpawn } from './lifecycle/session-spawn-flow';
+import { performSpawn, DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS } from './lifecycle/session-spawn-flow';
 import { SessionRegistry, toSession, filterCacheByProject, type ManagedSession } from './session-registry';
 import { createWriteQueue, type WriteQueue } from './write-queue';
 import { BackpressureController } from './buffer/backpressure-controller';
@@ -112,6 +112,18 @@ export class SessionManager extends EventEmitter {
           : undefined;
         if (this.firstOutputTracker.consume(sessionId, data, detector)) {
           this.emit('first-output', sessionId);
+          // Statusline-based agents (Claude) only write status.json - the sole
+          // source of the board card's live model + context % - when their TUI
+          // paints. In the app's pwsh-wrapped PTY a background (never-opened)
+          // session never does that initial paint on its own, so status.json is
+          // never written and the card is stuck on the spawn-time model
+          // placeholder. Now that the CLI has started rendering (first output),
+          // nudge the PTY once to force a paint; the settings' refreshInterval
+          // then keeps status.json fresh. Gated on the statusFile capability so
+          // it stays scoped to agents that use the statusline pipeline.
+          if (session?.agentParser?.runtime?.statusFile) {
+            this.kickStatuslineRepaint(sessionId);
+          }
           // Clear the resuming flag once the resumed CLI has actually
           // produced output. This unblocks card / overlay labels for
           // adapters (Codex, Gemini) that don't emit a usage statusline.
@@ -482,6 +494,45 @@ export class SessionManager extends EventEmitter {
     // transitions during the redraw burst that follows.
     this.resizeManager.notifyResize(sessionId);
     return { colsChanged };
+  }
+
+  /**
+   * One-time SIGWINCH nudge to force a statusline-based agent's TUI to paint,
+   * called when the CLI first produces output.
+   *
+   * Why: Claude only runs its statusLine command - the sole source of the live
+   * model + context % (status.json) - when its TUI actually paints. In the app's
+   * pwsh-wrapped PTY, a background (never-opened) session never does that initial
+   * paint on its own, so status.json is never written and the board card never
+   * advances past the spawn-time model placeholder. (`refreshInterval` only
+   * SUPPLEMENTS an already-painting statusline; it cannot kick off the first
+   * paint.) A resize forces the paint - which is exactly why opening a task
+   * historically "fixed" it (the terminal mount resized the PTY). This does the
+   * same once, automatically, so background cards get the real model + % without
+   * being opened.
+   *
+   * Nudge rows down then back to the PTY's CURRENT size so it ends where it
+   * started; routing through resize() reuses the redraw-suppression grace
+   * window so the forced repaint is not misread as activity.
+   *
+   * Nudge relative to the live `pty.cols`/`pty.rows` (falling back to the spawn
+   * defaults) rather than the hardcoded defaults: a background session is still
+   * at the spawn size, but a session whose task is already open has had its PTY
+   * fit to the real terminal viewport, and forcing it back to the spawn default
+   * would leave the PTY mismatched with the displayed xterm (wrong wrapping)
+   * until the next renderer-driven resize.
+   */
+  private kickStatuslineRepaint(sessionId: string): void {
+    const session = this.registry.get(sessionId);
+    if (!session?.pty) return;
+    const cols = session.pty.cols || DEFAULT_PTY_COLS;
+    const rows = session.pty.rows || DEFAULT_PTY_ROWS;
+    this.resize(sessionId, cols, rows - 1);
+    setTimeout(() => {
+      if (this.registry.get(sessionId)?.pty) {
+        this.resize(sessionId, cols, rows);
+      }
+    }, 200);
   }
 
   /**

--- a/src/renderer/components/board/TaskCard.tsx
+++ b/src/renderer/components/board/TaskCard.tsx
@@ -31,11 +31,11 @@ interface TaskCardProps {
 }
 
 const TaskCardInner = function TaskCard({ task, isDragOverlay, compact, onDelete }: TaskCardProps) {
-  // A single `useShallow`-gated selector replaces six individual subscriptions.
-  // Scaling: 100 cards × 6 subs each = 600 selector invocations per session-store
+  // A single `useShallow`-gated selector replaces four individual subscriptions.
+  // Scaling: 100 cards × 4 subs each = 400 selector invocations per session-store
   // update; with one selector it drops to 100, and shallow equality still skips
   // re-renders when the projected object hasn't actually changed.
-  const { sessionId, isHighlighted, isResuming, hasFirstOutput, hasActivityEntry, activityReason } = useSessionStore(
+  const { sessionId, isHighlighted, isResuming, activityReason } = useSessionStore(
     useShallow(
       useCallback(
         (s: ReturnType<typeof useSessionStore.getState>) => {
@@ -44,8 +44,6 @@ const TaskCardInner = function TaskCard({ task, isDragOverlay, compact, onDelete
             sessionId: resolvedSessionId,
             isHighlighted: !!resolvedSessionId && resolvedSessionId === s.activeSessionId,
             isResuming: s._sessionByTaskId.get(task.id)?.resuming ?? false,
-            hasFirstOutput: resolvedSessionId ? !!s.sessionFirstOutput[resolvedSessionId] : false,
-            hasActivityEntry: resolvedSessionId ? s.sessionActivity[resolvedSessionId] !== undefined : false,
             activityReason: resolvedSessionId ? s.sessionActivityReason[resolvedSessionId] : undefined,
           };
         },
@@ -328,13 +326,15 @@ const TaskCardInner = function TaskCard({ task, isDragOverlay, compact, onDelete
         {!isCompactDensity && (() => {
           switch (displayState.kind) {
             case 'running': {
+              // Footer model label comes only from the CLI's status.json (the
+              // human name, e.g. "Opus 4.8"). We deliberately do NOT fall back to
+              // the raw configured model id (e.g. "claude-opus-4-8") - a user
+              // doesn't know what that means. Until status.json reports, show the
+              // loading spinner; the spawn-time statusline kick + the settings'
+              // refreshInterval make the real name arrive within a moment, even
+              // for a background (never-opened) session.
               const resolvedModelName = displayState.usage?.model.displayName || null;
-              // Before the CLI has produced any signal (first output, activity
-              // event, or usage data), show a single spinner pill so we don't
-              // flash intermediate labels. Once any signal arrives, fall through
-              // to the rich or minimal pill.
-              const cliHasReported = hasFirstOutput || hasActivityEntry || !!displayState.usage;
-              if (!cliHasReported) {
+              if (!resolvedModelName) {
                 const spinnerLabel = isResuming ? 'Resuming agent...' : 'Starting agent...';
                 return (
                   <div className="mt-2 pt-2 border-t border-edge" data-testid="usage-bar">
@@ -366,16 +366,9 @@ const TaskCardInner = function TaskCard({ task, isDragOverlay, compact, onDelete
               return (
                 <div className="mt-2 pt-2 border-t border-edge" data-testid="usage-bar">
                   <div className="flex items-center justify-between mb-1.5">
-                    {resolvedModelName ? (
-                      <span className="text-xs text-fg-faint truncate">
-                        {resolvedModelName}
-                      </span>
-                    ) : (
-                      <span className="text-xs text-fg-faint flex items-center gap-1 truncate">
-                        <Loader2 size={12} className="animate-spin shrink-0" />
-                        Loading agent...
-                      </span>
-                    )}
+                    <span className="text-xs text-fg-faint truncate">
+                      {resolvedModelName}
+                    </span>
                     <span className="text-xs text-fg-faint">{pct}%</span>
                   </div>
                   <div className="w-full h-1 bg-surface-hover rounded-full overflow-hidden">

--- a/tests/ui/task-activity-indicators.spec.ts
+++ b/tests/ui/task-activity-indicators.spec.ts
@@ -46,7 +46,7 @@ const SESSION_ID = 'sess-activity-test';
 const SWIMLANE_ID = 'lane-backlog';
 
 /** Base pre-configure that creates a project with a task linked to a running session */
-function makePreConfig(opts: { sessionStatus: string; activity: string; withUsage: boolean; nullSessionId?: boolean; withEvents?: boolean; noActivityCache?: boolean; withRateLimits?: boolean; emptyRateLimits?: boolean; rateLimitResetsInPast?: boolean; rateLimitResetsWithin24h?: boolean; agent?: string | null }): string {
+function makePreConfig(opts: { sessionStatus: string; activity: string; withUsage: boolean; nullSessionId?: boolean; withEvents?: boolean; noActivityCache?: boolean; withRateLimits?: boolean; emptyRateLimits?: boolean; rateLimitResetsInPast?: boolean; rateLimitResetsWithin24h?: boolean; agent?: string | null; modelOverride?: string | null }): string {
   return `
     window.__mockPreConfigure(function (state) {
       var ts = new Date().toISOString();
@@ -103,6 +103,8 @@ function makePreConfig(opts: { sessionStatus: string; activity: string; withUsag
         swimlane_id: '${SWIMLANE_ID}',
         position: 0,
         agent: ${opts.agent !== undefined ? (opts.agent === null ? 'null' : `'${opts.agent}'`) : 'null'},
+        model_override: ${opts.modelOverride ? `'${opts.modelOverride}'` : 'null'},
+        effort_override: null,
         session_id: ${opts.sessionStatus === 'suspended' || opts.nullSessionId ? 'null' : `'${SESSION_ID}'`},
         worktree_path: null,
         branch_name: null,
@@ -555,25 +557,46 @@ test.describe('Task Activity Indicators', () => {
       }
     });
 
-    test('shows "Loading agent..." spinner with 0% bar when CLI has reported but usage is still null', async () => {
-      // hasActivityEntry (eventCache) flips cliHasReported true while usage is
-      // still null -- the running branch should render the full bar layout
-      // with a spinner + "Loading agent..." label and 0%, never an empty slot.
+    test('default session (no override) shows the loading spinner, never "Loading agent..." or an agent-name fallback', async () => {
+      // No model override and no live usage yet: the model is the agent's own
+      // default, which Kangentic only learns from status.json. The footer shows
+      // the loading spinner pill until then -- never the old stuck "Loading
+      // agent..." label, and never an agent-name ("Claude Code") fallback.
+      // refreshInterval keeps status.json flowing so it resolves to the real
+      // model. Regression guard for the board-card-stuck bug.
       const { browser, page } = await launchWithState(
-        makePreConfig({ sessionStatus: 'running', activity: 'idle', withUsage: false, withEvents: true }),
+        makePreConfig({ sessionStatus: 'running', activity: 'idle', withUsage: false, withEvents: true, agent: 'claude' }),
       );
       try {
         await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
         const usageBar = page.locator(`[data-task-id="${TASK_ID}"] [data-testid="usage-bar"]`);
         await expect(usageBar).toBeVisible({ timeout: 10000 });
-        await expect(usageBar).toContainText('Loading agent...');
-        await expect(usageBar).toContainText('0%');
+        await expect(usageBar).toContainText('Starting agent...');
         await expect(usageBar.locator('.lucide-loader-circle')).toBeVisible();
-        await expect(usageBar).not.toContainText('Starting agent...');
-        // Inner progress bar element exists at zero width
-        // Inner progress bar element exists at zero width (not "visible" since 0px wide)
-        await expect(usageBar.locator('div.h-full.rounded-full')).toHaveCount(1);
-        await expect(usageBar.locator('div.h-full.rounded-full')).toHaveAttribute('style', /width:\s*0%/);
+        await expect(usageBar).not.toContainText('Loading agent...');
+        await expect(usageBar).not.toContainText('Claude Code');
+      } finally {
+        await browser.close();
+      }
+    });
+
+    test('never flashes the raw model override id - shows the loading spinner until status.json reports', async () => {
+      // A task with a model override must NOT show the raw model id (e.g.
+      // "claude-opus-4-8") in the footer - a user doesn't know what that means.
+      // The footer shows the loading spinner until the CLI's status.json reports
+      // the human model name (e.g. "Opus 4.8"), which the spawn-time statusline
+      // kick + refreshInterval deliver shortly even for a background session.
+      // Regression guard for the raw-id flash.
+      const { browser, page } = await launchWithState(
+        makePreConfig({ sessionStatus: 'running', activity: 'idle', withUsage: false, withEvents: true, agent: 'claude', modelOverride: 'claude-opus-4-8' }),
+      );
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+        const usageBar = page.locator(`[data-task-id="${TASK_ID}"] [data-testid="usage-bar"]`);
+        await expect(usageBar).toBeVisible({ timeout: 10000 });
+        await expect(usageBar).toContainText('Starting agent...');
+        await expect(usageBar).not.toContainText('claude-opus-4-8');
+        await expect(usageBar).not.toContainText('Loading agent...');
       } finally {
         await browser.close();
       }

--- a/tests/unit/command-builder.test.ts
+++ b/tests/unit/command-builder.test.ts
@@ -847,6 +847,37 @@ describe('Merged Settings -- Local Settings Merge', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it('writes a coarse statusLine refreshInterval so background sessions keep writing status.json', () => {
+    // Claude only runs the statusLine command on event-driven triggers (never
+    // at session start), so a background/idle session can stall without ever
+    // writing status.json -- the board card then never learns the live model +
+    // context %. refreshInterval re-runs the command on a fixed timer. Kept
+    // coarse (not the 1s minimum) because the card already shows a placeholder
+    // instantly; this only backfills the slow-moving live numbers.
+    const builder = new CommandBuilder();
+    const statusOutput = path.join(tmpDir, '.kangentic', 'sessions', 'refresh-sess', 'status.json');
+    fs.mkdirSync(path.dirname(statusOutput), { recursive: true });
+
+    builder.buildClaudeCommand({
+      cliPath: '/usr/bin/claude',
+      taskId: 'refresh-task',
+      cwd: tmpDir,
+      permissionMode: 'default',
+      sessionId: 'refresh-sess',
+      statusOutputPath: statusOutput,
+    });
+
+    const mergedPath = path.join(tmpDir, '.kangentic', 'sessions', 'refresh-sess', 'settings.json');
+    const merged = JSON.parse(fs.readFileSync(mergedPath, 'utf-8'));
+
+    expect(merged.statusLine.type).toBe('command');
+    expect(merged.statusLine.command).toContain('status-bridge');
+    // Present, valid (docs: seconds, min 1), and coarse (not a 1s hot loop).
+    expect(typeof merged.statusLine.refreshInterval).toBe('number');
+    expect(merged.statusLine.refreshInterval).toBeGreaterThanOrEqual(1);
+    expect(merged.statusLine.refreshInterval).toBeLessThanOrEqual(60);
+  });
+
   it('merges user hooks from .claude/settings.local.json into session settings', () => {
     // Set up project with both settings.json and settings.local.json
     const claudeDir = path.join(tmpDir, '.claude');

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -50,6 +50,10 @@ function createMockPty() {
 
   const mockPty = {
     pid: 12345,
+    // node-pty's IPty exposes the live cols/rows; track them so resize() reads
+    // back the current size (the statusline kick nudges relative to it).
+    cols: 120,
+    rows: 30,
     onData: vi.fn((cb: (data: string) => void) => {
       dataHandler = cb;
     }),
@@ -57,7 +61,10 @@ function createMockPty() {
       exitHandler = cb;
     }),
     write: vi.fn(),
-    resize: vi.fn(),
+    resize: vi.fn((cols: number, rows: number) => {
+      mockPty.cols = cols;
+      mockPty.rows = rows;
+    }),
     kill: vi.fn(() => {
       if (exitHandler) setTimeout(() => exitHandler!({ exitCode: 0 }), 0);
     }),
@@ -997,6 +1004,109 @@ describe('Write and resize', () => {
     manager.resize(session.id, 80, 24);
 
     expect(mock.mockPty.resize).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11b. Statusline repaint kick (background status.json fix)
+// ---------------------------------------------------------------------------
+
+describe('Statusline repaint kick', () => {
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    manager = new SessionManager();
+  });
+
+  afterEach(async () => {
+    manager.killAll();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  });
+
+  // Claude only writes status.json - the board card's live model + context % -
+  // when its TUI paints. In the app's pwsh-wrapped PTY a background (never
+  // opened) session never does that initial paint on its own, so status.json is
+  // never written and the card stays on the spawn-time model placeholder until
+  // the task is opened (which resized the PTY). On first output we now nudge the
+  // PTY once - rows down then back to the spawn size - to force that first
+  // paint; the settings' refreshInterval then keeps status.json fresh.
+  // Regression guard for the board-card-stuck bug.
+  it('nudges the PTY rows down then back after first output for a statusline agent (Claude)', async () => {
+    const mock = createMockPty();
+    vi.mocked(pty.spawn).mockReturnValue(mock.mockPty as unknown as pty.IPty);
+    await manager.spawn({
+      taskId: 'task-kick',
+      command: '',
+      cwd: tmpDir,
+      agentParser: claudeAdapter,
+    });
+    mock.mockPty.resize.mockClear();
+
+    // Claude hides the cursor (ESC[?25l) when its TUI takes over - this is what
+    // detectFirstOutput matches, which drives the kick.
+    mock.feedData('\x1b[?25l');
+    // Wait for the buffer flush (~16ms) + the nudge-back setTimeout (200ms).
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    const resizeCalls = mock.mockPty.resize.mock.calls;
+    expect(resizeCalls).toContainEqual([120, 29]);
+    expect(resizeCalls).toContainEqual([120, 30]);
+  });
+
+  it('does not kick agents without a statusline pipeline (no runtime.statusFile)', async () => {
+    const mock = createMockPty();
+    vi.mocked(pty.spawn).mockReturnValue(mock.mockPty as unknown as pty.IPty);
+    // Stub adapter that reports first output but does NOT use the statusFile
+    // pipeline (mirrors Codex/Gemini, which derive usage from native logs).
+    const stub = {
+      ...claudeAdapter,
+      name: 'stub-no-statusfile',
+      detectFirstOutput: () => true,
+      removeHooks: () => {},
+      runtime: { activity: claudeAdapter.runtime.activity },
+    };
+    await manager.spawn({
+      taskId: 'task-no-kick',
+      command: '',
+      cwd: tmpDir,
+      agentParser: stub as unknown as typeof claudeAdapter,
+      agentName: 'stub-no-statusfile',
+    });
+    mock.mockPty.resize.mockClear();
+
+    mock.feedData('booting...');
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(mock.mockPty.resize).not.toHaveBeenCalled();
+  });
+
+  // A session whose task is already OPEN when it spawns has had its PTY fit to
+  // the real terminal viewport by the renderer. The kick must nudge relative to
+  // that live size, not the 120x30 spawn default -- otherwise it would leave the
+  // PTY mismatched with the displayed xterm (wrong wrapping) until the next
+  // renderer resize. Background sessions (never resized) still end at the spawn
+  // default because that IS their current size.
+  it('nudges relative to the terminal current size, preserving an open terminal dimensions', async () => {
+    const mock = createMockPty();
+    vi.mocked(pty.spawn).mockReturnValue(mock.mockPty as unknown as pty.IPty);
+    const session = await manager.spawn({
+      taskId: 'task-open-kick',
+      command: '',
+      cwd: tmpDir,
+      agentParser: claudeAdapter,
+    });
+    // Renderer fits the PTY to a real, non-default viewport (task open).
+    manager.resize(session.id, 150, 40);
+    mock.mockPty.resize.mockClear();
+
+    mock.feedData('\x1b[?25l');
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    const resizeCalls = mock.mockPty.resize.mock.calls;
+    expect(resizeCalls).toContainEqual([150, 39]);
+    expect(resizeCalls).toContainEqual([150, 40]);
+    // Must NOT clobber the open terminal back to the spawn default.
+    expect(resizeCalls).not.toContainEqual([120, 30]);
   });
 });
 


### PR DESCRIPTION
## What

A running task card's footer stayed on "Loading agent..." (and the model + context % never
appeared) until the user opened that task. This fixes it so a background, never-opened card shows
the real model ("Opus 4.8 N%") on its own.

Touches: `src/main/pty/session-manager.ts`, `src/main/pty/lifecycle/session-spawn-flow.ts`,
`src/main/agent/adapters/claude/command-builder.ts`, `src/renderer/components/board/TaskCard.tsx`.

Closes #312.

## Why

The card's model + context % come only from `status.json`, which Claude writes only when its TUI
**paints**. In the app's pwsh-wrapped PTY, a background (never-opened) session never does that
initial paint on its own, so `status.json` was never written and the card never learned the model.
Opening the task "fixed" it only because mounting the terminal resized the PTY (SIGWINCH), forcing
the paint. Verified empirically against the real Claude CLI: a one-time resize makes `status.json`
appear and the card flip to the live model without opening the task.

## How

1. **Kick the statusline paint (the root-cause fix).** On first PTY output, for agents whose
   `runtime.statusFile` is set (Claude), `SessionManager.kickStatuslineRepaint()` nudges the PTY
   rows down then back, forcing Claude's first statusline paint for background sessions. It nudges
   relative to the live `pty.cols`/`pty.rows` (falling back to the spawn defaults) so an
   already-open terminal keeps its viewport size, and routes through `resize()` so the redraw is
   suppressed as activity (no false "thinking"). Gated on the `runtime.statusFile` capability, not
   the agent name (respects `agent-adapters-boundary`).
2. **Keep it fresh.** Add `refreshInterval: 10` to the Claude `statusLine` config so `status.json`
   keeps updating after the kick. The timer only *sustains* an already-painting statusline; it
   cannot trigger the first paint, which is why it was not sufficient on its own.
3. **Clean label.** The card footer renders only the live `status.json` model name, with a brief
   loading spinner until it arrives. No raw model-id flash (e.g. `claude-opus-4-8`) and no
   agent-name fallback.

## Breaking changes

None.

## Tests

- Unit (`session-manager.test.ts`): the kick nudges the PTY after first output for a statusline
  agent (Claude), preserves an already-open terminal's size, and does NOT fire for agents without
  `runtime.statusFile`.
- Unit (`command-builder.test.ts`): the spawned `statusLine` config carries a coarse
  `refreshInterval`.
- UI (`task-activity-indicators.spec.ts`): a default session shows the loading spinner (never
  "Loading agent..." or an agent name); a model-override task never flashes the raw id; the live
  model name renders once usage arrives.
- The full unit / UI / Linux Electron E2E tiers run as CI checks on this PR.

Generated with [Claude Code](https://claude.com/claude-code)
