### PR TITLE
fix(sidebar): stop divider clicks from collapsing the project panel

### DIFF
--- a/src/renderer/components/layout/AppLayout.tsx
+++ b/src/renderer/components/layout/AppLayout.tsx
@@ -134,8 +134,10 @@ export function AppLayout() {
               </div>
             </div>
 
-            {/* Sidebar resize handle -- click to toggle, drag to resize */}
+            {/* Sidebar resize handle - drag to resize, drag past the threshold to collapse.
+                A plain click is a no-op (collapse is the PROJECTS-panel chevron only). */}
             <div
+              data-testid="sidebar-resize-handle"
               className="flex-shrink-0 cursor-col-resize transition-colors w-1 bg-edge hover:bg-fg-faint"
               onMouseDown={sidebar.onResizeStart}
             />

--- a/src/renderer/hooks/useSidebarResize.ts
+++ b/src/renderer/hooks/useSidebarResize.ts
@@ -7,7 +7,9 @@ const MAX_WIDTH = 400;
 const COLLAPSE_THRESHOLD = 200;
 const DEFAULT_WIDTH = MAX_WIDTH;
 export const COLLAPSED_STRIP_WIDTH = 36; // matches w-9 Tailwind class
-const DRAG_DEAD_ZONE = 1; // any movement at all starts a drag; 0 movement = click toggle
+// Movement below this many px is treated as a click (a no-op); at/past it a resize drag
+// begins. Matches the dnd-kit activationConstraint distance used across the app's sortables.
+const DRAG_ACTIVATION_DISTANCE = 5;
 
 export interface SidebarResizeState {
   open: boolean;
@@ -29,7 +31,6 @@ export function useSidebarResize(config: AppConfig): SidebarResizeState {
   openRef.current = open;
 
   const collapsedByDragRef = useRef(false);
-  const toggleRef = useRef<() => void>(() => {});
 
   // Sync from config on load
   useEffect(() => {
@@ -54,7 +55,6 @@ export function useSidebarResize(config: AppConfig): SidebarResizeState {
       return !prev;
     });
   }, []);
-  toggleRef.current = toggle;
 
   const onResizeStart = useCallback((event: React.MouseEvent) => {
     const startX = event.clientX;
@@ -64,14 +64,14 @@ export function useSidebarResize(config: AppConfig): SidebarResizeState {
     let didCollapse = false;
 
     startPanelDrag(event, {
-      // Cursor is set lazily below, only once the drag clears the dead zone, so a
-      // pure click never changes the cursor.
+      // Cursor is set lazily below, only once the drag clears the activation
+      // distance, so a pure click never changes the cursor.
       onMove: (moveEvent) => {
         const delta = Math.abs(moveEvent.clientX - startX);
 
-        // Don't start dragging until past the dead zone
+        // Don't start dragging until past the activation distance
         if (!isDragging) {
-          if (delta < DRAG_DEAD_ZONE) return;
+          if (delta < DRAG_ACTIVATION_DISTANCE) return;
           isDragging = true;
           setIsResizing(true);
           document.body.style.cursor = 'col-resize';
@@ -94,8 +94,9 @@ export function useSidebarResize(config: AppConfig): SidebarResizeState {
 
       onRelease: () => {
         if (!isDragging) {
-          // Pure click - toggle sidebar
-          toggleRef.current();
+          // A click (or a sub-threshold "dead drag") on the divider is intentionally
+          // inert. Collapsing happens only via the PROJECTS-panel chevron or by dragging
+          // the divider closed past COLLAPSE_THRESHOLD, never an accidental click here.
           return;
         }
 

--- a/tests/ui/sidebar-divider.spec.ts
+++ b/tests/ui/sidebar-divider.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * UI tests for the project-sidebar resize divider (useSidebarResize).
+ *
+ * The divider between the PROJECTS sidebar and the board is a resize handle.
+ * A plain click on it must NOT collapse the sidebar (that used to fire
+ * accidentally when a click landed on the thin divider). Collapse happens only
+ * via the PROJECTS-panel chevron or by dragging the divider closed past the
+ * COLLAPSE_THRESHOLD. Sub-threshold movement (a "dead drag") is treated as a
+ * click and is a no-op.
+ *
+ * Assertions read the mock's `sidebarVisible` / `sidebar.width` config (the
+ * programmatic source of truth the hook persists) rather than pixel geometry,
+ * per .claude/rules/cross-platform-parity.md. Drag input is driven from the
+ * divider's live boundingBox.
+ *
+ * All four tests share one Chromium launch; page.goto() in beforeEach resets the
+ * in-memory mock config so each test starts from a known open sidebar (default
+ * sidebarVisible: true, sidebar.width: 224).
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type BrowserContext, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'divider-proj';
+const DEFAULT_SIDEBAR_WIDTH = 224; // matches the mock config default
+
+/** One project with swimlanes, active, so the board and sidebar (with divider) render. */
+function oneProjectScript(): string {
+  return `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+
+      state.projects.push({
+        id: '${PROJECT_ID}',
+        name: 'Alpha',
+        path: '/mock/alpha',
+        github_url: null,
+        default_agent: 'claude',
+        group_id: null,
+        position: 0,
+        last_opened: ts,
+        created_at: ts,
+      });
+
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        state.swimlanes.push(Object.assign({}, s, {
+          id: 'divider-lane-' + i,
+          position: i,
+          created_at: ts,
+        }));
+      });
+
+      return { currentProjectId: '${PROJECT_ID}' };
+    });
+  `;
+}
+
+/** Read the current global config from the mock. */
+async function getConfig(page: Page): Promise<{ sidebarVisible: boolean; sidebar: { width: number } }> {
+  return page.evaluate(async () => {
+    // Settle any discrete-event React flush + a rAF before reading, so a would-be
+    // collapse has definitely landed by the time we assert a no-op.
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    const cfg = await window.electronAPI.config.getGlobal();
+    return cfg as { sidebarVisible: boolean; sidebar: { width: number } };
+  });
+}
+
+async function resetPage(page: Page): Promise<void> {
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  // Board rendered (sidebar + divider present alongside it).
+  await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+  await page.locator('[data-testid="sidebar-resize-handle"]').waitFor({ state: 'attached', timeout: 5000 });
+}
+
+/** Center of the divider from its live boundingBox (read immediately before use). */
+async function dividerCenter(page: Page): Promise<{ x: number; y: number }> {
+  const box = await page.locator('[data-testid="sidebar-resize-handle"]').boundingBox();
+  if (!box || box.width === 0) throw new Error('divider has no measurable box');
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+}
+
+test.describe('Sidebar resize divider', () => {
+  let browser: Browser;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    await waitForViteReady(VITE_URL);
+    browser = await chromium.launch({ headless: true });
+    const context: BrowserContext = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+    page = await context.newPage();
+    await page.addInitScript({ path: MOCK_SCRIPT });
+    await page.addInitScript(oneProjectScript());
+  });
+
+  test.afterAll(async () => {
+    await browser?.close();
+  });
+
+  test.beforeEach(async () => {
+    await resetPage(page);
+  });
+
+  test('a plain click on the divider does not collapse the sidebar', async () => {
+    // Sanity: sidebar starts open.
+    expect((await getConfig(page)).sidebarVisible).toBe(true);
+
+    const center = await dividerCenter(page);
+    // A pure click (mousedown + mouseup, zero movement) - the accidental-click case.
+    await page.mouse.click(center.x, center.y);
+
+    // Must remain open. (On the old click-to-toggle behavior this flipped to false.)
+    const config = await getConfig(page);
+    expect(config.sidebarVisible).toBe(true);
+  });
+
+  test('a sub-threshold "dead drag" is a no-op (no collapse, no resize)', async () => {
+    const before = await getConfig(page);
+    expect(before.sidebarVisible).toBe(true);
+
+    const center = await dividerCenter(page);
+    // Press, nudge 2px (below the 5px activation distance), release.
+    await page.mouse.move(center.x, center.y);
+    await page.mouse.down();
+    await page.mouse.move(center.x + 2, center.y);
+    await page.mouse.up();
+
+    // Sidebar stays open and its width is unwritten (a real drag would resize it).
+    const after = await getConfig(page);
+    expect(after.sidebarVisible).toBe(true);
+    expect(after.sidebar.width).toBe(DEFAULT_SIDEBAR_WIDTH);
+  });
+
+  test('dragging the divider past the collapse threshold still collapses', async () => {
+    expect((await getConfig(page)).sidebarVisible).toBe(true);
+
+    const center = await dividerCenter(page);
+    // Drag far left so the panel width falls below COLLAPSE_THRESHOLD (200).
+    await page.mouse.move(center.x, center.y);
+    await page.mouse.down();
+    await page.mouse.move(center.x - 220, center.y, { steps: 10 });
+    await page.mouse.up();
+
+    await expect
+      .poll(async () => (await getConfig(page)).sidebarVisible, { timeout: 5000 })
+      .toBe(false);
+  });
+
+  test('a normal drag still resizes the sidebar without collapsing', async () => {
+    const before = await getConfig(page);
+    expect(before.sidebar.width).toBe(DEFAULT_SIDEBAR_WIDTH);
+
+    const center = await dividerCenter(page);
+    // Drag right to widen well past the activation distance and above the threshold.
+    await page.mouse.move(center.x, center.y);
+    await page.mouse.down();
+    await page.mouse.move(center.x + 80, center.y, { steps: 10 });
+    await page.mouse.up();
+
+    const after = await getConfig(page);
+    expect(after.sidebarVisible).toBe(true);
+    // Width increased (tolerance-based: assert it grew, not an exact pixel value).
+    expect(after.sidebar.width).toBeGreaterThan(DEFAULT_SIDEBAR_WIDTH + 30);
+  });
+});


### PR DESCRIPTION
## What

Removes click-to-collapse on the vertical divider between the PROJECTS sidebar and the board. A plain click on the divider is now inert. Touches the sidebar resize hook and the layout that renders the divider, plus a new UI spec.

- `src/renderer/hooks/useSidebarResize.ts` - the `onRelease` non-drag branch now early-returns instead of toggling the panel; the click-vs-drag activation distance is raised from 1px to 5px; the now-dead `toggleRef` is removed.
- `src/renderer/components/layout/AppLayout.tsx` - `data-testid="sidebar-resize-handle"` added to the divider and the comment updated.
- `tests/ui/sidebar-divider.spec.ts` - new UI-tier coverage.

## Why

Clicking the thin divider used to toggle the project panel collapsed. That fired accidentally all the time when a click landed on the divider while aiming for something nearby. Collapse should be a deliberate act, not a stray click.

## How

Collapse now happens only via the two intentional paths, both unchanged: the dedicated chevron at the top of the PROJECTS panel (and the collapsed-rail expand button / `view.toggleSidebar` keybinding, which share the same `toggle()`), or dragging the divider closed past the existing `COLLAPSE_THRESHOLD`. A press-then-release with sub-threshold movement (a "dead drag") is treated as a click and is a no-op. Raising the activation distance to 5px matches the app's established dnd-kit `activationConstraint: { distance: 5 }` convention, so a small accidental nudge during a click no longer registers as a resize. Normal drag-to-resize is unchanged.

The change is isolated to the sidebar divider: the shared `panel-drag.ts` helper and the other resizers (terminal panel, task-detail split, window-manager `TileSplitter`) never had click-to-collapse and are untouched. All state is hook-local, so there are no IPC, store, keybinding, or HMR-pattern implications.

## Breaking changes

None. The divider is now purely a resize handle in both directions; when the sidebar is collapsed, a click on the divider no longer re-expands it, but the collapsed-rail expand button and the toggle keybinding still do.

## Tests

- New `tests/ui/sidebar-divider.spec.ts` (UI tier, headless mock): plain click is a no-op, sub-threshold dead drag is a no-op (no collapse, width unchanged), drag past the threshold still collapses, and a normal drag still resizes without collapsing. Assertions read the mock's `sidebarVisible`/`sidebar.width` config and drive input from the divider's live boundingBox, per the cross-platform-parity rule.
- The critical "click does not collapse" case was red-green verified (fails when the old click-to-toggle is restored, passes with the fix).
- Local gate: `npm run typecheck` and `npm run lint` clean. Unit/UI/E2E tiers run on CI.

Generated with [Claude Code](https://claude.com/claude-code)
