### PR TITLE
feat(settings): link each MCP tool pill to its docs page

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -75,6 +75,11 @@ No parameters. Returns each project's `name`, `id`, `path`, `lastOpened` timesta
 
 ## Available Tools
 
+The **Settings -> MCP Server** panel lists every tool below as a pill, grouped by the same
+categories. Each pill deep-links to that tool's entry on the live docs page
+(`https://kangentic.com/mcp-server/`, anchored by the tool name), opening it in the default
+browser.
+
 **Tool annotations.** Every registered tool declares MCP `annotations` from the shared constants
 in `src/main/agent/mcp-http/annotations.ts`: read-only tools carry
 `readOnlyHint: true, idempotentHint: true`; mutating tools carry

--- a/src/renderer/components/settings/tabs/McpServerTab.tsx
+++ b/src/renderer/components/settings/tabs/McpServerTab.tsx
@@ -1,6 +1,6 @@
-import { Plug } from 'lucide-react';
+import { ExternalLink, Plug } from 'lucide-react';
 import type { AppConfig } from '../../../../shared/types';
-import { MCP_TOOL_CATEGORIES, MCP_TOOL_MANIFEST } from '../../../../shared/mcp-tool-manifest';
+import { MCP_TOOL_CATEGORIES, MCP_TOOL_MANIFEST, mcpToolDocsUrl } from '../../../../shared/mcp-tool-manifest';
 import { SectionHeader, SettingToggleRow, useScopedUpdate } from '../shared';
 import { settingProps } from '../settings-registry';
 
