### PR TITLE
feat(changes): add markdown preview toggle to the diff viewer

### DIFF
--- a/src/devtools/main/seed-git-changes.ts
+++ b/src/devtools/main/seed-git-changes.ts
@@ -19,6 +19,12 @@
  *       gone.ts       a deletion (D)
  *       newfile.ts    an untracked file (U)
  *       logo.png      a binary file -> binary detection ("cannot display diff")
+ *       notes.md      a rich markdown edit (M) -> the markdown preview toggle
+ *       changelog.markdown  a .markdown edit (M) -> the .markdown extension map,
+ *                     and a second markdown file so the preview toggle's per-file
+ *                     reset can be exercised by switching between the two
+ *       removed.md    a deleted markdown file (D) -> preview falls back to the
+ *                     old content instead of rendering blank
  *
  * Seeds MULTIPLE repos in one click (every active task worktree the renderer
  * passes, plus the project), all sharing one `seed-N` directory so a single
@@ -56,9 +62,9 @@ const BINARY_PNG = Buffer.from(
 );
 
 // Per-repo file counts for the toast summary (kept in sync with seedOneRepo).
-const COMMITTED_COUNT = 7;
+const COMMITTED_COUNT = 10;
 const STAGED_COUNT = 4;
-const WORKING_COUNT = 6;
+const WORKING_COUNT = 9;
 
 // Module state; resets when the main process restarts. Each click uses a fresh
 // index so re-clicks pile on a new, non-colliding directory of changes.
@@ -94,6 +100,80 @@ function bigFile(index: number, mutate: boolean): string {
   return lines.join('\n');
 }
 
