### PR TITLE
fix(terminal): honor OSC 52 clipboard writes so copy-on-select works

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -307,10 +307,11 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 |---------|---------|---------|
 | `app:getVersion` | invoke | Get Electron app version string |
 
-### Clipboard (1 channel)
+### Clipboard (2 channels)
 | Channel | Pattern | Purpose |
 |---------|---------|---------|
 | `clipboard:readImage` | invoke | Read the native clipboard image, save it to a temp file, returns file path or null |
+| `clipboard:writeText` | invoke | Write text to the native clipboard (focus-independent; used by terminal copy and the OSC 52 handler) |
 
 ### Browser pane (8 channels)
 | Channel | Pattern | Purpose |

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -141,7 +141,7 @@ src/
       project-store.ts     # Project CRUD
       toast-store.ts       # Notification queue
     utils/
-      terminal-clipboard.ts # Terminal copy/paste with bracketed paste support
+      terminal-clipboard.ts # Terminal copy/paste (OSC 52 write handler, bracketed paste)
   shared/                  # Shared between main and renderer
     abort-utils.ts         # AbortSignal type guard for stale spawn prevention
     types.ts               # All TypeScript interfaces

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -325,6 +325,26 @@ Terminal paste operations use xterm.js's built-in `terminal.paste()` method, whi
 
 This ensures consistent behavior across keyboard shortcuts and context menu paste.
 
+## Terminal Copy Strategy
+
+Terminal copy operations write to the OS clipboard through the main process
+(`clipboard:writeText`), which is synchronous and focus- and permission-independent.
+`navigator.clipboard.writeText()` is deliberately not used: it rejects with `NotAllowedError`
+when the document lacks focus, which is exactly the state during a native context-menu click and
+when a TUI app emits its copy sequence. The copy paths are:
+
+- **Ctrl+C with a selection / Ctrl+Shift+C** - the custom key handler reads the xterm selection,
+  cleans soft-wraps, and writes it via the IPC.
+- **Context menu Copy** - the native menu dispatches a `terminal-copy` event; the handler writes
+  the selection via the same IPC.
+- **OSC 52** - a TUI app (e.g. Claude Code's copy-on-select) copies by emitting
+  `ESC]52;c;<base64>BEL`. A write-only OSC 52 handler decodes the payload and writes it via the
+  IPC. Read requests (`Pd` is `?`) are ignored so a TUI can never read the user's clipboard back
+  out of the terminal.
+- **Scrollback replay** - recorded scrollback may contain OSC 52 sequences from an earlier copy;
+  the replay path strips them so restoring a session (dialog reopen, resize, respawn) never
+  clobbers the user's current clipboard.
+
 ## See Also
 
 - [Configuration](configuration.md) -- permission modes and session limits

--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -541,6 +541,17 @@ export function registerSystemHandlers(context: IpcContext): void {
     return filePath;
   });
 
