### PR TITLE
feat(mcp): never prompt for Kangentic's own MCP tools

### DIFF
--- a/.claude/rules/mcp-tool-list-parity.md
+++ b/.claude/rules/mcp-tool-list-parity.md
@@ -45,9 +45,15 @@ are intentionally not part of this surface.
   `-tools.ts` suffix, so a brand-new registration file is auto-covered) and asserts (a) every
   registered tool has a manifest entry; (b) every manifest entry names a real registered tool
   (catches a rename/removal); (c) every manifest tool appears in
-  `docs/mcp-server.md`. Runs in CI via `npm run test:unit`. Because the rule is path-scoped, a
-  brand-new `*-tools.ts` file does not pre-load this rule (the read-trigger gap); the CI test is the
-  real guarantee.
+  `docs/mcp-server.md`. It additionally asserts (d) every registration declares `annotations:` via
+  one of the two shared constants in `src/main/agent/mcp-http/annotations.ts`
+  (`READ_ONLY_ANNOTATIONS` / `MUTATING_ANNOTATIONS`), that those constants keep their spec-correct
+  values, that no `*-tools.ts` redefines them locally, and that any tool named with a mutating verb
+  (`create` / `update` / `delete` / `move` / `promote` / `link`) is annotated mutating - so a tool
+  can never ship unannotated (which would prompt on every plan-mode call) or with a mutation
+  dishonestly marked read-only (which would be silently auto-approved in plan mode). Runs in CI via
+  `npm run test:unit`. Because the rule is path-scoped, a brand-new `*-tools.ts` file does not
+  pre-load this rule (the read-trigger gap); the CI test is the real guarantee.
 - **Review:** `/code-review` flags a new `registerTool` call site without a matching manifest entry,
   and the `doc-auditor` agent reports a tool missing from `docs/mcp-server.md`.
 

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -312,8 +312,9 @@ For every session, a merged settings file is built at `.kangentic/sessions/<clau
    - Hooks from the worktree are skipped (may be stale leftovers)
 4. Inject `statusLine` config pointing to the status bridge script
 5. Inject event-bridge hooks into all registered hook points
-6. Write merged file to session directory
-7. Pass `--settings <mergedSettingsPath>` to the CLI
+6. When the MCP server is attached, append `mcp__kangentic` to `permissions.allow` (append-if-absent) so kangentic's own tools never prompt in default mode
+7. Write merged file to session directory
+8. Pass `--settings <mergedSettingsPath>` to the CLI
 
 All Kangentic artifacts stay in `.kangentic/` - nothing is written to `.claude/settings.local.json`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -602,7 +602,8 @@ For each session, a merged settings file is created at `.kangentic/sessions/<ses
 2. Read `.claude/settings.local.json` (gitignored local settings)
 3. Deep-merge hooks from both
 4. Inject Kangentic bridge commands into hook points
-5. Write merged file, pass to CLI via `--settings`
+5. When the MCP server is attached, append `mcp__kangentic` to `permissions.allow` (append-if-absent) so kangentic's own tools never prompt in default mode
+6. Write merged file, pass to CLI via `--settings`
 
 ## Session Recovery
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -77,13 +77,16 @@ No parameters. Returns each project's `name`, `id`, `path`, `lastOpened` timesta
 
 **Tool annotations.** Every registered tool declares MCP `annotations` from the shared constants
 in `src/main/agent/mcp-http/annotations.ts`: read-only tools carry
-`readOnlyHint: true, idempotentHint: true`; mutating tools (`create` / `update` / `delete` /
-`move` / `promote` / `link`) carry `readOnlyHint: false, idempotentHint: false`. This is
-load-bearing for plan mode: Claude Code auto-approves read-only-annotated tools without a
-permission prompt while planning, so the plan-mode auto-approval surface is exactly the read-only
-set. Mutating tools still prompt in plan mode by design (allow rules do not punch through the
-plan-mode gate). The `tests/unit/mcp-tool-list-parity.test.ts` guard fails the build if a tool is
-registered without one of the two shared annotation constants.
+`readOnlyHint: true, idempotentHint: true`; mutating tools carry
+`readOnlyHint: false, idempotentHint: false`. Mutating covers both the board/backlog writers
+(`create` / `update` / `delete` / `move` / `promote` / `link`) and the `kangentic_browser_*` tools
+that change the loaded page (navigate, click, type, keypress, drag, eval). This is load-bearing for
+plan mode: Claude Code auto-approves read-only-annotated tools without a permission prompt while
+planning, so the plan-mode auto-approval surface is exactly the read-only set. Mutating tools still
+prompt in plan mode by design (allow rules do not punch through the plan-mode gate). The
+`tests/unit/mcp-tool-list-parity.test.ts` guard fails the build if a tool is registered without one
+of the two shared annotation constants, and separately checks the board/backlog verb prefixes and
+the browser capability tiers are annotated mutating.
 
 ### kangentic_create_task
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -30,7 +30,8 @@ Claude Code agent calls MCP tool (e.g. kangentic_create_task)
 | Session Tools | `src/main/agent/mcp-http/session-tools.ts` | Session inspection, backlog, read-only SQL (`kangentic_list_sessions`, `kangentic_get_transcript`, `kangentic_get_session_files`, `kangentic_get_session_events`, `kangentic_query_db`, `kangentic_list_backlog`, etc.). |
 | Project Tools | `src/main/agent/mcp-http/project-tools.ts` | Multi-project discovery (`kangentic_list_projects`). |
 | Search Tools | `src/main/agent/mcp-http/search-tools.ts` | Cross-project unified search (`kangentic_search_everything`). The board-scoped `kangentic_search_tasks` lives in `task-tools.ts`. |
-| Diagnostics Tools | `src/main/agent/mcp-http/diagnostics-tools.ts` | Read-only product tools backing crash records, persistent console logs, process metrics, IPC traffic recordings, and worktree state. Annotated `readOnlyHint: true, idempotentHint: true` per the MCP spec. |
+| Diagnostics Tools | `src/main/agent/mcp-http/diagnostics-tools.ts` | Read-only product tools backing crash records, persistent console logs, process metrics, IPC traffic recordings, and worktree state. |
+| Tool Annotations | `src/main/agent/mcp-http/annotations.ts` | Shared `READ_ONLY_ANNOTATIONS` / `MUTATING_ANNOTATIONS` MCP tool-annotation constants. Every tool in every `*-tools.ts` file declares one of these (see the Tool annotations note below). |
 | Browser Tools | `src/main/agent/mcp-http/browser-tools.ts` | Shipped `kangentic_browser_*` MCP tool family driving the embedded Browser pane via in-process CDP (no HTTP bridge, no lockfile). Gated by the global `browserAutomation.*` policy. |
 | Command Handlers | `src/main/agent/commands/` | Per-domain handlers shared by the HTTP tools: task, column, inventory, search, analytics, backlog, handoff, inspect (`get_transcript`, `query_db`), and session-files (`get_session_files`, `get_session_events`) commands. |
 | Column Resolver | `src/main/agent/commands/column-resolver.ts` | Shared case-insensitive column name to swimlane lookup used by multiple handlers. |
