### PR TITLE
feat(board-manager): redesign Edit Columns as master-detail with maximize parity

### DIFF
--- a/src/renderer/components/ToggleCard.tsx
+++ b/src/renderer/components/ToggleCard.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { Info } from 'lucide-react';
 
 interface ToggleCardProps {
   label: string;
@@ -9,6 +10,11 @@ interface ToggleCardProps {
   icon?: React.ReactNode;
   /** Override the announced label. Defaults to `label`. */
   ariaLabel?: string;
+  /**
+   * Optional longer explanation surfaced as a hover tooltip on an info icon
+   * beside the label, so a verbose "how it works" note need not occupy layout.
+   */
+  info?: string;
 }
 
 /**
@@ -42,7 +48,7 @@ export function ToggleIndicator({ checked, className = '' }: { checked: boolean;
  * Use this for any standalone boolean setting that has a label + description.
  * For dense lists of toggles, use `CompactToggleList` instead.
  */
-export function ToggleCard({ label, description, checked, onChange, icon, ariaLabel }: ToggleCardProps) {
+export function ToggleCard({ label, description, checked, onChange, icon, ariaLabel, info }: ToggleCardProps) {
   return (
     <button
       type="button"
@@ -54,7 +60,21 @@ export function ToggleCard({ label, description, checked, onChange, icon, ariaLa
     >
       {icon && <span className="flex-shrink-0 mt-0.5 text-fg-muted">{icon}</span>}
       <div className="flex-1 min-w-0">
-        <div className="text-sm font-medium text-fg-secondary">{label}</div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-sm font-medium text-fg-secondary">{label}</span>
+          {info && (
+            // Non-interactive span (nesting a button inside the card button is
+            // invalid); stopPropagation keeps a click on the icon from toggling.
+            <span
+              title={info}
+              aria-hidden="true"
+              onClick={(event) => event.stopPropagation()}
+              className="flex-shrink-0 text-fg-faint hover:text-fg-tertiary cursor-help"
+            >
+              <Info size={13} />
+            </span>
+          )}
+        </div>
         <p className="text-xs text-fg-faint mt-0.5">{description}</p>
       </div>
       <ToggleIndicator checked={checked} className="mt-0.5" />

--- a/src/renderer/components/dialogs/BoardManagerDialog.tsx
+++ b/src/renderer/components/dialogs/BoardManagerDialog.tsx
@@ -1,17 +1,22 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  Layers, Plus, Sliders, Bot, Zap, History,
+  Layers, Sliders, Bot, Zap, History,
   Trash2, RotateCcw, Palette, ChevronRight, X,
 } from 'lucide-react';
 import { HexColorPicker } from 'react-colorful';
 import { useBoardStore } from '../../stores/board-store';
 import { useConfigStore } from '../../stores/config-store';
 import { useProjectStore } from '../../stores/project-store';
+import { useSessionStore } from '../../stores/session-store';
 import { useToastStore } from '../../stores/toast-store';
 import { BaseDialog } from './BaseDialog';
 import { ConfirmDialog } from './ConfirmDialog';
 import { IconPickerDialog } from './IconPickerDialog';
 import { ModelCombobox } from './ModelCombobox';
+import { maximizedDialogLayout, MaximizeToggleButton } from './dialog-maximize';
+import { ColumnRail, ALL_COLUMNS_ID, type RailRow } from './board-manager/ColumnRail';
+import { ColumnsOverview, formatModelName, type OverviewRow } from './board-manager/ColumnsOverview';
+import { Pill } from '../Pill';
 import { ICON_REGISTRY, ROLE_DEFAULTS, getUsedIcons } from '../../utils/swimlane-icons';
 import { Select } from '../settings/shared';
 import { ToggleCard } from '../ToggleCard';
@@ -31,6 +36,9 @@ import {
   type SwimlaneCreateInput,
   type SwimlaneUpdateInput,
 } from '../../../shared/types';
+
+/** Sentinel entity id keying this dialog's maximize flag in the session store. */
+const BOARD_MANAGER_ENTITY_ID = 'board-manager-dialog';
 
 const PRESET_COLORS = [
   '#6b7280', '#ef4444', '#f43f5e', '#f97316',
@@ -80,6 +88,79 @@ export function hasOverride(_draft: Swimlane, _section: SectionId): boolean {
   return false;
 }
 
+/**
+ * Reconcile the local `laneOrder` against a fresh store snapshot when the store
+ * changes. When no local drag is in flight (`hasLocalReorder` false) the dialog
+ * adopts the store's position order, re-inserting any unsaved `new:` drafts just
+ * before Done (the historical behavior). When a local drag IS in flight it
+ * PRESERVES the user's order: it drops ids the store no longer has, keeps `new:`
+ * drafts in place, and appends any never-seen store ids (created elsewhere) just
+ * before Done. This is the risk-7 guard: without it, a store refresh (loadBoard
+ * HMR re-sync, config-watcher apply, another surface's reorder, or the save
+ * flow's own createSwimlane push) would re-sort by position and clobber the
+ * unsaved reorder.
+ */
+export function reconcileLaneOrder(
+  previousOrder: string[],
+  swimlanes: Swimlane[],
+  hasLocalReorder: boolean,
+): string[] {
+  const sorted = [...swimlanes].sort((a, b) => a.position - b.position).map((lane) => lane.id);
+  if (!hasLocalReorder) {
+    const newIds = previousOrder.filter((id) => id.startsWith(NEW_DRAFT_PREFIX));
+    if (newIds.length === 0) return sorted;
+    const result = [...sorted];
+    const doneIndex = result.findIndex((id) => swimlanes.find((lane) => lane.id === id)?.role === 'done');
+    const insertAt = doneIndex >= 0 ? doneIndex : result.length;
+    // Insert all drafts in one splice so their relative order is preserved. A
+    // per-draft splice at the fixed `insertAt` would land each one before the
+    // previous, silently reversing two or more newly-added columns.
+    const missingNewIds = newIds.filter((id) => !result.includes(id));
+    result.splice(insertAt, 0, ...missingNewIds);
+    return result;
+  }
+  const storeIds = new Set(sorted);
+  const kept = previousOrder.filter((id) => id.startsWith(NEW_DRAFT_PREFIX) || storeIds.has(id));
+  const known = new Set(kept);
+  const incoming = sorted.filter((id) => !known.has(id));
+  if (incoming.length === 0) return kept;
+  const result = [...kept];
+  const doneIndex = result.findIndex((id) => swimlanes.find((lane) => lane.id === id)?.role === 'done');
+  const insertAt = doneIndex >= 0 ? doneIndex : result.length;
+  result.splice(insertAt, 0, ...incoming);
+  return result;
+}
+
+/**
+ * The persisted column ids whose position differs from the store's
+ * position-sorted order. Empty when the order is unchanged, or when a
+ * create/delete is pending (a length mismatch, which carries its own dirty
+ * state). Unsaved `new:` drafts are ignored. Shared by `isOrderChanged` (the
+ * dirty gate) and the footer's affected-column summary so the two never drift.
+ */
+export function getReorderedColumnIds(laneOrder: string[], originals: Record<string, Swimlane>): Set<string> {
+  const moved = new Set<string>();
+  const persistedOrder = laneOrder.filter((id) => !isNewDraftId(id));
+  const originalOrder = Object.values(originals)
+    .sort((a, b) => a.position - b.position)
+    .map((lane) => lane.id);
+  if (persistedOrder.length !== originalOrder.length) return moved;
+  persistedOrder.forEach((id, index) => {
+    if (originalOrder[index] !== id) moved.add(id);
+  });
+  return moved;
+}
+
+/**
+ * True when the persisted columns' order in `laneOrder` differs from the store's
+ * position-sorted order. Unsaved `new:` drafts are ignored (their placement is
+ * handled by the create-then-reorder path on save). Gates the reorder IPC call
+ * in handleSave and the footer's modified-column summary.
+ */
+export function isOrderChanged(laneOrder: string[], originals: Record<string, Swimlane>): boolean {
+  return getReorderedColumnIds(laneOrder, originals).size > 0;
+}
+
 export function buildUpdateInput(draft: Swimlane, original: Swimlane): SwimlaneUpdateInput {
   const isTodoOrDone = original.role === 'todo' || original.role === 'done';
   const isPlanMode = draft.permission_mode === 'plan';
@@ -122,25 +203,6 @@ export function buildCreateInput(draft: Swimlane): SwimlaneCreateInput {
   };
 }
 
-/**
- * One-line description of a column's session behavior for the chosen target +
- * spawn strategy. Mirrors the matrix that `resolveForceFresh` encodes; it does
- * not re-derive the default (the Select values are always concrete here).
- */
-function describeSessionBehavior(
-  target: SessionTarget,
-  spawnStrategy: SessionSpawnStrategy,
-): string {
-  if (target === 'isolated') {
-    return spawnStrategy === 'always_spawn_new'
-      ? 'Runs this column on a fresh, isolated session each entry - a clean context independent of the main conversation (for example, a code review). Leaving the column resumes the main session. Pair with an Auto-command like /code-review.'
-      : 'Runs this column on its own isolated session, separate from the main conversation, and resumes that session on re-entry. Leaving the column resumes the main session.';
-  }
-  return spawnStrategy === 'always_spawn_new'
-    ? 'Restarts the main session from scratch each time a task enters this column, discarding its prior conversation.'
-    : 'Continues the task\'s main session, resuming it on entry (the default).';
-}
-
 function makeNewDraft(): Swimlane {
   const id = `${NEW_DRAFT_PREFIX}${crypto.randomUUID()}`;
   return {
@@ -171,18 +233,19 @@ function makeNewDraft(): Swimlane {
 // Local presentation helpers
 // ────────────────────────────────────────────────────────────────────────
 
-function SettingField({ label, description, hint, children }: {
+function SettingField({ label, description, hint, children, className = '' }: {
   label: string;
   description?: string;
   hint?: React.ReactNode;
   children: React.ReactNode;
+  /** Extra classes on the field wrapper (e.g. a grid col-span for full-width fields). */
+  className?: string;
 }) {
-  // Field block fills the section's content width so inputs don't look
-  // stranded against a wide empty gutter. `flex flex-col h-full` +
-  // `mt-auto` keeps inputs aligned to the bottom of their grid cell when
-  // descriptions in the same row vary in line count.
+  // Field block fills its grid cell. `flex flex-col h-full` + `mt-auto` keeps
+  // inputs aligned to the bottom of their cell when two fields in the same row
+  // have descriptions of differing line count.
   return (
-    <div className="flex flex-col h-full">
+    <div className={`flex flex-col h-full ${className}`}>
       <div className="flex items-center justify-between gap-2">
         <label className="text-sm font-medium text-fg-secondary">{label}</label>
         {hint}
@@ -190,7 +253,7 @@ function SettingField({ label, description, hint, children }: {
       {description && (
         <p className="text-xs text-fg-faint mt-0.5">{description}</p>
       )}
-      <div className={description ? 'mt-auto pt-2' : 'mt-2'}>{children}</div>
+      <div className={description ? 'mt-auto pt-1.5' : 'mt-1.5'}>{children}</div>
     </div>
   );
 }
@@ -209,11 +272,97 @@ function ResetHint({ onClick, title }: { onClick: () => void; title: string }) {
   );
 }
 
+/**
+ * Sticky section header inside the scrollable detail form. Sections are
+ * delineated softly: generous top spacing plus a single faint theme-aware
+ * hairline (`border-edge/50`), no filled band. The sticky background matches the
+ * dialog surface (`bg-surface-raised`, opaque so fields slide cleanly under when
+ * scrolling); `-mx-7 px-7` full-bleeds it and the hairline across the scroll
+ * container's padding. `first:` zeroes the rule/margin for General, which sits
+ * flush under the identity header. Keeps the `board-manager-section-<id>` testid.
+ */
+function SectionHeading({ section }: { section: typeof SECTIONS[number] }) {
+  const SectionIcon = section.icon;
+  return (
+    <div
+      data-testid={`board-manager-section-${section.id}`}
+      className="sticky top-0 z-10 -mx-7 mt-3 px-7 pt-3 pb-2 bg-surface-raised border-t border-edge/50 flex items-center gap-2 first:mt-0 first:border-t-0"
+    >
+      <SectionIcon size={13} strokeWidth={1.75} className="text-fg-faint" />
+      <span className="text-xs font-semibold uppercase tracking-wider text-fg-faint">{section.label}</span>
+    </div>
+  );
+}
+
+/** One-line inline explanation shown in place of a section's fields when it does not apply. */
+function DisabledSectionNotice({ reason }: { reason: string }) {
+  return <p className="text-xs text-fg-faint pt-3 pb-1 max-w-2xl">{reason}</p>;
+}
+
+/**
+ * Pinned identity header for the detail pane: large tinted column icon, name,
+ * role badge, board position, and the Delete control (named to its target).
+ */
+function DetailIdentityHeader({ draft, position, total, canDelete, onDelete }: {
+  draft: Swimlane;
+  position: number;
+  total: number;
+  canDelete: boolean;
+  onDelete: () => void;
+}) {
+  const Icon = draft.icon ? ICON_REGISTRY.get(draft.icon) : (draft.role ? ROLE_DEFAULTS[draft.role] : null);
+  const deleteLabel = `Delete "${draft.name || 'column'}"`;
+  // Single, lightweight identity row: small tinted icon + name + role badge +
+  // position, then the delete control. Keeps the header off the "heavy" look.
+  return (
+    <div className="flex items-center gap-2.5 px-7 py-2.5 border-b border-edge/60 flex-shrink-0">
+      {Icon ? (
+        <Icon size={18} strokeWidth={1.75} style={{ color: draft.color }} className="flex-shrink-0" />
+      ) : (
+        <span className="block w-4 h-4 rounded-full flex-shrink-0" style={{ backgroundColor: draft.color }} />
+      )}
+      <span className="text-sm font-semibold text-fg truncate">{draft.name || 'Untitled'}</span>
+      {draft.role && (
+        <Pill size="sm" className="bg-surface-hover/60 text-fg-faint flex-shrink-0">
+          {draft.role === 'todo' ? 'To Do' : 'Done'}
+        </Pill>
+      )}
+      <Pill size="sm" className="bg-surface-hover/60 text-fg-faint flex-shrink-0">{position} of {total}</Pill>
+      <div className="flex-1" />
+      {/* Always rendered (reserving its slot) so the header height and layout do
+          not shift when navigating between deletable columns and role-pinned
+          ones that cannot be deleted. Hidden (not just unmounted) for the latter. */}
+      <button
+        type="button"
+        onClick={canDelete ? onDelete : undefined}
+        data-testid="board-manager-delete"
+        aria-label={deleteLabel}
+        title={deleteLabel}
+        tabIndex={canDelete ? undefined : -1}
+        aria-hidden={canDelete ? undefined : true}
+        className={`p-1.5 rounded-full transition-colors flex-shrink-0 text-fg-faint ${
+          canDelete ? 'hover:text-red-400 hover:bg-red-500/10' : 'invisible pointer-events-none'
+        }`}
+      >
+        <Trash2 size={15} strokeWidth={1.75} />
+      </button>
+    </div>
+  );
+}
+
 // ────────────────────────────────────────────────────────────────────────
 // Main dialog
 // ────────────────────────────────────────────────────────────────────────
 
 const DIALOG_SELECT_CLASS = 'w-full appearance-none bg-surface-hover border border-edge-input rounded pl-3 pr-10 py-1.5 text-sm text-fg focus:outline-none focus:border-accent';
+
+// Responsive two-column form grid. Driven by a container query on the scroll
+// region (`@container`), so it lays out by the DETAIL PANE's width, not the
+// viewport: two columns when the pane is wide enough (maximized, even on a small
+// monitor), one column when it is narrow (windowed). Columns auto-size via 1fr.
+// Short single-line controls pair up; full-width fields carry `SECTION_FULL_SPAN`.
+const SECTION_GRID_CLASS = 'grid grid-cols-1 @[720px]:grid-cols-2 gap-x-6 gap-y-3 max-w-4xl pt-2';
+const SECTION_FULL_SPAN = '@[720px]:col-span-2';
 
 interface BoardManagerDialogProps {
   initialColumnId: string | null;
@@ -233,6 +382,12 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
 
   const globalPermissionMode = useConfigStore((s) => s.config.agent.permissionMode);
   const currentProject = useProjectStore((state) => state.currentProject);
+
+  // Maximize parity with the create dialogs: the flag lives in the session
+  // store's `maximizedTasks` set (keyed by a sentinel id) so it survives HMR.
+  const isMaximized = useSessionStore((s) => s.maximizedTasks.has(BOARD_MANAGER_ENTITY_ID));
+  const toggleMaximized = useSessionStore((s) => s.toggleMaximized);
+  const handleToggleMaximized = useCallback(() => toggleMaximized(BOARD_MANAGER_ENTITY_ID), [toggleMaximized]);
 
   // Live subscription to the store's agentList so the dialog stays in sync
   // with `useAgentCapabilityResolution` (which also reads from the store).
@@ -267,21 +422,21 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
         newDraftIds: new Set([draft.id]),
         laneOrder: orderWithDraft,
         activeId: draft.id,
-        activeSection: 'general' as SectionId,
         autoFocusNameId: draft.id as string | null,
       };
     }
 
+    // Land on the requested column, or the "All columns" overview when none was
+    // specified (no current caller hits the null path; this is the safe default).
     const fallbackActiveId = initialColumnId && swimlanes.some((lane) => lane.id === initialColumnId)
       ? initialColumnId
-      : (baseOrder[0] ?? '');
+      : ALL_COLUMNS_ID;
     return {
       originals: baseOriginals,
       drafts: { ...baseOriginals },
       newDraftIds: new Set<string>(),
       laneOrder: baseOrder,
       activeId: fallbackActiveId,
-      activeSection: 'general' as SectionId,
       autoFocusNameId: null as string | null,
     };
     // Mount-only: this initializer must capture the props/store at first
@@ -294,7 +449,11 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
   const [newDraftIds, setNewDraftIds] = useState<Set<string>>(initialState.newDraftIds);
   const [laneOrder, setLaneOrder] = useState<string[]>(initialState.laneOrder);
   const [activeId, setActiveId] = useState<string>(initialState.activeId);
-  const [activeSection, setActiveSection] = useState<SectionId>(initialState.activeSection);
+
+  // Set once the user drags a rail row. Tells the store-sync effect to preserve
+  // the local order instead of re-sorting from store positions. Never cleared
+  // while open (once local order equals store order, "preserve" is a no-op).
+  const hasLocalReorderRef = useRef(false);
 
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
@@ -356,21 +515,7 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
     }
     setDrafts(nextDrafts);
 
-    setLaneOrder((previousOrder) => {
-      const sorted = [...swimlanes].sort((a, b) => a.position - b.position).map((lane) => lane.id);
-      // Preserve unsaved new drafts at their current relative positions.
-      const newIds = previousOrder.filter((id) => id.startsWith(NEW_DRAFT_PREFIX));
-      if (newIds.length === 0) return sorted;
-      const result = [...sorted];
-      // Insert each new draft just before the Done column to match the
-      // existing create-then-reorder behavior.
-      const doneIndex = result.findIndex((id) => swimlanes.find((lane) => lane.id === id)?.role === 'done');
-      const insertAt = doneIndex >= 0 ? doneIndex : result.length;
-      for (const newId of newIds) {
-        if (!result.includes(newId)) result.splice(insertAt, 0, newId);
-      }
-      return result;
-    });
+    setLaneOrder((previousOrder) => reconcileLaneOrder(previousOrder, swimlanes, hasLocalReorderRef.current));
   }, [swimlanes]);
 
   // ── Refresh agent capabilities ─────────────────────────────────────
@@ -401,7 +546,6 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
       return result;
     });
     setActiveId(draft.id);
-    setActiveSection('general');
     setAutoFocusNameId(draft.id);
   }, [swimlanes]);
 
@@ -417,14 +561,13 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
   useEffect(() => {
     if (!autoFocusNameId) return;
     if (activeId !== autoFocusNameId) return;
-    if (activeSection !== 'general') return;
     const handle = window.requestAnimationFrame(() => {
       nameInputRef.current?.focus();
       nameInputRef.current?.select();
       setAutoFocusNameId(null);
     });
     return () => window.cancelAnimationFrame(handle);
-  }, [autoFocusNameId, activeId, activeSection]);
+  }, [autoFocusNameId, activeId]);
 
   // ── Derived ────────────────────────────────────────────────────────
   const draft = drafts[activeId];
@@ -432,28 +575,78 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
   const draftRole: SwimlaneRole | null = draft?.role ?? null;
   const isTodoOrDone = draftRole === 'todo' || draftRole === 'done';
 
-  // Agent / Automation / Handoff only apply when sessions actually run in
-  // the column. They are disabled (visible but greyed out and unclickable)
-  // for role-pinned To Do / Done columns and when Auto-spawn is off.
+  // Automation / Handoff only apply when sessions actually run in the column, so
+  // they collapse to a one-line inline explanation for role-pinned To Do / Done
+  // columns and when Auto-spawn is off. (The Agent section stays visible for a
+  // custom column even with Auto-spawn off; only its dependent fields hide.)
   const sessionsRunHere = !isTodoOrDone && draft?.auto_spawn === true;
-  const isSectionDisabled = useCallback(
-    (section: SectionId) => section !== 'general' && !sessionsRunHere,
-    [sessionsRunHere],
-  );
 
-  // If the active section becomes disabled (e.g. user toggled Auto-spawn off
-  // while sitting on Agent), bounce back to General automatically.
-  useEffect(() => {
-    if (isSectionDisabled(activeSection)) {
-      setActiveSection('general');
-    }
-  }, [isSectionDisabled, activeSection]);
+  const isOverview = activeId === ALL_COLUMNS_ID;
 
   const dirtyIds = useMemo(
     () => laneOrder.filter((id) => newDraftIds.has(id) || isDirty(drafts[id], originals[id])),
     [drafts, originals, laneOrder, newDraftIds],
   );
-  const hasDirty = dirtyIds.length > 0;
+  const orderDirty = useMemo(() => isOrderChanged(laneOrder, originals), [laneOrder, originals]);
+  const hasDirty = dirtyIds.length > 0 || orderDirty;
+
+  // Rows for the left rail. The inline override hints (agent / isolated) are
+  // suppressed for role-pinned To Do / Done columns, where they never apply.
+  const railRows: RailRow[] = useMemo(() => {
+    return laneOrder.flatMap((id) => {
+      const laneDraft = drafts[id];
+      if (!laneDraft) return [];
+      const applies = laneDraft.role !== 'todo' && laneDraft.role !== 'done';
+      const overrideName = laneDraft.agent_override;
+      const agentOverrideLabel = applies && overrideName
+        ? (agentList.find((agent) => agent.name === overrideName)?.displayName ?? overrideName)
+        : null;
+      return [{
+        id,
+        name: laneDraft.name,
+        tabName: originals[id]?.name ?? laneDraft.name,
+        color: laneDraft.color,
+        icon: laneDraft.icon,
+        role: laneDraft.role,
+        dirty: newDraftIds.has(id) || isDirty(laneDraft, originals[id]),
+        agentOverrideLabel,
+        isolated: applies && laneDraft.session_target === 'isolated',
+      }];
+    });
+  }, [laneOrder, drafts, originals, newDraftIds, agentList]);
+
+  // Rows for the "All columns" overview grid, read from drafts so unsaved edits show.
+  const overviewRows: OverviewRow[] = useMemo(() => {
+    return laneOrder.flatMap((id) => {
+      const laneDraft = drafts[id];
+      if (!laneDraft) return [];
+      const overrideName = laneDraft.agent_override;
+      // Show the effective agent: the override's display name, or the project
+      // default's (so it reads "Claude Code", not "Default"). Muted when default.
+      const agentLabel = overrideName
+        ? (agentList.find((agent) => agent.name === overrideName)?.displayName ?? overrideName)
+        : projectDefaultAgentLabel;
+      const modelOverride = laneDraft.model_override?.trim();
+      return [{
+        id,
+        name: laneDraft.name,
+        color: laneDraft.color,
+        icon: laneDraft.icon,
+        role: laneDraft.role,
+        dirty: newDraftIds.has(id) || isDirty(laneDraft, originals[id]),
+        autoSpawn: laneDraft.auto_spawn,
+        agentLabel,
+        agentIsDefault: !overrideName,
+        modelLabel: modelOverride ? formatModelName(modelOverride) : 'Default',
+        effortLabel: laneDraft.effort_override || 'Default',
+        permissionLabel: laneDraft.permission_mode
+          ? getPermissionLabel(DEFAULT_PERMISSIONS, laneDraft.permission_mode)
+          : 'Default',
+        isolated: laneDraft.session_target === 'isolated',
+        hasAutoCommand: !!laneDraft.auto_command?.trim(),
+      }];
+    });
+  }, [laneOrder, drafts, originals, newDraftIds, agentList, projectDefaultAgentLabel]);
 
   // Effective-agent resolution for the column manager: column draft's
   // override wins over the project default. (Tasks add a fourth tier in
@@ -525,7 +718,6 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
     });
     if (invalid) {
       setActiveId(invalid);
-      setActiveSection('general');
       setAutoFocusNameId(invalid);
       useToastStore.getState().addToast({
         message: 'Name a column before saving.',
@@ -544,7 +736,7 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
       }
     }
 
-    if (creates.length === 0 && updates.length === 0) {
+    if (creates.length === 0 && updates.length === 0 && !orderDirty) {
       onClose();
       return;
     }
@@ -638,11 +830,11 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
       }
     }
 
