### PR TITLE
perf: eliminate recurring UI freezes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,7 +65,7 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 | `projectGroup:reorder` | invoke | Reorder groups by ID array |
 | `projectGroup:setCollapsed` | invoke | Toggle group collapsed state |
 
-### Tasks (21 channels)
+### Tasks (22 channels)
 | Channel | Pattern | Purpose |
 |---------|---------|---------|
 | `task:list` | invoke | Fetch tasks, optionally by swimlane |
@@ -75,6 +75,7 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 | `task:move` | invoke | Move task between swimlanes (triggers transitions) |
 | `task:cancelSpawn` | invoke | Abort an in-flight spawn for a task (e.g. while parked in the git queue or fetching); aborts the move's AbortController and rolls the move back |
 | `task:list-archived` | invoke | Fetch archived tasks |
+| `task:list-archived-preview` | invoke | Fetch the newest N archived tasks plus the total archived count (cheap hydration payload; the full list loads lazily via `task:list-archived`) |
 | `task:unarchive` | invoke | Restore archived task |
 | `task:bulk-delete` | invoke | Delete multiple archived tasks by ID array |
 | `task:bulk-delete-progress` | on | Event: progress payload during bulk task delete (completed/total/failures) |

--- a/docs/database.md
+++ b/docs/database.md
@@ -428,6 +428,7 @@ Operates on a per-project DB.
 | `archive(id)` | Set `archived_at` to now (soft-delete for Done column) |
 | `unarchive(id, targetSwimlaneId, position)` | Clear `archived_at`, move to target swimlane and position |
 | `listArchived()` | All archived tasks ordered by `archived_at` DESC |