+/** A rich markdown file (headings, list, external link, inline + fenced code, a
+ *  gfm table and a task list). With `mutate` it grows into the fuller working-tree
+ *  version, so toggling the diff viewer's eye icon shows a substantial render. */
+function notesMarkdown(index: number, mutate: boolean): string {
+  if (!mutate) {
+    return [
+      '# Project Notes',
+      '',
+      `Initial notes for config ${index}.`,
+      '',
+      '- first item',
+      '- second item',
+      '',
+    ].join('\n');
+  }
+  return [
+    '# Project Notes',
+    '',
+    `Updated notes for config ${index}. Toggle the eye icon to preview this rendered.`,
+    '',
+    '## Highlights',
+    '',
+    '- rendered **bold** and _italic_ text',
+    '- a [link home](https://kangentic.com) routed through the shell',
+    '- inline `code` plus a fenced block:',
+    '',
+    '```ts',
+    'export const answer = 42;',
+    '```',
+    '',
+    '## Status',
+    '',
+    '| Feature | State |',
+    '| --- | --- |',
+    '| Preview toggle | done |',
+    '| Deleted fallback | done |',
+    '',
+    '- [x] preview renders the new content',
+    '- [ ] still reading the raw diff',
+    '',
+  ].join('\n');
+}
+
+/** A `.markdown`-extension file, exercising the extension the preview feature
+ *  added to the language map. `mutate` prepends a new release section. */
+function changelogMarkdown(index: number, mutate: boolean): string {
+  const initial = ['## 0.1.0', '', `- initial release for config ${index}`, ''];
+  const header = ['# Changelog', ''];
+  if (!mutate) {
+    return [...header, ...initial].join('\n');
+  }
+  return [
+    ...header,
+    '## 0.2.0',
+    '',
+    '- add markdown preview toggle to the diff viewer',
+    '- fix the per-file reset and the deleted-file fallback',
+    '',
+    ...initial,
+  ].join('\n');
+}
+
+/** The last-committed content of the file deleted in the working tree, so its
+ *  preview has old content to fall back to. */
+function removedMarkdown(index: number): string {
+  return [
+    '# Deprecated Notes',
+    '',
+    `These notes for config ${index} are going away. Previewing a deleted markdown`,
+    'file should still render THIS old content, not a blank page.',
+    '',
+  ].join('\n');
+}
+
 /** Seed one repo with the full fixture under `seed-<index>/`. */
 async function seedOneRepo(repoPath: string, dir: string, index: number): Promise<void> {
   const absolute = (relative: string): string => path.join(repoPath, relative);
@@ -111,6 +191,9 @@ async function seedOneRepo(repoPath: string, dir: string, index: number): Promis
   await writeFile(`${dir}/staged-mod.ts`, `export const stagedMod${index} = ${index};\n`);
   await writeFile(`${dir}/staged-del.ts`, `export const stagedDel${index} = ${index};\n`);
   await writeFile(`${dir}/staged-old.ts`, `export const stagedRen${index} = ${index};\n`);
+  await writeFile(`${dir}/notes.md`, notesMarkdown(index, false));
+  await writeFile(`${dir}/changelog.markdown`, changelogMarkdown(index, false));
+  await writeFile(`${dir}/removed.md`, removedMarkdown(index));
   await runGit(repoPath, ['add', dir]);
   await runGit(repoPath, [...SEED_IDENTITY, 'commit', '-m', `test(seed): baseline files ${index}`]);
 
@@ -131,6 +214,9 @@ async function seedOneRepo(repoPath: string, dir: string, index: number): Promis
   await writeFile(`${dir}/newfile.ts`, `export const fresh${index} = ${index};\n`);                          // U
   await fs.promises.mkdir(path.dirname(absolute(`${dir}/logo.png`)), { recursive: true });
   await fs.promises.writeFile(absolute(`${dir}/logo.png`), BINARY_PNG);                                      // U: binary
+  await writeFile(`${dir}/notes.md`, notesMarkdown(index, true));                                            // M: markdown preview
+  await writeFile(`${dir}/changelog.markdown`, changelogMarkdown(index, true));                              // M: .markdown preview
+  await fs.promises.rm(absolute(`${dir}/removed.md`), { force: true });                                      // D: deleted markdown
 }
 
 /**

--- a/src/main/git/diff-service.ts
+++ b/src/main/git/diff-service.ts
@@ -10,7 +10,7 @@ const EXTENSION_LANGUAGE_MAP: Record<string, string> = {
   '.css': 'css', '.scss': 'scss', '.less': 'less',
   '.html': 'html', '.htm': 'html',
   '.xml': 'xml', '.svg': 'xml',
-  '.md': 'markdown', '.mdx': 'markdown',
+  '.md': 'markdown', '.mdx': 'markdown', '.markdown': 'markdown',
   '.yml': 'yaml', '.yaml': 'yaml',
   '.py': 'python',
   '.rs': 'rust',

--- a/src/renderer/components/dialogs/task-detail/changes/DiffViewer.tsx
+++ b/src/renderer/components/dialogs/task-detail/changes/DiffViewer.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useRef, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { DiffEditor } from '@monaco-editor/react';
 import type { DiffOnMount, Monaco, MonacoDiffEditor } from '@monaco-editor/react';
-import { Loader2, Columns2, Rows2, FileCode, ChevronUp, ChevronDown, Pilcrow, FoldVertical } from 'lucide-react';
+import { Loader2, Columns2, Rows2, FileCode, ChevronUp, ChevronDown, Pilcrow, FoldVertical, Eye } from 'lucide-react';
+import { MarkdownRenderer } from '../../../MarkdownRenderer';
 import { useConfigStore } from '../../../../stores/config-store';
 import { useKeybinding } from '../../../../hooks/useKeybinding';
 import { NAMED_THEMES } from '../../../../../shared/types';
@@ -94,6 +95,15 @@ export function DiffViewer({
   const themeBase = NAMED_THEMES.find((namedTheme) => namedTheme.id === theme)?.base ?? 'dark';
   const monacoTheme = themeBase === 'dark' ? 'vs-dark' : 'vs';
   const statusConfig = STATUS_LABELS[status];
+
+  // Markdown files can flip from the Monaco diff to a rendered preview of their
+  // NEW content. `language` is the server-derived signal (diff-service maps
+  // .md/.mdx/.markdown -> 'markdown'). The toggle is a transient per-view choice:
+  // the diff shows by default, and a non-markdown file never previews regardless
+  // of this (sticky, hidden) value.
+  const isMarkdown = language === 'markdown';
+  const [showMarkdownPreview, setShowMarkdownPreview] = useState(false);
+  const previewActive = isMarkdown && showMarkdownPreview;
 
   // Diff-rendering preferences are single global config keys (the toolbar
   // toggles and the Layout settings tab read and write the same keys), so the
@@ -361,14 +371,16 @@ export function DiffViewer({
     consumePendingReveal(false);
   }, [scrollMemoryKey, contentFilePath, binary, consumePendingReveal]);
 
-  // The binary placeholder unmounts the child DiffEditor, which disposes the
-  // editor before this parent effect runs. Drop the stale ref so nothing
-  // touches a disposed editor; onMount repopulates it on remount.
+  // The binary placeholder and the markdown preview both unmount the child
+  // DiffEditor, which disposes the editor before this parent effect runs. Drop
+  // the stale ref so nothing (the whitespace/collapse effects below, reachable
+  // from the Layout settings tab while previewing) touches a disposed editor;
+  // onMount repopulates it on remount.
   useEffect(() => {
-    if (binary) {
+    if (binary || previewActive) {
       diffEditorRef.current = null;
     }
-  }, [binary]);
+  }, [binary, previewActive]);
 
   // Apply whitespace changes to the live editor so a toolbar or settings toggle
   // takes effect immediately, not just on the next file open.
@@ -390,8 +402,8 @@ export function DiffViewer({
   // Keyboard navigation: next/prev change, rolling into the adjacent file at a
   // boundary. Gated on the window being focused; capture phase so it beats the
   // embedded terminal. Bound here because the diff editor owns the line changes.
-  useKeybinding('changes.nextChange', () => navigateChange('next'), { capture: true, enabled: isFocused });
-  useKeybinding('changes.prevChange', () => navigateChange('prev'), { capture: true, enabled: isFocused });
+  useKeybinding('changes.nextChange', () => navigateChange('next'), { capture: true, enabled: isFocused && !previewActive });
+  useKeybinding('changes.prevChange', () => navigateChange('prev'), { capture: true, enabled: isFocused && !previewActive });
 
   return (
     <div className="flex flex-col h-full">
@@ -402,64 +414,85 @@ export function DiffViewer({
         <span className={`text-xs ${statusConfig.colorClass} flex-shrink-0`}>{statusConfig.label}</span>
 
         <div className="ml-auto flex items-center gap-1">
-          {/* Next / previous change navigation */}
-          <button
-            onClick={() => navigateChange('prev')}
-            className={toolbarButtonClass(false)}
-            title="Previous change"
-            data-testid="diff-prev-change"
-          >
-            <ChevronUp size={16} />
-          </button>
-          <button
-            onClick={() => navigateChange('next')}
-            className={toolbarButtonClass(false)}
-            title="Next change"
-            data-testid="diff-next-change"
-          >
-            <ChevronDown size={16} />
-          </button>
+          {/* Markdown files toggle between the diff and a rendered preview of the
+              new content. Only shown for markdown; while previewing, the diff-only
+              controls below are hidden since they do not apply to a rendered view. */}
+          {isMarkdown && (
+            <button
+              onClick={() => setShowMarkdownPreview((value) => !value)}
+              className={toolbarButtonClass(previewActive)}
+              title={previewActive ? 'Show diff' : 'Preview rendered markdown'}
+              aria-pressed={previewActive}
+              data-testid="diff-markdown-preview"
+            >
+              <Eye size={16} />
+            </button>
+          )}
 
