### PR TITLE
fix(resource-cleanup): grace period stops orphan sweep deleting fresh session dirs

### DIFF
--- a/src/main/transition-engine/resource-cleanup.ts
+++ b/src/main/transition-engine/resource-cleanup.ts
@@ -355,7 +355,22 @@ export async function pruneOrphanedDirectories(
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Remove unreferenced subdirectories with retry on EPERM. */
+/**
+ * Grace period for the orphan-directory sweep. Spawn paths (prepare-spawn
+ * session dirs, worktree creation) write directories to disk BEFORE the owning
+ * id becomes visible in the DB or PTY registry, so a freshly created directory
+ * can look orphaned to a concurrent sweep at cold project open. The sweep runs
+ * once per cold open and genuine orphans are typically days old, so a generous
+ * window costs nothing: a too-young true orphan simply survives until the next
+ * cold open.
+ */
+const ORPHAN_DIRECTORY_GRACE_PERIOD_MS = 10 * 60 * 1000;
+
+/**
+ * Remove unreferenced subdirectories with retry on EPERM. Skips directories
+ * modified within the grace period so the sweep never races a concurrent spawn
+ * path that creates directories before registering their ids.
+ */
 async function pruneDirectory(
   parentDir: string,
   isReferenced: (dirPath: string, name: string) => boolean,
@@ -373,6 +388,22 @@ async function pruneDirectory(
     if (!entry.isDirectory()) continue;
     const dirPath = path.join(parentDir, entry.name);
     if (isReferenced(dirPath, entry.name)) continue;
+
+    let modifiedAtMs: number;
+    try {
+      modifiedAtMs = (await fs.promises.stat(dirPath)).mtimeMs;
+    } catch (error) {
+      const statError = error as NodeJS.ErrnoException;
+      console.warn(
+        `[RESOURCE_CLEANUP] Skipping orphaned ${label} directory (stat failed): ${entry.name} `
+        + `(code=${statError.code ?? 'unknown'} errno=${statError.errno ?? '?'} syscall=${statError.syscall ?? '?'}): ${statError.message}`
+      );
+      continue;
+    }
+    if (Date.now() - modifiedAtMs < ORPHAN_DIRECTORY_GRACE_PERIOD_MS) {
+      console.log(`[RESOURCE_CLEANUP] Skipping recently modified ${label} directory (grace period): ${entry.name}`);
+      continue;
+    }
 
     console.log(`[RESOURCE_CLEANUP] Removing orphaned ${label} directory: ${entry.name}`);
 

--- a/tests/unit/prune-orphaned-dirs.test.ts
+++ b/tests/unit/prune-orphaned-dirs.test.ts
@@ -7,9 +7,13 @@ import path from 'node:path';
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const mockExistsSync = vi.fn((): boolean => true);
 const mockReaddir = vi.fn((): Promise<{ name: string; isDirectory: () => boolean }[]> => Promise.resolve([]));
 const mockRm = vi.fn((): Promise<void> => Promise.resolve());
+// Default to an old mtime so every existing deletion-asserting test still
+// sweeps. Computed at call time because these suites use fake timers.
+const mockStat = vi.fn((): Promise<{ mtimeMs: number }> => Promise.resolve({ mtimeMs: Date.now() - ONE_DAY_MS }));
 
 vi.mock('node:fs', () => ({
   default: {
@@ -22,6 +26,7 @@ vi.mock('node:fs', () => ({
     promises: {
       readdir: (...args: unknown[]) => mockReaddir(...args),
       rm: (...args: unknown[]) => mockRm(...args),
+      stat: (...args: unknown[]) => mockStat(...args),
     },
   },
 }));
@@ -139,6 +144,7 @@ describe('pruneStaleResources -- async background cleanup', () => {
     mockExistsSync.mockReturnValue(true);
     mockReaddir.mockResolvedValue([]);
     mockRm.mockResolvedValue(undefined);
+    mockStat.mockImplementation(() => Promise.resolve({ mtimeMs: Date.now() - ONE_DAY_MS }));
   });
 
   afterEach(() => {
@@ -293,6 +299,102 @@ describe('pruneStaleResources -- async background cleanup', () => {
     await runWithTimers();
 
     expect(mockRm).not.toHaveBeenCalled();
+  });
+
+  it('preserves an unreferenced session directory modified within the grace period (cold-open spawn race regression)', async () => {
+    // A recovery/auto-spawn writes sessions/<uuid>/ (settings.json + mcp.json)
+    // before the id is visible in the DB or PTY registry. A concurrent sweep at
+    // cold open sees it as orphaned. The grace period keeps freshly modified
+    // dirs alive so the sweep can never race a spawn path in flight.
+    const taskRepo = makeMockTaskRepo([]);
+    const sessionRepo = makeMockSessionRepo();
+    const sessionMgr = makeMockSessionManager();
+
+    mockStat.mockImplementation((dirPath: string) =>
+      Promise.resolve({
+        mtimeMs: String(dirPath).includes('freshly-spawned-uuid') ? Date.now() : Date.now() - ONE_DAY_MS,
+      }),
+    );
+    setupReaddir({
+      [SESSIONS_DIR]: [dirEntry('freshly-spawned-uuid'), dirEntry('stale-session-uuid')],
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await pruneOrphanedDirectories(PROJECT, taskRepo, sessionRepo, sessionMgr);
+    await runWithTimers();
+
+    // The genuinely-stale dir is removed...
+    expect(mockRm).toHaveBeenCalledWith(
+      path.join(SESSIONS_DIR, 'stale-session-uuid'),
+      expect.objectContaining({ recursive: true, force: true }),
+    );
+    // ...but the freshly written dir is never touched.
+    expect(mockRm).not.toHaveBeenCalledWith(
+      path.join(SESSIONS_DIR, 'freshly-spawned-uuid'),
+      expect.anything(),
+    );
+    logSpy.mockRestore();
+  });
+
+  it('still deletes an unreferenced session directory older than the grace period', async () => {
+    const taskRepo = makeMockTaskRepo([]);
+    const sessionRepo = makeMockSessionRepo();
+    const sessionMgr = makeMockSessionManager();
+
+    // mtime defaults to one day old (beforeEach), so this orphan is past the grace period.
+    setupReaddir({
+      [SESSIONS_DIR]: [dirEntry('old-orphan-uuid')],
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await pruneOrphanedDirectories(PROJECT, taskRepo, sessionRepo, sessionMgr);
+    await runWithTimers();
+
+    expect(mockRm).toHaveBeenCalledWith(
+      path.join(SESSIONS_DIR, 'old-orphan-uuid'),
+      expect.objectContaining({ recursive: true, force: true }),
+    );
+    logSpy.mockRestore();
+  });
+
+  it('skips a directory whose stat fails (removed between readdir and stat) and keeps sweeping the rest of the batch', async () => {
+    // A single-entry batch would pass this test identically whether the catch
+    // block does `continue` (correct) or aborts the whole sweep (a
+    // regression), since there'd be nothing left afterward to prove the loop
+    // kept going. Put a genuine, stat-resolvable orphan AFTER the
+    // stat-failing entry so an early return/break would leave it un-removed
+    // and fail the second assertion below.
+    const taskRepo = makeMockTaskRepo([]);
+    const sessionRepo = makeMockSessionRepo();
+    const sessionMgr = makeMockSessionManager();
+
+    mockStat.mockImplementation((dirPath: string) =>
+      String(dirPath).includes('vanished-uuid')
+        ? Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+        : Promise.resolve({ mtimeMs: Date.now() - ONE_DAY_MS }),
+    );
+    setupReaddir({
+      [SESSIONS_DIR]: [dirEntry('vanished-uuid'), dirEntry('surviving-orphan-uuid')],
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await pruneOrphanedDirectories(PROJECT, taskRepo, sessionRepo, sessionMgr);
+    await runWithTimers();
+
+    // The vanished dir is never removed and the failure is logged...
+    expect(mockRm).not.toHaveBeenCalledWith(
+      path.join(SESSIONS_DIR, 'vanished-uuid'),
+      expect.anything(),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('stat failed'));
+    // ...but the sweep keeps going and still removes the later genuine orphan.
+    expect(mockRm).toHaveBeenCalledWith(
+      path.join(SESSIONS_DIR, 'surviving-orphan-uuid'),
+      expect.objectContaining({ recursive: true, force: true }),
+    );
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
   it('retries rm on EPERM then succeeds', async () => {

--- a/tests/unit/resource-cleanup.test.ts
+++ b/tests/unit/resource-cleanup.test.ts
@@ -4,10 +4,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // Hoisted mocks
 // ---------------------------------------------------------------------------
 
-const { mockExistsSync, mockRm, mockReaddir, mockExecFile } = vi.hoisted(() => ({
+const { mockExistsSync, mockRm, mockReaddir, mockStat, mockExecFile } = vi.hoisted(() => ({
   mockExistsSync: vi.fn((): boolean => false),
   mockRm: vi.fn(async () => {}),
   mockReaddir: vi.fn(async () => []),
+  // Default to an old mtime so orphan sweeps proceed. Computed at call time
+  // because the relevant block uses fake timers.
+  mockStat: vi.fn(async () => ({ mtimeMs: Date.now() - 24 * 60 * 60 * 1000 })),
   mockExecFile: vi.fn(),
 }));
 
@@ -17,6 +20,7 @@ vi.mock('node:fs', () => ({
     promises: {
       rm: mockRm,
       readdir: mockReaddir,
+      stat: mockStat,
     },
   },
 }));
@@ -710,6 +714,7 @@ describe('pruneOrphanedDirectories -- pruneDirectory warn-and-continue', () => {
     mockExistsSync.mockReturnValue(false);
     mockRm.mockResolvedValue(undefined);
     mockReaddir.mockResolvedValue([]);
+    mockStat.mockImplementation(async () => ({ mtimeMs: Date.now() - 24 * 60 * 60 * 1000 }));
     setupExecFile(() => '');
   });
 


### PR DESCRIPTION
## What

Adds a grace period to the orphan-directory sweep in
`src/main/transition-engine/resource-cleanup.ts`. In the shared `pruneDirectory` helper, an
unreferenced directory is now `stat`ed and skipped when its `mtimeMs` is younger than a
10-minute window, before it can be deleted. Applies uniformly to the worktrees, sessions, and
tasks passes.

## Why

Closes #323. At cold project open, `cleanupStaleResourcesAsync` pass 3 (`pruneOrphanedDirectories`)
runs concurrently with `resumeSuspendedSessions` and `autoSpawnTasks`. Those spawn paths mkdir
`.kangentic/sessions/<uuid>/` and write `settings.json` + `mcp.json` via `prepareAgentSpawn`
BEFORE the new id becomes visible in the DB or the PTY registry. In that window the fresh dir is
referenced nowhere, so the sweep deleted it, and the recovered `claude --resume` launched into a
missing settings file ("Settings file not found"). Hit on multiple boots (tasks #317/#318/#320).

## How

The sweeper-side guard closes the whole race class instead of just the two known paths: any
present or future path that creates a directory before registering its id is protected, because a
freshly written dir is always younger than the grace window when a concurrent cold-open sweep
runs. A stat failure (the dir vanished between `readdir` and `stat`) warns and skips rather than
deleting a dir it cannot age-verify.

Trade-off: a genuinely orphaned dir younger than 10 minutes survives until the next cold open.
This is harmless. The sweep only runs once per project per app lifetime at cold open, and real
orphans are typically days old. 10 minutes (vs a tighter 60s) absorbs the unbounded skew on both
sides of the race: the sequential per-task `adapter.detect()` prep pass on the spawn side, and
the two git-I/O cleanup passes that run before pass 3 on the sweep side.

`mtimeMs` is used, not `birthtimeMs` (unreliable on Linux); the directory mtime updates when
`settings.json` / `mcp.json` are written into it. No platform branching. `projects.ts`
orchestration and the spawn paths are untouched.

## Breaking changes

None.

## Tests

The CI checks (typecheck, lint, unit, build, UI shards, Linux Electron E2E shards). New
regression tests in `tests/unit/prune-orphaned-dirs.test.ts` cover the interleaving: a freshly
modified unreferenced session dir survives the sweep (the real cold-open race), an old
unreferenced dir is still deleted, and a stat failure is a skip. `tests/unit/resource-cleanup.test.ts`
gains the matching `stat` mock so its warn-and-continue block stays green. A coverage audit
confirmed the shared-helper branches are fully exercised.

Generated with [Claude Code](https://claude.com/claude-code)