@@ -26,13 +26,17 @@ export function McpServerTab({ globalConfig }: { globalConfig: AppConfig }) {
               <h4 className="text-[11px] font-semibold uppercase tracking-wider text-fg-faint mb-1">{category.label}</h4>
               <ul className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-1.5 ml-1">
                 {tools.map((tool) => (
-                  <li
-                    key={tool.name}
-                    data-testid="mcp-tool-pill"
-                    title={`${tool.label} - ${tool.blurb}`}
-                    className="truncate rounded-md border border-edge/50 bg-surface-hover/30 px-2.5 py-1 text-xs text-fg-secondary"
-                  >
-                    {tool.label}
+                  <li key={tool.name}>
+                    <button
+                      type="button"
+                      data-testid="mcp-tool-pill"
+                      title={`${tool.label} - ${tool.blurb}. Opens the docs page.`}
+                      onClick={() => void window.electronAPI.shell.openExternal(mcpToolDocsUrl(tool.name))}
+                      className="w-full flex items-center gap-1 rounded-md border border-edge/50 bg-surface-hover/30 px-2.5 py-1 text-xs text-fg-secondary hover:bg-surface-hover hover:text-fg hover:border-edge transition-colors cursor-pointer"
+                    >
+                      <span className="truncate">{tool.label}</span>
+                      <ExternalLink size={11} className="ml-auto shrink-0 opacity-60" />
+                    </button>
                   </li>
                 ))}
               </ul>

--- a/src/shared/mcp-tool-manifest.ts
+++ b/src/shared/mcp-tool-manifest.ts
@@ -19,6 +19,11 @@
  * (the dev-leaning diagnostics group sorts last under its own header). The
  * array below is ordered to mirror that grouping; `category`, not array
  * position, is what drives the panel grouping.
+ *
+ * Each panel pill deep-links to its entry on the live docs page
+ * (`MCP_SERVER_DOCS_URL`) via `mcpToolDocsUrl(tool.name)`; the docs page uses
+ * one anchor per tool named after the registered tool, so the link is derived
+ * from `name` with no per-tool hardcoding.
  */
 
 export type McpToolCategoryId = 'tasks' | 'board' | 'sessions' | 'browser' | 'diagnostics';
@@ -100,3 +105,11 @@ export const MCP_TOOL_MANIFEST: McpToolManifestEntry[] = [
   { name: 'kangentic_get_ipc_log', label: 'IPC Log', blurb: 'recent IPC traffic with timings and errors', category: 'diagnostics' },
   { name: 'kangentic_list_worktrees', label: 'List Worktrees', blurb: 'enumerate worktrees with branch and dirty state', category: 'diagnostics' },
 ];
+
+/** Live docs reference for the MCP server. Each tool's heading anchor is its registered name. */
+export const MCP_SERVER_DOCS_URL = 'https://kangentic.com/mcp-server/';
+
+/** Deep link to a tool's entry on the docs page. Anchor = manifest/registered tool name. */
+export function mcpToolDocsUrl(toolName: string): string {
+  return `${MCP_SERVER_DOCS_URL}#${toolName}`;
+}

--- a/tests/ui/settings-panel.spec.ts
+++ b/tests/ui/settings-panel.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { launchPage, createProject } from './helpers';
 import type { Browser, Page } from '@playwright/test';
-import { MCP_TOOL_MANIFEST } from '../../src/shared/mcp-tool-manifest';
+import { MCP_TOOL_MANIFEST, mcpToolDocsUrl } from '../../src/shared/mcp-tool-manifest';
 
 let browser: Browser;
 let page: Page;
@@ -318,6 +318,26 @@ test.describe('Settings Panel', () => {
     await expect(page.getByText('Tail Logs', { exact: true })).toBeVisible();
     await expect(page.getByText('Query Database', { exact: true })).toBeVisible();
     await expect(page.getByText('List Worktrees', { exact: true })).toBeVisible();
+
+    // Each pill deep-links to its docs section. Patch the mock's no-op openExternal
+    // to record the URL, click one pill, and assert it opened the derived docs URL.
+    await page.evaluate(() => {
+      window.__openedExternalUrls = [];
+      window.electronAPI.shell.openExternal = async function (url: string) {
+        window.__openedExternalUrls?.push(url);
+      };
+    });
+    await page.getByTestId('mcp-tool-pill').filter({ hasText: 'Create Task' }).click();
+    await expect
+      .poll(() => page.evaluate(() => window.__openedExternalUrls))
+      .toEqual([mcpToolDocsUrl('kangentic_create_task')]);
+    // Restore the mock's default no-op so this patch does not leak into later tests
+    // on the shared page (matches mock-electron-api.js shell.openExternal).
+    await page.evaluate(() => {
+      window.electronAPI.shell.openExternal = async function () {
+        return;
+      };
+    });
 
     // How It Works section
     await expect(page.getByText('How It Works')).toBeVisible();

--- a/tests/ui/test-globals.d.ts
+++ b/tests/ui/test-globals.d.ts
@@ -23,6 +23,9 @@ declare global {
 
     /** Captures the URL most recently submitted by BrowserEmptyState mounts. */
     __lastEmptyStateUrl?: string | null;
+
+    /** Records URLs passed to a spec-patched `shell.openExternal`. */
+    __openedExternalUrls?: string[];
   }
 }
 

--- a/tests/unit/mcp-tool-docs-url.test.ts
+++ b/tests/unit/mcp-tool-docs-url.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Pins the literal MCP tool docs deep-link (see src/shared/mcp-tool-manifest.ts,
+ * lines 109-115).
+ *
+ * The only other coverage is tests/ui/settings-panel.spec.ts, which asserts a
+ * clicked pill opens `mcpToolDocsUrl('kangentic_create_task')` - but it computes
+ * the expected value by calling mcpToolDocsUrl itself, so both sides of that
+ * assertion move together. Reverting the anchor format (e.g. `?tool=` instead of
+ * `#`) or pointing MCP_SERVER_DOCS_URL at the wrong base would not fail anything.
+ *
+ * This test pins the literal output instead, so a format or base-URL regression
+ * goes red.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { MCP_SERVER_DOCS_URL, mcpToolDocsUrl, MCP_TOOL_MANIFEST } from '../../src/shared/mcp-tool-manifest';
+
+describe('mcpToolDocsUrl', () => {
+  it('pins the live docs base URL', () => {
+    expect(MCP_SERVER_DOCS_URL).toBe('https://kangentic.com/mcp-server/');
+  });
+
+  it('pins the literal deep-link for a known tool name', () => {
+    expect(mcpToolDocsUrl('kangentic_create_task')).toBe(
+      'https://kangentic.com/mcp-server/#kangentic_create_task',
+    );
+  });
+
+  it('derives every manifest entry link from the base URL and registered name, with no per-tool hardcoding', () => {
+    for (const entry of MCP_TOOL_MANIFEST) {
+      expect(mcpToolDocsUrl(entry.name)).toBe(`${MCP_SERVER_DOCS_URL}#${entry.name}`);
+    }
+  });
+});


### PR DESCRIPTION
## What

Each tool pill in **Settings -> MCP Server -> Available Tools** is now an interactive link. Clicking a pill opens the user's default browser at that tool's dedicated section on the live docs page (`https://kangentic.com/mcp-server/#<tool_name>`).

- `src/shared/mcp-tool-manifest.ts` - new `MCP_SERVER_DOCS_URL` constant and `mcpToolDocsUrl(toolName)` helper.
- `src/renderer/components/settings/tabs/McpServerTab.tsx` - each pill is now a `<button>` that calls `window.electronAPI.shell.openExternal(mcpToolDocsUrl(tool.name))`, with a resting hover affordance and a trailing `ExternalLink` icon.
- `docs/mcp-server.md` - notes that the panel deep-links each pill to the docs page.

## Why

The panel already lists every MCP tool as a pill (from `MCP_TOOL_MANIFEST`), but the pills were static text. The dedicated docs page at `https://kangentic.com/mcp-server/` now publishes one anchor per tool, so the pills can deep-link straight to a tool's reference entry, turning the catalogue into a discoverable jump-off point.

## How

The docs page anchors each tool by its registered name (verified against the website source), so the link is derived purely from the manifest `name` through `mcpToolDocsUrl` - no per-tool hardcoding. New tools added to the manifest get a working deep-link for free, keeping the surface self-maintaining (consistent with the `mcp-tool-list-parity` rule).

The pill keeps its uniform styling, `data-testid`, and `title` tooltip; the affordance follows the existing `PrLink` precedent (interactive at rest plus a trailing external-link icon), and stays always-visible rather than hover-only per the UI conventions.

## Breaking changes

None.

## Tests

- Unit (`tests/unit/mcp-tool-docs-url.test.ts`): pins the literal base URL and deep-link, and asserts every manifest entry derives its link from base + name.
- UI (`tests/ui/settings-panel.spec.ts`): patches `shell.openExternal` to record URLs, clicks a pill, asserts it opened the derived docs URL, and restores the mock to avoid cross-test leakage.
- Local: `npm run typecheck` and `npm run lint` pass; the scoped unit and UI specs pass. The full unit, UI, and Electron E2E tiers run as CI checks on this PR.

Generated with [Claude Code](https://claude.com/claude-code)