-          <div className="w-px h-4 bg-edge mx-1" aria-hidden="true" />
+          {!previewActive && (
+            <>
+              {isMarkdown && <div className="w-px h-4 bg-edge mx-1" aria-hidden="true" />}
 
-          {/* Diff-rendering toggles (persisted as global Layout settings) */}
-          <button
-            onClick={() => updateConfig({ diffIgnoreWhitespace: !ignoreWhitespace })}
-            className={toolbarButtonClass(ignoreWhitespace)}
-            title="Ignore whitespace"
-            aria-pressed={ignoreWhitespace}
-            data-testid="diff-ignore-whitespace"
-          >
-            <Pilcrow size={16} />
-          </button>
-          <button
-            onClick={() => updateConfig({ diffCollapseUnchanged: !collapseUnchanged })}
-            className={toolbarButtonClass(collapseUnchanged)}
-            title="Collapse unchanged regions"
-            aria-pressed={collapseUnchanged}
-            data-testid="diff-collapse-unchanged"
-          >
-            <FoldVertical size={16} />
-          </button>
+              {/* Next / previous change navigation */}
+              <button
+                onClick={() => navigateChange('prev')}
+                className={toolbarButtonClass(false)}
+                title="Previous change"
+                data-testid="diff-prev-change"
+              >
+                <ChevronUp size={16} />
+              </button>
+              <button
+                onClick={() => navigateChange('next')}
+                className={toolbarButtonClass(false)}
+                title="Next change"
+                data-testid="diff-next-change"
+              >
+                <ChevronDown size={16} />
+              </button>
 
-          <div className="w-px h-4 bg-edge mx-1" aria-hidden="true" />
+              <div className="w-px h-4 bg-edge mx-1" aria-hidden="true" />
 
-          <button
-            onClick={() => onViewModeChange('split')}
-            className={toolbarButtonClass(viewMode === 'split')}
-            title="Side by side"
-            data-testid="diff-view-split"
-          >
-            <Columns2 size={16} />
-          </button>
-          <button
-            onClick={() => onViewModeChange('inline')}
-            className={toolbarButtonClass(viewMode === 'inline')}
-            title="Inline"
-            data-testid="diff-view-inline"
-          >
-            <Rows2 size={16} />
-          </button>
+              {/* Diff-rendering toggles (persisted as global Layout settings) */}
+              <button
+                onClick={() => updateConfig({ diffIgnoreWhitespace: !ignoreWhitespace })}
+                className={toolbarButtonClass(ignoreWhitespace)}
+                title="Ignore whitespace"
+                aria-pressed={ignoreWhitespace}
+                data-testid="diff-ignore-whitespace"
+              >
+                <Pilcrow size={16} />
+              </button>
+              <button
+                onClick={() => updateConfig({ diffCollapseUnchanged: !collapseUnchanged })}
+                className={toolbarButtonClass(collapseUnchanged)}
+                title="Collapse unchanged regions"
+                aria-pressed={collapseUnchanged}
+                data-testid="diff-collapse-unchanged"
+              >
+                <FoldVertical size={16} />
+              </button>
+
+              <div className="w-px h-4 bg-edge mx-1" aria-hidden="true" />
+
+              <button
+                onClick={() => onViewModeChange('split')}
+                className={toolbarButtonClass(viewMode === 'split')}
+                title="Side by side"
+                data-testid="diff-view-split"
+              >
+                <Columns2 size={16} />
+              </button>
+              <button
+                onClick={() => onViewModeChange('inline')}
+                className={toolbarButtonClass(viewMode === 'inline')}
+                title="Inline"
+                data-testid="diff-view-inline"
+              >
+                <Rows2 size={16} />
+              </button>
+            </>
+          )}
           {trailingControls && (
             <>
               <div className="w-px h-4 bg-edge mx-1" aria-hidden="true" />
@@ -481,6 +514,16 @@ export function DiffViewer({
           // be misread as "no changes" for the first real file).
           <div className="flex items-center justify-center h-full">
             <Loader2 size={20} className="animate-spin text-fg-muted" />
+          </div>
+        ) : previewActive ? (
+          // Rendered markdown preview of the new content (falls back to the old
+          // content for a deleted file). Reuses the shared MarkdownRenderer so the
+          // preview is theme-aware and routes links through shell.openExternal.
+          <div
+            data-testid="diff-markdown-preview-content"
+            className="h-full overflow-y-auto px-4 py-3"
+          >
+            <MarkdownRenderer content={modified || original} />
           </div>
         ) : (
           // On unmount (panel close, Changes<->Browser switch, file deselect),

--- a/src/renderer/components/dialogs/task-detail/changes/DiffViewer.tsx
+++ b/src/renderer/components/dialogs/task-detail/changes/DiffViewer.tsx
@@ -98,12 +98,25 @@ export function DiffViewer({
 
   // Markdown files can flip from the Monaco diff to a rendered preview of their
   // NEW content. `language` is the server-derived signal (diff-service maps
-  // .md/.mdx/.markdown -> 'markdown'). The toggle is a transient per-view choice:
-  // the diff shows by default, and a non-markdown file never previews regardless
-  // of this (sticky, hidden) value.
-  const isMarkdown = language === 'markdown';
+  // .md/.mdx/.markdown -> 'markdown'); a binary-flagged file is excluded because
+  // it has no renderable text and its content pane shows the binary placeholder,
+  // not the preview. The diff shows by default and the toggle resets per file
+  // (see below), so every file opens on its diff.
+  const isMarkdown = language === 'markdown' && !binary;
   const [showMarkdownPreview, setShowMarkdownPreview] = useState(false);
   const previewActive = isMarkdown && showMarkdownPreview;
+
+  // Reset the preview toggle whenever the selected file changes, so each file
+  // opens on its diff - like changeIndexRef / pendingRevealRef, which also reset
+  // per file. DiffViewer is never re-keyed per file (Monaco stays mounted), so the
+  // reset is manual. Adjust state during render (React's supported reset-on-prop-
+  // change pattern) rather than in an effect, so switching between two markdown
+  // files never paints a frame of the previous file's preview.
+  const previousFilePathRef = useRef(filePath);
+  if (previousFilePathRef.current !== filePath) {
+    previousFilePathRef.current = filePath;
+    setShowMarkdownPreview(false);
+  }
 
   // Diff-rendering preferences are single global config keys (the toolbar
   // toggles and the Layout settings tab read and write the same keys), so the
@@ -382,6 +395,24 @@ export function DiffViewer({
     }
   }, [binary, previewActive]);
 
+  // Leaving the preview mounts a brand-new DiffEditor for the same file. The
+  // per-file arm effect above is keyed on scrollMemoryKey, so it does not fire on
+  // a preview toggle - without this, the fresh editor would open at Monaco's
+  // default top instead of the file's remembered/first-change position. Re-arm the
+  // reveal on the true->false transition so onMount restores it, mirroring a file
+  // open. (Deliberately not saving the live scroll on the false->true transition:
+  // the DiffEditor's disposal fires a clamp-to-zero scroll event, which would
+  // poison the saved position.)
+  const previousPreviewActiveRef = useRef(previewActive);
+  useEffect(() => {
+    const wasPreviewActive = previousPreviewActiveRef.current;
+    previousPreviewActiveRef.current = previewActive;
+    if (wasPreviewActive && !previewActive) {
+      pendingRevealRef.current = scrollMemoryKey;
+      changeIndexRef.current = -1;
+    }
+  }, [previewActive, scrollMemoryKey]);
+
   // Apply whitespace changes to the live editor so a toolbar or settings toggle
   // takes effect immediately, not just on the next file open.
   useEffect(() => {
@@ -401,7 +432,9 @@ export function DiffViewer({
 
   // Keyboard navigation: next/prev change, rolling into the adjacent file at a
   // boundary. Gated on the window being focused; capture phase so it beats the
-  // embedded terminal. Bound here because the diff editor owns the line changes.
+  // embedded terminal. Also gated off while previewing markdown: the diff editor
+  // is unmounted then, so there are no line changes to navigate. Bound here
+  // because the diff editor owns the line changes.
   useKeybinding('changes.nextChange', () => navigateChange('next'), { capture: true, enabled: isFocused && !previewActive });
   useKeybinding('changes.prevChange', () => navigateChange('prev'), { capture: true, enabled: isFocused && !previewActive });
 
@@ -516,14 +549,17 @@ export function DiffViewer({
             <Loader2 size={20} className="animate-spin text-fg-muted" />
           </div>
         ) : previewActive ? (
-          // Rendered markdown preview of the new content (falls back to the old
-          // content for a deleted file). Reuses the shared MarkdownRenderer so the
-          // preview is theme-aware and routes links through shell.openExternal.
+          // Rendered markdown preview. A deleted file (status 'D') has no new
+          // content, so preview its old content; every other status previews the
+          // new content - including a file legitimately emptied in the working
+          // tree, which must render blank rather than fall back to the stale old
+          // text. Reuses the shared MarkdownRenderer so the preview is theme-aware
+          // and routes links through shell.openExternal.
           <div
             data-testid="diff-markdown-preview-content"
             className="h-full overflow-y-auto px-4 py-3"
           >
-            <MarkdownRenderer content={modified || original} />
+            <MarkdownRenderer content={status === 'D' ? original : modified} />
           </div>
         ) : (
           // On unmount (panel close, Changes<->Browser switch, file deselect),

--- a/tests/ui/task-detail-changes-diffviewer-toolbar.spec.ts
+++ b/tests/ui/task-detail-changes-diffviewer-toolbar.spec.ts
@@ -236,6 +236,9 @@ test.describe('DiffViewer toolbar: trailingControls rendered when a file is sele
     // Wait for the toolbar (mounts synchronously once a file is selected).
     await expect(page.locator('[data-testid="diff-view-split"]')).toBeVisible({ timeout: 8000 });
 
+    // The markdown preview toggle is markdown-only: absent for this .tsx file.
+    await expect(page.locator('[data-testid="diff-markdown-preview"]')).not.toBeVisible();
+
     // Navigation buttons are present.
     await expect(page.locator('[data-testid="diff-prev-change"]')).toBeVisible();
     await expect(page.locator('[data-testid="diff-next-change"]')).toBeVisible();
@@ -256,6 +259,178 @@ test.describe('DiffViewer toolbar: trailingControls rendered when a file is sele
     await expect(collapse).toHaveAttribute('aria-pressed', 'true');
     await collapse.click();
     await expect(collapse).toHaveAttribute('aria-pressed', 'false');
+
+    await page.evaluate(() => {
+      (window as unknown as Record<string, unknown>).__mockGitDiff = null;
+    });
+
+    await changesPill.click();
+    await page.keyboard.press('Control+Shift+W');
+    await expect(dialog).not.toBeVisible({ timeout: 8000 });
+  });
+
+  test('markdown files show a preview toggle that renders the new content and hides diff-only controls', async () => {
+    // Seed a markdown file so ChangesPanel auto-selects it and DiffViewer mounts
+    // with the preview toggle (only rendered when language === 'markdown').
+    await page.evaluate(() => {
+      (window as unknown as { __mockGitDiff: unknown }).__mockGitDiff = {
+        files: [
+          {
+            path: 'docs/readme.md',
+            status: 'M',
+            insertions: 3,
+            deletions: 1,
+            binary: false,
+            original: '# Old Title\n',
+            modified: '# New Heading\n\nBody paragraph.\n',
+            language: 'markdown',
+          },
+        ],
+      };
+    });
+
+    const card = page
+      .locator('[data-swimlane-name="Code Review"]')
+      .locator('text=DiffViewer Toolbar Task')
+      .first();
+    await card.click();
+
+    const dialog = page.locator('[data-testid="task-detail-dialog"]');
+    await dialog.waitFor({ state: 'visible', timeout: 5000 });
+
+    const changesPill = page.locator('[data-testid="changes-toggle"]');
+    await changesPill.click();
+
+    // The toggle mounts synchronously with the toolbar once the markdown file is
+    // auto-selected. It starts off (showing the diff), so the diff-only controls
+    // are present.
+    const previewToggle = page.locator('[data-testid="diff-markdown-preview"]');
+    await expect(previewToggle).toBeVisible({ timeout: 8000 });
+    await expect(previewToggle).toHaveAttribute('aria-pressed', 'false');
+    await expect(page.locator('[data-testid="diff-view-split"]')).toBeVisible();
+
+    // Flip to the rendered preview: the new content renders (react-markdown runs
+    // in headless Chromium), and the diff-only controls hide.
+    await previewToggle.click();
+    await expect(previewToggle).toHaveAttribute('aria-pressed', 'true');
+    const preview = page.locator('[data-testid="diff-markdown-preview-content"]');
+    await expect(preview).toBeVisible();
+    await expect(preview.locator('h1')).toHaveText('New Heading');
+    await expect(page.locator('[data-testid="diff-view-split"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="diff-ignore-whitespace"]')).not.toBeVisible();
+
+    // Toggle back returns to the diff and restores the diff-only controls.
+    await previewToggle.click();
+    await expect(previewToggle).toHaveAttribute('aria-pressed', 'false');
+    await expect(preview).not.toBeVisible();
+    await expect(page.locator('[data-testid="diff-view-split"]')).toBeVisible();
+
+    await page.evaluate(() => {
+      (window as unknown as Record<string, unknown>).__mockGitDiff = null;
+    });
+
+    await changesPill.click();
+    await page.keyboard.press('Control+Shift+W');
+    await expect(dialog).not.toBeVisible({ timeout: 8000 });
+  });
+
+  test('next/prev-change keybindings are inert while the markdown preview is active', async () => {
+    // Three files so both next-change (F7) and prev-change (Shift+F7) have a
+    // real adjacent file to roll into IF the `enabled: isFocused && !previewActive`
+    // guard on DiffViewer's changes.nextChange/changes.prevChange bindings
+    // (DiffViewer.tsx:405-406) were broken. Entering preview mode nulls
+    // diffEditorRef (the `binary || previewActive` effect in DiffViewer.tsx), so
+    // if the handler fired while previewing it would hit navigateChange's
+    // "no diff mounted" branch and immediately roll to the adjacent file via
+    // onCrossFile - a Monaco-independent, unmistakable signal that the binding
+    // fired. Correct behavior attaches no listener at all while previewActive
+    // (enabled=false), so the shortcut is a true no-op and the panel stays on
+    // the markdown file with its preview open.
+    await page.evaluate(() => {
+      (window as unknown as { __mockGitDiff: unknown }).__mockGitDiff = {
+        files: [
+          {
+            path: 'src/nav-guard-before.ts',
+            status: 'M',
+            insertions: 1,
+            deletions: 1,
+            binary: false,
+            original: 'const a = 1;\n',
+            modified: 'const a = 2;\n',
+            language: 'typescript',
+          },
+          {
+            path: 'docs/nav-guard.md',
+            status: 'M',
+            insertions: 3,
+            deletions: 1,
+            binary: false,
+            original: '# Old Title\n',
+            modified: '# Nav Guard Heading\n\nBody paragraph.\n',
+            language: 'markdown',
+          },
+          {
+            path: 'src/nav-guard-after.ts',
+            status: 'M',
+            insertions: 1,
+            deletions: 1,
+            binary: false,
+            original: 'const b = 1;\n',
+            modified: 'const b = 2;\n',
+            language: 'typescript',
+          },
+        ],
+      };
+    });
+
+    const card = page
+      .locator('[data-swimlane-name="Code Review"]')
+      .locator('text=DiffViewer Toolbar Task')
+      .first();
+    await card.click();
+
+    const dialog = page.locator('[data-testid="task-detail-dialog"]');
+    await dialog.waitFor({ state: 'visible', timeout: 5000 });
+
+    const changesPill = page.locator('[data-testid="changes-toggle"]');
+    await changesPill.click();
+
+    // ChangesPanel auto-selects the first file (src/nav-guard-before.ts);
+    // select the markdown file explicitly so the preview toggle is available.
+    const markdownRow = page.locator('[data-testid="changes-file-row"][data-path="docs/nav-guard.md"]');
+    await markdownRow.locator('button').first().click();
+
+    const previewToggle = page.locator('[data-testid="diff-markdown-preview"]');
+    await expect(previewToggle).toBeVisible({ timeout: 8000 });
+    await previewToggle.click();
+    await expect(previewToggle).toHaveAttribute('aria-pressed', 'true');
+
+    const preview = page.locator('[data-testid="diff-markdown-preview-content"]');
+    await expect(preview).toBeVisible();
+    await expect(preview.locator('h1')).toHaveText('Nav Guard Heading');
+
+    // Fire next-change (F7, the alt combo for changes.nextChange). A broken
+    // guard would roll into src/nav-guard-after.ts.
+    await page.keyboard.press('F7');
+    // Fixed budget, not a poll: this asserts a NO-OP, which cannot be polled
+    // for (see test-builder anti-pattern 6). The mock IPC (mock-electron-api.js
+    // git.fileContent) resolves on a bare microtask with no artificial delay,
+    // and file selection itself is a synchronous state update, so any real
+    // navigation would already be reflected in the DOM well within this window.
+    await page.waitForTimeout(500);
+    await expect(markdownRow).toHaveAttribute('data-selected', 'true');
+    await expect(preview).toBeVisible();
+    await expect(preview.locator('h1')).toHaveText('Nav Guard Heading');
+    await expect(previewToggle).toHaveAttribute('aria-pressed', 'true');
+
+    // Fire prev-change (Shift+F7, the alt combo for changes.prevChange). A
+    // broken guard would roll into src/nav-guard-before.ts.
+    await page.keyboard.press('Shift+F7');
+    await page.waitForTimeout(500);
+    await expect(markdownRow).toHaveAttribute('data-selected', 'true');
+    await expect(preview).toBeVisible();
+    await expect(preview.locator('h1')).toHaveText('Nav Guard Heading');
+    await expect(previewToggle).toHaveAttribute('aria-pressed', 'true');
 
     await page.evaluate(() => {
       (window as unknown as Record<string, unknown>).__mockGitDiff = null;

--- a/tests/ui/task-detail-changes-diffviewer-toolbar.spec.ts
+++ b/tests/ui/task-detail-changes-diffviewer-toolbar.spec.ts
@@ -337,9 +337,9 @@ test.describe('DiffViewer toolbar: trailingControls rendered when a file is sele
   test('next/prev-change keybindings are inert while the markdown preview is active', async () => {
     // Three files so both next-change (F7) and prev-change (Shift+F7) have a
     // real adjacent file to roll into IF the `enabled: isFocused && !previewActive`
-    // guard on DiffViewer's changes.nextChange/changes.prevChange bindings
-    // (DiffViewer.tsx:405-406) were broken. Entering preview mode nulls
-    // diffEditorRef (the `binary || previewActive` effect in DiffViewer.tsx), so
+    // guard on DiffViewer's changes.nextChange/changes.prevChange bindings were
+    // broken. Entering preview mode nulls diffEditorRef (the
+    // `binary || previewActive` effect in DiffViewer.tsx), so
     // if the handler fired while previewing it would hit navigateChange's
     // "no diff mounted" branch and immediately roll to the adjacent file via
     // onCrossFile - a Monaco-independent, unmistakable signal that the binding
@@ -431,6 +431,141 @@ test.describe('DiffViewer toolbar: trailingControls rendered when a file is sele
     await expect(preview).toBeVisible();
     await expect(preview.locator('h1')).toHaveText('Nav Guard Heading');
     await expect(previewToggle).toHaveAttribute('aria-pressed', 'true');
+
+    await page.evaluate(() => {
+      (window as unknown as Record<string, unknown>).__mockGitDiff = null;
+    });
+
+    await changesPill.click();
+    await page.keyboard.press('Control+Shift+W');
+    await expect(dialog).not.toBeVisible({ timeout: 8000 });
+  });
+
+  test('a deleted markdown file previews its old content, not the empty new content', async () => {
+    // diff-service reports a deleted file with modified: '' and original holding
+    // the last committed text. DiffViewer's preview branch is
+    // `content={status === 'D' ? original : modified}` - if that fallback were
+    // reverted to always render `modified`, this file would preview blank
+    // instead of the old heading.
+    await page.evaluate(() => {
+      (window as unknown as { __mockGitDiff: unknown }).__mockGitDiff = {
+        files: [
+          {
+            path: 'docs/deleted.md',
+            status: 'D',
+            insertions: 0,
+            deletions: 2,
+            binary: false,
+            original: '# Deleted Doc\n\nOld body.\n',
+            modified: '',
+            language: 'markdown',
+          },
+        ],
+      };
+    });
+
+    const card = page
+      .locator('[data-swimlane-name="Code Review"]')
+      .locator('text=DiffViewer Toolbar Task')
+      .first();
+    await card.click();
+
+    const dialog = page.locator('[data-testid="task-detail-dialog"]');
+    await dialog.waitFor({ state: 'visible', timeout: 5000 });
+
+    const changesPill = page.locator('[data-testid="changes-toggle"]');
+    await changesPill.click();
+
+    // ChangesPanel auto-selects the single deleted markdown file; the preview
+    // toggle mounts once the toolbar renders (markdown-only, same as the other
+    // markdown tests above).
+    const previewToggle = page.locator('[data-testid="diff-markdown-preview"]');
+    await expect(previewToggle).toBeVisible({ timeout: 8000 });
+    await expect(previewToggle).toHaveAttribute('aria-pressed', 'false');
+
+    // Flip to the rendered preview. The old heading must render - this fails if
+    // the fallback branch is reverted to always use `modified` (blank preview).
+    await previewToggle.click();
+    await expect(previewToggle).toHaveAttribute('aria-pressed', 'true');
+    const preview = page.locator('[data-testid="diff-markdown-preview-content"]');
+    await expect(preview).toBeVisible();
+    await expect(preview.locator('h1')).toHaveText('Deleted Doc');
+
+    await page.evaluate(() => {
+      (window as unknown as Record<string, unknown>).__mockGitDiff = null;
+    });
+
+    await changesPill.click();
+    await page.keyboard.press('Control+Shift+W');
+    await expect(dialog).not.toBeVisible({ timeout: 8000 });
+  });
+
+  test('markdown preview toggle resets to the diff when switching to a different file', async () => {
+    // Two markdown files so previewing the first, then selecting the second,
+    // exercises DiffViewer's per-file reset (previousFilePathRef nulling
+    // showMarkdownPreview when filePath changes). Without that reset the second
+    // file would open already in preview mode.
+    await page.evaluate(() => {
+      (window as unknown as { __mockGitDiff: unknown }).__mockGitDiff = {
+        files: [
+          {
+            path: 'docs/first.md',
+            status: 'M',
+            insertions: 2,
+            deletions: 1,
+            binary: false,
+            original: '# First Old\n',
+            modified: '# First Heading\n\nBody.\n',
+            language: 'markdown',
+          },
+          {
+            path: 'docs/second.md',
+            status: 'M',
+            insertions: 2,
+            deletions: 1,
+            binary: false,
+            original: '# Second Old\n',
+            modified: '# Second Heading\n\nBody.\n',
+            language: 'markdown',
+          },
+        ],
+      };
+    });
+
+    const card = page
+      .locator('[data-swimlane-name="Code Review"]')
+      .locator('text=DiffViewer Toolbar Task')
+      .first();
+    await card.click();
+
+    const dialog = page.locator('[data-testid="task-detail-dialog"]');
+    await dialog.waitFor({ state: 'visible', timeout: 5000 });
+
+    const changesPill = page.locator('[data-testid="changes-toggle"]');
+    await changesPill.click();
+
+    // Select docs/first.md explicitly (ChangesPanel auto-selects the first
+    // file anyway, but select it by row so the assumption is unambiguous).
+    const firstFileRow = page.locator('[data-testid="changes-file-row"][data-path="docs/first.md"]');
+    await firstFileRow.locator('button').first().click();
+
+    const previewToggle = page.locator('[data-testid="diff-markdown-preview"]');
+    await expect(previewToggle).toBeVisible({ timeout: 8000 });
+    await previewToggle.click();
+    await expect(previewToggle).toHaveAttribute('aria-pressed', 'true');
+    const preview = page.locator('[data-testid="diff-markdown-preview-content"]');
+    await expect(preview).toBeVisible();
+    await expect(preview.locator('h1')).toHaveText('First Heading');
+
+    // Select docs/second.md. Correct behavior resets the toggle so the second
+    // file opens on its diff.
+    const secondFileRow = page.locator('[data-testid="changes-file-row"][data-path="docs/second.md"]');
+    await secondFileRow.locator('button').first().click();
+    await expect(secondFileRow).toHaveAttribute('data-selected', 'true');
+
+    await expect(previewToggle).toHaveAttribute('aria-pressed', 'false');
+    await expect(preview).not.toBeVisible();
+    await expect(page.locator('[data-testid="diff-view-split"]')).toBeVisible();
 
     await page.evaluate(() => {
       (window as unknown as Record<string, unknown>).__mockGitDiff = null;

--- a/tests/unit/diff-service.test.ts
+++ b/tests/unit/diff-service.test.ts
@@ -532,6 +532,8 @@ describe('DiffService', () => {
         { filePath: 'file.css', expectedLanguage: 'css' },
         { filePath: 'file.html', expectedLanguage: 'html' },
         { filePath: 'file.md', expectedLanguage: 'markdown' },
+        { filePath: 'file.mdx', expectedLanguage: 'markdown' },
+        { filePath: 'file.markdown', expectedLanguage: 'markdown' },
         { filePath: 'file.yml', expectedLanguage: 'yaml' },
         { filePath: 'file.rs', expectedLanguage: 'rust' },
         { filePath: 'file.go', expectedLanguage: 'go' },


### PR DESCRIPTION
## What

Add a markdown preview toggle to the Changes diff view. When a changed file is markdown
(`.md`, `.mdx`, `.markdown`), an Eye toggle appears in the diff toolbar; enabling it renders the
new file content through the shared `MarkdownRenderer` instead of the Monaco diff. Because the
toggle lives in the shared `DiffViewer`, it appears on every changes surface at once: the
task-detail Changes panel, the standalone `TaskChangesDialog`, and the completed-tasks view.

Affected components:
- `src/renderer/components/dialogs/task-detail/changes/DiffViewer.tsx` - the toggle, the preview
  render branch, and hiding the diff-only controls while previewing.
- `src/main/git/diff-service.ts` - map `.markdown` to the markdown language (`.md` / `.mdx` were
  already mapped).
- `tests/ui/task-detail-changes-diffviewer-toolbar.spec.ts`, `tests/unit/diff-service.test.ts` - coverage.

## Why

Reviewing changes to documentation and other markdown files as a raw text diff makes it hard to
see how the rendered output will actually look. A preview lets a reviewer flip a changed markdown
file to its rendered form without leaving the Changes panel. Implements Kangentic task #17.

## How

- Detect markdown from the server-derived `language === 'markdown'` signal, so no path re-parsing
  in the renderer.
- A component-local `useState` in `DiffViewer` holds the toggle. The diff shows by default, and a
  non-markdown file never renders the preview regardless of the (sticky, hidden) value.
- While previewing, the diff-only toolbar controls (prev/next change, whitespace, collapse,
  split/inline) hide since they do not apply, and the change-nav keybindings are gated off. The
  expand/collapse panel controls stay visible.
- Preview content is `modified || original`, so it shows new content normally and falls back to
  the old content for a deleted file.
- Reuses the existing `MarkdownRenderer` (react-markdown + remark-gfm, theme-aware `.markdown-body`
  styling, external-link routing), so no new dependency and no new CSS.

## Breaking changes

None. Component-local state only: no config schema, IPC, or migration.

## Tests

- UI: `tests/ui/task-detail-changes-diffviewer-toolbar.spec.ts` - the toggle appears only for
  markdown files, renders the new content, hides the diff-only controls, and toggles back; plus a
  negative assertion that a `.tsx` file shows no toggle.
- Unit: `tests/unit/diff-service.test.ts` - `.md`, `.mdx`, and `.markdown` all map to markdown.
- Local gate before this PR: typecheck, lint (`--max-warnings 0`), the scoped UI spec (3 passed),
  and the diff-service unit suite (34 passed) all green. CI runs the full unit / UI / Electron E2E
  tiers.

Generated with [Claude Code](https://claude.com/claude-code)