@@ -43,7 +44,7 @@ Claude Code agent calls MCP tool (e.g. kangentic_create_task)
 
 Claude Code supports a `--mcp-config` flag that accepts a path to a JSON file containing MCP server definitions. Kangentic uses this to deliver its MCP server config without modifying `.mcp.json` (which may be tracked in git). When Kangentic spawns a session:
 
-1. `CommandBuilder.createMergedSettings()` writes the kangentic MCP server config to `.kangentic/sessions/<sessionId>/mcp.json`. The entry is an HTTP MCP server pointing at the per-launch URL `http://127.0.0.1:<port>/mcp/<projectId>` with the `X-Kangentic-Token` header containing the per-launch token.
+1. `CommandBuilder.createMergedSettings()` writes the kangentic MCP server config to `.kangentic/sessions/<sessionId>/mcp.json`. The entry is an HTTP MCP server pointing at the per-launch URL `http://127.0.0.1:<port>/mcp/<projectId>` with the `X-Kangentic-Token` header containing the per-launch token. In the same gated block it also appends `mcp__kangentic` to the merged settings' `permissions.allow` (append-if-absent) so the spawned agent does not prompt for kangentic tools in default mode (see Permissions).
 2. `CommandBuilder.buildClaudeCommand()` adds `--mcp-config <path>` to the CLI command
 3. `ensureMcpServerTrust()` adds "kangentic" to `enabledMcpjsonServers` in `~/.claude.json`
 4. Claude Code starts, reads both `.mcp.json` (user servers) and the `--mcp-config` file (kangentic), and connects to the in-process HTTP MCP server over loopback. No child process is spawned for kangentic itself.
@@ -73,6 +74,16 @@ List every Kangentic project registered on this machine. Use the returned name o
 No parameters. Returns each project's `name`, `id`, `path`, `lastOpened` timestamp, and an `isActive` flag marking the project the MCP client is bound to.
 
 ## Available Tools
+
+**Tool annotations.** Every registered tool declares MCP `annotations` from the shared constants
+in `src/main/agent/mcp-http/annotations.ts`: read-only tools carry
+`readOnlyHint: true, idempotentHint: true`; mutating tools (`create` / `update` / `delete` /
+`move` / `promote` / `link`) carry `readOnlyHint: false, idempotentHint: false`. This is
+load-bearing for plan mode: Claude Code auto-approves read-only-annotated tools without a
+permission prompt while planning, so the plan-mode auto-approval surface is exactly the read-only
+set. Mutating tools still prompt in plan mode by design (allow rules do not punch through the
+plan-mode gate). The `tests/unit/mcp-tool-list-parity.test.ts` guard fails the build if a tool is
+registered without one of the two shared annotation constants.
 
 ### kangentic_create_task
 
@@ -489,7 +500,12 @@ Config key: `mcpServer.enabled` (boolean, default `true`)
 
 ### Permissions
 
-The `.claude/settings.json` file includes a wildcard permission entry (`mcp__kangentic`) that pre-approves all kangentic MCP tools at once. Agents can use any kangentic tool without prompting for approval. This avoids maintaining a separate permission entry for each individual tool name.
+Agents Kangentic spawns never see a permission prompt for Kangentic's own tools. Two layers cover the two axes (which mode, which project):
+
+1. **Auto-allow injection (all projects, default / acceptEdits mode).** Whenever the MCP server is attached, `CommandBuilder.createMergedSettings()` appends `mcp__kangentic` to `permissions.allow` in the per-session merged `settings.json` (`.kangentic/sessions/<sessionId>/settings.json`). This is gated on the same condition as the session `mcp.json` write and is append-if-absent, so a committed project rule or a Claude "always allow" grant is not duplicated. It lives only in the regenerated per-session settings, never written back to the user's own settings files, and an explicit user `deny` of `mcp__kangentic` still wins (deny outranks allow). So the no-prompt behavior holds for every project, not just ones that committed a rule.
+2. **Read-only annotations (all projects, plan mode).** Allow rules do not punch through plan mode. Plan-mode auto-approval comes from the tools' `readOnlyHint` annotations (see the Tool annotations note under Available Tools): read-only tools run without a prompt while planning; mutating tools still prompt, by design.
+
+The committed `.claude/settings.json` `mcp__kangentic` entry remains for humans running `claude` outside Kangentic; inside Kangentic the injection makes it redundant but harmless (deduped).
 
 ## Security
 
