### PR TITLE
fix(terminal): restore model/effort picker after a live column model change

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,7 +65,7 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 | `projectGroup:reorder` | invoke | Reorder groups by ID array |
 | `projectGroup:setCollapsed` | invoke | Toggle group collapsed state |
 
-### Tasks (22 channels)
+### Tasks (23 channels)
 | Channel | Pattern | Purpose |
 |---------|---------|---------|
 | `task:list` | invoke | Fetch tasks, optionally by swimlane |
@@ -87,6 +87,7 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 | `task:createdByAgent` | on | Event: task was created by an agent via MCP tool call |
 | `task:updatedByAgent` | on | Event: task was updated by an agent via MCP tool call |
 | `task:deletedByAgent` | on | Event: task was deleted by an agent via MCP tool call |
+| `task:sessionResync` | on | Event: quiet (toast-free) board re-sync after a column model-change session restart, so the board store's stale `task.session_id` reloads |
 | `task:spawnProgress` | on | Event: spawn progress phase label during task move |
 | `task:getSpawnProgress` | invoke | Fetch the queryable in-flight spawn-progress map (taskId -> phase label) so `syncSessions` can reconcile after HMR / project switch |
 | `task:setDetailViewState` | invoke | Persist the task-detail dialog's layout blob (debounced from the renderer) so it restores across restarts. Pass null to clear. Does not bump `updated_at`. |

