### PR TITLE
fix(pty): land PowerShell sessions in bracketed project paths

### DIFF
--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -38,6 +38,17 @@ Adaptations applied during the spawn flow (`src/main/pty/lifecycle/session-spawn
 | cmd | (none) | Standard execution |
 | Git Bash | `--login` | Paths may use `/c/...` format |
 
+### Spawn-time cwd fixups (Windows)
+
+`resolveSpawnCwd()` (`src/main/pty/spawn/pty-spawn.ts`) passes the working directory to node-pty via its `cwd` option, but two Windows shells mishandle certain valid directories at startup. In those cases it returns a `cwdFixupCommand` that the spawn flow writes into the PTY (raw, before the agent command) so the session lands in the real project directory:
+
+| Shell + cwd | Fixup written first | effectiveCwd |
+|-------------|--------------------|--------------|
+| cmd.exe + UNC path (`\\server\share\...`) | `pushd "<unc>"` (maps the UNC path to a temporary drive letter; cmd refuses UNC cwds) | Replaced with home |
+| PowerShell/pwsh + bracketed path (`D:\[foo]\bar`) | `Set-Location -LiteralPath '<cwd>'` | Left unchanged |
+
+The PowerShell case fixes a Windows PowerShell 5.1 quirk: it treats `[` / `]` in its startup path as wildcard characters, fails to resolve the location, and silently falls back to `$PSHOME` (`C:\Windows\System32\WindowsPowerShell\v1.0`). node-pty's `cwd` is still a valid Win32 directory, so only PowerShell's provider location needs correcting. Applied to the whole PowerShell family (the extra `Set-Location` is harmless in pwsh 7).
+
 ## Path Handling
 
 - `toForwardSlash()` -- normalizes backslashes to forward slashes for cross-platform CLI commands

--- a/src/main/pty/lifecycle/session-spawn-flow.ts
+++ b/src/main/pty/lifecycle/session-spawn-flow.ts
@@ -69,14 +69,15 @@ export interface SpawnFlowContext {
  *      (so the new session inherits them), remove from caches.
  *   3. Scrollback carry-over: the previous session's raw scrollback
  *      is preserved so resumes show unbroken history.
- *   4. Shell resolution + env + UNC-safe cwd (see spawn/pty-spawn.ts).
+ *   4. Shell resolution + env + cwd fixup resolution (see spawn/pty-spawn.ts).
  *   5. pty.spawn() with structured failure handling (a failed spawn
  *      still registers a placeholder so the renderer doesn't crash).
  *   6. Module initialization: buffer, session files, usage tracker,
  *      status file reader, session-ID capture, adapter attachment.
  *   7. Attach PTY handlers (see pty-data-handler, pty-exit-handler).
- *   8. Emit session-changed and optionally send an initial command
- *      (with Windows UNC `pushd` workaround for cmd.exe).
+ *   8. Emit session-changed, write any Windows cwd fixup (cmd.exe UNC
+ *      `pushd` / PowerShell bracket `Set-Location`), and optionally send
+ *      the initial command.
  *
  * All state lives in the SpawnFlowContext; this function is stateless
  * and can be unit-tested with mocks.
@@ -151,8 +152,8 @@ export async function performSpawn(
   }
   const cleanEnv = buildSpawnEnv(spawnEnv);
 
-  // Validate cwd + apply Windows UNC fallback for cmd.exe. See pty-spawn.ts.
-  const { effectiveCwd, uncPushdPrefix } = resolveSpawnCwd({
+  // Validate cwd + resolve any Windows cwd fixup command. See pty-spawn.ts.
+  const { effectiveCwd, cwdFixupCommand } = resolveSpawnCwd({
     requestedCwd: input.cwd,
     shellName,
     platform: process.platform,
@@ -441,16 +442,25 @@ export async function performSpawn(
 
   context.emit('session-changed', id, toSession(session));
 
-  // If there's a command to run, send it after a brief delay
-  if (input.command) {
+  // After a brief delay, write any Windows cwd fixup (so the session lands
+  // in the real project directory) and then the initial command. The fixup
+  // is written even when there is no command so a bare shell also lands
+  // correctly. It is written RAW (not through adaptCommandForShell, which
+  // would add a spurious `& ` prefix): cmd.exe `pushd "<unc>"` maps the UNC
+  // path to a temporary drive letter, PowerShell `Set-Location -LiteralPath`
+  // corrects its wildcard-mangled provider location for bracketed paths.
+  if (input.command || cwdFixupCommand) {
     setTimeout(() => {
-      const cmd = adaptCommandForShell(input.command!, shellName);
-      if (uncPushdPrefix) {
-        // pushd maps UNC path to a temporary drive letter, then run the command
-        ptyProcess.write(uncPushdPrefix + '\r');
-        setTimeout(() => ptyProcess.write(cmd + '\r'), 200);
-      } else {
-        ptyProcess.write(cmd + '\r');
+      if (cwdFixupCommand) {
+        ptyProcess.write(cwdFixupCommand + '\r');
+      }
+      if (input.command) {
+        const cmd = adaptCommandForShell(input.command, shellName);
+        if (cwdFixupCommand) {
+          setTimeout(() => ptyProcess.write(cmd + '\r'), 200);
+        } else {
+          ptyProcess.write(cmd + '\r');
+        }
       }
     }, 100);
   }

--- a/src/main/pty/spawn/pty-spawn.ts
+++ b/src/main/pty/spawn/pty-spawn.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import os from 'node:os';
-import { isUncPath } from '../../../shared/paths';
+import { isUncPath, isCmdShell } from '../../../shared/paths';
 import { trackEvent, sanitizeErrorMessage } from '../../analytics/analytics';
 
 /** Shell executable + args, split from a user-facing shell spec. */
@@ -75,13 +75,20 @@ export function buildSpawnEnv(
  * Resolution of the spawn working directory.
  *
  * - `effectiveCwd` is what should be passed to node-pty.
- * - `uncPushdPrefix`, when non-null, is a shell command the caller must
- *   write into the PTY before the user command so cmd.exe can reach the
- *   real UNC path via a mapped drive letter (cmd.exe refuses UNC cwds).
+ * - `cwdFixupCommand`, when non-null, is a shell command the caller must
+ *   write into the PTY before the user command so the session lands in the
+ *   real project directory. Two mutually-exclusive Windows quirks produce it:
+ *     1. cmd.exe + UNC cwd: cmd cannot use a UNC path as its cwd, so
+ *        `effectiveCwd` is REPLACED with home and the fixup is
+ *        `pushd "<unc>"` (maps the UNC path to a temporary drive letter).
+ *     2. PowerShell + bracketed cwd: `effectiveCwd` is LEFT UNCHANGED (the
+ *        Win32 process cwd is valid) and the fixup is
+ *        `Set-Location -LiteralPath '<cwd>'` to correct PowerShell's
+ *        provider location. See `resolveSpawnCwd` for the quirk details.
  */
 export interface SpawnCwdResolution {
   effectiveCwd: string;
-  uncPushdPrefix: string | null;
+  cwdFixupCommand: string | null;
 }
 
 /**
@@ -92,9 +99,20 @@ export interface SpawnCwdResolution {
  *    session with exit code -1. Emits a diagnostic analytics event.
  *  - cmd.exe cannot use a UNC path as its cwd (it prints
  *    "UNC paths are not supported" and defaults to C:\Windows). When
- *    we detect this, keep the cwd as home and return a `pushd "<unc>"`
- *    prefix that the caller must write before the user command.
- *    PowerShell and Git Bash handle UNC cwds natively, so no prefix.
+ *    we detect this, REPLACE the cwd with home and return a `pushd "<unc>"`
+ *    fixup that the caller must write before the user command.
+ *    PowerShell and Git Bash handle UNC cwds natively, so no fixup.
+ *  - Windows PowerShell 5.1 (`powershell.exe`, the default Windows shell)
+ *    treats `[` / `]` in its startup path as wildcard characters: launched
+ *    with a valid Win32 cwd like `D:\[foo]\bar` its path provider fails to
+ *    resolve the location and silently falls back to `$PSHOME`
+ *    (`C:\Windows\System32\WindowsPowerShell\v1.0`), so the agent CLI it
+ *    spawns runs against the wrong workspace. node-pty's `cwd` is still a
+ *    valid Win32 directory, so we LEAVE `effectiveCwd` unchanged and return
+ *    a `Set-Location -LiteralPath '<cwd>'` fixup that corrects the provider
+ *    location. Applied to the whole PowerShell family (powershell + pwsh):
+ *    the fixup is harmless in pwsh 7, and full shell paths make edition
+ *    detection by name unreliable.
  */
 export function resolveSpawnCwd(input: {
   requestedCwd: string;
@@ -111,17 +129,22 @@ export function resolveSpawnCwd(input: {
     });
   }
 
-  let uncPushdPrefix: string | null = null;
-  if (
-    input.platform === 'win32'
-    && isUncPath(effectiveCwd)
-    && input.shellName.toLowerCase().includes('cmd')
-  ) {
-    uncPushdPrefix = `pushd "${effectiveCwd}"`;
-    effectiveCwd = os.homedir();
+  const lowerShellName = input.shellName.toLowerCase();
+  let cwdFixupCommand: string | null = null;
+  if (input.platform === 'win32') {
+    if (isUncPath(effectiveCwd) && isCmdShell(input.shellName)) {
+      cwdFixupCommand = `pushd "${effectiveCwd}"`;
+      effectiveCwd = os.homedir();
+    } else if (
+      (lowerShellName.includes('powershell') || lowerShellName.includes('pwsh'))
+      && /[[\]]/.test(effectiveCwd)
+    ) {
+      const escapedCwd = effectiveCwd.replace(/'/g, "''");
+      cwdFixupCommand = `Set-Location -LiteralPath '${escapedCwd}'`;
+    }
   }
 
-  return { effectiveCwd, uncPushdPrefix };
+  return { effectiveCwd, cwdFixupCommand };
 }
 
 /**

--- a/tests/unit/pty-spawn.test.ts
+++ b/tests/unit/pty-spawn.test.ts
@@ -103,7 +103,7 @@ describe('resolveSpawnCwd', () => {
       platform: 'linux',
     });
     expect(result.effectiveCwd).toBe(existing);
-    expect(result.uncPushdPrefix).toBeNull();
+    expect(result.cwdFixupCommand).toBeNull();
   });
 
   it('falls back to home when cwd does not exist', () => {
@@ -116,7 +116,7 @@ describe('resolveSpawnCwd', () => {
     expect(result.effectiveCwd).toBe(os.homedir());
   });
 
-  it('emits a pushd prefix for UNC paths under cmd.exe on Windows', () => {
+  it('emits a pushd fixup for UNC paths under cmd.exe on Windows', () => {
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
     const result = resolveSpawnCwd({
       requestedCwd: '\\\\server\\share\\project',
@@ -124,10 +124,10 @@ describe('resolveSpawnCwd', () => {
       platform: 'win32',
     });
     expect(result.effectiveCwd).toBe(os.homedir());
-    expect(result.uncPushdPrefix).toBe('pushd "\\\\server\\share\\project"');
+    expect(result.cwdFixupCommand).toBe('pushd "\\\\server\\share\\project"');
   });
 
-  it('does NOT emit a pushd prefix for UNC paths under PowerShell', () => {
+  it('does NOT emit a pushd fixup for UNC paths under PowerShell', () => {
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
     const result = resolveSpawnCwd({
       requestedCwd: '\\\\server\\share\\project',
@@ -135,17 +135,167 @@ describe('resolveSpawnCwd', () => {
       platform: 'win32',
     });
     expect(result.effectiveCwd).toBe('\\\\server\\share\\project');
-    expect(result.uncPushdPrefix).toBeNull();
+    expect(result.cwdFixupCommand).toBeNull();
   });
 
-  it('does NOT emit a pushd prefix on non-Windows platforms', () => {
+  it('does NOT emit a pushd fixup on non-Windows platforms', () => {
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
     const result = resolveSpawnCwd({
       requestedCwd: '\\\\server\\share\\project',
       shellName: 'cmd.exe',
       platform: 'linux',
     });
-    expect(result.uncPushdPrefix).toBeNull();
+    expect(result.cwdFixupCommand).toBeNull();
+  });
+
+  // Windows PowerShell 5.1 treats `[` / `]` in its startup path as wildcards
+  // and falls back to $PSHOME, so the agent CLI runs in the wrong folder. The
+  // Win32 cwd is still valid, so effectiveCwd is left unchanged and a
+  // Set-Location -LiteralPath fixup corrects the provider location.
+  it('emits a Set-Location fixup for bracketed paths under powershell on Windows', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const result = resolveSpawnCwd({
+      requestedCwd: 'C:\\Users\\dev\\[foo]\\bar',
+      shellName: 'powershell',
+      platform: 'win32',
+    });
+    expect(result.effectiveCwd).toBe('C:\\Users\\dev\\[foo]\\bar');
+    expect(result.cwdFixupCommand).toBe("Set-Location -LiteralPath 'C:\\Users\\dev\\[foo]\\bar'");
+  });
+
+  it('emits the Set-Location fixup for pwsh too (family-wide)', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const result = resolveSpawnCwd({
+      requestedCwd: 'C:\\Users\\dev\\[foo]\\bar',
+      shellName: 'pwsh',
+      platform: 'win32',
+    });
+    expect(result.cwdFixupCommand).toBe("Set-Location -LiteralPath 'C:\\Users\\dev\\[foo]\\bar'");
+  });
+
+  it('matches a full PowerShell 7 exe path (powershell substring in the folder name)', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const result = resolveSpawnCwd({
+      requestedCwd: 'C:\\Users\\dev\\[foo]\\bar',
+      shellName: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+      platform: 'win32',
+    });
+    expect(result.cwdFixupCommand).toBe("Set-Location -LiteralPath 'C:\\Users\\dev\\[foo]\\bar'");
+  });
+
+  it('doubles single quotes inside a bracketed path for the fixup', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const result = resolveSpawnCwd({
+      requestedCwd: "C:\\Users\\dev\\[o'brien]\\bar",
+      shellName: 'powershell',
+      platform: 'win32',
+    });
+    expect(result.cwdFixupCommand).toBe("Set-Location -LiteralPath 'C:\\Users\\dev\\[o''brien]\\bar'");
+  });
+
+  it('emits the Set-Location fixup for a bracketed UNC path under PowerShell', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const result = resolveSpawnCwd({
+      requestedCwd: '\\\\server\\share\\[x]',
+      shellName: 'powershell',
+      platform: 'win32',
+    });
+    expect(result.effectiveCwd).toBe('\\\\server\\share\\[x]');
+    expect(result.cwdFixupCommand).toBe("Set-Location -LiteralPath '\\\\server\\share\\[x]'");
+  });
+
+  it('does NOT emit a fixup for a nonexistent bracketed cwd (falls back to home)', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    // Mock homedir to a bracket-free placeholder so the assertion is hermetic
+    // and does not depend on the host's real home directory.
+    vi.spyOn(os, 'homedir').mockReturnValue('C:\\Users\\dev');
+    const result = resolveSpawnCwd({
+      requestedCwd: 'C:\\Users\\dev\\[foo]\\bar',
+      shellName: 'powershell',
+      platform: 'win32',
+    });
+    expect(result.effectiveCwd).toBe(os.homedir());
+    expect(result.cwdFixupCommand).toBeNull();
+  });
+
+  it('does NOT emit a fixup for bracketed paths under cmd.exe (cmd is bracket-safe)', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const result = resolveSpawnCwd({
+      requestedCwd: 'C:\\Users\\dev\\[foo]\\bar',
+      shellName: 'cmd.exe',
+      platform: 'win32',
+    });
+    expect(result.cwdFixupCommand).toBeNull();
+  });
+
+  // A bracketed UNC path under cmd.exe must still take the UNC pushd branch
+  // (which precedes the PowerShell bracket branch), not the Set-Location one:
+  // cmd cannot use a UNC cwd, and cmd handles brackets fine. This pins the
+  // branch precedence so a future reorder can't silently emit Set-Location.
+  it('emits the pushd fixup (not Set-Location) for a bracketed UNC path under cmd.exe', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const result = resolveSpawnCwd({
+      requestedCwd: '\\\\server\\share\\[x]',
+      shellName: 'cmd.exe',
+      platform: 'win32',
+    });
+    expect(result.effectiveCwd).toBe(os.homedir());
+    expect(result.cwdFixupCommand).toBe('pushd "\\\\server\\share\\[x]"');
+  });
+
+  // The cmd branch matches on the basename (via isCmdShell), NOT a raw
+  // substring: a shell whose PATH merely contains "cmd" (e.g. Cmder's
+  // cmder.exe) must not be misclassified as cmd.exe and have its cwd
+  // force-replaced with home plus a spurious pushd written into the PTY.
+  it('does NOT emit a pushd fixup for a non-cmd shell whose path contains "cmd" (e.g. cmder)', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const result = resolveSpawnCwd({
+      requestedCwd: '\\\\server\\share\\project',
+      shellName: 'C:\\tools\\cmder\\cmder.exe',
+      platform: 'win32',
+    });
+    expect(result.effectiveCwd).toBe('\\\\server\\share\\project');
+    expect(result.cwdFixupCommand).toBeNull();
+  });
+
+  it('does NOT emit a fixup for bracketed paths under bash', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const result = resolveSpawnCwd({
+      requestedCwd: 'C:\\Users\\dev\\[foo]\\bar',
+      shellName: '/bin/bash',
+      platform: 'win32',
+    });
+    expect(result.cwdFixupCommand).toBeNull();
+  });
+
+  it('does NOT emit a fixup for bracketed paths under WSL', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const result = resolveSpawnCwd({
+      requestedCwd: 'C:\\Users\\dev\\[foo]\\bar',
+      shellName: 'wsl -d Ubuntu',
+      platform: 'win32',
+    });
+    expect(result.cwdFixupCommand).toBeNull();
+  });
+
+  it('does NOT emit a fixup for a plain (bracket-free) path under PowerShell', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const result = resolveSpawnCwd({
+      requestedCwd: 'C:\\Users\\dev\\project',
+      shellName: 'powershell',
+      platform: 'win32',
+    });
+    expect(result.cwdFixupCommand).toBeNull();
+  });
+
+  it('does NOT emit a Set-Location fixup for bracketed paths on non-Windows', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const result = resolveSpawnCwd({
+      requestedCwd: '/home/dev/[foo]/bar',
+      shellName: 'pwsh',
+      platform: 'linux',
+    });
+    expect(result.cwdFixupCommand).toBeNull();
   });
 });
 

--- a/tests/unit/session-exit-intentional.test.ts
+++ b/tests/unit/session-exit-intentional.test.ts
@@ -57,7 +57,7 @@ vi.mock('../../src/main/pty/spawn/pty-spawn', () => ({
   buildSpawnEnv: (env: Record<string, string> | undefined) => ({ ...env }),
   resolveSpawnCwd: ({ requestedCwd }: { requestedCwd: string }) => ({
     effectiveCwd: requestedCwd,
-    uncPushdPrefix: null,
+    cwdFixupCommand: null,
   }),
 }));
 

--- a/tests/unit/session-spawn-flow.test.ts
+++ b/tests/unit/session-spawn-flow.test.ts
@@ -75,15 +75,19 @@ vi.mock('../../src/main/pr/pr-registry', () => ({
   detectPR: vi.fn(() => null),
 }));
 
-// Stub shell path adaptation.
+// Stub shell path adaptation. adaptCommandForShell is a vi.fn() (default:
+// identity) so the cwd-fixup-order tests can override it per-call via
+// mockImplementationOnce to prove the fixup command bypasses it (see
+// "writes the fixup command RAW" below).
 vi.mock('../../src/shared/paths', () => ({
-  adaptCommandForShell: (cmd: string) => cmd,
+  adaptCommandForShell: vi.fn((cmd: string) => cmd),
 }));
 
 // ---- Import under test (after all vi.mock hoisting) ----
 import { performSpawn } from '../../src/main/pty/lifecycle/session-spawn-flow';
 import { SessionRegistry } from '../../src/main/pty/session-registry';
 import { resolveSpawnCwd } from '../../src/main/pty/spawn/pty-spawn';
+import { adaptCommandForShell } from '../../src/shared/paths';
 import * as ptyModule from 'node-pty';
 
 // ---- Helpers ----
@@ -523,6 +527,40 @@ describe('performSpawn - Windows cwd fixup write order', () => {
     vi.advanceTimersByTime(100);
     expect(writeMock).toHaveBeenCalledTimes(1);
     expect(writeMock.mock.calls[0][0]).toBe('echo hi\r');
+  });
+
+  it('writes the fixup command RAW, bypassing adaptCommandForShell (only the initial command is adapted)', async () => {
+    // The default adaptCommandForShell mock is identity, so it cannot tell
+    // "written raw" apart from "routed through adaptCommandForShell and
+    // happened to come back unchanged" - a regression that started routing
+    // cwdFixupCommand through adaptCommandForShell (e.g. picking up
+    // PowerShell's `& ` call-operator prefix, which would break the
+    // `Set-Location` syntax) would slip past every other test in this
+    // describe block. Override the mock with a non-identity transform for
+    // this one call so the two paths are distinguishable.
+    vi.mocked(resolveSpawnCwd).mockReturnValueOnce({
+      effectiveCwd: 'C:\\Users\\dev\\[foo]\\bar',
+      cwdFixupCommand: "Set-Location -LiteralPath 'C:\\Users\\dev\\[foo]\\bar'",
+    });
+    vi.mocked(adaptCommandForShell).mockImplementationOnce((cmd: string) => `ADAPTED:${cmd}`);
+
+    const context = makeContext();
+    const input = makeInput({ command: 'claude --resume abc' });
+
+    await performSpawn(input, context);
+
+    const writeMock = ptySpawnMock.mock.results[0]?.value.write as ReturnType<typeof vi.fn>;
+
+    vi.advanceTimersByTime(100);
+    vi.advanceTimersByTime(200);
+
+    expect(writeMock).toHaveBeenCalledTimes(2);
+    // The fixup must never pass through adaptCommandForShell, so no
+    // "ADAPTED:" marker even though the override would add one to anything
+    // routed through it.
+    expect(writeMock.mock.calls[0][0]).toBe("Set-Location -LiteralPath 'C:\\Users\\dev\\[foo]\\bar'\r");
+    // The initial command DOES go through adaptCommandForShell.
+    expect(writeMock.mock.calls[1][0]).toBe('ADAPTED:claude --resume abc\r');
   });
 });
 

--- a/tests/unit/session-spawn-flow.test.ts
+++ b/tests/unit/session-spawn-flow.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the caller-owned session ID branch in performSpawn.
  *
- * Scope: lines 207-247 of session-spawn-flow.ts — the new
+ * Scope: lines 207-247 of session-spawn-flow.ts - the new
  * `hasKnownAgentSessionId` flag wired into sessionIdManager.init(), and
  * the sessionHistoryReader.attach() short-circuit for adapters that
  * declare both supportsCallerSessionId and runtime.sessionHistory.
@@ -41,22 +41,24 @@ vi.mock('../../src/main/shutdown-state', () => ({
   isShuttingDown: () => false,
 }));
 
-// Stub spawn env/cwd helpers — return safe defaults, no real fs access.
+// Stub spawn env/cwd helpers - return safe defaults, no real fs access.
+// resolveSpawnCwd is a vi.fn() so write-order tests can override the fixup
+// command per-call via mockReturnValueOnce.
 vi.mock('../../src/main/pty/spawn/pty-spawn', () => ({
   resolveShellArgs: (shell: string) => ({ exe: shell, args: [] }),
   buildSpawnEnv: (env: Record<string, string> | undefined) => ({ ...env }),
-  resolveSpawnCwd: ({ requestedCwd }: { requestedCwd: string }) => ({
+  resolveSpawnCwd: vi.fn(({ requestedCwd }: { requestedCwd: string }) => ({
     effectiveCwd: requestedCwd,
-    uncPushdPrefix: null,
-  }),
+    cwdFixupCommand: null,
+  })),
 }));
 
-// Stub spawn-failure-handler — never used in happy-path tests.
+// Stub spawn-failure-handler - never used in happy-path tests.
 vi.mock('../../src/main/pty/spawn/spawn-failure-handler', () => ({
   handleSpawnFailure: vi.fn(),
 }));
 
-// Stub adapter lifecycle hooks — no-ops for these tests.
+// Stub adapter lifecycle hooks - no-ops for these tests.
 vi.mock('../../src/main/pty/lifecycle/adapter-lifecycle', () => ({
   attachAdapter: vi.fn(),
   disposeAdapterAttachment: vi.fn(),
@@ -81,6 +83,7 @@ vi.mock('../../src/shared/paths', () => ({
 // ---- Import under test (after all vi.mock hoisting) ----
 import { performSpawn } from '../../src/main/pty/lifecycle/session-spawn-flow';
 import { SessionRegistry } from '../../src/main/pty/session-registry';
+import { resolveSpawnCwd } from '../../src/main/pty/spawn/pty-spawn';
 import * as ptyModule from 'node-pty';
 
 // ---- Helpers ----
@@ -431,6 +434,95 @@ describe('performSpawn - caller-owned session ID wiring', () => {
     expect(warnMessage).toContain('[session-history] attach failed');
     // The session ID in the warning is the first 8 chars of input.id.
     expect(warnMessage).toContain(input.id!.slice(0, 8));
+  });
+});
+
+describe('performSpawn - Windows cwd fixup write order', () => {
+  // When resolveSpawnCwd returns a cwdFixupCommand (cmd.exe UNC pushd or
+  // PowerShell bracket Set-Location), performSpawn must write the fixup RAW
+  // into the PTY first, then write the initial command 200ms later so the
+  // session lands in the real project directory. The writes are setTimeout-
+  // based (100ms initial, 200ms fixup-to-command), so drive with fake timers.
+  //
+  // Red-green: drop the cwdFixupCommand write in session-spawn-flow.ts and the
+  // first-write assertion goes red; require input.command for the fixup write
+  // and the fixup-alone test goes red.
+  //
+  // Tier: Unit - pure mock collaborators, no PTY, no OS, no IPC.
+
+  const ptySpawnMock = ptyModule.spawn as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('writes the fixup command first, then the initial command', async () => {
+    vi.mocked(resolveSpawnCwd).mockReturnValueOnce({
+      effectiveCwd: 'C:\\Users\\dev\\[foo]\\bar',
+      cwdFixupCommand: "Set-Location -LiteralPath 'C:\\Users\\dev\\[foo]\\bar'",
+    });
+
+    const context = makeContext();
+    const input = makeInput({ command: 'claude --resume abc' });
+
+    await performSpawn(input, context);
+
+    const writeMock = ptySpawnMock.mock.results[0]?.value.write as ReturnType<typeof vi.fn>;
+
+    // Nothing written until the 100ms initial delay elapses.
+    expect(writeMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    // Only the fixup so far - the command waits another 200ms.
+    expect(writeMock).toHaveBeenCalledTimes(1);
+    expect(writeMock.mock.calls[0][0]).toBe("Set-Location -LiteralPath 'C:\\Users\\dev\\[foo]\\bar'\r");
+
+    vi.advanceTimersByTime(200);
+    expect(writeMock).toHaveBeenCalledTimes(2);
+    expect(writeMock.mock.calls[1][0]).toBe('claude --resume abc\r');
+  });
+
+  it('writes the fixup alone when there is no initial command', async () => {
+    vi.mocked(resolveSpawnCwd).mockReturnValueOnce({
+      effectiveCwd: 'C:\\Users\\dev\\[foo]\\bar',
+      cwdFixupCommand: "Set-Location -LiteralPath 'C:\\Users\\dev\\[foo]\\bar'",
+    });
+
+    const context = makeContext();
+    const input = makeInput({ command: '' });
+
+    await performSpawn(input, context);
+
+    const writeMock = ptySpawnMock.mock.results[0]?.value.write as ReturnType<typeof vi.fn>;
+
+    vi.advanceTimersByTime(100);
+    expect(writeMock).toHaveBeenCalledTimes(1);
+    expect(writeMock.mock.calls[0][0]).toBe("Set-Location -LiteralPath 'C:\\Users\\dev\\[foo]\\bar'\r");
+
+    // No command was scheduled, so advancing further writes nothing more.
+    vi.advanceTimersByTime(200);
+    expect(writeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes only the command (no fixup) when cwdFixupCommand is null', async () => {
+    // Default mock returns cwdFixupCommand: null - the common non-Windows /
+    // bracket-free case. The command is written directly, with no fixup and no
+    // 200ms stagger.
+    const context = makeContext();
+    const input = makeInput({ command: 'echo hi' });
+
+    await performSpawn(input, context);
+
+    const writeMock = ptySpawnMock.mock.results[0]?.value.write as ReturnType<typeof vi.fn>;
+
+    vi.advanceTimersByTime(100);
+    expect(writeMock).toHaveBeenCalledTimes(1);
+    expect(writeMock.mock.calls[0][0]).toBe('echo hi\r');
   });
 });
 


### PR DESCRIPTION
## What

Fixes agent sessions launching in the wrong directory when a project folder path contains square brackets (e.g. `D:\[foo]\bar`) on Windows.

- `src/main/pty/spawn/pty-spawn.ts` - generalized `SpawnCwdResolution.uncPushdPrefix` into a single `cwdFixupCommand` and added a PowerShell producer to `resolveSpawnCwd`.
- `src/main/pty/lifecycle/session-spawn-flow.ts` - the spawn flow now writes the fixup command into the PTY before the agent command, and even when there is no command.
- `docs/cross-platform.md` - documents both spawn-time cwd fixups.

## Why

Closes #85.

Windows PowerShell 5.1 (`powershell.exe`, the default Windows shell) treats `[` and `]` in its startup path as wildcard characters. Launched with a valid Win32 cwd like `D:\[foo]\bar`, its path provider fails to resolve the location and silently falls back to `$PSHOME` (`C:\Windows\System32\WindowsPowerShell\v1.0`), so the agent CLI runs against the wrong workspace, matching the screenshot in the issue.

Verified empirically against real `powershell.exe`: brackets are the only offenders (every other valid Windows filename character resolves correctly), and pwsh 7 / cmd.exe / Git Bash all handle a bracketed cwd fine.

## How

Kangentic already had a precedent for this class of quirk: `resolveSpawnCwd` returns a shell fixup command for cmd.exe + UNC cwds (`pushd "<unc>"`), written into the PTY before the agent command. This change reuses that mechanism:

- The field is renamed `uncPushdPrefix` -> `cwdFixupCommand` (one nullable field; the two producers are mutually exclusive by shell).
- On Windows, for the `powershell`/`pwsh` family with a bracketed cwd, it emits `Set-Location -LiteralPath '<cwd>'` (single quotes doubled). node-pty's process cwd is a valid Win32 directory, so `effectiveCwd` is left unchanged and only PowerShell's provider location is corrected. This is the documented asymmetry with the cmd/UNC branch, which instead replaces the cwd with home.
- Applied to the whole PowerShell family: the extra `Set-Location` is harmless in pwsh 7, and full shell paths make edition detection by name unreliable.
- The fixup is written raw (not through `adaptCommandForShell`, which would prepend a spurious `& ` call operator) and fires even for a bare shell with no initial command.

## Breaking changes

None.

## Tests

- `tests/unit/pty-spawn.test.ts` - extended `resolveSpawnCwd` coverage with bracket-path cases (powershell, pwsh, full PS7 exe path, single-quote doubling, bracketed UNC, nonexistent bracket cwd) and negatives (cmd, bash, WSL, plain path, non-win32).
- `tests/unit/session-spawn-flow.test.ts` - fake-timer write-order tests (fixup-then-command, fixup-alone when the command is empty, command-only when no fixup) plus a test asserting the fixup is written raw and bypasses `adaptCommandForShell`.
- `tests/unit/session-exit-intentional.test.ts` - field rename in the `resolveSpawnCwd` mock.
- Verified end-to-end against real `powershell.exe`: reproduced the `$PSHOME` fallback with a bracketed cwd, then confirmed the exact `Set-Location -LiteralPath '...'` string this change generates lands the shell in the bracket folder.

Generated with [Claude Code](https://claude.com/claude-code)
