### PR TITLE
feat: copyable terminal output blocks

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,7 @@ These settings appear only in App Settings and cannot be overridden per-project:
 - `agent.cliPaths`, `agent.maxConcurrentSessions`, `agent.queueOverflow`, `agent.autoResumeSessionsOnRestart`
 - `terminal.panelHeight`, `terminal.showPreview`
 - `autoFocusIdleSession`
+- `terminalBlockCopy`
 - `skipBoardConfigConfirm`
 - `windowLightDismiss`
 - `contextBar.*` (all context bar visibility toggles)
@@ -78,6 +79,7 @@ These settings appear in both App Settings (as defaults) and Project Settings (a
 | `diffFlatList` | boolean | `false` | Show changed files as a flat list of full paths instead of a nested directory tree. Global-only. |
 | `skipDeleteConfirm` | boolean | `false` | Skip confirmation dialog on task delete. Written by the delete dialog's "don't ask again" checkbox. No longer surfaced in the Settings panel. |
 | `autoFocusIdleSession` | boolean | `false` | Auto-switch to session tab when agent goes idle. Idle tabs are always highlighted regardless of this setting. |
+| `terminalBlockCopy` | boolean | `true` | Show the hover highlight, copy button, click-to-copy, and right-click "Copy Block" affordance over quote / code / message blocks in the terminal. Turn off to remove it. Global-only. |
 | `windowLightDismiss` | `'off'` \| `'single'` \| `'focused'` \| `'all'` | `'single'` | Click-outside (light-dismiss) policy for modeless task-detail windows. `off` disables; `single` closes the lone window (any state); `focused` closes the focused window (any state); `all` closes every window. Closing a window does not kill its session. Global-only. |
 | `restoreWindowPosition` | boolean | `true` | Remember window size and position between launches. Global-only. |
 | `hasCompletedFirstRun` | boolean | `false` | Whether the user has completed first-run onboarding. Auto-set, not shown in UI. |

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -142,6 +142,9 @@ src/
       toast-store.ts       # Notification queue
     utils/
       terminal-clipboard.ts # Terminal copy/paste (OSC 52 write handler, bracketed paste)
+      terminal-blocks.ts     # Pure quote/code block detection + clean extraction (DOM-free)
+      terminal-block-buffer.ts # Bridges a live xterm buffer to terminal-blocks (cell attrs, hit test)
+      terminal-registry.ts   # Registry of mounted terminals + block hit-test window global
   shared/                  # Shared between main and renderer
     abort-utils.ts         # AbortSignal type guard for stale spawn prevention
     types.ts               # All TypeScript interfaces

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -119,6 +119,21 @@ The leftmost tab shows an activity log - structured events from all sessions. Th
 
 Press **Ctrl+V** (Cmd+V on macOS) in the terminal to paste. Text on the clipboard is pasted directly. If the clipboard contains an image (and no text), the image is saved to a temporary file and the file path is written to the PTY, allowing Claude Code to pick it up as a vision input. Paths are automatically quoted for the active shell (PowerShell, bash, cmd, WSL, etc.).
 
+### Copying Output Blocks
+
+Copying agent output by hand tends to grab CLI decoration - the quote bar, list bullets, and leading indentation - so the pasted text needs cleanup. Kangentic detects the block under the cursor and copies just its content:
+
+- **Hover a block** to see a full-width highlight over the region that will be copied, with a copy button at its top-right corner (GitHub-style). Click the button, or click anywhere on the highlighted block, to copy. (Block clicks still pass through to the agent, so any interactive terminal actions keep working.)
+- **Right-click a block** and choose **Copy Block**.
+
+Detection covers message text, quote blocks (the colored left bar), and code / content boxes (a shaded background). A text message groups its consecutive lines - including the blank lines between its paragraphs - into one block, while an agent's de-emphasized status lines (its "thinking" indicators) are left out. The left bar, a leading bullet, and the CLI indentation are stripped; interior blank lines and relative indentation are preserved.
+
+A normal **Ctrl+C** copy of a selection also strips the quote bar from any decorated lines it spans, so a selection mixing plain text and quoted lines pastes cleanly.
+
+Because detection reads what is on screen, a long line that the agent wrapped across several terminal rows is copied with a line break at each wrap point.
+
+Turn the whole affordance off under Settings > Behavior > Terminal (the "Copyable Blocks" toggle, a global setting) if you would rather the terminal have no hover highlight or copy controls.
+
 ### File Drop to Terminal
 
 Drag files from your file manager onto the terminal to insert their file paths into the active session. Paths containing spaces are automatically quoted. Multiple files are inserted as a space-separated list. A visual overlay appears when files are dragged over the terminal area.
@@ -415,6 +430,8 @@ These are global-only settings that apply to the entire app.
 | Auto-Focus Idle Sessions | Automatically switch the bottom panel to idle sessions. Idle tabs are always highlighted regardless of this setting. |
 | Auto-Resume Agents on Restart | When a project opens, resume any agent sessions that were running at last close. When off, those sessions stay paused until you click Resume on each task. Turn off if resuming many agents at once slows your machine. |
 | Auto-Apply Board Config Changes | When a kangentic.json board change is detected (from a teammate or a pulled-back commit), apply it immediately instead of showing the confirmation dialog. |
+| Copyable Blocks | Hover a quote, code, or message block in the terminal to highlight it and copy its clean content (copy button, click, or right-click menu). Turn off to remove the highlight and copy affordances. |
+| Close on Outside Click | Click-outside (light-dismiss) policy for modeless task-detail windows. Closing a window does not kill its session. |
 
 ### MCP Server
 
@@ -608,7 +625,7 @@ Windows (modeless task-detail windows):
 
 Terminal:
 
-- **Mod+C** / **Mod+Shift+C** - Copy selected text (with no selection, Ctrl+C cancels the running command)
+- **Mod+C** / **Mod+Shift+C** - Copy selected text, stripping quote-bar decoration from any decorated lines (with no selection, Ctrl+C cancels the running command)
 - **Mod+V** / **Mod+Shift+V** - Paste text or an image into the terminal
 - Standard OS shortcuts for the rest of terminal editing
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -28,6 +28,7 @@ import { syncShutdownCleanup, startHardShutdownFailsafe } from './shutdown';
 import { prRefreshScheduler } from './pr/pr-refresh-scheduler';
 import { restoreShellEnv } from './shell-env';
 import { isFirstPartyPermissionAllowed } from './permission-policy';
+import { probeTerminalBlock, buildCopyBlockDispatchScript } from './terminal-context-menu';
 import { MIN_ZOOM, MAX_ZOOM } from '../shared/zoom-steps';
 
 initStartupTimer(PROCESS_START);
@@ -349,6 +350,86 @@ function getCwdArg(): string | null {
 // Re-export for external consumers (e.g. updater module)
 export { resolveIconPath } from './window-utils';
 
+// Build and show the standard (non-image) right-click context menu. First probes
+// the renderer for a copyable terminal block under the cursor; when one is found,
+// prepends a "Copy Block" item that copies the block's clean content (no CLI
+// quote bar / indentation). The probe is bounded (see probeTerminalBlock), so a
+// slow or absent renderer just yields the menu without the extra item.
+async function showTerminalAwareContextMenu(
+  wc: Electron.WebContents,
+  params: Electron.ContextMenuParams,
+): Promise<void> {
+  const { x, y } = params;
+  const probe = await probeTerminalBlock((script) => wc.executeJavaScript(script), x, y);
+
+  const template: Electron.MenuItemConstructorOptions[] = [];
+
+  if (probe.blockKind) {
+    template.push(
+      {
+        label: 'Copy Block',
+        click: () => { void wc.executeJavaScript(buildCopyBlockDispatchScript(x, y)).catch(() => { /* renderer gone */ }); },
+      },
+      { type: 'separator' },
+    );
+  }
+
+  template.push(
+    {
+      label: 'Copy',
+      accelerator: 'CmdOrCtrl+C',
+      enabled: params.editFlags.canCopy || true,
+      click: () => {
+        wc.executeJavaScript(`
+          (function() {
+            var el = document.elementFromPoint(${x}, ${y});
+            if (el && el.closest('.xterm')) {
+              window.dispatchEvent(new CustomEvent('terminal-copy', { detail: { x: ${x}, y: ${y} } }));
+            } else {
+              document.execCommand('copy');
+            }
+          })()
+        `);
+      },
+    },
+    {
+      label: 'Paste',
+      accelerator: 'CmdOrCtrl+V',
+      enabled: params.editFlags.canPaste,
+      click: () => {
+        wc.executeJavaScript(`
+          (function() {
+            var el = document.elementFromPoint(${x}, ${y});
+            if (el && el.closest('.xterm')) {
+              window.dispatchEvent(new CustomEvent('terminal-paste', { detail: { x: ${x}, y: ${y} } }));
+            }
+          })()
+        `);
+        wc.paste();
+      },
+    },
+    { type: 'separator' },
+    {
+      label: 'Select All',
+      accelerator: 'CmdOrCtrl+A',
+      click: () => {
+        wc.executeJavaScript(`
+          (function() {
+            var el = document.elementFromPoint(${x}, ${y});
+            if (el && el.closest('.xterm')) {
+              window.dispatchEvent(new CustomEvent('terminal-select-all', { detail: { x: ${x}, y: ${y} } }));
+            } else {
+              document.execCommand('selectAll');
+            }
+          })()
+        `);
+      },
+    },
+  );
+
+  Menu.buildFromTemplate(template).popup();
+}
+
 const createWindow = () => {
   phase('createWindow');
   const isTest = process.env.NODE_ENV === 'test';
@@ -457,8 +538,6 @@ const createWindow = () => {
   // hook can respond.
   const wc = mainWindow.webContents;
   mainWindow.webContents.on('context-menu', (_event, params) => {
-    const { x, y } = params;
-
     if (params.mediaType === 'image' && params.hasImageContents) {
       const imageMenu = Menu.buildFromTemplate([
         {
@@ -489,59 +568,10 @@ const createWindow = () => {
       return;
     }
 
-    const menu = Menu.buildFromTemplate([
-      {
-        label: 'Copy',
-        accelerator: 'CmdOrCtrl+C',
-        enabled: params.editFlags.canCopy || true,
-        click: () => {
-          wc.executeJavaScript(`
-            (function() {
-              var el = document.elementFromPoint(${x}, ${y});
-              if (el && el.closest('.xterm')) {
-                window.dispatchEvent(new CustomEvent('terminal-copy', { detail: { x: ${x}, y: ${y} } }));
-              } else {
-                document.execCommand('copy');
-              }
-            })()
-          `);
-        },
-      },
-      {
-        label: 'Paste',
-        accelerator: 'CmdOrCtrl+V',
-        enabled: params.editFlags.canPaste,
-        click: () => {
-          wc.executeJavaScript(`
-            (function() {
-              var el = document.elementFromPoint(${x}, ${y});
-              if (el && el.closest('.xterm')) {
-                window.dispatchEvent(new CustomEvent('terminal-paste', { detail: { x: ${x}, y: ${y} } }));
-              }
-            })()
-          `);
-          wc.paste();
-        },
-      },
-      { type: 'separator' },
-      {
-        label: 'Select All',
-        accelerator: 'CmdOrCtrl+A',
-        click: () => {
-          wc.executeJavaScript(`
-            (function() {
-              var el = document.elementFromPoint(${x}, ${y});
-              if (el && el.closest('.xterm')) {
-                window.dispatchEvent(new CustomEvent('terminal-select-all', { detail: { x: ${x}, y: ${y} } }));
-              } else {
-                document.execCommand('selectAll');
-              }
-            })()
-          `);
-        },
-      },
-    ]);
-    menu.popup();
+    // Probe the renderer for a copyable block under the cursor, then build the
+    // menu (with a "Copy Block" item when a quote/code block was hit). The probe
+    // is bounded, so the worst case is a menu that opens without the item.
+    void showTerminalAwareContextMenu(wc, params);
   });
 
   // Track renderer crashes (OOM, GPU process gone, etc.)

--- a/src/main/terminal-context-menu.ts
+++ b/src/main/terminal-context-menu.ts
@@ -1,0 +1,78 @@
+// Pure helpers for the terminal-aware right-click context menu. The main
+// process cannot read xterm's WebGL-rendered content directly, so it probes the
+// renderer (via executeJavaScript against a window-global query function) to ask
+// whether the click landed on a copyable block, then decides whether to show a
+// "Copy Block" item. Kept separate from index.ts so the script building, result
+// parsing, and timeout race are unit-testable without Electron.
+
+export type TerminalBlockKind = 'quote' | 'box' | 'text' | 'message';
+
+export interface TerminalBlockProbeResult {
+  isTerminal: boolean;
+  blockKind: TerminalBlockKind | null;
+}
+
+/** Upper bound on how long the menu waits for the renderer probe before opening without the item. */
+export const PROBE_TIMEOUT_MS = 100;
+
+const NO_BLOCK: TerminalBlockProbeResult = { isTerminal: false, blockKind: null };
+
+/**
+ * A renderer expression that returns `{ isTerminal, blockKind }` for a client
+ * point. Coordinates are rounded before interpolation so the built string can
+ * only ever contain numbers.
+ */
+export function buildBlockProbeScript(clientX: number, clientY: number): string {
+  const x = Math.round(clientX);
+  const y = Math.round(clientY);
+  return `(window.__kangenticTerminalBlockHitTest ? window.__kangenticTerminalBlockHitTest(${x}, ${y}) : ({ isTerminal: false, blockKind: null }))`;
+}
+
+/** A renderer expression that dispatches the copy-block action for a client point. */
+export function buildCopyBlockDispatchScript(clientX: number, clientY: number): string {
+  const x = Math.round(clientX);
+  const y = Math.round(clientY);
+  return `window.dispatchEvent(new CustomEvent('terminal-copy-block', { detail: { x: ${x}, y: ${y} } }))`;
+}
+
+/** Validate an unknown probe result into a well-formed shape (defaults to no block). */
+export function parseProbeResult(value: unknown): TerminalBlockProbeResult {
+  if (!value || typeof value !== 'object') return { ...NO_BLOCK };
+  const record = value as Record<string, unknown>;
+  const blockKind =
+    record.blockKind === 'quote' ||
+    record.blockKind === 'box' ||
+    record.blockKind === 'text' ||
+    record.blockKind === 'message'
+      ? record.blockKind
+      : null;
+  return { isTerminal: record.isTerminal === true, blockKind };
+}
+
+/**
+ * Probe the renderer for a copyable block under a point. Resolves to "no block"
+ * on any error or if the renderer does not answer within PROBE_TIMEOUT_MS, so
+ * the worst case is a context menu that opens without the "Copy Block" item.
+ */
+export async function probeTerminalBlock(
+  executeJavaScript: (script: string) => Promise<unknown>,
+  clientX: number,
+  clientY: number,
+): Promise<TerminalBlockProbeResult> {
+  try {
+    return await Promise.race([
+      executeJavaScript(buildBlockProbeScript(clientX, clientY))
+        .then(parseProbeResult)
+        // Swallow a rejection that lands AFTER the timeout already won the race
+        // (webContents navigated / destroyed): the loser promise is otherwise
+        // unhandled and would fire spurious app_error telemetry for what is
+        // benign, expected behavior of a best-effort bounded probe.
+        .catch((): TerminalBlockProbeResult => ({ ...NO_BLOCK })),
+      new Promise<TerminalBlockProbeResult>((resolve) => {
+        setTimeout(() => resolve({ ...NO_BLOCK }), PROBE_TIMEOUT_MS);
+      }),
+    ]);
+  } catch {
+    return { ...NO_BLOCK };
+  }
+}

--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -31,6 +31,7 @@ import { useTerminal } from '../../hooks/useTerminal';
 import { useKeybinding, useFormattedCombo } from '../../hooks/useKeybinding';
 import { useTerminalFileDrop } from '../../hooks/useTerminalFileDrop';
 import { FileDropOverlay } from '../terminal/FileDropOverlay';
+import { TerminalBlockCopyButton } from '../terminal/TerminalBlockCopyButton';
 import { ContextBar } from '../terminal/ContextBar';
 import { useSessionStore } from '../../stores/session-store';
 import { transientKey } from '../../stores/session-store/transient-session-slice';
@@ -137,6 +138,7 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
 
   const maximizeCombo = useFormattedCombo('panel.maximize');
   const spawnedRef = useRef(false);
+  const terminalPaneRef = useRef<HTMLDivElement>(null);
   const commandButtonRef = useRef<HTMLDivElement>(null);
   // The branch picker can fold into the kebab; this drives the kebab-anchored
   // fallback dropdown ("Switch branch").
@@ -299,7 +301,7 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
     ),
   );
 
-  const { terminalRef, initTerminal, fit, flushResize, focus } = useTerminal({
+  const { terminalRef, initTerminal, fit, flushResize, focus, getTerminal } = useTerminal({
     sessionId: effectiveSessionId,
     fontFamily: config.terminal.fontFamily,
     fontSize: config.terminal.fontSize,
@@ -702,7 +704,7 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
             to the terminal's column width, so it overflows the window and fit() reads
             the stale (too-wide) size and never reduces columns. overflow-hidden clips
             the brief pre-fit overflow. Mirrors the Changes panel sibling. */}
-        <div className={`${changesOpen ? 'w-1/2' : 'flex-1'} relative min-w-0 overflow-hidden`} style={{ backgroundColor: '#18181b' }}>
+        <div ref={terminalPaneRef} className={`${changesOpen ? 'w-1/2' : 'flex-1'} relative min-w-0 overflow-hidden`} style={{ backgroundColor: '#18181b' }}>
           {!terminalReady && <LaunchOverlay label="Starting Command Terminal..." />}
           <FileDropOverlay {...fileDrop} />
           <div
@@ -710,6 +712,7 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
             className="h-full"
             data-testid="command-bar-terminal"
           />
+          <TerminalBlockCopyButton containerRef={terminalPaneRef} getTerminal={getTerminal} />
         </div>
 
         {/* Changes panel */}

--- a/src/renderer/components/settings/settings-registry.ts
+++ b/src/renderer/components/settings/settings-registry.ts
@@ -95,14 +95,17 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
   // ── MCP Server ──
   { id: 'mcpServer.enabled', tabId: 'mcpServer', label: 'Kangentic MCP Server', description: 'Give agents tools to interact with your board', scope: 'global', keywords: ['mcp', 'tools', 'create task', 'agent', 'board', 'query', 'session', 'stats'] },
 
-  // ── Behavior > Session Limits ──
-  { id: 'agent.maxConcurrentSessions', tabId: 'behavior', label: 'Max Concurrent Sessions', description: 'Limit how many agents can run at the same time', scope: 'global', section: 'Session Limits', keywords: ['parallel', 'limit'] },
-  { id: 'agent.queueOverflow', tabId: 'behavior', label: 'When Max Sessions Reached', description: 'How new agent requests are handled when all slots are in use', scope: 'global', section: 'Session Limits', keywords: ['overflow', 'queue', 'reject'] },
+  // ── Behavior > Sessions ──
+  { id: 'agent.maxConcurrentSessions', tabId: 'behavior', label: 'Max Concurrent Sessions', description: 'Limit how many agents can run at the same time', scope: 'global', section: 'Sessions', keywords: ['parallel', 'limit'] },
+  { id: 'agent.queueOverflow', tabId: 'behavior', label: 'When Max Sessions Reached', description: 'How new agent requests are handled when all slots are in use', scope: 'global', section: 'Sessions', keywords: ['overflow', 'queue', 'reject', 'limit'] },
+  { id: 'autoFocusIdleSession', tabId: 'behavior', label: 'Auto-Focus Idle Sessions', description: 'Automatically switch the bottom panel to idle sessions. Idle tabs are always highlighted regardless of this setting.', scope: 'global', section: 'Sessions', keywords: ['switch', 'panel', 'attention'] },
+  { id: 'agent.autoResumeSessionsOnRestart', tabId: 'behavior', label: 'Auto-Resume Agents on Restart', description: 'When a project opens, resume any agent sessions that were running at last close. When off, those sessions stay paused until you click Resume on each task. Turn off if resuming many agents at once slows your machine.', scope: 'global', section: 'Sessions', keywords: ['resume', 'restart', 'startup', 'suspend', 'pause', 'stampede', 'auto', 'sessions', 'agents'] },
 
-  // ── Behavior ──
-  { id: 'autoFocusIdleSession', tabId: 'behavior', label: 'Auto-Focus Idle Sessions', description: 'Automatically switch the bottom panel to idle sessions. Idle tabs are always highlighted regardless of this setting.', scope: 'global', keywords: ['switch', 'panel', 'attention'] },
-  { id: 'agent.autoResumeSessionsOnRestart', tabId: 'behavior', label: 'Auto-Resume Agents on Restart', description: 'When a project opens, resume any agent sessions that were running at last close. When off, those sessions stay paused until you click Resume on each task. Turn off if resuming many agents at once slows your machine.', scope: 'global', keywords: ['resume', 'restart', 'startup', 'suspend', 'pause', 'stampede', 'auto', 'sessions', 'agents'] },
-  { id: 'skipBoardConfigConfirm', tabId: 'behavior', label: 'Auto-Apply Board Config Changes', description: 'When a kangentic.json board change is detected (from a teammate or your own pulled-back commit), apply it immediately instead of showing the confirmation dialog.', scope: 'global', keywords: ['board config', 'kangentic.json', 'reconcile', 'reconciliation', 'apply', 'confirm', 'dialog', 'pull', 'auto'] },
+  // ── Behavior > Board ──
+  { id: 'skipBoardConfigConfirm', tabId: 'behavior', label: 'Auto-Apply Board Config Changes', description: 'When a kangentic.json board change is detected (from a teammate or your own pulled-back commit), apply it immediately instead of showing the confirmation dialog.', scope: 'global', section: 'Board', keywords: ['board config', 'kangentic.json', 'reconcile', 'reconciliation', 'apply', 'confirm', 'dialog', 'pull', 'auto'] },
+
+  // ── Behavior > Terminal ──
+  { id: 'terminalBlockCopy', tabId: 'behavior', label: 'Copyable Blocks', description: 'Hover a quote, code, or message block in the terminal to highlight it and copy its clean content (via the copy button, a click, or the right-click menu). Turn off to remove the highlight and copy affordances.', scope: 'global', section: 'Terminal', keywords: ['copy', 'block', 'code', 'quote', 'message', 'clipboard', 'highlight', 'hover', 'terminal', 'output'] },
 
   // ── Behavior > Task Windows ──
   { id: 'windowLightDismiss', tabId: 'behavior', label: 'Close on Outside Click', description: 'Click empty space outside a task window (anything but a button or the terminal panel) to dismiss it. Closing keeps the agent running and hands its terminal back to the panel; reopening the task reattaches.', scope: 'global', section: 'Task Windows', keywords: ['dismiss', 'click outside', 'window', 'peek', 'close', 'light dismiss', 'task window'] },

--- a/src/renderer/components/settings/tabs/BehaviorTab.tsx
+++ b/src/renderer/components/settings/tabs/BehaviorTab.tsx
@@ -7,8 +7,8 @@ export function BehaviorTab({ globalConfig }: { globalConfig: AppConfig }) {
   return (
     <>
       <SectionHeader
-        label="Session Limits"
-        searchIds={['agent.maxConcurrentSessions', 'agent.queueOverflow']}
+        label="Sessions"
+        searchIds={['agent.maxConcurrentSessions', 'agent.queueOverflow', 'autoFocusIdleSession', 'agent.autoResumeSessionsOnRestart']}
       />
       <SettingRow {...settingProps('agent.maxConcurrentSessions')}>
         <input
@@ -38,10 +38,19 @@ export function BehaviorTab({ globalConfig }: { globalConfig: AppConfig }) {
         checked={globalConfig.agent.autoResumeSessionsOnRestart}
         onChange={(value) => updateGlobal({ agent: { autoResumeSessionsOnRestart: value } })}
       />
+
+      <SectionHeader label="Board" searchIds={['skipBoardConfigConfirm']} />
       <SettingToggleRow
         {...settingProps('skipBoardConfigConfirm')}
         checked={globalConfig.skipBoardConfigConfirm}
         onChange={(value) => updateGlobal({ skipBoardConfigConfirm: value })}
+      />
+
+      <SectionHeader label="Terminal" searchIds={['terminalBlockCopy']} />
+      <SettingToggleRow
+        {...settingProps('terminalBlockCopy')}
+        checked={globalConfig.terminalBlockCopy}
+        onChange={(value) => updateGlobal({ terminalBlockCopy: value })}
       />
 
       <SectionHeader label="Task Windows" searchIds={['windowLightDismiss']} />

--- a/src/renderer/components/terminal/TerminalBlockCopyButton.tsx
+++ b/src/renderer/components/terminal/TerminalBlockCopyButton.tsx
@@ -1,0 +1,235 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+import type { Terminal } from '@xterm/xterm';
+import {
+  findBlockAtPoint,
+  extractBlockContentAt,
+  pixelToBufferRow,
+  getScreenRect,
+  getBlockPixelBounds,
+  readCellDimensions,
+  createBufferLineSource,
+} from '../../utils/terminal-block-buffer';
+import { findBlockAt, type BlockRange } from '../../utils/terminal-blocks';
+import { useConfigStore } from '../../stores/config-store';
+
+interface TerminalBlockCopyButtonProps {
+  /** The relative wrapper that hosts the xterm div (the overlay positions within it). */
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  /** Reads the live xterm Terminal (or null when not yet initialized). */
+  getTerminal: () => Terminal | null;
+}
+
+/** A block rectangle in container-relative pixels, plus the terminal row height. */
+interface BlockRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+  rowHeight: number;
+}
+
+/**
+ * Hover affordance for copying a quote / code block. On hover it draws a
+ * highlight rectangle over the exact region that will be copied, and anchors a
+ * GitHub-style copy button to that rectangle's top-right corner. This is the
+ * progressive enhancement the feature request asked for; the right-click "Copy
+ * Block" menu item is the primary, accessible affordance (see ui-conventions.md).
+ *
+ * The overlay root is pointer-events: none so it never steals xterm's text
+ * selection; only the button is interactive. Block state is always re-derived
+ * from the live buffer (never cached across a remount), matching the
+ * one-xterm-per-session ownership rule.
+ */
+export function TerminalBlockCopyButton({ containerRef, getTerminal }: TerminalBlockCopyButtonProps) {
+  const [rect, setRect] = useState<BlockRect | null>(null);
+  const [copied, setCopied] = useState(false);
+  const rangeRef = useRef<BlockRange | null>(null);
+  const moveRafRef = useRef<number | null>(null);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  // Viewport-space bounds of the currently shown highlight. While the pointer is
+  // anywhere inside these, the highlight is held steady (no recompute), so moving
+  // across an interior blank line or the block's edge never makes it flicker.
+  const shownBoundsRef = useRef<{ top: number; left: number; right: number; bottom: number } | null>(null);
+  const enabled = useConfigStore((state) => state.config.terminalBlockCopy);
+
+  const visible = rect !== null;
+
+  const hide = useCallback(() => {
+    rangeRef.current = null;
+    shownBoundsRef.current = null;
+    setRect(null);
+  }, []);
+
+  // Tear down any shown highlight the moment the affordance is disabled.
+  useEffect(() => {
+    if (!enabled) hide();
+  }, [enabled, hide]);
+
+  // Container-relative rectangle for a block plus its viewport-space bounds, or
+  // null when the block is not on screen.
+  const rectForRange = useCallback((terminal: Terminal, range: BlockRange) => {
+    const container = containerRef.current;
+    const screenRect = getScreenRect(terminal);
+    const bounds = getBlockPixelBounds(terminal, range);
+    const dimensions = readCellDimensions(terminal);
+    if (!container || !screenRect || !bounds || !dimensions) return null;
+    const containerRect = container.getBoundingClientRect();
+    const top = screenRect.top - containerRect.top + bounds.top;
+    const left = screenRect.left - containerRect.left + bounds.left;
+    const rect: BlockRect = { top, left, width: bounds.width, height: bounds.height, rowHeight: dimensions.height };
+    const clientTop = containerRect.top + top;
+    const clientLeft = containerRect.left + left;
+    return {
+      rect,
+      bounds: { top: clientTop, left: clientLeft, right: clientLeft + bounds.width, bottom: clientTop + bounds.height },
+    };
+  }, [containerRef]);
+
+  const show = useCallback((terminal: Terminal, range: BlockRange) => {
+    const computed = rectForRange(terminal, range);
+    if (!computed) { hide(); return; }
+    rangeRef.current = range;
+    shownBoundsRef.current = computed.bounds;
+    setRect(computed.rect);
+  }, [rectForRange, hide]);
+
+  // Show / move the highlight as the pointer moves over a block (rAF-throttled).
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !enabled) return;
+
+    const handleMove = (event: MouseEvent) => {
+      if (moveRafRef.current != null) return;
+      const { clientX, clientY } = event;
+      moveRafRef.current = requestAnimationFrame(() => {
+        moveRafRef.current = null;
+        // Sticky: if the pointer is still inside the shown highlight, keep it.
+        const current = shownBoundsRef.current;
+        if (current && clientX >= current.left && clientX <= current.right
+          && clientY >= current.top && clientY <= current.bottom) return;
+        const terminal = getTerminal();
+        if (!terminal) { hide(); return; }
+        const range = findBlockAtPoint(terminal, clientX, clientY);
+        if (!range) { hide(); return; }
+        show(terminal, range);
+      });
+    };
+
+    container.addEventListener('mousemove', handleMove);
+    container.addEventListener('mouseleave', hide);
+    return () => {
+      container.removeEventListener('mousemove', handleMove);
+      container.removeEventListener('mouseleave', hide);
+      if (moveRafRef.current != null) cancelAnimationFrame(moveRafRef.current);
+    };
+  }, [containerRef, getTerminal, hide, show, enabled]);
+
+  // While visible, follow scroll / output writes / resize so the highlight stays
+  // anchored (or hides when the block scrolls off or changes). Subscribed only
+  // while visible so a busy agent's repaints don't churn.
+  useEffect(() => {
+    if (!visible) return;
+    const terminal = getTerminal();
+    if (!terminal) return;
+
+    let refreshRaf: number | null = null;
+    const refresh = () => {
+      if (refreshRaf != null) return;
+      refreshRaf = requestAnimationFrame(() => {
+        refreshRaf = null;
+        const range = rangeRef.current;
+        if (!range) { hide(); return; }
+        const current = findBlockAt(createBufferLineSource(terminal), range.startY);
+        if (!current || current.kind !== range.kind) { hide(); return; }
+        show(terminal, current);
+      });
+    };
+
+    const scrollDisposable = terminal.onScroll(refresh);
+    const writeDisposable = terminal.onWriteParsed(refresh);
+    const resizeDisposable = terminal.onResize(hide);
+    return () => {
+      scrollDisposable.dispose();
+      writeDisposable.dispose();
+      resizeDisposable.dispose();
+      if (refreshRaf != null) cancelAnimationFrame(refreshRaf);
+    };
+  }, [visible, getTerminal, hide, show]);
+
+  const copyBlockAt = useCallback((clientX: number, clientY: number) => {
+    const terminal = getTerminal();
+    if (!terminal) return;
+    const row = pixelToBufferRow(terminal, clientX, clientY);
+    if (row == null) return;
+    const hit = extractBlockContentAt(terminal, row);
+    if (!hit?.content) return;
+    navigator.clipboard.writeText(hit.content).then(() => {
+      setCopied(true);
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = setTimeout(() => setCopied(false), 1500);
+    }).catch(() => { /* clipboard access denied */ });
+  }, [getTerminal]);
+
+  // Clicking anywhere on a block copies it. Runs in the CAPTURE phase and never
+  // preventDefault/stopPropagation, so the same click still reaches xterm (which
+  // has mouse tracking on for Claude Code) - the copy is a passive side effect.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !enabled) return;
+    const handleClick = (event: MouseEvent) => {
+      if (buttonRef.current?.contains(event.target as Node)) return; // button has its own handler
+      copyBlockAt(event.clientX, event.clientY);
+    };
+    container.addEventListener('click', handleClick, true);
+    return () => container.removeEventListener('click', handleClick, true);
+  }, [containerRef, copyBlockAt, enabled]);
+
+  useEffect(() => () => {
+    if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+  }, []);
+
+  // A legible copy icon in a square chip one row tall, placed flush to the
+  // highlight's outer top-right corner and sharing its border radius so the two
+  // corners coincide seamlessly (the chip covers the border corner, no sliver).
+  const iconSize = 14;
+  const buttonSize = rect ? Math.max(rect.rowHeight, iconSize) : 0;
+
+  if (!enabled) return null;
+
+  return (
+    <div className="absolute inset-0 z-10 pointer-events-none" data-testid="terminal-block-copy-overlay">
+      {rect && (
+        <>
+          {/* Border-forward highlight: an accent outline reads identically over a
+              shaded user box and a plain black assistant line (a translucent fill
+              would look grey-on-grey on the box). */}
+          <div
+            className="absolute rounded-sm border border-accent bg-accent/5"
+            style={{ top: rect.top, left: rect.left, width: rect.width, height: rect.height }}
+            data-testid="terminal-block-copy-highlight"
+          />
+          <button
+            ref={buttonRef}
+            type="button"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={(e) => copyBlockAt(e.clientX, e.clientY)}
+            className="pointer-events-auto absolute flex items-center justify-center rounded-sm bg-accent-emphasis text-accent-on shadow-sm hover:bg-accent transition-colors"
+            style={{
+              top: rect.top,
+              left: rect.left + rect.width - buttonSize,
+              width: buttonSize,
+              height: buttonSize,
+            }}
+            title="Copy block"
+            data-testid="terminal-block-copy-button"
+          >
+            {/* translate-x nudges the Copy glyph, whose mass leans left, to optically center it. */}
+            {copied ? <Check size={iconSize} /> : <Copy size={iconSize} className="translate-x-[1px]" />}
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/terminal/TerminalTab.tsx
+++ b/src/renderer/components/terminal/TerminalTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTerminal } from '../../hooks/useTerminal';
 import { useTerminalFileDrop } from '../../hooks/useTerminalFileDrop';
 import { FileDropOverlay } from './FileDropOverlay';
+import { TerminalBlockCopyButton } from './TerminalBlockCopyButton';
 import { useConfigStore } from '../../stores/config-store';
 import { useSessionStore } from '../../stores/session-store';
 import { LaunchOverlay } from '../LaunchOverlay';
@@ -61,7 +62,7 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
   // PTY output from accumulating in xterm behind the overlay.
   const [terminalReady, setTerminalReady] = useState(() => hasFirstOutput || hasUsage);
 
-  const { terminalRef, initTerminal, fit, flushResize, focus, reloadScrollback, scrollbackPending, suppressDataRef } = useTerminal({
+  const { terminalRef, initTerminal, fit, flushResize, focus, reloadScrollback, scrollbackPending, suppressDataRef, getTerminal } = useTerminal({
     sessionId,
     fontFamily: config.terminal.fontFamily,
     fontSize: config.terminal.fontSize,
@@ -73,6 +74,9 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
 
   // Sync suppressDataRef with overlay state: suppress all PTY data while overlay is showing.
   suppressDataRef.current = !terminalReady;
+
+  // Relative wrapper that hosts the xterm div and the block-copy overlay.
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const initialized = useRef(false);
 
@@ -270,8 +274,9 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
   const fileDrop = useTerminalFileDrop(sessionId, focus, sessionShell);
 
   return (
-    <div className="h-full w-full bg-surface relative">
+    <div ref={containerRef} className="h-full w-full bg-surface relative">
       <div ref={terminalRef} className="h-full w-full" />
+      <TerminalBlockCopyButton containerRef={containerRef} getTerminal={getTerminal} />
       <FileDropOverlay {...fileDrop} />
       {/* Placeholder overlay while Claude CLI is loading (before first usage report).
           Stays visible until scrollback replay + clear are both done.

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -3,6 +3,8 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '../addons/fit-addon';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { copySelectionToClipboard, enableTerminalClipboard, stripOsc52Sequences } from '../utils/terminal-clipboard';
+import { registerTerminal } from '../utils/terminal-registry';
+import { pixelToBufferRow, extractBlockContentAt } from '../utils/terminal-block-buffer';
 import { createWriteBatcher, type WriteBatcher } from '../utils/write-batcher';
 import { createIncomingWriteQueue, writeChunkedToTerminal } from '../utils/incoming-write-queue';
 import { noteTerminalFocus } from '../utils/dictation-target';
@@ -100,6 +102,8 @@ export function useTerminal(options: UseTerminalOptions) {
   /** Coalesces xterm onData bursts (paste, key-repeat, clipboard callback)
    *  into one IPC write per microtask. */
   const writeBatcherRef = useRef<WriteBatcher | null>(null);
+  /** Unregisters this terminal from the block-copy hit-test registry on unmount. */
+  const unregisterTerminalRef = useRef<(() => void) | null>(null);
 
   const initTerminal = useCallback(() => {
     if (!terminalRef.current || xtermRef.current) return;
@@ -168,6 +172,9 @@ export function useTerminal(options: UseTerminalOptions) {
 
     xtermRef.current = terminal;
     fitAddonRef.current = fitAddon;
+
+    // Register for block-copy hit testing (right-click "Copy Block" + hover button).
+    unregisterTerminalRef.current = registerTerminal(terminal, terminalRef.current);
 
     // Send user input to PTY (via the microtask-batched queue above).
     if (options.sessionId) {
@@ -295,9 +302,10 @@ export function useTerminal(options: UseTerminalOptions) {
     };
   }, [options.sessionId]);
 
-  // Handle context-menu Copy / Select All dispatched from the main process.
-  // The event detail carries the right-click coordinates so we only act when
-  // the click landed inside THIS terminal's container.
+  // Handle context-menu actions dispatched from the main process: Copy, Copy
+  // Block, Select All, and Paste. The event detail carries the right-click
+  // coordinates so we only act when the click landed inside THIS terminal's
+  // container.
   useEffect(() => {
     const isInside = (e: Event): boolean => {
       const el = terminalRef.current;
@@ -313,6 +321,18 @@ export function useTerminal(options: UseTerminalOptions) {
       // Menu.popup steals document focus, so navigator.clipboard.writeText would reject.
       copySelectionToClipboard(xtermRef.current!);
     };
+    const handleCopyBlock = (e: Event) => {
+      if (!isInside(e)) return;
+      const term = xtermRef.current!;
+      const { x, y } = (e as CustomEvent).detail || {};
+      if (x == null || y == null) return;
+      const row = pixelToBufferRow(term, x, y);
+      if (row == null) return;
+      const hit = extractBlockContentAt(term, row);
+      // Focus-independent write: this fires from the native context menu, whose
+      // Menu.popup steals document focus (navigator.clipboard would reject).
+      if (hit?.content) window.electronAPI.clipboard.writeText(hit.content).catch(() => { /* best-effort */ });
+    };
     const handleSelectAll = (e: Event) => {
       if (!isInside(e)) return;
       xtermRef.current!.selectAll();
@@ -324,10 +344,12 @@ export function useTerminal(options: UseTerminalOptions) {
       }).catch(() => { /* clipboard access denied */ });
     };
     window.addEventListener('terminal-copy', handleCopy);
+    window.addEventListener('terminal-copy-block', handleCopyBlock);
     window.addEventListener('terminal-select-all', handleSelectAll);
     window.addEventListener('terminal-paste', handlePaste);
     return () => {
       window.removeEventListener('terminal-copy', handleCopy);
+      window.removeEventListener('terminal-copy-block', handleCopyBlock);
       window.removeEventListener('terminal-select-all', handleSelectAll);
       window.removeEventListener('terminal-paste', handlePaste);
     };
@@ -348,6 +370,8 @@ export function useTerminal(options: UseTerminalOptions) {
       } else if (options.sessionId) {
         savedScrollPositions.delete(options.sessionId);
       }
+      unregisterTerminalRef.current?.();
+      unregisterTerminalRef.current = null;
       xtermRef.current?.dispose();
       xtermRef.current = null;
       fitAddonRef.current = null;
@@ -460,6 +484,8 @@ export function useTerminal(options: UseTerminalOptions) {
     xtermRef.current?.focus();
   }, []);
 
+  const getTerminal = useCallback(() => xtermRef.current, []);
+
   return {
     terminalRef,
     initTerminal,
@@ -469,5 +495,6 @@ export function useTerminal(options: UseTerminalOptions) {
     reloadScrollback,
     scrollbackPending: scrollbackPendingRef,
     suppressDataRef,
+    getTerminal,
   };
 }

--- a/src/renderer/utils/terminal-block-buffer.ts
+++ b/src/renderer/utils/terminal-block-buffer.ts
@@ -1,0 +1,236 @@
+// Runtime bridge between a live xterm `Terminal` and the pure block-detection
+// core in `terminal-blocks.ts`. This is the only place that reads the xterm
+// buffer's cell attributes and does pixel-to-row hit testing; the detection and
+// extraction logic itself stays pure and DOM-free for unit testing.
+import type { Terminal, IBufferCell, IBufferLine } from '@xterm/xterm';
+import {
+  findBlockAt,
+  extractBlockContent,
+  cleanSelectionLines,
+  BAR_GLYPHS,
+  MIN_BOX_RUN_CELLS,
+  MAX_BOX_RUN_START_COLUMN,
+  type BlockLineFacts,
+  type BlockLineSource,
+  type BlockRange,
+  type BlockKind,
+} from './terminal-blocks';
+
+// Minimal shape of xterm's private render-service dimensions, accessed the same
+// way the custom FitAddon does (`src/renderer/addons/fit-addon.ts`). xterm does
+// not expose cell dimensions publicly.
+interface XtermRenderCore {
+  _core?: {
+    _renderService?: {
+      dimensions?: { css?: { cell?: { width?: number; height?: number } } };
+    };
+  };
+}
+
+function foregroundKey(cell: IBufferCell): string {
+  if (cell.isFgDefault()) return 'def';
+  if (cell.isFgRGB()) return `rgb:${cell.getFgColor()}`;
+  if (cell.isFgPalette()) return `p:${cell.getFgColor()}`;
+  return `o:${cell.getFgColor()}`;
+}
+
+function backgroundKey(cell: IBufferCell): string {
+  if (cell.isBgRGB()) return `rgb:${cell.getBgColor()}`;
+  if (cell.isBgPalette()) return `p:${cell.getBgColor()}`;
+  return `o:${cell.getBgColor()}`;
+}
+
+/** Classify one buffer line into the facts the pure detector needs. */
+function classifyLine(line: IBufferLine, cols: number, reusableCell: IBufferCell): {
+  quoteBar: { column: number; fgKey: string } | null;
+  bgRun: { key: string; startColumn: number; endColumn: number } | null;
+  hasDefaultFg: boolean;
+} {
+  let quoteBar: { column: number; fgKey: string } | null = null;
+  let firstNonSpaceSeen = false;
+  let hasDefaultFg = false;
+
+  let bgRun: { key: string; startColumn: number; endColumn: number } | null = null;
+  let runKey = 'def';
+  let runStart = -1;
+  let runLength = 0;
+
+  const commitRun = (): void => {
+    if (!bgRun && runKey !== 'def' && runLength >= MIN_BOX_RUN_CELLS && runStart <= MAX_BOX_RUN_START_COLUMN) {
+      bgRun = { key: runKey, startColumn: runStart, endColumn: runStart + runLength };
+    }
+  };
+
+  const limit = Math.min(line.length, cols);
+  for (let x = 0; x < limit; x += 1) {
+    const cell = line.getCell(x, reusableCell);
+    if (!cell) continue;
+
+    if (cell.getWidth() !== 0) {
+      const chars = cell.getChars();
+      if (chars !== '' && chars !== ' ') {
+        if (cell.isFgDefault()) hasDefaultFg = true;
+        if (!firstNonSpaceSeen) {
+          firstNonSpaceSeen = true;
+          if (BAR_GLYPHS.has(chars) && !cell.isFgDefault()) {
+            quoteBar = { column: x, fgKey: foregroundKey(cell) };
+          }
+        }
+      }
+    }
+
+    if (!cell.isBgDefault()) {
+      const key = backgroundKey(cell);
+      if (key === runKey) {
+        runLength += 1;
+      } else {
+        commitRun();
+        runKey = key;
+        runStart = x;
+        runLength = 1;
+      }
+    } else if (runKey !== 'def') {
+      commitRun();
+      runKey = 'def';
+      runLength = 0;
+    }
+  }
+  commitRun();
+
+  return { quoteBar, bgRun, hasDefaultFg };
+}
+
+/** Wrap a live terminal's active buffer as a pure `BlockLineSource`. */
+export function createBufferLineSource(terminal: Terminal): BlockLineSource {
+  const buffer = terminal.buffer.active;
+  const cols = terminal.cols;
+  const reusableCell = buffer.getNullCell();
+
+  return {
+    length: buffer.length,
+    cols,
+    getLine(y: number): BlockLineFacts | undefined {
+      const line = buffer.getLine(y);
+      if (!line) return undefined;
+      const { quoteBar, bgRun, hasDefaultFg } = classifyLine(line, cols, reusableCell);
+      return {
+        isWrapped: line.isWrapped,
+        quoteBar,
+        bgRun,
+        hasDefaultFg,
+        text(startColumn = 0, endColumn?: number): string {
+          // Re-fetch by index so the returned facts never hold a stale line ref
+          // (xterm warns getLine results are only valid until the next update).
+          const fresh = buffer.getLine(y);
+          return fresh ? fresh.translateToString(false, startColumn, endColumn) : '';
+        },
+      };
+    },
+  };
+}
+
+/** Read xterm's CSS cell dimensions, or null if the render service is not ready. */
+export function readCellDimensions(terminal: Terminal): { width: number; height: number } | null {
+  const core = (terminal as unknown as XtermRenderCore)._core;
+  const cell = core?._renderService?.dimensions?.css?.cell;
+  if (!cell || !cell.width || !cell.height) return null;
+  return { width: cell.width, height: cell.height };
+}
+
+/** The `.xterm-screen` element's client rect, or null when unavailable. */
+export function getScreenRect(terminal: Terminal): DOMRect | null {
+  const screen = terminal.element?.querySelector('.xterm-screen');
+  return screen ? screen.getBoundingClientRect() : null;
+}
+
+/**
+ * Map client (viewport) coordinates to an absolute buffer row, or null when the
+ * point is outside the terminal's screen area.
+ */
+export function pixelToBufferRow(terminal: Terminal, clientX: number, clientY: number): number | null {
+  const rect = getScreenRect(terminal);
+  if (!rect) return null;
+  if (clientX < rect.left || clientX > rect.right || clientY < rect.top || clientY > rect.bottom) {
+    return null;
+  }
+  const dimensions = readCellDimensions(terminal);
+  if (!dimensions) return null;
+  const rowInViewport = Math.floor((clientY - rect.top) / dimensions.height);
+  const buffer = terminal.buffer.active;
+  const absoluteRow = buffer.viewportY + rowInViewport;
+  return Math.max(0, Math.min(absoluteRow, buffer.length - 1));
+}
+
+/** Find the block under a client point (hit test + expansion), or null. */
+export function findBlockAtPoint(terminal: Terminal, clientX: number, clientY: number): BlockRange | null {
+  const row = pixelToBufferRow(terminal, clientX, clientY);
+  if (row == null) return null;
+  return findBlockAt(createBufferLineSource(terminal), row);
+}
+
+/** The kind of block under a client point, or null. Used by the hit-test probe. */
+export function blockKindAtPoint(terminal: Terminal, clientX: number, clientY: number): BlockKind | null {
+  return findBlockAtPoint(terminal, clientX, clientY)?.kind ?? null;
+}
+
+/** Extract the clean content of the block containing an absolute buffer row. */
+export function extractBlockContentAt(
+  terminal: Terminal,
+  bufferRow: number,
+): { kind: BlockKind; content: string; range: BlockRange } | null {
+  const source = createBufferLineSource(terminal);
+  const range = findBlockAt(source, bufferRow);
+  if (!range) return null;
+  return { kind: range.kind, content: extractBlockContent(source, range), range };
+}
+
+/** A block's pixel rectangle relative to the `.xterm-screen` top-left, clamped to the viewport. */
+export interface BlockPixelBounds {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Compute the pixel rectangle covering a block within the visible viewport, so
+ * the UI can draw a hover highlight and anchor the copy button to it. The
+ * highlight always spans the full terminal width (consistent framing regardless
+ * of block kind or content extent). Returns null when the block is fully
+ * scrolled out of view or metrics are unavailable. Coordinates are relative to
+ * the `.xterm-screen` element's top-left corner.
+ */
+export function getBlockPixelBounds(terminal: Terminal, range: BlockRange): BlockPixelBounds | null {
+  const dimensions = readCellDimensions(terminal);
+  if (!dimensions) return null;
+  const viewportY = terminal.buffer.active.viewportY;
+  const maxRow = terminal.rows - 1;
+
+  const topRow = Math.max(range.startY - viewportY, 0);
+  const bottomRow = Math.min(range.endY - viewportY, maxRow);
+  if (bottomRow < 0 || topRow > maxRow) return null;
+
+  return {
+    top: topRow * dimensions.height,
+    left: 0,
+    width: terminal.cols * dimensions.width,
+    height: (bottomRow - topRow + 1) * dimensions.height,
+  };
+}
+
+/**
+ * Clean the current terminal selection using buffer attributes (stripping quote
+ * decoration from decorated rows). Falls back to `fallback()` when there is no
+ * selection or the buffer read throws, so behavior is never worse than the
+ * legacy string-based clean. The fallback is injected to avoid a circular import
+ * with `terminal-clipboard.ts`.
+ */
+export function cleanTerminalSelection(terminal: Terminal, fallback: () => string): string {
+  const range = terminal.getSelectionPosition();
+  if (!range) return fallback();
+  try {
+    return cleanSelectionLines(createBufferLineSource(terminal), range);
+  } catch {
+    return fallback();
+  }
+}

--- a/src/renderer/utils/terminal-block-buffer.ts
+++ b/src/renderer/utils/terminal-block-buffer.ts
@@ -226,9 +226,9 @@ export function getBlockPixelBounds(terminal: Terminal, range: BlockRange): Bloc
  * with `terminal-clipboard.ts`.
  */
 export function cleanTerminalSelection(terminal: Terminal, fallback: () => string): string {
-  const range = terminal.getSelectionPosition();
-  if (!range) return fallback();
   try {
+    const range = terminal.getSelectionPosition();
+    if (!range) return fallback();
     return cleanSelectionLines(createBufferLineSource(terminal), range);
   } catch {
     return fallback();

--- a/src/renderer/utils/terminal-blocks.ts
+++ b/src/renderer/utils/terminal-blocks.ts
@@ -1,0 +1,438 @@
+// Pure detection and extraction of "special text blocks" (quote blocks and
+// shaded code/content boxes) from a terminal buffer, so their content can be
+// copied without the CLI's visual decoration (the left quote bar and the
+// leading indentation the agent paints in front of quoted / boxed text).
+//
+// This module is intentionally DOM-free and does not import any runtime value
+// from '@xterm/xterm', so it can be unit-tested under vitest (Node, no jsdom)
+// by feeding a synthetic BlockLineSource. The live bridge that adapts a real
+// xterm IBuffer to this interface lives in `terminal-block-buffer.ts`.
+//
+// Detection is a GENERIC VISUAL heuristic (glyph class + non-default cell
+// attributes), never keyed to an agent name or to specific RGB values, per
+// `.claude/rules/agent-adapters-boundary.md`. Color keys are opaque strings
+// compared only for equality WITHIN a candidate block, never matched against a
+// hardcoded constant.
+//
+// Empirical basis (captured from live Claude Code v2.1.198 by reconstructing the
+// interpreted xterm buffer from raw scrollback):
+//   - Quote lines paint a left bar glyph (U+258E "▎") as the first non-space
+//     cell with a non-default RGB foreground, repeated per row.
+//   - Boxed content paints an identical non-default RGB background across a run
+//     of consecutive cells (observed full-width, starting near column 0-3).
+//   - `getSelectionPosition()` returns a half-open range: end.x is EXCLUSIVE
+//     (a 3-char selection at column 2 reports start.x=2, end.x=5).
+
+/** Facts about one buffer row, produced by an adapter (real IBuffer or a test fake). */
+export interface BlockLineFacts {
+  /** True when this row is a soft-wrap continuation of the previous row. */
+  readonly isWrapped: boolean;
+  /**
+   * Present when the first non-space cell is a left-bar glyph painted with a
+   * non-default foreground (a quote-decorated line).
+   */
+  readonly quoteBar: { readonly column: number; readonly fgKey: string } | null;
+  /**
+   * The first qualifying run of consecutive cells sharing an identical
+   * non-default background color. `endColumn` is EXCLUSIVE.
+   */
+  readonly bgRun: { readonly key: string; readonly startColumn: number; readonly endColumn: number } | null;
+  /**
+   * True when the row has at least one non-space cell painted in the DEFAULT
+   * foreground (i.e. real body text). A row rendered entirely in a non-default
+   * foreground is a de-emphasized status / "thinking" line, not message content.
+   */
+  readonly hasDefaultFg: boolean;
+  /**
+   * The row text between buffer columns [startColumn, endColumn) (endColumn
+   * exclusive), wide-character safe. The adapter delegates to
+   * `IBufferLine.translateToString`; test fakes slice a plain string.
+   */
+  text(startColumn?: number, endColumn?: number): string;
+}
+
+/** A source of classified buffer rows. */
+export interface BlockLineSource {
+  /** Total buffer lines (scrollback + viewport). */
+  readonly length: number;
+  /** Terminal width in columns. */
+  readonly cols: number;
+  getLine(y: number): BlockLineFacts | undefined;
+}
+
+export type BlockKind = 'quote' | 'box' | 'text' | 'message';
+
+export interface BlockRange {
+  readonly kind: BlockKind;
+  readonly startY: number;
+  readonly endY: number;
+  /** Set for quote blocks: the buffer column of the bar glyph. */
+  readonly barColumn?: number;
+}
+
+/** A half-open selection range as reported by xterm's `getSelectionPosition()` (end.x exclusive). */
+export interface SelectionRange {
+  readonly start: { readonly x: number; readonly y: number };
+  readonly end: { readonly x: number; readonly y: number };
+}
+
+/**
+ * Left block-element bar glyphs (U+258F..U+2589) used as quote / emphasis bars.
+ * Box-drawing verticals (U+2502 "│", U+2503 "┃") are DELIBERATELY EXCLUDED: they
+ * form box borders, so including them would mis-detect a box sidewall as a quote.
+ */
+export const BAR_GLYPHS: ReadonlySet<string> = new Set(['▏', '▎', '▍', '▌', '▋', '▊', '▉']);
+
+/** A background run must span at least this many cells to count as a shaded box. */
+export const MIN_BOX_RUN_CELLS = 6;
+
+/** A background run must start at or before this column to count as a shaded box. */
+export const MAX_BOX_RUN_START_COLUMN = 8;
+
+/**
+ * Leading marker glyphs stripped from the first line of a block: list bullets and
+ * the CLI prompt marker (`❯`). A copied message / list item / prompt loses its
+ * marker. Restricted to these glyphs (not ASCII `-` / `*` / `>`) so a line of
+ * prose or code that happens to start with a dash or angle bracket is never altered.
+ */
+export const LEADING_MARKER_GLYPHS: ReadonlySet<string> = new Set(['•', '‣', '◦', '▪', '▫', '·', '●', '∙', '❯']);
+
+// Agent-TUI marker glyphs (Claude Code and similar CLIs). Detected as generic
+// visual markers (like the quote bar and list bullets), not by agent name.
+/** Bullet that starts an assistant message or tool call (e.g. "● Update(README.md)"). */
+const MESSAGE_BULLET = '●';
+/** Prompt marker that starts a user input line (a shaded box). */
+const PROMPT_GLYPH = '❯';
+/** Star / spinner glyphs that lead a de-emphasized "thinking" status line ("✻ Cogitated for 16s"). */
+const THINKING_GLYPHS: ReadonlySet<string> = new Set(['✻', '✽', '✶', '✳', '✢', '✷', '✴', '✵', '❋', '✱', '✲', '✦', '✧', '⏺']);
+
+/** The first non-space glyph of a row, or '' when blank. */
+function firstGlyph(line: BlockLineFacts | undefined): string {
+  if (!line) return '';
+  return line.text().replace(/^\s+/, '').charAt(0);
+}
+
+function isThinkingRow(line: BlockLineFacts | undefined): boolean {
+  return THINKING_GLYPHS.has(firstGlyph(line));
+}
+
+/** A row that bounds a message block: the next message's bullet, a thinking line, or a user prompt. */
+function isMessageBoundary(line: BlockLineFacts | undefined): boolean {
+  const glyph = firstGlyph(line);
+  return glyph === MESSAGE_BULLET || glyph === PROMPT_GLYPH || THINKING_GLYPHS.has(glyph);
+}
+
+/**
+ * How far a message-start scan looks back before giving up. `findBlockAt` calls
+ * `findMessageStart` unconditionally, so an uncapped scan is O(scrollback) on
+ * every hit test for any terminal with no bullet / boundary glyph above the hit
+ * row - a plain shell (the Command Terminal) or a hover deep inside one very
+ * large message - and that cost lands on the render-thread critical path (hover
+ * moves and up to ~60/sec streaming-refresh redraws). A message whose bullet
+ * sits more than this many rows above the hit row is simply not recognized as a
+ * single block (it degrades to a text / box / quote block), an acceptable trade.
+ */
+export const MAX_MESSAGE_LOOKBACK_ROWS = 500;
+
+/** Scan up from a row to the bullet that owns it, stopping at a thinking line, a user prompt, or the lookback limit. */
+function findMessageStart(source: BlockLineSource, y: number): number | null {
+  const limit = Math.max(0, y - MAX_MESSAGE_LOOKBACK_ROWS);
+  for (let currentRow = y; currentRow >= limit; currentRow -= 1) {
+    const glyph = firstGlyph(source.getLine(currentRow));
+    if (glyph === MESSAGE_BULLET) return currentRow;
+    if (glyph === PROMPT_GLYPH || THINKING_GLYPHS.has(glyph)) return null;
+  }
+  return null;
+}
+
+function isBlankRow(line: BlockLineFacts | undefined): boolean {
+  return !line || line.text().trim() === '';
+}
+
+function isDecoratedRow(line: BlockLineFacts | undefined): boolean {
+  return !!line && (!!line.quoteBar || !!line.bgRun);
+}
+
+/**
+ * A primary text-content row: non-blank, undecorated, with real default-fg text.
+ * A de-emphasized status / "thinking" line (undecorated but rendered entirely in
+ * a non-default foreground) fails this test, so it is never copyable and always
+ * bounds a text message rather than merging into it.
+ */
+function isContentRow(line: BlockLineFacts | undefined): boolean {
+  return !!line && !isBlankRow(line) && !isDecoratedRow(line) && line.hasDefaultFg;
+}
+
+/** A row that may be absorbed into a text message (content, or an interior blank). */
+function isMergeableRow(line: BlockLineFacts | undefined): boolean {
+  return isContentRow(line) || isBlankRow(line);
+}
+
+/**
+ * Given a buffer row, find the special block that contains it (expanding up and
+ * down to the block's bounds), or null when the row is not inside a block.
+ *
+ * Quote blocks expand while neighbor rows share the same bar column AND fg color.
+ * Box blocks expand while neighbor rows share the same background color key and
+ * their column runs overlap (so two vertically stacked but distinct boxes that
+ * happen to share a color do not merge).
+ */
+export function findBlockAt(source: BlockLineSource, y: number): BlockRange | null {
+  const line = source.getLine(y);
+  if (!line) return null;
+
+  // Thinking / status lines ("✻ Cogitated for 16s") are not copyable.
+  if (isThinkingRow(line)) return null;
+
+  // Message / tool block, delimited by "●" bullets. A block runs from its bullet
+  // down to (but not including) the next bullet, a thinking line, or a user
+  // prompt - so the bullet's sub-lines ("Searched...", "⎿ Added 1 line") and any
+  // code / diff it emitted stay in the same block. Takes precedence over the
+  // box / quote / text paths so a code block inside a message is not split out.
+  const messageStart = findMessageStart(source, y);
+  if (messageStart != null) {
+    let endY = messageStart;
+    while (endY + 1 < source.length && !isMessageBoundary(source.getLine(endY + 1))) endY += 1;
+    while (endY > messageStart && isBlankRow(source.getLine(endY))) endY -= 1;
+    return { kind: 'message', startY: messageStart, endY };
+  }
+
+  if (line.quoteBar) {
+    const { column, fgKey } = line.quoteBar;
+    let startY = y;
+    let endY = y;
+    while (startY - 1 >= 0) {
+      const previous = source.getLine(startY - 1);
+      if (previous?.quoteBar && previous.quoteBar.column === column && previous.quoteBar.fgKey === fgKey) {
+        startY -= 1;
+      } else {
+        break;
+      }
+    }
+    while (endY + 1 < source.length) {
+      const next = source.getLine(endY + 1);
+      if (next?.quoteBar && next.quoteBar.column === column && next.quoteBar.fgKey === fgKey) {
+        endY += 1;
+      } else {
+        break;
+      }
+    }
+    return { kind: 'quote', startY, endY, barColumn: column };
+  }
+
+  if (line.bgRun) {
+    let startY = y;
+    let endY = y;
+    while (startY - 1 >= 0) {
+      const previous = source.getLine(startY - 1);
+      const current = source.getLine(startY);
+      if (previous?.bgRun && current?.bgRun && bgRunsContinue(previous.bgRun, current.bgRun)) {
+        startY -= 1;
+      } else {
+        break;
+      }
+    }
+    while (endY + 1 < source.length) {
+      const next = source.getLine(endY + 1);
+      const current = source.getLine(endY);
+      if (next?.bgRun && current?.bgRun && bgRunsContinue(next.bgRun, current.bgRun)) {
+        endY += 1;
+      } else {
+        break;
+      }
+    }
+    return { kind: 'box', startY, endY };
+  }
+
+  if (isContentRow(line)) {
+    // A text message merges consecutive content rows AND the blank lines between
+    // them (so a multi-paragraph reply is one block), bounded by decorated blocks,
+    // muted / "thinking" lines, and the buffer edges. Blanks absorbed at the ends
+    // are then trimmed off.
+    let startY = y;
+    let endY = y;
+    while (startY - 1 >= 0 && isMergeableRow(source.getLine(startY - 1))) startY -= 1;
+    while (endY + 1 < source.length && isMergeableRow(source.getLine(endY + 1))) endY += 1;
+    while (startY < endY && isBlankRow(source.getLine(startY))) startY += 1;
+    while (endY > startY && isBlankRow(source.getLine(endY))) endY -= 1;
+    return { kind: 'text', startY, endY };
+  }
+
+  return null;
+}
+
+function bgRunsContinue(
+  a: { key: string; startColumn: number; endColumn: number },
+  b: { key: string; startColumn: number; endColumn: number },
+): boolean {
+  return a.key === b.key && a.startColumn < b.endColumn && b.startColumn < a.endColumn;
+}
+
+/**
+ * Extract the clean content of a block: the left bar / leading indent that the
+ * CLI painted for decoration is removed, while relative indentation inside the
+ * block and interior blank lines are preserved.
+ */
+export function extractBlockContent(source: BlockLineSource, range: BlockRange): string {
+  const rawLines: { text: string; isWrapped: boolean }[] = [];
+
+  let boxStart = Number.POSITIVE_INFINITY;
+  let boxEnd = Number.NEGATIVE_INFINITY;
+  if (range.kind === 'box') {
+    for (let y = range.startY; y <= range.endY; y += 1) {
+      const line = source.getLine(y);
+      if (line?.bgRun) {
+        boxStart = Math.min(boxStart, line.bgRun.startColumn);
+        boxEnd = Math.max(boxEnd, line.bgRun.endColumn);
+      }
+    }
+  }
+
+  // For a text paragraph, strip a leading marker (bullet / prompt) on the first
+  // line (and its trailing gap) so the content aligns; continuation lines are
+  // indented to the same column, so slicing every row there yields clean text.
+  const textContentColumn = range.kind === 'text' ? leadingMarkerContentColumn(source.getLine(range.startY)?.text() ?? '') : 0;
+
+  for (let y = range.startY; y <= range.endY; y += 1) {
+    const line = source.getLine(y);
+    if (!line) {
+      rawLines.push({ text: '', isWrapped: false });
+      continue;
+    }
+    let text: string;
+    if (range.kind === 'quote') {
+      text = line.text((range.barColumn ?? 0) + 1);
+    } else if (range.kind === 'box' && Number.isFinite(boxStart)) {
+      text = line.text(boxStart, boxEnd);
+    } else if (range.kind === 'text') {
+      text = line.text(textContentColumn);
+    } else {
+      text = line.text();
+    }
+    rawLines.push({ text, isWrapped: line.isWrapped });
+  }
+
+  // Box and message rows do not share one content column. Replace the leading
+  // marker (the `❯` prompt or `●` bullet) on the first non-blank line with a
+  // space rather than slicing it off, so the line keeps its left margin and the
+  // common-indent dedent below removes that margin uniformly (left-aligning it).
+  if (range.kind === 'box' || range.kind === 'message') {
+    const firstNonBlank = rawLines.find((row) => row.text.trim() !== '');
+    if (firstNonBlank) firstNonBlank.text = neutralizeLeadingMarker(firstNonBlank.text);
+  }
+
+  // Each visual row becomes its own line. xterm's wrap flag is unreliable in the
+  // agent TUI - a full-width background fill sets it on every box row, and
+  // word-wrapped prose leaves it unset - so merging on it both keeps padding
+  // (huge interior gaps) and falsely joins separate lines (e.g. two bullets).
+  // Keeping one line per row trims each row's padding and never mis-joins.
+  return finalizeLines(rawLines, undefined, false);
+}
+
+/**
+ * If a string's first non-space glyph is a leading marker (bullet / prompt),
+ * return the column where its content begins (past the marker and the following
+ * gap); otherwise 0.
+ */
+function leadingMarkerContentColumn(text: string): number {
+  const firstNonSpace = text.search(/\S/);
+  if (firstNonSpace < 0 || !LEADING_MARKER_GLYPHS.has(text[firstNonSpace])) return 0;
+  const afterMarker = text.slice(firstNonSpace + 1);
+  const gap = afterMarker.length - afterMarker.replace(/^ +/, '').length;
+  return firstNonSpace + 1 + gap;
+}
+
+/** Replace a leading marker glyph (bullet / prompt) with a space, keeping every column position so the common-indent dedent can remove it. */
+function neutralizeLeadingMarker(text: string): string {
+  const firstNonSpace = text.search(/\S/);
+  if (firstNonSpace < 0 || !LEADING_MARKER_GLYPHS.has(text[firstNonSpace])) return text;
+  return `${text.slice(0, firstNonSpace)} ${text.slice(firstNonSpace + 1)}`;
+}
+
+/**
+ * Clean a selection for copy: strip quote decoration on each selected row where
+ * the buffer proves the row is decorated (the first non-space cell is a bar
+ * glyph and the selection actually covers it). Plain rows are copied verbatim
+ * (within the selected columns). Soft wraps are unwrapped using the real
+ * `isWrapped` flag rather than a column heuristic.
+ */
+export function cleanSelectionLines(source: BlockLineSource, range: SelectionRange): string {
+  const rows: { text: string; isWrapped: boolean; decorated: boolean }[] = [];
+
+  for (let y = range.start.y; y <= range.end.y; y += 1) {
+    const line = source.getLine(y);
+    if (!line) {
+      rows.push({ text: '', isWrapped: false, decorated: false });
+      continue;
+    }
+    const lineStart = y === range.start.y ? range.start.x : 0;
+    const lineEnd = y === range.end.y ? range.end.x : source.cols;
+
+    if (line.quoteBar && lineStart <= line.quoteBar.column) {
+      // Selection covers the bar: this row is decorated. Take the text after
+      // the bar; the uniform leading gap is removed by the shared dedent below.
+      const contentStart = Math.max(lineStart, line.quoteBar.column + 1);
+      rows.push({ text: line.text(contentStart, lineEnd), isWrapped: line.isWrapped, decorated: true });
+    } else {
+      rows.push({ text: line.text(lineStart, lineEnd), isWrapped: line.isWrapped, decorated: false });
+    }
+  }
+
+  return finalizeLines(rows, (row) => row.decorated === true);
+}
+
+/**
+ * Join soft-wrapped rows, dedent the common leading whitespace of the eligible
+ * lines, trim trailing whitespace per line, and trim outer blank lines.
+ *
+ * `dedentEligible` selects which logical lines participate in the common-indent
+ * calculation and dedent. When omitted, every line is eligible (block
+ * extraction). For selection cleaning, only decorated rows are dedented so a
+ * plain line mixed into the selection keeps its own indentation.
+ */
+function finalizeLines(
+  rows: { text: string; isWrapped: boolean; decorated?: boolean }[],
+  dedentEligible?: (row: { text: string; isWrapped: boolean; decorated?: boolean }) => boolean,
+  mergeWrapped = true,
+): string {
+  // 1. Merge soft-wrap continuations into logical lines. Disabled for shaded
+  //    boxes: their full-width background fill sets xterm's wrap flag on every
+  //    row, so merging would collapse the box into one padded line.
+  const logical: { text: string; eligible: boolean }[] = [];
+  for (let i = 0; i < rows.length; i += 1) {
+    const row = rows[i];
+    const eligible = dedentEligible ? dedentEligible(row) : true;
+    if (mergeWrapped && i > 0 && row.isWrapped && logical.length > 0) {
+      logical[logical.length - 1].text += row.text;
+    } else {
+      logical.push({ text: row.text, eligible });
+    }
+  }
+
+  // 2. Trim trailing whitespace per logical line.
+  for (const entry of logical) {
+    entry.text = entry.text.replace(/\s+$/, '');
+  }
+
+  // 3. Dedent the common leading whitespace across eligible, non-blank lines.
+  let commonIndent = Number.POSITIVE_INFINITY;
+  for (const entry of logical) {
+    if (!entry.eligible || entry.text === '') continue;
+    const leading = entry.text.length - entry.text.replace(/^ +/, '').length;
+    commonIndent = Math.min(commonIndent, leading);
+  }
+  if (Number.isFinite(commonIndent) && commonIndent > 0) {
+    for (const entry of logical) {
+      if (entry.eligible && entry.text !== '') {
+        entry.text = entry.text.slice(commonIndent);
+      }
+    }
+  }
+
+  // 4. Trim outer blank lines; preserve interior blanks.
+  const result = logical.map((entry) => entry.text);
+  while (result.length > 0 && result[0] === '') result.shift();
+  while (result.length > 0 && result[result.length - 1] === '') result.pop();
+
+  return result.join('\n');
+}

--- a/src/renderer/utils/terminal-clipboard.ts
+++ b/src/renderer/utils/terminal-clipboard.ts
@@ -1,4 +1,5 @@
 import { Terminal } from '@xterm/xterm';
+import { cleanTerminalSelection } from './terminal-block-buffer';
 
 // ---------------------------------------------------------------------------
 // OSC 52 clipboard sequence handling
@@ -97,9 +98,9 @@ export function cleanSelection(raw: string, cols: number): string {
  * failed write is swallowed. No-op when there is no selection.
  */
 export function copySelectionToClipboard(terminal: Terminal): void {
-  const selection = terminal.getSelection();
-  if (!selection) return;
-  const cleaned = cleanSelection(selection, terminal.cols);
+  // Strip quote-bar decoration via the buffer when possible; fall back to the
+  // legacy string clean when the selection can't be read from the buffer.
+  const cleaned = cleanTerminalSelection(terminal, () => cleanSelection(terminal.getSelection(), terminal.cols));
   if (cleaned) window.electronAPI.clipboard.writeText(cleaned).catch(() => { /* best-effort */ });
 }
 

--- a/src/renderer/utils/terminal-registry.ts
+++ b/src/renderer/utils/terminal-registry.ts
@@ -1,0 +1,71 @@
+// A registry of mounted xterm terminals keyed by their container element, so
+// the main-process context-menu handler can hit-test a right-click against the
+// terminal under the cursor (via a window-global QUERY function) without any new
+// IPC channel. Actions still travel back as CustomEvents; this global only
+// answers "is there a block here, and what kind" so the menu can decide whether
+// to show a "Copy Block" item.
+import type { Terminal } from '@xterm/xterm';
+import { blockKindAtPoint } from './terminal-block-buffer';
+import type { BlockKind } from './terminal-blocks';
+import { useConfigStore } from '../stores/config-store';
+
+/** Result of probing a client point for a copyable terminal block. */
+export interface TerminalBlockHitTestResult {
+  isTerminal: boolean;
+  blockKind: BlockKind | null;
+}
+
+// Live terminals keyed by their container element. Preserved across HMR (Pattern
+// A in .claude/rules/hmr-patterns.md) so a hot edit of this module does not
+// orphan terminals that the previous module instance registered.
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+const registeredTerminals: Map<HTMLElement, Terminal> = import.meta.hot?.data?.registeredTerminals ?? new Map();
+
+// @ts-expect-error -- Vite handles import.meta.hot
+if (import.meta.hot) {
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.dispose((data: Record<string, unknown>) => {
+    data.registeredTerminals = registeredTerminals;
+  });
+}
+
+/** Register a mounted terminal and its container. Returns an unregister function. */
+export function registerTerminal(terminal: Terminal, container: HTMLElement): () => void {
+  registeredTerminals.set(container, terminal);
+  return () => {
+    if (registeredTerminals.get(container) === terminal) {
+      registeredTerminals.delete(container);
+    }
+  };
+}
+
+/** Find the registered terminal whose container contains a client point. */
+export function findTerminalAt(clientX: number, clientY: number): Terminal | null {
+  for (const [container, terminal] of registeredTerminals) {
+    const rect = container.getBoundingClientRect();
+    if (clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom) {
+      return terminal;
+    }
+  }
+  return null;
+}
+
+/** Answer whether a client point lands on a terminal and, if so, on a block. */
+export function hitTestTerminalBlock(clientX: number, clientY: number): TerminalBlockHitTestResult {
+  // Stand down entirely when the user has disabled the block-copy affordance.
+  if (!useConfigStore.getState().config.terminalBlockCopy) return { isTerminal: false, blockKind: null };
+  const terminal = findTerminalAt(clientX, clientY);
+  if (!terminal) return { isTerminal: false, blockKind: null };
+  return { isTerminal: true, blockKind: blockKindAtPoint(terminal, clientX, clientY) };
+}
+
+declare global {
+  interface Window {
+    __kangenticTerminalBlockHitTest?: (clientX: number, clientY: number) => TerminalBlockHitTestResult;
+  }
+}
+
+// Expose the hit-test as a window global for the main-process context-menu
+// probe (executeJavaScript). A module re-eval under HMR simply re-points it at
+// the new function, which reads the preserved registry, so no cleanup is needed.
+window.__kangenticTerminalBlockHitTest = hitTestTerminalBlock;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1571,6 +1571,9 @@ export interface AppConfig {
   skipDeleteConfirm: boolean;
   skipBoardConfigConfirm: boolean;
   autoFocusIdleSession: boolean;
+  /** Show the hover highlight, copy button, click-to-copy, and right-click "Copy Block"
+   *  affordance over quote / code / message blocks in the terminal. Default `true`. */
+  terminalBlockCopy: boolean;
   /** Click-outside dismiss policy for modeless task-detail windows. Default `single`. */
   windowLightDismiss: WindowLightDismiss;
   /** Task IDs that have already been offered an auto-rename suggestion. Persisted so a
@@ -1745,6 +1748,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   skipDeleteConfirm: false,
   skipBoardConfigConfirm: false,
   autoFocusIdleSession: false,
+  terminalBlockCopy: true,
   windowLightDismiss: 'single',
   autoNameAskedTaskIds: [],
   autoNameRateLimitPerHour: 60,

--- a/tests/ui/fixtures/terminal-block-fixture.ts
+++ b/tests/ui/fixtures/terminal-block-fixture.ts
@@ -1,0 +1,34 @@
+// Emulated PTY scrollback that paints a quote block and a shaded code box, using
+// the interpreted-buffer shapes captured from live Claude Code (see the Phase 0
+// notes in src/renderer/utils/terminal-blocks.ts): a left bar glyph (U+258E)
+// with a non-default RGB foreground for the quote, and an identical non-default
+// RGB background run for the box.
+//
+// CRLF (\r\n) here is real PTY output, not authored line-ending punctuation: a
+// bare \n advances the row without a carriage return, so the terminal would
+// render a staircase. This is recorded terminal data (the documented exception
+// in .claude/rules/text-formatting.md and cross-platform-parity.md).
+const NL = '\r\n';
+const ESC = '\x1b';
+const ORANGE = `${ESC}[38;2;215;119;87m`;
+const RESET = `${ESC}[m`;
+const BG = `${ESC}[48;2;55;55;55m`;
+const WHITE = `${ESC}[38;2;255;255;255m`;
+const CLEAR_EOL = `${ESC}[0K`;
+
+/** The clean lines the quote block should yield when copied (no bar, no gap). */
+export const QUOTE_LINES = ['Quote line one', 'Quote line two', 'Quote line three', 'Quote line four'];
+
+/** The clean lines the code box should yield when copied (dedented). */
+export const BOX_LINES = ['const answer = 42;', 'return answer;'];
+
+/** Emulated scrollback: intro, a 4-row quote block, a plain gap, a 2-row shaded box. */
+export const TERMINAL_BLOCK_FIXTURE =
+  [
+    'Normal intro line',
+    ...QUOTE_LINES.map((line) => `${ORANGE}▎${RESET} ${line}`),
+    'Between the blocks',
+    '',
+    ...BOX_LINES.map((line) => `${BG}${WHITE}  ${line}${CLEAR_EOL}${RESET}`),
+    'Trailing plain line',
+  ].join(NL) + NL;

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -134,6 +134,7 @@
     skipDeleteConfirm: false,
     skipBoardConfigConfirm: false,
     autoFocusIdleSession: false,
+    terminalBlockCopy: true,
     windowLightDismiss: 'single',
     autoNameAskedTaskIds: [],
     autoNameRateLimitPerHour: 60,

--- a/tests/ui/terminal-block-copy.spec.ts
+++ b/tests/ui/terminal-block-copy.spec.ts
@@ -1,0 +1,301 @@
+/**
+ * UI tests for copying special terminal blocks (quote / code) without CLI
+ * decoration. Drives a real mounted xterm in the command-bar terminal:
+ *
+ *   1. The renderer hit-test global (`window.__kangenticTerminalBlockHitTest`)
+ *      reports the correct block kind under a point (used by the main-process
+ *      context-menu probe).
+ *   2. Dispatching the `terminal-copy-block` CustomEvent (as the native "Copy
+ *      Block" menu item does) copies the block's clean content to the clipboard.
+ *   3. The hover copy button appears over a block and copies clean content.
+ *
+ * The block content is written into xterm via the scrollback-replay path
+ * (getScrollback override), the same mechanism used when a background session's
+ * terminal is rebuilt. navigator.clipboard.writeText is stubbed into a recorder.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+import { TERMINAL_BLOCK_FIXTURE, QUOTE_LINES, BOX_LINES } from './fixtures/terminal-block-fixture';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-block-copy-test';
+const TRANSIENT_SESSION_ID = 'sess-block-copy-1';
+
+function basePreConfigScript(): string {
+  return `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+      state.projects.push({
+        id: '${PROJECT_ID}',
+        name: 'Block Copy Test Project',
+        path: '/mock/block-copy-test',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        state.swimlanes.push(Object.assign({}, s, {
+          id: 'lane-bc-' + i,
+          position: i,
+          created_at: ts,
+        }));
+      });
+      return { currentProjectId: '${PROJECT_ID}' };
+    });
+  `;
+}
+
+// Deterministic transient spawn + getScrollback returning the block fixture +
+// a clipboard recorder. The fixture is painted into xterm by useTerminal's
+// scrollback replay once the command terminal resolves its session id.
+const setupScript = `
+  window.__clipboardWrites = [];
+  try {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: function (text) { window.__clipboardWrites.push(String(text)); return Promise.resolve(); },
+        readText: function () { return Promise.resolve(''); },
+      },
+    });
+  } catch (err) { /* clipboard already locked; test will surface it */ }
+
+  // The context-menu copy-block path writes via the focus-independent main-process
+  // clipboard (Menu.popup steals document focus, so navigator.clipboard rejects).
+  // Record both into the same recorder.
+  window.electronAPI.clipboard.writeText = function (text) { window.__clipboardWrites.push(String(text)); return Promise.resolve(); };
+
+  window.electronAPI.sessions.spawnTransient = async function (input) {
+    return {
+      session: {
+        id: '${TRANSIENT_SESSION_ID}',
+        taskId: '${TRANSIENT_SESSION_ID}',
+        projectId: input.projectId,
+        pid: null,
+        status: 'running',
+        shell: '/bin/bash',
+        cwd: '/mock/block-copy-test',
+        startedAt: new Date().toISOString(),
+        exitCode: null,
+        resuming: false,
+        transient: true,
+      },
+      branch: 'main',
+    };
+  };
+
+  window.electronAPI.sessions.getScrollback = async function () {
+    return ${JSON.stringify(TERMINAL_BLOCK_FIXTURE)};
+  };
+`;
+
+async function launch(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady();
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(basePreConfigScript());
+  await page.addInitScript(setupScript);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  return { browser, page };
+}
+
+async function openTerminalWithFixture(page: Page): Promise<void> {
+  await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+  await page.keyboard.press('Control+Shift+P');
+  await expect(page.getByTestId('command-terminal-window')).toBeVisible();
+
+  // Flip terminalReady so the command terminal resolves its session id and
+  // useTerminal replays the (overridden) scrollback fixture into xterm.
+  await page.evaluate((sessionId) => {
+    const stores = (window as unknown as {
+      __zustandStores?: { session?: { getState: () => { markFirstOutput: (id: string) => void } } };
+    }).__zustandStores;
+    stores?.session?.getState().markFirstOutput(sessionId);
+  }, TRANSIENT_SESSION_ID);
+
+  await expect(
+    page.getByTestId('command-terminal-window').locator('.xterm-helper-textarea').first(),
+  ).toBeAttached({ timeout: 8000 });
+}
+
+/**
+ * Sweep vertical points down the terminal screen and return, for each block
+ * kind, a client point that lands on it. Polls until the fixture has painted
+ * (a quote point is found), proving both the replay and detection work.
+ */
+async function findBlockPoints(page: Page): Promise<{ quote: { x: number; y: number } | null; box: { x: number; y: number } | null }> {
+  return await page.evaluate(() => {
+    const screen = document.querySelector('[data-testid="command-terminal-window"] .xterm-screen');
+    if (!screen) return { quote: null, box: null };
+    const rect = screen.getBoundingClientRect();
+    const hitTest = window.__kangenticTerminalBlockHitTest;
+    if (!hitTest) return { quote: null, box: null };
+    const x = Math.round(rect.left + rect.width * 0.3);
+    let quote: { x: number; y: number } | null = null;
+    let box: { x: number; y: number } | null = null;
+    for (let i = 1; i < 60; i += 1) {
+      const y = Math.round(rect.top + (rect.height * i) / 60);
+      const result = hitTest(x, y);
+      if (!quote && result.blockKind === 'quote') quote = { x, y };
+      if (!box && result.blockKind === 'box') box = { x, y };
+    }
+    return { quote, box };
+  });
+}
+
+test.describe('terminal block copy', () => {
+  test('hit-test reports quote and box block kinds, and dispatch copies clean content', async () => {
+    const { browser, page } = await launch();
+    try {
+      await openTerminalWithFixture(page);
+
+      // Poll until the fixture has painted and both blocks are detectable.
+      let points: Awaited<ReturnType<typeof findBlockPoints>> = { quote: null, box: null };
+      await expect.poll(async () => {
+        points = await findBlockPoints(page);
+        return Boolean(points.quote && points.box);
+      }, { timeout: 8000 }).toBe(true);
+
+      // The intro line is plain prose - now a copyable 'text' block.
+      const introResult = await page.evaluate(() => {
+        const screen = document.querySelector('[data-testid="command-terminal-window"] .xterm-screen');
+        const rect = screen!.getBoundingClientRect();
+        return window.__kangenticTerminalBlockHitTest!(Math.round(rect.left + rect.width * 0.3), Math.round(rect.top + 2));
+      });
+      expect(introResult.isTerminal).toBe(true);
+      expect(introResult.blockKind).toBe('text');
+
+      // Copying the intro text block yields its prose.
+      const introPoint = await page.evaluate(() => {
+        const screen = document.querySelector('[data-testid="command-terminal-window"] .xterm-screen');
+        const rect = screen!.getBoundingClientRect();
+        return { x: Math.round(rect.left + rect.width * 0.3), y: Math.round(rect.top + 2) };
+      });
+      await page.evaluate((pt) => {
+        window.dispatchEvent(new CustomEvent('terminal-copy-block', { detail: pt }));
+      }, introPoint);
+      await expect.poll(async () => {
+        return page.evaluate(() => window.__clipboardWrites as string[]);
+      }, { timeout: 3000 }).toContain('Normal intro line');
+
+      // Dispatch the copy-block action at the quote point (as the menu item does).
+      await page.evaluate((pt) => {
+        window.dispatchEvent(new CustomEvent('terminal-copy-block', { detail: pt }));
+      }, points.quote!);
+
+      await expect.poll(async () => {
+        return page.evaluate(() => window.__clipboardWrites as string[]);
+      }, { timeout: 3000 }).toContain(QUOTE_LINES.join('\n'));
+
+      // And at the box point.
+      await page.evaluate((pt) => {
+        window.dispatchEvent(new CustomEvent('terminal-copy-block', { detail: pt }));
+      }, points.box!);
+
+      await expect.poll(async () => {
+        return page.evaluate(() => window.__clipboardWrites as string[]);
+      }, { timeout: 3000 }).toContain(BOX_LINES.join('\n'));
+
+      // The copied text carries no CLI decoration.
+      const writes = await page.evaluate(() => window.__clipboardWrites as string[]);
+      expect(writes.some((w) => w.includes('▎'))).toBe(false);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('hover shows the copy button and clicking it copies clean block content', async () => {
+    const { browser, page } = await launch();
+    try {
+      await openTerminalWithFixture(page);
+
+      let points: Awaited<ReturnType<typeof findBlockPoints>> = { quote: null, box: null };
+      await expect.poll(async () => {
+        points = await findBlockPoints(page);
+        return Boolean(points.quote);
+      }, { timeout: 8000 }).toBe(true);
+
+      // Move the pointer over the quote block; the highlight and copy button appear.
+      await page.mouse.move(points.quote!.x, points.quote!.y, { steps: 5 });
+      const button = page.getByTestId('terminal-block-copy-button');
+      const highlight = page.getByTestId('terminal-block-copy-highlight');
+      await expect(button).toBeVisible({ timeout: 3000 });
+      await expect(highlight).toBeVisible({ timeout: 3000 });
+
+      await page.evaluate(() => { window.__clipboardWrites = []; });
+      await button.click();
+
+      await expect.poll(async () => {
+        return page.evaluate(() => window.__clipboardWrites as string[]);
+      }, { timeout: 3000 }).toContain(QUOTE_LINES.join('\n'));
+
+      // Moving the pointer off the terminal hides the button and highlight.
+      // `steps` forces intermediate moves so the boundary-crossing (mouseleave)
+      // actually fires (a single teleporting move dispatches nothing en route).
+      await page.mouse.move(5, 5, { steps: 10 });
+      await expect(button).toBeHidden({ timeout: 3000 });
+      await expect(highlight).toBeHidden({ timeout: 3000 });
+
+      // Clicking the block body (not the button) also copies it.
+      await page.evaluate(() => { window.__clipboardWrites = []; });
+      await page.mouse.click(points.quote!.x, points.quote!.y);
+      await expect.poll(async () => {
+        return page.evaluate(() => window.__clipboardWrites as string[]);
+      }, { timeout: 3000 }).toContain(QUOTE_LINES.join('\n'));
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('the terminalBlockCopy setting gates the whole affordance', async () => {
+    const { browser, page } = await launch();
+    try {
+      await openTerminalWithFixture(page);
+
+      let points: Awaited<ReturnType<typeof findBlockPoints>> = { quote: null, box: null };
+      await expect.poll(async () => {
+        points = await findBlockPoints(page);
+        return Boolean(points.quote);
+      }, { timeout: 8000 }).toBe(true);
+
+      // Feature on: the button appears on hover.
+      await page.mouse.move(points.quote!.x, points.quote!.y, { steps: 5 });
+      const button = page.getByTestId('terminal-block-copy-button');
+      await expect(button).toBeVisible({ timeout: 3000 });
+
+      // Turn the setting off via the config store.
+      await page.evaluate(() => {
+        const stores = (window as unknown as {
+          __zustandStores?: { config?: { setState: (fn: (s: { config: Record<string, unknown> }) => object) => void } };
+        }).__zustandStores;
+        stores?.config?.setState((s) => ({ config: { ...s.config, terminalBlockCopy: false } }));
+      });
+
+      // The hit-test global now stands down (no "Copy Block" menu item), and the
+      // hover button / highlight are gone.
+      await expect.poll(async () => {
+        return page.evaluate((pt) => window.__kangenticTerminalBlockHitTest!(pt!.x, pt!.y).blockKind, points.quote);
+      }, { timeout: 3000 }).toBeNull();
+      await expect(button).toBeHidden({ timeout: 3000 });
+    } finally {
+      await browser.close();
+    }
+  });
+});
+
+declare global {
+  interface Window {
+    __clipboardWrites: string[];
+  }
+}

--- a/tests/ui/terminal-block-copy.spec.ts
+++ b/tests/ui/terminal-block-copy.spec.ts
@@ -240,10 +240,23 @@ test.describe('terminal block copy', () => {
         return page.evaluate(() => window.__clipboardWrites as string[]);
       }, { timeout: 3000 }).toContain(QUOTE_LINES.join('\n'));
 
-      // Moving the pointer off the terminal hides the button and highlight.
-      // `steps` forces intermediate moves so the boundary-crossing (mouseleave)
-      // actually fires (a single teleporting move dispatches nothing en route).
-      await page.mouse.move(5, 5, { steps: 10 });
+      // Moving the pointer to a blank row (below the fixture content) hides the
+      // button and highlight. The move stays INSIDE the terminal, so mousemove
+      // fires reliably on every platform (exiting the element does not on the CI
+      // Linux runner); a blank row has no block, so handleMove hides it.
+      const blankPoint = await page.evaluate(() => {
+        const screen = document.querySelector('[data-testid="command-terminal-window"] .xterm-screen');
+        const rect = screen!.getBoundingClientRect();
+        const x = Math.round(rect.left + rect.width * 0.3);
+        for (let i = 59; i >= 1; i -= 1) {
+          const y = Math.round(rect.top + (rect.height * i) / 60);
+          const result = window.__kangenticTerminalBlockHitTest!(x, y);
+          if (result.isTerminal && result.blockKind === null) return { x, y };
+        }
+        return null;
+      });
+      expect(blankPoint).not.toBeNull();
+      await page.mouse.move(blankPoint!.x, blankPoint!.y, { steps: 10 });
       await expect(button).toBeHidden({ timeout: 3000 });
       await expect(highlight).toBeHidden({ timeout: 3000 });
 

--- a/tests/unit/terminal-block-buffer.test.ts
+++ b/tests/unit/terminal-block-buffer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Terminal, IBufferCell, IBufferLine } from '@xterm/xterm';
-import type { SelectionRange } from '../../src/renderer/utils/terminal-blocks';
+import type { SelectionRange, BlockRange } from '../../src/renderer/utils/terminal-blocks';
 
 // Spy on `cleanSelectionLines` while keeping every other export (including the
 // constants `classifyLine` uses) real, so `cleanTerminalSelection` can be
@@ -14,7 +14,12 @@ vi.mock('../../src/renderer/utils/terminal-blocks', async (importOriginal) => {
 });
 
 import { cleanSelectionLines, MIN_BOX_RUN_CELLS, MAX_BOX_RUN_START_COLUMN } from '../../src/renderer/utils/terminal-blocks';
-import { createBufferLineSource, cleanTerminalSelection } from '../../src/renderer/utils/terminal-block-buffer';
+import {
+  createBufferLineSource,
+  cleanTerminalSelection,
+  pixelToBufferRow,
+  getBlockPixelBounds,
+} from '../../src/renderer/utils/terminal-block-buffer';
 
 // This module (`terminal-block-buffer.ts`) is the only place that reads real
 // xterm cell attributes; `terminal-blocks.test.ts` covers the pure detector
@@ -216,6 +221,139 @@ describe('createBufferLineSource - width-0 (wide-char trailing) cells', () => {
     // Excluding the width-0 cell would drop the run one cell short of
     // MIN_BOX_RUN_CELLS, so bgRun would be null instead of detected.
     expect(facts.bgRun).toEqual({ key: 'rgb:555', startColumn: 0, endColumn: MIN_BOX_RUN_CELLS });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pixelToBufferRow / getBlockPixelBounds - the hit-test/highlight geometry
+// layer. Neither needs a real DOM: `readCellDimensions` reads xterm's private
+// `_core._renderService.dimensions.css.cell`, and `getScreenRect` reads
+// `terminal.element.querySelector('.xterm-screen').getBoundingClientRect()`,
+// both of which are plain fakeable shapes. The UI-tier spec
+// (terminal-block-copy.spec.ts) exercises this code path through a real
+// mounted xterm, but only ever with a block fully inside the viewport near
+// the top of a freshly-painted terminal - it never observes a block that
+// straddles a scroll boundary. These tests cover the scroll-clamping
+// contract documented on both functions directly.
+// ---------------------------------------------------------------------------
+
+interface GeometryTerminalOptions {
+  cols?: number;
+  rows?: number;
+  viewportY?: number;
+  bufferLength?: number;
+  cellWidth?: number;
+  cellHeight?: number;
+  /** When false, simulates the render service not being ready yet. */
+  hasDimensions?: boolean;
+  /** When null, simulates `.xterm-screen` not being present in the DOM yet. */
+  screenRect?: { left: number; top: number; right: number; bottom: number } | null;
+}
+
+function makeGeometryTerminal(options: GeometryTerminalOptions = {}): Terminal {
+  const {
+    cols = 80,
+    rows = 24,
+    viewportY = 0,
+    bufferLength = rows,
+    cellWidth = 8,
+    cellHeight = 16,
+    hasDimensions = true,
+    screenRect = { left: 0, top: 0, right: cols * cellWidth, bottom: rows * cellHeight },
+  } = options;
+
+  const terminal = {
+    cols,
+    rows,
+    buffer: { active: { viewportY, length: bufferLength } },
+    _core: hasDimensions
+      ? { _renderService: { dimensions: { css: { cell: { width: cellWidth, height: cellHeight } } } } }
+      : undefined,
+    element:
+      screenRect === null
+        ? null
+        : {
+            querySelector: (selector: string) =>
+              selector === '.xterm-screen' ? { getBoundingClientRect: () => screenRect as DOMRect } : null,
+          },
+  };
+  return terminal as unknown as Terminal;
+}
+
+describe('pixelToBufferRow', () => {
+  it('returns null for a point outside the terminal screen rect on any side', () => {
+    const terminal = makeGeometryTerminal({ screenRect: { left: 0, top: 0, right: 640, bottom: 384 } });
+    expect(pixelToBufferRow(terminal, -5, 100)).toBeNull(); // left of rect
+    expect(pixelToBufferRow(terminal, 700, 100)).toBeNull(); // right of rect
+    expect(pixelToBufferRow(terminal, 100, -5)).toBeNull(); // above rect
+    expect(pixelToBufferRow(terminal, 100, 500)).toBeNull(); // below rect
+  });
+
+  it('returns null when the render service has no cell dimensions yet', () => {
+    const terminal = makeGeometryTerminal({ hasDimensions: false });
+    expect(pixelToBufferRow(terminal, 10, 10)).toBeNull();
+  });
+
+  it('returns null when .xterm-screen is not present', () => {
+    const terminal = makeGeometryTerminal({ screenRect: null });
+    expect(pixelToBufferRow(terminal, 10, 10)).toBeNull();
+  });
+
+  it('maps a client point to the absolute buffer row, honoring the scroll offset', () => {
+    // Row 3 within the viewport (y between 3*16=48 and 4*16=64), with the
+    // buffer scrolled down 5 rows: absolute row = viewportY(5) + 3 = 8.
+    const terminal = makeGeometryTerminal({ viewportY: 5, cellHeight: 16, bufferLength: 100 });
+    expect(pixelToBufferRow(terminal, 100, 3 * 16 + 4)).toBe(8);
+  });
+
+  it('clamps the absolute row to the buffer length when the viewport extends past the scrollback', () => {
+    // The terminal has 24 rows of screen space but only 5 lines of real
+    // buffer content (a freshly-spawned session). Clicking near the bottom of
+    // the empty screen space must clamp to the last real row, not report a
+    // row that does not exist.
+    const terminal = makeGeometryTerminal({ rows: 24, bufferLength: 5, cellHeight: 16, viewportY: 0 });
+    expect(pixelToBufferRow(terminal, 10, 20 * 16 + 4)).toBe(4);
+  });
+});
+
+describe('getBlockPixelBounds', () => {
+  function range(startY: number, endY: number): BlockRange {
+    return { kind: 'text', startY, endY };
+  }
+
+  it('returns null when the render service has no cell dimensions yet', () => {
+    const terminal = makeGeometryTerminal({ hasDimensions: false });
+    expect(getBlockPixelBounds(terminal, range(0, 2))).toBeNull();
+  });
+
+  it('computes a full-width rectangle for a block entirely inside the viewport', () => {
+    const terminal = makeGeometryTerminal({ cols: 80, rows: 24, viewportY: 10, cellWidth: 8, cellHeight: 16 });
+    const bounds = getBlockPixelBounds(terminal, range(12, 14));
+    expect(bounds).toEqual({ top: 2 * 16, left: 0, width: 80 * 8, height: 3 * 16 });
+  });
+
+  it('returns null when the block is entirely scrolled above the viewport', () => {
+    const terminal = makeGeometryTerminal({ rows: 24, viewportY: 20 });
+    expect(getBlockPixelBounds(terminal, range(5, 15))).toBeNull();
+  });
+
+  it('returns null when the block is entirely scrolled below the viewport', () => {
+    const terminal = makeGeometryTerminal({ rows: 24, viewportY: 0 });
+    expect(getBlockPixelBounds(terminal, range(30, 35))).toBeNull();
+  });
+
+  it('clamps the top edge to the viewport when the block starts above it but extends into it', () => {
+    const terminal = makeGeometryTerminal({ rows: 24, viewportY: 10, cellHeight: 16 });
+    // startY=5 is 5 rows above the viewport; endY=15 is 5 rows into it.
+    const bounds = getBlockPixelBounds(terminal, range(5, 15));
+    expect(bounds).toEqual({ top: 0, left: 0, width: 80 * 8, height: 6 * 16 });
+  });
+
+  it('clamps the bottom edge to the last screen row when the block extends past the viewport', () => {
+    const terminal = makeGeometryTerminal({ rows: 24, viewportY: 0, cellHeight: 16 });
+    // maxRow = 23; startY=20 is inside, endY=30 runs past it.
+    const bounds = getBlockPixelBounds(terminal, range(20, 30));
+    expect(bounds).toEqual({ top: 20 * 16, left: 0, width: 80 * 8, height: 4 * 16 });
   });
 });
 

--- a/tests/unit/terminal-block-buffer.test.ts
+++ b/tests/unit/terminal-block-buffer.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Terminal, IBufferCell, IBufferLine } from '@xterm/xterm';
+import type { SelectionRange } from '../../src/renderer/utils/terminal-blocks';
+
+// Spy on `cleanSelectionLines` while keeping every other export (including the
+// constants `classifyLine` uses) real, so `cleanTerminalSelection` can be
+// proven to take (or skip) the buffer-read path without faking its own logic.
+vi.mock('../../src/renderer/utils/terminal-blocks', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/renderer/utils/terminal-blocks')>();
+  return {
+    ...actual,
+    cleanSelectionLines: vi.fn(actual.cleanSelectionLines),
+  };
+});
+
+import { cleanSelectionLines, MIN_BOX_RUN_CELLS, MAX_BOX_RUN_START_COLUMN } from '../../src/renderer/utils/terminal-blocks';
+import { createBufferLineSource, cleanTerminalSelection } from '../../src/renderer/utils/terminal-block-buffer';
+
+// This module (`terminal-block-buffer.ts`) is the only place that reads real
+// xterm cell attributes; `terminal-blocks.test.ts` covers the pure detector
+// with hand-built `BlockLineFacts`, never exercising `classifyLine` itself.
+// These tests build a minimal typed fake xterm buffer (no DOM, no real
+// `@xterm/xterm` instance) to close that gap, plus cover the
+// `cleanTerminalSelection` selection/fallback/throw branches.
+
+type ColorSpec = { default: true } | { default: false; mode: 'rgb' | 'palette' | 'other'; value: number };
+
+function defaultColor(): ColorSpec {
+  return { default: true };
+}
+
+function rgbColor(value: number): ColorSpec {
+  return { default: false, mode: 'rgb', value };
+}
+
+interface FakeCellSpec {
+  chars: string;
+  width?: number;
+  fg?: ColorSpec;
+  bg?: ColorSpec;
+}
+
+function makeCell(spec: FakeCellSpec): IBufferCell {
+  const fg = spec.fg ?? defaultColor();
+  const bg = spec.bg ?? defaultColor();
+  const width = spec.width ?? 1;
+  const cell = {
+    getChars: () => spec.chars,
+    getWidth: () => width,
+    isFgDefault: () => fg.default,
+    isFgRGB: () => !fg.default && fg.mode === 'rgb',
+    isFgPalette: () => !fg.default && fg.mode === 'palette',
+    getFgColor: () => (fg.default ? 0 : fg.value),
+    isBgDefault: () => bg.default,
+    isBgRGB: () => !bg.default && bg.mode === 'rgb',
+    isBgPalette: () => !bg.default && bg.mode === 'palette',
+    getBgColor: () => (bg.default ? 0 : bg.value),
+  };
+  return cell as unknown as IBufferCell;
+}
+
+// A sparse per-column cell list: index === buffer column. A missing index
+// (hole or explicit undefined) renders as a blank default-fg/default-bg space.
+interface FakeRowSpec {
+  cells?: (FakeCellSpec | undefined)[];
+  isWrapped?: boolean;
+}
+
+function makeLine(row: FakeRowSpec, cols: number): IBufferLine {
+  const specs: FakeCellSpec[] = [];
+  for (let column = 0; column < cols; column += 1) {
+    specs.push(row.cells?.[column] ?? { chars: ' ' });
+  }
+  const cells = specs.map(makeCell);
+  const line = {
+    isWrapped: row.isWrapped ?? false,
+    length: cols,
+    getCell: (x: number): IBufferCell | undefined => cells[x],
+    translateToString(trimRight = false, startColumn = 0, endColumn: number = cols): string {
+      let text = '';
+      for (let x = startColumn; x < endColumn; x += 1) {
+        const spec = specs[x];
+        if (!spec || (spec.width ?? 1) === 0) continue;
+        text += spec.chars;
+      }
+      return trimRight ? text.replace(/\s+$/, '') : text;
+    },
+  };
+  return line as unknown as IBufferLine;
+}
+
+function makeTerminal(rows: FakeRowSpec[], cols = 80, selection?: SelectionRange): Terminal {
+  const lines = rows.map((row) => makeLine(row, cols));
+  const buffer = {
+    length: lines.length,
+    getLine: (y: number): IBufferLine | undefined => lines[y],
+    getNullCell: (): IBufferCell => makeCell({ chars: ' ' }),
+  };
+  const terminal = {
+    cols,
+    buffer: { active: buffer },
+    getSelectionPosition: (): SelectionRange | undefined => selection,
+  };
+  return terminal as unknown as Terminal;
+}
+
+// Row builders mirroring the `plain` / `quote` helpers in terminal-blocks.test.ts,
+// but at the cell level (real glyph + real fg color) instead of pre-classified facts.
+function plainRow(text: string): FakeRowSpec {
+  const cells: FakeCellSpec[] = [];
+  for (let i = 0; i < text.length; i += 1) cells.push({ chars: text[i] });
+  return { cells };
+}
+
+function quoteRow(afterBar: string, fgValue = 111): FakeRowSpec {
+  const cells: FakeCellSpec[] = [{ chars: '▎', fg: rgbColor(fgValue) }];
+  for (let i = 0; i < afterBar.length; i += 1) cells.push({ chars: afterBar[i] });
+  return { cells };
+}
+
+describe('createBufferLineSource - quote bar detection (classifyLine)', () => {
+  it('detects a bar glyph painted with a non-default foreground as a quote bar', () => {
+    const terminal = makeTerminal([{ cells: [{ chars: '▎', fg: rgbColor(500) }] }], 20);
+    const facts = createBufferLineSource(terminal).getLine(0)!;
+    expect(facts.quoteBar).toEqual({ column: 0, fgKey: 'rgb:500' });
+  });
+
+  it('does not treat a bar glyph in the default foreground as a quote bar', () => {
+    const terminal = makeTerminal([{ cells: [{ chars: '▎', fg: defaultColor() }] }], 20);
+    const facts = createBufferLineSource(terminal).getLine(0)!;
+    expect(facts.quoteBar).toBeNull();
+  });
+});
+
+describe('createBufferLineSource - background run thresholds (classifyLine)', () => {
+  it('detects a run of exactly MIN_BOX_RUN_CELLS starting at or before MAX_BOX_RUN_START_COLUMN', () => {
+    const cells: FakeCellSpec[] = [];
+    for (let x = 0; x < MIN_BOX_RUN_CELLS; x += 1) cells[x] = { chars: ' ', bg: rgbColor(777) };
+    const terminal = makeTerminal([{ cells }], 20);
+    const facts = createBufferLineSource(terminal).getLine(0)!;
+    expect(facts.bgRun).toEqual({ key: 'rgb:777', startColumn: 0, endColumn: MIN_BOX_RUN_CELLS });
+  });
+
+  it('does not detect a run one cell short of MIN_BOX_RUN_CELLS', () => {
+    const cells: FakeCellSpec[] = [];
+    for (let x = 0; x < MIN_BOX_RUN_CELLS - 1; x += 1) cells[x] = { chars: ' ', bg: rgbColor(777) };
+    const terminal = makeTerminal([{ cells }], 20);
+    const facts = createBufferLineSource(terminal).getLine(0)!;
+    expect(facts.bgRun).toBeNull();
+  });
+
+  it('does not detect a qualifying run that starts past MAX_BOX_RUN_START_COLUMN', () => {
+    const startColumn = MAX_BOX_RUN_START_COLUMN + 1;
+    const cells: FakeCellSpec[] = [];
+    for (let x = 0; x < MIN_BOX_RUN_CELLS; x += 1) cells[startColumn + x] = { chars: ' ', bg: rgbColor(777) };
+    const terminal = makeTerminal([{ cells }], startColumn + MIN_BOX_RUN_CELLS + 5);
+    const facts = createBufferLineSource(terminal).getLine(0)!;
+    expect(facts.bgRun).toBeNull();
+  });
+});
+
+describe('createBufferLineSource - hasDefaultFg (classifyLine)', () => {
+  it('is true when the row has a non-space cell in the default foreground', () => {
+    const terminal = makeTerminal([{ cells: [{ chars: 'h', fg: defaultColor() }] }], 20);
+    const facts = createBufferLineSource(terminal).getLine(0)!;
+    expect(facts.hasDefaultFg).toBe(true);
+  });
+
+  it('is false when every non-space cell is a non-default foreground (a muted/thinking row)', () => {
+    const cells: FakeCellSpec[] = [
+      { chars: '✻', fg: rgbColor(9) },
+      { chars: ' ' },
+      { chars: 'C', fg: rgbColor(9) },
+      { chars: 'o', fg: rgbColor(9) },
+    ];
+    const terminal = makeTerminal([{ cells }], 20);
+    const facts = createBufferLineSource(terminal).getLine(0)!;
+    expect(facts.hasDefaultFg).toBe(false);
+  });
+});
+
+describe('createBufferLineSource - width-0 (wide-char trailing) cells', () => {
+  it('skips a width-0 cell for the first-glyph/quote-bar check', () => {
+    const cells: FakeCellSpec[] = [
+      { chars: '▎', fg: rgbColor(42), width: 0 },
+      { chars: ' ' },
+      { chars: '▎', fg: rgbColor(99) },
+    ];
+    const terminal = makeTerminal([{ cells }], 20);
+    const facts = createBufferLineSource(terminal).getLine(0)!;
+    // If the width-0 guard were dropped, column 0's bar would win (fgKey
+    // rgb:42) because it would be treated as the first non-space cell scanned.
+    expect(facts.quoteBar).toEqual({ column: 2, fgKey: 'rgb:99' });
+  });
+
+  it('skips a width-0 cell for the hasDefaultFg check', () => {
+    const cells: FakeCellSpec[] = [
+      { chars: 'Z', fg: defaultColor(), width: 0 },
+      { chars: ' ' },
+      { chars: 'Q', fg: rgbColor(7) },
+    ];
+    const terminal = makeTerminal([{ cells }], 20);
+    const facts = createBufferLineSource(terminal).getLine(0)!;
+    // If the width-0 guard were dropped, the default-fg cell at column 0 would
+    // flip hasDefaultFg to true even though no real (width !== 0) cell has it.
+    expect(facts.hasDefaultFg).toBe(false);
+  });
+
+  it('still counts a width-0 cell toward a background run', () => {
+    const cells: FakeCellSpec[] = [];
+    cells[0] = { chars: ' ', bg: rgbColor(555) };
+    cells[1] = { chars: ' ', bg: rgbColor(555), width: 0 };
+    for (let x = 2; x < MIN_BOX_RUN_CELLS; x += 1) cells[x] = { chars: ' ', bg: rgbColor(555) };
+    const terminal = makeTerminal([{ cells }], 20);
+    const facts = createBufferLineSource(terminal).getLine(0)!;
+    // Excluding the width-0 cell would drop the run one cell short of
+    // MIN_BOX_RUN_CELLS, so bgRun would be null instead of detected.
+    expect(facts.bgRun).toEqual({ key: 'rgb:555', startColumn: 0, endColumn: MIN_BOX_RUN_CELLS });
+  });
+});
+
+describe('cleanTerminalSelection', () => {
+  beforeEach(() => {
+    vi.mocked(cleanSelectionLines).mockClear();
+  });
+
+  it('returns the injected fallback verbatim when there is no selection, without invoking cleanSelectionLines', () => {
+    const terminal = makeTerminal([plainRow('hello')], 20, undefined);
+    const fallbackSentinel = 'FALLBACK_NO_SELECTION_SENTINEL';
+    const result = cleanTerminalSelection(terminal, () => fallbackSentinel);
+    expect(result).toBe(fallbackSentinel);
+    expect(cleanSelectionLines).not.toHaveBeenCalled();
+  });
+
+  it('cleans a selection over quote-decorated rows via the real buffer classifier (not the fallback)', () => {
+    const rows: FakeRowSpec[] = [
+      plainRow('Lorem ipsum dolor sit amet.'),
+      quoteRow(''),
+      quoteRow(' Sed do eiusmod tempor incididunt.'),
+      quoteRow(''),
+      quoteRow(' Duis aute irure dolor.'),
+    ];
+    const terminal = makeTerminal(rows, 80, { start: { x: 0, y: 0 }, end: { x: 80, y: 4 } });
+    const fallbackSentinel = 'FALLBACK_SHOULD_NOT_APPEAR';
+    const result = cleanTerminalSelection(terminal, () => fallbackSentinel);
+    expect(result).toBe(
+      'Lorem ipsum dolor sit amet.\n\nSed do eiusmod tempor incididunt.\n\nDuis aute irure dolor.',
+    );
+    expect(result).not.toBe(fallbackSentinel);
+    expect(cleanSelectionLines).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back when the buffer read throws', () => {
+    const terminal = makeTerminal([plainRow('hello')], 20, { start: { x: 0, y: 0 }, end: { x: 5, y: 0 } });
+    (terminal.buffer.active as unknown as { getLine: () => never }).getLine = () => {
+      throw new Error('simulated buffer read failure');
+    };
+    const fallbackSentinel = 'FALLBACK_ON_THROW_SENTINEL';
+    const result = cleanTerminalSelection(terminal, () => fallbackSentinel);
+    expect(result).toBe(fallbackSentinel);
+  });
+});

--- a/tests/unit/terminal-blocks.test.ts
+++ b/tests/unit/terminal-blocks.test.ts
@@ -1,0 +1,399 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findBlockAt,
+  extractBlockContent,
+  cleanSelectionLines,
+  BAR_GLYPHS,
+  MIN_BOX_RUN_CELLS,
+  MAX_BOX_RUN_START_COLUMN,
+  MAX_MESSAGE_LOOKBACK_ROWS,
+  type BlockLineFacts,
+  type BlockLineSource,
+} from '../../src/renderer/utils/terminal-blocks';
+
+// A fake buffer row. `raw` is the full row text where string index === buffer
+// column (all fixtures use single-cell characters), so `text(start, end)` slices
+// it directly, matching xterm's exclusive-endColumn `translateToString`.
+interface FakeLine {
+  raw: string;
+  isWrapped?: boolean;
+  quoteBar?: { column: number; fgKey: string } | null;
+  bgRun?: { key: string; startColumn: number; endColumn: number } | null;
+  hasDefaultFg?: boolean;
+}
+
+const ORANGE = 'rgb:14120791';
+const SHADE = 'rgb:3618615';
+
+function makeSource(lines: FakeLine[], cols = 80): BlockLineSource {
+  const facts: BlockLineFacts[] = lines.map((line) => ({
+    isWrapped: line.isWrapped ?? false,
+    quoteBar: line.quoteBar ?? null,
+    bgRun: line.bgRun ?? null,
+    hasDefaultFg: line.hasDefaultFg ?? true,
+    text(startColumn = 0, endColumn?: number) {
+      return line.raw.slice(startColumn, endColumn);
+    },
+  }));
+  return {
+    length: facts.length,
+    cols,
+    getLine: (y) => facts[y],
+  };
+}
+
+// A muted / "thinking" status row: undecorated, all non-default foreground.
+function muted(raw: string): FakeLine {
+  return { raw, hasDefaultFg: false };
+}
+
+// A quote row: optional indent before the bar glyph, then the bar, then content.
+function quote(afterBar: string, indent = 0, fgKey = ORANGE): FakeLine {
+  const column = indent;
+  return {
+    raw: ' '.repeat(indent) + '▎' + afterBar,
+    quoteBar: { column, fgKey },
+  };
+}
+
+// A shaded box row: the whole line carries the background run.
+function box(content: string, key = SHADE, startColumn = 0, endColumn = 80): FakeLine {
+  return { raw: content, bgRun: { key, startColumn, endColumn } };
+}
+
+function plain(raw: string, isWrapped = false): FakeLine {
+  return { raw, isWrapped };
+}
+
+describe('terminal-blocks constants', () => {
+  it('excludes box-drawing verticals from the bar glyph set (avoids box-border false positives)', () => {
+    expect(BAR_GLYPHS.has('▎')).toBe(true);
+    expect(BAR_GLYPHS.has('│')).toBe(false);
+    expect(BAR_GLYPHS.has('┃')).toBe(false);
+  });
+
+  it('keeps sensible box-run thresholds', () => {
+    expect(MIN_BOX_RUN_CELLS).toBeGreaterThan(0);
+    expect(MAX_BOX_RUN_START_COLUMN).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('findBlockAt - quote blocks', () => {
+  it('expands a hit in the middle to the full block bounds', () => {
+    const source = makeSource([
+      plain('intro'),
+      quote(' one'),
+      quote(' two'),
+      quote(' three'),
+      plain('after'),
+    ]);
+    const range = findBlockAt(source, 2);
+    expect(range).toEqual({ kind: 'quote', startY: 1, endY: 3, barColumn: 0 });
+  });
+
+  it('detects a single-row quote block', () => {
+    const source = makeSource([plain('a'), quote(' solo'), plain('b')]);
+    expect(findBlockAt(source, 1)).toEqual({ kind: 'quote', startY: 1, endY: 1, barColumn: 0 });
+  });
+
+  it('returns a text block (not null) on a plain row', () => {
+    const source = makeSource([plain('nothing here')]);
+    expect(findBlockAt(source, 0)).toEqual({ kind: 'text', startY: 0, endY: 0 });
+  });
+
+  it('does not merge adjacent quote blocks with a different fg color', () => {
+    const source = makeSource([
+      quote(' a', 0, ORANGE),
+      quote(' b', 0, ORANGE),
+      quote(' c', 0, 'rgb:999999'),
+    ]);
+    expect(findBlockAt(source, 0)).toEqual({ kind: 'quote', startY: 0, endY: 1, barColumn: 0 });
+    expect(findBlockAt(source, 2)).toEqual({ kind: 'quote', startY: 2, endY: 2, barColumn: 0 });
+  });
+
+  it('does not merge quote blocks whose bar sits at a different column', () => {
+    const source = makeSource([quote(' a', 0), quote(' b', 2)]);
+    expect(findBlockAt(source, 0)).toEqual({ kind: 'quote', startY: 0, endY: 0, barColumn: 0 });
+    expect(findBlockAt(source, 1)).toEqual({ kind: 'quote', startY: 1, endY: 1, barColumn: 2 });
+  });
+
+  it('clamps expansion at the top of the buffer (scrollback-evicted block start)', () => {
+    const source = makeSource([quote(' a'), quote(' b'), plain('end')]);
+    expect(findBlockAt(source, 1)).toEqual({ kind: 'quote', startY: 0, endY: 1, barColumn: 0 });
+  });
+});
+
+describe('findBlockAt - box blocks', () => {
+  it('expands a shaded box to its bounds', () => {
+    const source = makeSource([plain('x'), box('  a'), box('  b'), plain('y')]);
+    expect(findBlockAt(source, 1)).toEqual({ kind: 'box', startY: 1, endY: 2 });
+  });
+
+  it('splits boxes with a different background key', () => {
+    const source = makeSource([box('a', SHADE), box('b', 'rgb:111111')]);
+    expect(findBlockAt(source, 0)).toEqual({ kind: 'box', startY: 0, endY: 0 });
+    expect(findBlockAt(source, 1)).toEqual({ kind: 'box', startY: 1, endY: 1 });
+  });
+
+  it('splits boxes whose runs do not overlap in columns', () => {
+    const source = makeSource([
+      { raw: 'left', bgRun: { key: SHADE, startColumn: 0, endColumn: 4 } },
+      { raw: '      right', bgRun: { key: SHADE, startColumn: 6, endColumn: 11 } },
+    ]);
+    expect(findBlockAt(source, 0)).toEqual({ kind: 'box', startY: 0, endY: 0 });
+    expect(findBlockAt(source, 1)).toEqual({ kind: 'box', startY: 1, endY: 1 });
+  });
+});
+
+describe('findBlockAt - message blocks (bullet-delimited)', () => {
+  const build = () => makeSource([
+    plain('● I\'ll make a trivial change'),   // 0 message bullet
+    plain('  Searched for 2 patterns'),        // 1 sub-line (kept)
+    plain(''),                                  // 2 interior blank
+    plain('● I\'ll add a harmless comment'),   // 3 message bullet
+    plain('● Update(README.md)'),              // 4 tool bullet
+    plain('  ⎿ Added 1 line'),                 // 5 tool result (kept)
+    plain('      1 +<!-- test -->'),           // 6 code
+    plain('      2 </p>'),                      // 7 code
+    muted('✻ Cooked for 3s'),                  // 8 thinking (excluded)
+    plain('● Done. I made a change'),          // 9 message bullet
+  ]);
+
+  it('groups a bullet with its sub-lines up to the next bullet (from anywhere inside)', () => {
+    expect(findBlockAt(build(), 0)).toEqual({ kind: 'message', startY: 0, endY: 1 });
+    expect(findBlockAt(build(), 1)).toEqual({ kind: 'message', startY: 0, endY: 1 });
+  });
+
+  it('groups a tool bullet with its result and code lines', () => {
+    expect(findBlockAt(build(), 4)).toEqual({ kind: 'message', startY: 4, endY: 7 });
+    expect(findBlockAt(build(), 6)).toEqual({ kind: 'message', startY: 4, endY: 7 });
+  });
+
+  it('is not copyable on a thinking line, and a thinking line bounds a message', () => {
+    expect(findBlockAt(build(), 8)).toBeNull();
+    expect(findBlockAt(build(), 4)?.endY).toBe(7); // stops before the ✻ line at 8
+  });
+
+  it('starts a fresh block at each bullet', () => {
+    expect(findBlockAt(build(), 3)).toEqual({ kind: 'message', startY: 3, endY: 3 });
+    expect(findBlockAt(build(), 9)).toEqual({ kind: 'message', startY: 9, endY: 9 });
+  });
+
+  it('strips the bullet and left-aligns the message content', () => {
+    const source = makeSource([
+      plain('● Update(README.md)'),
+      plain('  ⎿ Added 1 line'),
+      plain('  1 +code'),
+    ]);
+    const range = findBlockAt(source, 0)!;
+    expect(extractBlockContent(source, range)).toBe('Update(README.md)\n⎿ Added 1 line\n1 +code');
+  });
+});
+
+describe('findBlockAt - message lookback bound', () => {
+  it('resolves a message when its bullet is within the lookback window', () => {
+    const source = makeSource([plain('● nearby message'), plain('  body a'), plain('  body b')]);
+    expect(findBlockAt(source, 2)).toEqual({ kind: 'message', startY: 0, endY: 2 });
+  });
+
+  it('does not scan past MAX_MESSAGE_LOOKBACK_ROWS to claim a distant bullet as the block start', () => {
+    // A single bullet at row 0, then more than the lookback limit of plain body
+    // rows. Hitting the last row must NOT walk all the way back to the bullet
+    // (that unbounded O(scrollback) scan is the perf regression this bound fixes)
+    // - it falls through to a local text block instead of a giant message block.
+    const lines: FakeLine[] = [plain('● far-away message start')];
+    for (let i = 0; i < MAX_MESSAGE_LOOKBACK_ROWS + 2; i += 1) lines.push(plain(`body line ${i}`));
+    const hitRow = lines.length - 1;
+    const range = findBlockAt(makeSource(lines), hitRow);
+    expect(range?.kind).toBe('text');
+    expect(range?.kind).not.toBe('message');
+  });
+});
+
+describe('findBlockAt - text messages', () => {
+  it('expands a run of content rows into one message, trimming outer blanks', () => {
+    const source = makeSource([plain(''), plain('line a'), plain('line b'), plain('')]);
+    expect(findBlockAt(source, 1)).toEqual({ kind: 'text', startY: 1, endY: 2 });
+  });
+
+  it('merges paragraphs across an interior blank line into one message', () => {
+    const source = makeSource([plain('first para'), plain(''), plain('second para')]);
+    expect(findBlockAt(source, 0)).toEqual({ kind: 'text', startY: 0, endY: 2 });
+    expect(findBlockAt(source, 2)).toEqual({ kind: 'text', startY: 0, endY: 2 });
+  });
+
+  it('returns null when hit-testing a blank row directly', () => {
+    const source = makeSource([plain('a'), plain(''), plain('b')]);
+    expect(findBlockAt(source, 1)).toBeNull();
+    // The surrounding content rows still merge into one message.
+    expect(findBlockAt(source, 0)).toEqual({ kind: 'text', startY: 0, endY: 2 });
+  });
+
+  it('is not copyable on a muted / thinking row, and a muted row bounds a message', () => {
+    const source = makeSource([plain('reply text'), plain(''), muted('* Crunched for 3s')]);
+    expect(findBlockAt(source, 2)).toBeNull();
+    // The message stops before the muted row (and the trailing blank is trimmed).
+    expect(findBlockAt(source, 0)).toEqual({ kind: 'text', startY: 0, endY: 0 });
+  });
+
+  it('does not merge two messages separated by a muted line', () => {
+    const source = makeSource([plain('first reply'), muted('* thinking'), plain('second reply')]);
+    expect(findBlockAt(source, 0)).toEqual({ kind: 'text', startY: 0, endY: 0 });
+    expect(findBlockAt(source, 2)).toEqual({ kind: 'text', startY: 2, endY: 2 });
+  });
+
+  it('does not swallow an adjacent box or quote row into a text message', () => {
+    const source = makeSource([plain('prose'), box('  code'), quote(' quoted')]);
+    expect(findBlockAt(source, 0)).toEqual({ kind: 'text', startY: 0, endY: 0 });
+    expect(findBlockAt(source, 1)).toEqual({ kind: 'box', startY: 1, endY: 1 });
+  });
+});
+
+describe('extractBlockContent - text messages', () => {
+  it('copies a plain paragraph verbatim (dedenting shared indent)', () => {
+    const source = makeSource([plain('  hello'), plain('  world')]);
+    const range = findBlockAt(source, 0)!;
+    expect(extractBlockContent(source, range)).toBe('hello\nworld');
+  });
+
+  it('keeps an interior blank line between merged paragraphs', () => {
+    const source = makeSource([plain('para one'), plain(''), plain('para two')]);
+    const range = findBlockAt(source, 0)!;
+    expect(extractBlockContent(source, range)).toBe('para one\n\npara two');
+  });
+
+  it('strips a leading bullet and aligns the continuation', () => {
+    const source = makeSource([plain('• First point of the reply'), plain('  continues here')]);
+    const range = findBlockAt(source, 0)!;
+    expect(extractBlockContent(source, range)).toBe('First point of the reply\ncontinues here');
+  });
+
+  it('leaves an ASCII dash-led line untouched (not treated as a bullet)', () => {
+    const source = makeSource([plain('- not a bullet glyph')]);
+    const range = findBlockAt(source, 0)!;
+    expect(extractBlockContent(source, range)).toBe('- not a bullet glyph');
+  });
+});
+
+describe('extractBlockContent - quote blocks', () => {
+  it('strips the bar and the uniform leading gap, preserving relative indent', () => {
+    const source = makeSource([
+      quote(' First quoted line here'),
+      quote(''),
+      quote('   indented code inside quote'),
+    ]);
+    const range = findBlockAt(source, 0)!;
+    expect(extractBlockContent(source, range)).toBe(
+      'First quoted line here\n\n  indented code inside quote',
+    );
+  });
+
+  it('preserves an interior blank (bar-only) line', () => {
+    const source = makeSource([quote(' a'), quote(''), quote(' b')]);
+    const range = findBlockAt(source, 0)!;
+    expect(extractBlockContent(source, range)).toBe('a\n\nb');
+  });
+
+  it('handles a bar sitting at a non-zero column', () => {
+    const source = makeSource([quote(' hello', 2), quote(' world', 2)]);
+    const range = findBlockAt(source, 0)!;
+    expect(extractBlockContent(source, range)).toBe('hello\nworld');
+  });
+});
+
+describe('extractBlockContent - box blocks', () => {
+  it('dedents the common leading whitespace and trims trailing padding', () => {
+    const source = makeSource([box('  const x = 42;   '), box('  return x;')]);
+    const range = findBlockAt(source, 0)!;
+    expect(extractBlockContent(source, range)).toBe('const x = 42;\nreturn x;');
+  });
+
+  it('preserves relative indentation inside the box', () => {
+    const source = makeSource([box('function f() {'), box('  return 1;'), box('}')]);
+    const range = findBlockAt(source, 0)!;
+    expect(extractBlockContent(source, range)).toBe('function f() {\n  return 1;\n}');
+  });
+
+  it('strips the prompt marker and left-aligns the box by removing its common margin', () => {
+    // The box has a uniform 2-space left margin; the first line carries a `❯`
+    // prompt marker in that margin. The result is dedented so <task> is flush left
+    // and the relative XML indentation is preserved.
+    const source = makeSource([box('❯ <task>'), box('    <title>x</title>'), box('  </task>')]);
+    const range = findBlockAt(source, 0)!;
+    expect(extractBlockContent(source, range)).toBe('<task>\n  <title>x</title>\n</task>');
+  });
+
+  it('keeps box rows on separate lines even when flagged wrapped (full-width fill artifact)', () => {
+    // A shaded box fills the full width, so xterm marks each row isWrapped; the
+    // rows must NOT collapse into one padded line.
+    const source = makeSource([
+      { raw: 'line one', isWrapped: false, bgRun: { key: SHADE, startColumn: 0, endColumn: 80 } },
+      { raw: 'line two', isWrapped: true, bgRun: { key: SHADE, startColumn: 0, endColumn: 80 } },
+      { raw: 'line three', isWrapped: true, bgRun: { key: SHADE, startColumn: 0, endColumn: 80 } },
+    ]);
+    const range = findBlockAt(source, 0)!;
+    expect(extractBlockContent(source, range)).toBe('line one\nline two\nline three');
+  });
+});
+
+describe('extractBlockContent - wrapped rows', () => {
+  it('keeps each visual row on its own line (the TUI wrap flag is unreliable)', () => {
+    // xterm's isWrapped is corrupted by full-width fills and word-wrap, so we do
+    // not merge on it - each row is copied as its own trimmed line.
+    const source = makeSource([
+      quote(' start of a very long'),
+      { raw: '▎ line that wrapped', quoteBar: { column: 0, fgKey: ORANGE }, isWrapped: true },
+    ]);
+    const range = findBlockAt(source, 0)!;
+    expect(extractBlockContent(source, range)).toBe('start of a very long\nline that wrapped');
+  });
+});
+
+describe('cleanSelectionLines', () => {
+  it('strips quote decoration only from decorated rows in a mixed selection', () => {
+    const source = makeSource([
+      plain('Lorem ipsum dolor sit amet.'),
+      quote(''),
+      quote(' Sed do eiusmod tempor incididunt.'),
+      quote(''),
+      quote(' Duis aute irure dolor.'),
+    ]);
+    const cleaned = cleanSelectionLines(source, { start: { x: 0, y: 0 }, end: { x: 80, y: 4 } });
+    expect(cleaned).toBe(
+      'Lorem ipsum dolor sit amet.\n\nSed do eiusmod tempor incididunt.\n\nDuis aute irure dolor.',
+    );
+    expect(cleaned).not.toContain('▎');
+  });
+
+  it('does not strip when the selection starts to the right of the bar', () => {
+    // Selection begins at column 4, past the bar at column 0.
+    const source = makeSource([quote(' hello world')]);
+    const cleaned = cleanSelectionLines(source, { start: { x: 4, y: 0 }, end: { x: 12, y: 0 } });
+    expect(cleaned).toBe('llo worl');
+  });
+
+  it('honors an exclusive end column on the last row', () => {
+    const source = makeSource([plain('0123456789')]);
+    // start.x=2, end.x=5 -> chars at columns 2,3,4.
+    const cleaned = cleanSelectionLines(source, { start: { x: 2, y: 0 }, end: { x: 5, y: 0 } });
+    expect(cleaned).toBe('234');
+  });
+
+  it('takes full width on intermediate rows and the start row of a multi-row selection', () => {
+    const source = makeSource([plain('first line'), plain('second line'), plain('third')]);
+    const cleaned = cleanSelectionLines(source, { start: { x: 6, y: 0 }, end: { x: 5, y: 2 } });
+    expect(cleaned).toBe('line\nsecond line\nthird');
+  });
+
+  it('unwraps soft-wrapped plain rows via the real isWrapped flag', () => {
+    const source = makeSource([plain('abcdef'), plain('ghij', true)]);
+    const cleaned = cleanSelectionLines(source, { start: { x: 0, y: 0 }, end: { x: 80, y: 1 } });
+    expect(cleaned).toBe('abcdefghij');
+  });
+
+  it('trims outer blank lines but keeps interior blanks', () => {
+    const source = makeSource([plain(''), plain('a'), plain(''), plain('b'), plain('')]);
+    const cleaned = cleanSelectionLines(source, { start: { x: 0, y: 0 }, end: { x: 80, y: 4 } });
+    expect(cleaned).toBe('a\n\nb');
+  });
+});

--- a/tests/unit/terminal-context-menu.test.ts
+++ b/tests/unit/terminal-context-menu.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildBlockProbeScript,
+  buildCopyBlockDispatchScript,
+  parseProbeResult,
+  probeTerminalBlock,
+  PROBE_TIMEOUT_MS,
+} from '../../src/main/terminal-context-menu';
+
+describe('buildBlockProbeScript', () => {
+  it('rounds coordinates and interpolates only numbers', () => {
+    const script = buildBlockProbeScript(12.7, 40.2);
+    expect(script).toContain('__kangenticTerminalBlockHitTest(13, 40)');
+    // No raw floats leak into the script.
+    expect(script).not.toContain('12.7');
+    expect(script).not.toContain('40.2');
+  });
+
+  it('falls back to a no-block object when the global is absent', () => {
+    const script = buildBlockProbeScript(0, 0);
+    expect(script).toContain('isTerminal: false');
+  });
+});
+
+describe('buildCopyBlockDispatchScript', () => {
+  it('dispatches a terminal-copy-block event with rounded coordinates', () => {
+    const script = buildCopyBlockDispatchScript(5.9, 9.1);
+    expect(script).toContain("CustomEvent('terminal-copy-block'");
+    expect(script).toContain('x: 6');
+    expect(script).toContain('y: 9');
+  });
+});
+
+describe('parseProbeResult', () => {
+  it('accepts a well-formed quote result', () => {
+    expect(parseProbeResult({ isTerminal: true, blockKind: 'quote' })).toEqual({
+      isTerminal: true,
+      blockKind: 'quote',
+    });
+  });
+
+  it('accepts a well-formed box result', () => {
+    expect(parseProbeResult({ isTerminal: true, blockKind: 'box' })).toEqual({
+      isTerminal: true,
+      blockKind: 'box',
+    });
+  });
+
+  it('accepts a well-formed text result', () => {
+    expect(parseProbeResult({ isTerminal: true, blockKind: 'text' })).toEqual({
+      isTerminal: true,
+      blockKind: 'text',
+    });
+  });
+
+  it('accepts a well-formed message result', () => {
+    // The renderer's blockKindAtPoint returns 'text' / 'message' for plain
+    // assistant output; the right-click "Copy Block" item depends on these
+    // round-tripping through parseProbeResult (regression: they were coerced to
+    // null, so the menu item never appeared for those kinds).
+    expect(parseProbeResult({ isTerminal: true, blockKind: 'message' })).toEqual({
+      isTerminal: true,
+      blockKind: 'message',
+    });
+  });
+
+  it('coerces an unknown blockKind to null', () => {
+    expect(parseProbeResult({ isTerminal: true, blockKind: 'banana' })).toEqual({
+      isTerminal: true,
+      blockKind: null,
+    });
+  });
+
+  it('defaults to no block for non-object values', () => {
+    expect(parseProbeResult(null)).toEqual({ isTerminal: false, blockKind: null });
+    expect(parseProbeResult('nope')).toEqual({ isTerminal: false, blockKind: null });
+    expect(parseProbeResult(undefined)).toEqual({ isTerminal: false, blockKind: null });
+  });
+
+  it('treats a missing isTerminal flag as false', () => {
+    expect(parseProbeResult({ blockKind: 'quote' })).toEqual({ isTerminal: false, blockKind: 'quote' });
+  });
+});
+
+describe('probeTerminalBlock', () => {
+  it('returns the parsed result when the renderer answers', async () => {
+    const result = await probeTerminalBlock(async () => ({ isTerminal: true, blockKind: 'box' }), 1, 2);
+    expect(result).toEqual({ isTerminal: true, blockKind: 'box' });
+  });
+
+  it('resolves to no block when the renderer rejects', async () => {
+    const result = await probeTerminalBlock(async () => { throw new Error('detached'); }, 1, 2);
+    expect(result).toEqual({ isTerminal: false, blockKind: null });
+  });
+
+  it('resolves to no block when the renderer never answers within the timeout', async () => {
+    const result = await probeTerminalBlock(() => new Promise(() => { /* never resolves */ }), 1, 2);
+    expect(result).toEqual({ isTerminal: false, blockKind: null });
+  }, PROBE_TIMEOUT_MS + 2000);
+});

--- a/tests/unit/terminal-selection-clean.test.ts
+++ b/tests/unit/terminal-selection-clean.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { cleanSelection } from '../../src/renderer/utils/terminal-clipboard';
+
+// Characterization tests locking the legacy string-based `cleanSelection`. This
+// feature adds a buffer-aware cleaner (`cleanSelectionLines`, covered in
+// terminal-blocks.test.ts) and leaves `cleanSelection` byte-identical as the
+// fallback path. A parallel worktree is fixing a bug in this same clipboard
+// module; these tests fail loudly if its semantics drift here unintentionally.
+describe('cleanSelection (legacy string cleaner)', () => {
+  it('leaves distinct lines as-is', () => {
+    expect(cleanSelection('hello\nworld', 80)).toBe('hello\nworld');
+  });
+
+  it('trims trailing whitespace per line', () => {
+    expect(cleanSelection('abc   \ndef  ', 80)).toBe('abc\ndef');
+  });
+
+  it('joins a line that fills exactly cols with the next (soft-wrap heuristic)', () => {
+    expect(cleanSelection('12345\n678', 5)).toBe('12345678');
+  });
+
+  it('does not join when a line is shorter than cols', () => {
+    expect(cleanSelection('1234\n678', 5)).toBe('1234\n678');
+  });
+
+  it('trims leading and trailing blank lines', () => {
+    expect(cleanSelection('\n\nhello\n\n', 80)).toBe('hello');
+  });
+});


### PR DESCRIPTION
## What

Adds a per-block copy affordance to the embedded terminal so agent output can be copied without the CLI's visual decoration (quote bars, box padding, bullets, indentation).

- **Hover** a quote, code, or message block to see a full-width highlight; a copy chip sits in its top-right corner. **Click** anywhere on the block to copy it (the click still passes through to the agent). **Right-click** adds a "Copy Block" item to the native terminal menu.
- **Ctrl+C** selection copy strips quote-bar decoration from the lines it spans.
- A global **"Copyable Blocks"** toggle (default on) under Settings > Behavior > Terminal turns the whole affordance off. The Behavior tab was also re-sectioned (Sessions / Board / Terminal / Task Windows).

New modules: `terminal-blocks.ts` (pure, DOM-free detection + extraction), `terminal-block-buffer.ts` (live-buffer bridge + hit testing), `terminal-registry.ts` (mounted-terminal registry + hit-test window global), `TerminalBlockCopyButton.tsx` (hover overlay), and `src/main/terminal-context-menu.ts` (the bounded renderer probe for the menu item).

## Why

Copying multi-line agent output currently drags along CLI decoration (the `▎` quote bar, box indentation, prompt/bullet glyphs), so pasted text needs manual cleanup. This gives a clean, one-action copy of the block under the cursor.

Closes #84

## How

Detection is a generic visual heuristic over the interpreted xterm buffer, never keyed to an agent name (per the agent-adapters-boundary rule): a left bar glyph with non-default foreground is a quote; a uniform non-default background run is a box; a `●` bullet delimits a message/tool block that runs to the next bullet, a `✻` thinking line, or a `❯` prompt (so a tool's code/diff stays in one block and thinking lines are excluded); anything else with default-foreground text is a plain text paragraph.

Extraction strips the bar/bullet/prompt marker and dedents the common margin, preserves interior blanks and relative indentation, and copies each visual row as its own line (xterm's `isWrapped` flag is unreliable in the agent TUI, so merging on it caused whitespace gaps and false joins). The context menu integrates via the existing `executeJavaScript` + `CustomEvent` pattern (a `window.__kangenticTerminalBlockHitTest` query probe with a 100ms bounded race), so no new IPC channel. Copy writes go through the focus-independent main-process clipboard where the trigger steals document focus (the native menu).

Trade-off worth noting: this reconstructs message structure from Claude's TUI marker glyphs (`●`/`✻`/`❯`), which is empirically correct today but coupled to that TUI. A transcript-powered copy would be the robust long-term source; it's deliberately out of scope here.

The rebase onto `main` reconciled with the parallel selection-copy fix: `copySelectionToClipboard` now routes its clean step through the buffer-aware `cleanTerminalSelection` (falling back to the legacy `cleanSelection`) while keeping the focus-independent clipboard write.

## Breaking changes

None. New config key `terminalBlockCopy` (global, default `true`) is additive; missing configs get the default.

## Tests

- **Unit:** `terminal-blocks.test.ts` (block detection / extraction / message grouping / thinking-line exclusion), `terminal-block-buffer.test.ts` (live-buffer classifier + pixel-bounds scroll clamping), `terminal-context-menu.test.ts` (probe helpers), `terminal-selection-clean.test.ts` (legacy `cleanSelection` characterization).
- **UI:** `terminal-block-copy.spec.ts` drives a real mounted xterm: hit-test kinds, hover button + click-to-copy, and the `terminalBlockCopy` setting gating the whole affordance.
- Local gate (typecheck + lint) green; the unit / UI / Electron E2E tiers run as CI checks.

Generated with [Claude Code](https://claude.com/claude-code)
