### PR TITLE
fix(pty): repaint-settle scrollback so restored terminals paint at the fitted width

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -497,6 +497,7 @@ Shell-specific adaptations:
 | MAX_SCROLLBACK | 512 KB | Terminal history per session |
 | MAX_EVENTS | 500 | Activity log cap per session |
 | Flush interval | 16 ms | Output batching (~60fps) |
+| Repaint-settle max wait | 400 ms | Ceiling for the post-resize repaint wait before sampling scrollback |
 | Status debounce | 100 ms | Usage file watch |
 | Event debounce | 50 ms | Event log + activity state watch |
 | Graceful shutdown | 2000 ms | `suspendAll()` timeout (exists in code but NOT used during app quit; synchronous shutdown kills PTYs immediately) |
@@ -622,6 +623,7 @@ On project open (`src/main/transition-engine/session-startup/`):
 
 - **WebGL xterm** -- attempts WebGL renderer first, falls back to canvas on context loss
 - **Resize debouncing** -- PTY resize calls debounced at 200ms, suppressed during panel drag
+- **Repaint-settled scrollback** - after a width-changing resize, `getScrollback` waits for the agent TUI's async repaint to land before sampling, so a restored terminal never replays a stale narrow frame (see [session-lifecycle](session-lifecycle.md))
 - **Activity log** -- plain DOM list instead of xterm. Events flow through JSONL files, not terminal output.
 - **Terminal ownership handoff** -- one xterm instance per session at a time prevents duplicate resize calls that corrupt TUI output
 - **Output batching** -- 16ms flush interval prevents per-character IPC overhead

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -265,6 +265,16 @@ The handoff is transparent to the user - the task card shows spawn progress phas
 - PTY `onData` accumulates into a per-session buffer.
 - A 16ms flush interval (~60fps) emits buffered data via IPC `session:data`.
 - A 512KB scrollback ring buffer per session supports terminal restoration.
+- **Repaint-settled scrollback sampling.** A session spawns at a default 120x30; on a cold launch
+  an auto-resumed PTY sits at that size until a card opens and the renderer fits it wider. When a
+  width-changing resize fires, a full-screen agent TUI repaints its frame asynchronously in
+  response to SIGWINCH. So `getScrollback` waits for that repaint to land and quiesce before
+  sampling (`PtyBufferManager.waitForResizeRepaint`), so a terminal restored right after a resize
+  replays the frame at the fitted width instead of a stale narrow one. The wait arms only when the
+  scrollback shows a TUI (a `\x1b[2J` clear) and is bounded by a max-wait ceiling, so a missing or
+  slow repaint can only delay a first paint, never hang the read. A resize that arrives before the
+  PTY exists (the renderer mounts before the auto-resume spawn lands) is stashed and applied at
+  spawn, so the PTY starts at the fitted size and no corrective resize is needed.
 
 ## Key Constants
 
@@ -273,6 +283,7 @@ The handoff is transparent to the user - the task card shows spawn progress phas
 | MAX_SCROLLBACK | 512 KB | Terminal history per session |
 | MAX_EVENTS | 500 | Activity log cap per session |
 | Flush interval | 16 ms | Output batching (~60fps) |
+| Repaint-settle max wait | 400 ms | Ceiling for the post-resize repaint wait before sampling scrollback |
 | Status debounce | 100 ms | Usage file watch |
 | Event debounce | 50 ms | Event log + activity state watch |
 | Hard shutdown deadline | 6000 ms | Failsafe timer before force-killing process tree |

--- a/src/main/pty/buffer/pty-buffer-manager.ts
+++ b/src/main/pty/buffer/pty-buffer-manager.ts
@@ -22,6 +22,29 @@ const SCROLLBACK_TRIM_THRESHOLD = MAX_SCROLLBACK + SCROLLBACK_TRIM_SLACK;
 const MAX_BYTES_PER_FLUSH = 256 * 1024;
 
 /**
+ * Repaint-settle window for getScrollback (see waitForResizeRepaint).
+ *
+ * When the terminal width changes, a full-screen agent TUI (Claude, Codex)
+ * repaints its frame asynchronously in response to SIGWINCH. A getScrollback
+ * that samples the buffer in the gap between the resize and that repaint would
+ * replay a frame laid out for the OLD width - the stale-frame bug this settle
+ * closes. So getScrollback waits for the repaint bytes to land and quiesce
+ * before sampling, bounded so a missing repaint can never hang the read.
+ *
+ *  - QUIESCE: no new data for this long counts as "the repaint has landed".
+ *    ~3 flush ticks (16ms each), long enough to bridge a multi-chunk redraw.
+ *  - MAX_WAIT: hard ceiling from wait entry. A width change with no repaint
+ *    (or a genuinely slow one) adds at most this to a first paint.
+ *  - STALE: a pending-repaint stamp older than this is treated as settled - the
+ *    repaint has long since landed, so sample immediately.
+ *  - POLL: settle poll cadence, matched to the flush tick.
+ */
+const REPAINT_QUIESCE_MS = 50;
+const REPAINT_MAX_WAIT_MS = 400;
+const REPAINT_STALE_MS = 2000;
+const REPAINT_POLL_MS = 16;
+
+/**
  * Largest slice end <= `max` that does not split a UTF-16 surrogate pair.
  * xterm's parser reassembles escape sequences across `write` calls, so the
  * only cross-slice hazard is a split surrogate pair (which would render as
@@ -91,10 +114,15 @@ interface BufferState {
   flushScheduled: boolean;
   scrollback: string;
   lastCols: number;
-  /** Whether the first resize has established the real terminal dimensions.
-   *  The initial resize must NOT clear scrollback - it contains carried-over
-   *  history from a previous session that hasn't been replayed yet. */
-  initialized: boolean;
+  /** Timestamp (Date.now()) of the most recent width-changing resize, or null
+   *  when none is pending. Set by onResize when cols change; consumed and
+   *  cleared by waitForResizeRepaint once the post-resize repaint has settled.
+   *  Drives the repaint-settle in getScrollback. */
+  pendingRepaintAt: number | null;
+  /** Timestamp (Date.now()) of the most recent onData, or null before any data.
+   *  Used by waitForResizeRepaint to detect that the SIGWINCH repaint has
+   *  landed (data after the resize stamp) and then quiesced. */
+  lastDataAt: number | null;
   /** Position of the first \x1b[2J (clear screen) in the scrollback, or -1
    *  if not found yet. Set once and cached. Used by getScrollback() to strip
    *  shell command noise that precedes the agent TUI's first draw. */