-    // Reorder to honour the tab strip order, but only for ids that exist in
-    // the DB now. Temp ids of creates that failed (or were skipped after a
-    // failure above) are filtered out so we don't ask the IPC to reorder
-    // ids it has never seen.
-    if (savedCreates > 0) {
+    // Reorder to honour the rail order when the user created columns or dragged
+    // to reorder, but only for ids that exist in the DB now. Temp ids of creates
+    // that failed (or were skipped after a failure above) are filtered out so we
+    // don't ask the IPC to reorder ids it has never seen.
+    if (savedCreates > 0 || orderDirty) {
       try {
         const finalOrder = laneOrder
           .map((id) => idMap.get(id) ?? id)
@@ -670,12 +862,13 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
     const parts: string[] = [];
     if (savedUpdates > 0) parts.push(`Saved ${savedUpdates} column${savedUpdates > 1 ? 's' : ''}`);
     if (savedCreates > 0) parts.push(`created ${savedCreates} column${savedCreates > 1 ? 's' : ''}`);
+    if (orderDirty) parts.push(parts.length === 0 ? 'Updated column order' : 'updated column order');
     useToastStore.getState().addToast({
       message: parts.join(' and '),
       variant: 'info',
     });
     onClose();
-  }, [saving, laneOrder, drafts, originals, newDraftIds, updateSwimlane, createSwimlane, reorderSwimlanes, onClose]);
+  }, [saving, laneOrder, drafts, originals, newDraftIds, orderDirty, updateSwimlane, createSwimlane, reorderSwimlanes, onClose]);
 
   // Cmd/Ctrl+S to save, via the central keybinding registry. Document-level,
   // bubble phase, preventDefault only - matching the original listener.
@@ -683,6 +876,34 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
     target: 'document',
     stopPropagation: false,
   });
+
+  // Reorder handler for the rail: local-only until Save. Flags the store-sync
+  // effect to preserve this order (see hasLocalReorderRef above).
+  const handleRailReorder = useCallback((nextOrder: string[]) => {
+    hasLocalReorderRef.current = true;
+    setLaneOrder(nextOrder);
+  }, []);
+
+  // Cycle the selection across [overview, ...columns] with wraparound. Bound to
+  // Mod+PageDown / Mod+PageUp so it works regardless of where focus sits.
+  const cycleColumn = useCallback((delta: number) => {
+    setActiveId((current) => {
+      const navIds = [ALL_COLUMNS_ID, ...laneOrder];
+      const index = navIds.indexOf(current);
+      if (index < 0) return current;
+      return navIds[(index + delta + navIds.length) % navIds.length];
+    });
+  }, [laneOrder]);
+
+  useKeybinding('panel.maximize', handleToggleMaximized, { capture: true });
+  // Suppress column cycling while a nested modal (delete confirm, icon picker, or
+  // the discard-changes confirm) is open, mirroring the Escape guard below.
+  // Otherwise a cycle changes activeId behind the modal, and since the delete
+  // confirm names drafts[confirmDeleteId] while handleDeletePersisted deletes
+  // activeId, the confirmation can name one column and delete another.
+  const columnCycleEnabled = !confirmDeleteId && !showIconPicker && !showCancelConfirm;
+  useKeybinding('boardManager.nextColumn', () => cycleColumn(1), { target: 'document', stopPropagation: false, enabled: columnCycleEnabled });
+  useKeybinding('boardManager.prevColumn', () => cycleColumn(-1), { target: 'document', stopPropagation: false, enabled: columnCycleEnabled });
 
   // Escape-to-cancel stays a hand-written listener: it is a structural dialog
   // key with conditional dismissal (suppressed while a nested confirm or picker
@@ -714,7 +935,8 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
     setActiveId((previous) => {
       if (previous !== id) return previous;
       const remaining = laneOrder.filter((entry) => entry !== id);
-      return remaining[0] ?? '';
+      // Fall back to the overview so an emptied selection degrades gracefully.
+      return remaining[0] ?? ALL_COLUMNS_ID;
     });
   }, [laneOrder]);
 
