### PR TITLE
fix(renderer): scope lazy-panel load failures and make retry recover

### DIFF
--- a/src/renderer/components/PanelErrorBoundary.tsx
+++ b/src/renderer/components/PanelErrorBoundary.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { RefreshCw } from 'lucide-react';
+import { isChunkLoadError } from '../utils/chunk-load-error';
+
+interface PanelErrorBoundaryProps {
+  children: React.ReactNode;
+  /** Names the surface in the message: "Failed to load the {label}". Default "panel". */
+  label?: string;
+}
+
+interface PanelErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * A SCOPED error boundary for a lazily-loaded panel. Unlike the root
+ * `ErrorBoundary` (which replaces the entire app with a full-screen error page),
+ * this fills only its own container, so one optional side panel failing to load
+ * never unmounts the rest of the app.
+ *
+ * Recovery depends on the failure:
+ * - A chunk-load failure (the code-split `import()` could not fetch) is cached by
+ *   the browser module map for the document's lifetime, so a remount re-imports
+ *   the same poisoned URL and fails again - the dead "Try again" loop this fix
+ *   exists to kill. The only reliable recovery is a full window reload, which
+ *   starts a fresh module map (and by then the dev server / network has usually
+ *   recovered; in production a reload fetches the new index with fresh chunk
+ *   URLs). So for these the action is Reload.
+ * - Any other render error may be transient, so the action is Retry, which resets
+ *   state and remounts the children (the module is already loaded, so no
+ *   re-import is needed).
+ *
+ * Modeled on the root `ErrorBoundary` and the `DiffErrorBoundary` in `ChangesPanel`.
+ */
+export class PanelErrorBoundary extends React.Component<
+  PanelErrorBoundaryProps,
+  PanelErrorBoundaryState
+> {
+  constructor(props: PanelErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): PanelErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error('PanelErrorBoundary caught:', error, info.componentStack);
+    window.electronAPI?.analytics?.trackRendererError(error.message);
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      const chunkLoadFailure = isChunkLoadError(this.state.error);
+      return (
+        <div
+          data-testid="panel-error-boundary"
+          className="flex h-full w-full flex-col items-center justify-center gap-2 p-4 text-center"
+        >
+          <span className="text-sm text-fg-secondary">
+            Failed to load the {this.props.label ?? 'panel'}
+          </span>
+          {this.state.error?.message && (
+            <span className="text-xs text-fg-muted max-w-xs break-words">
+              {this.state.error.message}
+            </span>
+          )}
+          <button
+            onClick={chunkLoadFailure ? this.handleReload : this.handleRetry}
+            data-testid="panel-error-retry"
+            className="flex items-center gap-1.5 text-xs px-3 py-1 rounded bg-surface-raised hover:bg-surface-raised/80 text-fg-secondary transition-colors"
+          >
+            <RefreshCw size={12} />
+            {chunkLoadFailure ? 'Reload' : 'Retry'}
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -47,6 +47,7 @@ import { useLayerStore } from '../../window-manager';
 import type { ManagedWindow } from '../../window-manager';
 import type { AgentCommand } from '../../../shared/types';
 import { useCommandTerminalLayer } from './command-terminal-context';
+import { PanelErrorBoundary } from '../PanelErrorBoundary';
 
 const ChangesPanel = lazy(() => import('../dialogs/task-detail/changes/ChangesPanel').then((module) => ({ default: module.ChangesPanel })));
 
@@ -714,19 +715,21 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
         {/* Changes panel */}
         {changesOpen && projectPath && (
           <div className="w-1/2 min-h-0 border-l border-edge">
-            <Suspense
-              fallback={
-                <div className="flex items-center justify-center h-full">
-                  <Loader2 size={20} className="animate-spin text-fg-muted" />
-                </div>
-              }
-            >
-              <ChangesPanel
-                entityId={COMMAND_TERMINAL_ENTITY_ID}
-                projectPath={projectPath}
-                baseBranch="HEAD"
-              />
-            </Suspense>
+            <PanelErrorBoundary label="Changes panel">
+              <Suspense
+                fallback={
+                  <div className="flex items-center justify-center h-full">
+                    <Loader2 size={20} className="animate-spin text-fg-muted" />
+                  </div>
+                }
+              >
+                <ChangesPanel
+                  entityId={COMMAND_TERMINAL_ENTITY_ID}
+                  projectPath={projectPath}
+                  baseBranch="HEAD"
+                />
+              </Suspense>
+            </PanelErrorBoundary>
           </div>
         )}
       </div>

--- a/src/renderer/components/dialogs/TaskChangesDialog.tsx
+++ b/src/renderer/components/dialogs/TaskChangesDialog.tsx
@@ -3,6 +3,7 @@ import { GitCompare, Loader2 } from 'lucide-react';
 import { BaseDialog } from './BaseDialog';
 import { useProjectStore } from '../../stores/project-store';
 import { useConfigStore } from '../../stores/config-store';
+import { PanelErrorBoundary } from '../PanelErrorBoundary';
 import type { Task } from '../../../shared/types';
 
 const ChangesPanel = lazy(() =>
@@ -40,22 +41,24 @@ export function TaskChangesDialog({ task, onClose }: TaskChangesDialogProps) {
             No changes on this branch
           </div>
         ) : (
-          <Suspense
-            fallback={
-              <div className="flex items-center justify-center h-full">
-                <Loader2 size={20} className="animate-spin text-fg-muted" />
-              </div>
-            }
-          >
-            <ChangesPanel
-              entityId={`dialog-${task.id}`}
-              scrollKey={task.id}
-              projectPath={projectPath}
-              worktreePath={task.worktree_path}
-              baseBranch={task.base_branch || defaultBaseBranch || 'main'}
-              emptyMessage="No changes on this branch"
-            />
-          </Suspense>
+          <PanelErrorBoundary label="Changes panel">
+            <Suspense
+              fallback={
+                <div className="flex items-center justify-center h-full">
+                  <Loader2 size={20} className="animate-spin text-fg-muted" />
+                </div>
+              }
+            >
+              <ChangesPanel
+                entityId={`dialog-${task.id}`}
+                scrollKey={task.id}
+                projectPath={projectPath}
+                worktreePath={task.worktree_path}
+                baseBranch={task.base_branch || defaultBaseBranch || 'main'}
+                emptyMessage="No changes on this branch"
+              />
+            </Suspense>
+          </PanelErrorBoundary>
         )}
       </div>
     </BaseDialog>

--- a/src/renderer/components/dialogs/task-detail/TaskDetailBody.tsx
+++ b/src/renderer/components/dialogs/task-detail/TaskDetailBody.tsx
@@ -17,6 +17,7 @@ import { MarkdownRenderer } from '../../MarkdownRenderer';
 import type { Task, SessionDisplayState } from '../../../../shared/types';
 import { useSessionStore } from '../../../stores/session-store';
 import { useTaskSplitResize } from '../../../hooks/useTaskSplitResize';
+import { PanelErrorBoundary } from '../../PanelErrorBoundary';
 
 const ChangesPanel = lazy(() => import('./changes/ChangesPanel').then((module) => ({ default: module.ChangesPanel })));
 
@@ -155,25 +156,27 @@ export function TaskDetailBody({
   }
 
   const changesContent = (
-    <Suspense
-      fallback={
-        <div className="flex items-center justify-center h-full">
-          <Loader2 size={20} className="animate-spin text-fg-muted" />
-        </div>
-      }
-    >
-      <ChangesPanel
-        entityId={task.id}
-        isFocused={isFocused}
-        scrollKey={task.id}
-        projectPath={projectPath}
-        worktreePath={task.worktree_path ?? undefined}
-        baseBranch={task.base_branch || defaultBaseBranch || 'main'}
-        panelMode={changesViewMode}
-        onExpand={handleChangesExpand}
-        onCollapse={handleChangesCollapse}
-      />
-    </Suspense>
+    <PanelErrorBoundary label="Changes panel">
+      <Suspense
+        fallback={
+          <div className="flex items-center justify-center h-full">
+            <Loader2 size={20} className="animate-spin text-fg-muted" />
+          </div>
+        }
+      >
+        <ChangesPanel
+          entityId={task.id}
+          isFocused={isFocused}
+          scrollKey={task.id}
+          projectPath={projectPath}
+          worktreePath={task.worktree_path ?? undefined}
+          baseBranch={task.base_branch || defaultBaseBranch || 'main'}
+          panelMode={changesViewMode}
+          onExpand={handleChangesExpand}
+          onCollapse={handleChangesCollapse}
+        />
+      </Suspense>
+    </PanelErrorBoundary>
   );
 
   // The diff panel for the suspended / changes-only layouts (never the Browser

--- a/src/renderer/utils/chunk-load-error.ts
+++ b/src/renderer/utils/chunk-load-error.ts
@@ -1,0 +1,35 @@
+/**
+ * Detect a dynamic-import ("chunk load") failure from a caught error.
+ *
+ * When a code-split module fails to fetch (a dev-server mid-invalidation, a
+ * transform error, or a stale chunk URL after a deploy), the browser rejects the
+ * `import()` with a message like "Failed to fetch dynamically imported module".
+ * Crucially, the browser then CACHES that failure in the page's module map for
+ * the lifetime of the document: re-importing the same URL returns the same cached
+ * rejection without a new fetch. So a remount / fresh `React.lazy` cannot recover
+ * a chunk-load failure - only a full page reload (which starts a fresh module
+ * map) can. This predicate lets an error boundary tell a chunk-load failure
+ * (needs reload) apart from an ordinary render error (a remount may recover).
+ *
+ * Messages vary by engine, so match a set of known substrings case-insensitively.
+ */
+const CHUNK_LOAD_ERROR_PATTERNS = [
+  'failed to fetch dynamically imported module',
+  'error loading dynamically imported module',
+  'importing a module script failed',
+  'failed to load module script',
+  'loading chunk',
+  'loading css chunk',
+];
+
+export function isChunkLoadError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : '';
+  if (!message) return false;
+  const normalized = message.toLowerCase();
+  return CHUNK_LOAD_ERROR_PATTERNS.some((pattern) => normalized.includes(pattern));
+}

--- a/src/renderer/window-manager/components/WindowContent.tsx
+++ b/src/renderer/window-manager/components/WindowContent.tsx
@@ -14,6 +14,7 @@
 import { Suspense, lazy } from 'react';
 import { Loader2 } from 'lucide-react';
 import { useBoardStore } from '../../stores/board-store';
+import { PanelErrorBoundary } from '../../components/PanelErrorBoundary';
 import { WindowTitleBar } from './WindowTitleBar';
 import { TaskDetailWindow } from './TaskDetailWindow';
 import type { ManagedWindow } from '../store/types';
@@ -41,19 +42,21 @@ export function WindowContent({
 }: WindowContentProps) {
   if (managedWindow.kind === 'command-terminal') {
     return (
-      <Suspense
-        fallback={
-          <div className="flex h-full w-full items-center justify-center">
-            <Loader2 size={20} className="animate-spin text-fg-muted" />
-          </div>
-        }
-      >
-        <CommandTerminalWindow
-          managedWindow={managedWindow}
-          isMaximized={isMaximized}
-          titleBarPointerDown={titleBarPointerDown}
-        />
-      </Suspense>
+      <PanelErrorBoundary label="Command Terminal">
+        <Suspense
+          fallback={
+            <div className="flex h-full w-full items-center justify-center">
+              <Loader2 size={20} className="animate-spin text-fg-muted" />
+            </div>
+          }
+        >
+          <CommandTerminalWindow
+            managedWindow={managedWindow}
+            isMaximized={isMaximized}
+            titleBarPointerDown={titleBarPointerDown}
+          />
+        </Suspense>
+      </PanelErrorBoundary>
     );
   }
 

--- a/tests/ui/changes-panel-lazy-retry.spec.ts
+++ b/tests/ui/changes-panel-lazy-retry.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * UI test for scoped, recoverable lazy loading of the Changes panel.
+ *
+ * Regression guard for the bug where a transient dynamic-import failure of the
+ * code-split ChangesPanel module crashed the ENTIRE app to the root error page,
+ * and "Try again" could never recover.
+ *
+ * The fix: each lazy site is wrapped in a scoped PanelErrorBoundary. A chunk-load
+ * failure is caught there (not at the root), so the rest of the app survives. The
+ * browser caches a failed module URL in its module map for the document's
+ * lifetime, so recovery from a chunk-load failure requires a full window reload
+ * (a fresh module map); the boundary surfaces a Reload action for exactly that.
+ *
+ * This test aborts the ChangesPanel module fetch, opens the panel, and asserts
+ * (a) the failure stays scoped to the panel (the app and dialog survive) and
+ * (b) after healing the network, reloading recovers (the panel then loads).
+ *
+ * Note: this spec deliberately breaks the network, so an aborted module fetch
+ * surfaces a console resource error and a React error-boundary console.error.
+ * Those are expected and handled by the boundary, so `collectPageErrors` is
+ * intentionally NOT used here.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+async function launchWithState(preConfigScript: string): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(preConfigScript);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+  return { browser, page };
+}
+
+const PROJECT_ID = 'proj-lazy-retry';
+const TASK_ID = 'task-lazy-retry';
+const SESSION_ID = 'sess-lazy-retry';
+
+const preConfig = `
+  window.__mockPreConfigure(function (state) {
+    var ts = new Date().toISOString();
+
+    state.projects.push({
+      id: '${PROJECT_ID}',
+      name: 'Lazy Retry Test',
+      path: '/mock/lazy-retry-test',
+      github_url: null,
+      default_agent: 'claude',
+      last_opened: ts,
+      created_at: ts,
+    });
+
+    var laneIds = {};
+    state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+      var id = 'lane-' + s.name.toLowerCase().replace(/\\s+/g, '-');
+      laneIds[s.name] = id;
+      state.swimlanes.push(Object.assign({}, s, { id: id, position: i, created_at: ts }));
+    });
+
+    // Running session so the dialog opens in non-editing mode and the Changes
+    // pill is rendered.
+    state.sessions.push({
+      id: '${SESSION_ID}',
+      taskId: '${TASK_ID}',
+      projectId: '${PROJECT_ID}',
+      pid: 9999,
+      status: 'running',
+      shell: 'bash',
+      cwd: '/mock/lazy-retry-test',
+      startedAt: ts,
+      exitCode: null,
+    });
+
+    state.tasks.push({
+      id: '${TASK_ID}',
+      title: 'Lazy Retry Task',
+      description: 'Task used for the Changes-panel lazy-retry test',
+      swimlane_id: laneIds['Code Review'],
+      position: 0,
+      agent: 'claude',
+      session_id: '${SESSION_ID}',
+      worktree_path: '/mock/worktrees/lazy-retry',
+      branch_name: 'feature/lazy-retry',
+      pr_number: null,
+      pr_url: null,
+      base_branch: 'main',
+      archived_at: null,
+      created_at: ts,
+      updated_at: ts,
+    });
+
+    return { currentProjectId: '${PROJECT_ID}' };
+  });
+`;
+
+let browser: Browser;
+let page: Page;
+
+test.beforeAll(async () => {
+  const result = await launchWithState(preConfig);
+  browser = result.browser;
+  page = result.page;
+  await page.locator('[data-swimlane-name="Code Review"]').waitFor({ state: 'visible', timeout: 10000 });
+});
+
+test.afterAll(async () => {
+  await browser?.close();
+});
+
+async function openTaskAndChanges(): Promise<void> {
+  const card = page
+    .locator('[data-swimlane-name="Code Review"]')
+    .locator('text=Lazy Retry Task')
+    .first();
+  await card.click();
+  await page.locator('[data-testid="task-detail-dialog"]').waitFor({ state: 'visible', timeout: 5000 });
+  await page.locator('[data-testid="changes-toggle"]').click();
+}
+
+test.describe('Changes panel: lazy-import failure is scoped and recoverable', () => {
+  test('a chunk failure shows a panel-scoped error, not a root crash, and reload recovers', async () => {
+    // Abort the ChangesPanel module fetch BEFORE anything imports it. The panel
+    // is only imported the first time the Changes pill is clicked (no static
+    // import exists), and this page's context has a cold module map, so the
+    // abort deterministically hits a fresh dynamic import. The trailing `*`
+    // matches Vite's optional `?t=` invalidation query.
+    await page.route('**/ChangesPanel.tsx*', (route) => route.abort());
+
+    await openTaskAndChanges();
+
+    // The lazy import fails and the SCOPED boundary catches it.
+    const boundary = page.locator('[data-testid="panel-error-boundary"]');
+    await expect(boundary).toBeVisible({ timeout: 10000 });
+
+    // Blast radius stayed scoped to the panel: the app did not fall to the root
+    // "Something went wrong" page, and the dialog is still open.
+    await expect(page.locator('text=Something went wrong')).not.toBeVisible();
+    await expect(page.locator('[data-testid="task-detail-dialog"]')).toBeVisible();
+
+    // A chunk-load failure cannot be healed by a remount (the module URL is
+    // poisoned in the module map), so the boundary offers Reload, not Retry.
+    const action = page.locator('[data-testid="panel-error-retry"]');
+    await expect(action).toHaveText(/Reload/);
+
+    // Heal the network, then reload. A fresh document has a fresh module map, so
+    // the panel loads on the next open.
+    await page.unroute('**/ChangesPanel.tsx*');
+    await action.click();
+
+    // The app comes back up cleanly (no root crash).
+    await page.waitForLoadState('load');
+    await page.locator('[data-swimlane-name="Code Review"]').waitFor({ state: 'visible', timeout: 15000 });
+    await expect(page.locator('text=Something went wrong')).not.toBeVisible();
+
+    // Reopen the task and the Changes panel: it now loads (changes-expand renders
+    // inside the lazy ChangesPanel module, proving the module loaded this time).
+    await openTaskAndChanges();
+    await expect(page.locator('[data-testid="changes-expand"]')).toBeVisible({ timeout: 10000 });
+    await expect(boundary).not.toBeVisible();
+
+    // Close the panel and dialog so state does not leak to other tests.
+    await page.locator('[data-testid="changes-toggle"]').click();
+    await page.keyboard.press('Control+Shift+W');
+    await expect(page.locator('[data-testid="task-detail-dialog"]')).not.toBeVisible({ timeout: 8000 });
+  });
+});

--- a/tests/ui/task-changes-dialog-lazy-retry.spec.ts
+++ b/tests/ui/task-changes-dialog-lazy-retry.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * UI test for scoped, recoverable lazy loading of the Changes panel at the
+ * STANDALONE TaskChangesDialog wiring site (opened via a task card's "Changes"
+ * context-menu entry), mirroring tests/ui/changes-panel-lazy-retry.spec.ts,
+ * which covers the same PanelErrorBoundary wrapper at the TaskDetailBody
+ * (task-detail dialog) site.
+ *
+ * The wrapper is byte-identical at both sites (`<PanelErrorBoundary
+ * label="Changes panel"><Suspense>...<ChangesPanel /></Suspense></PanelErrorBoundary>`),
+ * but the surrounding dialog differs (TaskChangesDialog vs TaskDetailBody), so
+ * this pins that the boundary catches a chunk-load failure and offers Reload
+ * at THIS site's own mount point too, without a root crash.
+ *
+ * Same abort/reload technique: aborting the ChangesPanel module fetch forces a
+ * dynamic-import failure on first open; healing the network and reloading lets
+ * a fresh module map load the panel on next open.
+ *
+ * Note: this spec deliberately breaks the network, so an aborted module fetch
+ * surfaces a console resource error and a React error-boundary console.error.
+ * Those are expected and handled by the boundary, so `collectPageErrors` is
+ * intentionally NOT used here (same rationale as changes-panel-lazy-retry.spec.ts).
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady, waitForBoard } from './helpers';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+async function launchWithState(preConfigScript: string): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(preConfigScript);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+  return { browser, page };
+}
+
+const PROJECT_ID = 'proj-changes-dialog-lazy-retry';
+const TASK_ID = 'task-changes-dialog-lazy-retry';
+
+// A task with a worktree_path is required for the context menu's "Changes"
+// entry to render at all (see tests/ui/task-changes-dialog.spec.ts, which
+// pins the entry HIDDEN for a task with no worktree). No session is needed:
+// TaskChangesDialog does not read session state.
+const preConfig = `
+  window.__mockPreConfigure(function (state) {
+    var ts = new Date().toISOString();
+
+    state.projects.push({
+      id: '${PROJECT_ID}',
+      name: 'Changes Dialog Lazy Retry Test',
+      path: '/mock/changes-dialog-lazy-retry-test',
+      github_url: null,
+      default_agent: 'claude',
+      last_opened: ts,
+      created_at: ts,
+    });
+
+    var laneIds = {};
+    state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+      var id = 'lane-' + s.name.toLowerCase().replace(/\\s+/g, '-');
+      laneIds[s.name] = id;
+      state.swimlanes.push(Object.assign({}, s, { id: id, position: i, created_at: ts }));
+    });
+
+    state.tasks.push({
+      id: '${TASK_ID}',
+      title: 'Changes Dialog Lazy Retry Task',
+      description: 'Task used for the standalone TaskChangesDialog lazy-retry test',
+      swimlane_id: laneIds['To Do'],
+      position: 0,
+      agent: null,
+      session_id: null,
+      worktree_path: '/mock/worktrees/changes-dialog-lazy-retry',
+      branch_name: 'feature/changes-dialog-lazy-retry',
+      pr_number: null,
+      pr_url: null,
+      base_branch: 'main',
+      archived_at: null,
+      created_at: ts,
+      updated_at: ts,
+    });
+
+    return { currentProjectId: '${PROJECT_ID}' };
+  });
+`;
+
+let browser: Browser;
+let page: Page;
+
+test.beforeAll(async () => {
+  const result = await launchWithState(preConfig);
+  browser = result.browser;
+  page = result.page;
+  await waitForBoard(page);
+});
+
+test.afterAll(async () => {
+  await browser?.close();
+});
+
+function taskCard(): ReturnType<Page['locator']> {
+  return page.locator('[data-swimlane-name="To Do"]').locator('text=Changes Dialog Lazy Retry Task').first();
+}
+
+async function openChangesDialogViaContextMenu(): Promise<void> {
+  await taskCard().click({ button: 'right' });
+  await page.locator('[data-testid="context-show-changes"]').click();
+  await page.locator('[data-testid="task-changes-dialog"]').waitFor({ state: 'visible', timeout: 5000 });
+}
+
+test.describe('Standalone Changes dialog: lazy-import failure is scoped and recoverable', () => {
+  test('a chunk failure shows a panel-scoped error, not a root crash, and reload recovers', async () => {
+    // Abort the ChangesPanel module fetch BEFORE anything imports it. This
+    // page's context has a cold module map (fresh browser context per spec
+    // file), so the abort deterministically hits a fresh dynamic import.
+    await page.route('**/ChangesPanel.tsx*', (route) => route.abort());
+
+    await openChangesDialogViaContextMenu();
+
+    // The lazy import fails and the SCOPED boundary catches it.
+    const boundary = page.locator('[data-testid="panel-error-boundary"]');
+    await expect(boundary).toBeVisible({ timeout: 10000 });
+
+    // Blast radius stayed scoped to the panel: the app did not fall to the
+    // root "Something went wrong" page, and the dialog is still open.
+    await expect(page.locator('text=Something went wrong')).not.toBeVisible();
+    await expect(page.locator('[data-testid="task-changes-dialog"]')).toBeVisible();
+
+    // A chunk-load failure cannot be healed by a remount (the module URL is
+    // poisoned in the module map), so the boundary offers Reload, not Retry.
+    const action = page.locator('[data-testid="panel-error-retry"]');
+    await expect(action).toHaveText(/Reload/);
+
+    // Heal the network, then reload. A fresh document has a fresh module map,
+    // so the panel loads on the next open.
+    await page.unroute('**/ChangesPanel.tsx*');
+    await action.click();
+
+    // The app comes back up cleanly (no root crash).
+    await page.waitForLoadState('load');
+    await waitForBoard(page);
+    await expect(page.locator('text=Something went wrong')).not.toBeVisible();
+
+    // Reopen the Changes dialog: it now loads for real. The mock's diffFiles
+    // returns an empty file list by default, and TaskChangesDialog passes
+    // emptyMessage="No changes on this branch", so that text is the
+    // definitive "the real ChangesPanel module loaded, not the boundary"
+    // signal here (TaskChangesDialog does not pass panelMode/onExpand, so
+    // the split-only "changes-expand" testid never renders at this site).
+    await openChangesDialogViaContextMenu();
+    await expect(page.locator('text=No changes on this branch')).toBeVisible({ timeout: 10000 });
+    await expect(boundary).not.toBeVisible();
+
+    // Close the dialog so state does not leak to other tests in this file.
+    await page.keyboard.press('Escape');
+    await expect(page.locator('[data-testid="task-changes-dialog"]')).not.toBeVisible({ timeout: 8000 });
+  });
+});