+| `listArchivedPreview(limit)` | The newest `limit` archived tasks plus the total archived count; cheap hydration for the Done column (full list loads lazily via `listArchived`) |
 | `delete(id)` | Hard delete with position shift in the owning swimlane |
 
 ### SwimlaneRepository

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -439,7 +439,7 @@ Live snapshot of memory + CPU usage per Electron process (main, renderer, GPU, u
 
 ### kangentic_get_ipc_log
 
-Read recent IPC traffic from `<projectRoot>/.kangentic/logs/ipc-<YYYY-MM-DD>.jsonl`. Each entry has `channel`, `args`, `result`, `durationMs`, and (on failure) `error`. Inbound `ipcMain.handle` invocations (renderer to main) leave `direction` absent; outbound `webContents.send` pushes (main to renderer, e.g. the `task:createdByAgent` board-invalidation events) set `direction: "out"`, and a push dropped because the window was destroyed carries an `error` with name `PushDropped`. Only available when `developer.recordIpcTraffic` is on. Channels carrying secrets (settings writes, MCP config, auth) are stored as `{ redacted: true, channel }`.
+Read recent IPC traffic from `<projectRoot>/.kangentic/logs/ipc-<YYYY-MM-DD>.jsonl`. Each entry has `channel`, `args`, `result`, `durationMs`, and (on failure) `error`. Inbound `ipcMain.handle` invocations (renderer to main) leave `direction` absent; outbound `webContents.send` pushes (main to renderer, e.g. the `task:createdByAgent` board-invalidation events) set `direction: "out"`, and a push dropped because the window was destroyed carries an `error` with name `PushDropped`. Only available when `developer.recordIpcTraffic` is on. Channels carrying secrets (settings writes, MCP config, auth) are stored as `{ redacted: true, channel }`. An oversized `args`/`result` payload (e.g. a large list) is stored as `{ truncated: true, serializedChars, preview }` instead of the full value, keeping each log line small.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/src/devtools/main/inspection-server.ts
+++ b/src/devtools/main/inspection-server.ts
@@ -39,6 +39,7 @@ import {
 import type { IpcContext } from '../../main/ipc/ipc-context';
 import { getProcessMetrics } from '../../main/diagnostics/process-metrics';
 import { getEventLoopLagReport } from '../../main/diagnostics/event-loop-lag';
+import { ROTATED_FILE_SUFFIX } from '../../main/diagnostics/async-file-queue';
 import type { SessionManager } from '../../main/pty/session-manager';
 
 /**
@@ -439,7 +440,12 @@ function respondIpcLog(
     limit: clampLimit(url.searchParams.get('limit'), 200, 2000),
   };
   const file = path.join(projectRoot, '.kangentic', 'logs', `ipc-${date}.jsonl`);
-  const entries = readJsonLines<Record<string, unknown>>(file);
+  // Read the rotated copy (older) before the primary (newer) so a fresh
+  // rotation doesn't blank recent-traffic queries; both are chronological.
+  const entries = [
+    ...readJsonLines<Record<string, unknown>>(file + ROTATED_FILE_SUFFIX),
+    ...readJsonLines<Record<string, unknown>>(file),
+  ];
   const filtered = entries.filter((entry) => {
     if (filter.since && typeof entry.ts === 'string' && entry.ts < filter.since) return false;
     if (filter.channel && entry.channel !== filter.channel) return false;
@@ -495,6 +501,10 @@ function respondEngineState(
  * `window.__kangenticLagReport` global, returning an `unavailable` marker when
  * the debugger is not attached or the recorder is not installed. Together they
  * are a retroactive freeze log - recorded stalls with timestamps + durations.
+ * The renderer report separates real freezes (`spikeCount` / `maxLagMs` /
+ * `recentSpikes`) from background-throttle artifacts, which land in
+ * `hiddenSpikeCount` / `maxHiddenLagMs` so a hidden window's ~900ms throttled
+ * ticks do not pollute freeze diagnosis.
  */
 async function respondEventLoopLag(
   options: InspectionServerOptions,

--- a/src/devtools/renderer/install.tsx
+++ b/src/devtools/renderer/install.tsx
@@ -6,6 +6,7 @@ import {
   stopRendererLagRecorder,
   getRendererLagReport,
 } from './lag-recorder';
+import { getTerminalRendererReport } from '../../renderer/utils/terminal-webgl';
 
 /**
  * Renderer-side bootstrap for the dev-only inspection bridge.
@@ -27,6 +28,7 @@ export function DevtoolsBootstrap(): null {
       __kangenticPreviewSnapshot?: () => unknown;
       __kangenticPreviewStoreState?: (storeName: string, path?: string | null) => unknown;
       __kangenticLagReport?: () => unknown;
+      __kangenticTerminalRenderers?: () => unknown;
     };
     (window as DevtoolsWindow).__kangenticPreviewSnapshot = buildPreviewSnapshot;
     (window as DevtoolsWindow).__kangenticPreviewStoreState = readStoreState;
@@ -35,6 +37,11 @@ export function DevtoolsBootstrap(): null {
     // inspection server's /event-loop-lag route can surface UI-freeze history.
     startRendererLagRecorder();
     (window as DevtoolsWindow).__kangenticLagReport = getRendererLagReport;
+
+    // Terminal renderer report: exposes each terminal's live renderer type
+    // (webgl vs the slow DOM fallback) + context-loss count, so a silently
+    // degraded terminal is observable via kangentic_devtools_eval.
+    (window as DevtoolsWindow).__kangenticTerminalRenderers = getTerminalRendererReport;
 
     // Subscribe to the toast store: every push lands in our ring.
     const unsubscribeToast = useToastStore.subscribe((state, prevState) => {
@@ -59,6 +66,7 @@ export function DevtoolsBootstrap(): null {
       delete (window as DevtoolsWindow).__kangenticPreviewSnapshot;
       delete (window as DevtoolsWindow).__kangenticPreviewStoreState;
       delete (window as DevtoolsWindow).__kangenticLagReport;
+      delete (window as DevtoolsWindow).__kangenticTerminalRenderers;
     };
   }, []);
 

--- a/src/devtools/renderer/lag-recorder.ts
+++ b/src/devtools/renderer/lag-recorder.ts
@@ -24,9 +24,18 @@ interface RendererLagReport {
   sampleIntervalMs: number;
   spikeThresholdMs: number;
   samples: number;
+  /** Max lag from a VISIBLE-window sample (throttle artifacts are excluded). */
   maxLagMs: number;
+  /** Spike count from VISIBLE-window samples only. */
   spikeCount: number;
+  /** Recent VISIBLE-window spikes only (background-throttle spikes never enter the ring). */
   recentSpikes: RendererLagSpike[];
+  /** Whether the window was hidden at report time. */
+  documentHidden: boolean;
+  /** Spikes attributed to background throttling (window hidden), not real freezes. */
+  hiddenSpikeCount: number;
+  /** Max lag observed while the window was throttled (background), in ms. */
+  maxHiddenLagMs: number;
 }
 
 // Keep these three constants in sync with event-loop-lag.ts (the main-process
@@ -42,6 +51,17 @@ let samples = 0;
 let maxLagMs = 0;
 let spikeCount = 0;
 const recentSpikes: RendererLagSpike[] = [];
+// Background-throttle artifacts are routed here instead of the ring. When
+// `document.hidden`, Chromium throttles this 100ms sampler to >=1s, so every
+// hidden sample reads as a ~900ms "spike" that would otherwise flood the ring
+// (2 minutes of background evicts all real freeze history) and dominate maxLagMs.
+let hiddenSpikeCount = 0;
+let maxHiddenLagMs = 0;
+let lastSampleHidden = false;
+
+function isDocumentHidden(): boolean {
+  return typeof document !== 'undefined' && document.hidden === true;
+}
 
 export function startRendererLagRecorder(): void {
   if (timer) return;
@@ -52,6 +72,16 @@ export function startRendererLagRecorder(): void {
     const lag = now - lastFire - SAMPLE_INTERVAL_MS;
     lastFire = now;
     samples += 1;
+    const hidden = isDocumentHidden();
+    // The first VISIBLE sample after foregrounding still carries the throttle
+    // backlog, so classify it as an artifact via the previous-sample flag.
+    const throttleArtifact = hidden || lastSampleHidden;
+    lastSampleHidden = hidden;
+    if (throttleArtifact) {
+      if (lag > maxHiddenLagMs) maxHiddenLagMs = lag;
+      if (lag >= SPIKE_THRESHOLD_MS) hiddenSpikeCount += 1;
+      return;
+    }
     if (lag > maxLagMs) maxLagMs = lag;
     if (lag >= SPIKE_THRESHOLD_MS) {
       spikeCount += 1;
@@ -78,5 +108,8 @@ export function getRendererLagReport(): RendererLagReport {
     maxLagMs: Math.round(maxLagMs),
     spikeCount,
     recentSpikes: [...recentSpikes],
+    documentHidden: isDocumentHidden(),
+    hiddenSpikeCount,
+    maxHiddenLagMs: Math.round(maxHiddenLagMs),
   };
 }

--- a/src/main/activity-engine/background-shell/watcher.ts
+++ b/src/main/activity-engine/background-shell/watcher.ts
@@ -246,6 +246,26 @@ const PID_CAPTURE_RETRY_CYCLES = 3;
  */
 export const NAMED_SHELL_QUIESCENT_RECLAIM_CYCLES = 30;
 
+/**
+ * Adaptive poll backoff. The full host-process enumeration (`listAllProcesses`,
+ * a ~200ms PowerShell CIM query on Windows) fires every cycle where any session
+ * "needs tree" - which, with several agents running tools, is nearly
+ * continuous. Under that sustained load the sweep burns CPU exactly when the
+ * machine is already saturated. So after a run of consecutive tree cycles the
+ * poll interval stretches (2s -> 4s -> 6s), and any background-shell lifecycle
+ * transition (a new capture, an observed deficit, a (re)registered session)
+ * snaps it back to the base cadence so detection latency stays tight when
+ * something is actually changing. Cost trade-off: Tier B natural-exit detection
+ * can lag up to one stretched interval before the 2-cycle deficit confirmation
+ * (which itself runs at base cadence once a deficit is seen), so worst-case
+ * ~8s vs ~4s today - well within the 5-min watchdog backstop. Multipliers are
+ * applied to `pollIntervalMs` so a test's small base interval scales too.
+ */
+export const POLL_BACKOFF_STAGE_ONE_TREE_CYCLES = 5;
+export const POLL_BACKOFF_STAGE_TWO_TREE_CYCLES = 15;
+const POLL_BACKOFF_STAGE_ONE_MULTIPLIER = 2;
+const POLL_BACKOFF_STAGE_TWO_MULTIPLIER = 3;
+
 export class BgShellWatcher {
   private readonly callbacks: BgShellWatcherCallbacks;
   private readonly probe: ProcessTreeProbe;
@@ -256,6 +276,9 @@ export class BgShellWatcher {
   private timer: NodeJS.Timeout | null = null;
   private polling = false;
   private disposed = false;
+  // Consecutive cycles that ran the full OS enumeration (reset by a skip cycle
+  // or any bg-shell lifecycle transition). Drives the adaptive poll backoff.
+  private consecutiveTreeCycles = 0;
 
   constructor(options: BgShellWatcherOptions) {
     this.callbacks = options.callbacks;
@@ -275,8 +298,11 @@ export class BgShellWatcher {
     if (!rootPid || rootPid <= 0) return;
     if (this.states.has(sessionId)) {
       this.states.get(sessionId)!.rootPid = rootPid;
+      // A resume is a transition too: watch the new tree at base cadence.
+      this.resetPollBackoff();
       return;
     }
+    this.resetPollBackoff();
     this.states.set(sessionId, {
       rootPid,
       // Anchored on the first cycle from the live probe.
@@ -307,6 +333,8 @@ export class BgShellWatcher {
     if (!state) return;
     if (!Number.isInteger(pid) || pid <= 0) return;
     state.trackedShellPids.set(shellId, pid);
+    // A newly-tracked shell PID is a transition: poll at base while it settles.
+    this.resetPollBackoff();
   }
 
   /**
@@ -325,6 +353,10 @@ export class BgShellWatcher {
     const state = this.states.get(sessionId);
     if (!state) return;
     if (state.trackedShellPids.has(shellId)) return;
+    // A new bg shell is the key transition: snap to base cadence so the
+    // PID_CAPTURE_RETRY_CYCLES budget operates on its designed ~2s window
+    // instead of a stretched interval.
+    this.resetPollBackoff();
     const memoPid = state.candidateForegroundShellPid;
     if (memoPid !== null && this.probe.isAlive(memoPid)) {
       state.trackedShellPids.set(shellId, memoPid);
@@ -358,20 +390,67 @@ export class BgShellWatcher {
     if (this.timer !== null) return;
     if (this.disposed) return;
     if (this.states.size === 0) return;
-    this.timer = setInterval(() => {
-      // Skip overlapping cycles - if last poll is still running, drop this tick.
-      if (this.polling) return;
-      this.cycle().catch(() => {
+    // A self-scheduling setTimeout chain (rather than a fixed setInterval) lets
+    // the next delay vary with the adaptive backoff. The chain never overlaps
+    // itself: the next tick is armed only after the current cycle resolves.
+    this.scheduleNextCycle(this.pollIntervalMs);
+  }
+
+  private scheduleNextCycle(delayMs: number): void {
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.runScheduledCycle();
+    }, delayMs);
+    this.timer.unref();
+  }
+
+  private async runScheduledCycle(): Promise<void> {
+    if (this.disposed || this.states.size === 0) return;
+    // Preserve the overlap-drop semantics for a concurrent pollNow() (tests):
+    // skip this scheduled cycle if one is already running, but still re-arm.
+    if (!this.polling) {
+      try {
+        await this.cycle();
+      } catch {
         // Probe failures are already handled inside cycle(); this catch
         // is just defense against unexpected throws.
-      });
-    }, this.pollIntervalMs);
-    this.timer.unref();
+      }
+    }
+    // A lifecycle transition during the await may have already armed a fresh
+    // base-delay timer (resetPollBackoff); don't double-arm over it.
+    if (this.disposed || this.states.size === 0 || this.timer !== null) return;
+    this.scheduleNextCycle(this.computeNextPollDelayMs());
+  }
+
+  private computeNextPollDelayMs(): number {
+    if (this.consecutiveTreeCycles >= POLL_BACKOFF_STAGE_TWO_TREE_CYCLES) {
+      return this.pollIntervalMs * POLL_BACKOFF_STAGE_TWO_MULTIPLIER;
+    }
+    if (this.consecutiveTreeCycles >= POLL_BACKOFF_STAGE_ONE_TREE_CYCLES) {
+      return this.pollIntervalMs * POLL_BACKOFF_STAGE_ONE_MULTIPLIER;
+    }
+    return this.pollIntervalMs;
+  }
+
+  /**
+   * Snap the poll cadence back to base on a bg-shell lifecycle transition. Zeroes
+   * the backoff counter, and if a stretched timer is currently armed, re-arms it
+   * at the base delay so a fresh transition is not left waiting out a 4-6s gap.
+   * When called mid-cycle (timer already consumed to null) it only zeroes the
+   * counter; runScheduledCycle then re-arms at base via computeNextPollDelayMs.
+   */
+  private resetPollBackoff(): void {
+    this.consecutiveTreeCycles = 0;
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+      this.scheduleNextCycle(this.pollIntervalMs);
+    }
   }
 
   private stopPolling(): void {
     if (this.timer !== null) {
-      clearInterval(this.timer);
+      clearTimeout(this.timer);
       this.timer = null;
     }
   }
@@ -400,9 +479,16 @@ export class BgShellWatcher {
         return state !== undefined && this.sessionNeedsTree(sessionId, state);
       });
       if (!anyNeedsTree) {
+        // A skip cycle costs nothing, so it resets the backoff: the moment work
+        // resumes we start from the base cadence again.
+        this.consecutiveTreeCycles = 0;
         for (const sessionId of sessionIds) this.skipCycleSession(sessionId);
         return;
       }
+
+      // A needy cycle ran the OS enumeration; count it toward the backoff. A
+      // probe that later times out to [] still cost a spawn, so it counts.
+      this.consecutiveTreeCycles += 1;
 
       // Single OS query shared across all sessions in this cycle.
       // Without this, each session's cycleSession would call
@@ -423,6 +509,15 @@ export class BgShellWatcher {
       for (const sessionId of sessionIds) {
         await this.cycleSession(sessionId, byParent, allProcessPids);
       }
+
+      // A live deficit is a state transition worth watching closely: snap back
+      // to the base cadence so the Tier B 2-cycle natural-exit confirmation runs
+      // at full resolution instead of a stretched interval.
+      const anyDeficit = sessionIds.some((sessionId) => {
+        const state = this.states.get(sessionId);
+        return state !== undefined && state.consecutiveDeficitCycles > 0;
+      });
+      if (anyDeficit) this.resetPollBackoff();
     } finally {
       this.polling = false;
     }

--- a/src/main/agent/mcp-http/diagnostics-tools.ts
+++ b/src/main/agent/mcp-http/diagnostics-tools.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod/v4';
 import { getProcessMetrics } from '../../diagnostics/process-metrics';
+import { ROTATED_FILE_SUFFIX } from '../../diagnostics/async-file-queue';
 import { enumerateWorktrees } from '../../git/worktree-list';
 import type { CrashRecord, IpcLogEntry, LogEntry } from '../../../shared/types';
 import { PROJECT_SELECTOR_DESCRIPTION } from './handler-helpers';
@@ -161,7 +162,7 @@ export function registerDiagnosticsTools(server: McpServer, resolver: RequestRes
     'kangentic_get_ipc_log',
     {
       description:
-        'Read recent IPC traffic from `<projectRoot>/.kangentic/logs/ipc-<YYYY-MM-DD>.jsonl`. Each entry has channel, args, result, durationMs, and (on failure) error. Inbound `ipcMain.handle` invocations (renderer -> main) leave `direction` absent; outbound `webContents.send` pushes (main -> renderer, e.g. `task:createdByAgent` board-invalidation events) set `direction: "out"` and, when the push was dropped because the window was destroyed, an `error` with name `PushDropped`. Only available when Settings → Developer → Record IPC Traffic is on. Channels carrying secrets (settings writes, MCP config, auth) are stored as `{ redacted: true, channel }`. Pass `project` to inspect another project.',
+        'Read recent IPC traffic from `<projectRoot>/.kangentic/logs/ipc-<YYYY-MM-DD>.jsonl`. Each entry has channel, args, result, durationMs, and (on failure) error. Inbound `ipcMain.handle` invocations (renderer -> main) leave `direction` absent; outbound `webContents.send` pushes (main -> renderer, e.g. `task:createdByAgent` board-invalidation events) set `direction: "out"` and, when the push was dropped because the window was destroyed, an `error` with name `PushDropped`. Only available when Settings → Developer → Record IPC Traffic is on. Channels carrying secrets (settings writes, MCP config, auth) are stored as `{ redacted: true, channel }`. An oversized args/result (e.g. a large list) is stored as `{ truncated: true, serializedChars, preview }` instead of the full payload. Pass `project` to inspect another project.',
       inputSchema: z.object({
         date: z
           .string()
@@ -194,7 +195,12 @@ export function registerDiagnosticsTools(server: McpServer, resolver: RequestRes
       const projectPath = resolved.context.getProjectPath();
       const targetDate = date ?? today();
       const filePath = path.join(projectPath, '.kangentic', 'logs', `ipc-${targetDate}.jsonl`);
-      const entries = readJsonLines<IpcLogEntry>(filePath);
+      // Read the rotated copy (older) before the primary (newer) so a fresh
+      // rotation doesn't blank a recent-traffic query.
+      const entries = [
+        ...readJsonLines<IpcLogEntry>(filePath + ROTATED_FILE_SUFFIX),
+        ...readJsonLines<IpcLogEntry>(filePath),
+      ];
       const filtered = entries.filter((entry) => {
         if (since && entry.ts < since) return false;
         if (channel && entry.channel !== channel) return false;

--- a/src/main/db/repositories/task-repository.ts
+++ b/src/main/db/repositories/task-repository.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import type Database from 'better-sqlite3';
-import type { Task, TaskCreateInput, TaskUpdateInput, TaskMoveInput } from '../../../shared/types';
+import type { Task, TaskCreateInput, TaskUpdateInput, TaskMoveInput, ArchivedTasksPreview } from '../../../shared/types';
 
 /** Raw row from SQLite - labels stored as JSON string. */
 interface TaskRow extends Omit<Task, 'labels'> {
@@ -210,6 +210,24 @@ export class TaskRepository {
       WHERE t.archived_at IS NOT NULL
       ORDER BY t.archived_at DESC`).all() as TaskRow[];
     return rows.map(rowToTask);
+  }
+
+  /**
+   * The newest `limit` archived tasks plus the total archived count. Lets the
+   * board hydrate the Done column's count + inline preview without fetching the
+   * whole archive (which can be many MB once hundreds of tasks accumulate). The
+   * full list is fetched via `listArchived` only when the Completed dialog opens.
+   */
+  listArchivedPreview(limit: number): ArchivedTasksPreview {
+    const boundedLimit = Math.max(1, Math.min(100, Math.floor(limit)));
+    const { count } = this.db
+      .prepare('SELECT COUNT(*) AS count FROM tasks WHERE archived_at IS NOT NULL')
+      .get() as { count: number };
+    const rows = this.db.prepare(`${TaskRepository.SELECT_WITH_COUNT}
+      WHERE t.archived_at IS NOT NULL
+      ORDER BY t.archived_at DESC
+      LIMIT ?`).all(boundedLimit) as TaskRow[];
+    return { totalCount: count, tasks: rows.map(rowToTask) };
   }
 
   /**

--- a/src/main/diagnostics/async-file-queue.ts
+++ b/src/main/diagnostics/async-file-queue.ts
@@ -92,11 +92,30 @@ export function queueAppendWithRotation(
 /**
  * Reset the in-memory primary byte count for a rotating path. Call this after
  * externally truncating or deleting the file (e.g. a session re-attach that
- * unlinks stale output) so the next append starts counting from zero rather
- * than a stale total that would trigger a spurious early rotation.
+ * unlinks stale output) so the next flush reseeds the total from the on-disk
+ * size (0 for a just-unlinked file) rather than a stale in-memory total that
+ * would trigger a spurious early rotation.
  */
 export function resetRotationState(filePath: string): void {
   rotationBytes.delete(filePath);
+}
+
+/**
+ * Seed the rotation byte counter from the on-disk file size the first time a
+ * rotating path is flushed in this process. `rotationBytes` starts empty per
+ * process, so without this a restart mid-file would begin counting from zero
+ * and let an already-large primary grow far past its cap before the first
+ * rotation. Runs once per path (cleared only by `resetRotationState`).
+ */
+async function ensureRotationCounterSeeded(filePath: string): Promise<void> {
+  if (!rotationMaxBytes.has(filePath) || rotationBytes.has(filePath)) return;
+  try {
+    const stats = await fs.promises.stat(filePath);
+    rotationBytes.set(filePath, stats.size);
+  } catch {
+    // Missing file (first write, or just unlinked) starts at zero.
+    rotationBytes.set(filePath, 0);
+  }
 }
 
 async function maybeRotate(filePath: string, addedBytes: number): Promise<void> {
@@ -142,6 +161,7 @@ async function flush(filePath: string): Promise<void> {
         await fs.promises.mkdir(directory, { recursive: true });
         dirReady.add(directory);
       }
+      await ensureRotationCounterSeeded(filePath);
       await maybeRotate(filePath, batch.length);
       await fs.promises.appendFile(filePath, batch, 'utf-8');
       if (rotationMaxBytes.has(filePath)) {

--- a/src/main/diagnostics/ipc-recorder.ts
+++ b/src/main/diagnostics/ipc-recorder.ts
@@ -1,7 +1,8 @@
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { ipcMain } from 'electron';
-import type { IpcLogEntry } from '../../shared/types';
-import { queueAppend } from './async-file-queue';
+import type { IpcLogEntry, IpcPayloadTruncated } from '../../shared/types';
+import { queueAppendWithRotation } from './async-file-queue';
 
 /**
  * Records every IPC handler invocation when `developer.recordIpcTraffic` is on.
@@ -71,13 +72,92 @@ const SAFE_PUSH_CHANNELS = new Set<string>([
 
 const REDACTED = (channel: string) => ({ redacted: true as const, channel });
 
+/**
+ * Cap a serialized args/result payload at this many UTF-16 chars. Above it the
+ * value is replaced with an `IpcPayloadTruncated` marker so the JSONL line stays
+ * small. 32KB is generous for a normal diagnostic payload while cutting the
+ * pathological cases (`task:list-archived`, `search:everything`) that stringify
+ * ~1MB on the main thread.
+ */
+const MAX_SERIALIZED_PAYLOAD_CHARS = 32 * 1024;
+/** How much of an over-cap payload's JSON to keep in the marker's preview. */
+const TRUNCATION_PREVIEW_CHARS = 2 * 1024;
+/** Per-day log file cap; the file rotates to `<file>.1` at this size (2x total on disk). */
+const IPC_LOG_MAX_FILE_BYTES = 64 * 1024 * 1024;
+/** Delete `ipc-<date>.jsonl(.1)` files older than this many days. */
+const IPC_LOG_RETENTION_DAYS = 7;
+/** Matches a daily IPC log file and its rotated copy, capturing the date. */
+const IPC_LOG_FILE_PATTERN = /^ipc-(\d{4}-\d{2}-\d{2})\.jsonl(\.1)?$/;
+
+/**
+ * Replace an args/result value with a compact marker when its serialized form
+ * exceeds the cap. Returns the value unchanged when it is within budget (or a
+ * marker when it cannot be serialized at all). The stringify is paid once here;
+ * with the archive fix removing the dominant offender, an over-cap value is a
+ * rare, user-triggered event.
+ */
+function capOversizedPayload(value: unknown): unknown {
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    const marker: IpcPayloadTruncated = { truncated: true, serializedChars: -1, preview: 'unserializable payload' };
+    return marker;
+  }
+  if (serialized === undefined || serialized.length <= MAX_SERIALIZED_PAYLOAD_CHARS) return value;
+  const marker: IpcPayloadTruncated = {
+    truncated: true,
+    serializedChars: serialized.length,
+    preview: serialized.slice(0, TRUNCATION_PREVIEW_CHARS),
+  };
+  return marker;
+}
+
 interface IpcRecorderOptions {
   getProjectRoot: () => string | null;
   enabled: () => boolean;
+  /** Per-day log-file rotation cap in bytes. Defaults to IPC_LOG_MAX_FILE_BYTES; overridable for tests. */
+  maxLogFileBytes?: number;
 }
 
 let installed = false;
 let recorderOptions: IpcRecorderOptions | null = null;
+// Latch so the async retention prune runs at most once per project root per
+// process. A Set (not a single last-root) so alternating between two projects
+// (A -> B -> A) does not re-prune A. Cleared in resetForTest.
+const prunedProjectRoots = new Set<string>();
+let pendingPrunePromise: Promise<void> | null = null;
+
+/**
+ * Best-effort async prune of `ipc-*.jsonl(.1)` files older than the retention
+ * window. Latched per project root so it runs once per process. Never on the
+ * shutdown path (the before-quit contract stays synchronous); a slow readdir
+ * only delays deletion, never a write.
+ */
+function schedulePruneOldIpcLogs(projectRoot: string): void {
+  if (prunedProjectRoots.has(projectRoot)) return;
+  prunedProjectRoots.add(projectRoot);
+  const cutoffDate = new Date(Date.now() - IPC_LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000)
+    .toISOString().slice(0, 10);
+  const logsDirectory = path.join(projectRoot, '.kangentic', 'logs');
+  pendingPrunePromise = (async () => {
+    try {
+      const names = await fs.promises.readdir(logsDirectory);
+      await Promise.allSettled(
+        names
+          .filter((name) => {
+            const match = IPC_LOG_FILE_PATTERN.exec(name);
+            // ISO date strings are zero-padded, so a lexical compare is a valid
+            // chronological compare.
+            return match !== null && match[1] < cutoffDate;
+          })
+          .map((name) => fs.promises.unlink(path.join(logsDirectory, name))),
+      );
+    } catch {
+      // Best-effort: a missing logs dir or a locked file is non-fatal.
+    }
+  })();
+}
 
 export function installIpcRecorder(options: IpcRecorderOptions): void {
   if (installed) return;
@@ -164,15 +244,32 @@ export function recordPush(
 
 function writeEntry(projectRoot: string | null, entry: IpcLogEntry): void {
   if (!projectRoot) return;
+  schedulePruneOldIpcLogs(projectRoot);
   const date = entry.ts.slice(0, 10);
   const file = path.join(projectRoot, '.kangentic', 'logs', `ipc-${date}.jsonl`);
-  // Async-buffered: queueAppend returns immediately. The previous
-  // appendFileSync ran inside the IPC handler's `finally`, blocking the
-  // main event loop on every IPC call (incl. IPC.SESSION_WRITE per
-  // terminal keystroke). On Windows that costs 5-50 ms per call and
-  // was the dominant source of typing-stutter when recordIpcTraffic
-  // is on.
-  queueAppend(file, JSON.stringify(entry) + '\n');
+  // Serialize the whole entry once. In the common case it is within the cap and
+  // is written directly - no extra per-field stringify. Only an oversized entry
+  // pays the per-field capping pass, which replaces the offending args/result
+  // with a compact marker so the recorder never serializes a multi-MB result in
+  // full a second time. Because every field's JSON is a substring of the entry's
+  // JSON, an entry within the per-payload cap cannot contain an over-cap field,
+  // so the fast path is exact, not a heuristic. Chokepointed here so both the
+  // inbound `finally` path and `recordPush` are covered.
+  let line = JSON.stringify(entry);
+  if (line.length > MAX_SERIALIZED_PAYLOAD_CHARS) {
+    const capped: IpcLogEntry = { ...entry, args: capOversizedPayload(entry.args) as IpcLogEntry['args'] };
+    if (entry.result !== undefined) capped.result = capOversizedPayload(entry.result);
+    line = JSON.stringify(capped);
+  }
+  // Async-buffered + size-capped rotation: queueAppendWithRotation returns
+  // immediately. The previous appendFileSync ran inside the IPC handler's
+  // `finally`, blocking the main event loop on every IPC call (incl.
+  // IPC.SESSION_WRITE per terminal keystroke). On Windows that costs 5-50 ms
+  // per call and was the dominant source of typing-stutter when
+  // recordIpcTraffic is on. Rotation bounds each day's file at 2x the cap so
+  // `.kangentic/logs/` stops accumulating unbounded gigabytes.
+  const maxBytes = recorderOptions?.maxLogFileBytes ?? IPC_LOG_MAX_FILE_BYTES;
+  queueAppendWithRotation(file, line + '\n', maxBytes);
 }
 
 /**
@@ -183,8 +280,16 @@ function writeEntry(projectRoot: string | null, entry: IpcLogEntry): void {
 export const __INTERNAL = {
   SAFE_CHANNELS,
   SAFE_PUSH_CHANNELS,
+  MAX_SERIALIZED_PAYLOAD_CHARS,
+  IPC_LOG_RETENTION_DAYS,
   resetForTest(): void {
     installed = false;
     recorderOptions = null;
+    prunedProjectRoots.clear();
+    pendingPrunePromise = null;
+  },
+  /** Await the in-flight retention prune (best-effort). */
+  async awaitPendingPruneForTest(): Promise<void> {
+    if (pendingPrunePromise) await pendingPrunePromise;
   },
 };

--- a/src/main/ipc/handlers/metrics-snapshot-timer.ts
+++ b/src/main/ipc/handlers/metrics-snapshot-timer.ts
@@ -3,6 +3,7 @@ import { SessionRepository } from '../../db/repositories/session-repository';
 import { UsageHistoryRepository } from '../../db/repositories/usage-history-repository';
 import { captureSessionMetrics } from './session-metrics';
 import type { SessionManager } from '../../pty/session-manager';
+import type { Session } from '../../../shared/types';
 
 /**
  * Crash-resilience snapshot interval. Session metrics otherwise persist only at
@@ -40,30 +41,56 @@ export function stopMetricsSnapshotTimer(): void {
 }
 
 /**
- * Flush metrics for every running session to its project DB. Mirrors the
- * shutdown capture loop, grouped implicitly by reading each session's project.
- * Fully best-effort: a transiently-unavailable project DB is skipped.
+ * Flush metrics for every running session to its project DB. Sessions are
+ * grouped by project so each project's captures commit in a SINGLE
+ * `db.transaction` (one WAL commit per project per tick) instead of two write
+ * transactions per session. Fully best-effort: a transiently-unavailable
+ * project DB is skipped, and each session's capture is wrapped in its own
+ * try/catch inside the shared transaction so one session's failure (in
+ * `getLatestForTask` or the capture itself) cannot roll back its siblings in the
+ * same project's batch. Mirrors the pre-batch per-session isolation.
  */
 function snapshotRunningSessions(sessionManager: SessionManager): void {
+  const runningSessionsByProject = new Map<string, Session[]>();
   for (const session of sessionManager.listSessions()) {
     if (session.status !== 'running') continue;
+    const group = runningSessionsByProject.get(session.projectId);
+    if (group) {
+      group.push(session);
+    } else {
+      runningSessionsByProject.set(session.projectId, [session]);
+    }
+  }
+
+  for (const [projectId, sessions] of runningSessionsByProject) {
     try {
-      const db = getProjectDb(session.projectId);
+      const db = getProjectDb(projectId);
       const sessionRepo = new SessionRepository(db);
       const usageHistoryRepo = new UsageHistoryRepository(db);
-      const record = sessionRepo.getLatestForTask(session.taskId);
-      if (!record || record.status !== 'running') continue;
-      captureSessionMetrics(
-        sessionManager,
-        sessionRepo,
-        usageHistoryRepo,
-        session.id,
-        record.id,
-        record.started_at,
-        record.session_type,
-      );
+      db.transaction(() => {
+        for (const session of sessions) {
+          try {
+            const record = sessionRepo.getLatestForTask(session.taskId);
+            if (!record || record.status !== 'running') continue;
+            captureSessionMetrics(
+              sessionManager,
+              sessionRepo,
+              usageHistoryRepo,
+              session.id,
+              record.id,
+              record.started_at,
+              record.session_type,
+            );
+          } catch {
+            // Isolate one session's failure (e.g. a transient getLatestForTask
+            // throw) inside the shared transaction so it cannot roll back its
+            // siblings' captures in this batch.
+          }
+        }
+      })();
     } catch {
-      // Best-effort: a project DB may be transiently unavailable.
+      // Best-effort: a project DB may be transiently unavailable. A throw here
+      // aborts only this project's batch; other projects still snapshot.
     }
   }
 }

--- a/src/main/ipc/handlers/task-archive.ts
+++ b/src/main/ipc/handlers/task-archive.ts
@@ -20,6 +20,11 @@ export function registerTaskArchiveHandlers(context: IpcContext): void {
     return tasks.listArchived();
   });
 
+  ipcMain.handle(IPC.TASK_LIST_ARCHIVED_PREVIEW, (_, limit: number) => {
+    const { tasks } = getProjectRepos(context);
+    return tasks.listArchivedPreview(limit);
+  });
+
   ipcMain.handle(IPC.TASK_UNARCHIVE, async (_, input: { id: string; targetSwimlaneId: string }, projectId?: string | null) => {
     const { projectId: resolvedProjectId, projectPath: resolvedProjectPath } = resolveProjectContext(context, projectId);
     if (!resolvedProjectId) throw new Error('No project is currently open');

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -66,6 +66,7 @@ const api: ElectronAPI = {
     move: (input, projectId) => ipcRenderer.invoke(IPC.TASK_MOVE, input, projectId),
     cancelSpawn: (taskId) => ipcRenderer.invoke(IPC.TASK_CANCEL_SPAWN, taskId),
     listArchived: () => ipcRenderer.invoke(IPC.TASK_LIST_ARCHIVED),
+    listArchivedPreview: (limit) => ipcRenderer.invoke(IPC.TASK_LIST_ARCHIVED_PREVIEW, limit),
     unarchive: (input, projectId) => ipcRenderer.invoke(IPC.TASK_UNARCHIVE, input, projectId),
     bulkDelete: (ids, projectId) => ipcRenderer.invoke(IPC.TASK_BULK_DELETE, ids, projectId),
     bulkUnarchive: (ids, targetSwimlaneId, projectId) => ipcRenderer.invoke(IPC.TASK_BULK_UNARCHIVE, ids, targetSwimlaneId, projectId),

--- a/src/renderer/components/board/DoneSwimlane.tsx
+++ b/src/renderer/components/board/DoneSwimlane.tsx
@@ -7,6 +7,7 @@ import { CompletedTasksDialog } from '../dialogs/CompletedTasksDialog';
 import { ConfirmDialog } from '../dialogs/ConfirmDialog';
 import { getSwimlaneIcon } from '../../utils/swimlane-icons';
 import { useBoardStore } from '../../stores/board-store';
+import { ARCHIVED_PREVIEW_LIMIT } from '../../stores/board-store/archived-tasks-slice';
 import { useConfigStore } from '../../stores/config-store';
 import { useColumnWidthClass } from './column-width';
 import { CountBadge } from '../CountBadge';
@@ -18,15 +19,15 @@ export interface DoneSwimlaneProps {
   dragHandleProps?: Record<string, unknown>;
 }
 
-/** Cap rendered cards in the inline preview list. */
-const MAX_RENDERED_PREVIEW = 15;
-
 export const DoneSwimlane = React.memo(function DoneSwimlane({ swimlane, tasks }: DoneSwimlaneProps) {
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [showCompletedDialog, setShowCompletedDialog] = useState(false);
 
   const openBoardManager = useBoardStore((state) => state.openBoardManager);
   const archivedTasks = useBoardStore((state) => state.archivedTasks);
+  // Authoritative count for the header/badges. archivedTasks may hold only the
+  // newest-N preview, so its length is not the true archived total.
+  const archivedTotalCount = useBoardStore((state) => state.archivedTotalCount);
   const deleteArchivedTask = useBoardStore((state) => state.deleteArchivedTask);
   const recentlyArchivedId = useBoardStore((state) => state.recentlyArchivedId);
   const clearRecentlyArchived = useBoardStore((state) => state.clearRecentlyArchived);
@@ -65,7 +66,8 @@ export const DoneSwimlane = React.memo(function DoneSwimlane({ swimlane, tasks }
     data: droppableData,
   });
 
-  const filteredArchivedTasks = archivedTasks;
+  const hasArchived = archivedTotalCount > 0;
+  const previewTasks = archivedTasks.slice(0, ARCHIVED_PREVIEW_LIMIT);
 
 
   return (
@@ -159,23 +161,23 @@ export const DoneSwimlane = React.memo(function DoneSwimlane({ swimlane, tasks }
         {/* Section header */}
         <button
           type="button"
-          onClick={filteredArchivedTasks.length > 0 ? () => setShowCompletedDialog(true) : undefined}
-          disabled={filteredArchivedTasks.length === 0}
-          className={`py-2 px-2.5 flex-shrink-0 flex items-center justify-between rounded-md transition-colors w-full text-left border ${filteredArchivedTasks.length > 0 ? 'border-edge/30 bg-surface-hover/20 hover:bg-surface-hover/40 hover:border-edge/50 cursor-pointer group' : 'border-transparent'}`}
+          onClick={hasArchived ? () => setShowCompletedDialog(true) : undefined}
+          disabled={!hasArchived}
+          className={`py-2 px-2.5 flex-shrink-0 flex items-center justify-between rounded-md transition-colors w-full text-left border ${hasArchived ? 'border-edge/30 bg-surface-hover/20 hover:bg-surface-hover/40 hover:border-edge/50 cursor-pointer group' : 'border-transparent'}`}
           data-testid="expand-completed-btn"
         >
           <span className="flex items-center gap-1.5 text-sm font-medium text-fg-muted">
             <ClipboardList size={14} />
-            Completed ({filteredArchivedTasks.length})
+            Completed ({archivedTotalCount})
           </span>
-          {filteredArchivedTasks.length > 0 && (
+          {hasArchived && (
             <Maximize2 size={14} className="text-fg-disabled group-hover:text-fg-muted transition-colors" />
           )}
         </button>
 
         {/* Recent archived tasks - scrollable list with View All at the bottom */}
         <div className="flex-1 min-h-0 overflow-y-auto space-y-1">
-          {filteredArchivedTasks.slice(0, MAX_RENDERED_PREVIEW).map((task) => {
+          {previewTasks.map((task) => {
             const isGrowingIn = recentlyArchivedId === task.id;
             return isGrowingIn ? (
               <div
@@ -194,11 +196,11 @@ export const DoneSwimlane = React.memo(function DoneSwimlane({ swimlane, tasks }
               />
             );
           })}
-          {filteredArchivedTasks.length === 0 && (
+          {!hasArchived && (
             <div className="text-xs text-fg-disabled text-center py-3">No completed tasks yet</div>
           )}
           {/* View all as last row in the list */}
-          {filteredArchivedTasks.length > 0 && (
+          {hasArchived && (
             <button
               type="button"
               onClick={() => setShowCompletedDialog(true)}
@@ -208,7 +210,7 @@ export const DoneSwimlane = React.memo(function DoneSwimlane({ swimlane, tasks }
               <Maximize2 size={14} />
               <span className="text-sm">View all</span>
               <span className="text-xs px-1.5 py-0.5 rounded-full font-medium bg-surface-hover/60 text-fg-secondary">
-                {filteredArchivedTasks.length}
+                {archivedTotalCount}
               </span>
             </button>
           )}

--- a/src/renderer/components/dialogs/BranchPicker.tsx
+++ b/src/renderer/components/dialogs/BranchPicker.tsx
@@ -3,6 +3,7 @@ import { GitBranch, Search, Loader2, ChevronDown } from 'lucide-react';
 import { usePopoverPosition } from '../../hooks/usePopoverPosition';
 import { OverlayPopover } from '../OverlayPopover';
 import { Pill } from '../Pill';
+import { fetchGitBranches } from '../../utils/git-branches';
 
 interface BranchPickerProps {
   value: string;
@@ -73,7 +74,7 @@ export function BranchPicker({
   const fetchBranches = useCallback(async () => {
     setLoading(true);
     try {
-      const result = await window.electronAPI.git.listBranches();
+      const result = await fetchGitBranches();
       setBranches(result);
     } catch {
       setBranches([]);

--- a/src/renderer/components/dialogs/CompletedTasksDialog.tsx
+++ b/src/renderer/components/dialogs/CompletedTasksDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useCallback } from 'react';
-import { Search, ClipboardList } from 'lucide-react';
+import { Search, ClipboardList, Loader2 } from 'lucide-react';
 import { BaseDialog } from './BaseDialog';
 import { TaskChangesDialog } from './TaskChangesDialog';
 import { ConfirmDialog } from './ConfirmDialog';
@@ -9,6 +9,7 @@ import { formatCost } from '../../utils/format-session';
 import { formatTokenCount } from '../../utils/format-tokens';
 import { useBoardStore } from '../../stores/board-store';
 import { useSessionStore } from '../../stores/session-store';
+import { useProjectStore } from '../../stores/project-store';
 import { useConfigStore } from '../../stores/config-store';
 import type { Task, SessionSummary } from '../../../shared/types';
 import { BulkToolbar } from './completed-tasks/BulkToolbar';
@@ -20,6 +21,7 @@ interface CompletedTasksDialogProps {
 
 export function CompletedTasksDialog({ onClose }: CompletedTasksDialogProps) {
   const archivedTasks = useBoardStore((state) => state.archivedTasks);
+  const archivedTotalCount = useBoardStore((state) => state.archivedTotalCount);
   const swimlanes = useBoardStore((state) => state.swimlanes);
   const unarchiveTask = useBoardStore((state) => state.unarchiveTask);
   const deleteArchivedTask = useBoardStore((state) => state.deleteArchivedTask);
@@ -29,7 +31,10 @@ export function CompletedTasksDialog({ onClose }: CompletedTasksDialogProps) {
   const skipDeleteConfirm = useConfigStore((state) => state.config.skipDeleteConfirm);
   const updateConfig = useConfigStore((state) => state.updateConfig);
 
+  const currentProjectId = useProjectStore((state) => state.currentProject?.id ?? null);
+
   const [summaries, setSummaries] = useState<Record<string, SessionSummary>>({});
+  const [loadingFullArchive, setLoadingFullArchive] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [restorePopoverId, setRestorePopoverId] = useState<string | null>(null);
@@ -37,6 +42,28 @@ export function CompletedTasksDialog({ onClose }: CompletedTasksDialogProps) {
   const [pendingBulkDelete, setPendingBulkDelete] = useState(false);
   const [contextMenu, setContextMenu] = useState<{ position: { x: number; y: number }; task: Task } | null>(null);
   const [changesTask, setChangesTask] = useState<Task | null>(null);
+
+  // This dialog needs the FULL archive, not just the board's newest-N preview.
+  // Refcount a viewer for the whole mount so board hydration keeps the full
+  // list loaded (and reconciled) while the dialog is open.
+  useEffect(() => {
+    useBoardStore.getState().acquireArchiveView();
+    return () => { useBoardStore.getState().releaseArchiveView(); };
+  }, []);
+
+  // Lazily fetch the full archive when it isn't loaded yet. Keyed on project id
+  // so switching projects while the dialog is open reloads for the new project.
+  // The preview rows render immediately; the full list replaces them in well
+  // under a second.
+  useEffect(() => {
+    if (useBoardStore.getState().archivedFullyLoaded) return;
+    let cancelled = false;
+    setLoadingFullArchive(true);
+    useBoardStore.getState().loadArchivedTasks()
+      .catch(() => { /* keep the preview rows already on screen */ })
+      .finally(() => { if (!cancelled) setLoadingFullArchive(false); });
+    return () => { cancelled = true; };
+  }, [currentProjectId]);
 
   // Fetch summaries on mount
   useEffect(() => {
@@ -218,9 +245,13 @@ export function CompletedTasksDialog({ onClose }: CompletedTasksDialogProps) {
         header={
           <div className="flex items-center gap-3 px-4 py-3">
             <ClipboardList size={18} className="text-fg-muted" />
-            <h3 className="text-base font-semibold text-fg flex-1">
-              Completed Tasks ({archivedTasks.length})
+            <h3 className="text-base font-semibold text-fg flex items-center gap-2">
+              Completed Tasks ({archivedTotalCount})
+              {loadingFullArchive && (
+                <Loader2 size={14} className="animate-spin text-fg-disabled" data-testid="archive-loading" />
+              )}
             </h3>
+            <div className="flex-1" />
             <div className="relative">
               <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-fg-disabled" />
               <input
@@ -237,8 +268,8 @@ export function CompletedTasksDialog({ onClose }: CompletedTasksDialogProps) {
         footer={
           <div className="flex items-center gap-4 text-xs text-fg-muted tabular-nums bg-surface-inset/40 -mx-4 -my-3 px-4 py-3">
             <span>
-              {searchQuery.trim() && filteredRows.length !== archivedTasks.length
-                ? `${filteredRows.length} of ${archivedTasks.length} tasks`
+              {filteredRows.length !== archivedTotalCount
+                ? `${filteredRows.length} of ${archivedTotalCount} tasks`
                 : `${filteredRows.length} tasks`
               }
             </span>

--- a/src/renderer/components/dialogs/NewTaskDialog.tsx
+++ b/src/renderer/components/dialogs/NewTaskDialog.tsx
@@ -16,6 +16,7 @@ import { WorktreeChip } from './WorktreeChip';
 import { AdvancedOverridesSection } from './AdvancedOverridesSection';
 import { Select } from '../settings/shared';
 import { LabelInput } from '../LabelInput';
+import { fetchGitBranches } from '../../utils/git-branches';
 import { isValidGitBranchName } from '../../../shared/git-utils';
 import { slugify, computeAutoBranchName } from '../../../shared/slugify';
 import { DEFAULT_PRIORITY_CONFIG } from '../../../shared/types';
@@ -65,7 +66,7 @@ export function NewTaskDialog({ swimlaneId, onClose }: NewTaskDialogProps) {
     : '';
   const [knownBranches, setKnownBranches] = useState<Set<string>>(new Set());
   useEffect(() => {
-    window.electronAPI.git.listBranches()
+    fetchGitBranches()
       .then(branches => setKnownBranches(new Set(branches)))
       .catch(() => setKnownBranches(new Set()));
   }, []);

--- a/src/renderer/components/dialogs/task-detail/useBranchConfig.tsx
+++ b/src/renderer/components/dialogs/task-detail/useBranchConfig.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useConfigStore } from '../../../stores/config-store';
+import { fetchGitBranches } from '../../../utils/git-branches';
 import { isValidGitBranchName } from '../../../../shared/git-utils';
 import { slugify, computeAutoBranchName } from '../../../../shared/slugify';
 import type { Task } from '../../../../shared/types';
@@ -20,7 +21,7 @@ export function useBranchConfig(task: Task, title: string, isInTodo: boolean) {
 
   useEffect(() => {
     if (isInTodo) {
-      window.electronAPI.git.listBranches()
+      fetchGitBranches()
         .then(branches => setKnownBranches(new Set(branches)))
         .catch(() => setKnownBranches(new Set()));
     }

--- a/src/renderer/hooks/useProjectSwitchEffect.ts
+++ b/src/renderer/hooks/useProjectSwitchEffect.ts
@@ -85,6 +85,8 @@ export function useProjectSwitchEffect(currentProject: Project | null): void {
           tasks: boardState.tasks,
           swimlanes: boardState.swimlanes,
           archivedTasks: boardState.archivedTasks,
+          archivedTotalCount: boardState.archivedTotalCount,
+          archivedFullyLoaded: boardState.archivedFullyLoaded,
           shortcuts: boardState.shortcuts,
         },
         backlog: backlogState.items,
@@ -133,6 +135,8 @@ export function useProjectSwitchEffect(currentProject: Project | null): void {
           tasks: snapshot.board.tasks,
           swimlanes: snapshot.board.swimlanes,
           archivedTasks: snapshot.board.archivedTasks,
+          archivedTotalCount: snapshot.board.archivedTotalCount,
+          archivedFullyLoaded: snapshot.board.archivedFullyLoaded,
           shortcuts: snapshot.board.shortcuts,
           hydrated: true,
           loading: false,
@@ -199,6 +203,13 @@ export function useProjectSwitchEffect(currentProject: Project | null): void {
         // Cold path: fire the IPC fan-out and reset stale per-project
         // view state. After loads resolve, mark the project as seen so
         // the next switch to it takes the warm path.
+        //
+        // Clear the archive state BEFORE loadBoard so a leftover
+        // archivedFullyLoaded:true from the previous project can neither keep
+        // the old archive visible nor make this project's first loadBoard
+        // fetch the full archive. archiveViewers is intentionally NOT reset:
+        // it is refcounted by live component mount/unmount, not by switches.
+        useBoardStore.setState({ archivedTasks: [], archivedTotalCount: 0, archivedFullyLoaded: false });
         const coldLoads = Promise.all([
           useBoardStore.getState().loadBoard(),
           useBacklogStore.getState().loadBacklog(),
@@ -296,7 +307,7 @@ export function useProjectSwitchEffect(currentProject: Project | null): void {
         useSessionStore.getState().setSelectedPeriod(savedPeriod);
       }
     } else {
-      useBoardStore.setState({ tasks: [], swimlanes: [], archivedTasks: [] });
+      useBoardStore.setState({ tasks: [], swimlanes: [], archivedTasks: [], archivedTotalCount: 0, archivedFullyLoaded: false });
       useSessionStore.setState({
         activeSessionId: null,
         dialogSessionIds: [],

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1,12 +1,13 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '../addons/fit-addon';
-import { WebglAddon } from '@xterm/addon-webgl';
+import { attachWebglRenderer } from '../utils/terminal-webgl';
 import { copySelectionToClipboard, enableTerminalClipboard, stripOsc52Sequences } from '../utils/terminal-clipboard';
 import { registerTerminal } from '../utils/terminal-registry';
 import { pixelToBufferRow, extractBlockContentAt } from '../utils/terminal-block-buffer';
 import { createWriteBatcher, type WriteBatcher } from '../utils/write-batcher';
 import { createIncomingWriteQueue, writeChunkedToTerminal } from '../utils/incoming-write-queue';
+import { isBoardDragActive, onBoardDragEnd } from '../lib/session-update-coalescer';
 import { noteTerminalFocus } from '../utils/dictation-target';
 import '@xterm/xterm/css/xterm.css';
 
@@ -27,6 +28,15 @@ if (import.meta.hot) {
   import.meta.hot.dispose((data: Record<string, unknown>) => {
     data.savedScrollPositions = savedScrollPositions;
   });
+}
+
+// hmr-safe: a monotonic counter only used to mint a unique renderer-report key
+// for a session-less (transient) terminal; resetting it on HMR at worst reuses
+// a key for a terminal that has since disposed its report entry.
+let transientRendererKeyCounter = 0;
+function nextTransientRendererKey(): number {
+  transientRendererKeyCounter += 1;
+  return transientRendererKeyCounter;
 }
 
 /** Fixed dark terminal theme -- Claude Code's TUI is designed for dark backgrounds. */
@@ -104,6 +114,8 @@ export function useTerminal(options: UseTerminalOptions) {
   const writeBatcherRef = useRef<WriteBatcher | null>(null);
   /** Unregisters this terminal from the block-copy hit-test registry on unmount. */
   const unregisterTerminalRef = useRef<(() => void) | null>(null);
+  /** Tears down the WebGL renderer attachment (cancels retries, disposes addon). */
+  const disposeWebglRef = useRef<(() => void) | null>(null);
 
   const initTerminal = useCallback(() => {
     if (!terminalRef.current || xtermRef.current) return;
@@ -159,16 +171,11 @@ export function useTerminal(options: UseTerminalOptions) {
       isAtBottomRef.current = buffer.viewportY >= buffer.baseY;
     });
 
-    // Try WebGL renderer
-    try {
-      const webglAddon = new WebglAddon();
-      webglAddon.onContextLoss(() => {
-        webglAddon.dispose();
-      });
-      terminal.loadAddon(webglAddon);
-    } catch {
-      // WebGL not available, use canvas fallback
-    }
+    // Attach the WebGL renderer with context-loss recovery (retry + backoff,
+    // logged, renderer type tracked). Keyed by session id, or a stable transient
+    // key for a session-less pane so the devtools report can distinguish them.
+    const rendererKey = options.sessionId ?? `transient-${nextTransientRendererKey()}`;
+    disposeWebglRef.current = attachWebglRenderer(terminal, rendererKey);
 
     xtermRef.current = terminal;
     fitAddonRef.current = fitAddon;
@@ -286,6 +293,11 @@ export function useTerminal(options: UseTerminalOptions) {
       // server-side getScrollback() drains the pending buffer, so this is
       // defense-in-depth. Dropped slices are still acked inside the queue.
       shouldDrop: () => scrollbackPendingRef.current || suppressDataRef.current,
+      // While a board drag is active, HOLD (not drop) inbound writes so xterm
+      // parsing doesn't compete with the drag on the renderer thread. Held bytes
+      // are retained and resumed on drag end; the coalescer's 30s watchdog
+      // bounds the hold if a drag end is ever missed.
+      shouldHold: () => isBoardDragActive(),
       ack: (bytes) => window.electronAPI.sessions.ackData(sessionId, bytes),
     });
 
@@ -293,11 +305,15 @@ export function useTerminal(options: UseTerminalOptions) {
       if (incomingSessionId !== sessionId) return;
       queue.push(data);
     });
+    // Resume the held drain the moment a board drag ends (also via the
+    // coalescer's watchdog / window-blur backstops, which route through here).
+    const unsubscribeDragEnd = onBoardDragEnd(() => queue.kick());
 
     cleanupRef.current = cleanup;
     return () => {
       cleanup();
       cleanupRef.current = null;
+      unsubscribeDragEnd();
       queue.reset();
     };
   }, [options.sessionId]);
@@ -372,6 +388,10 @@ export function useTerminal(options: UseTerminalOptions) {
       }
       unregisterTerminalRef.current?.();
       unregisterTerminalRef.current = null;
+      // Tear down WebGL (cancel any pending re-init retry, drop the report entry)
+      // before disposing the terminal it is attached to.
+      disposeWebglRef.current?.();
+      disposeWebglRef.current = null;
       xtermRef.current?.dispose();
       xtermRef.current = null;
       fitAddonRef.current = null;

--- a/src/renderer/lib/session-update-coalescer.ts
+++ b/src/renderer/lib/session-update-coalescer.ts
@@ -69,6 +69,42 @@ const pendingReloads = new Map<ReloadKey, () => void>();
 // hmr-safe: a board drag never survives a module reload - every <DndContext>
 // re-keys via hmrGeneration, so dragActive correctly resets to false on reload.
 let dragActive = false;
+
+/**
+ * Whether a board drag is currently in progress. Read by other renderer
+ * subsystems that want to pause expensive per-frame work during a drag (e.g. the
+ * incoming xterm write queue, which holds its buffer instead of parsing mid-drag).
+ */
+export function isBoardDragActive(): boolean {
+  return dragActive;
+}
+
+// hmr-safe: subscriptions are owned by live components (each re-registers on
+// remount). resetCoalescerForHmr NOTIFIES rather than clears, so a held consumer
+// (e.g. a paused write queue) resumes; a stale listener firing on an
+// already-reset consumer is a no-op.
+const dragEndListeners = new Set<() => void>();
+
+/**
+ * Subscribe to board-drag-end. Fires after `endBoardDrag()` has cleared the gate
+ * and flushed (also via the 30s watchdog and the window-blur backstop, which
+ * both route through `endBoardDrag`). Returns an unsubscribe function.
+ */
+export function onBoardDragEnd(listener: () => void): () => void {
+  dragEndListeners.add(listener);
+  return () => { dragEndListeners.delete(listener); };
+}
+
+function notifyDragEndListeners(): void {
+  // Copy first so an unsubscribe during iteration cannot skip a listener.
+  for (const listener of Array.from(dragEndListeners)) {
+    try {
+      listener();
+    } catch {
+      // A listener throwing must not block the others or the flush path.
+    }
+  }
+}
 // hmr-safe: transient scheduler flag; a stale microtask from a replaced module
 // no-ops because flush() reads live buffers and re-checks dragActive.
 let flushScheduled = false;
@@ -239,6 +275,8 @@ export function endBoardDrag(): void {
   }
   dragActive = false;
   flush();
+  // Resume any consumer that paused for the drag (e.g. held write queues).
+  notifyDragEndListeners();
 }
 
 /**
@@ -258,4 +296,8 @@ export function resetCoalescerForHmr(): void {
   }
   dragActive = false;
   flushScheduled = false;
+  // Notify (do NOT clear) so a held write queue resumes after the HMR reset.
+  // Live terminals do not remount on an unrelated Fast Refresh, so their
+  // subscriptions remain valid; a kick on an already-drained queue is a no-op.
+  notifyDragEndListeners();
 }

--- a/src/renderer/stores/board-store/archived-tasks-slice.ts
+++ b/src/renderer/stores/board-store/archived-tasks-slice.ts
@@ -6,11 +6,66 @@ import { useProjectStore } from '../project-store';
 import { applyStructuralSharing } from './structural-sharing';
 import type { BoardStore } from './types';
 
+/**
+ * How many of the newest archived tasks the board hydrates for the Done
+ * column's inline preview. Also the render cap in `DoneSwimlane`. The full
+ * archive loads lazily only when a consumer (the Completed dialog, or a
+ * detail window anchored to a deep archived task) is mounted.
+ */
+export const ARCHIVED_PREVIEW_LIMIT = 15;
+
+/**
+ * Collapses concurrent full-archive fetches into one round-trip. Several
+ * consumers can request the full list at once (the Completed dialog mounting,
+ * a deep-anchor detail window, loadBoard's out-of-band refresh, and React's
+ * StrictMode double-invoking the mount effect in dev). Without this each would
+ * fire its own ~1.2MB `listArchived`. This is an in-flight de-dupe, NOT a cache:
+ * once the fetch resolves the flag clears, so the next call fetches fresh. It is
+ * tagged with the project the fetch was started for so a different-project caller
+ * never joins it and a result that resolves after a project switch is dropped
+ * rather than applied to (and latched onto) the wrong project.
+ */
+// hmr-safe: transient in-flight guard; a reset-on-HMR just permits a fresh fetch.
+let archivedFullLoad: { projectId: string | null; promise: Promise<void> } | null = null;
+
+/**
+ * Fetch the archived data appropriate to the current load state. When the full
+ * archive is already loaded (a viewer is open), refetch the full list so the
+ * open dialog reconciles against agent-driven archives; otherwise fetch only
+ * the cheap newest-N preview. Exported for reconcile call sites in
+ * `task-slice.ts`. Deliberately NOT named `load*`/`sync*` so the HMR re-sync
+ * method scan (`hmr-resync.test.ts`) never treats it as a store load method.
+ */
+export async function fetchArchivedReconcile(
+  fullyLoaded: boolean,
+): Promise<{ tasks: Task[]; totalCount: number }> {
+  if (fullyLoaded) {
+    const tasks = await window.electronAPI.tasks.listArchived();
+    return { tasks, totalCount: tasks.length };
+  }
+  const preview = await window.electronAPI.tasks.listArchivedPreview(ARCHIVED_PREVIEW_LIMIT);
+  return { tasks: preview.tasks, totalCount: preview.totalCount };
+}
+
 export interface ArchivedTasksSlice {
+  /** "What we have": the newest-N preview, or the full archive once loaded. */
   archivedTasks: Task[];
+  /** Authoritative total archived count, source of truth for every header/badge. */
+  archivedTotalCount: number;
+  /** True while `archivedTasks` holds the full archive rather than the preview. */
+  archivedFullyLoaded: boolean;
+  /**
+   * Refcount of mounted consumers that need the FULL archive (the Completed
+   * dialog, deep-anchor detail windows). While > 0, board hydration keeps the
+   * full list; when it drops to 0 the next hydration downgrades to the preview.
+   * Refcounted purely by mount/unmount and never reset by a project switch.
+   */
+  archiveViewers: number;
   /** Non-null while a bulk delete is in flight; rendered as a progress indicator. */
   bulkDeleteProgress: TaskBulkDeleteProgress | null;
   loadArchivedTasks: () => Promise<void>;
+  acquireArchiveView: () => void;
+  releaseArchiveView: () => void;
   archiveTask: (id: string) => void;
   unarchiveTask: (input: TaskUnarchiveInput) => Promise<void>;
   deleteArchivedTask: (id: string) => Promise<void>;
@@ -20,11 +75,45 @@ export interface ArchivedTasksSlice {
 
 export const createArchivedTasksSlice: StateCreator<BoardStore, [], [], ArchivedTasksSlice> = (set, get) => ({
   archivedTasks: [],
+  archivedTotalCount: 0,
+  archivedFullyLoaded: false,
+  archiveViewers: 0,
   bulkDeleteProgress: null,
 
   loadArchivedTasks: async () => {
-    const archivedTasks = await window.electronAPI.tasks.listArchived();
-    set({ archivedTasks });
+    const projectId = useProjectStore.getState().currentProject?.id ?? null;
+    // Join an in-flight fetch for the SAME project instead of starting a
+    // redundant one (see archivedFullLoad).
+    if (archivedFullLoad && archivedFullLoad.projectId === projectId) return archivedFullLoad.promise;
+    const promise = window.electronAPI.tasks.listArchived()
+      .then((fullList) => {
+        // Drop a result that resolved after a project switch: applying project
+        // A's archive to project B (and latching archivedFullyLoaded) would show
+        // the wrong data and suppress B's own correctly-scoped load.
+        if ((useProjectStore.getState().currentProject?.id ?? null) !== projectId) return;
+        // Structural sharing keeps the preview objects' identity when the full
+        // list lands, so their already-mounted TaskCards don't churn.
+        set((state) => ({
+          archivedTasks: applyStructuralSharing(state.archivedTasks, fullList),
+          archivedTotalCount: fullList.length,
+          archivedFullyLoaded: true,
+        }));
+      })
+      .finally(() => {
+        // Clear the marker only if it is still ours (a project switch mid-flight
+        // may have replaced it).
+        if (archivedFullLoad?.promise === promise) archivedFullLoad = null;
+      });
+    archivedFullLoad = { projectId, promise };
+    return promise;
+  },
+
+  acquireArchiveView: () => {
+    set((state) => ({ archiveViewers: state.archiveViewers + 1 }));
+  },
+
+  releaseArchiveView: () => {
+    set((state) => ({ archiveViewers: Math.max(0, state.archiveViewers - 1) }));
   },
 
   archiveTask: (id) => {
@@ -33,9 +122,13 @@ export const createArchivedTasksSlice: StateCreator<BoardStore, [], [], Archived
       const task = s.tasks.find((t) => t.id === id);
       if (!task) return s;
       const archived = { ...task, archived_at: new Date().toISOString() };
+      // Prepend keeps the newly-archived card at the front of the preview (it is
+      // the newest by archived_at). DoneSwimlane slices to ARCHIVED_PREVIEW_LIMIT,
+      // so a transient 16th preview entry is harmless.
       return {
         tasks: s.tasks.filter((t) => t.id !== id),
         archivedTasks: [archived, ...s.archivedTasks],
+        archivedTotalCount: s.archivedTotalCount + 1,
       };
     });
   },
@@ -43,6 +136,7 @@ export const createArchivedTasksSlice: StateCreator<BoardStore, [], [], Archived
   unarchiveTask: async (input) => {
     const previousTasks = get().tasks;
     const previousArchivedTasks = get().archivedTasks;
+    const previousArchivedTotalCount = get().archivedTotalCount;
     const archivedRecord = previousArchivedTasks.find((t) => t.id === input.id);
     if (!archivedRecord) return;
 
@@ -62,6 +156,7 @@ export const createArchivedTasksSlice: StateCreator<BoardStore, [], [], Archived
     set((state) => ({
       tasks: [...state.tasks, optimisticTask],
       archivedTasks: state.archivedTasks.filter((t) => t.id !== input.id),
+      archivedTotalCount: Math.max(0, state.archivedTotalCount - 1),
     }));
 
     // Backend always attempts resume first on unarchive from Done; if no
@@ -74,13 +169,14 @@ export const createArchivedTasksSlice: StateCreator<BoardStore, [], [], Archived
     try {
       await window.electronAPI.tasks.unarchive(input, useProjectStore.getState().currentProject?.id ?? null);
 
-      const [nextTasks, nextArchivedTasks] = await Promise.all([
+      const [nextTasks, archivedReconcile] = await Promise.all([
         window.electronAPI.tasks.list(),
-        window.electronAPI.tasks.listArchived(),
+        fetchArchivedReconcile(get().archivedFullyLoaded),
       ]);
       set((state) => ({
         tasks: applyStructuralSharing(state.tasks, nextTasks),
-        archivedTasks: applyStructuralSharing(state.archivedTasks, nextArchivedTasks),
+        archivedTasks: applyStructuralSharing(state.archivedTasks, archivedReconcile.tasks),
+        archivedTotalCount: archivedReconcile.totalCount,
       }));
 
       useToastStore.getState().addToast({
@@ -103,7 +199,11 @@ export const createArchivedTasksSlice: StateCreator<BoardStore, [], [], Archived
       // Snapshot restore for immediate visual revert, then loadBoard() to
       // reconcile against concurrent ops that may have mutated either array
       // during the await window. Matches the pattern in bulkUnarchiveTasks.
-      set({ tasks: previousTasks, archivedTasks: previousArchivedTasks });
+      set({
+        tasks: previousTasks,
+        archivedTasks: previousArchivedTasks,
+        archivedTotalCount: previousArchivedTotalCount,
+      });
       await get().loadBoard();
       useToastStore.getState().addToast({
         message: `Failed to restore task: ${err instanceof Error ? err.message : 'Unknown error'}`,
@@ -120,10 +220,16 @@ export const createArchivedTasksSlice: StateCreator<BoardStore, [], [], Archived
   deleteArchivedTask: async (id) => {
     // Snapshot for rollback
     const prevArchived = get().archivedTasks;
-    // Optimistic: remove from archivedTasks
-    set((s) => ({
-      archivedTasks: s.archivedTasks.filter((t) => t.id !== id),
-    }));
+    const prevArchivedTotalCount = get().archivedTotalCount;
+    // Optimistic: remove from archivedTasks (decrement only when we actually
+    // held the row, so a preview miss doesn't skew the count).
+    set((s) => {
+      const held = s.archivedTasks.some((t) => t.id === id);
+      return {
+        archivedTasks: s.archivedTasks.filter((t) => t.id !== id),
+        archivedTotalCount: held ? Math.max(0, s.archivedTotalCount - 1) : s.archivedTotalCount,
+      };
+    });
     try {
       await window.electronAPI.tasks.delete(id, useProjectStore.getState().currentProject?.id ?? null);
       // Also clean up sessions in session store
@@ -132,7 +238,7 @@ export const createArchivedTasksSlice: StateCreator<BoardStore, [], [], Archived
       }));
     } catch (err) {
       // Revert optimistic removal so stale tasks don't reappear on next load
-      set({ archivedTasks: prevArchived });
+      set({ archivedTasks: prevArchived, archivedTotalCount: prevArchivedTotalCount });
       useToastStore.getState().addToast({
         message: `Failed to delete task: ${err instanceof Error ? err.message : 'Unknown error'}`,
         variant: 'error',
@@ -142,12 +248,18 @@ export const createArchivedTasksSlice: StateCreator<BoardStore, [], [], Archived
 
   bulkDeleteArchivedTasks: async (ids) => {
     const prevArchived = get().archivedTasks;
+    const prevArchivedTotalCount = get().archivedTotalCount;
     const idSet = new Set(ids);
-    // Optimistic removal
-    set((state) => ({
-      archivedTasks: state.archivedTasks.filter((task) => !idSet.has(task.id)),
-      bulkDeleteProgress: { completed: 0, total: ids.length, failures: [] },
-    }));
+    // Optimistic removal. Decrement by the number of rows we actually held, so
+    // ids not present in a preview don't skew the count.
+    set((state) => {
+      const removedCount = state.archivedTasks.filter((task) => idSet.has(task.id)).length;
+      return {
+        archivedTasks: state.archivedTasks.filter((task) => !idSet.has(task.id)),
+        archivedTotalCount: Math.max(0, state.archivedTotalCount - removedCount),
+        bulkDeleteProgress: { completed: 0, total: ids.length, failures: [] },
+      };
+    });
 
     // Subscribe to per-task progress events so the UI can show a running
     // counter during long deletes (hundreds of tasks with worktree cleanup).
@@ -177,7 +289,7 @@ export const createArchivedTasksSlice: StateCreator<BoardStore, [], [], Archived
     } catch (error) {
       // Hard failure (IPC threw - e.g. no project open). Revert optimistic
       // removal since we can't trust any partial state.
-      set({ archivedTasks: prevArchived });
+      set({ archivedTasks: prevArchived, archivedTotalCount: prevArchivedTotalCount });
       useToastStore.getState().addToast({
         message: `Failed to delete tasks: ${error instanceof Error ? error.message : 'Unknown error'}`,
         variant: 'error',
@@ -190,11 +302,16 @@ export const createArchivedTasksSlice: StateCreator<BoardStore, [], [], Archived
 
   bulkUnarchiveTasks: async (ids, targetSwimlaneId) => {
     const prevArchived = get().archivedTasks;
+    const prevArchivedTotalCount = get().archivedTotalCount;
     const idSet = new Set(ids);
-    // Optimistic removal from archived
-    set((state) => ({
-      archivedTasks: state.archivedTasks.filter((task) => !idSet.has(task.id)),
-    }));
+    // Optimistic removal from archived. Decrement by rows actually held.
+    set((state) => {
+      const removedCount = state.archivedTasks.filter((task) => idSet.has(task.id)).length;
+      return {
+        archivedTasks: state.archivedTasks.filter((task) => !idSet.has(task.id)),
+        archivedTotalCount: Math.max(0, state.archivedTotalCount - removedCount),
+      };
+    });
     try {
       await window.electronAPI.tasks.bulkUnarchive(ids, targetSwimlaneId, useProjectStore.getState().currentProject?.id ?? null);
       // Reload tasks (sessions arrive via push-based session-changed events)
@@ -207,7 +324,7 @@ export const createArchivedTasksSlice: StateCreator<BoardStore, [], [], Archived
         variant: 'success',
       });
     } catch (error) {
-      set({ archivedTasks: prevArchived });
+      set({ archivedTasks: prevArchived, archivedTotalCount: prevArchivedTotalCount });
       await get().loadBoard();
       useToastStore.getState().addToast({
         message: `Failed to restore tasks: ${error instanceof Error ? error.message : 'Unknown error'}`,

--- a/src/renderer/stores/board-store/board-hydration-slice.ts
+++ b/src/renderer/stores/board-store/board-hydration-slice.ts
@@ -1,7 +1,8 @@
 import { type StateCreator } from 'zustand';
 import type { ShortcutConfig } from '../../../shared/types';
 import type { BoardStore } from './types';
-import { applyStructuralSharing } from './structural-sharing';
+import { applyStructuralSharing, applySwimlaneStructuralSharing } from './structural-sharing';
+import { ARCHIVED_PREVIEW_LIMIT } from './archived-tasks-slice';
 
 export interface BoardHydrationSlice {
   loading: boolean;
@@ -26,22 +27,37 @@ export const createBoardHydrationSlice: StateCreator<BoardStore, [], [], BoardHy
   loadBoard: async () => {
     set({ loading: true });
     try {
-      const [nextTasks, swimlanes, nextArchivedTasks] = await Promise.all([
+      // Hydrate from the cheap archived PREVIEW (newest N + total count) instead
+      // of the full archive, which can be many MB once hundreds of tasks pile up
+      // and was cloned on every agent-driven reload. The full list loads lazily
+      // only while an archive viewer is mounted (Completed dialog / deep-anchor
+      // detail window), tracked by archiveViewers.
+      const [nextTasks, nextSwimlanes, archivedPreview] = await Promise.all([
         window.electronAPI.tasks.list(),
         window.electronAPI.swimlanes.list(),
-        window.electronAPI.tasks.listArchived(),
+        window.electronAPI.tasks.listArchivedPreview(ARCHIVED_PREVIEW_LIMIT),
       ]);
-      // Reuse object references for unchanged tasks so React.memo on TaskCard
-      // can short-circuit. Every IPC roundtrip returns fresh JSON objects - if
-      // we set them directly, 100 cards all re-render on every agent event even
-      // when only one task actually changed.
+      // Reuse object references for unchanged tasks/swimlanes so React.memo can
+      // short-circuit. Every IPC roundtrip returns fresh JSON objects - if we
+      // set them directly, every card and column re-renders on every agent event
+      // even when only one row actually changed.
+      const keepFull = get().archiveViewers > 0 && get().archivedFullyLoaded;
       set((state) => ({
         tasks: applyStructuralSharing(state.tasks, nextTasks),
-        swimlanes,
-        archivedTasks: applyStructuralSharing(state.archivedTasks, nextArchivedTasks),
+        swimlanes: applySwimlaneStructuralSharing(state.swimlanes, nextSwimlanes),
+        // While a viewer holds the full archive, keep it (reconciled out-of-band
+        // below); otherwise downgrade to the preview.
+        archivedTasks: keepFull
+          ? state.archivedTasks
+          : applyStructuralSharing(state.archivedTasks, archivedPreview.tasks),
+        archivedFullyLoaded: keepFull,
+        archivedTotalCount: archivedPreview.totalCount,
         loading: false,
         hydrated: true,
       }));
+      // A mounted viewer still needs an authoritative full refresh (an agent may
+      // have archived a task); do it off the hydration critical path.
+      if (keepFull) void get().loadArchivedTasks().catch(() => {});
     } catch (error) {
       console.error('[board-store] Failed to load board:', error);
       set({ loading: false, hydrated: true });

--- a/src/renderer/stores/board-store/structural-sharing.ts
+++ b/src/renderer/stores/board-store/structural-sharing.ts
@@ -1,42 +1,67 @@
-import type { Task } from '../../../shared/types';
+import type { Task, Swimlane } from '../../../shared/types';
 
 /**
- * Apply structural sharing to a freshly-fetched Task list: reuse the previous
- * object reference for every task whose field-by-field contents match. Every
- * `tasks.list()` IPC call returns freshly JSON-deserialized objects, so
- * without this step `React.memo` on `TaskCard` is defeated by identity churn -
- * every `loadBoard()` forces every card to re-render even when only one task
- * changed.
+ * Reuse the previous object reference for every element whose field-by-field
+ * contents match. Every IPC list call returns freshly JSON-deserialized
+ * objects, so without this step `React.memo` is defeated by identity churn -
+ * every `loadBoard()` forces every consumer to re-render even when only one
+ * element changed.
  *
  * This is the same optimization TanStack Query applies by default to every
  * query result; see
  * https://tanstack.com/query/latest/docs/framework/react/guides/render-optimizations
  * ("Structural Sharing" section). We implement a narrower, flat-top-level
- * version sufficient for our Task[] shape; full recursive structural sharing
- * would handle nested objects as well, which Task doesn't need.
+ * version sufficient for our row shapes; full recursive structural sharing
+ * would handle nested objects as well, which our rows don't need.
+ *
+ * Returns a NEW top-level array (callers rely on a fresh outer ref to
+ * retrigger downstream memos). Individual elements are reused when equal.
+ */
+function shareByContents<T extends { id: string }>(
+  previous: T[],
+  next: T[],
+  contentsMatch: (previous: T, next: T) => boolean,
+): T[] {
+  if (previous.length === 0) return next;
+
+  const previousById = new Map<string, T>();
+  for (const item of previous) previousById.set(item.id, item);
+
+  const result: T[] = new Array(next.length);
+  for (let index = 0; index < next.length; index += 1) {
+    const candidate = next[index];
+    const prior = previousById.get(candidate.id);
+    result[index] = prior && contentsMatch(prior, candidate) ? prior : candidate;
+  }
+  return result;
+}
+
+/**
+ * Apply structural sharing to a freshly-fetched Task list: reuse the previous
+ * object reference for every task whose field-by-field contents match. Without
+ * this, `React.memo` on `TaskCard` is defeated by identity churn - every
+ * `loadBoard()` forces every card to re-render even when only one task changed.
  *
  * Trade-off: we pay an O(N) pass with a shallow field compare per task to
  * avoid O(N) expensive card renders + their subscription re-evaluations.
  * At 100 tasks the compare is microseconds; the saved renders are
  * milliseconds. Break-even is very low.
- *
- * Returns a new top-level array (callers rely on a fresh outer ref to
- * retrigger downstream `tasksPerLane` / sort memos). Individual task
- * elements are reused when equal.
  */
 export function applyStructuralSharing(previousTasks: Task[], nextTasks: Task[]): Task[] {
-  if (previousTasks.length === 0) return nextTasks;
+  return shareByContents(previousTasks, nextTasks, taskContentsMatch);
+}
 
-  const previousById = new Map<string, Task>();
-  for (const previous of previousTasks) previousById.set(previous.id, previous);
-
-  const result: Task[] = new Array(nextTasks.length);
-  for (let index = 0; index < nextTasks.length; index += 1) {
-    const next = nextTasks[index];
-    const previous = previousById.get(next.id);
-    result[index] = previous && taskContentsMatch(previous, next) ? previous : next;
-  }
-  return result;
+/**
+ * Apply structural sharing to a freshly-fetched Swimlane list. `swimlanes.list()`
+ * returns fresh JSON objects on every hydration, so without this the whole array
+ * and every element churn identity, defeating every `Swimlane` memo even when no
+ * column changed. Tasks already get this treatment; swimlanes did not until now.
+ */
+export function applySwimlaneStructuralSharing(
+  previousSwimlanes: Swimlane[],
+  nextSwimlanes: Swimlane[],
+): Swimlane[] {
+  return shareByContents(previousSwimlanes, nextSwimlanes, swimlaneContentsMatch);
 }
 
 /**
@@ -83,4 +108,40 @@ function taskContentsMatch(previous: Task, next: Task): boolean {
     if (previousLabels[index] !== nextLabels[index]) return false;
   }
   return true;
+}
+
+/**
+ * Field-by-field equality for Swimlane. Every field is primitive-or-null (no
+ * nested arrays or objects), so a flat compare is exhaustive.
+ *
+ * When a new field is added to the `Swimlane` interface in
+ * `src/shared/types.ts`, add it here too. `tests/unit/structural-sharing.test.ts`
+ * asserts on `Object.keys(swimlane).length` as a drift guard - if that test
+ * fails after a Swimlane change, update the field list below to match before
+ * touching the guard count.
+ */
+function swimlaneContentsMatch(previous: Swimlane, next: Swimlane): boolean {
+  if (previous === next) return true;
+  return (
+    previous.id === next.id &&
+    previous.name === next.name &&
+    previous.description === next.description &&
+    previous.role === next.role &&
+    previous.position === next.position &&
+    previous.color === next.color &&
+    previous.icon === next.icon &&
+    previous.is_archived === next.is_archived &&
+    previous.is_ghost === next.is_ghost &&
+    previous.permission_mode === next.permission_mode &&
+    previous.auto_spawn === next.auto_spawn &&
+    previous.auto_command === next.auto_command &&
+    previous.plan_exit_target_id === next.plan_exit_target_id &&
+    previous.agent_override === next.agent_override &&
+    previous.model_override === next.model_override &&
+    previous.effort_override === next.effort_override &&
+    previous.handoff_context === next.handoff_context &&
+    previous.session_target === next.session_target &&
+    previous.session_spawn_strategy === next.session_spawn_strategy &&
+    previous.created_at === next.created_at
+  );
 }

--- a/src/renderer/stores/board-store/task-slice.ts
+++ b/src/renderer/stores/board-store/task-slice.ts
@@ -7,6 +7,7 @@ import { useToastStore } from '../toast-store';
 import { useProjectStore } from '../project-store';
 import { invalidateProject } from '../project-cache';
 import { applyStructuralSharing } from './structural-sharing';
+import { fetchArchivedReconcile } from './archived-tasks-slice';
 import type { BoardStore } from './types';
 
 /** Outcome of a moveTask call. `ok: false` means the IPC genuinely failed
@@ -154,12 +155,18 @@ export const createTaskSlice: StateCreator<BoardStore, [], [], TaskSlice> = (set
     // `tasks`, but we filter both defensively to match the prior behavior.
     const previousTasks = get().tasks;
     const previousArchivedTasks = get().archivedTasks;
+    const previousArchivedTotalCount = get().archivedTotalCount;
 
-    // Optimistic: remove the card from view immediately.
-    set((s) => ({
-      tasks: s.tasks.filter((t) => t.id !== id),
-      archivedTasks: s.archivedTasks.filter((t) => t.id !== id),
-    }));
+    // Optimistic: remove the card from view immediately. Decrement the archived
+    // count only when this id was actually an archived row.
+    set((s) => {
+      const wasArchived = s.archivedTasks.some((t) => t.id === id);
+      return {
+        tasks: s.tasks.filter((t) => t.id !== id),
+        archivedTasks: s.archivedTasks.filter((t) => t.id !== id),
+        archivedTotalCount: wasArchived ? Math.max(0, s.archivedTotalCount - 1) : s.archivedTotalCount,
+      };
+    });
 
     // Callers (TaskCard.handleContextDelete / useTaskActions.handleDelete)
     // already awaited killSession before invoking this, so the PTY is dead.
@@ -177,7 +184,7 @@ export const createTaskSlice: StateCreator<BoardStore, [], [], TaskSlice> = (set
       // No loadBoard() reconcile (unlike unarchiveTask): backend withTaskLock
       // already serializes per-task ops, and same-task is the only meaningful
       // race surface for a hard delete. Matches deleteArchivedTask.
-      set({ tasks: previousTasks, archivedTasks: previousArchivedTasks });
+      set({ tasks: previousTasks, archivedTasks: previousArchivedTasks, archivedTotalCount: previousArchivedTotalCount });
       useToastStore.getState().addToast({
         message: `Failed to delete task: ${err instanceof Error ? err.message : 'Unknown error'}`,
         variant: 'error',
@@ -332,10 +339,12 @@ export const createTaskSlice: StateCreator<BoardStore, [], [], TaskSlice> = (set
         return { ok: true };
       }
 
-      // Reload tasks and archived tasks (sessions arrive via push-based session-changed events)
-      const [nextTasks, nextArchivedTasks] = await Promise.all([
+      // Reload tasks and archived tasks (sessions arrive via push-based
+      // session-changed events). A move to Done archives the task; the archived
+      // side reconciles via the preview unless a viewer holds the full list.
+      const [nextTasks, archivedReconcile] = await Promise.all([
         window.electronAPI.tasks.list(),
-        window.electronAPI.tasks.listArchived(),
+        fetchArchivedReconcile(get().archivedFullyLoaded),
       ]);
       if (moveGeneration !== thisGen) return { ok: true }; // Skip stale reload
       // A switch can also land during the list round-trip above.
@@ -349,7 +358,8 @@ export const createTaskSlice: StateCreator<BoardStore, [], [], TaskSlice> = (set
       // their memo and don't re-render on every drag drop.
       set((state) => ({
         tasks: applyStructuralSharing(state.tasks, nextTasks),
-        archivedTasks: applyStructuralSharing(state.archivedTasks, nextArchivedTasks),
+        archivedTasks: applyStructuralSharing(state.archivedTasks, archivedReconcile.tasks),
+        archivedTotalCount: archivedReconcile.totalCount,
       }));
 
       // Detect if the moved task now has a new/different session

--- a/src/renderer/stores/project-cache.ts
+++ b/src/renderer/stores/project-cache.ts
@@ -49,6 +49,10 @@ interface ProjectSnapshot {
     tasks: Task[];
     swimlanes: Swimlane[];
     archivedTasks: Task[];
+    /** Total archived count (source of truth for badges); see archived-tasks-slice. */
+    archivedTotalCount: number;
+    /** Whether archivedTasks holds the full archive vs the newest-N preview. */
+    archivedFullyLoaded: boolean;
     /**
      * Per-project shortcut definitions (loaded from kangentic.json /
      * kangentic.local.json via `boardConfig.getShortcuts`). Consumed by

--- a/src/renderer/utils/git-branches.ts
+++ b/src/renderer/utils/git-branches.ts
@@ -1,0 +1,64 @@
+import { useProjectStore } from '../stores/project-store';
+
+/**
+ * In-flight de-dupe + short TTL cache for `git:listBranches`.
+ *
+ * The handler shells out to git (~900ms). Opening the New Task dialog or the
+ * Task Detail dialog fires TWO concurrent `git:listBranches` calls: the dialog's
+ * own branch-existence check and the embedded `BranchPicker`'s list fetch. This
+ * module collapses concurrent calls into one round-trip and serves a fresh
+ * result from a brief cache, keyed by the CURRENT project id (the main handler
+ * routes by the ambient project, so a cross-project cache hit would return the
+ * wrong repo's branches).
+ */
+const BRANCHES_CACHE_TTL_MS = 15_000;
+
+// hmr-safe: transient short-TTL cache; a reset-on-HMR just triggers a refetch.
+let inFlightRequest: { projectId: string | null; promise: Promise<string[]> } | null = null;
+// hmr-safe: see inFlightRequest.
+let cachedResult: { projectId: string | null; branches: string[]; fetchedAtMs: number } | null = null;
+
+/**
+ * Fetch the repo's branch list, sharing an in-flight request and a fresh cache
+ * across concurrent callers for the current project. Rejections are never
+ * cached, so a failed fetch is retried on the next call.
+ */
+export function fetchGitBranches(): Promise<string[]> {
+  const projectId = useProjectStore.getState().currentProject?.id ?? null;
+  const now = Date.now();
+
+  // Fresh same-project cache: serve it without touching IPC.
+  if (
+    cachedResult
+    && cachedResult.projectId === projectId
+    && now - cachedResult.fetchedAtMs < BRANCHES_CACHE_TTL_MS
+  ) {
+    return Promise.resolve(cachedResult.branches);
+  }
+
+  // Same-project request already in flight: join it (this is what collapses the
+  // dialog + BranchPicker double-fire into one ~900ms shell-out).
+  if (inFlightRequest && inFlightRequest.projectId === projectId) {
+    return inFlightRequest.promise;
+  }
+
+  const promise = window.electronAPI.git.listBranches()
+    .then((branches) => {
+      cachedResult = { projectId, branches, fetchedAtMs: Date.now() };
+      return branches;
+    })
+    .finally(() => {
+      // Clear the in-flight marker only if it is still ours (a project switch
+      // mid-flight may have replaced it).
+      if (inFlightRequest?.promise === promise) inFlightRequest = null;
+    });
+
+  inFlightRequest = { projectId, promise };
+  return promise;
+}
+
+/** Test-only: drop the cache and any in-flight marker. */
+export function invalidateGitBranchesCache(): void {
+  inFlightRequest = null;
+  cachedResult = null;
+}

--- a/src/renderer/utils/incoming-write-queue.ts
+++ b/src/renderer/utils/incoming-write-queue.ts
@@ -40,6 +40,12 @@ export interface IncomingWriteQueue {
   /** Append received PTY data; starts the paced drain loop if idle. */
   push(data: string): void;
   /**
+   * Resume a drain that was paused by `shouldHold`. Re-enters the loop when it
+   * is not already draining and the buffer is non-empty; a no-op otherwise.
+   * Call this on the signal that clears `shouldHold` (e.g. board drag end).
+   */
+  kick(): void;
+  /**
    * Drop buffered (not-yet-dispatched) bytes, acking them so backpressure is
    * released, and stop. Bytes already handed to `xterm.write` but awaiting its
    * callback are not covered here; the session-teardown path
@@ -53,6 +59,13 @@ export interface IncomingWriteQueueOptions {
   getTerminal: () => Terminal | null;
   /** True while incoming data must be discarded (scrollback replay / overlay). */
   shouldDrop: () => boolean;
+  /**
+   * True while the drain must PAUSE without discarding: the buffer is retained
+   * and no bytes are acked, so main-side backpressure naturally throttles the
+   * PTY at the source. Used to stop mid-drag xterm parsing (a board drag).
+   * Resume via `kick()`. Distinct from `shouldDrop`, which acks-and-discards.
+   */
+  shouldHold?: () => boolean;
   /** Report `bytes` consumed (written or dropped) to main's flow control. */
   ack: (bytes: number) => void;
   chunkSize?: number;
@@ -81,6 +94,14 @@ export function createIncomingWriteQueue(
       draining = false;
       return;
     }
+    if (options.shouldHold?.()) {
+      // Paused (e.g. a board drag): retain the buffer, ack nothing, and stop
+      // scheduling. Not routed through shouldDrop - dropping would discard live
+      // output. Un-acked bytes let main's backpressure pause the PTY at the
+      // source. Resume via kick() when the hold clears.
+      draining = false;
+      return;
+    }
     const end = safeSliceEnd(buffer, 0, chunkSize);
     const chunk = buffer.slice(0, end);
     buffer = buffer.slice(end);
@@ -106,6 +127,11 @@ export function createIncomingWriteQueue(
       if (data.length === 0) return;
       buffer += data;
       if (draining) return;
+      draining = true;
+      drain();
+    },
+    kick(): void {
+      if (draining || buffer.length === 0) return;
       draining = true;
       drain();
     },

--- a/src/renderer/utils/terminal-webgl.ts
+++ b/src/renderer/utils/terminal-webgl.ts
@@ -1,0 +1,164 @@
+import type { Terminal, ITerminalAddon } from '@xterm/xterm';
+import { WebglAddon } from '@xterm/addon-webgl';
+
+/**
+ * WebGL renderer attachment with context-loss recovery.
+ *
+ * xterm's WebGL renderer is 10-50x faster than its DOM fallback for output
+ * bursts. The GPU can drop the WebGL context (driver reset, tab throttling,
+ * memory pressure); when it does, the addon fires `onContextLoss`. The old code
+ * just `dispose()`d the addon on loss, silently and permanently reverting the
+ * terminal to the DOM renderer for the rest of the session - so every later
+ * burst became far more expensive with nothing recorded. This module retries
+ * re-initializing WebGL after a loss (with a short backoff), logs what happened,
+ * and tracks the live renderer type so devtools can observe a degraded terminal.
+ */
+
+export type TerminalRendererType = 'webgl' | 'dom';
+
+export interface TerminalRendererStatus {
+  /** The renderer currently backing this terminal. */
+  renderer: TerminalRendererType;
+  /** How many WebGL context losses this terminal has seen. */
+  contextLossCount: number;
+  /** True once retries are exhausted and the terminal is DOM-only for good. */
+  permanentDomFallback: boolean;
+}
+
+/** The subset of `WebglAddon` this module uses. Narrowed so tests can fake it. */
+interface WebglAddonLike {
+  onContextLoss(handler: () => void): void;
+  dispose(): void;
+}
+
+interface AttachWebglOptions {
+  /** Addon factory, injectable for tests. Defaults to a real `WebglAddon`. */
+  createAddon?: () => WebglAddonLike;
+  /**
+   * Backoff schedule for post-context-loss re-inits. Its length also caps the
+   * number of retries: after this many losses the terminal stays DOM-only.
+   * Default: retry once after 2s, once more after 10s, then give up.
+   */
+  retryDelaysMs?: number[];
+}
+
+const DEFAULT_RETRY_DELAYS_MS = [2_000, 10_000];
+
+// hmr-safe: transient per-terminal renderer status; terminals dispose and
+// re-register their entry across an HMR remount, and a devtools snapshot
+// reading a stale map after a Fast Refresh is a harmless diagnostic read.
+const rendererStatusByKey = new Map<string, TerminalRendererStatus>();
+
+/**
+ * Attach the WebGL renderer to `terminal`, recovering from context loss. Returns
+ * a dispose function that cancels any pending retry, disposes the live addon,
+ * and drops the status entry. `rendererKey` identifies this terminal in the
+ * renderer report (the session id, or a transient key for a session-less pane).
+ */
+export function attachWebglRenderer(
+  terminal: Terminal,
+  rendererKey: string,
+  options?: AttachWebglOptions,
+): () => void {
+  const createAddon = options?.createAddon ?? (() => new WebglAddon());
+  const retryDelaysMs = options?.retryDelaysMs ?? DEFAULT_RETRY_DELAYS_MS;
+
+  const status: TerminalRendererStatus = { renderer: 'dom', contextLossCount: 0, permanentDomFallback: false };
+  rendererStatusByKey.set(rendererKey, status);
+
+  let currentAddon: WebglAddonLike | null = null;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let disposed = false;
+
+  const clearRetryTimer = (): void => {
+    if (retryTimer !== null) {
+      clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+  };
+
+  const tryAttach = (): boolean => {
+    try {
+      const addon = createAddon();
+      addon.onContextLoss(handleContextLoss);
+      terminal.loadAddon(addon as unknown as ITerminalAddon);
+      currentAddon = addon;
+      status.renderer = 'webgl';
+      return true;
+    } catch {
+      status.renderer = 'dom';
+      return false;
+    }
+  };
+
+  function scheduleReattach(attempt: number): void {
+    // `attempt` is 1-based; retryDelaysMs[attempt - 1] is this attempt's delay.
+    clearRetryTimer();
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      if (disposed) return;
+      if (tryAttach()) {
+        console.warn(`[terminal-webgl] WebGL renderer recovered for ${rendererKey}`);
+        return;
+      }
+      // The re-init itself failed. Advance to the next backoff slot, or give up
+      // for good once the slots are exhausted - never leave the terminal stuck
+      // on DOM with permanentDomFallback still false and no retry armed.
+      if (attempt >= retryDelaysMs.length) {
+        status.permanentDomFallback = true;
+        console.warn(`[terminal-webgl] WebGL re-init failed for ${rendererKey}; staying on the DOM renderer`);
+        return;
+      }
+      const nextAttempt = attempt + 1;
+      console.warn(`[terminal-webgl] WebGL re-init failed for ${rendererKey}; retrying in ${retryDelaysMs[nextAttempt - 1]}ms`);
+      scheduleReattach(nextAttempt);
+    }, retryDelaysMs[attempt - 1]);
+  }
+
+  function handleContextLoss(): void {
+    if (disposed) return;
+    if (currentAddon) {
+      try { currentAddon.dispose(); } catch { /* addon may already be gone */ }
+      currentAddon = null;
+    }
+    status.renderer = 'dom';
+    status.contextLossCount += 1;
+    const lossNumber = status.contextLossCount;
+
+    if (lossNumber > retryDelaysMs.length) {
+      status.permanentDomFallback = true;
+      console.warn(`[terminal-webgl] WebGL context lost ${lossNumber}x for ${rendererKey}; staying on the DOM renderer`);
+      return;
+    }
+
+    console.warn(`[terminal-webgl] WebGL context lost (${lossNumber}) for ${rendererKey}; retrying in ${retryDelaysMs[lossNumber - 1]}ms`);
+    scheduleReattach(lossNumber);
+  }
+
+  // Initial attach. A construction throw means WebGL is unavailable in this
+  // environment (headless, blocklisted GPU): stay on DOM, but now logged rather
+  // than silently swallowed.
+  if (!tryAttach()) {
+    status.permanentDomFallback = true;
+    console.warn(`[terminal-webgl] WebGL unavailable for ${rendererKey}; using the DOM renderer`);
+  }
+
+  return () => {
+    disposed = true;
+    clearRetryTimer();
+    if (currentAddon) {
+      try { currentAddon.dispose(); } catch { /* best-effort */ }
+      currentAddon = null;
+    }
+    rendererStatusByKey.delete(rendererKey);
+  };
+}
+
+/** Snapshot of every live terminal's renderer status, keyed by renderer key. */
+export function getTerminalRendererReport(): Record<string, TerminalRendererStatus> {
+  const report: Record<string, TerminalRendererStatus> = {};
+  for (const [key, status] of rendererStatusByKey) {
+    report[key] = { ...status };
+  }
+  return report;
+}

--- a/src/renderer/window-manager/components/WindowContent.tsx
+++ b/src/renderer/window-manager/components/WindowContent.tsx
@@ -11,7 +11,7 @@
  * the content reads its maximize state from the window store via its `windowId`.
  */
 
-import { Suspense, lazy } from 'react';
+import { Suspense, lazy, useEffect } from 'react';
 import { Loader2 } from 'lucide-react';
 import { useBoardStore } from '../../stores/board-store';
 import { PanelErrorBoundary } from '../../components/PanelErrorBoundary';
@@ -82,6 +82,21 @@ function TaskDetailContent({
     ?? state.archivedTasks.find((candidate) => candidate.id === managedWindow.anchor)
     ?? null,
   );
+
+  // Deep-archive self-heal: a window anchored to an archived task older than the
+  // board's newest-N preview misses both lists. Pull the full archive so it can
+  // resolve, and hold a viewer for the duration so hydration keeps the full list
+  // loaded until this window closes or the task resolves. Normal (non-archived)
+  // windows resolve from `tasks` immediately and never trigger this.
+  const anchorUnresolved = task === null;
+  useEffect(() => {
+    if (!anchorUnresolved) return;
+    useBoardStore.getState().acquireArchiveView();
+    if (!useBoardStore.getState().archivedFullyLoaded) {
+      void useBoardStore.getState().loadArchivedTasks().catch(() => {});
+    }
+    return () => { useBoardStore.getState().releaseArchiveView(); };
+  }, [anchorUnresolved]);
 
   if (!task) {
     return (

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -36,6 +36,7 @@ export const IPC = {
   TASK_MOVE: 'task:move',
   TASK_CANCEL_SPAWN: 'task:cancelSpawn',
   TASK_LIST_ARCHIVED: 'task:list-archived',
+  TASK_LIST_ARCHIVED_PREVIEW: 'task:list-archived-preview',
   TASK_UNARCHIVE: 'task:unarchive',
   TASK_BULK_DELETE: 'task:bulk-delete',
   TASK_BULK_DELETE_PROGRESS: 'task:bulk-delete-progress',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2108,6 +2108,17 @@ export interface TaskUnarchiveInput {
   targetSwimlaneId: string;
 }
 
+/**
+ * Result of `tasks.listArchivedPreview(limit)`: the newest `limit` archived
+ * tasks plus the authoritative total archived count. The board hydrates from
+ * this small payload instead of the full archive (which can be many MB); the
+ * full list loads lazily only when the Completed dialog opens.
+ */
+export interface ArchivedTasksPreview {
+  totalCount: number;
+  tasks: Task[];
+}
+
 export interface TaskBulkDeleteFailure {
   id: string;
   error: string;
@@ -2727,6 +2738,12 @@ export interface ElectronAPI {
      */
     cancelSpawn: (taskId: string) => Promise<void>;
     listArchived: () => Promise<Task[]>;
+    /**
+     * The newest `limit` archived tasks plus the total archived count. Cheap
+     * hydration payload for the Done column's count + inline preview; the full
+     * archive loads lazily via `listArchived` when the Completed dialog opens.
+     */
+    listArchivedPreview: (limit: number) => Promise<ArchivedTasksPreview>;
     unarchive: (input: TaskUnarchiveInput, projectId?: string | null) => Promise<Task>;
     bulkDelete: (ids: string[], projectId?: string | null) => Promise<TaskBulkDeleteResult>;
     bulkUnarchive: (ids: string[], targetSwimlaneId: string, projectId?: string | null) => Promise<void>;
@@ -3301,6 +3318,20 @@ export interface ProcessMetrics {
  * renderer). Inbound entries leave `direction` absent so existing log
  * readers see no change; outbound pushes set `direction: 'out'`.
  */
+/**
+ * Placeholder substituted for an args/result payload whose serialized form
+ * exceeds the recorder's size cap. Keeps each JSONL line small (a single ~1.2MB
+ * `task:list-archived` result would otherwise be stringified in full on the main
+ * thread) while preserving enough signal to identify the oversized channel.
+ */
+export interface IpcPayloadTruncated {
+  truncated: true;
+  /** UTF-16 length of the full serialized payload (-1 when unserializable). */
+  serializedChars: number;
+  /** First ~2KB of the serialized JSON, enough to identify the payload shape. */
+  preview: string;
+}
+
 export interface IpcLogEntry {
   ts: string;
   channel: string;
@@ -3309,10 +3340,10 @@ export interface IpcLogEntry {
    * invocation; `'out'` means a main -> renderer `webContents.send` push.
    */
   direction?: 'in' | 'out';
-  /** Either the captured args array or a redaction placeholder. */
-  args: unknown[] | { redacted: true; channel: string };
-  /** Either the captured result or a redaction placeholder. Omitted on error. */
-  result?: unknown | { redacted: true; channel: string };
+  /** Captured args array, a redaction placeholder, or an over-cap truncation marker. */
+  args: unknown[] | { redacted: true; channel: string } | IpcPayloadTruncated;
+  /** Captured result, a redaction placeholder, or an over-cap truncation marker. Omitted on error. */
+  result?: unknown | { redacted: true; channel: string } | IpcPayloadTruncated;
   /** Handler round-trip time in ms. Always `0` for outbound pushes (no round trip to measure). */
   durationMs: number;
   /**

--- a/tests/ui/archived-lazy-load.spec.ts
+++ b/tests/ui/archived-lazy-load.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * UI tests for archive lazy-loading (the board hydrates a cheap preview, the
+ * full archive loads only while a viewer is mounted).
+ *
+ * Contract:
+ *   1. On board load the archive is fetched via `tasks.listArchivedPreview`
+ *      (newest 15 + total count), NEVER the full `tasks.listArchived`.
+ *   2. The Done column shows the true total count ("Completed (20)") and renders
+ *      exactly the newest 15 preview cards.
+ *   3. Opening the Completed dialog triggers exactly one full `tasks.listArchived`
+ *      and shows the full total.
+ *   4. An agent-driven reload while the dialog is open does NOT shrink the loaded
+ *      full list back to the preview.
+ *   5. After the dialog closes, the next agent-driven reload downgrades back to
+ *      the preview: no further full `tasks.listArchived`, only the preview fetch.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+// Each test launches its own page (separate context / goto reset), so the file
+// can fan out across the UI workers safely.
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-archived-lazy-load';
+const ARCHIVED_COUNT = 20;
+const PREVIEW_LIMIT = 15;
+
+async function launchWithArchivedTasks(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(`
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+
+      state.projects.push({
+        id: '${PROJECT_ID}',
+        name: 'Archived Lazy Load Test',
+        path: '/mock/archived-lazy-load-test',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+
+      var laneIds = {};
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        var id = 'lane-all-' + s.name.toLowerCase().replace(/\\s+/g, '-');
+        laneIds[s.name] = id;
+        state.swimlanes.push(Object.assign({}, s, {
+          id: id,
+          position: i,
+          created_at: ts,
+        }));
+      });
+
+      // Seed ${ARCHIVED_COUNT} archived tasks with strictly-descending archived_at
+      // so the newest-first preview order is deterministic.
+      for (var i = 0; i < ${ARCHIVED_COUNT}; i += 1) {
+        var archivedAt = new Date(Date.now() - i * 1000).toISOString();
+        state.archivedTasks.push({
+          id: 'arch-' + i,
+          title: 'Archived Task ' + i,
+          description: 'Completed task ' + i,
+          swimlane_id: laneIds['Done'],
+          position: 0,
+          agent: 'claude',
+          session_id: null,
+          worktree_path: null,
+          branch_name: null,
+          pr_number: null,
+          pr_url: null,
+          base_branch: 'main',
+          use_worktree: 0,
+          labels: [],
+          priority: 0,
+          attachment_count: 0,
+          archived_at: archivedAt,
+          created_at: ts,
+          updated_at: ts,
+        });
+      }
+
+      return { currentProjectId: '${PROJECT_ID}' };
+    });
+  `);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  // The Done column is always visible once the board hydrates.
+  await page.waitForSelector('[data-swimlane-name="Done"]', { timeout: 15000 });
+
+  return { browser, page };
+}
+
+function readCounts(page: Page): Promise<Record<string, number>> {
+  return page.evaluate(() =>
+    (window as unknown as { __getIpcCallCounts: () => Record<string, number> }).__getIpcCallCounts(),
+  );
+}
+
+function resetCounts(page: Page): Promise<void> {
+  return page.evaluate(() =>
+    (window as unknown as { __resetIpcCallCounts: () => void }).__resetIpcCallCounts(),
+  );
+}
+
+test.describe('archive lazy-load', () => {
+  test('board hydrates the preview, not the full archive', async () => {
+    const { browser, page } = await launchWithArchivedTasks();
+    try {
+      const doneColumn = page.locator('[data-swimlane-name="Done"]');
+
+      // The header shows the true total from the preview payload.
+      await expect(doneColumn.getByText(`Completed (${ARCHIVED_COUNT})`)).toBeVisible({ timeout: 5000 });
+
+      // Exactly the newest 15 preview cards are rendered inline.
+      const previewCards = doneColumn.locator('[data-testid="compact-title"]');
+      await expect(previewCards).toHaveCount(PREVIEW_LIMIT, { timeout: 5000 });
+
+      // The preview endpoint was used; the full archive was never fetched.
+      const counts = await readCounts(page);
+      expect(counts['tasks.listArchivedPreview'] ?? 0).toBeGreaterThan(0);
+      expect(counts['tasks.listArchived'] ?? 0).toBe(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('opening the Completed dialog loads the full archive exactly once', async () => {
+    const { browser, page } = await launchWithArchivedTasks();
+    try {
+      await resetCounts(page);
+
+      await page.locator('[data-testid="expand-completed-btn"]').click();
+
+      const dialog = page.locator('[data-testid="completed-tasks-dialog"]');
+      await expect(dialog).toBeVisible({ timeout: 5000 });
+      await expect(dialog.getByText(`Completed Tasks (${ARCHIVED_COUNT})`)).toBeVisible();
+
+      // The footer count is derived from the loaded rows (not virtualized DOM),
+      // so it reaches the full total only after the lazy full-load resolves.
+      await expect(dialog.getByText(`${ARCHIVED_COUNT} tasks`)).toBeVisible({ timeout: 5000 });
+
+      await expect
+        .poll(async () => (await readCounts(page))['tasks.listArchived'] ?? 0, { timeout: 5000 })
+        .toBe(1);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('agent-driven reload with the dialog open does not shrink the full list', async () => {
+    const { browser, page } = await launchWithArchivedTasks();
+    try {
+      await page.locator('[data-testid="expand-completed-btn"]').click();
+      const dialog = page.locator('[data-testid="completed-tasks-dialog"]');
+      await expect(dialog).toBeVisible({ timeout: 5000 });
+      await expect(dialog.getByText(`${ARCHIVED_COUNT} tasks`)).toBeVisible({ timeout: 5000 });
+
+      // Fire a current-project agent update; this schedules the 250ms-debounced
+      // loadBoard. With a viewer mounted it must keep the full list.
+      await page.evaluate((projectId) => {
+        (window as unknown as { __mockFireTaskUpdatedByAgent: (taskId: string, title: string, projectId: string) => void })
+          .__mockFireTaskUpdatedByAgent('arch-0', 'Archived Task 0', projectId);
+      }, PROJECT_ID);
+
+      // Give the debounce + reload time to run.
+      await page.waitForTimeout(600);
+
+      // The full list is still shown; it did NOT downgrade to the 15-row preview.
+      await expect(dialog.getByText(`${ARCHIVED_COUNT} tasks`)).toBeVisible();
+      await expect(dialog.getByText(`${PREVIEW_LIMIT} tasks`)).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('closing the dialog downgrades back to the preview on the next reload', async () => {
+    const { browser, page } = await launchWithArchivedTasks();
+    try {
+      // Open then close the dialog so the full archive was loaded and released.
+      await page.locator('[data-testid="expand-completed-btn"]').click();
+      const dialog = page.locator('[data-testid="completed-tasks-dialog"]');
+      await expect(dialog).toBeVisible({ timeout: 5000 });
+      await expect(dialog.getByText(`${ARCHIVED_COUNT} tasks`)).toBeVisible({ timeout: 5000 });
+
+      await page.keyboard.press('Escape');
+      await expect(dialog).toBeHidden({ timeout: 5000 });
+
+      await resetCounts(page);
+
+      // A current-project agent reload after the viewer is gone should refetch
+      // only the cheap preview, never the full archive again.
+      await page.evaluate((projectId) => {
+        (window as unknown as { __mockFireTaskUpdatedByAgent: (taskId: string, title: string, projectId: string) => void })
+          .__mockFireTaskUpdatedByAgent('arch-0', 'Archived Task 0', projectId);
+      }, PROJECT_ID);
+
+      await expect
+        .poll(async () => (await readCounts(page))['tasks.listArchivedPreview'] ?? 0, { timeout: 5000 })
+        .toBeGreaterThan(0);
+
+      const counts = await readCounts(page);
+      expect(counts['tasks.listArchived'] ?? 0).toBe(0);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -849,6 +849,19 @@
       listArchived: async function () {
         return withAttachmentCounts(archivedTasks);
       },
+      listArchivedPreview: async function (limit) {
+        // Mirror the repo: newest-first by archived_at, then LIMIT. Sorting a
+        // copy so seeds with more than `limit` archived tasks pick the correct
+        // preview subset (the same rows the real SELECT ... ORDER BY DESC would).
+        var boundedLimit = Math.max(1, Math.min(100, Math.floor(limit)));
+        var sorted = archivedTasks.slice().sort(function (a, b) {
+          return String(b.archived_at || '').localeCompare(String(a.archived_at || ''));
+        });
+        return {
+          totalCount: archivedTasks.length,
+          tasks: withAttachmentCounts(sorted.slice(0, boundedLimit)),
+        };
+      },
       onAutoMoved: function () {
         return noop;
       },
@@ -2483,6 +2496,7 @@
     var watched = [
       ['tasks', 'list'],
       ['tasks', 'listArchived'],
+      ['tasks', 'listArchivedPreview'],
       ['swimlanes', 'list'],
       ['backlog', 'list'],
       ['config', 'get'],

--- a/tests/ui/project-switch-warm-cache.spec.ts
+++ b/tests/ui/project-switch-warm-cache.spec.ts
@@ -192,6 +192,7 @@ test.describe('Project switch warm cache', () => {
       // Board, backlog, and config slices should be pure cache hits.
       expect(counts['tasks.list'] ?? 0).toBe(0);
       expect(counts['tasks.listArchived'] ?? 0).toBe(0);
+      expect(counts['tasks.listArchivedPreview'] ?? 0).toBe(0);
       expect(counts['swimlanes.list'] ?? 0).toBe(0);
       expect(counts['backlog.list'] ?? 0).toBe(0);
       expect(counts['config.get'] ?? 0).toBe(0);

--- a/tests/ui/window-content-deep-archive-self-heal.spec.ts
+++ b/tests/ui/window-content-deep-archive-self-heal.spec.ts
@@ -1,0 +1,338 @@
+/**
+ * UI tests for the deep-archive self-heal effect in WindowContent
+ * (src/renderer/window-manager/components/WindowContent.tsx).
+ *
+ * Contract: a task-detail window's anchor can fall out of BOTH `tasks` (not on
+ * the live board) and `archivedTasks` (only the newest-N preview is normally
+ * loaded) when OTHER tasks get archived while this window stays open - the
+ * window was opened while its task was still inside the preview, but enough
+ * newer archivals since have pushed it past the preview's newest-N cutoff.
+ * When that happens, `TaskDetailContent`'s effect:
+ *   1. acquires an archive viewer (`archiveViewers += 1`) so board hydration
+ *      keeps holding the full list once it loads,
+ *   2. triggers `loadArchivedTasks()` (the full-archive fetch) if the full
+ *      archive isn't already loaded,
+ *   3. releases the archive viewer the instant the anchor resolves again OR
+ *      the window unmounts - whichever comes first.
+ *
+ * `useWindowAutoCloseOnDone` does NOT interfere here: a window opened directly
+ * on an already-archived task carries `openedDone: true` (set by
+ * useTaskDetailWindowBridge), and that bridge explicitly skips such windows.
+ * So the window under test stays open the whole time, and its content
+ * transitions cleanly resolved -> unresolved -> resolved via the self-heal
+ * effect, never auto-closing.
+ *
+ * Tier: UI (headless Chromium). Entirely renderer-state-driven (Zustand +
+ * React effects); no PTY or real IPC is involved, so this cannot regress via
+ * anything the unit or E2E tiers would catch on their own.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady, collectPageErrors } from './helpers';
+import type { Task } from '../../src/shared/types';
+
+// Each test launches its own browser/page, so the file's tests can fan out
+// across the UI workers safely.
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-deep-archive-self-heal';
+const PREVIEW_LIMIT = 15;
+const TARGET_TASK_ID = 'arch-14';
+const TARGET_TASK_TITLE = 'Deep Archived Task 14';
+const EXTRA_TODO_TASK_ID = 'extra-todo';
+const DONE_LANE_ID = 'lane-das-done';
+const TODO_LANE_ID = 'lane-das-to-do';
+
+async function launchWithFixture(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(`
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+
+      state.projects.push({
+        id: '${PROJECT_ID}',
+        name: 'Deep Archive Self-Heal Test',
+        path: '/mock/deep-archive-self-heal',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        var id = 'lane-das-' + s.name.toLowerCase().replace(/\\s+/g, '-');
+        state.swimlanes.push(Object.assign({}, s, { id: id, position: i, created_at: ts }));
+      });
+
+      // ${PREVIEW_LIMIT} archived tasks, each a minute further in the past.
+      // arch-14 (the last / oldest) sits right at the tail of the preview - the
+      // first one to fall out once a newer task is archived.
+      for (var i = 0; i < ${PREVIEW_LIMIT}; i += 1) {
+        var archivedAt = new Date(Date.now() - (i + 1) * 60000).toISOString();
+        state.archivedTasks.push({
+          id: 'arch-' + i,
+          display_id: i + 1,
+          title: 'Deep Archived Task ' + i,
+          description: 'Archived fixture task ' + i,
+          swimlane_id: '${DONE_LANE_ID}',
+          position: 0,
+          agent: 'claude',
+          session_id: null,
+          worktree_path: null,
+          branch_name: null,
+          pr_number: null,
+          pr_url: null,
+          base_branch: 'main',
+          use_worktree: 0,
+          labels: [],
+          priority: 0,
+          attachment_count: 0,
+          archived_at: archivedAt,
+          created_at: ts,
+          updated_at: ts,
+        });
+      }
+
+      // A live To Do task the test moves to Done to push the tail archived
+      // task (arch-14) out of the newest-15 preview.
+      state.tasks.push({
+        id: '${EXTRA_TODO_TASK_ID}',
+        display_id: 100,
+        title: 'Extra To Do Task',
+        description: '',
+        swimlane_id: '${TODO_LANE_ID}',
+        position: 0,
+        agent: null,
+        session_id: null,
+        worktree_path: null,
+        branch_name: null,
+        pr_number: null,
+        pr_url: null,
+        base_branch: null,
+        archived_at: null,
+        created_at: ts,
+        updated_at: ts,
+      });
+
+      return { currentProjectId: '${PROJECT_ID}' };
+    });
+  `);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  await page.locator('[data-swimlane-name="Done"]').waitFor({ state: 'visible', timeout: 15000 });
+
+  return { browser, page };
+}
+
+/** Open the task-detail window the same way CompletedTasksDialog's "View
+ *  Details" row action does: drive the session store directly rather than
+ *  clicking a card (the target task is never rendered as a board card). */
+async function openDetailWindow(page: Page, taskId: string): Promise<void> {
+  await page.evaluate((detailTaskId) => {
+    const stores = (window as unknown as {
+      __zustandStores?: { session: { getState: () => { setDetailTaskId: (id: string) => void } } };
+    }).__zustandStores;
+    if (!stores?.session) throw new Error('session store not exposed on __zustandStores');
+    stores.session.getState().setDetailTaskId(detailTaskId);
+  }, taskId);
+}
+
+/** Resolve the live window id for a given anchor (taskId), polling until
+ *  useTaskDetailWindowBridge has opened it. */
+async function waitForWindowId(page: Page, anchorTaskId: string): Promise<string> {
+  let resolvedWindowId: string | null = null;
+  await expect.poll(async () => {
+    resolvedWindowId = await page.evaluate((anchorId) => {
+      const stores = (window as unknown as {
+        __zustandStores?: { window: { getState: () => { windows: Record<string, { id: string; anchor: string }> } } };
+      }).__zustandStores;
+      if (!stores?.window) throw new Error('window store not exposed on __zustandStores');
+      const found = Object.values(stores.window.getState().windows).find((candidate) => candidate.anchor === anchorId);
+      return found?.id ?? null;
+    }, anchorTaskId);
+    return resolvedWindowId;
+  }, { timeout: 5000 }).not.toBeNull();
+  return resolvedWindowId as string;
+}
+
+interface BoardArchiveDebugState {
+  archiveViewers: number;
+  archivedFullyLoaded: boolean;
+  archivedTotalCount: number;
+  hasTargetInArchivedTasks: boolean;
+}
+
+async function readBoardArchiveState(page: Page, targetTaskId: string): Promise<BoardArchiveDebugState> {
+  return page.evaluate((taskId) => {
+    const stores = (window as unknown as {
+      __zustandStores?: {
+        board: {
+          getState: () => {
+            archiveViewers: number;
+            archivedFullyLoaded: boolean;
+            archivedTotalCount: number;
+            archivedTasks: Array<{ id: string }>;
+          };
+        };
+      };
+    }).__zustandStores;
+    if (!stores?.board) throw new Error('board store not exposed on __zustandStores');
+    const state = stores.board.getState();
+    return {
+      archiveViewers: state.archiveViewers,
+      archivedFullyLoaded: state.archivedFullyLoaded,
+      archivedTotalCount: state.archivedTotalCount,
+      hasTargetInArchivedTasks: state.archivedTasks.some((candidate) => candidate.id === taskId),
+    };
+  }, targetTaskId);
+}
+
+/** Replace tasks.listArchived with a version the test controls: the returned
+ *  promise never settles until window.__releaseDeferredListArchived() runs,
+ *  at which point it resolves with the ORIGINAL (real) full archive. Lets the
+ *  test observe the "unresolved, fetch in flight" window deterministically
+ *  instead of racing the mock's normally-instant resolution. */
+async function installDeferredListArchived(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const original = window.electronAPI.tasks.listArchived;
+    let release: (() => void) | null = null;
+    (window as unknown as { __releaseDeferredListArchived?: () => void }).__releaseDeferredListArchived = () => release?.();
+    window.electronAPI.tasks.listArchived = (): Promise<Task[]> => new Promise<Task[]>((resolve) => {
+      release = () => { void original().then(resolve); };
+    });
+  });
+}
+
+async function releaseDeferredListArchived(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as unknown as { __releaseDeferredListArchived?: () => void }).__releaseDeferredListArchived?.();
+  });
+}
+
+/** Move the extra To Do task into Done, archiving it as the newest entry and
+ *  pushing arch-14 (the prior oldest-of-15) out of the newest-15 preview -
+ *  through the real `moveTask` store action, the same path a drag-to-Done
+ *  takes. */
+async function triggerFallout(page: Page): Promise<void> {
+  await page.evaluate(
+    async ({ taskId, targetSwimlaneId }) => {
+      const stores = (window as unknown as {
+        __zustandStores?: {
+          board: {
+            getState: () => {
+              moveTask: (
+                input: { taskId: string; targetSwimlaneId: string; targetPosition: number },
+                skipConfirmation?: boolean,
+              ) => Promise<{ ok: boolean }>;
+            };
+          };
+        };
+      }).__zustandStores;
+      if (!stores?.board) throw new Error('board store not exposed on __zustandStores');
+      await stores.board.getState().moveTask({ taskId, targetSwimlaneId, targetPosition: 0 }, true);
+    },
+    { taskId: EXTRA_TODO_TASK_ID, targetSwimlaneId: DONE_LANE_ID },
+  );
+}
+
+test.describe('WindowContent deep-archive self-heal', () => {
+  test('resolves via the full archive once the anchor falls out of the preview, and releases the archive viewer on resolve', async () => {
+    const { browser, page } = await launchWithFixture();
+    const getPageErrors = collectPageErrors(page);
+    try {
+      await openDetailWindow(page, TARGET_TASK_ID);
+      const windowId = await waitForWindowId(page, TARGET_TASK_ID);
+      const frame = page.locator(`[data-testid="window-frame-${windowId}"]`);
+
+      // Sanity: the window opens resolved (arch-14 is still in the initial
+      // preview) and holds no archive viewer yet.
+      await frame.locator('[data-testid="task-detail-dialog"]').waitFor({ state: 'visible', timeout: 5000 });
+      await expect(frame.locator('[data-testid="task-title-text"]')).toHaveText(TARGET_TASK_TITLE);
+      expect((await readBoardArchiveState(page, TARGET_TASK_ID)).archiveViewers).toBe(0);
+
+      // Hold the self-heal's fetch open so the unresolved window is observable.
+      await installDeferredListArchived(page);
+
+      // Archive a 16th, newer task - arch-14 now falls out of the newest-15
+      // preview on the reconcile that follows.
+      await triggerFallout(page);
+
+      // The window is still open (openedDone skips it in useWindowAutoCloseOnDone),
+      // but its anchor no longer resolves: the placeholder shows, and the
+      // self-heal effect has acquired an archive viewer and is fetching.
+      await expect(frame.getByText('This task is no longer available.')).toBeVisible({ timeout: 5000 });
+      await expect
+        .poll(async () => (await readBoardArchiveState(page, TARGET_TASK_ID)).archiveViewers, { timeout: 5000 })
+        .toBe(1);
+
+      // Let the fetch resolve with the real (full) archive.
+      await releaseDeferredListArchived(page);
+
+      // The window resolves again, showing the same task; the viewer is
+      // released the instant the anchor resolves - the window stays open the
+      // whole time, but archiveViewers drops back to 0 without it closing.
+      await frame.locator('[data-testid="task-detail-dialog"]').waitFor({ state: 'visible', timeout: 5000 });
+      await expect(frame.locator('[data-testid="task-title-text"]')).toHaveText(TARGET_TASK_TITLE);
+      await expect
+        .poll(async () => (await readBoardArchiveState(page, TARGET_TASK_ID)).archiveViewers, { timeout: 5000 })
+        .toBe(0);
+
+      const finalState = await readBoardArchiveState(page, TARGET_TASK_ID);
+      expect(finalState.archivedFullyLoaded).toBe(true);
+      expect(finalState.hasTargetInArchivedTasks).toBe(true);
+      expect(finalState.archivedTotalCount).toBe(PREVIEW_LIMIT + 1);
+
+      expect(getPageErrors()).toHaveLength(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('releases the archive viewer on unmount when the window closes before the self-heal resolves', async () => {
+    const { browser, page } = await launchWithFixture();
+    try {
+      await openDetailWindow(page, TARGET_TASK_ID);
+      const windowId = await waitForWindowId(page, TARGET_TASK_ID);
+      const frame = page.locator(`[data-testid="window-frame-${windowId}"]`);
+      await frame.locator('[data-testid="task-detail-dialog"]').waitFor({ state: 'visible', timeout: 5000 });
+
+      // Hold the self-heal fetch open and never release it - the window must
+      // close cleanly (releasing the viewer) without waiting on the fetch.
+      await installDeferredListArchived(page);
+      await triggerFallout(page);
+
+      await expect
+        .poll(async () => (await readBoardArchiveState(page, TARGET_TASK_ID)).archiveViewers, { timeout: 5000 })
+        .toBe(1);
+      await expect(frame.getByText('This task is no longer available.')).toBeVisible({ timeout: 5000 });
+
+      // Close the window directly (mirrors Ctrl+Shift+W / the title bar close)
+      // while the fetch is still in flight and unresolved.
+      await page.evaluate((targetWindowId) => {
+        const stores = (window as unknown as {
+          __zustandStores?: { window: { getState: () => { closeWindow: (id: string) => void } } };
+        }).__zustandStores;
+        if (!stores?.window) throw new Error('window store not exposed on __zustandStores');
+        stores.window.getState().closeWindow(targetWindowId);
+      }, windowId);
+
+      await expect(frame).toBeHidden({ timeout: 5000 });
+      await expect
+        .poll(async () => (await readBoardArchiveState(page, TARGET_TASK_ID)).archiveViewers, { timeout: 5000 })
+        .toBe(0);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/unit/archived-tasks-slice.test.ts
+++ b/tests/unit/archived-tasks-slice.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Unit tests for the archived-tasks-slice Zustand slice
+ * (`src/renderer/stores/board-store/archived-tasks-slice.ts`).
+ *
+ * Two behaviors are pinned here:
+ *
+ *  A. `archivedTotalCount` accounting. It is the authoritative archived
+ *     count, threaded through every mutation with a "decrement only when the
+ *     row was actually held in the loaded `archivedTasks` array" guard - a
+ *     preview that holds only the newest-N must not skew the count when an
+ *     id it never held is removed. Covers `archiveTask`, `deleteArchivedTask`
+ *     (held vs. preview-miss), `bulkDeleteArchivedTasks`,
+ *     `bulkUnarchiveTasks`, and the IPC-failure rollback path.
+ *
+ *  B. `loadArchivedTasks` project-switch guard. It captures the current
+ *     project id at start and drops a result that resolves after a project
+ *     switch, so project A's archive fetch can never overwrite project B's
+ *     `archivedTasks` / `archivedTotalCount` or latch `archivedFullyLoaded`
+ *     true for B.
+ *
+ * The slice is a Zustand `StateCreator` - a plain function of (set, get,
+ * api). We drive it directly via a minimal in-memory harness (the same
+ * pattern used by `board-manager-slice.test.ts` and
+ * `task-changes-panel-slice.test.ts`), so no real board store, Electron, or
+ * DOM is required. `useProjectStore` / `useToastStore` / `useSessionStore`
+ * are mocked via `vi.mock` (the slice imports them directly for the
+ * project-id stamp, toast surfacing, and session cleanup side effects).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Task, Swimlane } from '../../src/shared/types';
+
+// ---------------------------------------------------------------------------
+// Hoisted store mocks - vi.mock factories below run before this file's other
+// top-level statements, so mutable mock state must be created via vi.hoisted.
+// ---------------------------------------------------------------------------
+
+const storeMocks = vi.hoisted(() => ({
+  useProjectStore: { getState: vi.fn() },
+  useToastStore: { getState: vi.fn() },
+  useSessionStore: { getState: vi.fn(), setState: vi.fn() },
+}));
+
+vi.mock('../../src/renderer/stores/project-store', () => ({ useProjectStore: storeMocks.useProjectStore }));
+vi.mock('../../src/renderer/stores/toast-store', () => ({ useToastStore: storeMocks.useToastStore }));
+vi.mock('../../src/renderer/stores/session-store', () => ({ useSessionStore: storeMocks.useSessionStore }));
+
+const { useProjectStore, useToastStore, useSessionStore } = storeMocks;
+
+// window.electronAPI stub. vitest's default (node) environment has no
+// `window`, so we attach it to globalThis before importing the slice -
+// mirrors the pattern in `session-store-cache-reconcile.test.ts`.
+const tasksApi = {
+  delete: vi.fn(),
+  bulkDelete: vi.fn(),
+  bulkUnarchive: vi.fn(),
+  list: vi.fn(),
+  listArchived: vi.fn(),
+  onBulkDeleteProgress: vi.fn(),
+};
+
+(globalThis as Record<string, unknown>).window = {
+  electronAPI: { tasks: tasksApi },
+};
+
+// Imported after the mocks/stub so the slice module resolves the mocked
+// stores and the stubbed window.
+import { createArchivedTasksSlice } from '../../src/renderer/stores/board-store/archived-tasks-slice';
+import type { ArchivedTasksSlice } from '../../src/renderer/stores/board-store/archived-tasks-slice';
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+function makeTask(overrides: Partial<Task> & Pick<Task, 'id'>): Task {
+  return {
+    display_id: 1,
+    title: 'A task',
+    description: '',
+    swimlane_id: 'swim-1',
+    position: 0,
+    agent: null,
+    session_id: null,
+    worktree_path: null,
+    branch_name: null,
+    pr_number: null,
+    pr_url: null,
+    pr_state: null,
+    head_sha: null,
+    external_id: null,
+    external_source: null,
+    external_url: null,
+    base_branch: null,
+    use_worktree: null,
+    labels: [],
+    priority: 0,
+    model_override: null,
+    effort_override: null,
+    agent_override: null,
+    attachment_count: 0,
+    detail_view_state: null,
+    archived_at: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Slice harness - constructs the slice with a closure-backed set/get, plus
+// the sibling `tasks` / `swimlanes` fields the slice reads via `get()` from
+// other board-store slices in the real app.
+// ---------------------------------------------------------------------------
+
+type HarnessState = ArchivedTasksSlice & { tasks: Task[]; swimlanes: Swimlane[] };
+
+function buildHarness(initial: Partial<HarnessState> = {}): {
+  getState: () => HarnessState;
+  setState: (partial: Partial<HarnessState> | ((state: HarnessState) => Partial<HarnessState>)) => void;
+} {
+  let state: HarnessState;
+
+  const set = (
+    updater: Partial<HarnessState> | ((state: HarnessState) => Partial<HarnessState>),
+  ) => {
+    const patch = typeof updater === 'function' ? updater(state) : updater;
+    state = { ...state, ...patch };
+  };
+
+  const get = () => state;
+
+  // StateCreator signature: (set, get, api). Only set/get are exercised by
+  // the tests below, so the api position is stubbed.
+  const slice = createArchivedTasksSlice(set as never, get as never, {} as never);
+
+  state = {
+    tasks: [],
+    swimlanes: [],
+    ...slice,
+    ...initial,
+  };
+
+  return { getState: get, setState: set };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  tasksApi.onBulkDeleteProgress.mockImplementation(() => () => {});
+  useToastStore.getState.mockReturnValue({ addToast: vi.fn() });
+  useSessionStore.getState.mockReturnValue({ setSpawnProgress: vi.fn() });
+  useSessionStore.setState.mockImplementation(() => {});
+  useProjectStore.getState.mockReturnValue({ currentProject: null });
+});
+
+// ---------------------------------------------------------------------------
+// A. archivedTotalCount accounting
+// ---------------------------------------------------------------------------
+
+describe('archiveTask', () => {
+  it('moves the task from tasks to the front of archivedTasks and increments archivedTotalCount by 1', () => {
+    const movingTask = makeTask({ id: 'moving' });
+    const existingArchived = makeTask({ id: 'already-archived' });
+    const { getState } = buildHarness({
+      tasks: [movingTask],
+      archivedTasks: [existingArchived],
+      archivedTotalCount: 1,
+    });
+
+    getState().archiveTask('moving');
+
+    const state = getState();
+    expect(state.tasks.find((t) => t.id === 'moving')).toBeUndefined();
+    expect(state.archivedTasks).toHaveLength(2);
+    // Prepended - the newly archived task is the newest, so it sits at the front.
+    expect(state.archivedTasks[0].id).toBe('moving');
+    expect(state.archivedTasks[0].archived_at).not.toBeNull();
+    expect(state.archivedTasks[1]).toBe(existingArchived);
+    expect(state.archivedTotalCount).toBe(2);
+  });
+
+  it('is a no-op when the id is not found in tasks (does not touch archivedTotalCount)', () => {
+    const { getState } = buildHarness({
+      tasks: [],
+      archivedTasks: [],
+      archivedTotalCount: 4,
+    });
+
+    getState().archiveTask('missing-id');
+
+    expect(getState().archivedTotalCount).toBe(4);
+  });
+});
+
+describe('deleteArchivedTask', () => {
+  it('decrements archivedTotalCount when the id IS held in archivedTasks', async () => {
+    tasksApi.delete.mockResolvedValueOnce(undefined);
+    const held = makeTask({ id: 'held' });
+    const { getState } = buildHarness({
+      archivedTasks: [held],
+      archivedTotalCount: 3,
+    });
+
+    await getState().deleteArchivedTask('held');
+
+    const state = getState();
+    expect(state.archivedTasks).toEqual([]);
+    expect(state.archivedTotalCount).toBe(2);
+  });
+
+  it('leaves archivedTotalCount UNCHANGED when the id is a preview miss (not in archivedTasks)', async () => {
+    tasksApi.delete.mockResolvedValueOnce(undefined);
+    const { getState } = buildHarness({
+      archivedTasks: [],
+      archivedTotalCount: 5,
+    });
+
+    await getState().deleteArchivedTask('not-previewed');
+
+    const state = getState();
+    expect(state.archivedTasks).toEqual([]);
+    // A preview miss must not skew the authoritative count.
+    expect(state.archivedTotalCount).toBe(5);
+  });
+
+  it('rolls back the optimistic removal and restores archivedTotalCount on IPC failure', async () => {
+    tasksApi.delete.mockRejectedValueOnce(new Error('delete failed'));
+    const held = makeTask({ id: 'held' });
+    const { getState } = buildHarness({
+      archivedTasks: [held],
+      archivedTotalCount: 7,
+    });
+
+    await getState().deleteArchivedTask('held');
+
+    const state = getState();
+    expect(state.archivedTasks).toEqual([held]);
+    expect(state.archivedTotalCount).toBe(7);
+  });
+});
+
+describe('bulkDeleteArchivedTasks', () => {
+  it('decrements archivedTotalCount by the number of ids ACTUALLY present in archivedTasks, not ids.length', async () => {
+    tasksApi.bulkDelete.mockResolvedValueOnce({ deleted: 2, failures: [] });
+    const held1 = makeTask({ id: 'held-1' });
+    const held2 = makeTask({ id: 'held-2' });
+    const { getState } = buildHarness({
+      archivedTasks: [held1, held2],
+      // Total includes tasks beyond what the (preview) archivedTasks array holds.
+      archivedTotalCount: 5,
+    });
+
+    // Third id is a preview miss - present on the backend's full archive but
+    // never held in this loaded archivedTasks array.
+    await getState().bulkDeleteArchivedTasks(['held-1', 'held-2', 'preview-miss']);
+
+    const state = getState();
+    expect(state.archivedTasks).toEqual([]);
+    // Decrement by 2 (rows actually held), NOT by ids.length (3): 5 - 2 = 3.
+    expect(state.archivedTotalCount).toBe(3);
+  });
+
+  it('rolls back the optimistic removal and restores archivedTotalCount on IPC failure', async () => {
+    tasksApi.bulkDelete.mockRejectedValueOnce(new Error('bulk delete failed'));
+    const held = makeTask({ id: 'held' });
+    const { getState } = buildHarness({
+      archivedTasks: [held],
+      archivedTotalCount: 9,
+    });
+
+    await getState().bulkDeleteArchivedTasks(['held']);
+
+    const state = getState();
+    expect(state.archivedTasks).toEqual([held]);
+    expect(state.archivedTotalCount).toBe(9);
+  });
+});
+
+describe('bulkUnarchiveTasks', () => {
+  it('decrements archivedTotalCount by the number of ids ACTUALLY present in archivedTasks, not ids.length', async () => {
+    tasksApi.bulkUnarchive.mockResolvedValueOnce(undefined);
+    tasksApi.list.mockResolvedValueOnce([]);
+    const held = makeTask({ id: 'held-1' });
+    const { getState } = buildHarness({
+      archivedTasks: [held],
+      archivedTotalCount: 4,
+      swimlanes: [],
+    });
+
+    await getState().bulkUnarchiveTasks(['held-1', 'preview-miss'], 'lane-todo');
+
+    const state = getState();
+    expect(state.archivedTasks).toEqual([]);
+    // Only 1 of the 2 ids was actually held: 4 - 1 = 3, not 4 - 2 = 2.
+    expect(state.archivedTotalCount).toBe(3);
+  });
+
+  it('rolls back the optimistic removal and restores archivedTotalCount on IPC failure', async () => {
+    tasksApi.bulkUnarchive.mockRejectedValueOnce(new Error('bulk unarchive failed'));
+    const held = makeTask({ id: 'held' });
+    const { getState } = buildHarness({
+      tasks: [],
+      archivedTasks: [held],
+      archivedTotalCount: 6,
+      swimlanes: [],
+      // loadBoard is called in the catch branch; stub it directly on state
+      // since it belongs to a sibling slice not under test here.
+      loadBoard: vi.fn(async () => {}),
+    } as never);
+
+    await getState().bulkUnarchiveTasks(['held'], 'lane-todo');
+
+    const state = getState();
+    expect(state.archivedTasks).toEqual([held]);
+    expect(state.archivedTotalCount).toBe(6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B. loadArchivedTasks project-switch guard
+// ---------------------------------------------------------------------------
+
+describe('loadArchivedTasks - project-switch guard', () => {
+  it('drops a result that resolves AFTER a project switch (does not overwrite archivedTasks or latch archivedFullyLoaded)', async () => {
+    useProjectStore.getState.mockReturnValue({ currentProject: { id: 'project-a' } });
+
+    let resolveFetch: (tasks: Task[]) => void = () => {};
+    tasksApi.listArchived.mockReturnValueOnce(
+      new Promise<Task[]>((resolve) => { resolveFetch = resolve; }),
+    );
+
+    const { getState } = buildHarness({
+      archivedTasks: [],
+      archivedTotalCount: 0,
+      archivedFullyLoaded: false,
+    });
+
+    const loadPromise = getState().loadArchivedTasks();
+
+    // The user switches to project B while project A's fetch is still in flight.
+    useProjectStore.getState.mockReturnValue({ currentProject: { id: 'project-b' } });
+
+    // Project A's fetch resolves now - AFTER the switch.
+    resolveFetch([makeTask({ id: 'project-a-task' })]);
+    await loadPromise;
+
+    const state = getState();
+    expect(state.archivedTasks).toEqual([]);
+    expect(state.archivedTotalCount).toBe(0);
+    expect(state.archivedFullyLoaded).toBe(false);
+  });
+
+  it('applies the result when the project has NOT switched (contrast case)', async () => {
+    useProjectStore.getState.mockReturnValue({ currentProject: { id: 'project-a' } });
+
+    const fetchedTasks = [makeTask({ id: 'project-a-task' })];
+    tasksApi.listArchived.mockResolvedValueOnce(fetchedTasks);
+
+    const { getState } = buildHarness({
+      archivedTasks: [],
+      archivedTotalCount: 0,
+      archivedFullyLoaded: false,
+    });
+
+    await getState().loadArchivedTasks();
+
+    const state = getState();
+    expect(state.archivedTasks).toEqual(fetchedTasks);
+    expect(state.archivedTotalCount).toBe(1);
+    expect(state.archivedFullyLoaded).toBe(true);
+  });
+});

--- a/tests/unit/bg-shell-watcher.test.ts
+++ b/tests/unit/bg-shell-watcher.test.ts
@@ -4,7 +4,14 @@
  * spawning real children.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { BgShellWatcher, NAMED_SHELL_QUIESCENT_RECLAIM_CYCLES, type BgShellWatcherCallbacks, type OutputFileSample } from '../../src/main/activity-engine/background-shell/watcher';
+import {
+  BgShellWatcher,
+  NAMED_SHELL_QUIESCENT_RECLAIM_CYCLES,
+  POLL_BACKOFF_STAGE_ONE_TREE_CYCLES,
+  POLL_BACKOFF_STAGE_TWO_TREE_CYCLES,
+  type BgShellWatcherCallbacks,
+  type OutputFileSample,
+} from '../../src/main/activity-engine/background-shell/watcher';
 import type { ProcessInfo, ProcessTreeProbe } from '../../src/main/activity-engine/background-shell/process-tree';
 
 class MockProcessTreeProbe implements ProcessTreeProbe {
@@ -2453,6 +2460,131 @@ describe('BgShellWatcher', () => {
       watcher.registerSession('s1');
       watcher.dispose();
       await expect(watcher.pollNow()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('adaptive poll backoff', () => {
+    // A "needy" session keeps `sessionNeedsTree` true every cycle (via a pending
+    // tool), with an empty tree so no shell-count deficit machinery engages.
+    function makeNeedySession(pollIntervalMs = 100) {
+      const harness = makeWatcher({ pollIntervalMs });
+      const { watcher, probe, rootPids, pendingTools } = harness;
+      rootPids.set('s1', 2000);
+      probe.alive.add(2000);
+      probe.trees.set(2000, []); // no shell-like descendants -> no deficit
+      pendingTools.set('s1', 1); // keeps the session needy every cycle
+      watcher.registerSession('s1');
+      return harness;
+    }
+
+    it('stretches the interval to 2x after stage-one consecutive tree cycles', async () => {
+      expect(POLL_BACKOFF_STAGE_ONE_TREE_CYCLES).toBe(5);
+      const { watcher, probe } = makeNeedySession();
+      probe.listAllCalls = 0;
+
+      // Five needy cycles at the 100ms base.
+      await vi.advanceTimersByTimeAsync(5 * 100);
+      expect(probe.listAllCalls).toBe(5);
+
+      // Now stretched to 2x (200ms): a single 100ms advance produces nothing...
+      await vi.advanceTimersByTimeAsync(100);
+      expect(probe.listAllCalls).toBe(5);
+      // ...but a further 100ms (200 total since the last cycle) fires one.
+      await vi.advanceTimersByTimeAsync(100);
+      expect(probe.listAllCalls).toBe(6);
+      watcher.dispose();
+    });
+
+    it('caps the interval at 3x after stage-two consecutive tree cycles', async () => {
+      expect(POLL_BACKOFF_STAGE_TWO_TREE_CYCLES).toBe(15);
+      const { watcher, probe } = makeNeedySession();
+      probe.listAllCalls = 0;
+
+      // Cycles 1-5 at 100ms (t=100..500), 5-15 at 200ms (t=500..2500). By
+      // t=2500 exactly 15 cycles have run; the next is armed at t=2800 (3x).
+      await vi.advanceTimersByTimeAsync(2500);
+      expect(probe.listAllCalls).toBe(15);
+
+      // At 3x spacing (300ms), a 200ms advance yields nothing...
+      await vi.advanceTimersByTimeAsync(200);
+      expect(probe.listAllCalls).toBe(15);
+      // ...and the next 100ms (300 total) yields exactly one.
+      await vi.advanceTimersByTimeAsync(100);
+      expect(probe.listAllCalls).toBe(16);
+      watcher.dispose();
+    });
+
+    it('resets to the base cadence when a deficit is observed, and natural exit still fires', async () => {
+      const harness = makeWatcher({ pollIntervalMs: 100 });
+      const { watcher, probe, rootPids, shellCounts, log } = harness;
+      rootPids.set('s1', 1234);
+      probe.alive.add(1234);
+      probe.trees.set(1234, [
+        { pid: 5001, ppid: 1234, comm: 'bash' },
+        { pid: 5002, ppid: 1234, comm: 'sh' },
+      ]);
+      shellCounts.set('s1', 2); // needy every cycle; baseline anchors at 2
+      watcher.registerSession('s1');
+
+      // Reach the stretched (2x) state with a stable tree (no deficit).
+      await vi.advanceTimersByTimeAsync(5 * 100);
+      expect(probe.listAllCalls).toBeGreaterThanOrEqual(5);
+      expect(log.naturalExits).toHaveLength(0);
+
+      // One shell exits -> the next cycle observes a deficit.
+      probe.trees.set(1234, [{ pid: 5001, ppid: 1234, comm: 'bash' }]);
+
+      // Next cycle is armed at 2x (200ms): it observes deficit #1 and snaps the
+      // cadence back to base.
+      await vi.advanceTimersByTimeAsync(200);
+      expect(log.naturalExits).toHaveLength(0); // needs 2 deficit cycles
+
+      // Base cadence restored: a single 100ms advance fires deficit cycle #2,
+      // which reports the natural exit. If the reset had NOT happened the next
+      // cycle would still be 200ms out and this would fire nothing.
+      await vi.advanceTimersByTimeAsync(100);
+      expect(log.naturalExits).toEqual([{ sessionId: 's1', exitedCount: 1 }]);
+      watcher.dispose();
+    });
+
+    it('re-arms at base cadence when a new background shell is noted while stretched', async () => {
+      const { watcher, probe } = makeNeedySession();
+      probe.listAllCalls = 0;
+
+      // Reach the stretched (2x) state; next cycle would be armed 200ms out.
+      await vi.advanceTimersByTimeAsync(5 * 100);
+      expect(probe.listAllCalls).toBe(5);
+
+      // A new bg shell is a transition: it re-arms the timer at the base delay.
+      watcher.noteBackgroundShellStarted('s1', 'shell-a');
+
+      // A single 100ms advance now fires a cycle (base), not the stretched 200ms.
+      await vi.advanceTimersByTimeAsync(100);
+      expect(probe.listAllCalls).toBe(6);
+      watcher.dispose();
+    });
+
+    it('does not accrue backoff across cheap skip cycles', async () => {
+      // A session with no needy signal after its baseline anchors: cycle 1 is
+      // needy (to anchor), every cycle after is a cheap skip.
+      const harness = makeWatcher({ pollIntervalMs: 100 });
+      const { watcher, probe, rootPids, pendingTools } = harness;
+      rootPids.set('s1', 3000);
+      probe.alive.add(3000);
+      probe.trees.set(3000, []); // no shell-like descendants
+      watcher.registerSession('s1');
+
+      // Run many cycles: cycle 1 anchors (one listAllProcesses), the rest skip.
+      await vi.advanceTimersByTimeAsync(1000);
+      const callsAfterSkips = probe.listAllCalls;
+      expect(callsAfterSkips).toBe(1); // only the anchoring cycle enumerated
+
+      // Now make it needy. If skip cycles had accrued backoff we would already
+      // be stretched; instead the next five needy cycles run at the 100ms base.
+      pendingTools.set('s1', 1);
+      await vi.advanceTimersByTimeAsync(5 * 100);
+      expect(probe.listAllCalls).toBe(callsAfterSkips + 5);
+      watcher.dispose();
     });
   });
 });

--- a/tests/unit/devtools-lag-recorder.test.ts
+++ b/tests/unit/devtools-lag-recorder.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the renderer lag recorder's background-throttle classification
+ * (`src/devtools/renderer/lag-recorder.ts`).
+ *
+ * While the window is hidden, Chromium throttles the 100ms sampler to >=1s, so
+ * every hidden sample reads as a ~900ms "spike". These must be routed to the
+ * hidden counters instead of the real-freeze ring so background throttling does
+ * not pollute freeze diagnosis. The sampler's lag is derived from
+ * `performance.now()`, which the test controls to simulate spikes deterministically.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const docStub = { hidden: false };
+let nowValue = 0;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.resetModules();
+  nowValue = 0;
+  docStub.hidden = false;
+  vi.stubGlobal('document', docStub);
+  vi.spyOn(performance, 'now').mockImplementation(() => nowValue);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function loadRecorder() {
+  return import('../../src/devtools/renderer/lag-recorder');
+}
+
+/** Advance `performance.now` by (100ms interval + extraLagMs) then fire one tick. */
+function tick(extraLagMs: number): void {
+  nowValue += 100 + extraLagMs;
+  vi.advanceTimersByTime(100);
+}
+
+describe('renderer lag recorder - background throttle classification', () => {
+  it('records a visible spike in the ring and the visible counters', async () => {
+    const recorder = await loadRecorder();
+    recorder.startRendererLagRecorder();
+
+    tick(200); // visible, lag 200 >= 75 threshold
+
+    const report = recorder.getRendererLagReport();
+    expect(report.spikeCount).toBe(1);
+    expect(report.recentSpikes).toHaveLength(1);
+    expect(report.hiddenSpikeCount).toBe(0);
+    recorder.stopRendererLagRecorder();
+  });
+
+  it('routes a hidden-window spike to the hidden counters, not the ring', async () => {
+    const recorder = await loadRecorder();
+    recorder.startRendererLagRecorder();
+
+    docStub.hidden = true;
+    tick(900); // throttled ~900ms artifact
+
+    const report = recorder.getRendererLagReport();
+    expect(report.hiddenSpikeCount).toBe(1);
+    expect(report.maxHiddenLagMs).toBeGreaterThanOrEqual(900);
+    expect(report.spikeCount).toBe(0);
+    expect(report.recentSpikes).toHaveLength(0);
+    recorder.stopRendererLagRecorder();
+  });
+
+  it('classifies the first sample after foregrounding as a throttle artifact', async () => {
+    const recorder = await loadRecorder();
+    recorder.startRendererLagRecorder();
+
+    docStub.hidden = true;
+    tick(900); // hidden artifact -> hiddenSpikeCount 1
+
+    // Foreground again: the first visible sample still carries the throttle
+    // backlog, so it must be classified as an artifact (via lastSampleHidden).
+    docStub.hidden = false;
+    tick(500);
+
+    const report = recorder.getRendererLagReport();
+    expect(report.hiddenSpikeCount).toBe(2);
+    expect(report.spikeCount).toBe(0);
+    recorder.stopRendererLagRecorder();
+  });
+
+  it('mirrors document.hidden into the report', async () => {
+    const recorder = await loadRecorder();
+    recorder.startRendererLagRecorder();
+
+    expect(recorder.getRendererLagReport().documentHidden).toBe(false);
+    docStub.hidden = true;
+    expect(recorder.getRendererLagReport().documentHidden).toBe(true);
+    recorder.stopRendererLagRecorder();
+  });
+});

--- a/tests/unit/diagnostics-async-file-queue.test.ts
+++ b/tests/unit/diagnostics-async-file-queue.test.ts
@@ -300,6 +300,21 @@ describe('async-file-queue: queueAppendWithRotation', () => {
     expect(readRaw(filePath)).toBe('fresh\n');
     expect(fs.existsSync(filePath + '.1')).toBe(false);
   });
+
+  it('seeds the rotation counter from the on-disk size so a restart cannot grow an over-cap primary', async () => {
+    const filePath = path.join(tempDirectory, 'rot.jsonl');
+    const cap = 16;
+    // A primary left on disk by a prior process, already over the cap. The
+    // in-memory counter is empty this "process"; without seeding it would start
+    // at 0 and let the primary keep growing far past the cap before rotating.
+    fs.writeFileSync(filePath, 'x'.repeat(20) + '\n'); // 21 bytes > 16
+    // First rotating append: seeding the counter from the 21-byte on-disk size
+    // forces a rotation right away (21 + 6 > 16).
+    queueAppendWithRotation(filePath, 'fresh\n', cap);
+    await flushAllForTest();
+    expect(readRaw(filePath)).toBe('fresh\n');
+    expect(readRaw(filePath + '.1')).toBe('x'.repeat(20) + '\n');
+  });
 });
 
 describe('async-file-queue: resetForTest', () => {

--- a/tests/unit/diagnostics-ipc-recorder.test.ts
+++ b/tests/unit/diagnostics-ipc-recorder.test.ts
@@ -180,6 +180,106 @@ describe('ipc-recorder', () => {
     expect(entry.error).toEqual({ name: 'Error', message: 'database locked' });
     expect(entry.result).toBeUndefined();
   });
+
+  it('truncates an oversized safe-channel result to a marker, leaving small args intact', async () => {
+    const { installIpcRecorder } = await import('../../src/main/diagnostics/ipc-recorder');
+    const { ipcMain } = await import('electron');
+    installIpcRecorder({ getProjectRoot: () => tempDirectory, enabled: () => true });
+
+    const huge = 'x'.repeat(40_000); // JSON well over the 32KB cap
+    ipcMain.handle('project:list', async (_event: unknown, _arg: string) => [huge]);
+    await registeredHandler!({}, 'small-arg');
+
+    const entries = await readJsonlEntries('project:list');
+    expect(entries).toHaveLength(1);
+    const entry = entries[0] as {
+      args: unknown;
+      result: { truncated: boolean; serializedChars: number; preview: string };
+    };
+    // Small args pass through unchanged.
+    expect(entry.args).toEqual(['small-arg']);
+    // The oversized result is replaced with a compact marker; the line still
+    // parsed as valid JSON (readJsonlEntries did the JSON.parse).
+    expect(entry.result.truncated).toBe(true);
+    expect(entry.result.serializedChars).toBeGreaterThan(32 * 1024);
+    expect(entry.result.preview).toHaveLength(2 * 1024);
+  });
+
+  it('truncates oversized args independently of a small result', async () => {
+    const { installIpcRecorder } = await import('../../src/main/diagnostics/ipc-recorder');
+    const { ipcMain } = await import('electron');
+    installIpcRecorder({ getProjectRoot: () => tempDirectory, enabled: () => true });
+
+    ipcMain.handle('project:list', async () => ['ok']);
+    await registeredHandler!({}, 'y'.repeat(40_000));
+
+    const entries = await readJsonlEntries('project:list');
+    const entry = entries[0] as {
+      args: { truncated: boolean; serializedChars: number };
+      result: unknown;
+    };
+    expect(entry.args.truncated).toBe(true);
+    expect(entry.args.serializedChars).toBeGreaterThan(32 * 1024);
+    // The small result is untouched.
+    expect(entry.result).toEqual(['ok']);
+  });
+
+  it('rotates the daily log to <file>.1 when it exceeds the configured cap, keeping whole JSON lines', async () => {
+    const { installIpcRecorder } = await import('../../src/main/diagnostics/ipc-recorder');
+    const { ipcMain } = await import('electron');
+    const { flushAllForTest } = await import('../../src/main/diagnostics/async-file-queue');
+    // Tiny cap so a handful of entries forces a rotation.
+    installIpcRecorder({ getProjectRoot: () => tempDirectory, enabled: () => true, maxLogFileBytes: 256 });
+
+    ipcMain.handle('project:list', async () => ['project-a']);
+    for (let index = 0; index < 12; index += 1) {
+      await registeredHandler!({});
+      await flushAllForTest(); // separate flush batches so rotation can trigger between them
+    }
+
+    const today = new Date().toISOString().slice(0, 10);
+    const directory = path.join(tempDirectory, '.kangentic', 'logs');
+    const primary = path.join(directory, `ipc-${today}.jsonl`);
+    const rotated = `${primary}.1`;
+    expect(fs.existsSync(rotated)).toBe(true);
+
+    // Every non-empty line in both files must be complete, valid JSON.
+    for (const file of [rotated, primary]) {
+      const lines = fs.readFileSync(file, 'utf-8').split(/\r?\n/).filter((line) => line.trim().length > 0);
+      for (const line of lines) {
+        expect(() => JSON.parse(line)).not.toThrow();
+      }
+    }
+  });
+
+  it('prunes ipc log files older than the retention window, sparing recent and non-ipc files', async () => {
+    const { installIpcRecorder, __INTERNAL } = await import('../../src/main/diagnostics/ipc-recorder');
+    const { ipcMain } = await import('electron');
+    const directory = path.join(tempDirectory, '.kangentic', 'logs');
+    fs.mkdirSync(directory, { recursive: true });
+
+    const ancientPrimary = path.join(directory, 'ipc-2020-01-01.jsonl');
+    const ancientRotated = path.join(directory, 'ipc-2020-01-01.jsonl.1');
+    const recentDate = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const recentPrimary = path.join(directory, `ipc-${recentDate}.jsonl`);
+    const logMirror = path.join(directory, '2020-01-01.log'); // not an ipc file
+    fs.writeFileSync(ancientPrimary, '{}\n');
+    fs.writeFileSync(ancientRotated, '{}\n');
+    fs.writeFileSync(recentPrimary, '{}\n');
+    fs.writeFileSync(logMirror, 'stale\n');
+
+    installIpcRecorder({ getProjectRoot: () => tempDirectory, enabled: () => true });
+    ipcMain.handle('project:list', async () => ['project-a']);
+    await registeredHandler!({}); // triggers the one-shot prune
+    await __INTERNAL.awaitPendingPruneForTest();
+
+    // Ancient ipc files (primary + rotated) are gone.
+    expect(fs.existsSync(ancientPrimary)).toBe(false);
+    expect(fs.existsSync(ancientRotated)).toBe(false);
+    // In-retention ipc file and the non-ipc log mirror survive.
+    expect(fs.existsSync(recentPrimary)).toBe(true);
+    expect(fs.existsSync(logMirror)).toBe(true);
+  });
 });
 
 describe('ipc-recorder - outbound push recording', () => {

--- a/tests/unit/git-branches.test.ts
+++ b/tests/unit/git-branches.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for the git:listBranches in-flight de-dupe + short TTL cache
+ * (`src/renderer/utils/git-branches.ts`).
+ *
+ * The handler shells out to git (~900ms); opening a task dialog fires two
+ * concurrent list calls (the dialog's existence check + the embedded
+ * BranchPicker). These tests lock that concurrent calls collapse to one IPC,
+ * a fresh cache serves without IPC, the cache expires, a project switch forces
+ * a refetch, and rejections are not cached.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  useProjectStore: { getState: vi.fn() },
+  listBranches: vi.fn(),
+}));
+
+vi.mock('../../src/renderer/stores/project-store', () => ({ useProjectStore: mocks.useProjectStore }));
+
+import { fetchGitBranches, invalidateGitBranchesCache } from '../../src/renderer/utils/git-branches';
+
+function setProject(id: string | null): void {
+  mocks.useProjectStore.getState.mockReturnValue({ currentProject: id ? { id } : null });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  invalidateGitBranchesCache();
+  setProject('project-1');
+  (globalThis as unknown as { window: { electronAPI: { git: { listBranches: typeof mocks.listBranches } } } }).window = {
+    electronAPI: { git: { listBranches: mocks.listBranches } },
+  };
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('fetchGitBranches', () => {
+  it('collapses two concurrent calls into a single IPC invocation', async () => {
+    mocks.listBranches.mockResolvedValue(['main', 'dev']);
+
+    const first = fetchGitBranches();
+    const second = fetchGitBranches(); // concurrent, before the first resolves
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(a).toEqual(['main', 'dev']);
+    expect(b).toEqual(['main', 'dev']);
+    expect(mocks.listBranches).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves a fresh cache without a second IPC call', async () => {
+    mocks.listBranches.mockResolvedValue(['main']);
+    await fetchGitBranches();
+    // Well within the TTL.
+    await vi.advanceTimersByTimeAsync(1_000);
+    await fetchGitBranches();
+    expect(mocks.listBranches).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches once the cache TTL has elapsed', async () => {
+    mocks.listBranches.mockResolvedValue(['main']);
+    await fetchGitBranches();
+    // Past the 15s TTL.
+    await vi.advanceTimersByTimeAsync(15_001);
+    await fetchGitBranches();
+    expect(mocks.listBranches).toHaveBeenCalledTimes(2);
+  });
+
+  it('refetches when the current project changes, even within the TTL', async () => {
+    mocks.listBranches.mockResolvedValue(['main']);
+    await fetchGitBranches();
+    expect(mocks.listBranches).toHaveBeenCalledTimes(1);
+
+    // Switch projects: the cached branches belong to the old repo and must not
+    // be served for the new one.
+    setProject('project-2');
+    await fetchGitBranches();
+    expect(mocks.listBranches).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache a rejection: the next call retries', async () => {
+    mocks.listBranches.mockRejectedValueOnce(new Error('git failed'));
+    await expect(fetchGitBranches()).rejects.toThrow('git failed');
+
+    mocks.listBranches.mockResolvedValueOnce(['main']);
+    await expect(fetchGitBranches()).resolves.toEqual(['main']);
+    expect(mocks.listBranches).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/incoming-write-queue.test.ts
+++ b/tests/unit/incoming-write-queue.test.ts
@@ -101,6 +101,85 @@ describe('createIncomingWriteQueue', () => {
     // The buffered remainder is acked on reset.
     expect(ack).toHaveBeenCalledWith(4);
   });
+
+  it('holds buffered bytes without writing or acking while shouldHold is true', async () => {
+    const { term, writes } = fakeTerminal();
+    const ack = vi.fn();
+    let held = true;
+    const queue = createIncomingWriteQueue({
+      getTerminal: () => term,
+      shouldDrop: () => false,
+      shouldHold: () => held,
+      ack,
+      chunkSize: 4,
+    });
+    queue.push('abcdef');
+    await flush();
+    // Held: nothing written, nothing acked (so main backpressure throttles the PTY).
+    expect(writes).toEqual([]);
+    expect(ack).not.toHaveBeenCalled();
+
+    // Bytes pushed while held just accumulate.
+    queue.push('ghij');
+    await flush();
+    expect(writes).toEqual([]);
+
+    // Release + kick: the whole retained buffer drains in order and is acked.
+    held = false;
+    queue.kick();
+    await flush();
+    expect(writes.join('')).toBe('abcdefghij');
+    const totalAcked = ack.mock.calls.reduce((sum, call) => sum + call[0], 0);
+    expect(totalAcked).toBe(10);
+  });
+
+  it('kick is a no-op when the queue is empty', () => {
+    const { term, writes } = fakeTerminal();
+    const ack = vi.fn();
+    const queue = createIncomingWriteQueue({ getTerminal: () => term, shouldDrop: () => false, ack });
+    queue.kick();
+    expect(writes).toEqual([]);
+    expect(ack).not.toHaveBeenCalled();
+  });
+
+  it('resumes into the drop path if shouldDrop is true when the hold clears', async () => {
+    const { term, writes } = fakeTerminal();
+    const ack = vi.fn();
+    let held = true;
+    const queue = createIncomingWriteQueue({
+      getTerminal: () => term,
+      shouldDrop: () => true, // e.g. a scrollback replay took over during the hold
+      shouldHold: () => held,
+      ack,
+      chunkSize: 4,
+    });
+    queue.push('abcdef');
+    await flush();
+    expect(ack).not.toHaveBeenCalled(); // held, not dropped
+
+    held = false;
+    queue.kick();
+    await flush();
+    // Now drops-and-acks (no writes), releasing backpressure.
+    expect(writes).toEqual([]);
+    const totalAcked = ack.mock.calls.reduce((sum, call) => sum + call[0], 0);
+    expect(totalAcked).toBe(6);
+  });
+
+  it('reset while held still acks the retained bytes', () => {
+    const { term } = fakeTerminal();
+    const ack = vi.fn();
+    const queue = createIncomingWriteQueue({
+      getTerminal: () => term,
+      shouldDrop: () => false,
+      shouldHold: () => true,
+      ack,
+      chunkSize: 4,
+    });
+    queue.push('abcdef');
+    queue.reset();
+    expect(ack).toHaveBeenCalledWith(6);
+  });
 });
 
 describe('writeChunkedToTerminal', () => {

--- a/tests/unit/metrics-snapshot-timer.test.ts
+++ b/tests/unit/metrics-snapshot-timer.test.ts
@@ -28,9 +28,14 @@ import type { SessionManager } from '../../src/main/pty/session-manager';
 // are hoisted to the top of the file ahead of all imports).
 // ---------------------------------------------------------------------------
 
+// better-sqlite3's `db.transaction(fn)` returns a callable that runs `fn` inside
+// a transaction. The mock mirrors that: transaction(fn) => fn, so calling the
+// returned function synchronously runs the batch body.
+const makeMockDb = () => ({ transaction: (fn: () => void) => fn });
+
 const { mockCaptureSessionMetrics, mockGetProjectDb, mockGetLatestForTask } = vi.hoisted(() => ({
   mockCaptureSessionMetrics: vi.fn(),
-  mockGetProjectDb: vi.fn(() => ({})),
+  mockGetProjectDb: vi.fn(() => ({ transaction: (fn: () => void) => fn })),
   /** Shared getLatestForTask stub - re-configured per test in beforeEach. */
   mockGetLatestForTask: vi.fn(),
 }));
@@ -270,7 +275,7 @@ describe('snapshotRunningSessions filter', () => {
     // The first session throws; the second must still be processed.
     mockGetProjectDb
       .mockImplementationOnce(() => { throw new Error('DB unavailable'); })
-      .mockImplementation(() => ({}));
+      .mockImplementation(() => makeMockDb());
 
     const sessions = [
       makeSession({ id: 'session-a', taskId: 'task-a', projectId: 'proj-a', status: 'running' }),
@@ -305,6 +310,68 @@ describe('snapshotRunningSessions filter', () => {
     expect(mockCaptureSessionMetrics).toHaveBeenCalledTimes(2);
 
     vi.advanceTimersByTime(SNAPSHOT_INTERVAL_MS); // tick 3
+    expect(mockCaptureSessionMetrics).toHaveBeenCalledTimes(3);
+  });
+
+  it('isolates one session\'s getLatestForTask throw from its sibling in the same project transaction', () => {
+    // The fix: each session's body inside the shared per-project db.transaction
+    // is wrapped in its own try/catch, so one session's getLatestForTask throw
+    // must not roll back / skip its sibling's capture in the same batch. This is
+    // distinct from the "getProjectDb throws for one project" test above, which
+    // covers isolation ACROSS projects, not across sessions within one project's
+    // shared transaction.
+    mockGetLatestForTask.mockImplementation((taskId: string) => {
+      if (taskId === 'task-throws') {
+        throw new Error('DB read failed for task-throws');
+      }
+      return makeRunningRecord();
+    });
+
+    const sessions = [
+      makeSession({ id: 'session-throws', taskId: 'task-throws', projectId: 'proj-shared', status: 'running' }),
+      makeSession({ id: 'session-ok', taskId: 'task-ok', projectId: 'proj-shared', status: 'running' }),
+    ];
+    const manager = makeManagerStub(sessions);
+    startMetricsSnapshotTimer(manager);
+
+    vi.advanceTimersByTime(SNAPSHOT_INTERVAL_MS);
+
+    // session-throws's getLatestForTask threw; session-ok, in the same project's
+    // shared transaction, must still have been captured.
+    expect(mockCaptureSessionMetrics).toHaveBeenCalledTimes(1);
+    expect(mockCaptureSessionMetrics).toHaveBeenCalledWith(
+      manager,
+      expect.anything(),
+      expect.anything(),
+      'session-ok',
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+    );
+  });
+
+  it('groups sessions by project: one getProjectDb + one transaction per project', () => {
+    // Each project's captures commit in a single transaction, so a project with
+    // multiple running sessions opens the DB once and runs one transaction.
+    let transactionCalls = 0;
+    mockGetProjectDb.mockImplementation(() => ({
+      transaction: (fn: () => void) => () => { transactionCalls += 1; fn(); },
+    }));
+
+    const sessions = [
+      makeSession({ id: 's-a1', taskId: 't-a1', projectId: 'proj-a', status: 'running' }),
+      makeSession({ id: 's-a2', taskId: 't-a2', projectId: 'proj-a', status: 'running' }),
+      makeSession({ id: 's-b1', taskId: 't-b1', projectId: 'proj-b', status: 'running' }),
+    ];
+    const manager = makeManagerStub(sessions);
+    startMetricsSnapshotTimer(manager);
+
+    vi.advanceTimersByTime(SNAPSHOT_INTERVAL_MS);
+
+    // Two distinct projects -> two getProjectDb opens, two transactions, but all
+    // three sessions captured.
+    expect(mockGetProjectDb).toHaveBeenCalledTimes(2);
+    expect(transactionCalls).toBe(2);
     expect(mockCaptureSessionMetrics).toHaveBeenCalledTimes(3);
   });
 });

--- a/tests/unit/project-scoped-ipc.test.ts
+++ b/tests/unit/project-scoped-ipc.test.ts
@@ -43,6 +43,7 @@ const ALLOWLIST_CHANNELS = new Set([
   // Task reads / project-agnostic
   'TASK_LIST',
   'TASK_LIST_ARCHIVED',
+  'TASK_LIST_ARCHIVED_PREVIEW',
   'TASK_GET_SPAWN_PROGRESS',
   'TASK_CANCEL_SPAWN', // aborts a global per-task controller; no project lookup
   // Session reads

--- a/tests/unit/session-update-coalescer-reload-gate.test.ts
+++ b/tests/unit/session-update-coalescer-reload-gate.test.ts
@@ -35,6 +35,8 @@ import {
   endBoardDrag,
   flushDragGateOnWindowBlur,
   resetCoalescerForHmr,
+  isBoardDragActive,
+  onBoardDragEnd,
 } from '../../src/renderer/lib/session-update-coalescer';
 
 beforeEach(() => {
@@ -210,5 +212,61 @@ describe('enqueueReload - stuck-gate recovery', () => {
     // The gate is not active, so a reload runs immediately as usual.
     enqueueReload('board', reload);
     expect(reload).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The drag-active getter + drag-end subscription power the xterm write-queue
+ * pause: consumers read `isBoardDragActive()` to HOLD their work and subscribe
+ * via `onBoardDragEnd` to resume it.
+ */
+describe('board-drag signal for external consumers', () => {
+  it('isBoardDragActive tracks begin/end', () => {
+    expect(isBoardDragActive()).toBe(false);
+    beginBoardDrag();
+    expect(isBoardDragActive()).toBe(true);
+    endBoardDrag();
+    expect(isBoardDragActive()).toBe(false);
+  });
+
+  it('onBoardDragEnd fires on endBoardDrag, and unsubscribe stops delivery', () => {
+    const listener = vi.fn();
+    const unsubscribe = onBoardDragEnd(listener);
+
+    beginBoardDrag();
+    endBoardDrag();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    beginBoardDrag();
+    endBoardDrag();
+    expect(listener).toHaveBeenCalledTimes(1); // no further deliveries
+  });
+
+  it('onBoardDragEnd also fires via the window-blur backstop', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const listener = vi.fn();
+    const unsubscribe = onBoardDragEnd(listener);
+
+    beginBoardDrag();
+    flushDragGateOnWindowBlur(); // routes through endBoardDrag
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsubscribe();
+    warnSpy.mockRestore();
+  });
+
+  it('resetCoalescerForHmr notifies listeners and keeps subscriptions intact', () => {
+    const listener = vi.fn();
+    const unsubscribe = onBoardDragEnd(listener);
+
+    // HMR reset resumes any held consumer (e.g. a paused write queue)...
+    resetCoalescerForHmr();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // ...and does NOT drop the subscription: a later drag end still delivers.
+    beginBoardDrag();
+    endBoardDrag();
+    expect(listener).toHaveBeenCalledTimes(2);
+    unsubscribe();
   });
 });

--- a/tests/unit/structural-sharing.test.ts
+++ b/tests/unit/structural-sharing.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { applyStructuralSharing } from '../../src/renderer/stores/board-store/structural-sharing';
-import type { Task } from '../../src/shared/types';
+import {
+  applyStructuralSharing,
+  applySwimlaneStructuralSharing,
+} from '../../src/renderer/stores/board-store/structural-sharing';
+import type { Task, Swimlane } from '../../src/shared/types';
 
 /**
  * `applyStructuralSharing` is our narrow port of TanStack Query's default
@@ -178,5 +181,96 @@ describe('applyStructuralSharing', () => {
       [nextMalformed as unknown as Task],
     );
     expect(result[0]).toBe(previousMalformed);
+  });
+});
+
+function makeSwimlane(overrides: Partial<Swimlane> = {}): Swimlane {
+  return {
+    id: 'lane-1',
+    name: 'To Do',
+    description: null,
+    role: null,
+    position: 0,
+    color: '#888888',
+    icon: null,
+    is_archived: false,
+    is_ghost: false,
+    permission_mode: null,
+    auto_spawn: false,
+    auto_command: null,
+    plan_exit_target_id: null,
+    agent_override: null,
+    model_override: null,
+    effort_override: null,
+    handoff_context: false,
+    session_target: 'main',
+    session_spawn_strategy: 'create_or_resume',
+    created_at: '2026-04-17T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('applySwimlaneStructuralSharing', () => {
+  it('reuses the previous swimlane reference when fields are identical', () => {
+    const previous = makeSwimlane();
+    const next = makeSwimlane();
+    expect(previous).not.toBe(next);
+
+    const result = applySwimlaneStructuralSharing([previous], [next]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(previous);
+  });
+
+  it('uses the next reference when any field changed', () => {
+    const previous = makeSwimlane({ name: 'Old', auto_command: null });
+    const next = makeSwimlane({ name: 'Old', auto_command: '/code-review' });
+
+    const result = applySwimlaneStructuralSharing([previous], [next]);
+
+    expect(result[0]).toBe(next);
+  });
+
+  it('reuses siblings while one swimlane changed', () => {
+    const previousA = makeSwimlane({ id: 'a', name: 'A' });
+    const previousB = makeSwimlane({ id: 'b', name: 'B-old' });
+    const nextA = makeSwimlane({ id: 'a', name: 'A' });
+    const nextB = makeSwimlane({ id: 'b', name: 'B-new' });
+
+    const result = applySwimlaneStructuralSharing([previousA, previousB], [nextA, nextB]);
+
+    expect(result[0]).toBe(previousA);
+    expect(result[1]).toBe(nextB);
+  });
+
+  it('returns the next array verbatim when previous is empty', () => {
+    const next = [makeSwimlane({ id: 'a' }), makeSwimlane({ id: 'b' })];
+    const result = applySwimlaneStructuralSharing([], next);
+    expect(result).toBe(next);
+  });
+
+  it('returns a new outer array reference even when every swimlane was reused', () => {
+    const previous = [makeSwimlane({ id: 'a' }), makeSwimlane({ id: 'b' })];
+    const next = [makeSwimlane({ id: 'a' }), makeSwimlane({ id: 'b' })];
+
+    const result = applySwimlaneStructuralSharing(previous, next);
+
+    expect(result).not.toBe(previous);
+    expect(result).not.toBe(next);
+    expect(result[0]).toBe(previous[0]);
+    expect(result[1]).toBe(previous[1]);
+  });
+
+  // Guard against silent drift: when a new field is added to the Swimlane
+  // interface, swimlaneContentsMatch must be updated to compare it, otherwise a
+  // stale reference is reused and the column memo misses the change.
+  //
+  // How to update when this fails: read the field list in
+  // `structural-sharing.ts` swimlaneContentsMatch, add the new field there, then
+  // update SWIMLANE_FIELD_COUNT below to match.
+  it('guards against Swimlane-interface field drift', () => {
+    const SWIMLANE_FIELD_COUNT = 20; // keep in sync with swimlaneContentsMatch
+    const sample = makeSwimlane();
+    expect(Object.keys(sample)).toHaveLength(SWIMLANE_FIELD_COUNT);
   });
 });

--- a/tests/unit/task-archive-handler.test.ts
+++ b/tests/unit/task-archive-handler.test.ts
@@ -171,6 +171,7 @@ interface MockSwimlane {
 
 interface MockTaskRepo {
   listArchived: ReturnType<typeof vi.fn>;
+  listArchivedPreview: ReturnType<typeof vi.fn>;
   list: ReturnType<typeof vi.fn>;
   getById: ReturnType<typeof vi.fn>;
   unarchive: ReturnType<typeof vi.fn>;
@@ -236,6 +237,10 @@ function createMockTaskRepo(tasks: MockTask[]): MockTaskRepo {
   const taskMap = new Map(tasks.map((task) => [task.id, { ...task }]));
   return {
     listArchived: vi.fn(() => Array.from(taskMap.values())),
+    listArchivedPreview: vi.fn((limit: number) => {
+      const all = Array.from(taskMap.values());
+      return { totalCount: all.length, tasks: all.slice(0, Math.max(1, Math.min(100, Math.floor(limit)))) };
+    }),
     list: vi.fn((_swimlaneId?: string) => Array.from(taskMap.values())),
     getById: vi.fn((id: string) => taskMap.get(id) ?? null),
     unarchive: vi.fn((id: string, targetSwimlaneId: string, _position: number) => {
@@ -364,6 +369,31 @@ describe('task-archive handlers', () => {
       const result = await callHandler(IPC.TASK_LIST_ARCHIVED);
 
       expect(result).toEqual([]);
+    });
+  });
+
+  // =========================================================================
+  // TASK_LIST_ARCHIVED_PREVIEW
+  // =========================================================================
+
+  describe('TASK_LIST_ARCHIVED_PREVIEW', () => {
+    it('delegates to tasks.listArchivedPreview(limit) and returns the { totalCount, tasks } shape', async () => {
+      const preview = { totalCount: 42, tasks: [createMockTask('task-a')] };
+      taskRepo.listArchivedPreview.mockReturnValue(preview);
+
+      const result = await callHandler(IPC.TASK_LIST_ARCHIVED_PREVIEW, 15);
+
+      expect(taskRepo.listArchivedPreview).toHaveBeenCalledTimes(1);
+      expect(taskRepo.listArchivedPreview).toHaveBeenCalledWith(15);
+      expect(result).toEqual(preview);
+    });
+
+    it('forwards the requested limit to the repository', async () => {
+      taskRepo.listArchivedPreview.mockReturnValue({ totalCount: 0, tasks: [] });
+
+      await callHandler(IPC.TASK_LIST_ARCHIVED_PREVIEW, 5);
+
+      expect(taskRepo.listArchivedPreview).toHaveBeenCalledWith(5);
     });
   });
 

--- a/tests/unit/task-repository.test.ts
+++ b/tests/unit/task-repository.test.ts
@@ -47,6 +47,9 @@ function createSqlTracker() {
       }),
       get: vi.fn((...args: unknown[]) => {
         entry.args = args;
+        // COUNT(*) queries expect a { count } row; everything else models a
+        // "not found" lookup, matching real better-sqlite3 semantics.
+        if (/COUNT\(\*\)/i.test(sql)) return { count: 0 };
         return undefined;
       }),
       all: vi.fn((...args: unknown[]) => {
@@ -164,6 +167,46 @@ describe('TaskRepository SQL contracts', () => {
       );
       // No statement should contain archived_at when using listAllInSwimlane
       expect(allTasksStatements).toHaveLength(0);
+    });
+  });
+
+  describe('listArchivedPreview', () => {
+    it('counts all archived tasks and limits the returned rows', () => {
+      const result = repo.listArchivedPreview(15);
+
+      // Returns the { totalCount, tasks } shape (mock get() yields count 0,
+      // all() yields []).
+      expect(result).toEqual({ totalCount: 0, tasks: [] });
+
+      const countStatement = tracker.statements.find((s) => /COUNT\(\*\)/i.test(s.sql));
+      expect(countStatement).toBeDefined();
+      expect(countStatement!.sql).toContain('archived_at IS NOT NULL');
+    });
+
+    it('orders newest-first and applies a LIMIT binding', () => {
+      repo.listArchivedPreview(15);
+
+      const previewStatement = tracker.statements.find((s) =>
+        s.sql.includes('archived_at IS NOT NULL') && s.sql.includes('LIMIT ?'),
+      );
+      expect(previewStatement).toBeDefined();
+      expect(previewStatement!.sql).toContain('ORDER BY t.archived_at DESC');
+      expect(previewStatement!.args).toEqual([15]);
+    });
+
+    it('clamps the limit to [1, 100] and floors fractional values', () => {
+      const limitBindingFor = (requested: number): number => {
+        tracker = createSqlTracker();
+        repo = new TaskRepository(tracker.db);
+        repo.listArchivedPreview(requested);
+        const statement = tracker.statements.find((s) => s.sql.includes('LIMIT ?'));
+        return statement!.args[0] as number;
+      };
+
+      expect(limitBindingFor(500)).toBe(100); // over cap
+      expect(limitBindingFor(0)).toBe(1); // under floor
+      expect(limitBindingFor(-5)).toBe(1); // negative floor
+      expect(limitBindingFor(15.9)).toBe(15); // floored
     });
   });
 });

--- a/tests/unit/terminal-webgl.test.ts
+++ b/tests/unit/terminal-webgl.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for `src/renderer/utils/terminal-webgl.ts`.
+ *
+ * The WebGL renderer recovers from context loss by retrying re-initialization
+ * with a backoff, then permanently falling back to the DOM renderer. These tests
+ * inject a fake addon factory (capturing `onContextLoss`) and a fake terminal so
+ * the retry state machine can be driven deterministically with fake timers.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Terminal } from '@xterm/xterm';
+import {
+  attachWebglRenderer,
+  getTerminalRendererReport,
+} from '../../src/renderer/utils/terminal-webgl';
+
+interface FakeAddon {
+  lossHandlers: Array<() => void>;
+  disposed: boolean;
+  onContextLoss(handler: () => void): void;
+  dispose(): void;
+  triggerLoss(): void;
+}
+
+function makeFakeAddon(): FakeAddon {
+  const addon: FakeAddon = {
+    lossHandlers: [],
+    disposed: false,
+    onContextLoss(handler: () => void) { addon.lossHandlers.push(handler); },
+    dispose() { addon.disposed = true; },
+    triggerLoss() { for (const handler of addon.lossHandlers) handler(); },
+  };
+  return addon;
+}
+
+/**
+ * Builds a `createAddon` factory whose per-call behavior is scripted by `modes`
+ * (one entry per call, 'ok' or 'throw'; calls past the end of the array default
+ * to 'ok'). Only successful calls push a `FakeAddon` onto the returned `addons`
+ * array, so `addons[n]` always lines up with the n-th SUCCESSFUL attach.
+ */
+function makeAddonFactory(modes: Array<'ok' | 'throw'>): { createAddon: () => FakeAddon; addons: FakeAddon[] } {
+  const addons: FakeAddon[] = [];
+  let callIndex = 0;
+  const createAddon = (): FakeAddon => {
+    const mode = modes[callIndex] ?? 'ok';
+    callIndex += 1;
+    if (mode === 'throw') {
+      throw new Error('WebGL re-init failed');
+    }
+    const addon = makeFakeAddon();
+    addons.push(addon);
+    return addon;
+  };
+  return { createAddon, addons };
+}
+
+const fakeTerminal = { loadAddon: vi.fn() } as unknown as Terminal;
+const RETRY_DELAYS = [2_000, 10_000];
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  warnSpy.mockRestore();
+});
+
+describe('attachWebglRenderer', () => {
+  it('reports the webgl renderer on a successful attach', () => {
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-attach', {
+      createAddon: makeFakeAddon,
+      retryDelaysMs: RETRY_DELAYS,
+    });
+    expect(getTerminalRendererReport()['k-attach'].renderer).toBe('webgl');
+    expect(getTerminalRendererReport()['k-attach'].contextLossCount).toBe(0);
+    dispose();
+    expect(getTerminalRendererReport()['k-attach']).toBeUndefined();
+  });
+
+  it('falls back to DOM on context loss then recovers after the first backoff', () => {
+    const addons: FakeAddon[] = [];
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-recover', {
+      createAddon: () => { const addon = makeFakeAddon(); addons.push(addon); return addon; },
+      retryDelaysMs: RETRY_DELAYS,
+    });
+
+    addons[0].triggerLoss();
+    const afterLoss = getTerminalRendererReport()['k-recover'];
+    expect(afterLoss.renderer).toBe('dom');
+    expect(afterLoss.contextLossCount).toBe(1);
+    expect(afterLoss.permanentDomFallback).toBe(false);
+    expect(addons[0].disposed).toBe(true);
+
+    // Re-init is scheduled for +2000ms; nothing before then.
+    vi.advanceTimersByTime(1_999);
+    expect(getTerminalRendererReport()['k-recover'].renderer).toBe('dom');
+    vi.advanceTimersByTime(1);
+    expect(getTerminalRendererReport()['k-recover'].renderer).toBe('webgl');
+    expect(addons).toHaveLength(2);
+    dispose();
+  });
+
+  it('uses the second, longer backoff for a second loss', () => {
+    const addons: FakeAddon[] = [];
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-second', {
+      createAddon: () => { const addon = makeFakeAddon(); addons.push(addon); return addon; },
+      retryDelaysMs: RETRY_DELAYS,
+    });
+
+    addons[0].triggerLoss();
+    vi.advanceTimersByTime(2_000); // recovered on addon[1]
+    expect(getTerminalRendererReport()['k-second'].renderer).toBe('webgl');
+
+    addons[1].triggerLoss();
+    expect(getTerminalRendererReport()['k-second'].contextLossCount).toBe(2);
+    // Second backoff is 10s: not recovered at 2s...
+    vi.advanceTimersByTime(2_000);
+    expect(getTerminalRendererReport()['k-second'].renderer).toBe('dom');
+    // ...recovered at 10s total.
+    vi.advanceTimersByTime(8_000);
+    expect(getTerminalRendererReport()['k-second'].renderer).toBe('webgl');
+    expect(addons).toHaveLength(3);
+    dispose();
+  });
+
+  it('gives up permanently after the retries are exhausted', () => {
+    const addons: FakeAddon[] = [];
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-permanent', {
+      createAddon: () => { const addon = makeFakeAddon(); addons.push(addon); return addon; },
+      retryDelaysMs: RETRY_DELAYS,
+    });
+
+    addons[0].triggerLoss();
+    vi.advanceTimersByTime(2_000);
+    addons[1].triggerLoss();
+    vi.advanceTimersByTime(10_000);
+    // Third loss exceeds the 2 retry slots -> permanent DOM, no timer armed.
+    addons[2].triggerLoss();
+    const status = getTerminalRendererReport()['k-permanent'];
+    expect(status.renderer).toBe('dom');
+    expect(status.contextLossCount).toBe(3);
+    expect(status.permanentDomFallback).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+    dispose();
+  });
+
+  it('advances to the next backoff slot when a scheduled retry itself fails, and only sets permanentDomFallback once slots are exhausted', () => {
+    // Initial attach succeeds; the FIRST scheduled retry (after the loss) throws;
+    // the SECOND scheduled retry also throws. A failed non-final retry must not
+    // set permanentDomFallback and must arm the next backoff slot instead of
+    // leaving the terminal stuck on DOM with no further retry scheduled.
+    const { createAddon, addons } = makeAddonFactory(['ok', 'throw', 'throw']);
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-retry-fail', {
+      createAddon,
+      retryDelaysMs: RETRY_DELAYS,
+    });
+    expect(getTerminalRendererReport()['k-retry-fail'].renderer).toBe('webgl');
+
+    addons[0].triggerLoss();
+    expect(getTerminalRendererReport()['k-retry-fail'].contextLossCount).toBe(1);
+
+    // First scheduled retry (at +2000ms) itself throws inside tryAttach.
+    vi.advanceTimersByTime(RETRY_DELAYS[0]);
+    const afterFirstRetryFailure = getTerminalRendererReport()['k-retry-fail'];
+    expect(afterFirstRetryFailure.renderer).toBe('dom');
+    expect(afterFirstRetryFailure.permanentDomFallback).toBe(false);
+    // Not the final slot yet: the next backoff must be armed.
+    expect(vi.getTimerCount()).toBe(1);
+
+    // Second (final) scheduled retry also throws: slots exhausted -> permanent.
+    vi.advanceTimersByTime(RETRY_DELAYS[1]);
+    const afterSecondRetryFailure = getTerminalRendererReport()['k-retry-fail'];
+    expect(afterSecondRetryFailure.renderer).toBe('dom');
+    expect(afterSecondRetryFailure.permanentDomFallback).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+
+    dispose();
+  });
+
+  it('recovers if the next backoff slot succeeds after an earlier scheduled retry failed', () => {
+    const { createAddon, addons } = makeAddonFactory(['ok', 'throw', 'ok']);
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-retry-recover', {
+      createAddon,
+      retryDelaysMs: RETRY_DELAYS,
+    });
+
+    addons[0].triggerLoss();
+    // First scheduled retry throws; must advance to the next slot rather than
+    // giving up.
+    vi.advanceTimersByTime(RETRY_DELAYS[0]);
+    expect(getTerminalRendererReport()['k-retry-recover'].permanentDomFallback).toBe(false);
+    expect(vi.getTimerCount()).toBe(1);
+
+    // Second scheduled retry succeeds.
+    vi.advanceTimersByTime(RETRY_DELAYS[1]);
+    const status = getTerminalRendererReport()['k-retry-recover'];
+    expect(status.renderer).toBe('webgl');
+    expect(status.permanentDomFallback).toBe(false);
+    expect(addons).toHaveLength(2); // initial attach + the recovered retry
+
+    dispose();
+  });
+
+  it('records a permanent DOM fallback when WebGL construction throws', () => {
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-unavailable', {
+      createAddon: () => { throw new Error('WebGL unavailable'); },
+      retryDelaysMs: RETRY_DELAYS,
+    });
+    const status = getTerminalRendererReport()['k-unavailable'];
+    expect(status.renderer).toBe('dom');
+    expect(status.permanentDomFallback).toBe(true);
+    expect(status.contextLossCount).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+    dispose();
+  });
+
+  it('dispose cancels a pending retry and drops the report entry', () => {
+    const addons: FakeAddon[] = [];
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-dispose', {
+      createAddon: () => { const addon = makeFakeAddon(); addons.push(addon); return addon; },
+      retryDelaysMs: RETRY_DELAYS,
+    });
+
+    addons[0].triggerLoss(); // schedules a retry at +2000ms
+    expect(vi.getTimerCount()).toBe(1);
+
+    dispose();
+    expect(vi.getTimerCount()).toBe(0); // retry cancelled
+    expect(getTerminalRendererReport()['k-dispose']).toBeUndefined();
+
+    // Advancing past the would-be retry does nothing (no new addon).
+    vi.advanceTimersByTime(10_000);
+    expect(addons).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What

Eliminates the recurring UI freezes (0.1-0.8s stalls on a ~5-10s cadence, worst with 4 sessions running) that tracked agent turn completions rather than any timer.

- **Archive lazy-load (P0).** New `task:list-archived-preview` IPC endpoint (all 7 layers) returns the newest 15 archived tasks plus a total count. Board hydration uses it instead of refetching the full `task:list-archived` (~1.2MB) on every reload. The full archive loads lazily, in-flight-deduped and project-switch-guarded, only while a consumer is mounted (the Completed dialog, or a detail window anchored to a deep archived task), refcounted so it downgrades back to the preview when they close. Swimlanes now get the same structural sharing tasks already had.
- **IPC recorder (P0).** Caps oversized args/result payloads to a 32KB truncation marker (`{ truncated, serializedChars, preview }`), rotates the daily `ipc-*.jsonl` at 64MB, and prunes files older than 7 days. Fixes the 2GB+ log accumulation and the Windows Defender rescans it triggered; the sync `JSON.stringify` of a 1.2MB payload on the main thread is gone.
- **BgShellWatcher (P1).** The 2s host-wide `Get-CimInstance Win32_Process` sweep now backs off to 4s then 6s under sustained load, snapping back to the base cadence on any background-shell lifecycle transition. The single-shared-snapshot design (and its perf-regression guard) is untouched.
- **Terminal (P1).** xterm inbound writes now HOLD (retain buffer, no ack so the PTY throttles at the source) during a board drag and resume on drag end, instead of parsing mid-drag. WebGL context loss retries re-init with backoff (2s, then 10s) instead of silently degrading to the DOM renderer for the rest of the session; renderer type is tracked and observable via a dev global.
- **P2.** Metrics snapshot batches one DB transaction per project (was two per session); `git:listBranches` is in-flight-deduped with a short TTL (kills the New Task / Task Detail dialog double-fire); the dev flight recorder segregates background-throttle artifacts from real freezes so a hidden window's ~900ms throttled ticks no longer pollute freeze diagnosis.

## Why

Closes #333. Flight-recorder data showed main-process stall bursts of 368-838ms while agents ran tools. There is no 5-10s timer anywhere in `src/`; the cadence traced to every agent-driven board invalidation refetching the full archive and the IPC recorder then stringifying that same 1.2MB payload synchronously on the main thread. The remaining contributors (2s process sweep, un-gated mid-drag xterm parsing, silent WebGL degradation) compounded it exactly when the machine was already saturated.

## How

The dominant fix is removing the full archive from steady-state traffic: a small preview payload feeds the always-visible Done column (count + 15-card inline list), and the full list is fetched only when something actually needs it, with a refcount so opening the dialog once does not re-arm 1.2MB fetches for the rest of the session. The recorder cap is defense-in-depth for any large channel. The watcher trades a bounded increase in background-shell exit-detection latency (~4s to ~8s worst case, backstopped by the existing 5-min watchdog) for far less CPU under load. The drag-hold deliberately does NOT reuse the existing drop-and-ack path (that would discard live output); it retains the buffer and lets main-side backpressure pause the PTY, bounded by the coalescer's 30s drag watchdog.

Verified live against a worktree preview: the new endpoint round-trips correctly, a real `loadBoard` (task create) added zero main-process stalls, a live terminal reports the WebGL renderer, and the flight recorder correctly quarantined 497 background-throttle artifacts (including a 60s one) while the real-freeze ring stayed at 1 spike / 185ms.

## Breaking changes

None. The new IPC endpoint is additive; existing endpoints are unchanged. The Done column, its count, the 15-card preview, and the Completed dialog behave identically. The `IpcLogEntry` union and the dev lag-report shape gained fields but kept every existing field.

## Tests

- New/expanded unit coverage per changed area: structural sharing (swimlanes), archived-tasks-slice accounting + project-switch guard, repository `listArchivedPreview` SQL, IPC recorder cap/rotation/retention, async-file-queue counter seeding, watcher adaptive backoff, incoming-write-queue hold, coalescer drag signal, terminal WebGL recovery, metrics transaction batching, git-branches dedupe, and the dev lag recorder.
- New UI specs: `archived-lazy-load.spec.ts` (board hydrates preview not full archive; dialog-open loads full once; agent reload with the dialog open does not shrink; close then reload downgrades) and `window-content-deep-archive-self-heal.spec.ts` (a detail window that falls out of the preview self-heals by loading the full archive, releasing the viewer on resolve or unmount).
- Docs updated for the new IPC channel and repository method (`docs/architecture.md`, `docs/database.md`) and the recorder truncation marker (`docs/mcp-server.md`).
- CI runs typecheck, lint, unit, build, and the UI + Linux Electron E2E shards.

Generated with [Claude Code](https://claude.com/claude-code)
