### PR TITLE
fix(changes): isolate worktree Vite dep cache and pre-bundle discovered deep imports

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -186,7 +186,7 @@ Flags:
 
 ### Worktree Dev
 
-In worktrees, `dev.js` bypasses `vite.config.mts` and creates an inline Vite config. This avoids pattern-matching issues where `.kangentic/**` in the watch ignore would match the worktree's own path.
+In worktrees, `dev.js` bypasses `vite.config.mts` and creates an inline Vite config. This avoids pattern-matching issues where `.kangentic/**` in the watch ignore would match the worktree's own path. It also gives worktree servers an isolated Vite dep cache (`<worktree>/.kangentic/vite-cache`; `vite.config.mts` uses `.kangentic/vite-cache-tests` when loaded from a worktree, e.g. Playwright's webServer), because the worktree's `node_modules` is a junction to the main repo's, and sharing the default `node_modules/.vite` would let a worktree server boot invalidate the running main server's cache and break its dynamic imports.
 
 `scripts/worktree-preview.js` creates a `node_modules` junction/symlink from the worktree to the repo root, then opens a native terminal running the dev server.
 

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -80,6 +80,29 @@ async function start() {
   console.time('[dev] vite createServer');
   const { createServer } = await import('vite');
   const isWorktree = projectDir.replace(/\\/g, '/').includes('.kangentic/worktrees/');
+
+  // Per-server Vite dep cache. Computed BEFORE createServer, which creates the
+  // directory during boot, so the cold-cache message below stays accurate (the
+  // old placement checked existsSync AFTER createServer had already made it).
+  //
+  // Worktree servers must NOT use the default <root>/node_modules/.vite: a
+  // worktree's node_modules is a junction to the main repo's (see
+  // src/main/git/node-modules-link.ts), so that default cacheDir physically IS
+  // the main `npm start` server's live cache. The worktree branch below resolves
+  // a different config than vite.config.mts (configFile:false, different root,
+  // preserveSymlinks), so every preview boot would invalidate and rewrite that
+  // shared cache under the running main server, whose in-memory `?v=<hash>`
+  // module URLs then no longer match disk. The first lazy island opened after a
+  // clobber (the Changes panel) failed with "Failed to fetch dynamically imported
+  // module", which the browser caches for the document lifetime. .kangentic/ is
+  // gitignored, covered by the worktree watch ignorePatterns, and removed by the
+  // ephemeral cleanup() on exit. Guarded by
+  // tests/unit/renderer-optimize-deps-parity.test.ts.
+  const viteCacheDir = isWorktree
+    ? path.join(projectDir, '.kangentic', 'vite-cache')
+    : path.join(projectDir, 'node_modules', '.vite');
+  const coldCache = !fs.existsSync(viteCacheDir);
+
   if (isWorktree) {
     // Bypass vite.config.mts entirely. The config's watch.ignored pattern
     // (**/.kangentic/**) matches every file in the worktree (since the worktree
@@ -100,6 +123,9 @@ async function start() {
     viteServer = await createServer({
       configFile: false,
       root: projectDir,
+      // Isolated dep cache; see the viteCacheDir comment above. Never let a
+      // worktree server share node_modules/.vite with the main checkout.
+      cacheDir: viteCacheDir,
       plugins: [tailwindcss(), react()],
       resolve: {
         alias: { '@shared': '/src/shared' },
@@ -130,8 +156,6 @@ async function start() {
   //    optimizer to complete before Electron loads the page, preventing
   //    the renderer from blocking on mid-load re-optimization.
   console.time('[dev] esbuild');
-  const viteCacheDir = path.join(projectDir, 'node_modules', '.vite');
-  const coldCache = !fs.existsSync(viteCacheDir);
   await Promise.all([
     esbuild.build({
       ...esbuildCommon,

--- a/scripts/renderer-optimize-deps.json
+++ b/scripts/renderer-optimize-deps.json
@@ -3,6 +3,7 @@
   "react/jsx-runtime", "react/jsx-dev-runtime",
   "@dnd-kit/core", "@dnd-kit/sortable", "@dnd-kit/utilities",
   "@xterm/xterm", "@xterm/addon-webgl", "@xterm/addon-serialize",
-  "lucide-react", "react-colorful", "zustand",
-  "monaco-editor"
+  "lucide-react", "react-colorful",
+  "zustand", "zustand/react/shallow",
+  "monaco-editor", "monaco-editor/esm/vs/base/common/errors"
 ]

--- a/tests/unit/renderer-optimize-deps-parity.test.ts
+++ b/tests/unit/renderer-optimize-deps-parity.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Renderer optimizeDeps parity guard.
+ *
+ * scripts/renderer-optimize-deps.json is the single list of renderer deps that
+ * Vite pre-bundles at dev-server boot. It is consumed by BOTH vite.config.mts
+ * and the inline worktree config in scripts/dev.js (which cannot load
+ * vite.config.mts). Two invariants keep the dogfooded `npm start` app healthy:
+ *
+ * 1. DEEP imports of pre-bundled packages must be pre-bundled too. A dep
+ *    specifier Vite first meets after boot (reachable only behind a React.lazy
+ *    island, e.g. the Changes panel's monaco graph) can trigger a mid-session
+ *    re-optimization. Combined with the shared-cache clobbering fixed via the
+ *    worktree cacheDir (scripts/dev.js), this surfaced as "Failed to fetch
+ *    dynamically imported module" on the Changes panel, a failure the browser
+ *    then caches in the module map for the document lifetime.
+ *
+ * 2. @monaco-editor/react must NEVER be pre-bundled (commit 5bb2e089):
+ *    pre-bundling wraps it in Vite's CJS-ESM interop, handing it a React copy
+ *    whose hooks dispatcher is null (useState-on-null crash in DiffEditor on
+ *    React 19). Served un-bundled as native ESM, its react imports are
+ *    rewritten to the shared pre-bundled react and hooks work. JSON cannot
+ *    carry comments, so this test is where that constraint lives.
+ *
+ * Plus mechanical guards that worktree-started Vite servers keep their dep
+ * caches out of the junction-shared node_modules (the clobbering root cause).
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const OPTIMIZE_DEPS_JSON = path.join(REPO_ROOT, 'scripts', 'renderer-optimize-deps.json');
+// Everything Vite serves to the renderer in dev: the renderer itself plus the
+// dev-only devtools renderer surface imported from App.tsx / DeveloperTab.
+const SCAN_ROOTS = [
+  path.join(REPO_ROOT, 'src', 'renderer'),
+  path.join(REPO_ROOT, 'src', 'devtools', 'renderer'),
+];
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);
+
+// Specifiers the dep optimizer never handles:
+// - Vite query imports (?worker, ?url, ?raw) go through dedicated plugins.
+// - CSS/asset deep imports go through the CSS/asset pipeline.
+// - Relative, alias, and node builtin specifiers are not node_modules deps.
+const ASSET_EXTENSION = /\.(css|scss|sass|less|styl|svg|png|jpe?g|gif|webp|woff2?)$/i;
+
+function isOptimizerCandidate(specifier: string): boolean {
+  if (specifier.includes('?')) return false;
+  if (specifier.startsWith('.') || specifier.startsWith('/')) return false;
+  if (specifier.startsWith('@shared/')) return false; // resolve.alias, not a package
+  if (specifier.startsWith('node:')) return false;
+  if (ASSET_EXTENSION.test(specifier)) return false;
+  return true;
+}
+
+// '@dnd-kit/core' is a package NAME (scoped packages span two segments);
+// 'monaco-editor/esm/vs/base/common/errors' is a deep subpath of 'monaco-editor'.
+function packageNameOf(specifier: string): string {
+  const segments = specifier.split('/');
+  return specifier.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0];
+}
+
+function collectSourceFiles(directory: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath));
+    } else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function isCommentLine(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*');
+}
+
+// Static imports and re-exports, dynamic import() with a string literal, and
+// side-effect imports. Multi-line import statements keep their from-clause on
+// one line, so line-based scanning (which lets us skip comment lines, the same
+// approach as external-scripts-parity.test.ts) sees every specifier.
+const SPECIFIER_PATTERNS: RegExp[] = [
+  /\bfrom\s*(['"])([^'"]+)\1/g,
+  /\bimport\s*\(\s*(['"])([^'"]+)\1/g,
+  /^\s*import\s+(['"])([^'"]+)\1/g,
+];
+
+type FoundSpecifier = { specifier: string; location: string };
+
+function collectBareSpecifiers(): FoundSpecifier[] {
+  const found: FoundSpecifier[] = [];
+  for (const root of SCAN_ROOTS) {
+    if (!fs.existsSync(root)) continue;
+    for (const filePath of collectSourceFiles(root)) {
+      const lines = fs.readFileSync(filePath, 'utf-8').split('\n');
+      lines.forEach((line, index) => {
+        if (isCommentLine(line)) return;
+        for (const pattern of SPECIFIER_PATTERNS) {
+          for (const match of line.matchAll(pattern)) {
+            const specifier = match[2];
+            if (!isOptimizerCandidate(specifier)) continue;
+            found.push({
+              specifier,
+              location: `${path.relative(REPO_ROOT, filePath).replace(/\\/g, '/')}:${index + 1}`,
+            });
+          }
+        }
+      });
+    }
+  }
+  return found;
+}
+
+const includeList = JSON.parse(fs.readFileSync(OPTIMIZE_DEPS_JSON, 'utf-8')) as unknown;
+
+describe('renderer optimizeDeps parity', () => {
+  it('renderer-optimize-deps.json is a string array of installed packages', () => {
+    expect(Array.isArray(includeList)).toBe(true);
+    for (const entry of includeList as unknown[]) {
+      expect(typeof entry, `non-string entry: ${JSON.stringify(entry)}`).toBe('string');
+      const packageName = packageNameOf(entry as string);
+      expect(
+        fs.existsSync(path.join(REPO_ROOT, 'node_modules', packageName)),
+        `entry '${String(entry)}' references package '${packageName}', which is not installed`,
+      ).toBe(true);
+    }
+  });
+
+  it('every deep import of a pre-bundled package is itself pre-bundled', () => {
+    const entries = includeList as string[];
+    const includeSet = new Set(entries);
+    const listedPackages = new Set(entries.map(packageNameOf));
+    const violations: string[] = [];
+    for (const { specifier, location } of collectBareSpecifiers()) {
+      const packageName = packageNameOf(specifier);
+      if (specifier === packageName) continue; // package root; the boot scan handles it
+      if (!listedPackages.has(packageName)) continue; // family not force-included
+      if (includeSet.has(specifier)) continue;
+      violations.push(`${location} -> '${specifier}'`);
+    }
+    expect(
+      violations,
+      `Deep imports of pre-bundled packages must be listed in `
+        + `scripts/renderer-optimize-deps.json, or Vite can meet them after boot and `
+        + `re-bundle mid-session (the Changes panel "Failed to fetch dynamically `
+        + `imported module" bug). Add these specifiers to the JSON:\n${violations.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('never pre-bundles @monaco-editor/react (React 19 useState crash, commit 5bb2e089)', () => {
+    // Pre-bundling wraps @monaco-editor/react in Vite's CJS-ESM interop and
+    // hands it a React copy whose hooks dispatcher is null, crashing
+    // DiffEditor's useState. Served un-bundled as native ESM, its react
+    // imports rewrite to the shared pre-bundled react. Do NOT re-add it.
+    expect((includeList as string[]).includes('@monaco-editor/react')).toBe(false);
+  });
+});
+
+describe('worktree vite cache isolation', () => {
+  // The worktree's node_modules is a junction to the main repo's
+  // (src/main/git/node-modules-link.ts), so a worktree dev server using the
+  // default cacheDir (<root>/node_modules/.vite) physically shares, and with a
+  // differently-resolved config clobbers, the running main server's dep cache.
+  // Do not delete these assertions to silence a refactor; move the cacheDir
+  // and update the patterns instead.
+  it('scripts/dev.js gives worktree servers a cacheDir outside node_modules', () => {
+    const source = fs.readFileSync(path.join(REPO_ROOT, 'scripts', 'dev.js'), 'utf-8');
+    expect(
+      /cacheDir:\s*viteCacheDir/.test(source),
+      'scripts/dev.js worktree createServer config must set cacheDir: viteCacheDir',
+    ).toBe(true);
+    expect(
+      /['"]\.kangentic['"],\s*['"]vite-cache['"]/.test(source),
+      'scripts/dev.js must place the worktree vite cache at <worktree>/.kangentic/vite-cache',
+    ).toBe(true);
+  });
+
+  it('vite.config.mts isolates worktree-started servers (Playwright webServer) the same way', () => {
+    const source = fs.readFileSync(path.join(REPO_ROOT, 'vite.config.mts'), 'utf-8');
+    expect(
+      /cacheDir:\s*path\.join\(configDir,\s*['"]\.kangentic['"],\s*['"]vite-cache-tests['"]\)/.test(source),
+      'vite.config.mts must set a worktree-conditional cacheDir '
+        + '(.kangentic/vite-cache-tests) so a Playwright-started server in a worktree '
+        + 'never rewrites the main checkout node_modules/.vite',
+    ).toBe(true);
+  });
+});

--- a/tests/unit/renderer-optimize-deps-parity.test.ts
+++ b/tests/unit/renderer-optimize-deps-parity.test.ts
@@ -179,6 +179,22 @@ describe('worktree vite cache isolation', () => {
     ).toBe(true);
   });
 
+  it('scripts/dev.js keeps the non-worktree branch on the default node_modules/.vite cache', () => {
+    // The worktree isolation above only guards the isWorktree branch. Nothing
+    // else pins the OTHER side of that ternary: if a future refactor collapsed
+    // it to always resolve .kangentic/vite-cache, the main `npm start` server
+    // would start writing into an isolated cache too (silently defeating the
+    // whole point, since the isolation only matters relative to the shared
+    // default) and the two assertions above would keep passing unchanged.
+    const source = fs.readFileSync(path.join(REPO_ROOT, 'scripts', 'dev.js'), 'utf-8');
+    expect(
+      /:\s*path\.join\(projectDir,\s*['"]node_modules['"],\s*['"]\.vite['"]\)/.test(source),
+      'scripts/dev.js must keep the non-worktree viteCacheDir branch at '
+        + "path.join(projectDir, 'node_modules', '.vite') (Vite's own default), "
+        + 'so the main dev server never gets routed into the worktree-only cache',
+    ).toBe(true);
+  });
+
   it('vite.config.mts isolates worktree-started servers (Playwright webServer) the same way', () => {
     const source = fs.readFileSync(path.join(REPO_ROOT, 'vite.config.mts'), 'utf-8');
     expect(

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,9 +1,31 @@
 import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import rendererOptimizeDeps from './scripts/renderer-optimize-deps.json';
 
+// fileURLToPath(import.meta.url) rather than a __dirname shim: this config is
+// bundled/evaluated as ESM.
+const configDir = path.dirname(fileURLToPath(import.meta.url));
+const isWorktree = configDir.replace(/\\/g, '/').includes('.kangentic/worktrees/');
+
 export default defineConfig(({ mode }) => ({
+  // Worktree checkouts share the main repo's physical node_modules via a
+  // junction (src/main/git/node-modules-link.ts). A server started from a
+  // worktree with THIS config (Playwright's webServer for UI tests, or a manual
+  // `npx vite`) resolves a different config hash than the main `npm start`
+  // server and would invalidate/rewrite the live server's dep cache at the
+  // default <root>/node_modules/.vite. Give it a worktree-local cache instead.
+  // Deliberately distinct from scripts/dev.js's worktree cache
+  // (.kangentic/vite-cache): the two configs resolve differently, so sharing one
+  // directory would just recreate the cross-server clobbering inside the
+  // worktree (a UI-test run would poison a live preview). Non-worktree servers
+  // (main dev, CI) keep the default cache. Guarded by
+  // tests/unit/renderer-optimize-deps-parity.test.ts.
+  ...(isWorktree
+    ? { cacheDir: path.join(configDir, '.kangentic', 'vite-cache-tests') }
+    : {}),
   // Build-time constant gating dev-only renderer code (DevtoolsBootstrap,
   // DevToolsSections). `mode === 'production'` happens during `npm run build`,
   // dropping the conditional blocks from the production renderer bundle.
@@ -27,6 +49,18 @@ export default defineConfig(({ mode }) => ({
       ignored: ['**/.kangentic/**', '**/.claude/**', '**/.codex/**', '**/.aider/**', '**/.qwen/**', '**/docs/**', '**/tests/**', '**/kangentic.json', '**/kangentic.local.json'],
     },
   },
+  // Renderer deps pre-bundled at dev-server boot. The list lives in
+  // scripts/renderer-optimize-deps.json so scripts/dev.js's inline worktree
+  // config (which cannot load this file) shares it. Two invariants, both
+  // enforced by tests/unit/renderer-optimize-deps-parity.test.ts:
+  // 1. Every DEEP import of a listed package used by the renderer must be listed
+  //    too. A dep first met after boot triggers a mid-session re-optimization;
+  //    the Changes panel's lazy monaco graph hit this and died with "Failed to
+  //    fetch dynamically imported module".
+  // 2. @monaco-editor/react stays OUT: pre-bundling wraps it in Vite's CJS-ESM
+  //    interop and hands it a React whose hooks dispatcher is null (useState
+  //    crash in DiffEditor, commit 5bb2e089). As native ESM its react imports
+  //    rewrite to the shared pre-bundled react.
   optimizeDeps: {
     include: rendererOptimizeDeps,
   },


### PR DESCRIPTION
## What

Fixes the Changes panel dying on load in the dogfooded `npm start` app with "Failed to fetch dynamically imported module: .../ChangesPanel.tsx". Touches the Vite dev-server plumbing:

- `scripts/renderer-optimize-deps.json` - pre-bundle the two runtime-discovered deep imports (`monaco-editor/esm/vs/base/common/errors`, `zustand/react/shallow`).
- `scripts/dev.js` - worktree dev servers get an isolated `cacheDir` (`<worktree>/.kangentic/vite-cache`) instead of the junction-shared `node_modules/.vite`.
- `vite.config.mts` - a worktree-loaded config (Playwright's UI-test webServer) gets its own `.kangentic/vite-cache-tests`.
- `tests/unit/renderer-optimize-deps-parity.test.ts` (new) - self-maintaining guard for the invariants.
- `docs/developer-guide.md` - one sentence on the per-worktree caches.

## Why

Two interacting causes:

1. **Shared deps cache.** A worktree's `node_modules` is a junction to the main repo's (`src/main/git/node-modules-link.ts`), and no server set `cacheDir`, so the main `npm start` server (5173) and every worktree preview (5174+) physically shared `node_modules/.vite`. The worktree branch of `dev.js` resolves a different config, so each preview boot rebuilt the shared cache under the running main server, whose in-memory `?v=<hash>` module URLs then no longer matched disk. Chrome caches the failed dynamic import in the per-document module map, so the panel stayed dead.
2. **Runtime-discovered deps.** `monacoConfig.ts` deep-imports `monaco-editor/esm/vs/base/common/errors` and the renderer uses `zustand/react/shallow`, neither in `optimizeDeps`, so they were discovered after boot. The Changes panel is the only lazy island pulling that graph, so its first open always landed on a stale or mid-rebuild cache era.

## How

Two independent fixes. Pre-bundling the deep imports makes each server's optimize complete at boot (Vite's documented guidance for deep imports). Per-server `cacheDir` closes the whole clobbering class: no foreign server can rewrite the main server's cache. The worktree config uses a deliberately different cache dir than `dev.js` (`vite-cache-tests` vs `vite-cache`) because their resolved config hashes differ, so sharing one dir would just recreate the clobbering inside the worktree (a UI-test run poisoning a live preview).

`@monaco-editor/react` was deliberately NOT re-added: pre-bundling it reintroduces the React 19 `useState`-on-null crash in `DiffEditor` (commit 5bb2e089). The new parity test guards that constraint (JSON cannot carry the comment).

The PanelErrorBoundary reload path was left as-is: the module map is per-document so its existing `window.location.reload()` already recovers, and once caches are per-server a given `?v=<hash>` URL can never change content.

## Breaking changes

None. Runtime behavior of the shipped app is unchanged; this only affects the dev-server dependency cache. The running `npm start` benefits on its next restart (one full re-optimization on that boot as the config hash changes).

## Tests

- New `tests/unit/renderer-optimize-deps-parity.test.ts`: every deep import of a listed package must be listed; `@monaco-editor/react` must stay out; both worktree cacheDir wirings must exist and the non-worktree branch must keep the default cache. Red-green validated (failed on the exact violations before the fix, passes after).
- Empirically verified with a scratch Vite-boot script: booting a worktree server left the main cache's `browserHash` and mtime unchanged, both deep imports were pre-bundled at boot, and the full Changes-panel graph resolved with zero mid-session re-optimization.
- Local typecheck + lint clean. Full unit / UI / Linux E2E tiers run as the CI checks on this PR.

Generated with [Claude Code](https://claude.com/claude-code)