--- a/src/main/diagnostics/ipc-recorder.ts
+++ b/src/main/diagnostics/ipc-recorder.ts
@@ -65,6 +65,7 @@ const SAFE_PUSH_CHANNELS = new Set<string>([
   'task:createdByAgent',
   'task:updatedByAgent',
   'task:deletedByAgent',
+  'task:sessionResync',
   'swimlane:updatedByAgent',
   'backlog:changedByAgent',
   'backlog:labelColorsChanged',

--- a/src/main/ipc/handlers/board.ts
+++ b/src/main/ipc/handlers/board.ts
@@ -148,6 +148,15 @@ export function registerBoardHandlers(context: IpcContext): void {
                   `[SWIMLANE_UPDATE] Could not restart session for task ${taskId.slice(0, 8)}`
                   + ` after model change in column "${result.name}": ${restart.reason}`,
                 );
+                return;
+              }
+              // The restart respawned the task with a new session_id; the board
+              // store still has the pre-restart session_id until it reloads.
+              // Push a quiet (toast-free) re-sync trigger, distinct from
+              // TASK_UPDATED_BY_AGENT, since this is a consequence of the
+              // user's own column edit, not an agent-driven change.
+              if (!context.mainWindow.isDestroyed()) {
+                context.mainWindow.webContents.send(IPC.TASK_SESSION_RESYNC, projectId);
               }
             });
           } else {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -98,6 +98,12 @@ const api: ElectronAPI = {
       ipcRenderer.on(IPC.TASK_DELETED_BY_AGENT, handler);
       return () => ipcRenderer.removeListener(IPC.TASK_DELETED_BY_AGENT, handler);
     },
+    onSessionResync: (callback) => {
+      const handler = (_event: Electron.IpcRendererEvent, projectId?: string) =>
+        callback(projectId);
+      ipcRenderer.on(IPC.TASK_SESSION_RESYNC, handler);
+      return () => ipcRenderer.removeListener(IPC.TASK_SESSION_RESYNC, handler);
+    },
     onSpawnProgress: (callback) => {
       const handler = (_event: Electron.IpcRendererEvent, taskId: string, label: string | null) =>
         callback(taskId, label);

--- a/src/renderer/components/terminal/ContextBar.tsx
+++ b/src/renderer/components/terminal/ContextBar.tsx
@@ -135,7 +135,14 @@ export function ContextBar({ sessionId, agentFallback = null }: ContextBarProps)
   const sessionShell = session?.shell;
   const isResuming = session?.resuming ?? false;
   const injectTransientSettings = useSessionStore((s) => s.injectTransientSettings);
-  const task = useBoardStore((s) => s.tasks.find((t) => t.session_id === sessionId));
+  // Resolve via the session's own taskId, not the task's forward session_id: a
+  // model/effort restart (column edit or manual override) respawns the session
+  // and updates the DB row, but the board store's task.session_id goes stale
+  // until the next reload. session.taskId stays correct across the restart.
+  // Transient command-terminal sessions carry a synthetic uuid taskId that
+  // matches no tasks row, so they still fall through to the transient/static
+  // branches below.
+  const task = useBoardStore((s) => s.tasks.find((t) => t.id === session?.taskId));
   const taskAgent = task?.agent ?? agentFallback;
   // Resolve the agent that contributed the latest rate-limit snapshot so the
   // tooltip can name it. Falls back to undefined when the source session has

--- a/src/renderer/hooks/useAgentDrivenInvalidation.ts
+++ b/src/renderer/hooks/useAgentDrivenInvalidation.ts
@@ -18,6 +18,11 @@
  * policy reviewable in one place rather than spread across 100 lines
  * of repetitive IPC wiring in App.tsx.
  *
+ * `onSessionResync` is the deliberate exception to "toast unconditionally"
+ * below: it fires after a column-model-change restart to keep the board
+ * store's task.session_id current, which is a board-consistency reconcile
+ * the user already knows they triggered, not agent-driven news.
+ *
  * Not included here (and intentionally left in App.tsx):
  *   - `tasks.onAutoMoved`: agent-driven but tangled with notification
  *     policy (`shouldNotify`/`sendNotification`). Splitting its concerns
@@ -145,6 +150,25 @@ export function useAgentDrivenInvalidation(): void {
           message: `Task deleted by agent: "${taskTitle}"`,
           variant: 'info',
         });
+      }));
+    }
+
+    if (tasks?.onSessionResync) {
+      cleanups.push(tasks.onSessionResync((sessionResyncProjectId) => {
+        const activeProjectId = useProjectStore.getState().currentProject?.id;
+        const matchesActiveProject = !sessionResyncProjectId || sessionResyncProjectId === activeProjectId;
+        console.debug('[agent-push] task:sessionResync received', {
+          pushProjectId: sessionResyncProjectId,
+          activeProjectId,
+          action: matchesActiveProject ? 'reload' : 'invalidate-cache',
+        });
+        if (matchesActiveProject) {
+          scheduleBoardReload();
+        } else {
+          invalidateProject(sessionResyncProjectId);
+        }
+        // Deliberately no toast: this is a quiet board-consistency reconcile
+        // after the user's own column model-change restart, not agent news.
       }));
     }
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -46,6 +46,7 @@ export const IPC = {
   TASK_CREATED_BY_AGENT: 'task:createdByAgent',
   TASK_UPDATED_BY_AGENT: 'task:updatedByAgent',
   TASK_DELETED_BY_AGENT: 'task:deletedByAgent',
+  TASK_SESSION_RESYNC: 'task:sessionResync',
   TASK_SPAWN_PROGRESS: 'task:spawnProgress',
   TASK_GET_SPAWN_PROGRESS: 'task:getSpawnProgress',
   TASK_SET_RUNTIME_OVERRIDE: 'task:setRuntimeOverride',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2822,6 +2822,7 @@ export interface ElectronAPI {
     onCreatedByAgent: (callback: (taskId: string, taskTitle: string, columnName: string, projectId?: string) => void) => () => void;
     onUpdatedByAgent: (callback: (taskId: string, taskTitle: string, projectId?: string) => void) => () => void;
     onDeletedByAgent: (callback: (taskId: string, taskTitle: string, projectId?: string) => void) => () => void;
+    onSessionResync: (callback: (projectId?: string) => void) => () => void;
     onSpawnProgress: (callback: (taskId: string, label: string | null) => void) => () => void;
     /**
      * Queryable snapshot of in-flight spawn-progress labels (keyed by taskId).

--- a/tests/ui/agent-driven-invalidation.spec.ts
+++ b/tests/ui/agent-driven-invalidation.spec.ts
@@ -623,3 +623,112 @@ test.describe('useAgentDrivenInvalidation - current project create renders the c
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Test: task:sessionResync push is a quiet reconcile (regression guard)
+//
+// `onSessionResync` fires after a column-model-change session restart to keep
+// the board store's task.session_id current. It follows the same
+// current-vs-background routing as its on*ByAgent siblings (scheduleBoardReload
+// vs invalidateProject), but is the DELIBERATE exception to "toast
+// unconditionally": a naive implementation that copied the sibling shape would
+// toast just like tasks.onCreatedByAgent/onUpdatedByAgent/onDeletedByAgent. The
+// no-toast behavior is documented directly above the listener in
+// useAgentDrivenInvalidation.ts and is the key thing this test pins.
+// ---------------------------------------------------------------------------
+
+test.describe('useAgentDrivenInvalidation - task:sessionResync is a quiet reconcile', () => {
+  /**
+   * Snapshot the current toast count without Playwright's own assertion
+   * retry. `expect(locator).toHaveCount(0)` auto-retries for up to the
+   * expect timeout (default ~5s), and the mock config's toast
+   * `durationSeconds` is 4, so a wrongly-raised toast would auto-dismiss
+   * itself WITHIN that retry window and the assertion would report a false
+   * pass once it disappeared. A single un-retried `.count()` read is the
+   * only way to correctly assert "no toast right now".
+   */
+  async function toastCountRightNow(page: Page): Promise<number> {
+    return page.getByTestId('toast').count();
+  }
+
+  test('same-project resync reloads the board and raises no toast', async () => {
+    const { browser, page } = await launch();
+
+    try {
+      await warmBothProjectsAndResetCounter(page);
+
+      // Alpha is current. Fire a session-resync push targeting Alpha.
+      await page.evaluate((currentProjectId) => {
+        (window as unknown as { __mockFireTaskSessionResync: (projectId?: string) => void })
+          .__mockFireTaskSessionResync(currentProjectId);
+      }, PROJECT_A_ID);
+
+      // The debounced loadBoard (250ms) refetches tasks/swimlanes for the active
+      // project. Poll instead of a fixed wait so this is stable across machine speed.
+      await expect
+        .poll(async () => {
+          const counts = await page.evaluate(() =>
+            (window as unknown as { __getIpcCallCounts: () => Record<string, number> }).__getIpcCallCounts(),
+          );
+          return (counts['tasks.list'] ?? 0) + (counts['swimlanes.list'] ?? 0);
+        }, { timeout: 3000 })
+        .toBeGreaterThan(0);
+
+      // Deliberately no toast: onSessionResync is a quiet board-consistency
+      // reconcile, not agent news, unlike its on*ByAgent siblings which always
+      // toast. This is the regression this test guards against. A single
+      // snapshot read (not a retrying locator assertion, see toastCountRightNow)
+      // right after the reload lands is the correct check here.
+      expect(await toastCountRightNow(page)).toBe(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('background-project resync invalidates that project cache, does not reload the active board, and raises no toast', async () => {
+    const { browser, page } = await launch();
+
+    try {
+      await warmBothProjectsAndResetCounter(page);
+
+      // Alpha is current. Fire a session-resync push targeting Beta (background).
+      await page.evaluate((backgroundProjectId) => {
+        (window as unknown as { __mockFireTaskSessionResync: (projectId?: string) => void })
+          .__mockFireTaskSessionResync(backgroundProjectId);
+      }, PROJECT_B_ID);
+
+      // Give any (incorrect) same-project reload a budget to fire, then assert
+      // Alpha's own board did NOT refetch and no toast appeared. (Intentional
+      // fixed wait - negative assertion; cannot poll for non-occurrence.)
+      await page.waitForTimeout(500);
+      const countsAfterPush = await page.evaluate(() =>
+        (window as unknown as { __getIpcCallCounts: () => Record<string, number> }).__getIpcCallCounts(),
+      );
+      expect(countsAfterPush['tasks.list'] ?? 0).toBe(0);
+      expect(countsAfterPush['swimlanes.list'] ?? 0).toBe(0);
+      expect(await toastCountRightNow(page)).toBe(0);
+
+      // Reset the counter, then switch to Beta. Because the push invalidated
+      // Beta's warm-switch cache, the switch must trigger a cold IPC fan-out.
+      await page.evaluate(() => {
+        (window as unknown as { __resetIpcCallCounts: () => void }).__resetIpcCallCounts();
+      });
+      await page.locator('[role="button"]:has-text("Inv Beta")').click();
+      await expect(page.locator('[data-swimlane-name="To Do"]')).toBeVisible({ timeout: 5000 });
+
+      await expect
+        .poll(async () => {
+          const counts = await page.evaluate(() =>
+            (window as unknown as { __getIpcCallCounts: () => Record<string, number> }).__getIpcCallCounts(),
+          );
+          return (counts['tasks.list'] ?? 0) + (counts['swimlanes.list'] ?? 0);
+        }, { timeout: 3000 })
+        .toBeGreaterThan(0);
+
+      // The Beta cold load must not have raised a toast either.
+      expect(await toastCountRightNow(page)).toBe(0);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/ui/context-bar-stale-session-id.spec.ts
+++ b/tests/ui/context-bar-stale-session-id.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Red-green guard for the ContextBar model/effort picker vanishing after a
+ * live column model change.
+ *
+ * Root cause: a model-override restart (column edit or manual override)
+ * suspends the old session and respawns a new one; the DB `tasks.session_id`
+ * is updated to the new session, but the board store keeps the stale
+ * (now-exited) session id until the next reload. `ContextBar` used to join
+ * its task via `tasks.find(t => t.session_id === sessionId)`, which misses
+ * once the board row is stale, dropping the interactive model/effort
+ * triggers in favor of static pill text.
+ *
+ * This spec seeds that exact mismatch directly (no restart needed to
+ * reproduce it): a running, non-transient session whose own `taskId` names a
+ * real task, but whose task row's `session_id` points at a dangling id that
+ * is never itself seeded as a session (modeling "exited/gone"). The fix
+ * resolves the task via the session's own `taskId` instead, so the pickers
+ * mount regardless of the task's stale `session_id`.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-ctx-bar-stale-session';
+const TASK_ID = 'task-ctx-bar-stale-session';
+const LIVE_SESSION_ID = 'sess-ctx-bar-live';
+const STALE_SESSION_ID = 'sess-ctx-bar-stale-gone';
+const SWIMLANE_ID = 'lane-ctx-bar-stale-session';
+
+async function launchWithState(preConfigScript: string): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(preConfigScript);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+  return { browser, page };
+}
+
+// Task's session_id points at STALE_SESSION_ID (never seeded as a session -
+// models an exited session after a restart). The one running session in the
+// project is LIVE_SESSION_ID, whose own taskId correctly names TASK_ID.
+const STALE_SESSION_PRECONFIG = `
+  window.__mockPreConfigure(function (state) {
+    var ts = new Date().toISOString();
+
+    state.projects.push({
+      id: '${PROJECT_ID}',
+      name: 'Stale Session ContextBar Test',
+      path: '/mock/ctx-bar-stale-session',
+      github_url: null,
+      default_agent: 'claude',
+      last_opened: ts,
+      created_at: ts,
+    });
+
+    state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+      var id = i === 0 ? '${SWIMLANE_ID}' : state.uuid();
+      state.swimlanes.push({
+        id: id,
+        name: s.name,
+        role: s.role,
+        color: s.color,
+        icon: s.icon,
+        is_archived: s.is_archived,
+        permission_strategy: s.permission_strategy ?? null,
+        auto_spawn: s.auto_spawn ?? false,
+        position: i,
+        created_at: ts,
+      });
+    });
+
+    state.sessions.push({
+      id: '${LIVE_SESSION_ID}',
+      taskId: '${TASK_ID}',
+      projectId: '${PROJECT_ID}',
+      pid: 9999,
+      status: 'running',
+      shell: 'bash',
+      cwd: '/mock/ctx-bar-stale-session',
+      startedAt: ts,
+      exitCode: null,
+      resuming: false,
+    });
+
+    state.tasks.push({
+      id: '${TASK_ID}',
+      title: 'Stale Session Task',
+      description: '',
+      swimlane_id: '${SWIMLANE_ID}',
+      position: 0,
+      agent: 'claude',
+      session_id: '${STALE_SESSION_ID}',
+      worktree_path: null,
+      branch_name: null,
+      pr_number: null,
+      pr_url: null,
+      base_branch: null,
+      labels: [],
+      priority: 0,
+      model_override: null,
+      effort_override: null,
+      attachment_count: 0,
+      archived_at: null,
+      created_at: ts,
+      updated_at: ts,
+    });
+
+    return { currentProjectId: '${PROJECT_ID}' };
+  });
+`;
+
+async function applyClaudeUsage(page: Page, sessionId: string): Promise<void> {
+  await page.evaluate((id) => {
+    const stores = (window as unknown as {
+      __zustandStores?: {
+        session: { getState: () => { updateUsage: (id: string, data: unknown) => void } };
+      };
+    }).__zustandStores;
+    stores?.session.getState().updateUsage(id, {
+      model: { id: 'opus', displayName: 'Opus 4.8 (1M context)', effort: 'high' },
+      contextWindow: {
+        usedPercentage: 0,
+        usedTokens: 0,
+        cacheTokens: 0,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        contextWindowSize: 1_000_000,
+      },
+      cost: { totalCostUsd: 0, totalDurationMs: 0 },
+    });
+  }, sessionId);
+}
+
+test.describe('ContextBar model/effort picker - stale task.session_id', () => {
+  test('renders interactive triggers by resolving the task via the session\'s own taskId', async () => {
+    const { browser, page } = await launchWithState(STALE_SESSION_PRECONFIG);
+    try {
+      await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+      const usageBar = page.locator('[data-testid="usage-bar"].min-h-8');
+      await expect(usageBar).toBeVisible({ timeout: 10000 });
+
+      await applyClaudeUsage(page, LIVE_SESSION_ID);
+
+      // Sanity check: the board's task row genuinely carries the stale,
+      // never-seeded session id (not the live session rendering this bar).
+      const taskSessionId = await page.evaluate((taskId) => {
+        const stores = (window as unknown as {
+          __zustandStores?: { board: { getState: () => { tasks: Array<{ id: string; session_id: string | null }> } } };
+        }).__zustandStores;
+        return stores?.board.getState().tasks.find((row) => row.id === taskId)?.session_id ?? null;
+      }, TASK_ID);
+      expect(taskSessionId).toBe(STALE_SESSION_ID);
+
+      // The join must succeed via session.taskId despite the stale forward
+      // pointer, so both pickers mount as interactive buttons, not static text.
+      await expect(page.locator('[data-testid="context-bar-model-trigger"]')).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('[data-testid="context-bar-effort-trigger"]')).toBeVisible({ timeout: 5000 });
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -913,6 +913,22 @@
           if (idx >= 0) listeners.splice(idx, 1);
         };
       },
+      onSessionResync: function (callback) {
+        // Tests can fire this via window.__mockFireTaskSessionResync(projectId).
+        if (!window.__mockTaskSessionResyncListeners) window.__mockTaskSessionResyncListeners = [];
+        window.__mockTaskSessionResyncListeners.push(callback);
+        if (!window.__mockFireTaskSessionResync) {
+          window.__mockFireTaskSessionResync = function (projectId) {
+            var listeners = (window.__mockTaskSessionResyncListeners || []).slice();
+            for (var i = 0; i < listeners.length; i++) { listeners[i](projectId); }
+          };
+        }
+        return function () {
+          var listeners = window.__mockTaskSessionResyncListeners || [];
+          var idx = listeners.indexOf(callback);
+          if (idx >= 0) listeners.splice(idx, 1);
+        };
+      },
       onSpawnProgress: function (callback) {
         // Tests can fire this via window.__mockFireSpawnProgress(taskId, label).
         if (!window.__mockSpawnProgressListeners) window.__mockSpawnProgressListeners = [];

--- a/tests/unit/board-swimlane-update-restart.test.ts
+++ b/tests/unit/board-swimlane-update-restart.test.ts
@@ -143,6 +143,10 @@ interface MockContext {
   projectRepo: {
     getById: ReturnType<typeof vi.fn>;
   };
+  mainWindow: {
+    isDestroyed: ReturnType<typeof vi.fn>;
+    webContents: { send: ReturnType<typeof vi.fn> };
+  };
 }
 
 function createMockContext(overrides: Partial<MockContext> = {}): MockContext {
@@ -164,6 +168,10 @@ function createMockContext(overrides: Partial<MockContext> = {}): MockContext {
     },
     projectRepo: {
       getById: vi.fn(() => ({ id: 'proj-board-1', name: 'Test Project', path: '/mock/board-project' })),
+    },
+    mainWindow: {
+      isDestroyed: vi.fn(() => false),
+      webContents: { send: vi.fn() },
     },
     ...overrides,
   };
@@ -513,5 +521,81 @@ describe('SWIMLANE_UPDATE handler - restart-on-model and effort live-inject bran
 
     // Model is unchanged, so no restart should be triggered.
     expect(hoisted.restartSessionForSettingsChange).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // Test 7: MODEL change, restart succeeds -> TASK_SESSION_RESYNC pushed
+  // =========================================================================
+
+  it('MODEL change, restart succeeds: pushes TASK_SESSION_RESYNC to the renderer', async () => {
+    // The board store keeps the pre-restart session_id until it re-syncs. The
+    // handler must push a quiet (toast-free) TASK_SESSION_RESYNC once the
+    // restart resolves ok, so ContextBar's task join (and every other
+    // session_id-keyed consumer) recovers without a full reload.
+    const task = createTaskInLane({ id: 'task-board-7', session_id: 'session-board-7' });
+    const swimlaneBefore = createSwimlaneBefore({ id: 'lane-executing' });
+    const updatedSwimlane = { ...swimlaneBefore, model_override: 'opus', name: 'Executing' };
+
+    const repos = buildProjectRepos(swimlaneBefore, updatedSwimlane, [task]);
+    mockGetProjectRepos.mockReturnValue(repos);
+
+    context.sessionManager.getSession.mockReturnValue({ status: 'running' });
+    mockAgentRegistryGet.mockReturnValue({ name: 'claude' });
+
+    hoisted.prepareInjectionPlan.mockReturnValue({
+      sequence: [],
+      verifier: null,
+      verifiedPrefixLength: 0,
+      needsRestartForModel: true,
+    });
+    hoisted.restartSessionForSettingsChange.mockResolvedValue({ ok: true });
+
+    await callSwimlaneUpdate({ id: 'lane-executing', model_override: 'opus' }, context);
+
+    await vi.waitFor(() => {
+      expect(context.mainWindow.webContents.send).toHaveBeenCalledTimes(1);
+    }, { timeout: 2000 });
+
+    expect(context.mainWindow.webContents.send).toHaveBeenCalledWith(
+      IPC.TASK_SESSION_RESYNC,
+      'proj-board-1',
+    );
+  });
+
+  // =========================================================================
+  // Test 8: MODEL change, restart fails -> TASK_SESSION_RESYNC is NOT pushed
+  // =========================================================================
+
+  it('MODEL change, restart fails: does NOT push TASK_SESSION_RESYNC', async () => {
+    // If the restart could not resolve a new session, there is nothing for the
+    // renderer to re-sync to; pushing anyway would race the (now stale) id
+    // against whatever the failed restart left behind.
+    const task = createTaskInLane({ id: 'task-board-8', session_id: 'session-board-8' });
+    const swimlaneBefore = createSwimlaneBefore({ id: 'lane-executing' });
+    const updatedSwimlane = { ...swimlaneBefore, model_override: 'opus', name: 'Executing' };
+
+    const repos = buildProjectRepos(swimlaneBefore, updatedSwimlane, [task]);
+    mockGetProjectRepos.mockReturnValue(repos);
+
+    context.sessionManager.getSession.mockReturnValue({ status: 'running' });
+    mockAgentRegistryGet.mockReturnValue({ name: 'claude' });
+
+    hoisted.prepareInjectionPlan.mockReturnValue({
+      sequence: [],
+      verifier: null,
+      verifiedPrefixLength: 0,
+      needsRestartForModel: true,
+    });
+    hoisted.restartSessionForSettingsChange.mockResolvedValue({ ok: false, reason: 'no session found' });
+
+    await callSwimlaneUpdate({ id: 'lane-executing', model_override: 'opus' }, context);
+
+    // Wait for the fire-and-forget restart to have run before asserting the
+    // negative (there is no positive condition to poll for here).
+    await vi.waitFor(() => {
+      expect(hoisted.restartSessionForSettingsChange).toHaveBeenCalledTimes(1);
+    }, { timeout: 2000 });
+
+    expect(context.mainWindow.webContents.send).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

Fixes the model/effort picker vanishing from a task's context bar after a live column model-change restart. Adds a quiet, toast-free board re-sync push so the board store's `task.session_id` stays current after that restart, and covers both with tests.

## Why

Changing a column's model override while a task in that column is running correctly restarts the agent with the new model, but the model/effort dropdowns disappear from that task's context bar afterward, rendering static "Sonnet 5" / "high" text with no chevrons.

Root cause: the restart respawns the session and updates `tasks.session_id` in the DB, but the `SWIMLANE_UPDATE` handler runs the restart fire-and-forget and never notifies the renderer, so the board store keeps the stale (now-exited) session id. `ContextBar` joined its task via `tasks.find(t => t.session_id === sessionId)`, which then misses, and the picker falls back to static text.

## How

- **`ContextBar.tsx`**: resolve the task via the session's own `taskId` back-pointer instead of the task's forward `session_id`. The session's `taskId` stays correct across a restart; the task's `session_id` does not. Transient command-terminal sessions carry a synthetic `taskId` matching no task row, so they still fall through to the existing transient/static branches unchanged.
- **New `task:sessionResync` push channel**: after a successful column-model restart, the main process sends a quiet, toast-free reconcile trigger (distinct from `task:updatedByAgent`, since this is a consequence of the user's own column edit, not agent-driven news) so the board store's `task.session_id` catches up for every other consumer keyed on it (e.g. board-card usage bars).

## Breaking changes

None.

## Tests

- New UI test `tests/ui/context-bar-stale-session-id.spec.ts`: seeds the exact stale-`session_id` mismatch and asserts both picker triggers render. Verified red (fails against the old join) and green (passes with the fix).
- New cases in `tests/ui/agent-driven-invalidation.spec.ts`: the new `task:sessionResync` listener reloads the board on a same-project push (or invalidates the cache on a background-project push) and never toasts, unlike its `on*ByAgent` siblings.
- New cases in `tests/unit/board-swimlane-update-restart.test.ts`: the push fires once with the project id on a successful restart, and never fires when the restart fails.
- Full existing ContextBar/command-terminal UI suites re-run clean, no regressions.
- `npm run typecheck` and `npm run lint` clean.

Generated with [Claude Code](https://claude.com/claude-code)