@@ -758,53 +980,58 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
     }
   }, [activeId, newDraftIds, tasks, drafts, deleteSwimlane, removeDraftLocally]);
 
-  // ── Tab strip / section nav keyboard ─────────────────────────────
-  const handleTabStripKey = (event: React.KeyboardEvent) => {
-    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
-    event.preventDefault();
-    const index = laneOrder.indexOf(activeId);
-    if (index < 0) return;
-    const delta = event.key === 'ArrowRight' ? 1 : -1;
-    const nextIndex = (index + delta + laneOrder.length) % laneOrder.length;
-    setActiveId(laneOrder[nextIndex]);
-  };
-
-  const handleSectionNavKey = (event: React.KeyboardEvent) => {
-    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
-    event.preventDefault();
-    // Walk to the next *enabled* section in the requested direction.
-    const startIndex = SECTIONS.findIndex((entry) => entry.id === activeSection);
-    if (startIndex < 0) return;
-    const delta = event.key === 'ArrowDown' ? 1 : -1;
-    for (let step = 1; step <= SECTIONS.length; step += 1) {
-      const candidate = SECTIONS[(startIndex + delta * step + SECTIONS.length) % SECTIONS.length];
-      if (!isSectionDisabled(candidate.id)) {
-        setActiveSection(candidate.id);
-        return;
-      }
-    }
-  };
-
   // ── Rendering ─────────────────────────────────────────────────────
