### PR TITLE
fix(board-config): persist MCP update_column edits to kangentic.json

### DIFF
--- a/src/main/agent/mcp-project-context.ts
+++ b/src/main/agent/mcp-project-context.ts
@@ -110,6 +110,13 @@ export function buildCommandContextForProject(
 
     onSwimlaneUpdated: (swimlane) => {
       sendToRenderer(ipcContext.mainWindow, IPC.SWIMLANE_UPDATED_BY_AGENT, swimlane.id, swimlane.name, projectId);
+      // Persist team-shared column fields (color, model/effort/permission
+      // overrides, auto-command, ...) to kangentic.json so an agent's column
+      // edit survives a restart and reaches teammates via git. Project-scoped
+      // so a cross-project update_column reaches the right project's file, not
+      // just the currently-active one. Best-effort: writeBackForProject never
+      // throws.
+      ipcContext.boardConfigManager.writeBackForProject(projectId, projectPath);
     },
 
     onBacklogChanged: () => {

--- a/src/main/config/board-config-manager.ts
+++ b/src/main/config/board-config-manager.ts
@@ -335,32 +335,57 @@ export class BoardConfigManager {
     }, 500);
   }
 
-  private doWriteBack(): void {
-    if (!this.activeProjectId || !this.activeProjectPath) return;
+  /**
+   * Write a specific project's current DB state to its kangentic.json,
+   * regardless of which project is currently attached/active. Used by the MCP
+   * command path, where a tool call can target a project other than the one
+   * open in the UI (see mcp-http/project-resolver). Best-effort: never throws.
+   * Writes immediately (no debounce) because MCP tool calls are discrete, not
+   * the rapid successive edits a UI drag produces.
+   */
+  writeBackForProject(projectId: string, projectPath: string): void {
+    if (this.isEphemeral) return;
+    this.doWriteBack(projectId, projectPath);
+  }
+
+  private doWriteBack(
+    projectId: string | null = this.activeProjectId,
+    projectPath: string | null = this.activeProjectPath,
+  ): void {
+    if (!projectId || !projectPath) return;
+
+    // The watcher-suppression bookkeeping (isWritingBack / lastTeamContentHash)
+    // only applies to the active project, which is the one with live file
+    // watchers. A cross-project write (an MCP tool call against a non-active
+    // project) has no watcher attached here, so it must not set or clobber the
+    // active project's suppression state.
+    const isActive =
+      projectId === this.activeProjectId && projectPath === this.activeProjectPath;
 
     try {
-      const existingTeam = this.loadTeamConfig();
+      const existingTeam = this.loadTeamConfigForPath(projectPath);
       const boardConfig = buildBoardConfigFromDb({
-        projectId: this.activeProjectId,
+        projectId,
         existingTeamConfig: existingTeam,
         fingerprint: this.fingerprint,
       });
 
-      const teamFilePath = path.join(this.activeProjectPath, TEAM_FILE);
+      const teamFilePath = path.join(projectPath, TEAM_FILE);
 
       const fileCheck = contentMatchesFile(teamFilePath, boardConfig);
       if (fileCheck.matches) {
-        this.lastTeamContentHash = fileCheck.contentHash;
+        if (isActive) this.lastTeamContentHash = fileCheck.contentHash;
         return;
       }
 
-      this.isWritingBack = true;
-      this.lastTeamContentHash = atomicWriteJson(teamFilePath, boardConfig);
+      if (isActive) this.isWritingBack = true;
+      const contentHash = atomicWriteJson(teamFilePath, boardConfig);
+      if (isActive) this.lastTeamContentHash = contentHash;
     } catch (error) {
       console.warn('[BOARD_CONFIG] Write-back failed:', error);
     } finally {
       // Keep isWritingBack true for a bit to suppress watcher re-entry
-      if (this.isWritingBack) {
+      if (isActive && this.isWritingBack) {
         setTimeout(() => {
           this.isWritingBack = false;
         }, 1000);

--- a/tests/unit/board-config-writeback-for-project.test.ts
+++ b/tests/unit/board-config-writeback-for-project.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit coverage for BoardConfigManager.writeBackForProject - the project-scoped
+ * write-back used by the MCP command path (kangentic_update_column). Unlike the
+ * debounced, active-only writeBack(), this must persist an ARBITRARY project's
+ * DB state to its kangentic.json, so a tool call targeting a project other than
+ * the one open in the UI still round-trips team-shared column fields.
+ *
+ * better-sqlite3 cannot load under vitest, so the DB + repositories the
+ * build/apply import graph pulls in are mocked (same pattern as
+ * board-config-onfilechange.test.ts). build-config and atomic-write are also
+ * mocked so the test asserts doWriteBack's control flow (which project, whether
+ * it writes, active-state guarding) via spies rather than real fs.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+
+vi.mock('../../src/main/db/database', () => ({ getProjectDb: vi.fn(() => ({})) }));
+vi.mock('../../src/main/db/repositories/swimlane-repository', () => ({ SwimlaneRepository: class {} }));
+vi.mock('../../src/main/db/repositories/action-repository', () => ({ ActionRepository: class {} }));
+
+vi.mock('../../src/main/config/board-config/build-config', () => ({
+  buildBoardConfigFromDb: vi.fn(() => ({
+    version: 1,
+    columns: [{ id: 'lane-1', name: 'To Do', modelOverride: 'opus' }],
+    actions: [],
+    transitions: [],
+    _modifiedBy: 'fingerprint-test',
+  })),
+}));
+
+vi.mock('../../src/main/config/board-config/atomic-write', () => ({
+  atomicWriteJson: vi.fn(() => 'hash-written'),
+  contentMatchesFile: vi.fn(() => ({ matches: false, contentHash: 'hash-current' })),
+  computeFingerprint: vi.fn(() => 'fingerprint-test'),
+  hashFilePath: vi.fn(() => 'hash-file'),
+}));
+
+import { BoardConfigManager } from '../../src/main/config/board-config-manager';
+import { buildBoardConfigFromDb } from '../../src/main/config/board-config/build-config';
+import { atomicWriteJson, contentMatchesFile } from '../../src/main/config/board-config/atomic-write';
+import { TEAM_FILE } from '../../src/main/config/board-config/config-helpers';
+
+/** The private state the active-project guard reads, set directly via a typed cast. */
+interface ManagerInternals {
+  activeProjectId: string | null;
+  activeProjectPath: string | null;
+  isWritingBack: boolean;
+  lastTeamContentHash: string | null;
+}
+
+describe('BoardConfigManager.writeBackForProject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The active-project write sets isWritingBack then schedules a reset via
+    // setTimeout; fake timers keep that off the real event loop.
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('writes a non-active project by its own id + path (cross-project MCP path)', () => {
+    const manager = new BoardConfigManager({ ephemeral: false });
+
+    manager.writeBackForProject('proj-B', '/mock/projB');
+
+    // The targeted project's DB is read (not the active one), and the file
+    // lands in the targeted project's directory.
+    expect(buildBoardConfigFromDb).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'proj-B' }),
+    );
+    expect(atomicWriteJson).toHaveBeenCalledWith(
+      path.join('/mock/projB', TEAM_FILE),
+      expect.anything(),
+    );
+  });
+
+  it("does not touch the active project's watcher-suppression state", () => {
+    const manager = new BoardConfigManager({ ephemeral: false });
+    const internals = manager as unknown as ManagerInternals;
+    internals.activeProjectId = 'proj-A';
+    internals.activeProjectPath = '/mock/projA';
+    internals.isWritingBack = false;
+    internals.lastTeamContentHash = 'active-hash';
+
+    manager.writeBackForProject('proj-B', '/mock/projB');
+
+    expect(atomicWriteJson).toHaveBeenCalledWith(
+      path.join('/mock/projB', TEAM_FILE),
+      expect.anything(),
+    );
+    // proj-B has no watcher here, so writing it must not flip the active
+    // project's suppression flag or clobber its last-seen content hash.
+    expect(internals.isWritingBack).toBe(false);
+    expect(internals.lastTeamContentHash).toBe('active-hash');
+  });
+
+  it('updates suppression bookkeeping when the target IS the active project', () => {
+    const manager = new BoardConfigManager({ ephemeral: false });
+    const internals = manager as unknown as ManagerInternals;
+    internals.activeProjectId = 'proj-A';
+    internals.activeProjectPath = '/mock/projA';
+    internals.isWritingBack = false;
+    internals.lastTeamContentHash = null;
+
+    manager.writeBackForProject('proj-A', '/mock/projA');
+
+    expect(atomicWriteJson).toHaveBeenCalledWith(
+      path.join('/mock/projA', TEAM_FILE),
+      expect.anything(),
+    );
+    // Writing the active project suppresses the watcher echo: the written hash
+    // is recorded and isWritingBack is set (reset later on a timer we don't run).
+    expect(internals.lastTeamContentHash).toBe('hash-written');
+    expect(internals.isWritingBack).toBe(true);
+  });
+
+  it('skips the write when on-disk content already matches', () => {
+    vi.mocked(contentMatchesFile).mockReturnValueOnce({ matches: true, contentHash: 'same-hash' });
+    const manager = new BoardConfigManager({ ephemeral: false });
+
+    manager.writeBackForProject('proj-B', '/mock/projB');
+
+    expect(atomicWriteJson).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for an ephemeral manager', () => {
+    const manager = new BoardConfigManager({ ephemeral: true });
+
+    manager.writeBackForProject('proj-B', '/mock/projB');
+
+    expect(buildBoardConfigFromDb).not.toHaveBeenCalled();
+    expect(atomicWriteJson).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/mcp-project-context.test.ts
+++ b/tests/unit/mcp-project-context.test.ts
@@ -37,6 +37,12 @@ vi.mock('../../src/shared/ipc-channels', () => ({
   IPC: new Proxy({}, { get: (_target, prop) => String(prop) }),
 }));
 
+// sendToRenderer (invoked when a callback fires) mirrors into the IPC traffic
+// recorder; stub it so invoking a callback stays a pure unit test.
+vi.mock('../../src/main/diagnostics/ipc-recorder', () => ({
+  recordPush: vi.fn(),
+}));
+
 // RequestResolver is imported by mcp-project-context and called with `new`.
 // Track constructor calls via a hoisted spy variable that the test body can
 // inspect after each call.
@@ -52,7 +58,7 @@ vi.mock('../../src/main/agent/mcp-http/project-resolver', () => {
 
 import { createRequestResolver, buildCommandContextForProject } from '../../src/main/agent/mcp-project-context';
 import type { IpcContext } from '../../src/main/ipc/ipc-context';
-import type { Project } from '../../src/shared/types';
+import type { Project, Swimlane } from '../../src/shared/types';
 
 function makeProject(overrides: Partial<Project> = {}): Project {
   return {
@@ -180,5 +186,72 @@ describe('buildCommandContextForProject', () => {
     expect(typeof context!.onSwimlaneUpdated).toBe('function');
     expect(typeof context!.onBacklogChanged).toBe('function');
     expect(typeof context!.onLabelColorsChanged).toBe('function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onSwimlaneUpdated write-back
+//
+// Regression lock: an MCP update_column edits a swimlane row and fires
+// onSwimlaneUpdated. That callback must persist the team-shared column fields
+// to kangentic.json (via BoardConfigManager.writeBackForProject), not only push
+// the renderer notification - otherwise an agent's model/effort/permission edit
+// is lost on restart and never reaches teammates via git. It must be
+// project-scoped so a cross-project update_column reaches the right file.
+// ---------------------------------------------------------------------------
+
+describe('buildCommandContextForProject - onSwimlaneUpdated write-back', () => {
+  const PROJECT_PATH = '/projects/example';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeWriteBackContext() {
+    const project = makeProject({ id: DEFAULT_ID, path: PROJECT_PATH });
+    const send = vi.fn();
+    const writeBackForProject = vi.fn();
+    const ipcContext = {
+      projectRepo: { getById: vi.fn(() => project), list: vi.fn(() => [project]) },
+      mainWindow: { isDestroyed: () => false, webContents: { send } },
+      boardConfigManager: { writeBackForProject },
+    } as unknown as IpcContext;
+    return { ipcContext, send, writeBackForProject };
+  }
+
+  // onSwimlaneUpdated only reads id + name off the swimlane.
+  const fakeSwimlane = (): Swimlane => ({ id: 'lane-1', name: 'To Do' }) as unknown as Swimlane;
+
+  it('writes back the targeted project id and path (project-scoped)', () => {
+    const { ipcContext, writeBackForProject } = makeWriteBackContext();
+    const context = buildCommandContextForProject(ipcContext, DEFAULT_ID);
+    expect(context).not.toBeNull();
+
+    context!.onSwimlaneUpdated(fakeSwimlane());
+
+    expect(writeBackForProject).toHaveBeenCalledTimes(1);
+    expect(writeBackForProject).toHaveBeenCalledWith(DEFAULT_ID, PROJECT_PATH);
+  });
+
+  it('still notifies the renderer (write-back is additive)', () => {
+    const { ipcContext, send } = makeWriteBackContext();
+    const context = buildCommandContextForProject(ipcContext, DEFAULT_ID);
+
+    context!.onSwimlaneUpdated(fakeSwimlane());
+
+    // The ipc-channels mock is a Proxy that returns each key as its own string,
+    // so the channel arrives as the literal 'SWIMLANE_UPDATED_BY_AGENT'.
+    expect(send).toHaveBeenCalledWith(
+      'SWIMLANE_UPDATED_BY_AGENT', 'lane-1', 'To Do', DEFAULT_ID,
+    );
+  });
+
+  it('does not write back for non-swimlane callbacks (onBacklogChanged)', () => {
+    const { ipcContext, writeBackForProject } = makeWriteBackContext();
+    const context = buildCommandContextForProject(ipcContext, DEFAULT_ID);
+
+    context!.onBacklogChanged();
+
+    expect(writeBackForProject).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

Makes the MCP `kangentic_update_column` tool persist a column edit to `kangentic.json`, not just
to the project DB and the live board.

- `src/main/config/board-config-manager.ts` - generalizes the private `doWriteBack()` to take an
  optional `(projectId, projectPath)` target (defaulting to the active project, so existing
  behavior is unchanged), guards the watcher-suppression bookkeeping (`isWritingBack` /
  `lastTeamContentHash`) behind an `isActive` check, and adds a public
  `writeBackForProject(projectId, projectPath)` that writes immediately (no debounce).
- `src/main/agent/mcp-project-context.ts` - `onSwimlaneUpdated` now calls
  `boardConfigManager.writeBackForProject(projectId, projectPath)` after the renderer notify.

## Why

`kangentic_update_column` updated the swimlane row and fired `onSwimlaneUpdated`, but in the MCP
context that callback only pushed the `SWIMLANE_UPDATED_BY_AGENT` renderer event. It never
triggered a board-config write-back, so team-shared column fields an agent changed (`color`,
`autoSpawn`, `modelOverride`, `effortOverride`, `permissionMode`, `autoCommand`, `agentOverride`,
`handoffContext`) updated the board live but never reached `kangentic.json`: they were lost on
restart and never shared with teammates via git. Every UI/IPC swimlane path already wrote back;
only the MCP path was missing it. This is the same failure class `board-config-parity.md`
documents (the `session_target` bug), at the call-site level.

## How

The fix is deliberately **project-scoped**. `boardConfigManager.writeBack()` only ever targets the
app's currently-open project (the singleton is attached to one active project on `project:open`).
Because an MCP `update_column` can target a *different* project via the tool's `project` argument,
a naive `writeBack()` would rebuild the active project's config (a no-op) and never write the
targeted project's `kangentic.json`. `buildBoardConfigFromDb({ projectId })` already reads
`getProjectDb(projectId)`, so generalizing `doWriteBack` to an arbitrary `(projectId, projectPath)`
closes the gap cleanly. The active-project watcher-suppression state is only touched when the
target is the active project (a non-active project has no file watcher attached here).

`board.ts` is intentionally left unchanged: its UI handlers only ever edit the active project, so
the existing debounced `writeBack()` there is already correct. `update_column` is the only MCP
command that mutates a swimlane, so no other call site needs this.

## Breaking changes

None. `update_column`'s signature is unchanged; only its side-effect completeness. The generalized
`doWriteBack()` defaults to the active project, so `writeBack()` / `exportFromDb()` behavior is
unchanged.

## Tests

CI (lint, typecheck, unit, build, UI shards, Linux Electron E2E shards). New unit coverage:

- `tests/unit/mcp-project-context.test.ts` - `onSwimlaneUpdated` triggers `writeBackForProject`
  with the targeted project id and path, still notifies the renderer, and does not fire for
  `onBacklogChanged`.
- `tests/unit/board-config-writeback-for-project.test.ts` - the new method: cross-project write
  targets the right DB/path, the active project's suppression state is left untouched by a
  cross-project write, that state is updated when the target IS active, the content-match
  short-circuit, and the ephemeral no-op.

Both regression tests were red-greened (they fail without the fix). Typecheck and lint are green
locally.

Generated with [Claude Code](https://claude.com/claude-code)