--- a/tests/unit/chunk-load-error.test.ts
+++ b/tests/unit/chunk-load-error.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { isChunkLoadError } from '../../src/renderer/utils/chunk-load-error';
+
+describe('isChunkLoadError', () => {
+  it('detects the Chromium dynamic-import failure message', () => {
+    const error = new Error(
+      'Failed to fetch dynamically imported module: http://localhost:5173/src/renderer/components/dialogs/task-detail/changes/ChangesPanel.tsx',
+    );
+    expect(isChunkLoadError(error)).toBe(true);
+  });
+
+  it('detects other engines and bundler chunk messages case-insensitively', () => {
+    expect(isChunkLoadError(new Error('error loading dynamically imported module'))).toBe(true);
+    expect(isChunkLoadError(new Error('Importing a module script failed.'))).toBe(true);
+    expect(isChunkLoadError(new Error('Failed to load module script'))).toBe(true);
+    expect(isChunkLoadError(new Error('Loading chunk 42 failed'))).toBe(true);
+    expect(isChunkLoadError(new Error('Loading CSS chunk foo failed'))).toBe(true);
+  });
+
+  it('accepts a plain string error message', () => {
+    expect(isChunkLoadError('Failed to fetch dynamically imported module: /x.js')).toBe(true);
+  });
+
+  it('returns false for an ordinary render error', () => {
+    expect(isChunkLoadError(new Error('Cannot read properties of undefined (reading map)'))).toBe(false);
+  });
+
+  it('returns false for non-error, empty, and nullish inputs', () => {
+    expect(isChunkLoadError(new Error(''))).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError(42)).toBe(false);
+    expect(isChunkLoadError({})).toBe(false);
+  });
+});