-  if (!draft) {
+  if (!isOverview && !draft) {
     // Defensive: store had no swimlanes at mount. Render nothing rather than crash.
     return null;
   }
 
-  const dirtyCount = dirtyIds.length;
+  // A single count of affected columns: those with field edits or a pending
+  // create, plus any whose position changed from a reorder. The user just wants
+  // "how many columns will change", not an order-vs-options breakdown.
+  const affectedIds = new Set(dirtyIds);
+  for (const movedId of getReorderedColumnIds(laneOrder, originals)) affectedIds.add(movedId);
+  const affectedCount = affectedIds.size;
+  const dirtySummary = affectedCount > 0 ? `${affectedCount} column${affectedCount === 1 ? '' : 's'} modified` : '';
+
+  // Windowed size. Width clears the two-column container-query threshold (~720px)
+  // without maximizing and fits the overview grid; shared by both views so
+  // toggling to the overview never resizes the dialog. A FIXED height (capped at
+  // 94vh on short screens) keeps the modal stable as the user navigates between
+  // columns of differing content height: the detail pane scrolls when a column is
+  // taller, and shorter columns show some empty space, rather than the whole
+  // modal resizing and re-centering (which reads as jank). `max-w-[95vw]` caps
+  // width on small screens, where the form falls back to a single column.
+  const windowedClass = 'w-[1180px] max-w-[95vw] h-[1236px] max-h-[94vh]';
+  const { dialogClassName, backdropPositionClass, backdropClassName, contentRadiusClass } =
+    maximizedDialogLayout(isMaximized, windowedClass);
+
+  const activePosition = laneOrder.indexOf(activeId) + 1;
+
+  // Disabled-section explanation strings (preserve the exact wording the old
+  // native tooltips used, now shown inline).
+  const disabledReasonFor = (label: string): string =>
+    isTodoOrDone
+      ? `Sessions don't run in ${draftRole === 'todo' ? 'To Do' : 'Done'} columns, so ${label} doesn't apply.`
+      : `Turn on Auto-spawn in the Agent section to enable ${label}.`;
 
   return (
     <>
     <BaseDialog
       onClose={onClose}
       testId="board-manager-dialog"
-      className="w-[880px] max-w-[95vw] max-h-[90vh]"
+      className={dialogClassName}
+      backdropPositionClass={backdropPositionClass}
+      backdropClassName={backdropClassName}
+      contentRadiusClass={contentRadiusClass}
+      onHeaderDoubleClick={handleToggleMaximized}
       preventBackdropClose
       onBackdropClick={requestCancel}
       header={
-        <div className="flex items-center gap-3 px-4 py-3">
+        <div className="flex items-center gap-3 px-4 py-2">
           <Layers size={14} className="text-fg-muted flex-shrink-0" />
           <h3 className="text-sm font-semibold text-fg flex-1 min-w-0">Edit Columns</h3>
+          <MaximizeToggleButton isMaximized={isMaximized} onToggle={handleToggleMaximized} />
           <button
             type="button"
             onClick={requestCancel}
@@ -817,164 +1044,62 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
       }
       rawBody
       footer={
-        <div className="flex justify-end gap-3">
+        <div className="flex items-center gap-3">
+          <span data-testid="board-manager-dirty-summary" className="text-xs text-fg-faint mr-auto">
+            {dirtySummary}
+          </span>
           <button
             type="button"
             onClick={requestCancel}
-            className="px-4 py-1.5 text-xs text-fg-muted hover:text-fg-secondary border border-edge-input hover:border-fg-faint rounded transition-colors"
+            className="px-6 py-1.5 min-w-[96px] text-xs text-fg-muted hover:text-fg-secondary border border-edge-input hover:border-fg-faint rounded transition-colors"
           >
             Cancel
           </button>
           <button
             type="button"
             onClick={() => void handleSave()}
-            disabled={saving || dirtyCount === 0}
+            disabled={saving || !hasDirty}
             data-testid="board-manager-save"
-            className="px-4 py-1.5 text-xs font-medium bg-accent-emphasis hover:bg-accent text-accent-on rounded transition-colors disabled:opacity-50"
+            className="px-6 py-1.5 min-w-[96px] text-xs font-medium bg-accent-emphasis hover:bg-accent text-accent-on rounded transition-colors disabled:opacity-50"
           >
             {saving ? 'Saving...' : 'Save'}
           </button>
         </div>
       }
     >
-      <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-        {/* Tab strip */}
-        <div
-          onKeyDown={handleTabStripKey}
-          className="flex bg-surface/40 border-b border-edge overflow-x-auto flex-shrink-0"
-          role="tablist"
-        >
-          {laneOrder.map((id) => {
-            const tabDraft = drafts[id];
-            if (!tabDraft) return null;
-            const isActive = id === activeId;
-            const tabIsDirty = newDraftIds.has(id) || isDirty(tabDraft, originals[id]);
-            const Icon = tabDraft.icon ? ICON_REGISTRY.get(tabDraft.icon) : (tabDraft.role ? ROLE_DEFAULTS[tabDraft.role] : null);
-            return (
-              <button
-                key={id}
-                type="button"
-                role="tab"
-                aria-selected={isActive}
-                data-testid="board-manager-tab"
-                data-tab-name={originals[id]?.name ?? tabDraft.name}
-                data-tab-id={id}
-                onClick={() => setActiveId(id)}
-                className={`relative flex items-center gap-2 px-3.5 py-3 text-xs whitespace-nowrap border-r border-edge/40 transition-colors ${
-                  isActive
-                    ? 'bg-surface text-fg font-medium'
-                    : 'text-fg-muted hover:text-fg-secondary hover:bg-surface-hover/30'
-                }`}
-              >
-                {Icon ? (
-                  <Icon size={13} strokeWidth={1.75} style={{ color: isActive ? tabDraft.color : undefined }} className={isActive ? '' : 'text-fg-faint'} />
-                ) : (
-                  <span
-                    className="w-2 h-2 rounded-full flex-shrink-0"
-                    style={{ backgroundColor: tabDraft.color }}
-                  />
-                )}
-                <span className="truncate max-w-[140px]">{tabDraft.name || 'Untitled'}</span>
-                {tabIsDirty && (
-                  <span
-                    aria-label="unsaved changes"
-                    data-testid="board-manager-tab-dirty"
-                    className="w-1.5 h-1.5 rounded-full bg-accent flex-shrink-0"
-                  />
-                )}
-                {isActive && (
-                  <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-accent" />
-                )}
-              </button>
-            );
-          })}
-          <div className="flex-1" />
-          <div className="flex items-center pr-3">
-            <button
-              type="button"
-              onClick={addNewDraft}
-              data-testid="board-manager-add-column"
-              className="flex items-center gap-1 px-2.5 py-1 text-xs text-fg-muted hover:text-fg bg-surface-hover/50 hover:bg-surface-hover border border-edge/60 hover:border-edge rounded-full transition-colors whitespace-nowrap"
-            >
-              <Plus size={12} />
-              Add column
-            </button>
-          </div>
-        </div>
+      <div className="flex flex-1 min-h-[540px] overflow-hidden">
+        <ColumnRail
+          rows={railRows}
+          activeId={activeId}
+          onSelect={setActiveId}
+          onSelectOverview={() => setActiveId(ALL_COLUMNS_ID)}
+          onReorder={handleRailReorder}
+          onAddColumn={addNewDraft}
+        />
 
-        {/* Body split */}
-        <div className="flex flex-1 min-h-[540px] overflow-hidden">
-          {/* Section nav */}
-          <div
-            onKeyDown={handleSectionNavKey}
-            role="tablist"
-            aria-orientation="vertical"
-            className="w-[170px] flex-shrink-0 py-3 px-2 bg-surface/40 border-r border-edge/60 flex flex-col"
-          >
-            <div className="text-[11px] uppercase tracking-wider text-fg-faint px-2 mb-1.5">Sections</div>
-            <div className="flex flex-col gap-0.5">
-              {SECTIONS.map((section) => {
-                const isActive = section.id === activeSection;
-                const isDisabled = isSectionDisabled(section.id);
-                const SectionIcon = section.icon;
-                const stateClasses = isDisabled
-                  ? 'text-fg-disabled cursor-not-allowed'
-                  : isActive
-                    ? 'bg-surface-hover/50 text-fg'
-                    : 'text-fg-muted hover:text-fg-secondary hover:bg-surface-hover/30';
-                const iconClass = isDisabled
-                  ? 'text-fg-disabled'
-                  : isActive ? 'text-fg-secondary' : 'text-fg-faint';
-                // Title (native tooltip) explains why a section is locked.
-                // Two reasons: role-pinned columns (To Do, Done) never run
-                // sessions, and Auto-spawn-off columns won't either until
-                // the user opts in. Tells the user how to unlock it when
-                // applicable. We avoid the HTML `disabled` attribute so
-                // the tooltip still surfaces on hover.
-                const disabledReason = isDisabled
-                  ? isTodoOrDone
-                    ? `Sessions don't run in ${draft.role === 'todo' ? 'To Do' : 'Done'} columns, so ${section.label} doesn't apply.`
-                    : `Turn on Auto-spawn in General to enable ${section.label}.`
-                  : undefined;
-                return (
-                  <button
-                    key={section.id}
-                    type="button"
-                    role="tab"
-                    aria-selected={isActive}
-                    aria-disabled={isDisabled}
-                    title={disabledReason}
-                    data-testid={`board-manager-section-${section.id}`}
-                    onClick={isDisabled ? undefined : () => setActiveSection(section.id)}
-                    className={`flex items-center gap-2 w-full px-2 py-1.5 rounded text-xs transition-colors ${stateClasses}`}
-                  >
-                    <SectionIcon size={13} strokeWidth={1.75} className={iconClass} />
-                    <span className="flex-1 text-left">{section.label}</span>
-                  </button>
-                );
-              })}
-            </div>
+        {isOverview || !draft ? (
+          <ColumnsOverview rows={overviewRows} onSelect={setActiveId} />
+        ) : (
+          <div className="flex-1 min-w-0 flex flex-col min-h-0">
+            <DetailIdentityHeader
+              draft={draft}
+              position={activePosition}
+              total={laneOrder.length}
+              canDelete={!isTodoOrDone}
+              onDelete={isNewDraft ? handleDiscardNewDraft : () => setConfirmDeleteId(activeId)}
+            />
 
-            {!isTodoOrDone && (
-              <div className="mt-auto border-t border-edge/40 pt-2 px-0">
-                <button
-                  type="button"
-                  onClick={isNewDraft ? handleDiscardNewDraft : () => setConfirmDeleteId(activeId)}
-                  data-testid="board-manager-delete"
-                  className="flex items-center gap-2 w-full px-2 py-1.5 rounded text-xs text-red-400 hover:text-red-300 hover:bg-red-500/10 transition-colors"
-                >
-                  <Trash2 size={13} strokeWidth={1.75} />
-                  <span className="flex-1 text-left">Delete column</span>
-                </button>
-              </div>
-            )}
-          </div>
-
-          {/* Section body */}
-          <div className="flex-1 overflow-y-auto px-7 py-6 min-w-0">
-            {activeSection === 'general' && (
-              <div className="space-y-4">
-                <SettingField label="Name">
+            {/* One scrollable form with sticky section headers. `@container`
+                lets the section grids lay out by the pane width. A modest bottom
+                pad keeps the content off the boundary so sub-pixel rounding does
+                not summon a phantom 1px scrollbar. `scrollbar-gutter:stable`
+                reserves the scrollbar's width always, so switching between a
+                short column and a taller (scrolling) one never shifts the
+                content horizontally. */}
+            <div className="flex-1 overflow-y-auto px-7 pb-4 min-w-0 @container [scrollbar-gutter:stable]">
+              <SectionHeading section={SECTIONS[0]} />
+              <div className={SECTION_GRID_CLASS}>
+                <SettingField label="Name" className={SECTION_FULL_SPAN}>
                   <input
                     ref={nameInputRef}
                     type="text"
@@ -989,19 +1114,26 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
 
                 <SettingField
                   label="Description"
+                  className={SECTION_FULL_SPAN}
                   description="Shown when you hover the column header. Shared with your team via kangentic.json."
                 >
                   <textarea
                     value={draft.description ?? ''}
                     placeholder="What is this column for?"
                     onChange={(event) => updateDraft((current) => ({ ...current, description: event.target.value }))}
-                    rows={2}
+                    rows={1}
                     maxLength={1000}
                     data-testid="board-manager-description"
                     className="w-full bg-surface-hover border border-edge-input rounded px-3 py-1.5 text-sm text-fg placeholder-fg-faint focus:outline-none focus:border-accent resize-y"
                   />
                 </SettingField>
 
+                {/* Icon and Color pair on one row (a vertical divider between)
+                    when the pane is wide; they stack when it is narrow. `order`
+                    puts the filled Icon control first so the divider spacing is
+                    even (the color swatches under-fill their cell). */}
+                <div className={`${SECTION_FULL_SPAN} flex flex-col @[720px]:flex-row @[720px]:items-start gap-3 @[720px]:gap-6`}>
+                  <div className="@[720px]:flex-1 min-w-0 order-3">
                 <SettingField label="Color">
                   <div className="flex gap-2 flex-wrap items-center">
                     {PRESET_COLORS.map((presetColor) => {
@@ -1070,7 +1202,9 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
                     </div>
                   )}
                 </SettingField>
-
+                  </div>
+                  <div className="hidden @[720px]:block w-px self-stretch bg-edge/50 order-2" />
+                  <div className="@[720px]:flex-1 min-w-0 order-1">
                 <SettingField label="Icon">
                   <button
                     type="button"
@@ -1103,20 +1237,28 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
                     <ChevronRight size={14} className="text-fg-faint group-hover:text-fg-muted flex-shrink-0" />
                   </button>
                 </SettingField>
+                  </div>
+                </div>
 
-                {!isTodoOrDone && (
-                  <ToggleCard
-                    label="Auto-spawn"
-                    description="Start an agent automatically when a task enters this column."
-                    checked={draft.auto_spawn}
-                    onChange={(next) => updateDraft((current) => ({ ...current, auto_spawn: next }))}
-                  />
-                )}
               </div>
-            )}
 
-            {activeSection === 'agent' && (
-              <div className="space-y-4">
+              <SectionHeading section={SECTIONS[1]} />
+              {isTodoOrDone ? (
+                <DisabledSectionNotice reason={disabledReasonFor('Agent')} />
+              ) : (
+                <div className={SECTION_GRID_CLASS}>
+                  {/* Auto-spawn leads the section: it gates whether the agent
+                      config below is shown, so it comes first. Agent / Model and
+                      Effort / Permissions then pair up as two-column rows. */}
+                  <div className={SECTION_FULL_SPAN}>
+                    <ToggleCard
+                      label="Auto-spawn"
+                      description="Start an agent automatically when a task enters this column."
+                      checked={draft.auto_spawn}
+                      onChange={(next) => updateDraft((current) => ({ ...current, auto_spawn: next }))}
+                    />
+                  </div>
+                  {draft.auto_spawn && (<>
                   <SettingField
                     label="Agent"
                     description="Which agent CLI to run for sessions in this column."
@@ -1243,6 +1385,7 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
                   {draft.permission_mode === 'plan' && (
                     <SettingField
                       label="After Plan Mode"
+                      className={SECTION_FULL_SPAN}
                       description="Where the task goes when the agent exits Plan mode."
                     >
                       <Select
@@ -1262,16 +1405,16 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
                       </Select>
                     </SettingField>
                   )}
-              </div>
-            )}
+                  </>)}
+                </div>
+              )}
 
-            {activeSection === 'auto' && (
-              <div className="space-y-5">
-                <div>
-                  <div className="grid grid-cols-2 gap-4">
+              <SectionHeading section={SECTIONS[2]} />
+              {sessionsRunHere ? (
+                <div className={SECTION_GRID_CLASS}>
                     <SettingField
                       label="Session"
-                      description="Which session track a task runs on here."
+                      description="Share the task's main session, or run a separate isolated one for this column."
                     >
                       <Select
                         value={draft.session_target ?? 'main'}
@@ -1320,13 +1463,8 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
                         <option value="always_spawn_new">Always spawn new</option>
                       </Select>
                     </SettingField>
-                  </div>
-                  <p className="text-xs text-fg-faint mt-2">
-                    {describeSessionBehavior(draft.session_target ?? 'main', draft.session_spawn_strategy ?? 'create_or_resume')}
-                  </p>
-                </div>
 
-                <SettingField label="Auto-command">
+                <SettingField label="Auto-command" className={SECTION_FULL_SPAN}>
                 <p className="text-xs text-fg-faint -mt-2 mb-2">
                   Runs in the agent on startup, the moment a task enters this column. Supports template variables.
                 </p>
@@ -1334,7 +1472,7 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
                   ref={autoCommandRef}
                   value={draft.auto_command ?? ''}
                   onChange={(event) => updateDraft((current) => ({ ...current, auto_command: event.target.value }))}
-                  rows={3}
+                  rows={1}
                   placeholder="/review {{title}}"
                   data-testid="auto-command-input"
                   className="w-full bg-surface-hover border border-edge-input rounded px-3 py-1.5 text-sm text-fg font-mono placeholder-fg-faint focus:outline-none focus:border-accent resize-y"
@@ -1368,38 +1506,30 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
                   ))}
                 </div>
                 </SettingField>
-              </div>
-            )}
-
-            {activeSection === 'handoff' && (
-              <div className="space-y-5">
-                <ToggleCard
-                  label="Receive context from prior agent"
-                  description="On cross-agent moves into this column, hand the previous agent's conversation to the new one."
-                  checked={draft.handoff_context}
-                  onChange={(next) => updateDraft((current) => ({ ...current, handoff_context: next }))}
-                />
-
-                <div className="border-t border-edge/50 pt-4 max-w-md space-y-3">
-                  <div className="text-[11px] uppercase tracking-wider text-fg-faint">How it works</div>
-                  <p className="text-xs text-fg-muted leading-relaxed">
-                    When a task moves into this column and the agent assigned here is different from the one that ran in the previous column, Kangentic injects the previous session's transcript as the first message to the new agent.
-                  </p>
-                  <p className="text-xs text-fg-muted leading-relaxed">
-                    The new agent reads it like a continuation of the conversation and picks up with full awareness of what was already tried, decided, and produced. Without passthrough, every cross-agent move resets the new agent's working memory and it starts from the task description alone.
-                  </p>
-                  <p className="text-xs text-fg-faint leading-relaxed">
-                    Same-agent moves (e.g. Claude to Claude) always resume natively via the agent's own session id and ignore this setting.
-                  </p>
                 </div>
-              </div>
-            )}
+              ) : <DisabledSectionNotice reason={disabledReasonFor('Automation')} />}
+
+              <SectionHeading section={SECTIONS[3]} />
+              {sessionsRunHere ? (
+                <div className={SECTION_GRID_CLASS}>
+                  <div className={SECTION_FULL_SPAN}>
+                    <ToggleCard
+                      label="Receive context from prior agent"
+                      description="On cross-agent moves into this column, hand the previous agent's conversation to the new one."
+                      checked={draft.handoff_context}
+                      onChange={(next) => updateDraft((current) => ({ ...current, handoff_context: next }))}
+                      info={'When a task enters this column and the assigned agent differs from the one that ran in the previous column, Kangentic injects the previous session\'s transcript as the first message, so the new agent continues with full context instead of starting from the task description alone.\n\nSame-agent moves (e.g. Claude to Claude) resume natively via the agent\'s own session id and ignore this setting.'}
+                    />
+                  </div>
+                </div>
+              ) : <DisabledSectionNotice reason={disabledReasonFor('Handoff')} />}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </BaseDialog>
 
-      {showIconPicker && (
+      {showIconPicker && draft && (
         <IconPickerDialog
           selectedIcon={draft.icon}
           accentColor={draft.color}
@@ -1414,7 +1544,7 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
 
       {confirmDeleteId && (
         <ConfirmDialog
-          title="Delete column"
+          title={`Delete "${drafts[confirmDeleteId]?.name?.trim() || 'column'}"`}
           message={<>
             <p>Are you sure you want to delete this column?</p>
             <p className="text-fg-secondary bg-surface rounded px-3 py-2 truncate" title={drafts[confirmDeleteId]?.name}>
@@ -1436,15 +1566,24 @@ export function BoardManagerDialog({ initialColumnId, seedNewDraft, addDraftRequ
           cancelLabel="Keep editing"
           message={
             <div className="space-y-2.5">
-              <p>Closing now will discard unsaved changes in:</p>
-              <ul className="space-y-1">
-                {dirtyIds.map((id) => (
-                  <li key={id} className="flex items-baseline gap-2">
-                    <span className="text-fg-faint">•</span>
-                    <span className="font-medium text-fg-secondary">{drafts[id]?.name?.trim() || 'Untitled column'}</span>
-                  </li>
-                ))}
-              </ul>
+              {dirtyIds.length > 0 && (
+                <>
+                  <p>Closing now will discard unsaved changes in:</p>
+                  <ul className="space-y-1">
+                    {dirtyIds.map((id) => (
+                      <li key={id} className="flex items-baseline gap-2">
+                        <span className="text-fg-faint">•</span>
+                        <span className="font-medium text-fg-secondary">{drafts[id]?.name?.trim() || 'Untitled column'}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
+              {orderDirty && (
+                <p className="text-fg-secondary">
+                  {dirtyIds.length > 0 ? 'Column order changes will also be discarded.' : 'Your column order changes will be discarded.'}
+                </p>
+              )}
             </div>
           }
           onConfirm={() => {

--- a/src/renderer/components/dialogs/board-manager/ColumnRail.tsx
+++ b/src/renderer/components/dialogs/board-manager/ColumnRail.tsx
@@ -1,0 +1,234 @@
+import React from 'react';
+import { Plus, GripVertical, LayoutGrid, Bot, Split } from 'lucide-react';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { ICON_REGISTRY, ROLE_DEFAULTS } from '../../../utils/swimlane-icons';
+import { useHmrGeneration } from '../../../utils/hmr-generation';
+import type { SwimlaneRole } from '../../../../shared/types';
+
+/** Sentinel id for the "All columns" overview entry. Shared with the dialog. */
+export const ALL_COLUMNS_ID = 'overview';
+
+/** One precomputed row for the left rail (derived from the dialog's drafts). */
+export interface RailRow {
+  id: string;
+  /** Display name (draft name; falls back to 'Untitled' in render). */
+  name: string;
+  /** Saved name if persisted, else the draft name. Drives `data-tab-name`. */
+  tabName: string;
+  color: string;
+  icon: string | null;
+  role: SwimlaneRole | null;
+  dirty: boolean;
+  /** Display label of the column's agent override, or null when none. */
+  agentOverrideLabel: string | null;
+  isolated: boolean;
+}
+
+interface ColumnRailProps {
+  rows: RailRow[];
+  /** The selected id: a column id, or ALL_COLUMNS_ID for the overview. */
+  activeId: string;
+  onSelect: (id: string) => void;
+  onSelectOverview: () => void;
+  onReorder: (nextOrder: string[]) => void;
+  onAddColumn: () => void;
+}
+
+function ColumnRailRow({ row, active, sortable, onSelect }: {
+  row: RailRow;
+  active: boolean;
+  sortable: boolean;
+  onSelect: (id: string) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: row.id,
+    disabled: !sortable,
+  });
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+  const Icon = row.icon ? ICON_REGISTRY.get(row.icon) : (row.role ? ROLE_DEFAULTS[row.role] : null);
+
+  // Single-line row of uniform height: variable-height rows break @dnd-kit's
+  // verticalListSortingStrategy (drag displacement looks amplified/jumpy). At-a-
+  // glance config lives in the "All columns" overview; the rail keeps only tiny
+  // icon hints for the genuinely distinguishing overrides (agent, isolated).
+  return (
+    <div ref={setNodeRef} style={style} className="flex items-stretch gap-0.5">
+      {sortable ? (
+        <div
+          {...attributes}
+          {...listeners}
+          data-drag-handle
+          title="Drag to reorder"
+          className="flex items-center px-0.5 cursor-grab active:cursor-grabbing text-fg-disabled hover:text-fg-muted flex-shrink-0"
+        >
+          <GripVertical size={13} />
+        </div>
+      ) : (
+        <div className="w-[17px] flex-shrink-0" />
+      )}
+      <button
+        type="button"
+        role="tab"
+        aria-selected={active}
+        data-testid="board-manager-tab"
+        data-tab-name={row.tabName}
+        data-tab-id={row.id}
+        onClick={() => onSelect(row.id)}
+        className={`flex-1 min-w-0 flex items-center gap-2 px-2 py-2 rounded text-left transition-colors ${
+          active
+            ? 'bg-surface-hover text-fg'
+            : 'text-fg-muted hover:text-fg-secondary hover:bg-surface-hover/50'
+        }`}
+      >
+        {Icon ? (
+          <Icon size={14} strokeWidth={1.75} style={{ color: row.color }} className="flex-shrink-0" />
+        ) : (
+          <span className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: row.color }} />
+        )}
+        <span className="flex-1 min-w-0 truncate text-sm">{row.name || 'Untitled'}</span>
+        {row.agentOverrideLabel && (
+          <span title={`Agent: ${row.agentOverrideLabel}`} className="flex-shrink-0 text-fg-faint">
+            <Bot size={12} strokeWidth={2} />
+          </span>
+        )}
+        {row.isolated && (
+          <span title="Isolated session" className="flex-shrink-0 text-fg-faint">
+            <Split size={12} strokeWidth={2} />
+          </span>
+        )}
+        {row.dirty && (
+          <span
+            aria-label="unsaved changes"
+            data-testid="board-manager-tab-dirty"
+            className="w-1.5 h-1.5 rounded-full bg-accent flex-shrink-0"
+          />
+        )}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * The left rail: an "All columns" overview entry, a drag-to-reorder list of
+ * columns, and an "Add column" button. The To Do column is pinned at the top
+ * (no drag handle, outside the SortableContext) so index 0 is structurally
+ * unreachable, matching `swimlane-repository.reorder`'s constraint that To Do
+ * stays first. Reorder is local (mutates the dialog's laneOrder); persistence
+ * happens on Save.
+ */
+export function ColumnRail({ rows, activeId, onSelect, onSelectOverview, onReorder, onAddColumn }: ColumnRailProps) {
+  // Re-key DndContext on HMR; see src/renderer/utils/hmr-generation.ts (Pattern C).
+  const hmrGeneration = useHmrGeneration();
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const overviewSelected = activeId === ALL_COLUMNS_ID;
+  const todoRow = rows.find((row) => row.role === 'todo') ?? null;
+  const sortableRows = rows.filter((row) => row.role !== 'todo');
+  const sortableIds = sortableRows.map((row) => row.id);
+
+  const handleDragEnd = (event: { active: { id: string | number }; over: { id: string | number } | null }) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const from = sortableIds.indexOf(String(active.id));
+    const to = sortableIds.indexOf(String(over.id));
+    if (from < 0 || to < 0) return;
+    const movedSubset = arrayMove(sortableIds, from, to);
+    onReorder(todoRow ? [todoRow.id, ...movedSubset] : movedSubset);
+  };
+
+  // Focus-scoped ArrowUp/Down to walk the rail (overview + every column),
+  // wrapping. Skipped while a drag handle is focused so the KeyboardSensor
+  // owns the arrows during a keyboard-initiated sort.
+  const handleRailKey = (event: React.KeyboardEvent) => {
+    if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
+    if ((event.target as HTMLElement).closest('[data-drag-handle]')) return;
+    event.preventDefault();
+    const navIds = [ALL_COLUMNS_ID, ...rows.map((row) => row.id)];
+    const index = navIds.indexOf(activeId);
+    if (index < 0) return;
+    const delta = event.key === 'ArrowDown' ? 1 : -1;
+    const nextKey = navIds[(index + delta + navIds.length) % navIds.length];
+    if (nextKey === ALL_COLUMNS_ID) onSelectOverview();
+    else onSelect(nextKey);
+  };
+
+  return (
+    <div
+      role="tablist"
+      aria-orientation="vertical"
+      onKeyDown={handleRailKey}
+      className="w-[224px] flex-shrink-0 border-r border-edge/60 bg-surface/40 flex flex-col"
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={overviewSelected}
+        data-testid="board-manager-tab-all"
+        onClick={onSelectOverview}
+        className={`flex items-center gap-2 mx-2 mt-2 mb-1 px-2 py-2 rounded text-sm transition-colors ${
+          overviewSelected
+            ? 'bg-surface-hover text-fg'
+            : 'text-fg-muted hover:text-fg-secondary hover:bg-surface-hover/50'
+        }`}
+      >
+        <LayoutGrid size={14} strokeWidth={1.75} className="flex-shrink-0" />
+        <span className="flex-1 text-left">All columns</span>
+      </button>
+      <div className="mx-2 border-b border-edge/50" />
+
+      <div className="flex-1 overflow-y-auto px-2 py-2 space-y-0.5">
+        {todoRow && (
+          <ColumnRailRow row={todoRow} active={todoRow.id === activeId} sortable={false} onSelect={onSelect} />
+        )}
+        <DndContext
+          key={hmrGeneration}
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+            <div className="space-y-0.5">
+              {sortableRows.map((row) => (
+                <ColumnRailRow key={row.id} row={row} active={row.id === activeId} sortable onSelect={onSelect} />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      </div>
+
+      <div className="flex-shrink-0 border-t border-edge/60 p-2">
+        <button
+          type="button"
+          onClick={onAddColumn}
+          data-testid="board-manager-add-column"
+          className="flex items-center gap-2 w-full px-2 py-1.5 rounded text-xs text-fg-muted hover:text-fg hover:bg-surface-hover/60 transition-colors"
+        >
+          <Plus size={14} />
+          Add column
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/dialogs/board-manager/ColumnsOverview.tsx
+++ b/src/renderer/components/dialogs/board-manager/ColumnsOverview.tsx
@@ -1,0 +1,165 @@
+import { Check } from 'lucide-react';
+import { DataTable, type DataTableColumn } from '../../DataTable';
+import { Pill } from '../../Pill';
+import { ICON_REGISTRY, ROLE_DEFAULTS } from '../../../utils/swimlane-icons';
+import type { SwimlaneRole } from '../../../../shared/types';
+
+/** One precomputed row for the overview grid (derived from the dialog's drafts). */
+export interface OverviewRow {
+  id: string;
+  name: string;
+  color: string;
+  icon: string | null;
+  role: SwimlaneRole | null;
+  dirty: boolean;
+  autoSpawn: boolean;
+  /** Effective agent display name (the override's, or the project default's). */
+  agentLabel: string;
+  /** True when the column uses the project default agent (no override) - shown muted. */
+  agentIsDefault: boolean;
+  /** Model override (friendly-formatted), or 'Default' when none. */
+  modelLabel: string;
+  /** Effort override, or 'Default' when none. */
+  effortLabel: string;
+  /** Permission-mode label, or 'Default' when none. */
+  permissionLabel: string;
+  isolated: boolean;
+  hasAutoCommand: boolean;
+}
+
+interface ColumnsOverviewProps {
+  rows: OverviewRow[];
+  onSelect: (id: string) => void;
+}
+
+/**
+ * Humanize a model id for display (e.g. `claude-fable-5` -> "Fable 5",
+ * `claude-opus-4-8` -> "Opus 4.8"). A generic display formatter (not agent-name
+ * branching): strips a vendor prefix, title-cases the name parts, and joins the
+ * numeric version parts with dots. Mirrors the Claude adapter's
+ * `humanizeClaudeModelId`; falls back to the raw id when nothing is derivable.
+ */
+export function formatModelName(modelId: string): string {
+  const trimmed = modelId.trim();
+  if (!trimmed) return trimmed;
+  const bracketMatch = trimmed.match(/\[([^\]]+)\]/);
+  const base = trimmed.replace(/\[[^\]]*\]/, '');
+  const segments = base.replace(/^claude-/i, '').split('-').filter(Boolean);
+  if (segments.length === 0) return trimmed;
+  const nameParts: string[] = [];
+  const versionParts: string[] = [];
+  for (const segment of segments) {
+    if (/^\d+$/.test(segment)) {
+      if (segment.length < 6) versionParts.push(segment); // drop date stamps
+    } else {
+      nameParts.push(segment.charAt(0).toUpperCase() + segment.slice(1));
+    }
+  }
+  const label = [nameParts.join(' '), versionParts.join('.')].filter(Boolean).join(' ');
+  if (!label) return trimmed;
+  return bracketMatch ? `${label} (${bracketMatch[1].toUpperCase()})` : label;
+}
+
+/** Muted em-dash-free placeholder for cells that do not apply to a row. */
+function NotApplicable() {
+  return <span className="text-fg-disabled">-</span>;
+}
+
+function BoolCell({ on }: { on: boolean }) {
+  return on ? <Check size={14} className="text-accent-fg" /> : <NotApplicable />;
+}
+
+function MutedCell({ value, muted }: { value: string; muted: boolean }) {
+  return <span className={`whitespace-nowrap ${muted ? 'text-fg-faint' : 'text-fg-secondary'}`}>{value}</span>;
+}
+
+/**
+ * At-a-glance audit grid: one row per column, one cell per key setting. Values
+ * are read from the live drafts so unsaved edits show. Clicking a row opens that
+ * column's detail. Reuses the shared DataTable (non-virtualized, no header sort
+ * so rows stay in board order).
+ */
+export function ColumnsOverview({ rows, onSelect }: ColumnsOverviewProps) {
+  const columns: DataTableColumn<OverviewRow>[] = [
+    {
+      key: 'name',
+      label: 'Column',
+      width: 'w-[18%]',
+      render: (row) => {
+        const Icon = row.icon ? ICON_REGISTRY.get(row.icon) : (row.role ? ROLE_DEFAULTS[row.role] : null);
+        return (
+          <span className="flex items-center gap-2 min-w-0">
+            {Icon ? (
+              <Icon size={14} strokeWidth={1.75} style={{ color: row.color }} className="flex-shrink-0" />
+            ) : (
+              <span className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: row.color }} />
+            )}
+            <span className="truncate text-fg">{row.name || 'Untitled'}</span>
+            {row.role && (
+              <Pill size="sm" className="bg-surface-hover/60 text-fg-faint flex-shrink-0">
+                {row.role === 'todo' ? 'To Do' : 'Done'}
+              </Pill>
+            )}
+            {row.dirty && (
+              <span aria-label="unsaved changes" className="w-1.5 h-1.5 rounded-full bg-accent flex-shrink-0" />
+            )}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'autoSpawn',
+      label: 'Spawn',
+      width: 'w-[8%]',
+      render: (row) => (row.role ? <NotApplicable /> : <BoolCell on={row.autoSpawn} />),
+    },
+    {
+      key: 'agentLabel',
+      label: 'Agent',
+      width: 'w-[13%]',
+      render: (row) => (row.role ? <NotApplicable /> : <MutedCell value={row.agentLabel} muted={row.agentIsDefault} />),
+    },
+    {
+      key: 'modelLabel',
+      label: 'Model',
+      width: 'w-[11%]',
+      render: (row) => (row.role ? <NotApplicable /> : <MutedCell value={row.modelLabel} muted={row.modelLabel === 'Default'} />),
+    },
+    {
+      key: 'effortLabel',
+      label: 'Effort',
+      width: 'w-[9%]',
+      render: (row) => (row.role ? <NotApplicable /> : <MutedCell value={row.effortLabel} muted={row.effortLabel === 'Default'} />),
+    },
+    {
+      key: 'permissionLabel',
+      label: 'Permissions',
+      width: 'w-[19%]',
+      render: (row) => (row.role ? <NotApplicable /> : <MutedCell value={row.permissionLabel} muted={row.permissionLabel === 'Default'} />),
+    },
+    {
+      key: 'isolated',
+      label: 'Session',
+      width: 'w-[11%]',
+      render: (row) => (row.role ? <NotApplicable /> : <MutedCell value={row.isolated ? 'Isolated' : 'Main'} muted={!row.isolated} />),
+    },
+    {
+      key: 'hasAutoCommand',
+      label: 'Auto-cmd',
+      width: 'w-[11%]',
+      render: (row) => (row.role ? <NotApplicable /> : <BoolCell on={row.hasAutoCommand} />),
+    },
+  ];
+
+  return (
+    <div className="flex-1 min-w-0 flex flex-col">
+      <DataTable
+        columns={columns}
+        data={rows}
+        rowKey={(row) => row.id}
+        onRowClick={(row) => onSelect(row.id)}
+        rowTestId="board-manager-overview-row"
+      />
+    </div>
+  );
+}

--- a/src/renderer/stores/session-store/task-changes-panel-slice.ts
+++ b/src/renderer/stores/session-store/task-changes-panel-slice.ts
@@ -43,8 +43,9 @@ export interface TaskChangesPanelSlice {
   /**
    * Entity IDs whose dialog is maximized (persists across dialog open/close).
    * Keyed by task ID for the task detail dialog, and by a non-task sentinel id
-   * for the command terminal ('command-terminal') and the create dialogs
-   * ('new-task-dialog', 'new-backlog-task-dialog').
+   * for the command terminal ('command-terminal'), the create dialogs
+   * ('new-task-dialog', 'new-backlog-task-dialog'), and the Edit Columns dialog
+   * ('board-manager-dialog').
    */
   maximizedTasks: Set<string>;
   /**
@@ -121,13 +122,13 @@ function buildDetailViewBlob(state: SessionStore, taskId: string): TaskDetailVie
 }
 
 /**
- * Non-task entity ids that share the Changes-panel setters (the create dialogs
- * and the Command Terminal) but have no `tasks` row to persist into. They must
- * not schedule a `detail_view_state` save: the DB UPDATE would be a no-op, and
- * the Command Terminal would otherwise emit a spurious IPC write on every Changes
- * interaction.
+ * Non-task entity ids that share the Changes-panel setters (the create dialogs,
+ * the Command Terminal, and the Edit Columns dialog) but have no `tasks` row to
+ * persist into. They must not schedule a `detail_view_state` save: the DB UPDATE
+ * would be a no-op, and the Command Terminal would otherwise emit a spurious IPC
+ * write on every Changes interaction.
  */
-const NON_TASK_DETAIL_VIEW_IDS = new Set(['new-task-dialog', 'new-backlog-task-dialog', 'command-terminal']);
+const NON_TASK_DETAIL_VIEW_IDS = new Set(['new-task-dialog', 'new-backlog-task-dialog', 'command-terminal', 'board-manager-dialog']);
 
 /**
  * Schedule a debounced persist of a task's detail-view layout. Captures the

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -191,6 +191,26 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     rebindable: false,
     hidden: true,
   },
+  {
+    id: 'boardManager.nextColumn',
+    label: 'Next Column',
+    description: 'Select the next column (or the overview) in the Edit Columns dialog. Fixed.',
+    group: 'General',
+    scope: 'dialog',
+    defaultCombo: 'Mod+PageDown',
+    rebindable: false,
+    hidden: true,
+  },
+  {
+    id: 'boardManager.prevColumn',
+    label: 'Previous Column',
+    description: 'Select the previous column (or the overview) in the Edit Columns dialog. Fixed.',
+    group: 'General',
+    scope: 'dialog',
+    defaultCombo: 'Mod+PageUp',
+    rebindable: false,
+    hidden: true,
+  },
 
   // ── Task Detail ──
   // Maximize / Close are the shared panel.* bindings: they act on whichever panel
@@ -198,7 +218,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
   {
     id: 'panel.maximize',
     label: 'Maximize',
-    description: 'Maximize the open panel: the command terminal, the task detail dialog (view or edit mode), or a create dialog (New Task / New Backlog Task).',
+    description: 'Maximize the open panel: the command terminal, the task detail dialog (view or edit mode), a create dialog (New Task / New Backlog Task), or the Edit Columns dialog.',
     group: 'Task Detail',
     scope: 'panel',
     defaultCombo: 'Mod+Shift+M',

--- a/tests/ui/board-manager-dialog-ext.spec.ts
+++ b/tests/ui/board-manager-dialog-ext.spec.ts
@@ -5,14 +5,16 @@
  * 1. BaseDialog.onBackdropClick synchronous escape-hatch (fires immediately,
  *    does not call requestClose, works even with preventBackdropClose=true).
  * 2. Save fan-out partial-failure (one update succeeds, one rejects).
- * 3. Section-disabled tooltip text for To Do and for auto_spawn=false columns.
- * 4. Auto-bounce: toggling Auto-spawn off while on the Agent section bounces
- *    the active section back to General.
+ * 3. Section-disabled inline explanations for To Do and auto_spawn=false columns.
+ * 4. Toggling Auto-spawn expands / collapses the dependent sections in place.
  * 5. DoneSwimlane header button click opens manager with Done tab preselected.
  * 6. ViewToggle "Add column" while manager is already open increments the
  *    counter and adds a second new-draft tab.
  * 7. Discard confirm bullet rendering (1 dirty = 1 li, 3 dirty = 3 li each
  *    with the column name; untitled new drafts render as "Untitled column").
+ * 8. Delete control names its target - the delete button's aria-label/title
+ *    is `Delete "<column name>"`, and the confirm dialog it opens reuses the
+ *    same string as its title (was the static "Delete column").
  */
 import { test, expect } from '@playwright/test';
 import { launchPage, waitForBoard, createProject } from './helpers';
@@ -175,33 +177,31 @@ test.describe('BoardManagerDialog extended', () => {
     await dialog.waitFor({ state: 'detached', timeout: 2000 });
   });
 
-  // ── Gap 3: Section-disabled tooltip text ─────────────────────────────────
+  // ── Gap 3: Section-disabled inline explanations ──────────────────────────
   //
-  // Two branches:
-  // (a) Role-pinned column (To Do): tooltip says "Sessions don't run in To Do
-  //     columns, so Agent doesn't apply." (and similar for Automation/Handoff).
-  // (b) Custom column with auto_spawn=false: tooltip says "Turn on Auto-spawn
-  //     in General to enable Agent." (etc).
+  // Sections that do not apply collapse to a one-line inline explanation in the
+  // scrollable form (replacing the old greyed section-nav button + native
+  // tooltip). Two branches:
+  // (a) Role-pinned column (To Do): "Sessions don't run in To Do columns, so
+  //     Agent doesn't apply." (and similar for Automation/Handoff).
+  // (b) Custom column with auto_spawn=false: "Turn on Auto-spawn in General to
+  //     enable Agent." (etc). In both, the section's fields are absent.
 
-  test('section buttons carry correct aria-disabled and title on To Do tab', async () => {
+  test('To Do column collapses Agent/Automation/Handoff to inline explanations', async () => {
     await openManagerByHeader('To Do');
     const dialog = page.locator('[data-testid="board-manager-dialog"]');
 
-    const agentBtn = dialog.locator('[data-testid="board-manager-section-agent"]');
-    const autoBtn = dialog.locator('[data-testid="board-manager-section-auto"]');
-    const handoffBtn = dialog.locator('[data-testid="board-manager-section-handoff"]');
+    await expect(dialog.getByText("Sessions don't run in To Do columns, so Agent doesn't apply.")).toBeVisible();
+    await expect(dialog.getByText("Sessions don't run in To Do columns, so Automation doesn't apply.")).toBeVisible();
+    await expect(dialog.getByText("Sessions don't run in To Do columns, so Handoff doesn't apply.")).toBeVisible();
 
-    await expect(agentBtn).toHaveAttribute('aria-disabled', 'true');
-    await expect(autoBtn).toHaveAttribute('aria-disabled', 'true');
-    await expect(handoffBtn).toHaveAttribute('aria-disabled', 'true');
-
-    await expect(agentBtn).toHaveAttribute('title', "Sessions don't run in To Do columns, so Agent doesn't apply.");
-    await expect(autoBtn).toHaveAttribute('title', "Sessions don't run in To Do columns, so Automation doesn't apply.");
-    await expect(handoffBtn).toHaveAttribute('title', "Sessions don't run in To Do columns, so Handoff doesn't apply.");
+    // The collapsed sections render no fields.
+    await expect(dialog.locator('[data-testid="column-agent-override"]')).toHaveCount(0);
+    await expect(dialog.locator('[data-testid="column-session-target"]')).toHaveCount(0);
   });
 
-  test('section buttons carry correct aria-disabled and title when auto_spawn is off', async () => {
-    // Create a custom column with auto_spawn=false to test the other disabled branch.
+  test('auto_spawn-off column collapses the dependent sections with an Auto-spawn hint', async () => {
+    // Create a custom column with auto_spawn=false to test the other branch.
     await page.evaluate(async () => {
       await window.electronAPI.swimlanes.create({
         name: 'NoSpawnCol',
@@ -218,21 +218,12 @@ test.describe('BoardManagerDialog extended', () => {
       });
     });
 
-    // The board store needs to reload swimlanes. Navigate away and back or wait for store refresh.
-    // Easier: reload the swimlanes list via the store's loadBoard if exposed, but it isn't in the
-    // mock. Instead, open the manager and let it pick up the new column from the store sync.
-    // We open via store-level swimlanes since the board won't have the new column rendered yet.
-    // Wait briefly for Zustand store to receive the updated swimlane list:
+    // Force a board-store sync so the new column renders (the mock has no push).
     await page.evaluate(async () => {
-      // Force a store sync by re-fetching swimlanes and injecting into board store
-      const lanes = await window.electronAPI.swimlanes.list();
       const store = (window as unknown as { __zustandStores?: { board: { getState: () => { loadBoard: () => void } } } }).__zustandStores;
-      if (store?.board) {
-        store.board.getState().loadBoard();
-      }
+      if (store?.board) store.board.getState().loadBoard();
     });
 
-    // Give the board a moment to re-render the new swimlane
     await expect.poll(async () => {
       return page.locator('[data-swimlane-name="NoSpawnCol"]').isVisible();
     }, { timeout: 3000 }).toBe(true);
@@ -240,16 +231,15 @@ test.describe('BoardManagerDialog extended', () => {
     await openManagerByHeader('NoSpawnCol');
     const dialog = page.locator('[data-testid="board-manager-dialog"]');
 
-    const agentBtn = dialog.locator('[data-testid="board-manager-section-agent"]');
-    const autoBtn = dialog.locator('[data-testid="board-manager-section-auto"]');
-    const handoffBtn = dialog.locator('[data-testid="board-manager-section-handoff"]');
+    // Auto-spawn leads the Agent section: the toggle is present (off), its agent
+    // fields are hidden, and the downstream sections point back to it.
+    await expect(dialog.locator('[role="switch"][aria-label="Auto-spawn"]')).toBeVisible();
+    await expect(dialog.locator('[data-testid="column-agent-override"]')).toHaveCount(0);
+    await expect(dialog.getByText('Turn on Auto-spawn in the Agent section to enable Automation.')).toBeVisible();
+    await expect(dialog.getByText('Turn on Auto-spawn in the Agent section to enable Handoff.')).toBeVisible();
 
-    await expect(agentBtn).toHaveAttribute('aria-disabled', 'true');
-    await expect(agentBtn).toHaveAttribute('title', 'Turn on Auto-spawn in General to enable Agent.');
-    await expect(autoBtn).toHaveAttribute('title', 'Turn on Auto-spawn in General to enable Automation.');
-    await expect(handoffBtn).toHaveAttribute('title', 'Turn on Auto-spawn in General to enable Handoff.');
-
-    // Cleanup: delete the test column
+    // Close before cleanup, then delete the test column.
+    await closeManager();
     await page.evaluate(async () => {
       const lanes = await window.electronAPI.swimlanes.list();
       const lane = lanes.find((s) => s.name === 'NoSpawnCol');
@@ -257,57 +247,35 @@ test.describe('BoardManagerDialog extended', () => {
     });
   });
 
-  // ── Gap 4: Auto-bounce off disabled section ───────────────────────────────
+  // ── Gap 4: Auto-spawn toggle expands / collapses sections in place ────────
   //
-  // Open manager on a column with auto_spawn=true. Navigate to the Agent
-  // section. Then toggle Auto-spawn off via the General section toggle.
-  // After the toggle, the Agent section is now disabled, so the bounce
-  // useEffect must fire and return the active section to 'general'.
+  // Auto-spawn leads the Agent section and gates the agent-behavior config. The
+  // one-scroll form renders every section at once; toggling Auto-spawn off hides
+  // the agent fields (the toggle itself stays) and collapses Automation/Handoff
+  // to their inline explanations; toggling it back on restores the fields.
 
-  test('toggling auto_spawn off while on Agent section bounces back to General', async () => {
+  test('toggling Auto-spawn expands and collapses the dependent sections in place', async () => {
     await openManagerByHeader('Code Review'); // auto_spawn=true
     const dialog = page.locator('[data-testid="board-manager-dialog"]');
 
-    // Navigate to Agent section
-    await dialog.locator('[data-testid="board-manager-section-agent"]').click();
-    await expect(dialog.locator('[data-testid="board-manager-section-agent"]')).toHaveAttribute('aria-selected', 'true');
+    // With Auto-spawn on, the Agent field is present and the Automation hint is absent.
+    await expect(dialog.locator('[data-testid="column-agent-override"]')).toBeVisible();
+    await expect(dialog.getByText('Turn on Auto-spawn in the Agent section to enable Automation.')).toHaveCount(0);
 
-    // Go back to General to toggle Auto-spawn off
-    await dialog.locator('[data-testid="board-manager-section-general"]').click();
-
-    // Toggle the Auto-spawn switch off
     const autoSpawnSwitch = dialog.locator('[role="switch"][aria-label="Auto-spawn"]');
     await expect(autoSpawnSwitch).toHaveAttribute('aria-checked', 'true');
     await autoSpawnSwitch.click();
     await expect(autoSpawnSwitch).toHaveAttribute('aria-checked', 'false');
 
-    // Now navigate back to Agent - it should be disabled
-    const agentBtn = dialog.locator('[data-testid="board-manager-section-agent"]');
-    await expect(agentBtn).toHaveAttribute('aria-disabled', 'true');
+    // The agent fields unmount (the toggle stays) and the downstream hint appears.
+    await expect(dialog.locator('[data-testid="column-agent-override"]')).toHaveCount(0);
+    await expect(autoSpawnSwitch).toBeVisible();
+    await expect(dialog.getByText('Turn on Auto-spawn in the Agent section to enable Automation.')).toBeVisible();
 
-    // Verify General is the active section (bounce should prevent leaving General)
-    const generalBtn = dialog.locator('[data-testid="board-manager-section-general"]');
-    await expect(generalBtn).toHaveAttribute('aria-selected', 'true');
-  });
-
-  test('switching to Agent then toggling auto_spawn off bounces back to General', async () => {
-    await openManagerByHeader('Code Review');
-    const dialog = page.locator('[data-testid="board-manager-dialog"]');
-
-    // Go to Agent
-    await dialog.locator('[data-testid="board-manager-section-agent"]').click();
-    await expect(dialog.locator('[data-testid="board-manager-section-agent"]')).toHaveAttribute('aria-selected', 'true');
-
-    // The Auto-spawn toggle lives in General. Navigate there and turn it off.
-    await dialog.locator('[data-testid="board-manager-section-general"]').click();
-    const autoSpawnSwitch = dialog.locator('[role="switch"][aria-label="Auto-spawn"]');
+    // Toggle back on: the field returns (net no change, so the dialog stays clean).
     await autoSpawnSwitch.click();
-    await expect(autoSpawnSwitch).toHaveAttribute('aria-checked', 'false');
-
-    // Agent section must now be aria-disabled
-    await expect(dialog.locator('[data-testid="board-manager-section-agent"]')).toHaveAttribute('aria-disabled', 'true');
-    // Active section must be General (bounced)
-    await expect(dialog.locator('[data-testid="board-manager-section-general"]')).toHaveAttribute('aria-selected', 'true');
+    await expect(autoSpawnSwitch).toHaveAttribute('aria-checked', 'true');
+    await expect(dialog.locator('[data-testid="column-agent-override"]')).toBeVisible();
   });
 
   // ── Gap 5: DoneSwimlane header button click ───────────────────────────────
@@ -382,7 +350,6 @@ test.describe('BoardManagerDialog extended', () => {
     await page.locator('[data-testid="board-manager-dialog"]').getByRole('button', { name: 'Cancel' }).click();
     await expect(page.locator('h3', { hasText: 'Discard unsaved changes?' })).toBeVisible({ timeout: 1500 });
 
-    const listItems = page.locator('[data-testid="board-manager-dialog"] ~ *').locator('li');
     // ConfirmDialog renders the bullet list in a separate modal; scope to all
     // visible <li>s in the confirm dialog. The ConfirmDialog is a sibling of
     // the manager's <> fragment in the DOM, so we locate it broadly.
@@ -448,6 +415,44 @@ test.describe('BoardManagerDialog extended', () => {
     await dialog.waitFor({ state: 'detached', timeout: 2000 });
   });
 
+  // ── Gap 8: Delete control names its target ────────────────────────────────
+  //
+  // DetailIdentityHeader's delete button carries an aria-label/title of
+  // `Delete "<column name>"`, and the ConfirmDialog it opens reuses that same
+  // string as its title (previously a static "Delete column").
+
+  test('delete control aria-label/title name the column; confirm dialog title matches', async () => {
+    await openManagerByHeader('Code Review');
+    const dialog = page.locator('[data-testid="board-manager-dialog"]');
+
+    const deleteButton = dialog.locator('[data-testid="board-manager-delete"]');
+    await expect(deleteButton).toHaveAttribute('aria-label', 'Delete "Code Review"');
+    await expect(deleteButton).toHaveAttribute('title', 'Delete "Code Review"');
+
+    await deleteButton.click();
+    await expect(page.locator('h3', { hasText: 'Delete "Code Review"' })).toBeVisible({ timeout: 1500 });
+
+    // Cancel out via Escape rather than a "Cancel" button click: the delete
+    // ConfirmDialog's own Cancel button shares its accessible name with the
+    // manager dialog's own footer Cancel button (both render underneath the
+    // confirm's z-[60] overlay), so a plain role/name locator would be
+    // ambiguous. Escape is unambiguous here: BoardManagerDialog's hand-rolled
+    // Escape listener is deliberately guarded off while confirmDeleteId is
+    // set (see the `!confirmDeleteId` check in BoardManagerDialog.tsx), and
+    // its own BaseDialog's Escape effect no-ops under preventBackdropClose,
+    // so only the ConfirmDialog's Escape handler fires, closing just the
+    // confirm and leaving the manager open with nothing deleted.
+    await page.keyboard.press('Escape');
+    await expect(page.locator('h3', { hasText: 'Delete "Code Review"' })).toBeHidden({ timeout: 1500 });
+    await expect(dialog).toBeVisible();
+
+    const stillExists = await page.evaluate(async () => {
+      const lanes = await window.electronAPI.swimlanes.list();
+      return lanes.some((lane) => lane.name === 'Code Review');
+    });
+    expect(stillExists).toBe(true);
+  });
+
   // ── Session target + spawn strategy selects ──────────────────────────────
   //
   // The Automation tab exposes two Selects: "Session" (session_target: main /
@@ -459,8 +464,8 @@ test.describe('BoardManagerDialog extended', () => {
     await openManagerByHeader('Code Review');
     const dialog = page.locator('[data-testid="board-manager-dialog"]');
 
-    await dialog.locator('[data-testid="board-manager-section-auto"]').click();
-
+    // Code Review has auto_spawn=true, so the Automation section renders its
+    // fields inline in the one-scroll form (no section nav to click).
     const targetSelect = dialog.locator('[data-testid="column-session-target"]');
     const spawnSelect = dialog.locator('[data-testid="column-session-spawn-strategy"]');
     await expect(targetSelect).toBeVisible();
@@ -492,5 +497,177 @@ test.describe('BoardManagerDialog extended', () => {
       const lane = lanes.find((s) => s.name === 'Code Review');
       if (lane) await window.electronAPI.swimlanes.update({ id: lane.id, session_target: 'main', session_spawn_strategy: 'create_or_resume' });
     });
+  });
+
+  // ── Maximize parity ──────────────────────────────────────────────────────
+  //
+  // The dialog reuses the shared maximize pattern (maximizedDialogLayout +
+  // MaximizeToggleButton + panel.maximize). The toggle button's aria-label
+  // flips Maximize <-> Restore; Mod+Shift+M drives the same toggle.
+
+  test('maximize toggle flips via the header button and the panel.maximize hotkey', async () => {
+    await openManagerByHeader('Code Review');
+    const dialog = page.locator('[data-testid="board-manager-dialog"]');
+    const maxBtn = dialog.locator('[data-testid="dialog-maximize"]');
+
+    await expect(maxBtn).toHaveAttribute('aria-label', 'Maximize dialog');
+    await maxBtn.click();
+    await expect(maxBtn).toHaveAttribute('aria-label', 'Restore dialog');
+
+    // Mod+Shift+M restores it (Mod = Ctrl on Windows/Linux, Cmd on macOS).
+    await page.keyboard.press('ControlOrMeta+Shift+M');
+    await expect(maxBtn).toHaveAttribute('aria-label', 'Maximize dialog');
+  });
+
+  // ── All-columns overview ─────────────────────────────────────────────────
+  //
+  // The rail's "All columns" entry swaps the detail pane for a grid, one row per
+  // column, read from DRAFTS so unsaved edits show. Clicking a row opens its
+  // detail. The overview entry itself does not carry the board-manager-tab id.
+
+  test('overview lists every column, reflects unsaved edits, and navigates on row click', async () => {
+    await openManagerByHeader('Code Review');
+    const dialog = page.locator('[data-testid="board-manager-dialog"]');
+
+    // Make an unsaved edit that the overview must reflect.
+    await dialog.locator('[data-testid="board-manager-name"]').fill('Reviewed');
+
+    const tabCount = await dialog.locator('[data-testid="board-manager-tab"]').count();
+    await dialog.locator('[data-testid="board-manager-tab-all"]').click();
+
+    const rows = dialog.locator('[data-testid="board-manager-overview-row"]');
+    await expect(rows).toHaveCount(tabCount);
+    await expect(rows.filter({ hasText: 'Reviewed' })).toBeVisible();
+
+    // Clicking the row opens that column's detail with the draft value intact.
+    await rows.filter({ hasText: 'Reviewed' }).click();
+    await expect(dialog.locator('[data-testid="board-manager-name"]')).toHaveValue('Reviewed');
+    // Dirty edit is discarded by afterEach.
+  });
+
+  // ── Footer dirty summary ─────────────────────────────────────────────────
+
+  test('footer summarises the number of modified columns', async () => {
+    await openManagerByHeader('Code Review');
+    const dialog = page.locator('[data-testid="board-manager-dialog"]');
+    const summary = dialog.locator('[data-testid="board-manager-dirty-summary"]');
+
+    await expect(summary).toBeEmpty();
+
+    await dialog.locator('[data-testid="board-manager-name"]').fill('One');
+    await expect(summary).toHaveText('1 column modified');
+
+    await dialog.locator('[data-testid="board-manager-tab"][data-tab-name="Tests"]').click();
+    await dialog.locator('[data-testid="board-manager-name"]').fill('Two');
+    await expect(summary).toHaveText('2 columns modified');
+    // Dirty edits are discarded by afterEach.
+  });
+
+  // ── Column-cycle keybinding ──────────────────────────────────────────────
+  //
+  // Mod+PageDown / Mod+PageUp cycle the selection across [overview, ...columns]
+  // with wraparound, regardless of focus.
+
+  test('Mod+PageDown / Mod+PageUp cycle the selected column with wraparound', async () => {
+    await openManagerByHeader('To Do');
+    const dialog = page.locator('[data-testid="board-manager-dialog"]');
+
+    const todoTab = dialog.locator('[data-testid="board-manager-tab"][data-tab-name="To Do"]');
+    const planningTab = dialog.locator('[data-testid="board-manager-tab"][data-tab-name="Planning"]');
+    const overviewTab = dialog.locator('[data-testid="board-manager-tab-all"]');
+
+    await expect(todoTab).toHaveAttribute('aria-selected', 'true');
+
+    // To Do is laneOrder[0]; navIds = [overview, To Do, Planning, ...].
+    await page.keyboard.press('ControlOrMeta+PageDown');
+    await expect(planningTab).toHaveAttribute('aria-selected', 'true');
+
+    await page.keyboard.press('ControlOrMeta+PageUp');
+    await expect(todoTab).toHaveAttribute('aria-selected', 'true');
+
+    // Wrap up past To Do lands on the overview entry.
+    await page.keyboard.press('ControlOrMeta+PageUp');
+    await expect(overviewTab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  // ── Drag-to-reorder ──────────────────────────────────────────────────────
+  //
+  // The rail reorders via @dnd-kit. To Do is pinned first (no handle, outside the
+  // SortableContext). Reorder is local until Save; the store-sync effect must
+  // preserve an unsaved reorder across a loadBoard() re-sync (the risk-7 fix).
+
+  test('To Do has no drag handle; custom columns do', async () => {
+    await openManagerByHeader('Code Review');
+    const dialog = page.locator('[data-testid="board-manager-dialog"]');
+
+    const todoBtn = dialog.locator('[data-testid="board-manager-tab"][data-tab-name="To Do"]');
+    const reviewBtn = dialog.locator('[data-testid="board-manager-tab"][data-tab-name="Code Review"]');
+    await expect(todoBtn.locator('xpath=../*[@data-drag-handle]')).toHaveCount(0);
+    await expect(reviewBtn.locator('xpath=../*[@data-drag-handle]')).toHaveCount(1);
+  });
+
+  // A single @dnd-kit drag of a rail row's handle, dropped `deltaRows` below its
+  // current slot. Mirrors the mouse-drag pattern in drag-and-drop.spec.ts (move
+  // >5px to fire the PointerSensor, step to the target, settle, release). The
+  // caller retries until the order changes, since a saturated event loop can
+  // starve the final collision compute.
+  async function dragRailRowDown(name: string, deltaRows: number) {
+    const dialog = page.locator('[data-testid="board-manager-dialog"]');
+    const handle = dialog
+      .locator(`[data-testid="board-manager-tab"][data-tab-name="${name}"]`)
+      .locator('xpath=../*[@data-drag-handle]');
+    const row = dialog.locator(`[data-testid="board-manager-tab"][data-tab-name="${name}"]`);
+    const handleBox = await handle.boundingBox();
+    const rowBox = await row.boundingBox();
+    if (!handleBox || !rowBox) return;
+    const startX = handleBox.x + handleBox.width / 2;
+    const startY = handleBox.y + handleBox.height / 2;
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX, startY + 8, { steps: 3 }); // activate (>5px)
+    await page.mouse.move(startX, startY + rowBox.height * deltaRows, { steps: 20 });
+    await page.waitForTimeout(200); // let dnd-kit process the final pointermove
+    await page.mouse.up();
+  }
+
+  test('drag reorder counts toward the modified summary and persists on save', async () => {
+    await openManagerByHeader('Code Review');
+    const dialog = page.locator('[data-testid="board-manager-dialog"]');
+    const summary = dialog.locator('[data-testid="board-manager-dirty-summary"]');
+
+    const readOrder = () =>
+      dialog.locator('[data-testid="board-manager-tab"]').evaluateAll((els) =>
+        els.map((el) => el.getAttribute('data-tab-name')));
+    const orderBefore = await readOrder();
+
+    // Drag "Code Review" down two slots. Retry on a starved drop (mirrors the
+    // established DnD-under-load pattern).
+    for (let attempt = 0; attempt < 3; attempt++) {
+      if ((await readOrder()).join(',') !== orderBefore.join(',')) break;
+      await dragRailRowDown('Code Review', 2);
+      await page.waitForTimeout(150);
+    }
+
+    await expect.poll(async () => (await readOrder()).join(',')).not.toBe(orderBefore.join(','));
+    // A reorder counts the moved columns toward the affected-column summary.
+    await expect(summary).toContainText('modified');
+    const orderAfterDrag = await readOrder();
+
+    // Save persists the new order (risk-7 preservation across the save flow's
+    // own store churn is covered deterministically by reconcileLaneOrder units).
+    await dialog.locator('[data-testid="board-manager-save"]').click();
+    await dialog.waitFor({ state: 'detached', timeout: 3000 });
+
+    const persisted = await page.evaluate(async () =>
+      (await window.electronAPI.swimlanes.list()).sort((a, b) => a.position - b.position).map((s) => s.name));
+    expect(persisted).toEqual(orderAfterDrag);
+
+    // Cleanup: restore the original persisted order.
+    await page.evaluate(async (names: (string | null)[]) => {
+      const lanes = await window.electronAPI.swimlanes.list();
+      const byName = new Map(lanes.map((lane) => [lane.name, lane.id] as const));
+      const ids = names.map((name) => (name ? byName.get(name) : undefined)).filter((id): id is string => !!id);
+      if (ids.length === names.length) await window.electronAPI.swimlanes.reorder(ids);
+    }, orderBefore);
   });
 });

--- a/tests/ui/board-manager-dialog-ext.spec.ts
+++ b/tests/ui/board-manager-dialog-ext.spec.ts
@@ -590,6 +590,52 @@ test.describe('BoardManagerDialog extended', () => {
     await expect(overviewTab).toHaveAttribute('aria-selected', 'true');
   });
 
+  // ── Rail arrow-key navigation ─────────────────────────────────────────────
+  //
+  // ColumnRail's own onKeyDown (scoped to the `role="tablist"` wrapper, so it
+  // only fires while focus is somewhere inside the rail) walks the same
+  // [overview, ...columns] list as the Mod+PageDown/PageUp keybinding above,
+  // with wraparound - but is keyed to ArrowUp/ArrowDown and DOM focus rather
+  // than a document-level shortcut. It is explicitly suppressed while a drag
+  // handle is focused, so @dnd-kit's KeyboardSensor can own the arrows during
+  // a keyboard-initiated sort instead of the rail also reacting to them.
+
+  test('ArrowUp/ArrowDown navigate the rail with wraparound; suppressed when a drag handle is focused', async () => {
+    await openManagerByHeader('To Do');
+    const dialog = page.locator('[data-testid="board-manager-dialog"]');
+
+    const todoTab = dialog.locator('[data-testid="board-manager-tab"][data-tab-name="To Do"]');
+    const planningTab = dialog.locator('[data-testid="board-manager-tab"][data-tab-name="Planning"]');
+    const overviewTab = dialog.locator('[data-testid="board-manager-tab-all"]');
+
+    // Clicking focuses the row's button (Chromium focuses on click), which is
+    // what puts DOM focus inside the rail for the keydown to bubble from.
+    await todoTab.click();
+    await expect(todoTab).toHaveAttribute('aria-selected', 'true');
+
+    // To Do is laneOrder[0]; navIds = [overview, To Do, Planning, ...].
+    await page.keyboard.press('ArrowDown');
+    await expect(planningTab).toHaveAttribute('aria-selected', 'true');
+
+    await page.keyboard.press('ArrowUp');
+    await expect(todoTab).toHaveAttribute('aria-selected', 'true');
+
+    // Wrap up past To Do lands on the overview entry.
+    await page.keyboard.press('ArrowUp');
+    await expect(overviewTab).toHaveAttribute('aria-selected', 'true');
+
+    // Re-select To Do, then focus Planning's drag handle. Arrow keys must be
+    // a no-op here - the guard blocks rail navigation while a handle is
+    // focused, and no drag was activated (that needs Space/Enter first), so
+    // the active tab must stay exactly where it was.
+    await todoTab.click();
+    const planningHandle = planningTab.locator('xpath=../*[@data-drag-handle]');
+    await planningHandle.focus();
+    await page.keyboard.press('ArrowDown');
+    await expect(todoTab).toHaveAttribute('aria-selected', 'true');
+    await expect(planningTab).toHaveAttribute('aria-selected', 'false');
+  });
+
   // ── Drag-to-reorder ──────────────────────────────────────────────────────
   //
   // The rail reorders via @dnd-kit. To Do is pinned first (no handle, outside the

--- a/tests/ui/board-manager-dialog.spec.ts
+++ b/tests/ui/board-manager-dialog.spec.ts
@@ -170,12 +170,12 @@ test.describe('BoardManagerDialog', () => {
 
   test('After Plan Mode row only renders when permission_mode is plan', async () => {
     await openManagerByHeader('Code Review');
-    await page.locator('[data-testid="board-manager-section-agent"]').click();
 
-    // Code Review has no permission override so plan-exit-target should be hidden.
+    // Code Review has no permission override so plan-exit-target should be hidden
+    // (the Agent section renders inline in the one-scroll form).
     await expect(page.locator('[data-testid="plan-exit-target"]')).toBeHidden();
 
-    // Switch to Planning tab where permission_mode = 'plan'.
+    // Switch to Planning column where permission_mode = 'plan'.
     await page.locator('[data-testid="board-manager-tab"][data-tab-name="Planning"]').click();
     await expect(page.locator('[data-testid="plan-exit-target"]')).toBeVisible();
   });

--- a/tests/ui/toggle-card.spec.ts
+++ b/tests/ui/toggle-card.spec.ts
@@ -19,6 +19,10 @@
  * 8. BrowserAutomationTab master-switch gating - the four dependent toggles
  *    are wrapped in an opacity-40 + inert div when the master switch is off,
  *    and fully interactable when it is on.
+ * 9. Info icon variant (BoardManagerDialog Handoff toggle) - the optional
+ *    `info` prop renders an aria-hidden Info icon with a title tooltip beside
+ *    the label, a ToggleCard without `info` renders no such icon, and
+ *    clicking the icon does not flip the switch (stopPropagation).
  *
  * All tests are UI-tier (headless Chromium, no Electron, no PTY).
  * One shared browser+page across the whole file.
@@ -430,5 +434,82 @@ test.describe('BrowserAutomationTab master-switch gating', () => {
     await expect(page.getByRole('switch', { name: 'Allow Interaction' })).toBeVisible();
 
     await closeSettings();
+  });
+});
+
+// ── Gap 9: Info icon variant (BoardManagerDialog Handoff toggle) ─────────────
+//
+// ToggleCard's optional `info` prop renders an aria-hidden Info icon beside the
+// label, with the info text as its `title` tooltip. Clicking the icon must NOT
+// flip the switch (the icon's onClick calls stopPropagation). The Board
+// Manager's "Receive context from prior agent" toggle (Handoff section) is the
+// sole current usage; "Auto-spawn" in the same dialog has no `info` and is the
+// negative case.
+
+test.describe('ToggleCard info icon', () => {
+  async function openManagerByHeader(columnName: string) {
+    const column = page.locator(`[data-swimlane-name="${columnName}"]`);
+    await column.locator(`text=${columnName}`).click();
+    await expect(page.locator('[data-testid="board-manager-dialog"]')).toBeVisible({ timeout: 3000 });
+  }
+
+  async function closeManager() {
+    const dialog = page.locator('[data-testid="board-manager-dialog"]');
+    const cancelBtn = dialog.getByRole('button', { name: 'Cancel' });
+    await cancelBtn.click();
+    // Accept any discard confirm that may appear (a test may have left a dirty draft).
+    const discardBtn = page.locator('button', { hasText: 'Discard' });
+    if (await discardBtn.isVisible({ timeout: 500 }).catch(() => false)) {
+      await discardBtn.click();
+    }
+    await dialog.waitFor({ state: 'detached', timeout: 2000 });
+  }
+
+  test('a ToggleCard with `info` renders an Info icon with the expected title', async () => {
+    await openManagerByHeader('Code Review'); // auto_spawn=true, so Handoff renders inline
+
+    const handoffSwitch = page.getByRole('switch', { name: 'Receive context from prior agent' });
+    await expect(handoffSwitch).toBeVisible();
+
+    // ToggleIndicator is also an aria-hidden span but carries no `title`, so
+    // span[title] uniquely selects the info icon within the switch button.
+    const infoSpan = handoffSwitch.locator('span[title]');
+    await expect(infoSpan).toHaveCount(1);
+    await expect(infoSpan).toHaveAttribute('title', /Kangentic injects the previous session's transcript as the first message/);
+    await expect(infoSpan.locator('svg')).toBeVisible();
+
+    await closeManager();
+  });
+
+  test('a ToggleCard without `info` renders no Info icon', async () => {
+    await openManagerByHeader('Code Review');
+
+    const autoSpawnSwitch = page.getByRole('switch', { name: 'Auto-spawn' });
+    await expect(autoSpawnSwitch).toBeVisible();
+    await expect(autoSpawnSwitch.locator('span[title]')).toHaveCount(0);
+
+    await closeManager();
+  });
+
+  test('clicking the info icon does not toggle the switch', async () => {
+    await openManagerByHeader('Code Review');
+
+    const handoffSwitch = page.getByRole('switch', { name: 'Receive context from prior agent' });
+    await expect(handoffSwitch).toHaveAttribute('aria-checked', 'false');
+
+    await handoffSwitch.locator('span[title]').click();
+
+    // stopPropagation on the icon's onClick must prevent the click from
+    // bubbling to the parent switch button.
+    await expect(handoffSwitch).toHaveAttribute('aria-checked', 'false');
+
+    // Sanity: clicking the label text (not the icon) still flips it, proving
+    // the switch itself is wired correctly and the prior click was a no-op
+    // specifically because of the icon, not some other reason.
+    await handoffSwitch.locator('text=Receive context from prior agent').first().click();
+    await expect(handoffSwitch).toHaveAttribute('aria-checked', 'true');
+
+    // Discard the dirty change on close (closeManager accepts the confirm).
+    await closeManager();
   });
 });

--- a/tests/unit/board-manager-predicates.test.ts
+++ b/tests/unit/board-manager-predicates.test.ts
@@ -3,6 +3,9 @@ import {
   isDirty,
   hasOverride,
   isNewDraftId,
+  isOrderChanged,
+  reconcileLaneOrder,
+  getReorderedColumnIds,
   buildUpdateInput,
   buildCreateInput,
 } from '../../src/renderer/components/dialogs/BoardManagerDialog';
@@ -89,6 +92,130 @@ describe('hasOverride', () => {
         expect(hasOverride(draft, section)).toBe(false);
       }
     }
+  });
+});
+
+describe('isOrderChanged', () => {
+  function originalsFrom(lanes: Swimlane[]): Record<string, Swimlane> {
+    const map: Record<string, Swimlane> = {};
+    for (const lane of lanes) map[lane.id] = lane;
+    return map;
+  }
+
+  const todo = makeSwimlane({ id: 'todo', role: 'todo', position: 0 });
+  const mid = makeSwimlane({ id: 'mid', position: 1 });
+  const done = makeSwimlane({ id: 'done', role: 'done', position: 2 });
+  const originals = originalsFrom([todo, mid, done]);
+
+  it('returns false when laneOrder matches the position-sorted originals', () => {
+    expect(isOrderChanged(['todo', 'mid', 'done'], originals)).toBe(false);
+  });
+
+  it('returns true when two persisted columns are swapped', () => {
+    expect(isOrderChanged(['todo', 'done', 'mid'], originals)).toBe(true);
+  });
+
+  it('ignores unsaved new: drafts when comparing order', () => {
+    expect(isOrderChanged(['todo', 'mid', 'new:x', 'done'], originals)).toBe(false);
+  });
+
+  it('returns false on a length mismatch (a pending create/delete, not a reorder)', () => {
+    expect(isOrderChanged(['todo', 'mid'], originals)).toBe(false);
+  });
+});
+
+describe('reconcileLaneOrder', () => {
+  const todo = makeSwimlane({ id: 'todo', role: 'todo', position: 0 });
+  const mid = makeSwimlane({ id: 'mid', position: 1 });
+  const done = makeSwimlane({ id: 'done', role: 'done', position: 2 });
+  const lanes = [todo, mid, done];
+
+  it('adopts store order when no local reorder is in flight', () => {
+    // previousOrder is stale; without a local reorder we snap to store positions.
+    expect(reconcileLaneOrder(['todo', 'done', 'mid'], lanes, false)).toEqual(['todo', 'mid', 'done']);
+  });
+
+  it('re-inserts unsaved new drafts before Done when adopting store order', () => {
+    expect(reconcileLaneOrder(['todo', 'mid', 'new:x', 'done'], lanes, false))
+      .toEqual(['todo', 'mid', 'new:x', 'done']);
+  });
+
+  it('preserves the relative order of TWO unsaved new: drafts when adopting store order (bug fix)', () => {
+    // Regression test for the fixed bug: the old code spliced each draft into
+    // `result` one at a time at a FIXED `insertAt` index, which lands each
+    // subsequent draft before the previous one, silently reversing two or more
+    // newly-added columns. The store snapshot only has todo/done (no 'mid');
+    // previousOrder carries two never-persisted drafts that must come out in
+    // the same relative order they were typed in.
+    const todoOnly = makeSwimlane({ id: 'todo', role: 'todo', position: 0 });
+    const doneOnly = makeSwimlane({ id: 'done', role: 'done', position: 2 });
+    const previousOrder = ['todo', 'new:a', 'new:b', 'done'];
+    expect(reconcileLaneOrder(previousOrder, [todoOnly, doneOnly], false))
+      .toEqual(['todo', 'new:a', 'new:b', 'done']);
+  });
+
+  it('PRESERVES a local reorder against a store snapshot with different positions (risk-7)', () => {
+    // The user dragged mid after done locally; a store re-sync (still old
+    // positions) must not revert it.
+    const localOrder = ['todo', 'done', 'mid'];
+    expect(reconcileLaneOrder(localOrder, lanes, true)).toEqual(['todo', 'done', 'mid']);
+  });
+
+  it('drops ids the store no longer has while preserving a local reorder', () => {
+    const localOrder = ['todo', 'done', 'mid'];
+    const withoutMid = [todo, done];
+    expect(reconcileLaneOrder(localOrder, withoutMid, true)).toEqual(['todo', 'done']);
+  });
+
+  it('appends never-seen store ids before Done while preserving a local reorder', () => {
+    const localOrder = ['todo', 'done', 'mid'];
+    const extra = makeSwimlane({ id: 'extra', position: 3 });
+    // 'extra' was created elsewhere; it lands before Done, order otherwise intact.
+    expect(reconcileLaneOrder(localOrder, [...lanes, extra], true)).toEqual(['todo', 'extra', 'done', 'mid']);
+  });
+
+  it('keeps unsaved new drafts in place while preserving a local reorder', () => {
+    const localOrder = ['todo', 'new:x', 'mid', 'done'];
+    expect(reconcileLaneOrder(localOrder, lanes, true)).toEqual(['todo', 'new:x', 'mid', 'done']);
+  });
+
+  it('appends a never-seen store id at the END when there is no Done lane (preserve path)', () => {
+    // No role:'done' lane in this store snapshot, so doneIndex is -1 and the
+    // incoming id has nowhere to insert "before Done" - it must append at the
+    // end instead of being dropped or landing at some other position.
+    const localOrder = ['todo', 'mid'];
+    const extraNoDone = makeSwimlane({ id: 'extra', position: 3 });
+    expect(reconcileLaneOrder(localOrder, [todo, mid, extraNoDone], true))
+      .toEqual(['todo', 'mid', 'extra']);
+  });
+});
+
+describe('getReorderedColumnIds', () => {
+  function originalsFrom(lanes: Swimlane[]): Record<string, Swimlane> {
+    const map: Record<string, Swimlane> = {};
+    for (const lane of lanes) map[lane.id] = lane;
+    return map;
+  }
+
+  const todo = makeSwimlane({ id: 'todo', role: 'todo', position: 0 });
+  const mid = makeSwimlane({ id: 'mid', position: 1 });
+  const done = makeSwimlane({ id: 'done', role: 'done', position: 2 });
+  const originals = originalsFrom([todo, mid, done]);
+
+  it('returns an empty Set when laneOrder matches the position-sorted originals', () => {
+    expect(getReorderedColumnIds(['todo', 'mid', 'done'], originals)).toEqual(new Set());
+  });
+
+  it('returns the set of both moved ids on a swap', () => {
+    expect(getReorderedColumnIds(['todo', 'done', 'mid'], originals)).toEqual(new Set(['done', 'mid']));
+  });
+
+  it('returns an empty Set on a length mismatch (pending create/delete)', () => {
+    expect(getReorderedColumnIds(['todo', 'mid'], originals)).toEqual(new Set());
+  });
+
+  it('ignores unsaved new: drafts', () => {
+    expect(getReorderedColumnIds(['todo', 'mid', 'new:x', 'done'], originals)).toEqual(new Set());
   });
 });
 

--- a/tests/unit/overview-model-name.test.ts
+++ b/tests/unit/overview-model-name.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { formatModelName } from '../../src/renderer/components/dialogs/board-manager/ColumnsOverview';
+
+describe('formatModelName', () => {
+  it('humanizes Claude model ids to friendly names', () => {
+    expect(formatModelName('claude-fable-5')).toBe('Fable 5');
+    expect(formatModelName('claude-opus-4-8')).toBe('Opus 4.8');
+    expect(formatModelName('claude-sonnet-5')).toBe('Sonnet 5');
+    expect(formatModelName('claude-haiku-4-5')).toBe('Haiku 4.5');
+  });
+
+  it('surfaces a context-window bracket variant', () => {
+    expect(formatModelName('claude-opus-4-8[1m]')).toBe('Opus 4.8 (1M)');
+  });
+
+  it('drops a trailing date stamp', () => {
+    expect(formatModelName('claude-haiku-4-5-20251001')).toBe('Haiku 4.5');
+  });
+
+  it('title-cases a non-Claude id and trims', () => {
+    expect(formatModelName('gpt-5')).toBe('Gpt 5');
+    expect(formatModelName('  claude-opus-4-8  ')).toBe('Opus 4.8');
+  });
+
+  it('returns the input when nothing meaningful can be derived', () => {
+    expect(formatModelName('')).toBe('');
+  });
+
+  it('returns the trimmed input verbatim when the vendor-prefix strip leaves no segments', () => {
+    // 'claude-' strips to '' after removing the 'claude-' prefix; split('-')
+    // on an empty string yields [''], which .filter(Boolean) drops entirely,
+    // so segments.length === 0 short-circuits to the raw trimmed input.
+    expect(formatModelName('claude-')).toBe('claude-');
+  });
+
+  it('returns the trimmed input verbatim when the whole id is a bracket suffix (bracketMatch is never consulted)', () => {
+    // bracketMatch DOES match '[1m]' -> '1m', but `base` (the string with the
+    // bracket stripped) becomes '', which also yields zero segments. The
+    // segments.length === 0 branch returns `trimmed` immediately, before the
+    // label/bracketMatch formatting is ever reached - so the bracket is NOT
+    // rendered as "(1M)" here, unlike the `claude-opus-4-8[1m]` case above.
+    expect(formatModelName('[1m]')).toBe('[1m]');
+  });
+
+  it('returns the trimmed input verbatim when every segment is a >=6-digit date stamp', () => {
+    // '20260703' survives segmenting (one non-empty segment), but it is an
+    // 8-digit all-numeric run, so the `segment.length < 6` date-stamp guard
+    // drops it from versionParts and it never reaches nameParts either
+    // (it's numeric). Both parts end empty, so `label` is '' and the
+    // `if (!label) return trimmed;` fallback fires.
+    expect(formatModelName('20260703')).toBe('20260703');
+  });
+});


### PR DESCRIPTION
## What

Redesigns the **Edit Columns** dialog (`BoardManagerDialog`) from a compact
two-axis layout (a horizontal column tab strip plus a vertical section nav)
into a master-detail dialog:

- Columns live in a left **rail** with drag-to-reorder (To Do pinned first,
  Done draggable) and per-column summary hints.
- Each column's settings render as **one scrollable form** with sticky section
  headers; disabled sections collapse to a single inline explanation instead of
  hover-only tooltips.
- A new **"All columns" overview grid** gives an at-a-glance audit of every
  column's spawn/agent/model/effort/permissions/session/auto-command settings,
  showing the effective agent name ("Claude Code") and friendly model names
  ("Opus 4.8") with content-proportional column widths.
- **Maximize parity** with NewTaskDialog: a toggle button, double-click header,
  and Mod+Shift+M. Plus Mod+PageUp/PageDown to cycle columns and focus-scoped
  ArrowUp/ArrowDown rail navigation.

Components: `ColumnRail` and `ColumnsOverview` are extracted to
`components/dialogs/board-manager/`; the pure helpers stay exported from
`BoardManagerDialog` so unit tests keep importing from that path. `ToggleCard`
gains an optional info tooltip.

## Why

Edit Columns was the last major surface stuck in the old compact layout with
two competing navigation axes, which made it easy to lose track of which column
you were editing. It also lacked reorder, an at-a-glance audit, and the
maximize parity every other detail surface now has. This brings it in line with
the app's master-detail patterns (settings-panel rail, NewTaskDialog maximize)
and fixes the disorientation.

Closes #331.

## How

- **Master-detail inversion:** columns move from the top strip into a left rail;
  the section nav is gone. The detail pane is a pinned identity header plus one
  scrollable form with sticky flat section headers (settings-pane language).
- **Reorder safety:** drag-reorder is guarded by a
  store-resync-preserves-local-reorder invariant (`reconcileLaneOrder`), so an
  HMR re-sync or another surface's board change never clobbers an unsaved local
  reorder. To Do is structurally pinned to index 0; partial-failure save keeps
  `new:` drafts out of IPC and leaves the dialog open for retry.
- **Overview:** reuses the shared `DataTable`, rows derived from live drafts so
  unsaved edits show. `formatModelName` is a pure renderer-side display
  formatter (mirrors the Claude adapter's humanizer but stays generic, no
  agent-name branching).
- **Keybindings:** `boardManager.nextColumn` / `boardManager.prevColumn` are
  registered in the central registry as hidden, non-rebindable dialog-scoped
  bindings; the maximize sentinel `board-manager-dialog` is added to
  `NON_TASK_DETAIL_VIEW_IDS`.
- Preserves the draft/dirty model, role pinning in the build helpers, and all
  existing field testids.

## Breaking changes

None. Purely a renderer-side redesign of an existing dialog; no API, config,
schema, or persisted-state changes.

## Tests

- **Unit:** `board-manager-predicates.test.ts` extended for `isOrderChanged` and
  `reconcileLaneOrder` (the store-sync-preserves-reorder case); new
  `overview-model-name.test.ts` for `formatModelName`.
- **UI:** `board-manager-dialog-ext.spec.ts` covers maximize toggle, the
  overview grid (row count, live draft values, click-to-navigate), the footer
  dirty summary, column-cycle keybinding wraparound, To-Do-has-no-drag-handle,
  drag reorder (mouse-with-retry), inline disabled-section explanations, the
  auto-spawn expand/collapse, and rail ArrowUp/Down navigation with the
  drag-handle guard; `toggle-card.spec.ts` covers the new info tooltip.
- Typecheck and lint clean locally; the unit, UI, and Linux Electron E2E tiers
  run as the PR checks.

Generated with [Claude Code](https://claude.com/claude-code)