@@ -501,6 +517,7 @@ The `.claude/settings.json` file includes a wildcard permission entry (`mcp__kan
 - **Input validation** - Zod schemas enforce title (200 chars) and description (10000 chars) limits at the protocol level; the command handlers validate again.
 - **Column safety** - `kangentic_create_task` defaults to the To Do column; creating in an auto_spawn column intentionally triggers agent spawn.
 - **Destructive operations are explicit** - `kangentic_delete_task`, `kangentic_delete_backlog_item`, and `kangentic_move_task` mutate the board. Agents must invoke them by name; there is no implicit fallback.
+- **Honest mutating annotations** - mutating tools carry `readOnlyHint: false`, so the plan-mode auto-approval surface is exactly the read-only set. Deletes, moves, and creates always prompt while planning, even though the auto-allow injection pre-approves them in default mode.
 
 ## Build
 

--- a/docs/worktree-strategy.md
+++ b/docs/worktree-strategy.md
@@ -123,8 +123,9 @@ All sessions (main repo and worktree) use a unified approach. For each session, 
 2. Deep-merge `.claude/settings.local.json` from project root (gitignored, personal)
 3. For worktrees: merge permissions from the worktree's `.claude/settings.local.json` (captures "always allow" grants -- hooks are skipped since they may be stale leftovers from before the unified approach)
 4. Inject bridge commands into appropriate hook points
-5. Write merged file to session directory
-6. Pass `--settings <mergedSettingsPath>` to the CLI
+5. When the MCP server is attached, append `mcp__kangentic` to `permissions.allow` (append-if-absent) so kangentic's own tools never prompt in default mode
+6. Write merged file to session directory
+7. Pass `--settings <mergedSettingsPath>` to the CLI
 
 All Kangentic artifacts stay in `.kangentic/` -- nothing is written to `.claude/settings.local.json`. When users hit "always allow" on a permission prompt, Claude writes to `settings.local.json` in the CWD (worktree or project root). These grants are read back on session resume (step 3) so they persist across restarts.
 

--- a/src/main/agent/adapters/claude/command-builder.ts
+++ b/src/main/agent/adapters/claude/command-builder.ts
@@ -23,10 +23,24 @@ import type { CommandOptions } from '../../agent-adapter';
  */
 const STATUS_LINE_REFRESH_INTERVAL_SECONDS = 10;
 
+/**
+ * Allow rule injected into every spawned session's merged settings whenever
+ * the kangentic MCP server is attached. The bare server-scope form
+ * pre-approves every mcp__kangentic__* tool so agents Kangentic spawns never
+ * see a permission prompt for Kangentic's own in-process tools in default /
+ * acceptEdits mode, regardless of the project's committed settings.
+ *
+ * Allow rules cover default mode only. Plan mode does NOT honor allow rules;
+ * plan-mode auto-approval of the read-only tools comes from their
+ * `readOnlyHint` annotations (see src/main/agent/mcp-http/annotations.ts).
+ */
+const KANGENTIC_MCP_ALLOW_RULE = 'mcp__kangentic';
+
 /** Subset of Claude Code settings.json that we read/write. */
 interface ClaudeSettings {
   statusLine?: { type: string; command: string; refreshInterval?: number };
   hooks?: Record<string, ClaudeHookEntry[]>;
+  permissions?: { allow?: string[]; deny?: string[] };
   [key: string]: unknown; // preserve unknown keys from user's settings
 }
 
@@ -208,10 +222,7 @@ export class CommandBuilder {
       const raw = fs.readFileSync(localSettingsPath, 'utf-8');
       const localSettings: ClaudeSettings = JSON.parse(raw);
       const { hooks: localHooks, permissions: localPerms, ...localRest } = localSettings;
-      const mergedPerms = mergePermissions(
-        baseSettings.permissions as { allow?: string[]; deny?: string[] } | undefined,
-        localPerms as { allow?: string[]; deny?: string[] } | undefined,
-      );
+      const mergedPerms = mergePermissions(baseSettings.permissions, localPerms);
       baseSettings = {
         ...baseSettings,
         ...localRest,
@@ -252,12 +263,9 @@ export class CommandBuilder {
       try {
         const raw = fs.readFileSync(wtLocalPath, 'utf-8');
         const wtLocal: ClaudeSettings = JSON.parse(raw);
-        const wtPerms = wtLocal.permissions as { allow?: string[]; deny?: string[] } | undefined;
+        const wtPerms = wtLocal.permissions;
         if (wtPerms) {
-          const mergedPerms = mergePermissions(
-            baseSettings.permissions as { allow?: string[]; deny?: string[] } | undefined,
-            wtPerms,
-          );
+          const mergedPerms = mergePermissions(baseSettings.permissions, wtPerms);
           if (mergedPerms) {
             baseSettings = { ...baseSettings, permissions: mergedPerms };
           }
@@ -335,6 +343,22 @@ export class CommandBuilder {
       const mcpConfigPath = path.join(sessionDir, 'mcp.json');
       fs.writeFileSync(mcpConfigPath, JSON.stringify(mcpConfig, null, 2));
       this.lastMcpConfigPath = mcpConfigPath;
+
+      // Pre-approve kangentic's own tools so a spawned agent never sees a
+      // permission prompt for them in default / acceptEdits mode. Gated on
+      // the SAME condition as the mcp.json write above (server actually
+      // attached), so the rule is never injected when the server is absent.
+      // This lives only in the per-session merged settings, which are
+      // regenerated from base sources on every spawn and resume, never
+      // written back to the user's own settings files. Append-if-absent so a
+      // committed project rule or a Claude "always allow" grant merged
+      // earlier is not duplicated. `deny` is untouched: an explicit user deny
+      // of mcp__kangentic still wins (Claude Code deny outranks allow).
+      const permissions = merged.permissions ?? {};
+      const allowEntries = permissions.allow ?? [];
+      if (!allowEntries.includes(KANGENTIC_MCP_ALLOW_RULE)) {
+        merged.permissions = { ...permissions, allow: [...allowEntries, KANGENTIC_MCP_ALLOW_RULE] };
+      }
     }
 
     // Write merged settings to <sessionDir>/settings.json (used with --settings flag)

--- a/src/main/agent/mcp-http/annotations.ts
+++ b/src/main/agent/mcp-http/annotations.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared MCP tool annotations for the Kangentic in-process MCP server.
+ *
+ * Every tool registered under `mcp-http/*-tools.ts` declares one of these two
+ * constants as its `annotations`. They are the single audit point for which
+ * kangentic tools are read-only versus mutating, so classification stays
+ * honest and auditable (a mutation must never be silently marked read-only).
+ *
+ * Why the annotations matter:
+ *
+ * 1. Plan mode. Claude Code auto-approves tools annotated `readOnlyHint: true`
+ *    in plan mode without a permission prompt, while everything else prompts.
+ *    Allow rules do NOT punch through the plan-mode gate. Verified empirically
+ *    2026-07-01 (annotated `kangentic_get_process_metrics` ran with no prompt,
+ *    unannotated `kangentic_query_db` prompted on every call, both with the
+ *    same `mcp__kangentic` allow rule). This behavior is undocumented for the
+ *    Claude Code CLI, so the empirical result is the authoritative evidence.
+ * 2. Speculative / parallel calls. `readOnlyHint` lets the model treat a tool
+ *    as safe to call speculatively (parallel reads, retries on transient
+ *    errors). MCP spec: https://modelcontextprotocol.io/specification/server/tools
+ *
+ * `MUTATING_ANNOTATIONS` is the explicit honest opposite: a mutating tool
+ * carries `readOnlyHint: false` so it can never be auto-approved in plan mode.
+ * In default mode an allow rule still auto-approves it (a `readOnlyHint: false`
+ * annotation does not defeat an allow rule), so this does not add prompts to
+ * the normal working modes.
+ */
+export const READ_ONLY_ANNOTATIONS = {
+  readOnlyHint: true,
+  idempotentHint: true,
+} as const;
+
+export const MUTATING_ANNOTATIONS = {
+  readOnlyHint: false,
+  idempotentHint: false,
+} as const;

--- a/src/main/agent/mcp-http/browser-tools.ts
+++ b/src/main/agent/mcp-http/browser-tools.ts
@@ -31,6 +31,7 @@ import {
   captureElementClip,
 } from '../../browser/cdp/screenshot';
 import { driverToolResult, screenshotToolResult, errorToolResult } from './tool-result';
+import { READ_ONLY_ANNOTATIONS, MUTATING_ANNOTATIONS } from './annotations';
 
 /**
  * The user-facing `kangentic_browser_*` MCP tool family. Drives the embedded
@@ -44,9 +45,6 @@ import { driverToolResult, screenshotToolResult, errorToolResult } from './tool-
  * a `{ kind, detail }` error envelope. Capability tiers: observe (screenshot,
  * query, console, wait), interact (click/type/keypress/drag), navigate, eval.
  */
-
-const READ_ONLY_ANNOTATIONS = { readOnlyHint: true, idempotentHint: true } as const;
-const MUTATING_ANNOTATIONS = { readOnlyHint: false, idempotentHint: false } as const;
 
 const SESSION_DESC =
   'Optional Kangentic sessionId of the task whose Browser pane to target. Omit to use the single open pane (errors if more than one is open). Use kangentic_browser_list_panes to discover panes.';

--- a/src/main/agent/mcp-http/diagnostics-tools.ts
+++ b/src/main/agent/mcp-http/diagnostics-tools.ts
@@ -6,6 +6,7 @@ import { getProcessMetrics } from '../../diagnostics/process-metrics';
 import { enumerateWorktrees } from '../../git/worktree-list';
 import type { CrashRecord, IpcLogEntry, LogEntry } from '../../../shared/types';
 import { PROJECT_SELECTOR_DESCRIPTION } from './handler-helpers';
+import { READ_ONLY_ANNOTATIONS } from './annotations';
 import type { RequestResolver } from './project-resolver';
 
 /**
@@ -17,18 +18,10 @@ import type { RequestResolver } from './project-resolver';
  * inspection bridge over these same on-disk artifacts plus screenshot,
  * DOM, and UI-driving capabilities; they are excluded from production
  * builds at compile time. See `src/devtools/mcp/preview-tools.ts`.
- */
-
-/**
+ *
  * Every tool here is a pure read of on-disk artifacts or a synchronous
- * snapshot. `readOnlyHint` lets the LLM treat these as safe to call
- * speculatively (parallel reads, retries on transient errors). MCP spec:
- * https://modelcontextprotocol.io/specification/server/tools
+ * snapshot, so all carry `READ_ONLY_ANNOTATIONS` (see ./annotations).
  */
-const READ_ONLY_ANNOTATIONS = {
-  readOnlyHint: true,
-  idempotentHint: true,
-} as const;
 
 export function registerDiagnosticsTools(server: McpServer, resolver: RequestResolver): void {
   // --- kangentic_tail_logs ---

--- a/src/main/agent/mcp-http/project-tools.ts
+++ b/src/main/agent/mcp-http/project-tools.ts
@@ -9,6 +9,7 @@
  */
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod/v4';
+import { READ_ONLY_ANNOTATIONS } from './annotations';
 import type { RequestResolver } from './project-resolver';
 
 export function registerProjectTools(server: McpServer, resolver: RequestResolver): void {
@@ -17,6 +18,7 @@ export function registerProjectTools(server: McpServer, resolver: RequestResolve
     {
       description: 'List every Kangentic project registered on this machine. Returns name, id, on-disk path, and last-opened timestamp for each project, plus an isActive flag marking the project the MCP client is bound to. Use the returned name or id as the `project` argument on any other kangentic_* tool to route that call to a different project.',
       inputSchema: z.object({}),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async () => {
       const projects = resolver.listProjects();

--- a/src/main/agent/mcp-http/search-tools.ts
+++ b/src/main/agent/mcp-http/search-tools.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod/v4';
 import { PROJECT_SELECTOR_DESCRIPTION, type McpToolResult } from './handler-helpers';
+import { READ_ONLY_ANNOTATIONS } from './annotations';
 import type { RequestResolver } from './project-resolver';
 import { runSearchEverything } from '../../search/search-core';
 import type { SearchHit, Project } from '../../../shared/types';
@@ -37,6 +38,7 @@ export function registerSearchTools(
         scope: z.enum(['current', 'all']).optional().describe('"current" (default) searches only the active or `project`-routed project. "all" widens to every registered project on this machine and additionally surfaces project-name hits so an agent can discover routing targets. Ignored (forced to "current") when `project` is set.'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ query, scope, project }): Promise<McpToolResult> => {
       const resolved = resolver.resolveProject(project);

--- a/src/main/agent/mcp-http/session-tools.ts
+++ b/src/main/agent/mcp-http/session-tools.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod/v4';
 import { callHandler, runHandler, withProject, PROJECT_SELECTOR_DESCRIPTION } from './handler-helpers';
+import { READ_ONLY_ANNOTATIONS, MUTATING_ANNOTATIONS } from './annotations';
 import { TRANSCRIPT_TAIL_MAX, TRANSCRIPT_CHAR_BUDGET_MAX } from '../../../shared/transcript-format';
 import type { RequestResolver } from './project-resolver';
 
@@ -31,6 +32,7 @@ export function registerSessionTools(server: McpServer, resolver: RequestResolve
         taskId: z.string().describe('Task ID (numeric display ID like "42" or full UUID).'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ taskId, project }) => withProject(resolver, project, (ctx) => callHandler('list_sessions', { taskId }, ctx, 'Failed to list sessions')),
   );
@@ -44,6 +46,7 @@ export function registerSessionTools(server: McpServer, resolver: RequestResolve
         taskId: z.string().describe('Task ID (numeric display ID like "42" or full UUID).'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ taskId, project }) => withProject(resolver, project, async (ctx) => {
       const result = await runHandler('get_session_history', { taskId }, ctx);
@@ -64,6 +67,7 @@ export function registerSessionTools(server: McpServer, resolver: RequestResolve
         query: z.string().optional().describe('Search keyword to filter items by title, description, or labels (case-insensitive).'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ priority, query, project }) => withProject(resolver, project, (ctx) => callHandler('list_backlog', {
       priority: priority ?? null,
@@ -81,6 +85,7 @@ export function registerSessionTools(server: McpServer, resolver: RequestResolve
         column: z.string().optional().describe('Target column name. Defaults to the To Do column.'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: MUTATING_ANNOTATIONS,
     },
     async ({ itemIds, column, project }) => withProject(resolver, project, (ctx) => callHandler('promote_backlog', {
       itemIds,
@@ -104,6 +109,7 @@ export function registerSessionTools(server: McpServer, resolver: RequestResolve
         ])).optional().describe('Full replacement label set. Strings, or {name, color} objects to also set the label color.'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: MUTATING_ANNOTATIONS,
     },
     async ({ itemId, title, description, priority, labels, project }) => withProject(resolver, project, (ctx) => callHandler('update_backlog_item', {
       itemId,
@@ -123,6 +129,7 @@ export function registerSessionTools(server: McpServer, resolver: RequestResolve
         itemId: z.string().describe('Backlog item UUID to delete.'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: MUTATING_ANNOTATIONS,
     },
     async ({ itemId, project }) => withProject(resolver, project, (ctx) => callHandler('delete_backlog_item', { itemId }, ctx, 'Failed to delete backlog item')),
   );
@@ -136,6 +143,7 @@ export function registerSessionTools(server: McpServer, resolver: RequestResolve
         taskId: z.string().describe('Task ID (numeric display ID like "42" or full UUID).'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ taskId, project }) => withProject(resolver, project, (ctx) => callHandler('get_handoff_context', {
       taskId: taskId ?? null,
@@ -158,6 +166,7 @@ export function registerSessionTools(server: McpServer, resolver: RequestResolve
         maxChars: z.number().int().min(1000).max(TRANSCRIPT_CHAR_BUDGET_MAX).optional().describe('Override the default ~50k-char output cap (hard ceiling 500000). Use to pull a long transcript in full. Applies to structured and raw.'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ taskId, sessionId, sessionIndex, format, view, tail, search, maxChars, project }) => withProject(resolver, project, (ctx) => callHandler('get_transcript', {
       taskId: taskId ?? null,
@@ -182,6 +191,7 @@ export function registerSessionTools(server: McpServer, resolver: RequestResolve
         sessionIndex: z.number().int().min(0).optional().describe('When taskId is given, which session to pick: 0 = newest (default), 1 = previous, etc. Sessions are ordered started_at DESC.'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ taskId, sessionId, sessionIndex, project }) => withProject(resolver, project, async (ctx) => {
       const result = await runHandler('get_session_files', { taskId, sessionId, sessionIndex }, ctx);
@@ -206,6 +216,7 @@ export function registerSessionTools(server: McpServer, resolver: RequestResolve
         eventTypes: z.array(z.string()).optional().describe('Only return events whose hook_event_name or type matches one of these (e.g. ["PreToolUse", "Stop", "Notification"]).'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ taskId, sessionId, sessionIndex, tail, since, eventTypes, project }) => withProject(resolver, project, async (ctx) => {
       const result = await runHandler('get_session_events', { taskId, sessionId, sessionIndex, tail, since, eventTypes }, ctx);
@@ -225,6 +236,7 @@ export function registerSessionTools(server: McpServer, resolver: RequestResolve
         sql: z.string().describe('SQL query to execute. Must be a SELECT, PRAGMA, or WITH statement. Examples: "SELECT * FROM session_transcripts", "SELECT name, sql FROM sqlite_master WHERE type=\'table\'", "PRAGMA table_info(sessions)"'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ sql, project }) => withProject(resolver, project, (ctx) => callHandler('query_db', { sql }, ctx, 'Query error')),
   );

--- a/src/main/agent/mcp-http/task-tools.ts
+++ b/src/main/agent/mcp-http/task-tools.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod/v4';
 import { callHandler, runHandler, withProject, detectCrossProjectMention, sanitizeProjectName, PROJECT_SELECTOR_DESCRIPTION, type TaskCounter } from './handler-helpers';
+import { READ_ONLY_ANNOTATIONS, MUTATING_ANNOTATIONS } from './annotations';
 import type { RequestResolver } from './project-resolver';
 import type { BoardHit, BacklogHit, SearchScope } from '../commands/search-commands';
 
@@ -66,6 +67,7 @@ export function registerTaskTools(
         })).optional().describe('File attachments. Always include here any local files the user referenced in the prompt by absolute path - reading a file for context does not replace attaching it. Each entry needs `filePath` (absolute) and may override the display `filename`. Skip only when the user explicitly said the file is "for context only, don\'t attach."'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: MUTATING_ANNOTATIONS,
     },
     async ({ title, description, column, priority, labels, branchName, baseBranch, useWorktree, attachments, project }) => withProject(resolver, project, (ctx, resolved) => {
       // Routing guardrail: when the caller defaulted to the active
@@ -121,6 +123,7 @@ export function registerTaskTools(
       inputSchema: z.object({
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ project }) => withProject(resolver, project, async (ctx) => {
       const response = await runHandler('list_columns', {}, ctx);
@@ -145,6 +148,7 @@ export function registerTaskTools(
         column: z.string().optional().describe('Filter by column name. If omitted, returns all tasks.'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ column, project }) => withProject(resolver, project, async (ctx) => {
       const response = await runHandler('list_tasks', { column: column ?? null }, ctx);
@@ -177,6 +181,7 @@ export function registerTaskTools(
         status: z.enum(['active', 'completed', 'all']).optional().describe('Filter board hits by status. "active" = on the board, "completed" = in Done/archived. Ignored for backlog hits. Defaults to "all".'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ query, scope, status, project }) => withProject(resolver, project, async (ctx) => {
       const effectiveScope: SearchScope = scope ?? 'both';
@@ -251,6 +256,7 @@ export function registerTaskTools(
         sortBy: z.enum(['tokens', 'cost', 'duration', 'toolCalls', 'linesChanged']).optional().describe('Sort results by this metric (descending). Defaults to "tokens". Only applies when querying multiple tasks.'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ taskId, query, sortBy, project }) => withProject(resolver, project, (ctx) => callHandler('get_task_stats', {
       taskId: taskId ?? null,
@@ -272,6 +278,7 @@ export function registerTaskTools(
         prNumber: z.number().optional().describe('Pull request number to search for. Board-only.'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ displayId, id, branch, title, prNumber, project }) => {
       if (displayId === undefined && !id && !branch && !title && prNumber === undefined) {
@@ -303,6 +310,7 @@ export function registerTaskTools(
         cwd: z.string().optional().describe('Absolute working directory path. The tool extracts the worktree slug from .kangentic/worktrees/<slug> and matches against tasks.worktree_path.'),
         branch: z.string().optional().describe('Current git branch name. Exact (case-insensitive) match against tasks.branch_name.'),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ cwd, branch }) => {
       if (!cwd && !branch) {
@@ -324,6 +332,7 @@ export function registerTaskTools(
       inputSchema: z.object({
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ project }) => withProject(resolver, project, (ctx) => callHandler('board_summary', {}, ctx, 'Failed to get board summary')),
   );
@@ -337,6 +346,7 @@ export function registerTaskTools(
         column: z.string().describe('Column name (case-insensitive).'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: READ_ONLY_ANNOTATIONS,
     },
     async ({ column, project }) => withProject(resolver, project, (ctx) => callHandler('get_column_detail', { column }, ctx, 'Failed to get column detail')),
   );
@@ -359,6 +369,7 @@ export function registerTaskTools(
         useWorktree: z.boolean().optional().describe('Whether the task uses an isolated git worktree.'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: MUTATING_ANNOTATIONS,
     },
     async ({ taskId, title, description, prUrl, prNumber, agent, priority, labels, baseBranch, useWorktree, project }) => {
       if (
@@ -391,6 +402,7 @@ export function registerTaskTools(
         taskId: z.string().describe('Task ID (numeric display ID like "42" or full UUID).'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: MUTATING_ANNOTATIONS,
     },
     async ({ taskId, project }) => withProject(resolver, project, (ctx) => callHandler('link_pr', { taskId }, ctx, 'Failed to resolve PR')),
   );
@@ -405,6 +417,7 @@ export function registerTaskTools(
         column: z.string().describe('Target column name (case-insensitive, e.g. "Review", "In Progress", "Done").'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: MUTATING_ANNOTATIONS,
     },
     async ({ taskId, column, project }) => withProject(resolver, project, (ctx) => callHandler('move_task', { taskId, column }, ctx, 'Failed to move task')),
   );
@@ -430,6 +443,7 @@ export function registerTaskTools(
         planExitTargetColumn: z.string().nullable().optional().describe('Column to auto-move the task to when an agent in plan mode exits planning. Null to disable.'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: MUTATING_ANNOTATIONS,
     },
     async ({ column, name, description, color, icon, autoSpawn, autoCommand, agentOverride, modelOverride, effortOverride, permissionMode, handoffContext, planExitTargetColumn, project }) => withProject(resolver, project, (ctx) => callHandler('update_column', {
       column,
@@ -457,6 +471,7 @@ export function registerTaskTools(
         taskId: z.string().describe('Task ID (numeric display ID like "42" or full UUID).'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
+      annotations: MUTATING_ANNOTATIONS,
     },
     async ({ taskId, project }) => withProject(resolver, project, (ctx) => callHandler('delete_task', { taskId }, ctx, 'Failed to delete task')),
   );

--- a/tests/unit/command-builder.test.ts
+++ b/tests/unit/command-builder.test.ts
@@ -1481,6 +1481,128 @@ describe('Merged Settings -- MCP Server via --mcp-config', () => {
 
 });
 
+describe('Merged Settings - kangentic MCP allow-rule injection', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-allow-'));
+    fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, '.claude', 'settings.json'), '{}');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Build a session and return its written merged settings.json object. */
+  function buildAndReadSettings(
+    sessionId: string,
+    options: Record<string, unknown>,
+  ): { allow?: string[]; deny?: string[] } | undefined {
+    const builder = new CommandBuilder();
+    const statusOutput = path.join(tmpDir, '.kangentic', 'sessions', sessionId, 'status.json');
+    fs.mkdirSync(path.dirname(statusOutput), { recursive: true });
+    builder.buildClaudeCommand({
+      cliPath: '/usr/bin/claude',
+      taskId: `${sessionId}-task`,
+      cwd: tmpDir,
+      permissionMode: 'default',
+      sessionId,
+      statusOutputPath: statusOutput,
+      ...options,
+    });
+    const settingsPath = path.join(tmpDir, '.kangentic', 'sessions', sessionId, 'settings.json');
+    const merged = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    return merged.permissions;
+  }
+
+  it('injects mcp__kangentic into permissions.allow when the MCP server is attached', () => {
+    const permissions = buildAndReadSettings('inject-basic', {
+      mcpServerUrl: 'http://127.0.0.1:54321/mcp/test-project',
+      mcpServerToken: 'deadbeef-test-token',
+    });
+    expect(permissions?.allow).toContain('mcp__kangentic');
+  });
+
+  it('does not duplicate the rule when project settings already carry it', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.claude', 'settings.json'),
+      JSON.stringify({ permissions: { allow: ['mcp__kangentic', 'Read'] } }),
+    );
+    const permissions = buildAndReadSettings('inject-dedup', {
+      mcpServerUrl: 'http://127.0.0.1:54321/mcp/test-project',
+      mcpServerToken: 'deadbeef-test-token',
+    });
+    const occurrences = (permissions?.allow ?? []).filter((rule) => rule === 'mcp__kangentic');
+    expect(occurrences).toHaveLength(1);
+    // The pre-existing user entry is preserved alongside the (deduped) rule.
+    expect(permissions?.allow).toContain('Read');
+    expect(permissions?.allow).toHaveLength(2);
+  });
+
+  it('does not inject when the MCP server is disabled, even with url and token set', () => {
+    const permissions = buildAndReadSettings('inject-disabled', {
+      mcpServerEnabled: false,
+      mcpServerUrl: 'http://127.0.0.1:54321/mcp/test-project',
+      mcpServerToken: 'deadbeef-test-token',
+    });
+    // Base settings had no permissions, and the gate did not fire, so no key.
+    expect(permissions).toBeUndefined();
+    // The gate is shared with the mcp.json write, so that is absent too.
+    const sessionMcpPath = path.join(tmpDir, '.kangentic', 'sessions', 'inject-disabled', 'mcp.json');
+    expect(fs.existsSync(sessionMcpPath)).toBe(false);
+  });
+
+  it('does not inject when mcpServerUrl/Token are missing', () => {
+    const permissions = buildAndReadSettings('inject-nourl', {});
+    expect(permissions?.allow ?? []).not.toContain('mcp__kangentic');
+  });
+
+  it('preserves user allow entries (project + local) and deny alongside the injection', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.claude', 'settings.json'),
+      JSON.stringify({ permissions: { allow: ['Read'], deny: ['WebFetch'] } }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.claude', 'settings.local.json'),
+      JSON.stringify({ permissions: { allow: ['Bash(test:*)'] } }),
+    );
+    const permissions = buildAndReadSettings('inject-preserve', {
+      mcpServerUrl: 'http://127.0.0.1:54321/mcp/test-project',
+      mcpServerToken: 'deadbeef-test-token',
+    });
+    expect(permissions?.allow).toEqual(
+      expect.arrayContaining(['Read', 'Bash(test:*)', 'mcp__kangentic']),
+    );
+    expect(permissions?.allow).toHaveLength(3);
+    expect(permissions?.deny).toEqual(['WebFetch']);
+  });
+
+  it('stays idempotent across a resume (exactly one rule)', () => {
+    const first = new CommandBuilder();
+    const statusOutput = path.join(tmpDir, '.kangentic', 'sessions', 'inject-resume', 'status.json');
+    fs.mkdirSync(path.dirname(statusOutput), { recursive: true });
+    const spawnOptions = {
+      cliPath: '/usr/bin/claude',
+      taskId: 'inject-resume-task',
+      cwd: tmpDir,
+      permissionMode: 'default' as const,
+      sessionId: 'inject-resume',
+      statusOutputPath: statusOutput,
+      mcpServerUrl: 'http://127.0.0.1:54321/mcp/test-project',
+      mcpServerToken: 'deadbeef-test-token',
+    };
+    first.buildClaudeCommand(spawnOptions);
+    // Resume against the same session dir: settings are regenerated from base.
+    new CommandBuilder().buildClaudeCommand({ ...spawnOptions, resume: true });
+
+    const settingsPath = path.join(tmpDir, '.kangentic', 'sessions', 'inject-resume', 'settings.json');
+    const merged = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    const occurrences = (merged.permissions?.allow ?? []).filter((rule: string) => rule === 'mcp__kangentic');
+    expect(occurrences).toHaveLength(1);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // UNC Path Support (Windows network shares like \\server\share)
 // Pure string transforms - run on all platforms, no platform guard needed.

--- a/tests/unit/mcp-tool-list-parity.test.ts
+++ b/tests/unit/mcp-tool-list-parity.test.ts
@@ -26,6 +26,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { MCP_TOOL_MANIFEST } from '../../src/shared/mcp-tool-manifest';
+import { READ_ONLY_ANNOTATIONS, MUTATING_ANNOTATIONS } from '../../src/main/agent/mcp-http/annotations';
 
 const REPO_ROOT = path.resolve(__dirname, '../..');
 const MCP_HTTP_DIR = path.join(REPO_ROOT, 'src/main/agent/mcp-http');
@@ -39,24 +40,75 @@ function collectToolFiles(): string[] {
     .map((entry) => path.join(MCP_HTTP_DIR, entry.name));
 }
 
-/**
- * Collect every registerTool('<name>', ...) literal. The name literal sits on
- * the line AFTER `registerTool(`, so we scan whole-file content (JS `\s`
- * matches the newline) rather than line-by-line.
- */
-function collectRegisteredToolNames(): Set<string> {
-  const names = new Set<string>();
-  const pattern = /registerTool\(\s*(['"])([^'"]+)\1/g;
-  for (const filePath of collectToolFiles()) {
-    const content = fs.readFileSync(filePath, 'utf-8');
-    for (const match of content.matchAll(pattern)) {
-      names.add(match[2]);
-    }
-  }
-  return names;
+const SHARED_ANNOTATION_TOKENS = ['READ_ONLY_ANNOTATIONS', 'MUTATING_ANNOTATIONS'] as const;
+type SharedAnnotationToken = (typeof SHARED_ANNOTATION_TOKENS)[number];
+
+interface ToolRegistration {
+  name: string;
+  file: string;
+  /** Which shared annotation constant the registration declares, or null if none/inline. */
+  annotation: SharedAnnotationToken | null;
 }
 
-const registeredNames = collectRegisteredToolNames();
+/**
+ * Slice every registerTool('<name>', ...) call into its own segment (from one
+ * `registerTool(` to the next, or - for the last in a file - the enclosing
+ * function's closing brace) and record which shared annotation
+ * constant that segment declares. The name literal sits on the line AFTER
+ * `registerTool(`, so we scan whole-file content (JS `\s` matches the newline)
+ * rather than line-by-line. Attributing the annotation to a specific
+ * registration (vs a per-file count) lets a failure name the offending tool
+ * and requires the exact shared-constant tokens, which cannot plausibly appear
+ * in prose.
+ */
+function collectToolRegistrations(): ToolRegistration[] {
+  const registrations: ToolRegistration[] = [];
+  const namePattern = /registerTool\(\s*(['"])([^'"]+)\1/g;
+  const annotationPattern = /annotations:\s*(READ_ONLY_ANNOTATIONS|MUTATING_ANNOTATIONS)\b/;
+  for (const filePath of collectToolFiles()) {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const fileName = path.basename(filePath);
+    const matches = [...content.matchAll(namePattern)];
+    for (let index = 0; index < matches.length; index += 1) {
+      const start = matches[index].index ?? 0;
+      // Bound the segment at the NEXT registerTool( call. For the last
+      // registration in a file, bound at the enclosing register*Tools
+      // function's closing brace (the first top-level `}`) rather than EOF, so
+      // trailing top-level helper functions can never be scanned as part of
+      // this tool's segment and false-match an `annotations:` token in their
+      // code or prose - which would mask a deleted or flipped annotation on the
+      // final tool.
+      let end: number;
+      if (index + 1 < matches.length) {
+        end = matches[index + 1].index ?? content.length;
+      } else {
+        const functionCloseOffset = content.slice(start).search(/\n}/);
+        end = functionCloseOffset === -1 ? content.length : start + functionCloseOffset;
+      }
+      const segment = content.slice(start, end);
+      const annotationMatch = segment.match(annotationPattern);
+      registrations.push({
+        name: matches[index][2],
+        file: fileName,
+        annotation: annotationMatch ? (annotationMatch[1] as SharedAnnotationToken) : null,
+      });
+    }
+  }
+  return registrations;
+}
+
+/** Tool-name prefixes that unambiguously denote a board/backlog mutation. */
+const MUTATING_NAME_PREFIXES = [
+  'kangentic_create_',
+  'kangentic_update_',
+  'kangentic_delete_',
+  'kangentic_move_',
+  'kangentic_promote_',
+  'kangentic_link_',
+];
+
+const toolRegistrations = collectToolRegistrations();
+const registeredNames = new Set(toolRegistrations.map((registration) => registration.name));
 const manifestNames = new Set(MCP_TOOL_MANIFEST.map((entry) => entry.name));
 
 describe('mcp tool-list parity', () => {
@@ -96,6 +148,72 @@ describe('mcp tool-list parity', () => {
       undocumented,
       `These tools are not documented in docs/mcp-server.md (the exhaustive reference). Add a `
         + `description for each:\n${undocumented.join('\n')}`,
+    ).toEqual([]);
+  });
+});
+
+/**
+ * Annotation parity guard (see .claude/rules/mcp-tool-list-parity.md).
+ *
+ * Every registered tool must declare `annotations:` using one of the two
+ * shared constants in src/main/agent/mcp-http/annotations.ts. `readOnlyHint`
+ * is load-bearing: Claude Code auto-approves read-only-annotated tools in plan
+ * mode (no permission prompt), so a tool with no annotation prompts on every
+ * call, and a mutation dishonestly marked read-only would be silently
+ * auto-approved. These checks keep the classification present, honest, and
+ * sourced from the single shared audit point.
+ */
+describe('mcp tool annotation parity', () => {
+  it('every registered tool declares annotations via a shared constant', () => {
+    const unannotated = toolRegistrations
+      .filter((registration) => registration.annotation === null)
+      .map((registration) => `${registration.file}: ${registration.name}`)
+      .sort();
+    expect(
+      unannotated,
+      `These tools are registered without \`annotations:\` referencing a shared constant. Add `
+        + `\`annotations: READ_ONLY_ANNOTATIONS\` or \`annotations: MUTATING_ANNOTATIONS\` (imported `
+        + `from src/main/agent/mcp-http/annotations.ts) to each registration. An unannotated tool `
+        + `prompts for permission on every call in plan mode:\n${unannotated.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('the shared annotation constants carry the spec-correct values', () => {
+    // Guards the hole the source regex cannot see: someone editing the
+    // constant values in annotations.ts (e.g. flipping readOnlyHint).
+    expect(READ_ONLY_ANNOTATIONS).toEqual({ readOnlyHint: true, idempotentHint: true });
+    expect(MUTATING_ANNOTATIONS).toEqual({ readOnlyHint: false, idempotentHint: false });
+  });
+
+  it('no *-tools.ts file redefines the shared annotation constants locally', () => {
+    // The consts were duplicated in browser-tools.ts and diagnostics-tools.ts
+    // before they were hoisted; a local shadow would silently diverge from the
+    // audited source, so forbid it.
+    const shadowPattern = /const\s+(READ_ONLY|MUTATING)_ANNOTATIONS\s*=/;
+    const offenders = collectToolFiles()
+      .filter((filePath) => shadowPattern.test(fs.readFileSync(filePath, 'utf-8')))
+      .map((filePath) => path.basename(filePath))
+      .sort();
+    expect(
+      offenders,
+      `These files redefine READ_ONLY_ANNOTATIONS / MUTATING_ANNOTATIONS locally. Import them from `
+        + `src/main/agent/mcp-http/annotations.ts instead:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('tools named with a mutating verb are annotated MUTATING_ANNOTATIONS', () => {
+    // The worst failure mode is a mutation marked read-only (auto-approved in
+    // plan mode). Prefix-anchored and one-directional: a create/update/delete/
+    // move/promote/link tool must be mutating; read-only tools are unconstrained.
+    const dishonest = toolRegistrations
+      .filter((registration) => MUTATING_NAME_PREFIXES.some((prefix) => registration.name.startsWith(prefix)))
+      .filter((registration) => registration.annotation !== 'MUTATING_ANNOTATIONS')
+      .map((registration) => `${registration.file}: ${registration.name} (is ${registration.annotation ?? 'unannotated'})`)
+      .sort();
+    expect(
+      dishonest,
+      `These tools have a mutating-verb name but are not annotated MUTATING_ANNOTATIONS. A mutation `
+        + `marked read-only is silently auto-approved in plan mode:\n${dishonest.join('\n')}`,
     ).toEqual([]);
   });
 });

--- a/tests/unit/mcp-tool-list-parity.test.ts
+++ b/tests/unit/mcp-tool-list-parity.test.ts
@@ -217,3 +217,89 @@ describe('mcp tool annotation parity', () => {
     ).toEqual([]);
   });
 });
+
+/**
+ * Browser-tool capability-tier annotation parity.
+ *
+ * The "mutating verb" check above only recognizes the
+ * kangentic_create_/update_/delete_/move_/promote_/link_ board-mutation
+ * prefixes, so it structurally cannot see the kangentic_browser_* family:
+ * none of navigate/click/type/keypress/drag/eval start with a recognized
+ * verb, yet every one of them mutates the user's loaded page (a click, a
+ * keystroke, a navigation, arbitrary eval). A future edit that flipped one of
+ * these to READ_ONLY_ANNOTATIONS would pass every existing assertion in this
+ * file and be silently auto-approved in plan mode - exactly the worst failure
+ * mode the annotation system exists to prevent.
+ *
+ * browser-tools.ts documents four capability tiers ("observe (screenshot,
+ * query, console, wait), interact (click/type/keypress/drag), navigate,
+ * eval") and every tool passes its tier as the first argument to the shared
+ * `drive(<capability>, ...)` gate (see .claude/rules/browser-automation-driver.md,
+ * "every CDP-driving tool routes through withGuest and declares its
+ * capability tier"). That capability string is an independent,
+ * architecturally load-bearing signal - withGuest uses it to gate
+ * interaction, unrelated to the MCP `annotations:` field - so deriving the
+ * expected annotation from it (rather than hand-listing tool names) keeps
+ * this check honest and self-maintaining as tools are renamed or added.
+ * The one non-`drive`-calling tool, kangentic_browser_list_panes, is a pure
+ * registry read (discovery), so it is expected read-only too.
+ */
+describe('mcp browser tool capability-tier annotation parity', () => {
+  const BROWSER_TOOLS_PATH = path.join(MCP_HTTP_DIR, 'browser-tools.ts');
+
+  interface BrowserToolCapability {
+    name: string;
+    /** The capability literal passed to drive(), or 'discovery' for the one tool with no drive() call. */
+    capability: string;
+    annotation: SharedAnnotationToken | null;
+  }
+
+  function collectBrowserToolCapabilities(): BrowserToolCapability[] {
+    const content = fs.readFileSync(BROWSER_TOOLS_PATH, 'utf-8');
+    const namePattern = /registerTool\(\s*(['"])([^'"]+)\1/g;
+    const annotationPattern = /annotations:\s*(READ_ONLY_ANNOTATIONS|MUTATING_ANNOTATIONS)\b/;
+    const capabilityPattern = /\bdrive(?:<[^>]*>)?\(\s*(['"])([^'"]+)\1/;
+    const matches = [...content.matchAll(namePattern)];
+    const results: BrowserToolCapability[] = [];
+    for (let index = 0; index < matches.length; index += 1) {
+      const start = matches[index].index ?? 0;
+      const end = index + 1 < matches.length ? (matches[index + 1].index ?? content.length) : content.length;
+      const segment = content.slice(start, end);
+      const annotationMatch = segment.match(annotationPattern);
+      const capabilityMatch = segment.match(capabilityPattern);
+      results.push({
+        name: matches[index][2],
+        capability: capabilityMatch ? capabilityMatch[2] : 'discovery',
+        annotation: annotationMatch ? (annotationMatch[1] as SharedAnnotationToken) : null,
+      });
+    }
+    return results;
+  }
+
+  it('finds the browser tools (regex did not silently miss the file)', () => {
+    // Guards the check below: if this regresses to 0, every filter() in the
+    // next test would vacuously pass and hide a real annotation flip.
+    expect(collectBrowserToolCapabilities().length).toBeGreaterThan(0);
+  });
+
+  it('every browser tool is annotated per its documented capability tier', () => {
+    const capabilities = collectBrowserToolCapabilities();
+    const mismatched = capabilities
+      .filter((tool) => {
+        const expectedAnnotation: SharedAnnotationToken =
+          tool.capability === 'observe' || tool.capability === 'discovery'
+            ? 'READ_ONLY_ANNOTATIONS'
+            : 'MUTATING_ANNOTATIONS';
+        return tool.annotation !== expectedAnnotation;
+      })
+      .map((tool) => `${tool.name} (capability=${tool.capability}, annotation=${tool.annotation ?? 'unannotated'})`)
+      .sort();
+    expect(
+      mismatched,
+      `These kangentic_browser_* tools are annotated inconsistently with their capability tier. `
+        + `observe/discovery tools (no page side effects) must be READ_ONLY_ANNOTATIONS; `
+        + `interact/navigate/eval tools (mutate the user's loaded page) must be `
+        + `MUTATING_ANNOTATIONS:\n${mismatched.join('\n')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Agents Kangentic spawns no longer see permission prompts for the MCP tools Kangentic itself provides. Two layers cover the two axes (which permission mode, which project):

- **Read-only annotations (plan mode, all projects).** A new leaf module `src/main/agent/mcp-http/annotations.ts` exports the shared `READ_ONLY_ANNOTATIONS` / `MUTATING_ANNOTATIONS` constants. All 46 tools across the six `mcp-http/*-tools.ts` files now declare one of them; `browser-tools.ts` and `diagnostics-tools.ts` switched off their local duplicate consts.
- **Auto-allow injection (default / acceptEdits mode, all projects).** The Claude adapter's `createMergedSettings` (`command-builder.ts`) appends `mcp__kangentic` to `permissions.allow` of the per-session merged settings, inside the existing MCP-gate block, append-if-absent.

## Why

Planning-lane sessions prompted on every kangentic MCP call (e.g. `kangentic_query_db`), because plan mode only auto-approves tools Claude Code knows are read-only, and only the browser and diagnostics families carried the `readOnlyHint` annotation. Separately, the `mcp__kangentic` allow rule only existed in this repo's committed `.claude/settings.json`, so end users on other projects got prompts even in default mode.

Verified empirically in a live plan-mode session: an annotated read-only tool ran with no prompt, while an unannotated one prompted on every call, both under the same allow rule. So `readOnlyHint` is what plan mode honors; allow rules cover default mode only.

Closes #322.

## How

- Classification is honest and auditable: mutating tools (`create` / `update` / `delete` / `move` / `promote` / `link`, plus the page-changing `kangentic_browser_*` tools) carry `readOnlyHint: false` and still prompt in plan mode by design. Only the read-only set (DB, transcript, board, and session inspection) auto-approves while planning.
- The injection is gated on the same condition as the session `mcp.json` write, preserves user/project/worktree allow entries and `deny` (an explicit user deny still wins), lives only in the regenerated per-session settings, and is idempotent across resumes. `ClaudeSettings` gained a named `permissions` field, dropping two inline casts.
- Scope is the Claude adapter plus the shared MCP registrations. Other adapters have their own permission systems; the annotations benefit every MCP-speaking agent.

## Breaking changes

None. Adding `readOnlyHint: false` to mutating tools does not add prompts to normal working modes (browser tools already carried it and are auto-approved daily under the allow rule).

## Tests

- Extended `tests/unit/mcp-tool-list-parity.test.ts`: every registration must declare `annotations:` via a shared const; the consts must hold their spec-correct values; no file may redefine them locally; board/backlog mutating-verb names must be marked mutating; and the `kangentic_browser_*` tools must match their capability tier (observe = read-only, interact/navigate/eval = mutating). Red-green verified.
- Added a `Merged Settings -- kangentic MCP allow-rule injection` block to `tests/unit/command-builder.test.ts` (6 cases: inject-when-attached, no-duplicate, gate off when disabled/missing-config, user allow+deny preserved, resume idempotency).
- The unit, UI, and Linux Electron E2E tiers run as CI checks on this PR.

Generated with [Claude Code](https://claude.com/claude-code)