@@ -128,7 +156,8 @@ export class PtyBufferManager {
       flushScheduled: false,
       scrollback: previousScrollback,
       lastCols: initialCols,
-      initialized: false,
+      pendingRepaintAt: null,
+      lastDataAt: null,
       tuiStartIndex: previousScrollback ? 0 : -1,
       // Start empty even on carry-over: the new process re-emits its own modes.
       decPrivateModes: new Set<number>(),
@@ -166,6 +195,9 @@ export class PtyBufferManager {
 
     state.buffer += data;
     state.scrollback += data;
+    // Stamp the arrival so a pending repaint-settle can tell that the
+    // post-resize redraw has landed (data after the resize) and then quiesced.
+    state.lastDataAt = Date.now();
     if (state.scrollback.length > SCROLLBACK_TRIM_THRESHOLD) {
       state.scrollback = state.scrollback.slice(-MAX_SCROLLBACK);
       const safeStart = findSafeStartIndex(state.scrollback);
@@ -204,28 +236,97 @@ export class PtyBufferManager {
   }
 
   /**
-   * When column width changes, report it so the renderer can decide whether
-   * to skip scrollback replay (TUI escape sequences garble at wrong width).
+   * Record a resize and report whether the column width changed from the last
+   * known width. The session is seeded (initSession) with the actual spawn
+   * cols, so the first renderer resize truthfully reports the 120-to-fitted
+   * width change on a cold launch - the signal the repaint-settle keys on.
    *
-   * The FIRST resize after initSession is special: it establishes the real
-   * terminal dimensions (the renderer fits to its container). We must NOT
-   * report cols changed on this initial resize because it may contain
-   * carried-over history from a suspended session that hasn't been replayed
-   * to the xterm instance yet.
+   * A width change stamps pendingRepaintAt: a full-screen agent TUI repaints
+   * asynchronously in response to the SIGWINCH this resize triggers, and
+   * getScrollback must wait for that repaint before sampling (see
+   * waitForResizeRepaint). onResize itself does not touch scrollback; a stale
+   * "must not clear on the first resize" guard used to swallow this signal and
+   * has been removed (nothing consumes it to clear anything).
    */
   onResize(sessionId: string, cols: number): boolean {
     const state = this.buffers.get(sessionId);
     if (!state) return false;
 
-    if (!state.initialized) {
-      state.initialized = true;
-      state.lastCols = cols;
-      return false;
-    }
-
     const colsChanged = cols !== state.lastCols;
     state.lastCols = cols;
+    if (colsChanged) {
+      state.pendingRepaintAt = Date.now();
+    }
     return colsChanged;
+  }
+
+  /**
+   * Wait until the async repaint that follows a width-changing resize has
+   * landed in the buffer and quiesced, so a getScrollback taken right after a
+   * resize replays the frame at the NEW width instead of a stale one. Awaited
+   * by SessionManager.getScrollback before it samples.
+   *
+   * No-op (resolves immediately) unless a fresh width change is pending AND the
+   * session's scrollback shows a full-screen TUI (a \x1b[2J clear). Plain-shell
+   * sessions and agents whose TUI never clears the screen have no SIGWINCH
+   * repaint to wait for, so they keep sampling immediately - the pre-existing
+   * behavior. Bounded by REPAINT_MAX_WAIT_MS from wait entry so a missing or
+   * slow repaint can only delay a first paint, never hang the read.
+   */
+  async waitForResizeRepaint(sessionId: string): Promise<void> {
+    const state = this.buffers.get(sessionId);
+    if (!state || state.pendingRepaintAt === null) return;
+
+    const stamp = state.pendingRepaintAt;
+    const entryTime = Date.now();
+
+    // A stamp older than STALE means the repaint has long since landed (or
+    // never will) - clear it and sample now rather than wait pointlessly.
+    if (entryTime - stamp > REPAINT_STALE_MS) {
+      state.pendingRepaintAt = null;
+      return;
+    }
+
+    // Gate on the TUI clear marker via a direct scan (NOT tuiStartIndex, which
+    // cannot distinguish "marker absent" from "marker at index 0"). No marker
+    // means no full-screen repaint to wait for.
+    if (!state.scrollback.includes('\x1b[2J')) {
+      state.pendingRepaintAt = null;
+      return;
+    }
+
+    // Poll until repaint bytes have arrived after the resize stamp and then
+    // gone quiet, or the deadline (measured from wait entry, so re-resizes
+    // during a window drag cannot push it out indefinitely) is reached.
+    const deadline = entryTime + REPAINT_MAX_WAIT_MS;
+    await new Promise<void>((resolve) => {
+      const poll = (): void => {
+        const current = this.buffers.get(sessionId);
+        // Session torn down mid-wait (killed): stop waiting.
+        if (!current) {
+          resolve();
+          return;
+        }
+        const now = Date.now();
+        const settled =
+          current.lastDataAt !== null &&
+          current.lastDataAt > stamp &&
+          now - current.lastDataAt >= REPAINT_QUIESCE_MS;
+        if (settled || now >= deadline) {
+          // Only clear the stamp this wait was anchored to. A second
+          // width-changing resize during this wait re-stamps pendingRepaintAt
+          // to a newer value for a not-yet-settled repaint; nulling it
+          // unconditionally would let the next getScrollback skip the wait and
+          // sample that newer repaint stale. Leave a newer stamp in place so it
+          // gets its own settle.
+          if (current.pendingRepaintAt === stamp) current.pendingRepaintAt = null;
+          resolve();
+          return;
+        }
+        setTimeout(poll, REPAINT_POLL_MS);
+      };
+      setTimeout(poll, REPAINT_POLL_MS);
+    });
   }
 
   getScrollback(sessionId: string): string {

--- a/src/main/pty/lifecycle/session-spawn-flow.ts
+++ b/src/main/pty/lifecycle/session-spawn-flow.ts
@@ -51,6 +51,12 @@ export interface SpawnFlowContext {
   sessionQueue: SessionQueue;
   getTranscriptWriter: () => TranscriptWriter | null;
   getShell: () => Promise<string>;
+  /**
+   * Consume any resize that arrived before this session's PTY existed (see
+   * SessionManager.pendingResizes). Returns the stashed dims and clears the
+   * entry, or undefined if none. Lets the spawn use the real fitted size.
+   */
+  takePendingResize: (sessionId: string) => { cols: number; rows: number } | undefined;
   emit: (event: string, ...args: unknown[]) => void;
 }
 
@@ -156,12 +162,22 @@ export async function performSpawn(
     platform: process.platform,
   });
 
+  // Spawn at the real fitted dimensions if a resize arrived before the PTY
+  // existed (auto-resume / queued / suspended-resume race). Otherwise the
+  // default: a background session that is never opened keeps this size, and an
+  // opened one is resized to its container on mount. Spawning at the fitted
+  // size means that mount-time resize is a no-op, avoiding the stale-width
+  // repaint window entirely.
+  const pendingResize = context.takePendingResize(id);
+  const spawnCols = pendingResize?.cols ?? DEFAULT_PTY_COLS;
+  const spawnRows = pendingResize?.rows ?? DEFAULT_PTY_ROWS;
+
   let ptyProcess: pty.IPty;
   try {
     ptyProcess = pty.spawn(shellExe, shellArgs, {
       name: 'xterm-256color',
-      cols: DEFAULT_PTY_COLS,
-      rows: DEFAULT_PTY_ROWS,
+      cols: spawnCols,
+      rows: spawnRows,
       cwd: effectiveCwd,
       env: cleanEnv,
     });
@@ -201,8 +217,12 @@ export async function performSpawn(
 
   context.registry.set(id, session);
 
-  // Initialize extracted modules for this session
-  context.bufferManager.initSession(id, previousScrollback, 0);
+  // Initialize extracted modules for this session. Seed the buffer manager with
+  // the ACTUAL spawn cols so the first renderer resize reports colsChanged
+  // truthfully: an unchanged width (PTY spawned at the fitted size) reports
+  // false and skips the repaint-settle, while the cold-launch 120-to-fitted
+  // change reports true and arms it. See PtyBufferManager.onResize.
+  context.bufferManager.initSession(id, previousScrollback, spawnCols);
   context.sessionFiles.register({
     sessionId: id,
     statusOutputPath: input.statusOutputPath || null,

--- a/src/main/pty/session-manager.ts
+++ b/src/main/pty/session-manager.ts
@@ -70,6 +70,17 @@ export class SessionManager extends EventEmitter {
    */
   private writeQueues = new Map<string, WriteQueue>();
   /**
+   * Terminal dimensions from a resize that arrived before the session's PTY
+   * existed (the renderer mounted and fit its container before the auto-resume
+   * spawn landed, or while the session was queued/suspended awaiting spawn).
+   * performSpawn consumes this so the PTY spawns at the real fitted size
+   * instead of the 120x30 default, so no post-spawn corrective resize (and its
+   * stale-width repaint window) is needed. Keyed by session id, independent of
+   * the registry so it survives the registry.delete during a respawn. Consumed
+   * at spawn (takePendingResize) or dropped on kill.
+   */
+  private pendingResizes = new Map<string, { cols: number; rows: number }>();
+  /**
    * Per-session output backpressure: pauses a session's PTY when the renderer
    * falls behind on its emitted bytes, resuming as the renderer acks. Only
    * tracks sessions actively emitting to the renderer (focused); reset on focus
@@ -430,6 +441,11 @@ export class SessionManager extends EventEmitter {
       sessionQueue: this.sessionQueue,
       getTranscriptWriter: () => this.transcriptWriter,
       getShell: () => this.getShell(),
+      takePendingResize: (sessionId) => {
+        const dims = this.pendingResizes.get(sessionId);
+        this.pendingResizes.delete(sessionId);
+        return dims;
+      },
       emit: (event, ...args) => this.emit(event, ...args),
     });
   }
@@ -489,7 +505,6 @@ export class SessionManager extends EventEmitter {
 
   resize(sessionId: string, cols: number, rows: number): { colsChanged: boolean } {
     const session = this.registry.get(sessionId);
-    if (!session?.pty) return { colsChanged: false };
 
     // Guard against NaN/Infinity from layout edge cases (e.g. getComputedStyle
     // returning "" during unmount, yielding parseInt -> NaN)
@@ -498,6 +513,20 @@ export class SessionManager extends EventEmitter {
     // Clamp to valid dimensions (node-pty throws on 0 or negative)
     const clampedCols = Math.max(2, Math.floor(cols));
     const clampedRows = Math.max(1, Math.floor(rows));
+
+    if (!session?.pty) {
+      // The PTY does not exist yet. A resize can beat the auto-resume spawn (the
+      // renderer mounts and fits before the main-process spawn lands), or arrive
+      // while a session is queued/suspended awaiting (re)spawn. Stash the dims so
+      // performSpawn spawns the PTY at the real size instead of the default,
+      // closing the stale-width race at the source. Never stash for an
+      // exited/killed session - it is not coming back, and xterm never re-sends
+      // unchanged dims, so a resurrected 120x30 would stick forever.
+      if (session && (session.status === 'queued' || session.status === 'suspended')) {
+        this.pendingResizes.set(sessionId, { cols: clampedCols, rows: clampedRows });
+      }
+      return { colsChanged: false };
+    }
 
     const colsChanged = this.bufferManager.onResize(sessionId, clampedCols);
     session.pty.resize(clampedCols, clampedRows);
@@ -562,6 +591,9 @@ export class SessionManager extends EventEmitter {
     // status='suspended' (a hard reset is 'exited', not resumable), so this
     // orthogonal marker carries the intent.
     if (session) session.intentionalExit = true;
+    // Drop any queued pre-spawn resize: a killed session will not respawn to
+    // consume it, and a stale entry keyed by this id must not survive.
+    this.pendingResizes.delete(sessionId);
     // Release backpressure BEFORE nulling the PTY so a paused session is
     // resumed (lets any buffered output flush) and its accounting entry is
     // dropped immediately, rather than waiting for the async onExit handler.
@@ -713,7 +745,12 @@ export class SessionManager extends EventEmitter {
     this.sessionQueue.notifySlotFreed();
   }
 
-  getScrollback(sessionId: string): string {
+  async getScrollback(sessionId: string): Promise<string> {
+    // If a width-changing resize just fired, wait for the agent TUI's async
+    // repaint to land before sampling, so the replay shows the frame at the
+    // fitted width rather than the stale pre-resize one. No-op for sessions
+    // with no pending width change (see PtyBufferManager.waitForResizeRepaint).
+    await this.bufferManager.waitForResizeRepaint(sessionId);
     return this.bufferManager.getScrollback(sessionId);
   }
 

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -199,11 +199,9 @@ export function useTerminal(options: UseTerminalOptions) {
       });
 
       // Resize-first scrollback replay: fit the terminal to the container
-      // FIRST, then send an immediate (non-debounced) resize to the PTY.
-      // If cols changed, skip scrollback entirely -- the PTY may still flush
-      // output at the old width before SIGWINCH is processed, so replaying
-      // scrollback would show truncated/garbled content. Instead, let Claude
-      // Code's SIGWINCH redraw populate the terminal via live onData.
+      // FIRST, then fetch scrollback. The width change (if any) and the sample
+      // are ordered on the main process, not here - see the parallel-IPC note
+      // below.
       scrollbackPendingRef.current = true;
       const scrollbackGeneration = ++scrollbackGenerationRef.current;
       const suppressScrollback = suppressDataRef.current;
@@ -213,16 +211,14 @@ export function useTerminal(options: UseTerminalOptions) {
       const { cols, rows } = terminal;
 
       // Parallel IPCs: resize forwards SIGWINCH on main; getScrollback is a
-      // pure in-memory read. Firing them together hides the cheaper read
-      // inside the resize round-trip instead of chaining them serially.
-      //
-      // Timing caveat: SIGWINCH-redraw bytes from Claude can now land in the
-      // main-process buffer *after* getScrollback has already sampled it, so
-      // the replayed scrollback may be one frame stale. Those bytes arrive
-      // via live onData and get dropped by the scrollbackPendingRef guard
-      // while we're mid-write. The post-write force-resize at line 202
-      // compensates: once scrollbackPendingRef clears, it triggers a fresh
-      // SIGWINCH and Claude's next redraw flows through live onData cleanly.
+      // pure in-memory read. Firing them together is safe because main
+      // preserves per-renderer IPC order and the resize handler is synchronous,
+      // so main records the width change before getScrollback runs. When cols
+      // changed, main's getScrollback waits for the agent TUI's async SIGWINCH
+      // repaint to land before sampling (PtyBufferManager.waitForResizeRepaint),
+      // so the replay is at the fitted width - no stale frame, no compensating
+      // resize needed here. The colsChanged field of the resize result is
+      // therefore intentionally unused by the renderer.
       const resizePromise = window.electronAPI.sessions.resize(sid, cols, rows);
       const scrollbackPromise = suppressScrollback
         ? Promise.resolve<string | null>(null)
@@ -246,14 +242,11 @@ export function useTerminal(options: UseTerminalOptions) {
               isAtBottomRef.current = restoreScrollPosition(xtermRef.current, options.sessionId);
             }
             scrollbackPendingRef.current = false;
-            // Force an explicit resize to the PTY even if dimensions haven't
-            // changed, so the running process (Claude Code's TUI) re-renders.
-            // Focus the terminal after the full init chain completes.
+            // Focus the terminal after the full init chain completes. No
+            // corrective resize: main already sampled the settled frame at the
+            // fitted width, and a same-dims resize is a documented no-op (POSIX
+            // sends SIGWINCH only on a real size change; ConPTY likewise).
             requestAnimationFrame(() => {
-              if (xtermRef.current && options.sessionId) {
-                const { cols, rows } = xtermRef.current;
-                window.electronAPI.sessions.resize(options.sessionId, cols, rows);
-              }
               xtermRef.current?.focus();
             });
           };
@@ -450,9 +443,11 @@ export function useTerminal(options: UseTerminalOptions) {
     const sessionId = options.sessionId;
 
     // Parallel IPCs: same shape as initTerminal's mount-time path. Resize
-    // forwards SIGWINCH on main; getScrollback is an in-memory read. See the
-    // initTerminal comment for the SIGWINCH-frame staleness caveat - the
-    // post-write force-resize compensates here too.
+    // forwards SIGWINCH on main; getScrollback is an in-memory read. When cols
+    // changed, main waits for the agent TUI's repaint to settle before sampling
+    // (see the initTerminal note), so the reload lands the fitted-width frame.
+    // skipResize sends no SIGWINCH: the window manager calls it once resizing
+    // has already settled, so there is nothing to wait for.
     const resizePromise = skipResize
       ? Promise.resolve(undefined)
       : window.electronAPI.sessions.resize(sessionId, cols, rows);
@@ -473,13 +468,10 @@ export function useTerminal(options: UseTerminalOptions) {
             isAtBottomRef.current = restoreScrollPosition(xtermRef.current, options.sessionId);
           }
           scrollbackPendingRef.current = false;
+          // Focus after the reload completes. No corrective resize: when a
+          // resize was sent above, main sampled the settled frame; a same-dims
+          // resize is a no-op either way.
           requestAnimationFrame(() => {
-            // Skip the force-resize for a skipResize replay: a SIGWINCH here
-            // would make the TUI redraw and re-pollute the just-cleaned buffer.
-            if (!skipResize && xtermRef.current && options.sessionId) {
-              const { cols, rows } = xtermRef.current;
-              window.electronAPI.sessions.resize(options.sessionId, cols, rows);
-            }
             xtermRef.current?.focus();
           });
         };

--- a/tests/unit/pty-buffer-manager.test.ts
+++ b/tests/unit/pty-buffer-manager.test.ts
@@ -102,63 +102,225 @@ describe('PtyBufferManager', () => {
     });
   });
 
-  describe('initial resize preserves carried-over scrollback', () => {
-    it('does not clear scrollback on the first resize after initSession', () => {
+  describe('resize reports width changes truthfully and preserves scrollback', () => {
+    it('reports colsChanged=true on the first resize to a new width (no initial-resize swallow)', () => {
       const onFlush = vi.fn();
       const manager = new PtyBufferManager({ onFlush });
-      // Simulate a resumed session with carried-over scrollback
-      manager.initSession(SESSION, 'previous session output', 0);
+      // Cold-launch shape: the PTY was spawned at 120, the buffer is seeded with
+      // that real width, and the renderer fits to ~190 on mount. The first
+      // resize must report the change truthfully so getScrollback's
+      // repaint-settle arms. A stale first-resize swallow used to hide this.
+      manager.initSession(SESSION, 'previous session output', 120);
 
-      // First resize (renderer establishing container dimensions) must NOT clear
-      const colsChanged = manager.onResize(SESSION, 120);
+      const colsChanged = manager.onResize(SESSION, 190);
+      expect(colsChanged).toBe(true);
+      // onResize never clears scrollback; carried-over history is preserved.
+      expect(manager.getScrollback(SESSION)).toContain('previous session output');
+    });
+
+    it('reports colsChanged=false when the first resize matches the seeded spawn width', () => {
+      const onFlush = vi.fn();
+      const manager = new PtyBufferManager({ onFlush });
+      // Pre-spawn-resize shape: the PTY was spawned AT the fitted width, so the
+      // renderer's follow-up resize is a no-op and must not arm a needless wait.
+      manager.initSession(SESSION, 'previous session output', 190);
+
+      const colsChanged = manager.onResize(SESSION, 190);
       expect(colsChanged).toBe(false);
       expect(manager.getScrollback(SESSION)).toContain('previous session output');
     });
 
-    it('preserves scrollback on second resize with different cols', () => {
+    it('preserves scrollback across a later width change', () => {
       const onFlush = vi.fn();
       const manager = new PtyBufferManager({ onFlush });
-      manager.initSession(SESSION, 'previous session output', 0);
-
-      // First resize: establishes dimensions
-      manager.onResize(SESSION, 120);
-
-      // Add some live data at the current width
+      manager.initSession(SESSION, 'previous session output', 120);
+      manager.onResize(SESSION, 190);
       manager.onData(SESSION, 'live data');
 
-      // Second resize: user resizes window to different width
-      // Scrollback is no longer cleared on resize (KISS read-time strip)
       const colsChanged = manager.onResize(SESSION, 200);
       expect(colsChanged).toBe(true);
       expect(manager.getScrollback(SESSION)).toContain('previous session output');
+      expect(manager.getScrollback(SESSION)).toContain('live data');
     });
 
-    it('does not clear scrollback on second resize with same cols', () => {
+    it('reports colsChanged=false on a same-width resize (rows-only change)', () => {
       const onFlush = vi.fn();
       const manager = new PtyBufferManager({ onFlush });
-      manager.initSession(SESSION, 'previous session output', 0);
-
-      // First resize
+      manager.initSession(SESSION, 'previous session output', 120);
       manager.onResize(SESSION, 120);
-      // Add live data
       manager.onData(SESSION, ' plus new data');
 
-      // Second resize with same cols (rows-only change)
       const colsChanged = manager.onResize(SESSION, 120);
       expect(colsChanged).toBe(false);
       expect(manager.getScrollback(SESSION)).toContain('previous session output');
       expect(manager.getScrollback(SESSION)).toContain('plus new data');
     });
 
-    it('fresh session with empty scrollback is unaffected by initial resize', () => {
+    it('fresh session seeded at spawn width reports no change on a matching resize', () => {
       const onFlush = vi.fn();
       const manager = new PtyBufferManager({ onFlush });
-      manager.initSession(SESSION, '', 0);
+      manager.initSession(SESSION, '', 120);
 
-      // First resize: cols change from 0 to 120 but scrollback is empty
       const colsChanged = manager.onResize(SESSION, 120);
       expect(colsChanged).toBe(false);
       expect(manager.getScrollback(SESSION)).toBe('');
+    });
+  });
+
+  describe('waitForResizeRepaint (repaint-settle before sampling)', () => {
+    // Build the precondition the settle keys on: a full-screen TUI frame (with a
+    // \x1b[2J clear) in the buffer, then a width change that stamps the pending
+    // repaint. Returns the manager so each test drives the settle from there.
+    function armWidthChange(tui = true): PtyBufferManager {
+      const manager = new PtyBufferManager({ onFlush: vi.fn() });
+      manager.initSession(SESSION, '', 120);
+      manager.onData(SESSION, tui ? '\x1b[2Jold frame at 120 cols' : 'plain shell output');
+      expect(manager.onResize(SESSION, 190)).toBe(true);
+      return manager;
+    }
+
+    it('defers sampling until the post-resize repaint lands and quiesces', async () => {
+      vi.useFakeTimers();
+      const manager = armWidthChange();
+
+      let settled = false;
+      const waitPromise = manager.waitForResizeRepaint(SESSION).then(() => {
+        settled = true;
+      });
+
+      // No repaint yet: the settle is still pending.
+      await vi.advanceTimersByTimeAsync(16);
+      expect(settled).toBe(false);
+
+      // The SIGWINCH repaint lands.
+      manager.onData(SESSION, '\x1b[2Jrepaint at 190 cols');
+
+      // Data just arrived: not yet quiesced.
+      await vi.advanceTimersByTimeAsync(16);
+      expect(settled).toBe(false);
+
+      // Quiesce window elapses -> the settle resolves.
+      await vi.advanceTimersByTimeAsync(80);
+      await waitPromise;
+      expect(settled).toBe(true);
+
+      // The sample now includes the fitted-width repaint, not just the stale frame.
+      expect(manager.getScrollback(SESSION)).toContain('repaint at 190 cols');
+
+      vi.useRealTimers();
+    });
+
+    it('resolves at the max-wait ceiling when no repaint ever arrives', async () => {
+      vi.useFakeTimers();
+      const manager = armWidthChange();
+
+      let settled = false;
+      const waitPromise = manager.waitForResizeRepaint(SESSION).then(() => {
+        settled = true;
+      });
+
+      // Well past a few polls but short of the ceiling: still waiting.
+      await vi.advanceTimersByTimeAsync(200);
+      expect(settled).toBe(false);
+
+      // Ceiling (400ms from entry) reached: resolves without a repaint.
+      await vi.advanceTimersByTimeAsync(200);
+      await waitPromise;
+      expect(settled).toBe(true);
+
+      vi.useRealTimers();
+    });
+
+    it('samples immediately when the pending resize is stale', async () => {
+      vi.useFakeTimers();
+      const manager = armWidthChange();
+
+      // Time passes beyond the stale window with no sample taken.
+      await vi.advanceTimersByTimeAsync(2001);
+
+      // No timers need to fire for the wait: it short-circuits.
+      await manager.waitForResizeRepaint(SESSION);
+
+      vi.useRealTimers();
+    });
+
+    it('samples immediately when the session has no full-screen TUI (no clear marker)', async () => {
+      vi.useFakeTimers();
+      const manager = armWidthChange(false);
+
+      await manager.waitForResizeRepaint(SESSION);
+
+      vi.useRealTimers();
+    });
+
+    it('resolves if the session is torn down mid-wait', async () => {
+      vi.useFakeTimers();
+      const manager = armWidthChange();
+
+      let settled = false;
+      const waitPromise = manager.waitForResizeRepaint(SESSION).then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(16);
+      expect(settled).toBe(false);
+
+      // Killed: the session's buffer state is removed.
+      manager.removeSession(SESSION);
+
+      await vi.advanceTimersByTimeAsync(16);
+      await waitPromise;
+      expect(settled).toBe(true);
+
+      vi.useRealTimers();
+    });
+
+    it('does not arm a wait when the width did not change', async () => {
+      vi.useFakeTimers();
+      const manager = new PtyBufferManager({ onFlush: vi.fn() });
+      manager.initSession(SESSION, '', 120);
+      manager.onData(SESSION, '\x1b[2Jframe at 120 cols');
+      // Same-width resize: colsChanged false, no pending repaint stamped.
+      expect(manager.onResize(SESSION, 120)).toBe(false);
+
+      // No pending repaint -> short-circuits with no timers.
+      await manager.waitForResizeRepaint(SESSION);
+
+      vi.useRealTimers();
+    });
+
+    it('does not clobber a newer pending repaint stamped by a second resize mid-wait', async () => {
+      vi.useFakeTimers();
+      const manager = armWidthChange(); // onResize(190) stamps the first repaint; TUI marker present
+
+      // A first getScrollback wait anchors to the first resize's stamp.
+      const firstWait = manager.waitForResizeRepaint(SESSION);
+
+      // A second width-changing resize lands before the first wait resolves,
+      // re-stamping pendingRepaintAt for a fresh, not-yet-settled repaint.
+      await vi.advanceTimersByTimeAsync(50);
+      expect(manager.onResize(SESSION, 200)).toBe(true);
+
+      // The first wait reaches its ceiling (400ms from entry) and resolves. It
+      // must NOT null out the newer stamp it was never anchored to.
+      await vi.advanceTimersByTimeAsync(400);
+      await firstWait;
+
+      // A subsequent getScrollback must still defer for the second repaint,
+      // which never landed. If the first wait had clobbered the stamp, this
+      // read would short-circuit and sample the frame stale.
+      let secondSettled = false;
+      const secondWait = manager.waitForResizeRepaint(SESSION).then(() => {
+        secondSettled = true;
+      });
+      await vi.advanceTimersByTimeAsync(16);
+      expect(secondSettled).toBe(false);
+
+      // Let it resolve at its own ceiling so no timer leaks into the next test.
+      await vi.advanceTimersByTimeAsync(400);
+      await secondWait;
+
+      vi.useRealTimers();
     });
   });
 

--- a/tests/unit/session-exit-intentional.test.ts
+++ b/tests/unit/session-exit-intentional.test.ts
@@ -148,6 +148,7 @@ function makeContext(): SpawnFlowContext {
     },
     getTranscriptWriter: vi.fn(() => null),
     getShell: vi.fn().mockResolvedValue('/bin/bash'),
+    takePendingResize: vi.fn(() => undefined),
     emit: vi.fn(),
   } as unknown as SpawnFlowContext;
 }

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -126,7 +126,7 @@ describe('Scrollback', () => {
     const chunk = 'x'.repeat(600 * 1024);
     feedData(chunk);
 
-    const scrollback = manager.getScrollback(session.id);
+    const scrollback = await manager.getScrollback(session.id);
     // getScrollback() prepends \x1b[0m (4 bytes) and findSafeStartIndex
     // may trim up to 32 bytes at the truncation boundary
     expect(scrollback.startsWith('\x1b[0m')).toBe(true);
@@ -140,7 +140,7 @@ describe('Scrollback', () => {
     const chunk = 'y'.repeat(100 * 1024);
     feedData(chunk);
 
-    const scrollback = manager.getScrollback(session.id);
+    const scrollback = await manager.getScrollback(session.id);
     // No truncation, so only the 4-byte SGR reset prefix is added
     expect(scrollback.startsWith('\x1b[0m')).toBe(true);
     expect(scrollback.length).toBe(100 * 1024 + 4);
@@ -155,7 +155,7 @@ describe('Scrollback', () => {
     feedData(chunk);
     feedData(chunk);
 
-    const scrollback = manager.getScrollback(session.id);
+    const scrollback = await manager.getScrollback(session.id);
     expect(scrollback.startsWith('\x1b[0m')).toBe(true);
     expect(scrollback.length).toBeLessThanOrEqual(512 * 1024 + 4);
     expect(scrollback.length).toBeGreaterThan(512 * 1024 - 32);
@@ -210,7 +210,7 @@ describe('Scrollback clearing on resize', () => {
     const result = manager.resize(session.id, 120, 50);
     expect(result).toEqual({ colsChanged: false });
 
-    const scrollback = manager.getScrollback(session.id);
+    const scrollback = await manager.getScrollback(session.id);
     expect(scrollback).toContain('hello world');
   });
 
@@ -223,7 +223,7 @@ describe('Scrollback clearing on resize', () => {
     const result = manager.resize(session.id, 80, 24);
     expect(result).toEqual({ colsChanged: true });
 
-    const scrollback = manager.getScrollback(session.id);
+    const scrollback = await manager.getScrollback(session.id);
     // Scrollback is preserved on resize (KISS read-time strip approach)
     expect(scrollback).toContain('hello world');
   });
@@ -239,11 +239,11 @@ describe('Scrollback clearing on resize', () => {
 
     // Resize to same 80 cols (should preserve)
     manager.resize(session.id, 80, 30);
-    expect(manager.getScrollback(session.id)).toContain('data at 80 cols');
+    expect(await manager.getScrollback(session.id)).toContain('data at 80 cols');
 
     // Resize to different cols - scrollback preserved (no write-time clearing)
     manager.resize(session.id, 100, 30);
-    expect(manager.getScrollback(session.id)).toContain('data at 80 cols');
+    expect(await manager.getScrollback(session.id)).toContain('data at 80 cols');
   });
 
   it('clamps cols to minimum of 2', async () => {
@@ -286,12 +286,78 @@ describe('Scrollback clearing on resize', () => {
 
     // Change cols - scrollback preserved
     manager.resize(session.id, 80, 24);
-    expect(manager.getScrollback(session.id)).toContain('old data');
+    expect(await manager.getScrollback(session.id)).toContain('old data');
 
     // New data arrives at new width
     feedData('new data');
-    expect(manager.getScrollback(session.id)).toContain('new data');
-    expect(manager.getScrollback(session.id)).toContain('old data');
+    expect(await manager.getScrollback(session.id)).toContain('new data');
+    expect(await manager.getScrollback(session.id)).toContain('old data');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2b. Pre-spawn resize queue (stale-width race on auto-resume)
+// ---------------------------------------------------------------------------
+
+describe('Pre-spawn resize queue', () => {
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    manager = new SessionManager();
+  });
+
+  it('spawns a resumed session at dimensions from a resize that arrived while suspended', async () => {
+    const mock1 = createMockPty();
+    vi.mocked(pty.spawn).mockReturnValue(mock1.mockPty as unknown as pty.IPty);
+    const session = await manager.spawn({ taskId: 'task-pending-resize', command: '', cwd: tmpDir });
+
+    // Suspend: the PTY is torn down (pty=null) but the record persists for resume.
+    await manager.suspend(session.id);
+
+    // A renderer resize arrives while suspended, before the resume spawn. It is
+    // stashed rather than dropped (the secondary stale-width hole: xterm never
+    // re-sends unchanged dims, so a dropped resize would strand the PTY at the
+    // default width forever).
+    expect(manager.resize(session.id, 190, 40)).toEqual({ colsChanged: false });
+
+    // Resume: performSpawn consumes the stash and spawns the PTY at 190x40
+    // instead of the 120x30 default, so the mount-time resize is a no-op and no
+    // corrective repaint window opens.
+    const mock2 = createMockPty();
+    vi.mocked(pty.spawn).mockReturnValue(mock2.mockPty as unknown as pty.IPty);
+    await manager.spawn({ id: session.id, taskId: 'task-pending-resize', command: '', cwd: tmpDir, resuming: true });
+
+    expect(pty.spawn).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ cols: 190, rows: 40 }),
+    );
+
+    manager.kill(session.id);
+  });
+
+  it('drops a queued resize when the session is killed before respawn', async () => {
+    const mock1 = createMockPty();
+    vi.mocked(pty.spawn).mockReturnValue(mock1.mockPty as unknown as pty.IPty);
+    const session = await manager.spawn({ taskId: 'task-killed-resize', command: '', cwd: tmpDir });
+
+    await manager.suspend(session.id);
+    manager.resize(session.id, 190, 40); // stashed while suspended
+    manager.kill(session.id); // deliberate teardown clears the stash
+
+    // A fresh spawn for the same task must NOT inherit the killed session's
+    // stashed dims: it spawns at the default.
+    const mock2 = createMockPty();
+    vi.mocked(pty.spawn).mockReturnValue(mock2.mockPty as unknown as pty.IPty);
+    const fresh = await manager.spawn({ taskId: 'task-killed-resize', command: '', cwd: tmpDir });
+
+    expect(pty.spawn).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ cols: 120, rows: 30 }),
+    );
+
+    manager.kill(fresh.id);
   });
 });
 
@@ -326,7 +392,7 @@ describe('Remove', () => {
     manager.remove(session.id);
 
     expect(manager.getSession(session.id)).toBeUndefined();
-    expect(manager.getScrollback(session.id)).toBe('');
+    expect(await manager.getScrollback(session.id)).toBe('');
     expect(manager.getEventsForSession(session.id)).toEqual([]);
     expect(manager.getUsageCache()[session.id]).toBeUndefined();
     expect(manager.getActivityCache()[session.id]).toBeUndefined();
@@ -672,7 +738,7 @@ describe('PTY spawn failure', () => {
       cwd: tmpDir,
     });
 
-    const scrollback = manager.getScrollback(session.id);
+    const scrollback = await manager.getScrollback(session.id);
     expect(scrollback).toContain('posix_spawnp');
     expect(scrollback).toContain('spawn-helper');
 
@@ -691,7 +757,7 @@ describe('PTY spawn failure', () => {
       cwd: tmpDir,
     });
 
-    const scrollback = manager.getScrollback(session.id);
+    const scrollback = await manager.getScrollback(session.id);
     expect(scrollback).not.toContain('posix_spawnp');
     expect(scrollback).not.toContain('spawn-helper');
 
@@ -1255,10 +1321,10 @@ describe('Query methods for missing sessions', () => {
     manager = new SessionManager();
   });
 
-  it('returns empty/undefined for non-existent session ID', () => {
+  it('returns empty/undefined for non-existent session ID', async () => {
     expect(manager.getSession('ghost')).toBeUndefined();
     expect(manager.getEventsForSession('ghost')).toEqual([]);
-    expect(manager.getScrollback('ghost')).toBe('');
+    expect(await manager.getScrollback('ghost')).toBe('');
   });
 
   it('returns empty objects when no sessions exist', () => {

--- a/tests/unit/session-respawn.test.ts
+++ b/tests/unit/session-respawn.test.ts
@@ -164,7 +164,7 @@ describe('Session respawn (column transition)', () => {
     const { session: second } = await spawnForTask('task-6');
 
     // Non-resume respawn preserves scrollback across column transitions
-    const scrollback = manager.getScrollback(second.id);
+    const scrollback = await manager.getScrollback(second.id);
     expect(scrollback).toContain('previous output');
   });
 
@@ -178,7 +178,7 @@ describe('Session respawn (column transition)', () => {
 
     // Resume spawns preserve scrollback so terminal scroll history is
     // available. Claude CLI's TUI overwrites the viewport without corrupting it.
-    const scrollback = manager.getScrollback(second.id);
+    const scrollback = await manager.getScrollback(second.id);
     expect(scrollback).toContain('previous output');
   });
 
@@ -190,7 +190,7 @@ describe('Session respawn (column transition)', () => {
     await spawnForTask('task-7');
 
     // Old session ID returns empty scrollback (session removed from map)
-    expect(manager.getScrollback(first.id)).toBe('');
+    expect(await manager.getScrollback(first.id)).toBe('');
   });
 
   it('old PTY is killed during respawn', async () => {

--- a/tests/unit/session-spawn-flow.test.ts
+++ b/tests/unit/session-spawn-flow.test.ts
@@ -176,6 +176,7 @@ function makeContext(): SpawnFlowContext {
     },
     getTranscriptWriter: vi.fn(() => null),
     getShell: vi.fn().mockResolvedValue('/bin/bash'),
+    takePendingResize: vi.fn(() => undefined),
     emit: vi.fn(),
   } as unknown as SpawnFlowContext;
 }


### PR DESCRIPTION
## What

Fixes the stale-width TUI on first launch: a restored task-detail terminal painted the agent's
frame at a stale narrow width (prompt box stops mid-pane, wrapped paths reflow above it, input row
misplaced) until a manual window resize or a close/reopen repainted it.

Touches the PTY scrollback/resize path:
- `src/main/pty/buffer/pty-buffer-manager.ts` - repaint-settle + truthful `colsChanged`
- `src/main/pty/session-manager.ts` - async `getScrollback`, pre-PTY resize queue
- `src/main/pty/lifecycle/session-spawn-flow.ts` - spawn at fitted dims, seed real cols
- `src/renderer/hooks/useTerminal.ts` - remove the dead force-resize, document the contract

## Why

On a cold launch a suspended session auto-resumes in the main process before any renderer terminal
exists, so the PTY spawns at the default 120x30 and the agent TUI paints there. When the restored
window mounts it fits xterm wider and fires `resize` + `getScrollback` in parallel; main sampled
the buffer before the agent's asynchronous SIGWINCH repaint landed, so the replay was the stale
120-col frame. The repaint then arrived via live `onData` mid-replay and was dropped. Both designed
recoveries were dead code: the renderer discarded the `colsChanged` result, and the post-replay
"force resize" re-sent identical dims, which is a documented no-op (POSIX sends SIGWINCH only on a
real size change; ConPTY likewise). Nothing else fired on initial restore, so the frame stayed
garbled.

Closes #335.

## How

Main becomes the single choke point and defers the scrollback sample until the repaint has landed,
so every replay path (mount, overlay-lift reload, window-manager settle reload) is correct by
construction:

- **Repaint-settled `getScrollback`.** `SessionManager.getScrollback` is now async and awaits
  `PtyBufferManager.waitForResizeRepaint`, which - only when a width change is pending and the
  scrollback shows a full-screen TUI (a `\x1b[2J` clear) - waits for post-resize data to land and
  quiesce before sampling, bounded by a 400ms ceiling measured from wait entry so a missing or slow
  repaint can only delay a first paint, never hang. Plain-shell sessions never pay the wait. The
  IPC contract is unchanged (the renderer type was already `Promise<string>`).
- **Truthful `colsChanged`.** The buffer manager is seeded with the real spawn cols and the
  first-resize swallow is removed, so the 120-to-fitted change reports `true` instead of the `false`
  it used to report on exactly the launch resize that mattered.
- **Pre-PTY resize queue.** A resize that arrives before the PTY exists (renderer mounts before the
  auto-resume spawn) is stashed and applied at spawn, so the PTY starts at the fitted size and the
  mount-time resize is a no-op - removing the race at its source. Cleared on kill.
- **Renderer cleanup.** The dead same-dims force-resize is removed from both replay paths and the
  stale comments are rewritten to document the main-side settle.

Trade-off: a genuine first-open width change now adds up to 400ms (only when a repaint is missing or
slow) to the first paint of that one terminal, imperceptible against window-restore time and bounded.

## Breaking changes

None. `SessionManager.getScrollback` becoming async is internal; the renderer-facing IPC return type
was already `Promise<string>`.

## Tests

Unit tier (deterministic, fake-timer driven - no flaky visual/timing assertions for the race):
- `tests/unit/pty-buffer-manager.test.ts` - `waitForResizeRepaint` settle (deferral-until-quiesce,
  max-wait ceiling, stale-stamp skip, no-TUI-marker skip, killed-mid-wait, no-arm-on-same-width) and
  the rewritten truthful-`colsChanged` describe. The deferral tests are red-green: they fail if the
  settle is removed.
- `tests/unit/session-manager.test.ts` - pre-spawn resize queue (resume applies the stashed dims;
  kill drops the stash), plus all `getScrollback` call sites updated to `await`.
- `tests/unit/session-respawn.test.ts` - awaited `getScrollback`.

CI runs the full unit, UI, and Linux Electron E2E tiers.

Generated with [Claude Code](https://claude.com/claude-code)