+  // Write text to the clipboard natively in the main process rather than via the web
+  // `navigator.clipboard.writeText()`. Electron's clipboard module is synchronous and
+  // focus- and permission-independent, whereas the web API rejects with NotAllowedError
+  // when the document does not hold focus - exactly the state during a native context-menu
+  // click (Menu.popup steals focus) and the case a TUI app's OSC 52 copy sequence hits.
+  // Same rationale as CLIPBOARD_READ_IMAGE above.
+  ipcMain.handle(IPC.CLIPBOARD_WRITE_TEXT, (_event, text: string): void => {
+    if (typeof text !== 'string' || text.length === 0) return;
+    clipboard.writeText(text);
+  });
+
   // === Handoffs ===
   ipcMain.handle(IPC.HANDOFF_LIST, (_, taskId: string): HandoffRecord[] => {
     const projectId = context.currentProjectId;

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -405,6 +405,7 @@ const api: ElectronAPI = {
 
   clipboard: {
     readImage: () => ipcRenderer.invoke(IPC.CLIPBOARD_READ_IMAGE),
+    writeText: (text) => ipcRenderer.invoke(IPC.CLIPBOARD_WRITE_TEXT, text),
   },
 
   browser: {

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '../addons/fit-addon';
 import { WebglAddon } from '@xterm/addon-webgl';
-import { cleanSelection, enableTerminalClipboard } from '../utils/terminal-clipboard';
+import { copySelectionToClipboard, enableTerminalClipboard, stripOsc52Sequences } from '../utils/terminal-clipboard';
 import { createWriteBatcher, type WriteBatcher } from '../utils/write-batcher';
 import { createIncomingWriteQueue, writeChunkedToTerminal } from '../utils/incoming-write-queue';
 import { noteTerminalFocus } from '../utils/dictation-target';
@@ -245,7 +245,8 @@ export function useTerminal(options: UseTerminalOptions) {
           };
           if (scrollback && xtermRef.current) {
             // Chunked so a 512KB replay doesn't parse in one synchronous write.
-            writeChunkedToTerminal(xtermRef.current, scrollback, afterWrite);
+            // Strip OSC 52 so replaying recorded output never clobbers the live clipboard.
+            writeChunkedToTerminal(xtermRef.current, stripOsc52Sequences(scrollback), afterWrite);
           } else {
             afterWrite();
           }
@@ -308,12 +309,9 @@ export function useTerminal(options: UseTerminalOptions) {
     };
     const handleCopy = (e: Event) => {
       if (!isInside(e)) return;
-      const term = xtermRef.current!;
-      const selection = term.getSelection();
-      if (selection) {
-        const cleaned = cleanSelection(selection, term.cols);
-        if (cleaned) navigator.clipboard.writeText(cleaned);
-      }
+      // Write via the main process (focus-independent). The native context menu's
+      // Menu.popup steals document focus, so navigator.clipboard.writeText would reject.
+      copySelectionToClipboard(xtermRef.current!);
     };
     const handleSelectAll = (e: Event) => {
       if (!isInside(e)) return;
@@ -444,7 +442,8 @@ export function useTerminal(options: UseTerminalOptions) {
         if (scrollback && xtermRef.current) {
           // Chunked so a 512KB replay (tab/window switch, resize) doesn't parse
           // in one synchronous write that stalls the renderer mid-drag.
-          writeChunkedToTerminal(xtermRef.current, scrollback, afterWrite);
+          // Strip OSC 52 so replaying recorded output never clobbers the live clipboard.
+          writeChunkedToTerminal(xtermRef.current, stripOsc52Sequences(scrollback), afterWrite);
         } else {
           afterWrite();
         }

--- a/src/renderer/utils/terminal-clipboard.ts
+++ b/src/renderer/utils/terminal-clipboard.ts
@@ -1,5 +1,66 @@
 import { Terminal } from '@xterm/xterm';
 
+// ---------------------------------------------------------------------------
+// OSC 52 clipboard sequence handling
+// ---------------------------------------------------------------------------
+
+/**
+ * Cap on the base64 payload of an OSC 52 write (~768KB of decoded text). Guards
+ * against a malicious or runaway TUI streaming an enormous clipboard payload.
+ */
+const OSC52_MAX_BASE64_LENGTH = 1024 * 1024;
+
+/**
+ * Decode the data portion of an OSC 52 sequence ("<Pc>;<Pd>").
+ *
+ * Returns the decoded UTF-8 text for a write, or null for:
+ * - a read request (`Pd === '?'`) - deliberately unsupported, so a TUI app can
+ *   never READ the user's clipboard back out of the terminal,
+ * - a missing separator, an empty payload, or an oversized payload,
+ * - malformed base64.
+ *
+ * Pc (the clipboard selection: 'c', 'p', 's', combos, or empty) is ignored;
+ * every write targets the system clipboard.
+ */
+export function decodeOsc52Payload(data: string): string | null {
+  const separator = data.indexOf(';');
+  if (separator === -1) return null;
+  const payload = data.slice(separator + 1);
+  if (!payload || payload === '?') return null;
+  if (payload.length > OSC52_MAX_BASE64_LENGTH) return null;
+  try {
+    const binary = atob(payload);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    const text = new TextDecoder().decode(bytes);
+    return text || null;
+  } catch {
+    return null; // malformed base64
+  }
+}
+
+/**
+ * Matches complete OSC 52 sequences terminated by BEL, ESC\ (ST), C1 ST, or a
+ * bare ESC that introduces the NEXT escape sequence. The bare-ESC case matters
+ * because xterm's parser ends (and dispatches) an OSC string on any of
+ * [0x9c, 0x1b, 0x18, 0x1a, 0x07] (EscapeSequenceParser transition table), so an
+ * OSC 52 write followed directly by e.g. a CSI (`ESC[0m`) instead of a proper
+ * BEL/ST is still dispatched on replay. The trailing `(?=\x1b)` alternative
+ * matches that boundary with a zero-width lookahead, so the following escape
+ * sequence is left intact for the terminal to interpret.
+ */
+const OSC52_SEQUENCE_RE = /\x1b\]52;[^\x07\x1b\x9c]*(?:\x07|\x1b\\|\x9c|(?=\x1b))/g;
+
+/**
+ * Remove OSC 52 sequences from recorded scrollback before replaying it into a
+ * live terminal, so replaying a session that once copied text does not clobber
+ * the user's CURRENT clipboard. Base64 never contains BEL/ESC/C1-ST, so the
+ * payload match cannot over-run its terminator.
+ */
+export function stripOsc52Sequences(text: string): string {
+  if (!text.includes('\x1b]52;')) return text; // fast path for the common replay
+  return text.replace(OSC52_SEQUENCE_RE, '');
+}
+
 /**
  * Clean a terminal selection string:
  * 1. Unwrap soft line breaks (lines that fill exactly `cols` are joined)
@@ -25,6 +86,21 @@ export function cleanSelection(raw: string, cols: number): string {
   if (current) result.push(current.trimEnd());
 
   return result.join('\n').trim();
+}
+
+/**
+ * Copy the terminal's current selection to the system clipboard, cleaning soft
+ * wraps first. Writes via the main process (window.electronAPI.clipboard.writeText),
+ * which is focus- and permission-independent, rather than navigator.clipboard.writeText,
+ * which rejects with NotAllowedError when the document lacks focus - exactly the state
+ * during a native context-menu copy (Menu.popup steals document focus). Best-effort: a
+ * failed write is swallowed. No-op when there is no selection.
+ */
+export function copySelectionToClipboard(terminal: Terminal): void {
+  const selection = terminal.getSelection();
+  if (!selection) return;
+  const cleaned = cleanSelection(selection, terminal.cols);
+  if (cleaned) window.electronAPI.clipboard.writeText(cleaned).catch(() => { /* best-effort */ });
 }
 
 // ---------------------------------------------------------------------------
@@ -136,6 +212,10 @@ async function handlePaste(
 /**
  * Enable clipboard copy support for an xterm.js Terminal instance.
  *
+ * - OSC 52 write sequences (ESC]52;c;<base64>BEL) from a TUI app write the system
+ *   clipboard. This is how Claude Code's TUI copies a mouse selection; without a
+ *   handler xterm silently drops the sequence. Write-only: read requests (Pd '?')
+ *   are ignored so a TUI can never read the user's clipboard.
  * - Ctrl+C copies selected text instead of sending SIGINT (when a selection exists)
  * - Ctrl+Shift+C always copies the selection
  * - Ctrl+V / Cmd+V pastes text or image from clipboard
@@ -163,6 +243,22 @@ export function enableTerminalClipboard(
   sessionId?: string,
   releaseEscapeWhenPointerOutside?: boolean,
 ): void {
+  // OSC 52 clipboard writes (write-only). Claude Code's TUI copies a selection by
+  // emitting ESC]52;c;<base64>BEL alongside a fire-and-forget PowerShell Set-Clipboard;
+  // without this handler the OSC channel is silently dropped and copy fails entirely on
+  // machines where the PowerShell path fails. Read requests (Pd === '?') are deliberately
+  // never answered - answering would let any TUI app silently read the user's clipboard.
+  // The write routes through the main process (window.electronAPI.clipboard.writeText),
+  // which is focus- and permission-independent unlike navigator.clipboard.writeText.
+  // Disposed automatically with the terminal.
+  terminal.parser.registerOscHandler(52, (data) => {
+    const text = decodeOsc52Payload(data);
+    if (text) {
+      window.electronAPI.clipboard.writeText(text).catch(() => { /* best-effort */ });
+    }
+    return true; // consume the sequence either way
+  });
+
   terminal.attachCustomKeyEventHandler((event) => {
     if (event.type !== 'keydown') return true;
 
@@ -185,11 +281,7 @@ export function enableTerminalClipboard(
       ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key === 'C');
 
     if (isCopy) {
-      const selection = terminal.getSelection();
-      if (selection) {
-        const cleaned = cleanSelection(selection, terminal.cols);
-        if (cleaned) navigator.clipboard.writeText(cleaned);
-      }
+      copySelectionToClipboard(terminal);
       return false;
     }
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -228,6 +228,7 @@ export const IPC = {
 
   // Clipboard
   CLIPBOARD_READ_IMAGE: 'clipboard:readImage',
+  CLIPBOARD_WRITE_TEXT: 'clipboard:writeText',
 
   // Browser pane: embedded webview capture-and-send
   BROWSER_CAPTURE_SEND: 'browser:captureSend',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3059,6 +3059,7 @@ export interface ElectronAPI {
   // Clipboard
   clipboard: {
     readImage: () => Promise<string | null>;
+    writeText: (text: string) => Promise<void>;
   };
 
   // Browser pane: embedded webview capture-and-send

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -1310,8 +1310,22 @@
       getUsage: async function (/* projectId */) {
         return {};
       },
-      onData: function () {
-        return noop;
+      onData: function (callback) {
+        // Tests can push live PTY data via window.__mockFireSessionData(sessionId, data),
+        // which routes through the incoming-write-queue into the mounted xterm instance.
+        if (!window.__mockDataListeners) window.__mockDataListeners = [];
+        window.__mockDataListeners.push(callback);
+        if (!window.__mockFireSessionData) {
+          window.__mockFireSessionData = function (sessionId, data) {
+            var listeners = (window.__mockDataListeners || []).slice();
+            for (var i = 0; i < listeners.length; i++) { listeners[i](sessionId, data); }
+          };
+        }
+        return function () {
+          var listeners = window.__mockDataListeners || [];
+          var idx = listeners.indexOf(callback);
+          if (idx >= 0) listeners.splice(idx, 1);
+        };
       },
       ackData: function () {
         // No-op in the headless mock: backpressure pause/resume has no PTY here.
@@ -2319,6 +2333,12 @@
 
     clipboard: {
       readImage: function () { return Promise.resolve('/tmp/kangentic-clipboard/pasted-image-1234567890.png'); },
+      // Call log for test assertions. Reset with window.electronAPI.clipboard.__writeTextCalls.length = 0.
+      __writeTextCalls: [],
+      writeText: function (text) {
+        window.electronAPI.clipboard.__writeTextCalls.push(text);
+        return Promise.resolve();
+      },
     },
 
     search: {

--- a/tests/ui/terminal-osc52-copy.spec.ts
+++ b/tests/ui/terminal-osc52-copy.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * UI tests for the OSC 52 clipboard copy path in enableTerminalClipboard.
+ *
+ * Claude Code's TUI copies a mouse selection by emitting an OSC 52 sequence
+ * (ESC]52;c;<base64>BEL) into the terminal. useTerminal registers a write-only
+ * OSC 52 handler that decodes the payload and routes it to the focus-independent
+ * main-process clipboard write (window.electronAPI.clipboard.writeText).
+ *
+ * These tests drive a real mounted xterm (the command bar overlay) and push live
+ * PTY data through window.__mockFireSessionData, proving end-to-end that:
+ *   1. an OSC 52 write reaches clipboard.writeText with the decoded text,
+ *   2. an OSC 52 READ request (Pd '?') is ignored (never writes the clipboard),
+ *   3. an OSC 52 sequence embedded in replayed scrollback is stripped and does
+ *      NOT clobber the live clipboard on restore.
+ *
+ * The pure decode/strip helpers and the handler registration are unit-tested in
+ * tests/unit/terminal-clipboard-osc52.test.ts; these tests cover the live wiring.
+ *
+ * A mouse-drag selection + Ctrl+C copy path is intentionally NOT covered here:
+ * xterm's selection lives in its own buffer and cannot be created deterministically
+ * from outside under headless Linux. The unit registration test plus test 1 below
+ * carry that branch's coverage.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+// Each test launches its own page/goto, so the file can fan out across UI workers.
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-osc52-copy-test';
+const TRANSIENT_SESSION_ID = 'sess-osc52-copy-1';
+
+function basePreConfigScript(): string {
+  return `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+      state.projects.push({
+        id: '${PROJECT_ID}',
+        name: 'OSC 52 Copy Test Project',
+        path: '/mock/osc52-copy-test',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        state.swimlanes.push(Object.assign({}, s, {
+          id: 'lane-osc52-' + i,
+          position: i,
+          created_at: ts,
+        }));
+      });
+      return { currentProjectId: '${PROJECT_ID}' };
+    });
+  `;
+}
+
+/** Deterministic transient session so onData fires route to a known id. */
+const deterministicSpawnScript = `
+  window.electronAPI.sessions.spawnTransient = async function (input) {
+    return {
+      session: {
+        id: '${TRANSIENT_SESSION_ID}',
+        taskId: '${TRANSIENT_SESSION_ID}',
+        projectId: input.projectId,
+        pid: null,
+        status: 'running',
+        shell: '/bin/bash',
+        cwd: '/mock/osc52-copy-test',
+        startedAt: new Date().toISOString(),
+        exitCode: null,
+        resuming: false,
+        transient: true,
+      },
+      branch: 'main',
+    };
+  };
+`;
+
+async function launchWithState(extraScript: string): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady();
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(basePreConfigScript());
+  await page.addInitScript(extraScript);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+  return { browser, page };
+}
+
+async function openCommandBarWithTerminal(page: Page): Promise<void> {
+  await page.keyboard.press('Control+Shift+P');
+  await expect(page.getByTestId('command-terminal-window')).toBeVisible();
+
+  await page.evaluate((sessionId) => {
+    const stores = (window as unknown as {
+      __zustandStores?: {
+        session?: { getState: () => { markFirstOutput: (id: string) => void } };
+      };
+    }).__zustandStores;
+    stores?.session?.getState().markFirstOutput(sessionId);
+  }, TRANSIENT_SESSION_ID);
+
+  await expect(
+    page.getByTestId('command-terminal-window').locator('.xterm-helper-textarea').first()
+  ).toBeAttached({ timeout: 8000 });
+
+  await page.getByTestId('command-terminal-window').locator('.xterm-helper-textarea').focus();
+}
+
+/** Build an OSC 52 write sequence (ESC]52;c;<base64(text)>BEL). */
+function osc52Write(text: string): string {
+  // btoa runs in the page; here we build the base64 in Node for the injected literal.
+  const base64 = Buffer.from(text, 'utf8').toString('base64');
+  return `\x1b]52;c;${base64}\x07`;
+}
+
+test.describe('terminal OSC 52 copy', () => {
+  test('an OSC 52 write reaches clipboard.writeText with the decoded text', async () => {
+    const { browser, page } = await launchWithState(deterministicSpawnScript);
+    try {
+      await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+      await openCommandBarWithTerminal(page);
+
+      await page.evaluate(() => {
+        window.electronAPI.clipboard.__writeTextCalls.length = 0;
+      });
+
+      // Poll-fire the OSC write: any fire that lands during the brief scrollback
+      // replay window is dropped, so re-fire each iteration until one lands after
+      // the terminal is live. All landed fires carry the same value.
+      const sequence = osc52Write('copied-via-osc52');
+      await expect.poll(async () => {
+        return page.evaluate(({ sessionId, seq }) => {
+          window.__mockFireSessionData(sessionId, seq);
+          return window.electronAPI.clipboard.__writeTextCalls.length;
+        }, { sessionId: TRANSIENT_SESSION_ID, seq: sequence });
+      }, { timeout: 5000 }).toBeGreaterThan(0);
+
+      const calls = await page.evaluate(() => window.electronAPI.clipboard.__writeTextCalls as string[]);
+      expect(calls.length).toBeGreaterThan(0);
+      for (const value of calls) expect(value).toBe('copied-via-osc52');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('an OSC 52 read request is ignored (never writes the clipboard)', async () => {
+    const { browser, page } = await launchWithState(deterministicSpawnScript);
+    try {
+      await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+      await openCommandBarWithTerminal(page);
+
+      // Establish that live OSC data flows and the terminal is past its replay
+      // window: poll-fire a real write until it lands.
+      const writeSeq = osc52Write('readiness-probe');
+      await expect.poll(async () => {
+        return page.evaluate(({ sessionId, seq }) => {
+          window.__mockFireSessionData(sessionId, seq);
+          return window.electronAPI.clipboard.__writeTextCalls.length;
+        }, { sessionId: TRANSIENT_SESSION_ID, seq: writeSeq });
+      }, { timeout: 5000 }).toBeGreaterThan(0);
+
+      // Now clear the log and fire a READ request; it must NOT write the clipboard.
+      await page.evaluate(() => {
+        window.electronAPI.clipboard.__writeTextCalls.length = 0;
+      });
+      await page.evaluate((sessionId) => {
+        window.__mockFireSessionData(sessionId, '\x1b]52;c;?\x07');
+      }, TRANSIENT_SESSION_ID);
+
+      // Intentional fixed wait - cannot poll for non-occurrence.
+      await page.waitForTimeout(800);
+
+      const count = await page.evaluate(() => window.electronAPI.clipboard.__writeTextCalls.length);
+      expect(count).toBe(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('an OSC 52 sequence in replayed scrollback does not clobber the clipboard', async () => {
+    // getScrollback returns recorded output that CONTAINS an OSC 52 sequence, as it
+    // would after a session that copied text. The replay path must strip it so the
+    // user's live clipboard is untouched on restore.
+    const replayScript = `
+      ${deterministicSpawnScript}
+      window.electronAPI.sessions.getScrollback = async function () {
+        var raw = 'before-marker \\x1b]52;c;' + btoa('should-not-copy') + '\\x07 after-marker';
+        return raw;
+      };
+    `;
+    const { browser, page } = await launchWithState(replayScript);
+    try {
+      await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+      await page.evaluate(() => {
+        window.electronAPI.clipboard.__writeTextCalls.length = 0;
+      });
+
+      await openCommandBarWithTerminal(page);
+
+      // Prove the OSC pipeline is live and replay has completed: poll-fire a real
+      // OSC write and wait for it to land. If the strip had failed, the replayed
+      // 'should-not-copy' would already be in the log by now.
+      const writeSeq = osc52Write('live-after-replay');
+      await expect.poll(async () => {
+        return page.evaluate(({ sessionId, seq }) => {
+          window.__mockFireSessionData(sessionId, seq);
+          return window.electronAPI.clipboard.__writeTextCalls.length;
+        }, { sessionId: TRANSIENT_SESSION_ID, seq: writeSeq });
+      }, { timeout: 5000 }).toBeGreaterThan(0);
+
+      const calls = await page.evaluate(() => window.electronAPI.clipboard.__writeTextCalls as string[]);
+      // The live write landed, but the replayed OSC 52 was stripped.
+      expect(calls).toContain('live-after-replay');
+      expect(calls).not.toContain('should-not-copy');
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/unit/clipboard-write-text-handler.test.ts
+++ b/tests/unit/clipboard-write-text-handler.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for the CLIPBOARD_WRITE_TEXT IPC handler in
+ * src/main/ipc/handlers/system.ts.
+ *
+ * The handler writes text to the native clipboard via Electron's synchronous,
+ * focus-independent `clipboard.writeText`, guarded against non-string and
+ * empty-string input:
+ *
+ *   ipcMain.handle(IPC.CLIPBOARD_WRITE_TEXT, (_event, text: string): void => {
+ *     if (typeof text !== 'string' || text.length === 0) return;
+ *     clipboard.writeText(text);
+ *   });
+ *
+ * This guard matters because both the OSC 52 terminal handler and the
+ * context-menu / Ctrl+C copy path forward whatever `cleanSelection` /
+ * `decodeOsc52Payload` produce, which can legitimately be an empty string
+ * (nothing selected, a malformed OSC 52 payload) - the handler must not hand
+ * an empty write to the OS clipboard, and must not throw on a caller sending
+ * an unexpected non-string.
+ *
+ * Strategy mirrors keybindings-probe-handler.test.ts: mock electron's ipcMain
+ * to capture registered handlers, then invoke the CLIPBOARD_WRITE_TEXT
+ * handler directly with controlled inputs and assert against a mocked
+ * `clipboard.writeText`.
+ *
+ * Tier: Unit (vitest, no browser, no Electron).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { IPC } from '../../src/shared/ipc-channels';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks - must be declared before any imports that trigger them.
+// ---------------------------------------------------------------------------
+
+const { capturedHandlers, mockClipboard } = vi.hoisted(() => {
+  const capturedHandlers = new Map<string, (...args: unknown[]) => unknown>();
+  const mockClipboard = {
+    writeText: vi.fn(),
+    readImage: vi.fn(),
+  };
+  return { capturedHandlers, mockClipboard };
+});
+
+vi.mock('electron', () => ({
+  app: { getVersion: vi.fn(() => '0.0.0'), getPath: vi.fn(() => '/tmp') },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      capturedHandlers.set(channel, handler);
+    }),
+    on: vi.fn(),
+  },
+  Notification: { isSupported: vi.fn(() => false) },
+  dialog: { showOpenDialog: vi.fn() },
+  shell: { openPath: vi.fn(), openExternal: vi.fn(), showItemInFolder: vi.fn() },
+  globalShortcut: { isRegistered: vi.fn(() => false), register: vi.fn(() => true), unregister: vi.fn() },
+  clipboard: mockClipboard,
+}));
+
+vi.mock('../../src/main/agent/agent-registry', () => ({
+  agentRegistry: {
+    list: vi.fn(() => []),
+    get: vi.fn(() => null),
+    getOrThrow: vi.fn(),
+    has: vi.fn(() => false),
+  },
+}));
+
+vi.mock('../../src/main/git/worktree-manager', () => ({ WorktreeManager: class {} }));
+vi.mock('../../src/main/git/git-checks', () => ({ isGitRepo: vi.fn(() => false) }));
+vi.mock('../../src/main/db/database', () => ({ getProjectDb: vi.fn() }));
+vi.mock('../../src/main/db/repositories/handoff-repository', () => ({
+  HandoffRepository: class { listByTaskId = vi.fn(() => []); },
+}));
+vi.mock('../../src/shared/object-utils', () => ({
+  deepMergeConfig: vi.fn((a: unknown, b: unknown) => ({ ...(a as object), ...(b as object) })),
+}));
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => ({ pid: 1234, unref: vi.fn() })),
+  exec: vi.fn(),
+  execFile: vi.fn(),
+}));
+vi.mock('../../src/main/config/apply-runtime-config', () => ({
+  applyRuntimeConfig: vi.fn(),
+}));
+vi.mock('../../src/main/ipc/handlers/projects', () => ({
+  syncProjectMcpConfig: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after all mocks are registered).
+// ---------------------------------------------------------------------------
+
+import { registerSystemHandlers } from '../../src/main/ipc/handlers/system';
+
+// ---------------------------------------------------------------------------
+// Test context factory (minimal - the clipboard handler needs no project state).
+// ---------------------------------------------------------------------------
+
+function makeContext() {
+  return {
+    configManager: {
+      load: vi.fn(() => ({
+        agent: { cliPaths: {}, maxConcurrentSessions: 5, idleTimeoutMinutes: 30 },
+        terminal: { shell: null },
+        mcpServer: { enabled: false },
+        autoNameRateLimitPerHour: 60,
+      })),
+      getEffectiveConfig: vi.fn(() => ({
+        agent: { maxConcurrentSessions: 5, idleTimeoutMinutes: 30 },
+        terminal: { shell: null },
+      })),
+      save: vi.fn(),
+      saveProjectOverrides: vi.fn(),
+      loadProjectOverrides: vi.fn(() => null),
+    },
+    sessionManager: {
+      setMaxConcurrent: vi.fn(),
+      setShell: vi.fn(),
+      setIdleTimeout: vi.fn(),
+    },
+    boardConfigManager: { getDefaultBaseBranch: vi.fn(() => null) },
+    projectRepo: { list: vi.fn(() => []) },
+    shellResolver: { getAvailableShells: vi.fn(() => []), getDefaultShell: vi.fn(() => 'bash') },
+    gitDetector: { detect: vi.fn(() => ({ found: false })) },
+    mainWindow: {
+      minimize: vi.fn(), maximize: vi.fn(), unmaximize: vi.fn(),
+      isMaximized: vi.fn(() => false), close: vi.fn(), isFocused: vi.fn(() => true),
+      flashFrame: vi.fn(), isDestroyed: vi.fn(() => false),
+      isMinimized: vi.fn(() => false), restore: vi.fn(), show: vi.fn(),
+      focus: vi.fn(), once: vi.fn(), webContents: { send: vi.fn() },
+    },
+    currentProjectPath: null,
+    currentProjectId: null,
+    mcpServerHandle: null,
+  };
+}
+
+function invokeClipboardWriteTextHandler(text: unknown): void {
+  const handler = capturedHandlers.get(IPC.CLIPBOARD_WRITE_TEXT);
+  if (!handler) throw new Error(`Handler not registered for ${IPC.CLIPBOARD_WRITE_TEXT}`);
+  handler(undefined, text);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CLIPBOARD_WRITE_TEXT IPC handler', () => {
+  beforeEach(() => {
+    capturedHandlers.clear();
+    mockClipboard.writeText.mockReset();
+    registerSystemHandlers(makeContext() as Parameters<typeof registerSystemHandlers>[0]);
+  });
+
+  it('writes a valid non-empty string to the native clipboard', () => {
+    invokeClipboardWriteTextHandler('copied-text');
+
+    expect(mockClipboard.writeText).toHaveBeenCalledWith('copied-text');
+  });
+
+  it('is a no-op for an empty string', () => {
+    invokeClipboardWriteTextHandler('');
+
+    expect(mockClipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for null', () => {
+    invokeClipboardWriteTextHandler(null);
+
+    expect(mockClipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for undefined', () => {
+    invokeClipboardWriteTextHandler(undefined);
+
+    expect(mockClipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for a non-string number', () => {
+    invokeClipboardWriteTextHandler(42);
+
+    expect(mockClipboard.writeText).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/terminal-clipboard-osc52.test.ts
+++ b/tests/unit/terminal-clipboard-osc52.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Terminal } from '@xterm/xterm';
+import {
+  decodeOsc52Payload,
+  stripOsc52Sequences,
+  enableTerminalClipboard,
+  copySelectionToClipboard,
+} from '../../src/renderer/utils/terminal-clipboard';
+
+/**
+ * Unit coverage for the OSC 52 clipboard path added so Claude Code's TUI
+ * copy-on-select (and any TUI emitting ESC]52) actually reaches the OS clipboard
+ * in the embedded terminal. Covers the two pure helpers plus the write-only
+ * handler registration and its read-request rejection.
+ */
+
+/** Base64-encode a UTF-8 string the way a TUI would build an OSC 52 payload. */
+function toBase64Utf8(text: string): string {
+  return Buffer.from(text, 'utf8').toString('base64');
+}
+
+describe('decodeOsc52Payload', () => {
+  it('decodes an ASCII write payload', () => {
+    expect(decodeOsc52Payload(`c;${toBase64Utf8('hello')}`)).toBe('hello');
+  });
+
+  it('round-trips multibyte UTF-8', () => {
+    const original = 'héllo ✓ 漢字';
+    expect(decodeOsc52Payload(`c;${toBase64Utf8(original)}`)).toBe(original);
+  });
+
+  it('returns null for a read request (Pd === "?")', () => {
+    expect(decodeOsc52Payload('c;?')).toBeNull();
+  });
+
+  it('returns null when there is no separator', () => {
+    expect(decodeOsc52Payload('cnoseparator')).toBeNull();
+  });
+
+  it('returns null for an empty payload', () => {
+    expect(decodeOsc52Payload('c;')).toBeNull();
+  });
+
+  it('returns null for malformed base64', () => {
+    // A '*' is outside the base64 alphabet, so atob throws.
+    expect(decodeOsc52Payload('c;****')).toBeNull();
+  });
+
+  it('returns null for an oversized payload', () => {
+    const huge = 'A'.repeat(1024 * 1024 + 4); // exceeds the ~1MB base64 cap
+    expect(decodeOsc52Payload(`c;${huge}`)).toBeNull();
+  });
+
+  it('decodes regardless of the Pc selection field', () => {
+    const payload = toBase64Utf8('sel');
+    for (const pc of ['', 'c', 'p', 's', 'cp0']) {
+      expect(decodeOsc52Payload(`${pc};${payload}`)).toBe('sel');
+    }
+  });
+});
+
+describe('stripOsc52Sequences', () => {
+  it('removes a BEL-terminated sequence', () => {
+    const input = `before\x1b]52;c;${toBase64Utf8('x')}\x07after`;
+    expect(stripOsc52Sequences(input)).toBe('beforeafter');
+  });
+
+  it('removes an ST-terminated (ESC\\) sequence', () => {
+    const input = `a\x1b]52;c;${toBase64Utf8('x')}\x1b\\b`;
+    expect(stripOsc52Sequences(input)).toBe('ab');
+  });
+
+  it('removes a C1 ST (\\x9c) terminated sequence', () => {
+    const input = `a\x1b]52;c;${toBase64Utf8('x')}\x9cb`;
+    expect(stripOsc52Sequences(input)).toBe('ab');
+  });
+
+  it('removes multiple occurrences', () => {
+    const one = `\x1b]52;c;${toBase64Utf8('1')}\x07`;
+    const two = `\x1b]52;c;${toBase64Utf8('2')}\x07`;
+    expect(stripOsc52Sequences(`x${one}y${two}z`)).toBe('xyz');
+  });
+
+  it('preserves surrounding text byte-for-byte', () => {
+    const input = `line1\r\nline2 ${'\x1b]52;c;' + toBase64Utf8('copied') + '\x07'} tail`;
+    expect(stripOsc52Sequences(input)).toBe('line1\r\nline2  tail');
+  });
+
+  it('leaves other OSC and CSI sequences untouched', () => {
+    const title = '\x1b]0;my title\x07';
+    const hyperlink = '\x1b]8;;https://example.com\x07link\x1b]8;;\x07';
+    const csi = '\x1b[1;31mred\x1b[0m';
+    const input = `${title}${hyperlink}${csi}`;
+    expect(stripOsc52Sequences(input)).toBe(input);
+  });
+
+  it('returns ESC-free input unchanged', () => {
+    expect(stripOsc52Sequences('plain scrollback text')).toBe('plain scrollback text');
+  });
+
+  // -------------------------------------------------------------------------
+  // Bare-ESC termination: xterm's EscapeSequenceParser dispatches (ends) an OSC
+  // string on a bare ESC that introduces the next escape sequence, not only on
+  // BEL/ST/C1-ST. A recorded OSC 52 write immediately followed by another
+  // escape sequence (no BEL/ST in between) must still be stripped, and the
+  // following sequence must be left completely intact.
+  // -------------------------------------------------------------------------
+
+  it('strips an OSC 52 sequence terminated by a bare ESC that introduces a CSI sequence, leaving the CSI intact', () => {
+    const input = `x\x1b]52;c;${toBase64Utf8('copied')}\x1b[0my`;
+    expect(stripOsc52Sequences(input)).toBe('x\x1b[0my');
+  });
+
+  it('strips an OSC 52 sequence terminated by a bare ESC that introduces another OSC sequence, leaving it intact', () => {
+    const input = `x\x1b]52;c;${toBase64Utf8('copied')}\x1b]0;title\x07y`;
+    expect(stripOsc52Sequences(input)).toBe('x\x1b]0;title\x07y');
+  });
+
+  it('strips a BEL-terminated sequence immediately followed by a bare-ESC-terminated sequence, both removed', () => {
+    const input = `\x1b]52;c;${toBase64Utf8('one')}\x07\x1b]52;c;${toBase64Utf8('two')}\x1b[0m`;
+    expect(stripOsc52Sequences(input)).toBe('\x1b[0m');
+  });
+});
+
+describe('enableTerminalClipboard OSC 52 handler registration', () => {
+  const originalWindow = globalThis.window;
+
+  afterEach(() => {
+    globalThis.window = originalWindow;
+  });
+
+  type OscHandler = (data: string) => boolean;
+
+  function setup(): { oscHandler: OscHandler; writeText: ReturnType<typeof vi.fn> } {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    // @ts-expect-error -- minimal window stub for the handler's clipboard call
+    globalThis.window = { electronAPI: { clipboard: { writeText } } };
+
+    let oscHandler: OscHandler | null = null;
+    const terminal = {
+      attachCustomKeyEventHandler: () => undefined,
+      parser: {
+        registerOscHandler: (code: number, handler: OscHandler) => {
+          if (code === 52) oscHandler = handler;
+          return { dispose() { /* noop */ } };
+        },
+      },
+      hasSelection: () => false,
+      getSelection: () => '',
+      cols: 80,
+    } as unknown as Terminal;
+    const el = {
+      querySelector: () => null,
+      addEventListener: () => undefined,
+      matches: () => false,
+    } as unknown as HTMLElement;
+
+    enableTerminalClipboard(terminal, el);
+    if (!oscHandler) throw new Error('OSC 52 handler was not registered');
+    return { oscHandler, writeText };
+  }
+
+  it('writes decoded text to the clipboard on a valid OSC 52 write and consumes the sequence', () => {
+    const { oscHandler, writeText } = setup();
+    expect(oscHandler(`c;${toBase64Utf8('copied-text')}`)).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('copied-text');
+  });
+
+  it('ignores a read request but still consumes the sequence', () => {
+    const { oscHandler, writeText } = setup();
+    expect(oscHandler('c;?')).toBe(true);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});
+
+describe('copySelectionToClipboard', () => {
+  const originalWindow = globalThis.window;
+
+  afterEach(() => {
+    globalThis.window = originalWindow;
+  });
+
+  function stubWindowClipboard(): ReturnType<typeof vi.fn> {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    // @ts-expect-error -- minimal window stub for the write call
+    globalThis.window = { electronAPI: { clipboard: { writeText } } };
+    return writeText;
+  }
+
+  function makeTerminalStub(selection: string, cols = 80): Terminal {
+    return { getSelection: () => selection, cols } as unknown as Terminal;
+  }
+
+  it('writes the cleaned selection via window.electronAPI.clipboard.writeText (focus-independent main-process write)', () => {
+    const writeText = stubWindowClipboard();
+
+    copySelectionToClipboard(makeTerminalStub('selected text  '));
+
+    expect(writeText).toHaveBeenCalledWith('selected text');
+  });
+
+  it('is a no-op when there is no selection', () => {
+    const writeText = stubWindowClipboard();
+
+    copySelectionToClipboard(makeTerminalStub(''));
+
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});
+
+describe('copy routing via the Ctrl+C / Ctrl+Shift+C key handler', () => {
+  const originalWindow = globalThis.window;
+
+  afterEach(() => {
+    globalThis.window = originalWindow;
+  });
+
+  type KeyEventHandler = (event: KeyboardEvent) => boolean;
+
+  /**
+   * Captures the key handler attachCustomKeyEventHandler is given, from a
+   * terminal stub that reports an active selection - mirrors the handler-capture
+   * pattern in terminal-escape-release.test.ts, extended with a real
+   * getSelection() so the copy branch has text to clean and write.
+   */
+  function setupKeyHandler(): { handler: KeyEventHandler; writeText: ReturnType<typeof vi.fn> } {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    // @ts-expect-error -- minimal window stub for the handler's clipboard call
+    globalThis.window = { electronAPI: { clipboard: { writeText } } };
+
+    let handler: KeyEventHandler | null = null;
+    const terminal = {
+      attachCustomKeyEventHandler: (keyEventHandler: KeyEventHandler) => { handler = keyEventHandler; },
+      parser: { registerOscHandler: () => ({ dispose() { /* noop */ } }) },
+      hasSelection: () => true,
+      getSelection: () => 'some selected text',
+      cols: 80,
+    } as unknown as Terminal;
+    const el = {
+      querySelector: () => null,
+      addEventListener: () => undefined,
+      matches: () => false,
+    } as unknown as HTMLElement;
+
+    enableTerminalClipboard(terminal, el);
+    if (!handler) throw new Error('key handler was not registered');
+    return { handler, writeText };
+  }
+
+  function keydown(overrides: Partial<KeyboardEvent>): KeyboardEvent {
+    return {
+      type: 'keydown',
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      key: '',
+      ...overrides,
+    } as unknown as KeyboardEvent;
+  }
+
+  it('routes Ctrl+C (with an active selection) to window.electronAPI.clipboard.writeText and suppresses the default key behavior', () => {
+    const { handler, writeText } = setupKeyHandler();
+
+    const handled = handler(keydown({ ctrlKey: true, key: 'c' }));
+
+    expect(handled).toBe(false);
+    expect(writeText).toHaveBeenCalledWith('some selected text');
+  });
+
+  it('routes Ctrl+Shift+C to window.electronAPI.clipboard.writeText and suppresses the default key behavior', () => {
+    const { handler, writeText } = setupKeyHandler();
+
+    const handled = handler(keydown({ ctrlKey: true, shiftKey: true, key: 'C' }));
+
+    expect(handled).toBe(false);
+    expect(writeText).toHaveBeenCalledWith('some selected text');
+  });
+});

--- a/tests/unit/terminal-escape-release.test.ts
+++ b/tests/unit/terminal-escape-release.test.ts
@@ -17,6 +17,7 @@ function captureKeyHandler(options: { hover: boolean; release?: boolean }): {
   let handler: KeyEventHandler | null = null;
   const terminal = {
     attachCustomKeyEventHandler: (keyEventHandler: KeyEventHandler) => { handler = keyEventHandler; },
+    parser: { registerOscHandler: () => ({ dispose() { /* noop */ } }) },
     hasSelection: () => false,
     getSelection: () => '',
     cols: 80,


### PR DESCRIPTION
## What

Fixes broken terminal "copy selected text" in the embedded terminal. Selecting text in a Claude
Code TUI session (copy-on-select, or Ctrl+C on a selection) showed "copied N chars to clipboard"
but nothing reached the OS clipboard.

- Registers a write-only OSC 52 clipboard handler on every terminal (`terminal-clipboard.ts`,
  wired in `useTerminal.ts`).
- Adds a focus- and permission-independent `clipboard:writeText` IPC (`system.ts` + preload +
  types + channel constant), mirroring the existing `clipboard:readImage`.
- Routes the Ctrl+C / Ctrl+Shift+C and right-click context-menu copy paths through a shared
  `copySelectionToClipboard` helper.
- Strips OSC 52 sequences from replayed scrollback so restoring a session does not clobber the
  live clipboard.

## Why

The "auto-copy" toggle and the "copied N chars to clipboard" message are Claude Code CLI's own
TUI copy-on-select, not Kangentic features. The CLI copies via two channels: a fire-and-forget
`powershell Set-Clipboard` (2s kill timeout, per-machine fragile) and an OSC 52 escape sequence
(`ESC]52;c;<base64>BEL`), the standard way a TUI asks the terminal emulator to write the
clipboard. xterm.js drops OSC 52 without a registered handler, so on any machine where the
PowerShell path fails (AV-slowed cold start past the 2s timeout, PATH/policy issues), copy fails
entirely and looks like a Kangentic bug. Verified by extracting the shipped `claude.exe` bundle.

This is a real gap in Kangentic's terminal emulation (a terminal hosting TUI apps is expected to
honor OSC 52), not user error or a settings bug. "Worked before" predates the CLI's TUI
copy-on-select, when mouse selection was xterm-local and Kangentic's own Ctrl+C copy handled it.

## How

- The OSC 52 handler is deliberately write-only: read requests (`Pd` is `?`) are ignored so a
  TUI can never read the user's clipboard back out of the terminal. `decodeOsc52Payload` also
  caps payload size and rejects malformed base64.
- The write goes through the main-process Electron clipboard, which is synchronous and
  focus/permission-independent, unlike `navigator.clipboard.writeText` (which rejects with
  `NotAllowedError` when the document lacks focus, exactly the state during a native context-menu
  click). The two prior fire-and-forget `navigator.clipboard.writeText` copy sites now route
  through the same helper.
- `stripOsc52Sequences` runs on both scrollback-replay call sites before the chunked write. It
  handles all OSC terminators xterm's parser recognizes (BEL, ST, C1 ST, and a bare ESC that
  begins the next sequence), preserving any following sequence intact.

## Breaking changes

None.

## Tests

- Unit: `terminal-clipboard-osc52.test.ts` (decode/strip helpers incl. bare-ESC termination,
  handler registration write + read-ignored, `copySelectionToClipboard`, Ctrl+C/Ctrl+Shift+C
  routing), `clipboard-write-text-handler.test.ts` (handler input guard), and the extended
  `terminal-escape-release.test.ts` stub.
- UI: `terminal-osc52-copy.spec.ts` drives a live mounted xterm and asserts an OSC 52 write
  reaches `clipboard.writeText`, a read request is ignored, and a replayed OSC 52 in scrollback
  is stripped.
- Local: typecheck, lint (no warnings), the new unit files, and the UI spec all green. The full
  unit / UI / Linux E2E tiers run as CI checks on this PR.

Generated with [Claude Code](https://claude.com/claude-code)