--- a/tests/unit/panel-error-boundary.test.ts
+++ b/tests/unit/panel-error-boundary.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit coverage for PanelErrorBoundary's ordinary-error (Retry) recovery
+ * path, complementing tests/ui/changes-panel-lazy-retry.spec.ts, which
+ * exclusively drives the chunk-load (Reload) path at the TaskDetailBody
+ * wiring site.
+ *
+ * This project's vitest config has no jsdom environment and no
+ * @testing-library/react dependency (see use-task-split-resize.test.ts and
+ * hmr-generation.test.ts for the established rationale and pattern), so a
+ * click-driven `render + fireEvent` test is not available here. Instead
+ * these tests call the REAL production class's static and instance methods
+ * directly and inspect the plain React element objects `render()` returns --
+ * `React.createElement` output is a `{ type, props }` object graph that
+ * requires no renderer to walk. This exercises the actual
+ * `PanelErrorBoundary` code, not a hand-rolled mirror of its logic.
+ *
+ * `handleRetry`'s real implementation calls `this.setState(...)`. A class
+ * instantiated outside a React reconciler (`new PanelErrorBoundary(props)`,
+ * no createRoot/render call) gets React's built-in no-op update queue, so an
+ * unmodified `this.setState(...)` call would silently do nothing. The
+ * `withWorkingSetState` helper below stubs the instance's `setState` to
+ * perform the same shallow merge a real reconciler would, so `handleRetry`'s
+ * real body runs untouched and its effect on `instance.state` is directly
+ * observable.
+ */
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { PanelErrorBoundary } from '../../src/renderer/components/PanelErrorBoundary';
+
+interface BoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+interface ElementLike {
+  type: unknown;
+  props: Record<string, unknown>;
+}
+
+function isElementLike(node: unknown): node is ElementLike {
+  return typeof node === 'object' && node !== null && 'props' in node;
+}
+
+function collectText(node: unknown): string {
+  if (node === null || node === undefined || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join('');
+  if (isElementLike(node)) return collectText(node.props.children);
+  return '';
+}
+
+function findByTestId(node: unknown, testId: string): ElementLike | null {
+  if (node === null || node === undefined || typeof node === 'boolean') return null;
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findByTestId(child, testId);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (isElementLike(node)) {
+    if (node.props['data-testid'] === testId) return node;
+    return findByTestId(node.props.children, testId);
+  }
+  return null;
+}
+
+/** See file header: stubs setState with a shallow-merge so handleRetry's real body is observable. */
+function withWorkingSetState(
+  instance: PanelErrorBoundary,
+): PanelErrorBoundary & { state: BoundaryState } {
+  const stateful = instance as unknown as PanelErrorBoundary & {
+    state: BoundaryState;
+    setState: (
+      update: Partial<BoundaryState> | ((previous: BoundaryState) => Partial<BoundaryState>),
+    ) => void;
+  };
+  stateful.setState = (update) => {
+    const partial = typeof update === 'function' ? update(stateful.state) : update;
+    stateful.state = { ...stateful.state, ...partial };
+  };
+  return stateful;
+}
+
+describe('PanelErrorBoundary', () => {
+  it('shows the Retry action (not Reload) for an ordinary render error, and reflects the label prop', () => {
+    const children = React.createElement('span', null, 'child content');
+    const instance = withWorkingSetState(new PanelErrorBoundary({ children, label: 'Changes panel' }));
+
+    const derived = PanelErrorBoundary.getDerivedStateFromError(
+      new Error('Cannot read properties of undefined (reading map)'),
+    );
+    instance.state = { ...instance.state, ...derived };
+
+    const output = instance.render();
+    const boundary = findByTestId(output, 'panel-error-boundary');
+    expect(boundary).not.toBeNull();
+    expect(collectText(boundary)).toContain('Failed to load the Changes panel');
+    expect(collectText(boundary)).toContain('Cannot read properties of undefined (reading map)');
+
+    const button = findByTestId(output, 'panel-error-retry');
+    expect(button).not.toBeNull();
+    expect(collectText(button)).toContain('Retry');
+    expect(collectText(button)).not.toContain('Reload');
+    // Reverting the `chunkLoadFailure ? handleReload : handleRetry` ternary
+    // (hardcoding Reload for both) would rewire this onClick to
+    // handleReload instead - this pins the real handler wired up.
+    expect(button?.props.onClick).toBe(instance.handleRetry);
+  });
+
+  it('defaults the label to "panel" when no label prop is given', () => {
+    const children = React.createElement('span', null, 'child content');
+    const instance = withWorkingSetState(new PanelErrorBoundary({ children }));
+
+    instance.state = {
+      ...instance.state,
+      ...PanelErrorBoundary.getDerivedStateFromError(new Error('boom')),
+    };
+
+    const boundary = findByTestId(instance.render(), 'panel-error-boundary');
+    expect(collectText(boundary)).toContain('Failed to load the panel');
+  });
+
+  it('handleRetry resets error state so render() passes through children again (recovery)', () => {
+    const children = React.createElement('span', null, 'recovered content');
+    const instance = withWorkingSetState(new PanelErrorBoundary({ children }));
+
+    // Simulate a caught ordinary error, same as getDerivedStateFromError
+    // being invoked by a real reconciler.
+    instance.state = {
+      ...instance.state,
+      ...PanelErrorBoundary.getDerivedStateFromError(new Error('boom')),
+    };
+    expect(findByTestId(instance.render(), 'panel-error-boundary')).not.toBeNull();
+
+    // The REAL handleRetry, wired through the working setState stub - not a
+    // re-derivation of its logic.
+    instance.handleRetry();
+
+    expect(instance.state).toEqual({ hasError: false, error: null });
+    const recovered = instance.render();
+    expect(recovered).toBe(children);
+    expect(findByTestId(recovered, 'panel-error-boundary')).toBeNull();
+  });
+
+  it('shows the Reload action (not Retry) for a chunk-load error, without invoking it', () => {
+    const children = React.createElement('span', null, 'child content');
+    const instance = withWorkingSetState(new PanelErrorBoundary({ children }));
+
+    instance.state = {
+      ...instance.state,
+      ...PanelErrorBoundary.getDerivedStateFromError(
+        new Error('Failed to fetch dynamically imported module: /ChangesPanel.tsx'),
+      ),
+    };
+
+    const output = instance.render();
+    const button = findByTestId(output, 'panel-error-retry');
+    expect(button).not.toBeNull();
+    expect(collectText(button)).toContain('Reload');
+    expect(collectText(button)).not.toContain('Retry');
+    expect(button?.props.onClick).toBe(instance.handleReload);
+    // Do NOT invoke the click handler: jsdom is not available here, and
+    // handleReload calls the real window.location.reload(), which is
+    // neither implemented nor safe to trigger in a unit test process.
+  });
+});


### PR DESCRIPTION
## What

Fixes the Changes panel (and every other code-split panel) taking down the whole app when its
dynamic import fails, with a dead "Try again".

- Adds a scoped `PanelErrorBoundary` (`src/renderer/components/PanelErrorBoundary.tsx`) around all
  4 lazy panel sites: `WindowContent` (CommandTerminalWindow), `CommandTerminalWindow`,
  `TaskChangesDialog`, and `TaskDetailBody` (ChangesPanel). A load failure now fills only the
  panel instead of unmounting the app to the root error page.
- Adds `isChunkLoadError()` (`src/renderer/utils/chunk-load-error.ts`) and wires the boundary to
  recover per failure type: a chunk-load error offers **Reload**; any other render error offers
  **Retry** (remount).
- Coverage: unit tests for the detector and both boundary branches; UI tests for the
  scoped-failure and reload-recovery flow at both the task-detail and standalone-dialog sites.

## Why

Opening the Changes panel during a Vite dev-server invalidation replaced the entire app with the
root "Something went wrong" page, and Try again never recovered. Three stacked problems: a
transient chunk fetch failure, a whole-app blast radius (the only error boundary was at the root),
and a dead retry (`React.lazy` caches the rejected import, so re-rendering re-throws the cached
rejection). The blast radius and dead retry are product bugs in any build, not just dev.

Closes #317.

## How

The scoped boundary caps the blast radius. For recovery, I verified empirically (Playwright
route interception against the real Vite dev server) that Chromium caches a **failed** dynamic
import URL in the page module map for the document's lifetime: re-importing the same URL returns
the cached rejection with no new fetch, even after the network heals. So a `lazyWithRetry` /
fresh-`import()`-on-remount cannot recover a chunk-load failure. The only reliable recovery is a
window reload (a fresh module map), which is exactly what the boundary offers for chunk-load
errors; a plain remount is kept for ordinary render errors. All 4 sites use plain `React.lazy`
again (the wrapper was actively suppressing the rejection).

## Breaking changes

None.

## Tests

- CI: lint, typecheck, unit, build, UI shards, and the Linux Electron E2E shards.
- New unit: `tests/unit/chunk-load-error.test.ts`, `tests/unit/panel-error-boundary.test.ts`.
- New UI: `tests/ui/changes-panel-lazy-retry.spec.ts`,
  `tests/ui/task-changes-dialog-lazy-retry.spec.ts` (abort the ChangesPanel module fetch, assert
  the failure is scoped and no root crash, then heal + reload and assert the panel loads).
- Verified locally: typecheck, lint, the new unit and UI specs, plus the existing
  `task-detail-changes-panel`, `task-changes-dialog`, and `command-terminal` specs (no regression).

Generated with [Claude Code](https://claude.com/claude-code)
