### PR TITLE
fix(command-terminal): reconcile window population per project on open

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,9 +114,18 @@ won't be found.
   MARCHES (`@keyframes march-border` + a `pathLength`-normalized stroke-dash). The `+` add
   affordance lives in the CENTER of the glyph (replacing the shell prompt) when the layer is open
   and below the cap, not a corner badge, so it never clashes with the activity color. This replaces
-  the old background dot. Project switching keeps every slot's PTY alive in the map (no
-  stash/restore); the bar closes on switch and its windows rebind to the new project's slots on
-  reopen.
+  the old background dot. GEOMETRY is global but POPULATION is per-project: the window layout blob
+  is shared, yet WHICH slots get windows is reconciled to the current project's live transient
+  sessions on open (`reconcileCommandTerminalWindows` +
+  `planCommandWindowReconciliation` in `command-window-reconcile.ts`). Project switching keeps every
+  slot's PTY alive in the map (no stash/restore); the bar closes on switch, and on reopen the
+  reconcile closes carried-over windows whose slot has no live session for the new project (keeping
+  one default terminal) and opens a window for every live session that lacks one (so switching BACK
+  reattaches all of a project's terminals instead of leaking a window-less PTY). The reconcile runs
+  BEFORE the layer mounts (`useCommandBar.open()`, plus the empty-store branch of
+  `useEnsureCommandWindow` for the app-restart blob-restore path), because a carried-over window
+  committed into the store would otherwise spawn a fresh PTY under the wrong project before a
+  bridge-effect reconcile could close it.
 - **Settings tab separator** - In `AppSettingsPanel`, tabs above the `separator: true` marker
   are per-project settings (saved to `.kangentic/config.json`). Tabs below the separator
   (Behavior, Notifications, Privacy) are shared settings that apply across all projects (saved

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -17,7 +17,7 @@ import { requiresUserInteraction } from '../shared/activity-state';
 import { bumpHmrGeneration } from './utils/hmr-generation';
 import { clearSnapPreviewDom } from './window-manager';
 import { setRebindCaptureActive } from './utils/rebind-state';
-import { useWindowStore } from './window-manager/store/window-store';
+import { useWindowStore, commandWindowManager } from './window-manager/store/window-store';
 import {
   autoNameTimers,
   scheduleAutoNameSuggestion,
@@ -703,5 +703,6 @@ if (import.meta.env.DEV) {
     project: useProjectStore,
     session: useSessionStore,
     window: useWindowStore,
+    commandWindow: commandWindowManager.store,
   };
 }

--- a/src/renderer/components/command-bar/CommandTerminalLayer.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalLayer.tsx
@@ -2,8 +2,14 @@
  * The command-terminal window layer: a second, independent window-manager layer
  * (separate from the board task-detail layer) that hosts the Command Terminal as
  * a movable / resizable / maximizable / snappable window, top-layered over a
- * slight backdrop blur. Its arrangement persists GLOBALLY (one blob shared across
- * all projects); the session stays per-project and ephemeral.
+ * slight backdrop blur.
+ *
+ * GEOMETRY is GLOBAL: one blob (`AppConfig.commandTerminalWorkspace`) holds the
+ * size / position / tiling shared across all projects. POPULATION is PER-PROJECT:
+ * which slots get windows is derived from the current project's live transient
+ * sessions on open (see `reconcileCommandTerminalWindows`), because the session
+ * store is keyed per `(projectId, slot)`. Without that split the window count
+ * carried over from one project would spawn that many fresh PTYs in the next.
  *
  * Mounted by `AppLayout` only while open (Ctrl+Shift+P). The command window-store
  * instance is a module singleton that survives the mount/unmount, so hiding the
@@ -20,9 +26,12 @@ import {
 } from '../../window-manager';
 import type { WindowManagerLayerOptions } from '../../window-manager';
 import { useConfigStore } from '../../stores/config-store';
+import { useProjectStore } from '../../stores/project-store';
+import { useSessionStore } from '../../stores/session-store';
 import { useKeybinding } from '../../hooks/useKeybinding';
 import { getIsHmrReload } from '../../utils/hmr-flag';
 import { CommandTerminalLayerProvider } from './command-terminal-context';
+import { planCommandWindowReconciliation } from './command-window-reconcile';
 
 /** The single command-terminal slot anchor (Phase 1 is one window; Phase 2 adds
  *  more slots). The on-disk layout is anchored by this stable id, not a task. */
@@ -58,17 +67,20 @@ export function canSpawnAdditionalCommandTerminal(): boolean {
   return Object.keys(commandWindowManager.store.getState().windows).length < MAX_COMMAND_TERMINALS;
 }
 
-/** Open another Command Terminal in the next free slot (up to the cap) and SPLIT
- *  it into the existing window's footprint (side by side, keeping the size /
- *  position the user set), rather than tiling everything full-screen. Operates on
- *  the module-singleton store, so the title-bar button can call it whether or not
- *  the layer is currently mounted. Returns false if already at the cap. */
-export function spawnAdditionalCommandTerminal(): boolean {
+/** Open a Command Terminal in a specific slot and SPLIT it into the existing
+ *  window's footprint (side by side, keeping the size / position the user set),
+ *  rather than tiling everything full-screen. Operates on the module-singleton
+ *  store, so callers work whether or not the layer is currently mounted.
+ *
+ *  Placement is dock-into-last: reconciliation-opened windows cannot recover
+ *  their old rect from the global blob (the saver persists continuously, so once
+ *  a slot's window is trimmed in one project its geometry is gone), so appending
+ *  left-to-right is the pragmatic answer, matching multi-terminal spawn. Pass
+ *  `skipEnterAnimation` for a programmatic restore (a project-switch reconcile)
+ *  so the window paints flat; a plain user spawn omits it and keeps the entrance. */
+function openCommandTerminalWindowInSlot(slot: string, options?: { skipEnterAnimation?: boolean }): void {
   const store = commandWindowManager.store;
   const existingWindows = Object.values(store.getState().windows);
-  const usedSlots = new Set(existingWindows.map((managedWindow) => managedWindow.anchor));
-  const slot = nextFreeSlot(usedSlots);
-  if (!slot) return false;
 
   // Dock the new window to the RIGHT of the most-recently-opened existing window,
   // so terminals append left-to-right. `dockIntoWindow` confines the pair to the
@@ -82,6 +94,7 @@ export function spawnAdditionalCommandTerminal(): boolean {
     anchor: slot,
     sessionId: null,
     title: COMMAND_WINDOW_TITLE,
+    ...(options?.skipEnterAnimation ? { skipEnterAnimation: true } : {}),
   });
 
   if (dockTarget) {
@@ -101,12 +114,76 @@ export function spawnAdditionalCommandTerminal(): boolean {
       window.innerHeight || 1,
     );
   }
+}
+
+/** Open another Command Terminal in the next free slot (up to the cap). Operates
+ *  on the module-singleton store, so the title-bar button can call it whether or
+ *  not the layer is currently mounted. Returns false if already at the cap. */
+export function spawnAdditionalCommandTerminal(): boolean {
+  const store = commandWindowManager.store;
+  const usedSlots = new Set(
+    Object.values(store.getState().windows).map((managedWindow) => managedWindow.anchor),
+  );
+  const slot = nextFreeSlot(usedSlots);
+  if (!slot) return false;
+
+  // A user-created terminal keeps its entrance animation.
+  openCommandTerminalWindowInSlot(slot);
   return true;
 }
 
-/** Ensure the command layer has its single window once mounted: reuse the live
- *  one (reopen after hide), else restore the saved global layout, else open a
- *  fresh slot. Runs once per mount. */
+/** Reconcile the singleton window POPULATION to the current project's live
+ *  transient sessions: close carried-over windows whose slot has no live session
+ *  for the project, and open a window for every live session that lacks one (so a
+ *  back-switch reattaches the PTY instead of orphaning it). Geometry stays global
+ *  (the blob); only which slots get windows is per project.
+ *
+ *  MUST run while the layer is UNMOUNTED (the `open()` path) or inside
+ *  `useEnsureCommandWindow`'s empty-store branch, so no `CommandTerminalWindow`
+ *  mount effect can observe a pre-reconcile population and spawn under the wrong
+ *  project. Closes are applied before opens so docking never targets a window
+ *  about to close.
+ *
+ *  `skipWhenEmpty` (the `open()` caller) bails when the store holds no windows. An
+ *  empty store has no carried-over windows to reconcile, and populating it here
+ *  would open DEFAULT-geometry windows that pre-empt `useEnsureCommandWindow`'s
+ *  saved-layout restore: its `windows.length > 0` guard would then skip
+ *  `applyWorkspace`, losing the blob geometry on a first open after a hard reload
+ *  with surviving PTYs. The mount effect owns the empty-store case. */
+export function reconcileCommandTerminalWindows(options?: { skipWhenEmpty?: boolean }): void {
+  const projectId = useProjectStore.getState().currentProject?.id ?? null;
+  if (!projectId) return;
+
+  const store = commandWindowManager.store;
+  if (options?.skipWhenEmpty && Object.keys(store.getState().windows).length === 0) return;
+
+  const sessionState = useSessionStore.getState();
+  const plan = planCommandWindowReconciliation({
+    windows: Object.values(store.getState().windows).map((managedWindow) => ({
+      windowId: managedWindow.id,
+      slot: managedWindow.anchor,
+    })),
+    transientSessions: sessionState.transientSessions,
+    sessions: sessionState.sessions,
+    projectId,
+    maxWindows: MAX_COMMAND_TERMINALS,
+  });
+
+  for (const windowId of plan.closeWindowIds) store.getState().closeWindow(windowId);
+  for (const slot of plan.openSlots) openCommandTerminalWindowInSlot(slot, { skipEnterAnimation: true });
+}
+
+/** Ensure the command layer has its windows once mounted. Runs once per mount.
+ *
+ *  Non-empty store: reopen after a hide (`open()` already reconciled the
+ *  population) or an HMR remount (the live layout and `transientSessions` are
+ *  both HMR-preserved and consistent). Leave it alone.
+ *
+ *  Empty store (first open this app run): restore the GLOBAL geometry blob, then
+ *  reconcile the population to this project's live sessions (trim restored
+ *  windows whose slot has no live PTY, keeping one default; open windows for live
+ *  PTYs the blob did not cover, e.g. hard-reload survivors re-paired by
+ *  `syncSessions`), then fall back to a fresh default window if still empty. */
 function useEnsureCommandWindow(): void {
   useEffect(() => {
     const store = commandWindowManager.store;
@@ -115,9 +192,14 @@ function useEnsureCommandWindow(): void {
     const saved = useConfigStore.getState().globalConfig.commandTerminalWorkspace;
     if (saved) {
       // Slot anchors are always valid; the transient session is ephemeral, so the
-      // restored window resolves to no session and the window spawns a fresh one.
+      // restored windows resolve to no session (reconciliation decides which stay).
       store.getState().applyWorkspace(saved, () => null, () => true);
     }
+
+    // Safe here (unlike a bridge effect on a non-empty store): an empty store
+    // committed zero window frames, so no window mount effect can spawn until this
+    // effect finishes and React re-renders the reconciled population.
+    reconcileCommandTerminalWindows();
 
     if (Object.keys(store.getState().windows).length === 0) {
       store.getState().openWindow({

--- a/src/renderer/components/command-bar/command-window-reconcile.ts
+++ b/src/renderer/components/command-bar/command-window-reconcile.ts
@@ -1,0 +1,110 @@
+/**
+ * Pure planner for reconciling the Command Terminal window POPULATION to a
+ * project's live transient sessions.
+ *
+ * The command window store is a global module singleton, but transient PTY
+ * sessions are keyed per `(projectId, slot)`. Without reconciliation, windows
+ * carried over from project A remount under project B and each spawns a fresh
+ * PTY (the window count leaks across projects). This planner computes which
+ * carried-over windows to close (their slot has no live session for the current
+ * project) and which windows to open (a live session lacks a window, so a
+ * back-switch reattaches instead of orphaning the PTY).
+ *
+ * Kept pure and store-free so it is unit-testable without jsdom, Zustand, or
+ * React, mirroring the `workspace-saver.ts` precedent. The caller applies the
+ * plan against the singleton store (see `reconcileCommandTerminalWindows`).
+ */
+
+import type { SessionStatus } from '../../../shared/types';
+
+/** A window's identity for reconciliation: its store id and its durable slot
+ *  anchor (`slot-N`). Structural so a real `ManagedWindow` maps in cheaply. */
+export interface CommandWindowSlotRef {
+  windowId: string;
+  /** The window's durable anchor, a `slot-N` id (equals `ManagedWindow.anchor`). */
+  slot: string;
+}
+
+/** A minimal transient-session entry: only the fields liveness needs. Structural
+ *  so a real `TransientSessionEntry` assigns without an import. */
+export interface CommandWindowTransientEntry {
+  projectId: string;
+  slot: string;
+  sessionId: string;
+}
+
+/** A minimal session row: only the fields liveness needs. `status` uses the real
+ *  `SessionStatus` union (a type-only import, erased at build, so the module stays
+ *  runtime-pure) to keep the `'running'` liveness check typo-proof and tracking
+ *  the source enum. A real `Session` still assigns structurally. */
+export interface CommandWindowSessionRef {
+  id: string;
+  status: SessionStatus;
+}
+
+export interface CommandWindowReconcilePlan {
+  /** Windows whose slot has no live transient session for the current project. */
+  closeWindowIds: string[];
+  /** Slots with a live session but no window, ascending slot order. */
+  openSlots: string[];
+}
+
+/** Parse the numeric suffix of a `slot-N` id for ordering; unparseable ids sort
+ *  last (stable, deterministic). */
+function slotNumber(slot: string): number {
+  const match = /^slot-(\d+)$/.exec(slot);
+  return match ? Number(match[1]) : Number.POSITIVE_INFINITY;
+}
+
+/** Plan the per-project window reconciliation. See the module header for intent.
+ *
+ *  Liveness matches the window mount effect exactly (`CommandTerminalWindow.tsx`):
+ *  a map entry counts as live only when it belongs to the current project AND a
+ *  `sessions` row with the same id is still `running`. */
+export function planCommandWindowReconciliation(input: {
+  windows: ReadonlyArray<CommandWindowSlotRef>;
+  transientSessions: Readonly<Record<string, CommandWindowTransientEntry>>;
+  sessions: ReadonlyArray<CommandWindowSessionRef>;
+  projectId: string;
+  maxWindows: number;
+}): CommandWindowReconcilePlan {
+  const { windows, transientSessions, sessions, projectId, maxWindows } = input;
+
+  const runningSessionIds = new Set(
+    sessions.filter((session) => session.status === 'running').map((session) => session.id),
+  );
+  const liveSlots = new Set(
+    Object.values(transientSessions)
+      .filter((entry) => entry.projectId === projectId && runningSessionIds.has(entry.sessionId))
+      .map((entry) => entry.slot),
+  );
+
+  // No live session for this project: keep exactly one window (lowest slot, so
+  // the layer always opens with a terminal) and close the rest. That kept window
+  // fresh-spawns for the current project via its own mount effect. Fills from the
+  // lowest slot to match `syncSessions` re-pairing (slot-1 up).
+  if (liveSlots.size === 0 && windows.length > 0) {
+    const bySlotAscending = [...windows].sort((first, second) => slotNumber(first.slot) - slotNumber(second.slot));
+    const [, ...surplus] = bySlotAscending;
+    return { closeWindowIds: surplus.map((managedWindow) => managedWindow.windowId), openSlots: [] };
+  }
+
+  // Otherwise every remaining window must map to a live slot (reattach) and every
+  // live slot must have a window (so a back-switch reattaches the PTY).
+  const closeWindowIds = windows
+    .filter((managedWindow) => !liveSlots.has(managedWindow.slot))
+    .map((managedWindow) => managedWindow.windowId);
+
+  const windowSlots = new Set(windows.map((managedWindow) => managedWindow.slot));
+  const missingLiveSlots = [...liveSlots]
+    .filter((slot) => !windowSlots.has(slot))
+    .sort((first, second) => slotNumber(first) - slotNumber(second));
+
+  // Defensive cap: kept + opened must never exceed the terminal cap. In practice
+  // live slots are already bounded by the slot allocator, so this never trims.
+  const keptCount = windows.length - closeWindowIds.length;
+  const openBudget = Math.max(0, maxWindows - keptCount);
+  const openSlots = missingLiveSlots.slice(0, openBudget);
+
+  return { closeWindowIds, openSlots };
+}

--- a/src/renderer/hooks/useCommandBar.ts
+++ b/src/renderer/hooks/useCommandBar.ts
@@ -3,6 +3,7 @@ import { useProjectStore } from '../stores/project-store';
 import { useSessionStore } from '../stores/session-store';
 import { useToastStore } from '../stores/toast-store';
 import { useKeybinding } from './useKeybinding';
+import { reconcileCommandTerminalWindows } from '../components/command-bar/CommandTerminalLayer';
 
 /** Preserved across HMR so the command bar overlay stays mounted during
  *  hot module replacement instead of resetting to closed. */
@@ -17,7 +18,9 @@ if (import.meta.hot) {
   });
 }
 
-/** Tracks the latest isOpen value so dispose() can snapshot it. */
+/** Tracks the latest isOpen value. Read by the HMR dispose() snapshot AND by
+ *  `open()`'s reconcile gate (`!_lastIsOpen` stands in for "layer currently
+ *  unmounted"), so it must stay in sync with the real open state. */
 let _lastIsOpen = hmrCommandBarOpen;
 
 /**
@@ -50,6 +53,15 @@ export function useCommandBar() {
       });
       return;
     }
+    // Reconcile the singleton window population to THIS project's live transient
+    // sessions BEFORE the layer mounts, so a carried-over window can never mount
+    // (and spawn) under the wrong project. Skipped when the layer is already open:
+    // the population was reconciled at open time, and a mid-open reconcile could
+    // transiently empty the store under the live hide-on-empty bridge.
+    // `skipWhenEmpty` defers the empty-store case to `useEnsureCommandWindow`, which
+    // restores the saved layout blob first; reconciling an empty store here would
+    // open default-geometry windows and defeat that restore.
+    if (!_lastIsOpen) reconcileCommandTerminalWindows({ skipWhenEmpty: true });
     setIsOpen(true);
   }, []);
 
@@ -60,12 +72,13 @@ export function useCommandBar() {
   // Consume pending-open flag set by notification clicks for transient sessions.
   // Runs after currentProjectId settles, so cross-project notification clicks
   // (which call openProject first) reopen the overlay on the correct project.
+  // Route through open() so the population reconciles for the target project.
   useEffect(() => {
     if (!pendingOpenCommandTerminal) return;
     if (!currentProjectId) return;
     useSessionStore.getState().setPendingOpenCommandTerminal(false);
-    setIsOpen(true);
-  }, [pendingOpenCommandTerminal, currentProjectId]);
+    open();
+  }, [pendingOpenCommandTerminal, currentProjectId, open]);
 
   useKeybinding('commandBar.toggle', () => {
     if (isOpen) close();

--- a/src/renderer/window-manager/store/window-store.ts
+++ b/src/renderer/window-manager/store/window-store.ts
@@ -177,6 +177,12 @@ interface OpenWindowInput {
   initialEdit?: boolean;
   /** The task is already Done/archived at open time (so it must NOT auto-close). */
   openedDone?: boolean;
+  /** Stamp the opened window to paint flat (no entrance animation). Used by
+   *  programmatic population restores (the command layer's per-project
+   *  reconcile) so a rebuilt window matches the flat presentation of a
+   *  workspace-restored one. A plain user open leaves it unset so the entrance
+   *  plays. Transient, never persisted (mirrors `deserializeWorkspace`). */
+  skipEnterAnimation?: boolean;
 }
 
 export interface WindowStoreState {
@@ -313,6 +319,9 @@ export function createWindowManagerStore(options: WindowManagerStoreOptions): Wi
         title: input.title,
         initialEdit: input.initialEdit,
         openedDone: input.openedDone,
+        // Only set when true so a plain open leaves the property absent (a
+        // freshly opened window keeps its entrance animation).
+        ...(input.skipEnterAnimation ? { skipEnterAnimation: true } : {}),
       };
 
       set((current) => ({

--- a/tests/ui/command-terminal.spec.ts
+++ b/tests/ui/command-terminal.spec.ts
@@ -276,6 +276,222 @@ function multiTerminalPreConfig(): string {
   `;
 }
 
+const RECONCILE_PROJECT_ID = 'proj-cmd-restart';
+const HARD_RELOAD_PROJECT_ID = 'proj-cmd-hard-reload';
+
+/**
+ * Init-script fragment that decorates the DEFAULT mock spawnTransient (which
+ * returns unique ids and pushes into the real sessions array) to tally spawns
+ * per project on `window.__transientSpawnsByProject`. Lets a test assert exactly
+ * how many fresh PTYs a project got. page.goto in the shared-browser beforeEach
+ * re-runs it, resetting the tally per test.
+ */
+function spawnCounterSource(): string {
+  return `
+    var __originalSpawnTransient = window.electronAPI.sessions.spawnTransient;
+    window.__transientSpawnsByProject = {};
+    window.electronAPI.sessions.spawnTransient = async function (input) {
+      window.__transientSpawnsByProject[input.projectId] =
+        (window.__transientSpawnsByProject[input.projectId] || 0) + 1;
+      return __originalSpawnTransient(input);
+    };
+  `;
+}
+
+/** A version-1 serialized command workspace with two floating windows (slot-1,
+ *  slot-2), as `serializeWorkspace` would produce. `taskId` is the on-disk field
+ *  that carries the slot anchor. */
+function twoWindowBlobSource(): string {
+  return `{
+    version: 1,
+    windows: [
+      { taskId: 'slot-1', title: 'Command Terminal', geometry: { x: 0.1, y: 0.1, w: 0.4, h: 0.6 }, restoreGeometry: null, state: 'floating' },
+      { taskId: 'slot-2', title: 'Command Terminal', geometry: { x: 0.5, y: 0.1, w: 0.4, h: 0.6 }, restoreGeometry: null, state: 'floating' }
+    ],
+    tileTree: null,
+    tileTreeRect: { x: 0, y: 0, w: 1, h: 1 },
+    focusedTaskId: 'slot-1'
+  }`;
+}
+
+/** twoProjectPreConfig plus the spawn counter, for the cross-project repro tests. */
+function twoProjectSpawnCountingPreConfig(): string {
+  return `
+    ${twoProjectPreConfig()}
+    ${spawnCounterSource()}
+  `;
+}
+
+/** One project with a persisted 2-window layout blob but NO live sessions: the
+ *  app-restart path. On first open the blob restores two windows and reconcile
+ *  trims to one (no live session to keep the second). */
+function restartBlobPreConfig(): string {
+  return `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+      state.projects.push({
+        id: '${RECONCILE_PROJECT_ID}',
+        name: 'Restart Project',
+        path: '/mock/restart-project',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        state.swimlanes.push(Object.assign({}, s, { id: 'lane-restart-' + i, position: i, created_at: ts }));
+      });
+      return { currentProjectId: '${RECONCILE_PROJECT_ID}' };
+    });
+    window.electronAPI.config.set({ commandTerminalWorkspace: ${twoWindowBlobSource()} });
+    ${spawnCounterSource()}
+  `;
+}
+
+/** One project with the same 2-window blob PLUS two surviving running transient
+ *  PTYs: the hard-reload path. syncSessions re-pairs the survivors to slot-1 /
+ *  slot-2 at boot, so on first open both windows restore and reattach. */
+function hardReloadPreConfig(): string {
+  return `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+      state.projects.push({
+        id: '${HARD_RELOAD_PROJECT_ID}',
+        name: 'Hard Reload Project',
+        path: '/mock/hard-reload-project',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        state.swimlanes.push(Object.assign({}, s, { id: 'lane-hr-' + i, position: i, created_at: ts }));
+      });
+      state.sessions.push({
+        id: 'hr-sess-1', taskId: 'hr-sess-1', projectId: '${HARD_RELOAD_PROJECT_ID}', pid: 3001,
+        status: 'running', shell: 'bash', cwd: '/mock/hard-reload-project', startedAt: ts,
+        exitCode: null, resuming: false, transient: true,
+      });
+      state.sessions.push({
+        id: 'hr-sess-2', taskId: 'hr-sess-2', projectId: '${HARD_RELOAD_PROJECT_ID}', pid: 3002,
+        status: 'running', shell: 'bash', cwd: '/mock/hard-reload-project', startedAt: ts,
+        exitCode: null, resuming: false, transient: true,
+      });
+      return { currentProjectId: '${HARD_RELOAD_PROJECT_ID}' };
+    });
+    window.electronAPI.config.set({ commandTerminalWorkspace: ${twoWindowBlobSource()} });
+    ${spawnCounterSource()}
+  `;
+}
+
+/** Transient-session entries (slot + sessionId) tracked for a project. */
+async function transientEntriesFor(page: Page, projectId: string): Promise<Array<{ slot: string; sessionId: string }>> {
+  return page.evaluate((projectId) => {
+    const stores = (window as unknown as {
+      __zustandStores?: { session?: { getState: () => { transientSessions: Record<string, { projectId: string; slot: string; sessionId: string }> } } };
+    }).__zustandStores;
+    const map = stores?.session?.getState().transientSessions ?? {};
+    return Object.values(map)
+      .filter((entry) => entry.projectId === projectId)
+      .map((entry) => ({ slot: entry.slot, sessionId: entry.sessionId }));
+  }, projectId);
+}
+
+/** Count of fresh spawnTransient calls recorded for a project. */
+async function spawnCountFor(page: Page, projectId: string): Promise<number> {
+  return page.evaluate((projectId) => {
+    const counts = (window as unknown as { __transientSpawnsByProject?: Record<string, number> }).__transientSpawnsByProject ?? {};
+    return counts[projectId] ?? 0;
+  }, projectId);
+}
+
+/** Slot anchors of the command-terminal windows currently in the singleton store, sorted. */
+async function commandWindowAnchors(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const stores = (window as unknown as {
+      __zustandStores?: { commandWindow?: { getState: () => { windows: Record<string, { anchor: string }> } } };
+    }).__zustandStores;
+    const windows = stores?.commandWindow?.getState().windows ?? {};
+    return Object.values(windows).map((managedWindow) => managedWindow.anchor).sort();
+  });
+}
+
+/** Fractional geometry, keyed by slot anchor, for every command-terminal window in
+ *  the singleton store. Used to verify a restored window carries the PERSISTED
+ *  blob geometry (not a freshly-opened default rect) - a population-count
+ *  assertion alone cannot distinguish "restored from the blob" from "reconciled
+ *  open at the default size", which is exactly the bug this covers. */
+async function commandWindowGeometryBySlot(
+  page: Page,
+): Promise<Record<string, { x: number; y: number; w: number; h: number }>> {
+  return page.evaluate(() => {
+    const stores = (window as unknown as {
+      __zustandStores?: {
+        commandWindow?: {
+          getState: () => {
+            windows: Record<string, { anchor: string; geometry: { x: number; y: number; w: number; h: number } }>;
+          };
+        };
+      };
+    }).__zustandStores;
+    const windows = stores?.commandWindow?.getState().windows ?? {};
+    const bySlot: Record<string, { x: number; y: number; w: number; h: number }> = {};
+    for (const managedWindow of Object.values(windows)) {
+      bySlot[managedWindow.anchor] = managedWindow.geometry;
+    }
+    return bySlot;
+  });
+}
+
+/** Numeric tolerance for fractional geometry comparisons. Per the cross-platform
+ *  rule, never compare a freshly-measured/derived float with zero tolerance. */
+const GEOMETRY_TOLERANCE = 0.001;
+
+/** Assert `actual` geometry is within GEOMETRY_TOLERANCE of `expected` on every axis. */
+function expectGeometryNear(
+  actual: { x: number; y: number; w: number; h: number } | undefined,
+  expected: { x: number; y: number; w: number; h: number },
+): void {
+  expect(actual, 'expected a geometry entry for this slot').toBeDefined();
+  if (!actual) return;
+  expect(Math.abs(actual.x - expected.x)).toBeLessThanOrEqual(GEOMETRY_TOLERANCE);
+  expect(Math.abs(actual.y - expected.y)).toBeLessThanOrEqual(GEOMETRY_TOLERANCE);
+  expect(Math.abs(actual.w - expected.w)).toBeLessThanOrEqual(GEOMETRY_TOLERANCE);
+  expect(Math.abs(actual.h - expected.h)).toBeLessThanOrEqual(GEOMETRY_TOLERANCE);
+}
+
+/** The two window geometries seeded by `twoWindowBlobSource()`, keyed by slot. A
+ *  restored window that carries these values (rather than the centered default
+ *  from `defaultWindowGeometry`) proves the saved blob geometry survived the
+ *  first-open reconcile, not just that a window count matched. */
+const HARD_RELOAD_BLOB_GEOMETRY: Record<string, { x: number; y: number; w: number; h: number }> = {
+  'slot-1': { x: 0.1, y: 0.1, w: 0.4, h: 0.6 },
+  'slot-2': { x: 0.5, y: 0.1, w: 0.4, h: 0.6 },
+};
+
+/** Of the given session ids, which are present and still running in the session store. */
+async function runningSessionIds(page: Page, sessionIds: string[]): Promise<string[]> {
+  return page.evaluate((ids) => {
+    const stores = (window as unknown as {
+      __zustandStores?: { session?: { getState: () => { sessions: Array<{ id: string; status: string }> } } };
+    }).__zustandStores;
+    const sessions = stores?.session?.getState().sessions ?? [];
+    return sessions.filter((session) => ids.includes(session.id) && session.status === 'running').map((session) => session.id);
+  }, sessionIds);
+}
+
+/** The active project's id (null when none). Used to wait for a project switch to
+ *  settle before opening the layer, since open() reconciles against the current
+ *  project the instant it runs. */
+async function activeProjectId(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const stores = (window as unknown as {
+      __zustandStores?: { project?: { getState: () => { currentProject: { id: string } | null } } };
+    }).__zustandStores;
+    return stores?.project?.getState().currentProject?.id ?? null;
+  });
+}
+
 test.describe('Command Terminal', () => {
   // ---------------------------------------------------------------------------
   // TitleBar Button - these two tests use different base preconfigs so each
@@ -830,6 +1046,186 @@ test.describe('Command Terminal', () => {
         // At cap (4 windows) - the centered `+` is gone.
         await expect(page.getByTestId('command-terminal-window')).toHaveCount(4);
         await expect(page.getByTestId('quick-session-icon')).toHaveAttribute('data-plus', 'false', { timeout: 3000 });
+      } finally {
+        await browser.close();
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Window population reconciliation (per project) - the headline bug fix: the
+  // GLOBAL window store's population is reconciled to the CURRENT project's live
+  // transient sessions on open, so a window count carried from one project never
+  // spawns that many fresh PTYs in the next.
+  // ---------------------------------------------------------------------------
+  test.describe('Window population reconciliation (per project)', () => {
+    let reconcileBrowser: Browser;
+    let reconcilePage: Page;
+
+    test.beforeAll(async () => {
+      ({ browser: reconcileBrowser, page: reconcilePage } = await launchSharedBrowser(
+        twoProjectSpawnCountingPreConfig(),
+      ));
+    });
+
+    test.afterAll(async () => {
+      await reconcileBrowser?.close();
+    });
+
+    test.beforeEach(async () => {
+      await reconcilePage.goto(VITE_URL);
+      await reconcilePage.waitForLoadState('load');
+      await reconcilePage.waitForSelector('text=Kangentic', { timeout: 15000 });
+      await reconcilePage.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+    });
+
+    test('two terminals in project A collapse to one fresh terminal in project B', async () => {
+      const page = reconcilePage;
+
+      // Two terminals in Project A (2 windows, 2 tracked A sessions).
+      await page.keyboard.press('Control+Shift+P');
+      await expect(page.getByTestId('command-terminal-window')).toHaveCount(1, { timeout: 5000 });
+      await page.getByTestId('quick-session-button').click();
+      await expect(page.getByTestId('command-terminal-window')).toHaveCount(2, { timeout: 5000 });
+      await expect
+        .poll(async () => (await transientEntriesFor(page, PROJECT_A_ID)).length, { timeout: 5000, intervals: [100, 200, 500] })
+        .toBe(2);
+
+      // Hide the layer, then switch to Project B (wait for the switch to settle).
+      await page.keyboard.press('Control+Shift+P');
+      await expect(page.getByTestId('command-terminal-window')).not.toBeVisible({ timeout: 5000 });
+      await page.locator('[role="button"]:has-text("Project Beta")').click();
+      await expect.poll(() => activeProjectId(page), { timeout: 5000, intervals: [100, 200, 500] }).toBe(PROJECT_B_ID);
+
+      // Open in Project B: reconcile trims the 2 carried windows to 1, which
+      // spawns exactly one fresh PTY for B.
+      await page.keyboard.press('Control+Shift+P');
+      await expect(page.getByTestId('command-terminal-window')).toHaveCount(1, { timeout: 5000 });
+      await expect
+        .poll(() => spawnCountFor(page, PROJECT_B_ID), { timeout: 5000, intervals: [100, 200, 500] })
+        .toBe(1);
+      await expect
+        .poll(async () => (await transientEntriesFor(page, PROJECT_B_ID)).length, { timeout: 5000, intervals: [100, 200, 500] })
+        .toBe(1);
+
+      // A's two sessions were never touched: both still tracked and running.
+      const aEntries = await transientEntriesFor(page, PROJECT_A_ID);
+      expect(aEntries).toHaveLength(2);
+      const aSessionIds = aEntries.map((entry) => entry.sessionId).sort();
+      const stillRunning = await runningSessionIds(page, aSessionIds);
+      expect(stillRunning.sort()).toEqual(aSessionIds);
+
+      // Exactly one window, on a slot with a live B session; B never got a 2nd spawn.
+      const anchors = await commandWindowAnchors(page);
+      expect(anchors).toHaveLength(1);
+      const bSlots = (await transientEntriesFor(page, PROJECT_B_ID)).map((entry) => entry.slot);
+      expect(bSlots).toContain(anchors[0]);
+      expect(await spawnCountFor(page, PROJECT_B_ID)).toBe(1);
+    });
+
+    test('returning to a project reopens a window per live session and reattaches without spawning', async () => {
+      const page = reconcilePage;
+
+      // Two terminals in Project A; capture their session ids.
+      await page.keyboard.press('Control+Shift+P');
+      await expect(page.getByTestId('command-terminal-window')).toHaveCount(1, { timeout: 5000 });
+      await page.getByTestId('quick-session-button').click();
+      await expect(page.getByTestId('command-terminal-window')).toHaveCount(2, { timeout: 5000 });
+      await expect
+        .poll(async () => (await transientEntriesFor(page, PROJECT_A_ID)).length, { timeout: 5000, intervals: [100, 200, 500] })
+        .toBe(2);
+      const originalASessionIds = (await transientEntriesFor(page, PROJECT_A_ID)).map((entry) => entry.sessionId).sort();
+
+      // Hide, switch to B, open (spawns B's one terminal), hide again.
+      await page.keyboard.press('Control+Shift+P');
+      await expect(page.getByTestId('command-terminal-window')).not.toBeVisible({ timeout: 5000 });
+      await page.locator('[role="button"]:has-text("Project Beta")').click();
+      await expect.poll(() => activeProjectId(page), { timeout: 5000, intervals: [100, 200, 500] }).toBe(PROJECT_B_ID);
+      await page.keyboard.press('Control+Shift+P');
+      await expect(page.getByTestId('command-terminal-window')).toHaveCount(1, { timeout: 5000 });
+      await page.keyboard.press('Control+Shift+P');
+      await expect(page.getByTestId('command-terminal-window')).not.toBeVisible({ timeout: 5000 });
+
+      // Switch back to A and reopen: both windows return and reattach, no new spawns.
+      await page.locator('[role="button"]:has-text("Project Alpha")').click();
+      await expect.poll(() => activeProjectId(page), { timeout: 5000, intervals: [100, 200, 500] }).toBe(PROJECT_A_ID);
+      await page.keyboard.press('Control+Shift+P');
+      await expect(page.getByTestId('command-terminal-window')).toHaveCount(2, { timeout: 5000 });
+      await expect.poll(() => commandWindowAnchors(page), { timeout: 5000, intervals: [100, 200, 500] }).toEqual(['slot-1', 'slot-2']);
+
+      // The two A entries carry the ORIGINAL session ids (reattach, not respawn),
+      // and A never got a spawn beyond the initial two.
+      await expect
+        .poll(async () => (await transientEntriesFor(page, PROJECT_A_ID)).map((entry) => entry.sessionId).sort().join(','), { timeout: 5000, intervals: [100, 200, 500] })
+        .toBe(originalASessionIds.join(','));
+      expect(await spawnCountFor(page, PROJECT_A_ID)).toBe(2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Window population reconciliation (restart and hard reload) - the app-restart
+  // path restores the GLOBAL geometry blob, then reconciles the population to the
+  // project's live sessions before the layer mounts.
+  // ---------------------------------------------------------------------------
+  test.describe('Window population reconciliation (restart and hard reload)', () => {
+    test('a persisted multi-window layout is trimmed to one window on first open', async () => {
+      const { browser, page } = await launchWithState(restartBlobPreConfig());
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+        // The seeded 2-window blob is in global config BEFORE opening, so a trim
+        // to one window proves reconcile ran (not merely an empty layout).
+        await expect
+          .poll(() => page.evaluate(() => {
+            const stores = (window as unknown as {
+              __zustandStores?: { config?: { getState: () => { globalConfig: { commandTerminalWorkspace: { windows?: unknown[] } | null } } } };
+            }).__zustandStores;
+            return stores?.config?.getState().globalConfig.commandTerminalWorkspace?.windows?.length ?? 0;
+          }), { timeout: 5000, intervals: [100, 200, 500] })
+          .toBe(2);
+
+        await page.keyboard.press('Control+Shift+P');
+        await expect(page.getByTestId('command-terminal-window')).toHaveCount(1, { timeout: 5000 });
+        await expect
+          .poll(() => spawnCountFor(page, RECONCILE_PROJECT_ID), { timeout: 5000, intervals: [100, 200, 500] })
+          .toBe(1);
+      } finally {
+        await browser.close();
+      }
+    });
+
+    test('a hard reload with surviving PTYs restores a window per survivor and reattaches', async () => {
+      const { browser, page } = await launchWithState(hardReloadPreConfig());
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+        // syncSessions re-pairs the two surviving transient PTYs to slot-1 /
+        // slot-2 at boot; wait for that before opening (avoids the boot race).
+        await expect
+          .poll(async () => (await transientEntriesFor(page, HARD_RELOAD_PROJECT_ID)).length, { timeout: 8000, intervals: [100, 200, 500] })
+          .toBe(2);
+
+        await page.keyboard.press('Control+Shift+P');
+        await expect(page.getByTestId('command-terminal-window')).toHaveCount(2, { timeout: 5000 });
+        // Both reattached: no fresh spawns for the project.
+        expect(await spawnCountFor(page, HARD_RELOAD_PROJECT_ID)).toBe(0);
+
+        // Regression guard: a count/spawn match alone does not prove the SAVED
+        // geometry blob was restored - a reconcile that pre-populated the empty
+        // store with default-geometry windows (before `useEnsureCommandWindow` got
+        // a chance to `applyWorkspace`) also reattaches both slots with 0 spawns,
+        // just at the wrong (centered default) rects. Wait for both slots to be
+        // present (store update can lag a tick behind the DOM count above), then
+        // assert each restored slot carries the persisted blob geometry.
+        await expect
+          .poll(async () => Object.keys(await commandWindowGeometryBySlot(page)).sort(), {
+            timeout: 5000,
+            intervals: [100, 200, 500],
+          })
+          .toEqual(['slot-1', 'slot-2']);
+        const geometryBySlot = await commandWindowGeometryBySlot(page);
+        expectGeometryNear(geometryBySlot['slot-1'], HARD_RELOAD_BLOB_GEOMETRY['slot-1']);
+        expectGeometryNear(geometryBySlot['slot-2'], HARD_RELOAD_BLOB_GEOMETRY['slot-2']);
       } finally {
         await browser.close();
       }

--- a/tests/unit/command-window-reconcile.test.ts
+++ b/tests/unit/command-window-reconcile.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import {
+  planCommandWindowReconciliation,
+  type CommandWindowSlotRef,
+  type CommandWindowTransientEntry,
+  type CommandWindowSessionRef,
+} from '../../src/renderer/components/command-bar/command-window-reconcile';
+
+const PROJECT_A = 'project-a';
+const PROJECT_B = 'project-b';
+const MAX_WINDOWS = 4;
+
+function windowRef(slot: string): CommandWindowSlotRef {
+  return { windowId: `win-${slot}`, slot };
+}
+
+function transientMap(entries: CommandWindowTransientEntry[]): Record<string, CommandWindowTransientEntry> {
+  const map: Record<string, CommandWindowTransientEntry> = {};
+  for (const entry of entries) map[`${entry.projectId}::${entry.slot}`] = entry;
+  return map;
+}
+
+function runningSession(id: string): CommandWindowSessionRef {
+  return { id, status: 'running' };
+}
+
+describe('planCommandWindowReconciliation', () => {
+  it('keeps only the lowest-slot window when the project has no live sessions', () => {
+    const plan = planCommandWindowReconciliation({
+      windows: [windowRef('slot-1'), windowRef('slot-2')],
+      transientSessions: {},
+      sessions: [],
+      projectId: PROJECT_A,
+      maxWindows: MAX_WINDOWS,
+    });
+    expect(plan.closeWindowIds).toEqual(['win-slot-2']);
+    expect(plan.openSlots).toEqual([]);
+  });
+
+  it('keeps the lowest EXISTING slot when slot-1 has no window', () => {
+    const plan = planCommandWindowReconciliation({
+      windows: [windowRef('slot-2'), windowRef('slot-3')],
+      transientSessions: {},
+      sessions: [],
+      projectId: PROJECT_A,
+      maxWindows: MAX_WINDOWS,
+    });
+    expect(plan.closeWindowIds).toEqual(['win-slot-3']);
+    expect(plan.openSlots).toEqual([]);
+  });
+
+  it('opens windows for live sessions that lack one, ascending', () => {
+    const plan = planCommandWindowReconciliation({
+      windows: [windowRef('slot-1')],
+      transientSessions: transientMap([
+        { projectId: PROJECT_A, slot: 'slot-1', sessionId: 'sess-1' },
+        { projectId: PROJECT_A, slot: 'slot-3', sessionId: 'sess-3' },
+        { projectId: PROJECT_A, slot: 'slot-2', sessionId: 'sess-2' },
+      ]),
+      sessions: [runningSession('sess-1'), runningSession('sess-2'), runningSession('sess-3')],
+      projectId: PROJECT_A,
+      maxWindows: MAX_WINDOWS,
+    });
+    expect(plan.closeWindowIds).toEqual([]);
+    expect(plan.openSlots).toEqual(['slot-2', 'slot-3']);
+  });
+
+  it('closes a window whose slot has no live session while opening the live slot', () => {
+    const plan = planCommandWindowReconciliation({
+      windows: [windowRef('slot-1')],
+      transientSessions: transientMap([{ projectId: PROJECT_A, slot: 'slot-2', sessionId: 'sess-2' }]),
+      sessions: [runningSession('sess-2')],
+      projectId: PROJECT_A,
+      maxWindows: MAX_WINDOWS,
+    });
+    expect(plan.closeWindowIds).toEqual(['win-slot-1']);
+    expect(plan.openSlots).toEqual(['slot-2']);
+  });
+
+  it('treats a map entry without a running session row as dead (exited or missing)', () => {
+    const exited = planCommandWindowReconciliation({
+      windows: [windowRef('slot-1'), windowRef('slot-2')],
+      transientSessions: transientMap([{ projectId: PROJECT_A, slot: 'slot-2', sessionId: 'sess-2' }]),
+      sessions: [{ id: 'sess-2', status: 'exited' }],
+      projectId: PROJECT_A,
+      maxWindows: MAX_WINDOWS,
+    });
+    // No live session -> keep only the lowest-slot window.
+    expect(exited.closeWindowIds).toEqual(['win-slot-2']);
+    expect(exited.openSlots).toEqual([]);
+
+    const missingRow = planCommandWindowReconciliation({
+      windows: [windowRef('slot-1'), windowRef('slot-2')],
+      transientSessions: transientMap([{ projectId: PROJECT_A, slot: 'slot-2', sessionId: 'sess-2' }]),
+      sessions: [],
+      projectId: PROJECT_A,
+      maxWindows: MAX_WINDOWS,
+    });
+    expect(missingRow.closeWindowIds).toEqual(['win-slot-2']);
+    expect(missingRow.openSlots).toEqual([]);
+  });
+
+  it("ignores other projects' transient entries", () => {
+    const plan = planCommandWindowReconciliation({
+      windows: [windowRef('slot-1'), windowRef('slot-2')],
+      transientSessions: transientMap([
+        { projectId: PROJECT_A, slot: 'slot-1', sessionId: 'sess-a1' },
+        { projectId: PROJECT_B, slot: 'slot-2', sessionId: 'sess-b2' },
+      ]),
+      sessions: [runningSession('sess-a1'), runningSession('sess-b2')],
+      projectId: PROJECT_A,
+      maxWindows: MAX_WINDOWS,
+    });
+    // Only slot-1 is live for project A; slot-2 belongs to project B and is closed.
+    expect(plan.closeWindowIds).toEqual(['win-slot-2']);
+    expect(plan.openSlots).toEqual([]);
+  });
+
+  it('returns an empty plan when windows already match live sessions (HMR no-op)', () => {
+    const plan = planCommandWindowReconciliation({
+      windows: [windowRef('slot-1'), windowRef('slot-2')],
+      transientSessions: transientMap([
+        { projectId: PROJECT_A, slot: 'slot-1', sessionId: 'sess-1' },
+        { projectId: PROJECT_A, slot: 'slot-2', sessionId: 'sess-2' },
+      ]),
+      sessions: [runningSession('sess-1'), runningSession('sess-2')],
+      projectId: PROJECT_A,
+      maxWindows: MAX_WINDOWS,
+    });
+    expect(plan.closeWindowIds).toEqual([]);
+    expect(plan.openSlots).toEqual([]);
+  });
+
+  it('opens all live slots when no windows exist (hard reload without a blob)', () => {
+    const plan = planCommandWindowReconciliation({
+      windows: [],
+      transientSessions: transientMap([
+        { projectId: PROJECT_A, slot: 'slot-1', sessionId: 'sess-1' },
+        { projectId: PROJECT_A, slot: 'slot-2', sessionId: 'sess-2' },
+      ]),
+      sessions: [runningSession('sess-1'), runningSession('sess-2')],
+      projectId: PROJECT_A,
+      maxWindows: MAX_WINDOWS,
+    });
+    expect(plan.closeWindowIds).toEqual([]);
+    expect(plan.openSlots).toEqual(['slot-1', 'slot-2']);
+  });
+
+  it('returns a fully empty plan when there are no windows and no live sessions', () => {
+    // The empty store with no survivors: the caller opens the single default window itself.
+    const plan = planCommandWindowReconciliation({
+      windows: [],
+      transientSessions: {},
+      sessions: [],
+      projectId: PROJECT_A,
+      maxWindows: MAX_WINDOWS,
+    });
+    expect(plan.closeWindowIds).toEqual([]);
+    expect(plan.openSlots).toEqual([]);
+  });
+
+  it('never plans more windows than maxWindows', () => {
+    // Defensive: a live slot beyond the cap must not be planned open.
+    const plan = planCommandWindowReconciliation({
+      windows: [windowRef('slot-1')],
+      transientSessions: transientMap([
+        { projectId: PROJECT_A, slot: 'slot-1', sessionId: 'sess-1' },
+        { projectId: PROJECT_A, slot: 'slot-2', sessionId: 'sess-2' },
+        { projectId: PROJECT_A, slot: 'slot-3', sessionId: 'sess-3' },
+      ]),
+      sessions: [runningSession('sess-1'), runningSession('sess-2'), runningSession('sess-3')],
+      projectId: PROJECT_A,
+      maxWindows: 2,
+    });
+    // 1 kept (slot-1) + at most 1 opened = 2 total.
+    expect(plan.openSlots).toEqual(['slot-2']);
+  });
+});

--- a/tests/unit/window-manager.test.ts
+++ b/tests/unit/window-manager.test.ts
@@ -114,6 +114,15 @@ describe('window-store actions', () => {
     expect(useWindowStore.getState().windows[id].skipEnterAnimation).toBeUndefined();
   });
 
+  it('stamps skipEnterAnimation when opened with the restore hint, so a programmatic restore paints flat', () => {
+    // A per-project reconcile (reconcileCommandTerminalWindows) opens windows with this hint so
+    // they match the flat presentation of a workspace-restored window instead of animating in.
+    const id = useWindowStore
+      .getState()
+      .openWindow({ anchor: 'slot-2', sessionId: null, title: 'Command Terminal', skipEnterAnimation: true });
+    expect(useWindowStore.getState().windows[id].skipEnterAnimation).toBe(true);
+  });
+
   it('focuses the existing window when re-opening the same task (one window per task)', () => {
     const first = useWindowStore.getState().openWindow({ anchor: 'task-a', sessionId: 'sess-a', title: 'A' });
     const second = useWindowStore.getState().openWindow({ anchor: 'task-a', sessionId: 'sess-a', title: 'A again' });


### PR DESCRIPTION
## What

Fixes the Command Terminal window count leaking across projects. Spawning N terminals in project A, switching to project B, and reopening the layer (Ctrl+Shift+P) used to remount all N carried-over windows and spawn N fresh PTYs in B. The persisted global layout blob had the same failure after an app restart.

Affected components:
- `src/renderer/components/command-bar/command-window-reconcile.ts` (new pure planner)
- `src/renderer/components/command-bar/CommandTerminalLayer.tsx` (reconcile + extracted slot-open helper)
- `src/renderer/hooks/useCommandBar.ts` (reconcile before the layer mounts)
- `src/renderer/window-manager/store/window-store.ts` (`skipEnterAnimation` open hint)
- `src/renderer/App.tsx` (dev-only store handle for tests)

## Why

The command window store is a global module singleton, but transient PTY sessions are keyed per `(projectId, slot)`. The window population from one project therefore dictated how many sessions spawned in every other project. `useEnsureCommandWindow` early-returned whenever the store was non-empty, so carried-over windows remounted under the new project and each spawned a fresh PTY.

## How

Reconcile the window POPULATION to the current project's live transient sessions, keeping the geometry blob global (deliberate design):
- Close carried-over windows whose slot has no live session for the current project, keeping one default so the layer always opens with a terminal.
- Open a window for every live session that lacks one, so switching BACK to a project with live PTYs reattaches all of them instead of orphaning a window-less PTY.

The reconcile runs synchronously BEFORE the layer mounts (in `useCommandBar.open()`, and in the empty-store branch of `useEnsureCommandWindow` for the app-restart blob-restore path). A bridge effect would be too late: carried-over windows commit and their mount effects fire in the same render, spawning under the wrong project before a `closeWindow` could take effect. The decision logic lives in a pure, unit-tested planner (`planCommandWindowReconciliation`).

Reconcile-opened windows carry a new `skipEnterAnimation` open hint so a project-switch restore paints flat, matching the existing restore-no-animation rule.

## Breaking changes

None. Behavioral fix only; the global geometry blob schema is unchanged.

## Tests

- Unit (`tests/unit/command-window-reconcile.test.ts`): 10 cases covering every planner branch (keep-lowest-slot when no live sessions, open missing live slots ascending, close-stale + open-live, dead/other-project entries, HMR no-op, cap enforcement).
- Unit (`tests/unit/window-manager.test.ts`): `openWindow` stamps `skipEnterAnimation` only with the restore hint.
- UI (`tests/ui/command-terminal.spec.ts`): 4 tests covering the exact repro (2 in A collapse to 1 fresh in B), return-to-A reattach with zero new spawns, the restart-blob trim path, and the hard-reload survivor-reattach path. Verified green across repeated runs.
- CI runs the full unit, UI, and Electron E2E tiers.

Generated with [Claude Code](https://claude.com/claude-code)
