### PR TITLE
fix(backlog): populate import filters over the full unbounded source

### DIFF
--- a/src/renderer/components/MultiSelectDropdown.tsx
+++ b/src/renderer/components/MultiSelectDropdown.tsx
@@ -63,6 +63,7 @@ export function MultiSelectDropdown({
           {options.map((option) => (
             <label
               key={option}
+              data-testid={`filter-option-${label.toLowerCase()}-${option}`}
               className="flex items-center gap-2.5 px-3 py-2 text-sm text-fg hover:bg-surface-hover/40 cursor-pointer whitespace-nowrap"
             >
               <input

--- a/src/renderer/components/backlog/ImportDialog.tsx
+++ b/src/renderer/components/backlog/ImportDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo, useDeferredValue } from 'react';
 import { Check, Loader2, Paperclip, Search, AlertCircle, RefreshCw, EyeOff, Eye } from 'lucide-react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { formatRelativeTime } from '../../lib/datetime';
 import { BaseDialog } from '../dialogs/BaseDialog';
 import { Pill } from '../Pill';
@@ -17,21 +18,29 @@ interface ImportDialogProps {
 
 type StateFilter = 'open' | 'closed' | 'all';
 
-const PER_PAGE = 30;
+// Internal fetch chunk size. The dialog has no "page" concept in the UI - every
+// item is loaded automatically - this is purely how many items are requested
+// per round-trip to the adapter.
+const FETCH_CHUNK_SIZE = 30;
+const ESTIMATED_ROW_HEIGHT = 64;
+
+function sortByCreatedDesc(list: ExternalIssue[]): ExternalIssue[] {
+  return list.slice().sort(
+    (itemA, itemB) => new Date(itemB.createdAt).getTime() - new Date(itemA.createdAt).getTime(),
+  );
+}
 
 export function ImportDialog({ source, onClose }: ImportDialogProps) {
   const [issues, setIssues] = useState<ExternalIssue[]>([]);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [importing, setImporting] = useState(false);
-  const [page, setPage] = useState(1);
-  const [hasNextPage, setHasNextPage] = useState(false);
   const [stateFilter, setStateFilter] = useState<StateFilter>('open');
-  const [serverSearchQuery, setServerSearchQuery] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [cliError, setCliError] = useState<string | null>(null);
 
-  // Client-side filters (universal, source-agnostic)
+  // Client-side filters, evaluated live over the full (unbounded) issue set
   const [filterText, setFilterText] = useState('');
   const [filterStatuses, setFilterStatuses] = useState<Set<string>>(new Set());
   const [filterAssignees, setFilterAssignees] = useState<Set<string>>(new Set());
@@ -39,18 +48,96 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
   const [filterLabels, setFilterLabels] = useState<Set<string>>(new Set());
   const [hideImported, setHideImported] = useState(true);
 
-  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fetchSequenceRef = useRef(0);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const loadBacklog = useBacklogStore((state) => state.loadBacklog);
   const addToast = useToastStore((state) => state.addToast);
 
   const isProjectsSource = source.source === 'github_projects';
 
-  // Clean up search debounce on unmount
+  // Stop any in-flight background paging once the dialog unmounts.
   useEffect(() => {
     return () => {
-      if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+      // Bumping the LIVE ref value at unmount is the cancellation signal for any
+      // in-flight loadAllIssues loop, so we intentionally read/write current here
+      // rather than a copied-in snapshot (which is what the rule would suggest).
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      fetchSequenceRef.current++;
     };
   }, []);
+
+  // Fetches every page for the given state filter, streaming each page into
+  // `issues` as it lands so rows and filter facets fill in progressively.
+  // `fetchSequenceRef` supersedes any older in-flight loop (e.g. a rapid state
+  // filter change) so a stale page can never append to a newer query's list.
+  const loadAllIssues = useCallback(async (state: StateFilter) => {
+    const token = ++fetchSequenceRef.current;
+    setError(null);
+    setLoading(true);
+    setLoadingMore(false);
+
+    let pageNumber = 1;
+    let isFirstPage = true;
+    try {
+      while (true) {
+        let result;
+        try {
+          result = await window.electronAPI.backlog.importFetch({
+            source: source.source,
+            repository: source.repository,
+            page: pageNumber,
+            perPage: FETCH_CHUNK_SIZE,
+            state,
+          });
+        } catch (fetchError: unknown) {
+          if (fetchSequenceRef.current !== token) return;
+          setError(fetchError instanceof Error ? fetchError.message : 'Failed to fetch issues');
+          return;
+        }
+        if (fetchSequenceRef.current !== token) return;
+
+        // Capture into a per-iteration const before mutating `isFirstPage` below:
+        // the updater closure is invoked by React at flush time, not at call
+        // time, so referencing the outer mutable `isFirstPage` directly would
+        // have it read as already-`false` for every page, including the first -
+        // silently turning the intended "replace" into an "append" and leaking
+        // the previous state filter's stale data into the new one.
+        const wasFirstPage = isFirstPage;
+        const sorted = sortByCreatedDesc(result.issues);
+        setIssues((previous) => {
+          const merged = wasFirstPage ? sorted : [...previous, ...sorted];
+          // Dedupe by externalId: a source can return the same item on two pages
+          // when its ordering shifts between sequential fetches, which would
+          // otherwise collide the virtualizer's item key and double-submit the row
+          // on import. Keep the first occurrence.
+          const seenIds = new Set<string>();
+          return merged.filter((issue) => {
+            if (seenIds.has(issue.externalId)) return false;
+            seenIds.add(issue.externalId);
+            return true;
+          });
+        });
+        if (isFirstPage) setLoading(false);
+        isFirstPage = false;
+
+        if (!result.hasNextPage) return;
+        setLoadingMore(true);
+        pageNumber += 1;
+      }
+    } catch (unexpectedError: unknown) {
+      // Guards against a malformed adapter response (e.g. a non-array `issues`)
+      // throwing after a successful fetch, which would otherwise surface only
+      // as a silent unhandled rejection with no error banner shown.
+      if (fetchSequenceRef.current === token) {
+        setError(unexpectedError instanceof Error ? unexpectedError.message : 'Failed to process issues');
+      }
+    } finally {
+      if (fetchSequenceRef.current === token) {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    }
+  }, [source.source, source.repository]);
 
   // Check CLI on mount
   useEffect(() => {
@@ -59,7 +146,7 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
         setCliError(result.error ?? 'CLI not available');
         setLoading(false);
       } else {
-        fetchIssues(1, stateFilter, '');
+        loadAllIssues(stateFilter);
       }
     }).catch((fetchError: unknown) => {
       setCliError(fetchError instanceof Error ? fetchError.message : 'CLI check failed');
@@ -68,56 +155,16 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const fetchIssues = useCallback(async (
-    fetchPage: number,
-    state: StateFilter,
-    search: string,
-    append = false,
-  ) => {
-    setLoading(true);
-    setError(null);
-    try {
-      const result = await window.electronAPI.backlog.importFetch({
-        source: source.source,
-        repository: source.repository,
-        page: fetchPage,
-        perPage: PER_PAGE,
-        searchQuery: search || undefined,
-        state,
-      });
-      const sortedResult = result.issues.slice().sort(
-        (itemA, itemB) => new Date(itemB.createdAt).getTime() - new Date(itemA.createdAt).getTime(),
-      );
-      setIssues((previous) => append ? [...previous, ...sortedResult] : sortedResult);
-      setHasNextPage(result.hasNextPage);
-      setPage(fetchPage);
-    } catch (fetchError: unknown) {
-      setError(fetchError instanceof Error ? fetchError.message : 'Failed to fetch issues');
-    } finally {
-      setLoading(false);
-    }
-  }, [source.source, source.repository]);
-
   const handleStateFilterChange = (newState: StateFilter) => {
     setStateFilter(newState);
     setSelectedIds(new Set());
-    fetchIssues(1, newState, serverSearchQuery);
+    loadAllIssues(newState);
   };
 
-  const handleServerSearchChange = (value: string) => {
-    setServerSearchQuery(value);
-    if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
-    searchTimeoutRef.current = setTimeout(() => {
-      setSelectedIds(new Set());
-      fetchIssues(1, stateFilter, value);
-    }, 200);
-  };
-
-  const handleLoadMore = () => {
-    fetchIssues(page + 1, stateFilter, serverSearchQuery, true);
-  };
-
-  // Derive unique filter values from fetched data
+  // Derive unique filter values from the full (unbounded) fetched set. Because
+  // this is a useMemo over `issues`, every streamed page recomputes it - a
+  // filter option that only exists on a later page appears as soon as that
+  // page lands, with no user action required.
   const uniqueStatuses = useMemo(() =>
     [...new Set(issues.map((issue) => issue.state).filter((state): state is string => Boolean(state) && state !== 'unknown'))].sort(),
     [issues],
@@ -138,20 +185,13 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
     [issues],
   );
 
-  // Defer text-search inputs so typing stays responsive even when the row list is large.
-  // The <input value> binds to the live state; this deferred copy drives the filter computation.
-  // Note: deferred values are used only for visible-filter math. Fetch triggers and the
-  // hasActiveFilters predicate use the live values so the network and the empty-state UI
-  // reflect what the user has actually typed, not last frame's input.
+  // Defer the search input so typing stays responsive even with a large loaded set.
   const deferredFilterText = useDeferredValue(filterText);
-  const deferredServerSearchQuery = useDeferredValue(serverSearchQuery);
+  const titleSearchLower = deferredFilterText.toLowerCase();
 
-  // For non-Projects sources, prefilter the already-fetched list against the live server query
-  // so the visible list narrows immediately while the debounced remote refetch is in flight.
-  const titleSearchTerm = isProjectsSource ? deferredFilterText : deferredServerSearchQuery;
-  const titleSearchLower = titleSearchTerm.toLowerCase();
-
-  // Client-side filtering (issues are pre-sorted by createdAt desc on fetch)
+  // Client-side filtering over the full loaded set (pre-sorted by createdAt desc
+  // on fetch). This recomputes on every streamed page, so a filter applied
+  // early keeps picking up matching items that arrive later.
   const filteredIssues = useMemo(() => {
     return issues.filter((issue) => {
       if (hideImported && issue.alreadyImported) return false;
@@ -164,9 +204,26 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
     });
   }, [issues, titleSearchLower, filterStatuses, filterAssignees, filterTypes, filterLabels, hideImported]);
 
-  const selectableIssues = filteredIssues.filter((issue) => !issue.alreadyImported);
-  const allImported = issues.length > 0 && issues.every((issue) => issue.alreadyImported);
-  const hasActiveFilters = filterText !== '' || serverSearchQuery !== '' || filterStatuses.size > 0 || filterAssignees.size > 0 || filterTypes.size > 0 || filterLabels.size > 0;
+  const selectableIssues = useMemo(
+    () => filteredIssues.filter((issue) => !issue.alreadyImported),
+    [filteredIssues],
+  );
+  const allImported = useMemo(
+    () => issues.length > 0 && issues.every((issue) => issue.alreadyImported),
+    [issues],
+  );
+  const hasActiveFilters = filterText !== '' || filterStatuses.size > 0 || filterAssignees.size > 0 || filterTypes.size > 0 || filterLabels.size > 0;
+
+  const virtualizer = useVirtualizer({
+    count: filteredIssues.length,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    // Key measurements by issue identity, not position: filtering can remove an
+    // item mid-list and shift every later index, which would otherwise apply a
+    // stale cached height (from whatever used to be at that index) to the wrong row.
+    getItemKey: (index) => filteredIssues[index].externalId,
+    overscan: 10,
+  });
 
   const handleToggleSelect = useCallback((externalId: string) => {
     setSelectedIds((previous) => {
@@ -194,12 +251,6 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
     setFilterAssignees(new Set());
     setFilterTypes(new Set());
     setFilterLabels(new Set());
-    if (serverSearchQuery !== '') {
-      setServerSearchQuery('');
-      if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
-      setSelectedIds(new Set());
-      fetchIssues(1, stateFilter, '');
-    }
   };
 
   const toggleFilterStatus = (status: string) => {
@@ -307,14 +358,17 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
       ? `Import (${selectedIds.size})`
       : 'Import';
 
+  // Whether background paging is still in progress is communicated by the
+  // dedicated streaming indicator below the list, not repeated here.
+  const showingSubset = hasActiveFilters || hideImported;
+  const footerCountLabel = showingSubset
+    ? `${filteredIssues.length} of ${issues.length} items`
+    : `${issues.length} items loaded`;
+
   const footer = (
     <div className="flex items-center justify-between">
       <span className="text-xs text-fg-faint">
-        {selectedIds.size > 0
-          ? `${selectedIds.size} selected`
-          : hasActiveFilters || hideImported
-            ? `${filteredIssues.length} of ${issues.length} items`
-            : `${issues.length} items loaded`}
+        {selectedIds.size > 0 ? `${selectedIds.size} selected` : footerCountLabel}
       </span>
       <div className="flex gap-2">
         <button
@@ -338,6 +392,8 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
     </div>
   );
 
+  const virtualItems = virtualizer.getVirtualItems();
+
   return (
     <BaseDialog
       onClose={onClose}
@@ -348,18 +404,15 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
       preventBackdropClose={importing}
       testId="import-dialog"
     >
-      {/* Universal filter toolbar */}
+      {/* Universal filter toolbar - live client-side over the full loaded set */}
       <div className="flex items-center gap-2 px-4 py-2 border-b border-edge/50">
         {/* Text search */}
         <div className="relative flex-1">
           <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-fg-disabled" />
           <input
             type="text"
-            value={isProjectsSource ? filterText : serverSearchQuery}
-            onChange={(event) => isProjectsSource
-              ? setFilterText(event.target.value)
-              : handleServerSearchChange(event.target.value)
-            }
+            value={filterText}
+            onChange={(event) => setFilterText(event.target.value)}
             placeholder="Filter by title..."
             className="w-full bg-surface/50 border border-edge/50 rounded text-sm text-fg placeholder-fg-disabled pl-8 pr-3 py-1.5 outline-none focus:border-edge-input"
             data-testid="import-search"
@@ -446,7 +499,7 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
             <span className="text-xs text-danger">{error}</span>
             <button
               type="button"
-              onClick={() => fetchIssues(1, stateFilter, serverSearchQuery)}
+              onClick={() => loadAllIssues(stateFilter)}
               className="ml-auto text-xs text-accent-fg hover:underline"
             >
               Retry
@@ -455,31 +508,53 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
         </div>
       )}
 
-      {/* Issue list */}
-      <div className="overflow-y-auto flex-1">
-        {!cliError && selectableIssues.length > 0 && (
-          <div className="flex items-center gap-2 px-4 py-1.5 border-b border-edge/30 bg-surface-hover/20">
-            <input
-              type="checkbox"
-              checked={selectedIds.size === selectableIssues.length}
-              onChange={handleSelectAll}
-              className="accent-accent-emphasis"
-              data-testid="import-select-all"
-            />
-            <span className="text-xs text-fg-faint">Select all</span>
+      {/* Select-all header - lives outside the virtualized scroll region so it
+          never participates in the virtualizer's offset math. Gated on !loading
+          too, so a state-filter switch doesn't show a stale select-all against
+          the outgoing filter's items while the new filter's first page loads. */}
+      {!cliError && !loading && selectableIssues.length > 0 && (
+        <div className="flex items-center gap-2 px-4 py-1.5 border-b border-edge/30 bg-surface-hover/20 flex-shrink-0">
+          <input
+            type="checkbox"
+            checked={selectedIds.size === selectableIssues.length}
+            onChange={handleSelectAll}
+            className="accent-accent-emphasis"
+            data-testid="import-select-all"
+          />
+          <span className="text-xs text-fg-faint">Select all</span>
+        </div>
+      )}
+
+      <div ref={scrollContainerRef} className="overflow-y-auto flex-1 min-h-0">
+        {!cliError && !loading && filteredIssues.length > 0 && (
+          <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
+            {virtualItems.map((virtualRow) => {
+              const issue = filteredIssues[virtualRow.index];
+              return (
+                <div
+                  key={issue.externalId}
+                  data-index={virtualRow.index}
+                  ref={virtualizer.measureElement}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    transform: `translateY(${virtualRow.start}px)`,
+                  }}
+                >
+                  <ImportIssueRow
+                    issue={issue}
+                    selected={selectedIds.has(issue.externalId)}
+                    onToggle={handleToggleSelect}
+                  />
+                </div>
+              );
+            })}
           </div>
         )}
 
-        {filteredIssues.map((issue) => (
-          <ImportIssueRow
-            key={issue.externalId}
-            issue={issue}
-            selected={selectedIds.has(issue.externalId)}
-            onToggle={handleToggleSelect}
-          />
-        ))}
-
-        {/* Loading state */}
+        {/* Loading state (first page only - subsequent pages stream in via the loading-more indicator below the list) */}
         {loading && (
           <div
             data-testid="import-loading"
@@ -489,8 +564,10 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
           </div>
         )}
 
-        {/* Empty state */}
-        {!loading && !cliError && filteredIssues.length === 0 && !error && (
+        {/* Empty state - suppressed while background pages are still streaming, so
+            a transient empty result never asserts a definitive state (e.g. "All
+            items have been imported") that a later page would contradict. */}
+        {!loading && !loadingMore && !cliError && filteredIssues.length === 0 && !error && (
           <div
             data-testid="import-empty-state"
             className="flex flex-col items-center justify-center flex-1 min-h-[200px] text-fg-faint gap-2"
@@ -501,7 +578,7 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
                 <span className="text-sm">All items have been imported</span>
                 <button
                   type="button"
-                  onClick={() => fetchIssues(1, stateFilter, serverSearchQuery)}
+                  onClick={() => loadAllIssues(stateFilter)}
                   className="flex items-center gap-1.5 mt-1 text-xs text-accent-fg hover:underline"
                 >
                   <RefreshCw size={12} />
@@ -525,21 +602,19 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
             )}
           </div>
         )}
-
-        {/* Load more */}
-        {hasNextPage && !loading && (
-          <div className="flex justify-center py-3 border-t border-edge/30">
-            <button
-              type="button"
-              onClick={handleLoadMore}
-              className="text-xs text-accent-fg hover:underline"
-              data-testid="import-load-more"
-            >
-              Load more items
-            </button>
-          </div>
-        )}
       </div>
+
+      {/* Streaming indicator - persistent while background pages continue loading,
+          independent of scroll position. */}
+      {loadingMore && (
+        <div
+          data-testid="import-loading-more"
+          className="flex items-center justify-center gap-2 py-2 border-t border-edge/30 text-xs text-fg-faint flex-shrink-0"
+        >
+          <Loader2 size={12} className="animate-spin" />
+          Loading more items...
+        </div>
+      )}
     </BaseDialog>
   );
 }

--- a/tests/ui/import-filter.spec.ts
+++ b/tests/ui/import-filter.spec.ts
@@ -1,27 +1,68 @@
 /**
- * UI spec: ImportDialog filter behaviour introduced in the slow-filter perf fix.
+ * UI spec: ImportDialog filter/streaming behaviour.
  *
- * Covers four scenarios that are purely renderer/React state - no PTY, no
+ * Covers scenarios that are purely renderer/React state - no PTY, no
  * main process, no real IPC - so the UI tier is the correct home.
  *
- * 1. Empty-state messaging via serverSearchQuery
- *    Type a server search on a non-Projects source, seed importFetch to return
- *    zero results, assert "No items match your filters" and the Clear button.
+ * The dialog has no manual pagination: it auto-loads every page of a source
+ * in the background (streaming), and all filtering/search/sort is client-side
+ * over the full loaded set, re-evaluating live as later pages land.
  *
- * 2. clearFilters triggers a refetch when serverSearchQuery was non-empty
- *    Set a server search, click Clear filters, assert importFetch was called a
- *    second time and that the second call passed an empty searchQuery.
+ * 1. Empty-state messaging via the client-side title search
+ *    Seed one issue, type a search term that matches nothing, assert
+ *    "No items match your filters" and the Clear button - no new fetch.
  *
- * 3. Stale-prefilter narrows the visible list immediately on non-Projects sources
+ * 2. clearFilters clears client-side state without a refetch
+ *    Set a title search, click Clear filters, assert the fetch call count is
+ *    unchanged (filtering never touches the network).
+ *
+ * 3. Typing narrows the visible list immediately (client-side, no server call)
  *    Seed multiple issues with distinct titles. Type a partial match. Assert
- *    non-matching rows disappear before the debounced refetch fires.
+ *    non-matching rows disappear and no additional fetch fired.
  *
  * 4. onToggle signature regression guard
  *    Click an individual row checkbox (not select-all). Assert only that row's
  *    checkbox becomes checked; all other rows remain unchecked.
+ *
+ * 5. Filter facets populate as later pages stream in (the bug this dialog fixes)
+ *    Seed two pages with distinct statuses. Assert the Status dropdown shows
+ *    both values once streaming settles, without a "Load more" click.
+ *
+ * 6. A filter applied while a later page is still in flight keeps matching
+ *    items that land after the filter was set (live re-evaluation).
+ *
+ * 7. Virtualization renders a windowed subset of a large list while the
+ *    footer still reports the full loaded count.
+ *
+ * 8. Switching the state filter mid-stream cancels the previous filter's
+ *    in-flight background page via fetchSequenceRef, so a stale page never
+ *    lands in the new filter's list.
+ *
+ * 9. Closing the dialog while a background page-stream is in flight stops
+ *    further fetches and does not throw an unmounted-component warning.
+ *
+ * 10. A fetch failure mid-stream shows the error banner with Retry; Retry
+ *     re-runs the loader and clears the error once it succeeds.
+ *
+ * 11. Select-all checked against page 1 becomes unchecked (mixed state) once
+ *     a later page streams in more selectable items, without changing the
+ *     already-made selection.
+ *
+ * 12. The all-imported empty state ("All items have been imported") shows a
+ *     Refresh button, and clicking it re-runs loadAllIssues (a real refetch,
+ *     not a dead handler).
+ *
+ * 13. The all-imported empty-state message never renders while a later page
+ *     is still streaming - the `!loadingMore` gate on the empty-state block
+ *     prevents a transient "nothing left" result from asserting a completion
+ *     claim that a later page could (and does) contradict.
+ *
+ * 14. A malformed page response (a non-array `issues` field) is caught by
+ *     loadAllIssues's outer try/catch and shows the error banner with Retry,
+ *     instead of an unhandled rejection or a silently-stuck loading state.
  */
 import { test, expect, type Page } from '@playwright/test';
-import { launchPage, createProject } from './helpers';
+import { launchPage, createProject, collectPageErrors } from './helpers';
 
 // Each describe is isolated per worker (separate process; per-test page launch / goto reset),
 // so the file's tests can fan out across the UI workers safely.
@@ -31,50 +72,34 @@ test.describe.configure({ mode: 'parallel' });
 // Shared issue fixtures
 // ---------------------------------------------------------------------------
 
-const ISSUE_ALPHA = {
-  externalId: 'alpha-1',
-  externalUrl: 'https://github.com/org/repo/issues/1',
-  title: 'Alpha: fix the login bug',
-  body: '',
-  labels: [],
-  assignee: null,
-  state: 'open',
-  createdAt: new Date('2025-01-01').toISOString(),
-  updatedAt: new Date('2025-01-01').toISOString(),
-  alreadyImported: false,
-  fileAttachments: [],
-  attachmentCount: 0,
-};
+function makeIssue(overrides: Partial<{
+  externalId: string;
+  title: string;
+  state: string;
+  assignee: string | null;
+  labels: string[];
+  createdAt: string;
+  alreadyImported: boolean;
+}>) {
+  return {
+    externalId: overrides.externalId ?? 'issue-1',
+    externalUrl: `https://github.com/org/repo/issues/${overrides.externalId ?? '1'}`,
+    title: overrides.title ?? 'An issue',
+    body: '',
+    labels: overrides.labels ?? [],
+    assignee: overrides.assignee ?? null,
+    state: overrides.state ?? 'open',
+    createdAt: overrides.createdAt ?? new Date('2025-01-01').toISOString(),
+    updatedAt: overrides.createdAt ?? new Date('2025-01-01').toISOString(),
+    alreadyImported: overrides.alreadyImported ?? false,
+    fileAttachments: [],
+    attachmentCount: 0,
+  };
+}
 
-const ISSUE_BETA = {
-  externalId: 'beta-2',
-  externalUrl: 'https://github.com/org/repo/issues/2',
-  title: 'Beta: add dark mode',
-  body: '',
-  labels: [],
-  assignee: null,
-  state: 'open',
-  createdAt: new Date('2025-01-02').toISOString(),
-  updatedAt: new Date('2025-01-02').toISOString(),
-  alreadyImported: false,
-  fileAttachments: [],
-  attachmentCount: 0,
-};
-
-const ISSUE_GAMMA = {
-  externalId: 'gamma-3',
-  externalUrl: 'https://github.com/org/repo/issues/3',
-  title: 'Gamma: improve performance',
-  body: '',
-  labels: [],
-  assignee: null,
-  state: 'open',
-  createdAt: new Date('2025-01-03').toISOString(),
-  updatedAt: new Date('2025-01-03').toISOString(),
-  alreadyImported: false,
-  fileAttachments: [],
-  attachmentCount: 0,
-};
+const ISSUE_ALPHA = makeIssue({ externalId: 'alpha-1', title: 'Alpha: fix the login bug', createdAt: new Date('2025-01-01').toISOString() });
+const ISSUE_BETA = makeIssue({ externalId: 'beta-2', title: 'Beta: add dark mode', createdAt: new Date('2025-01-02').toISOString() });
+const ISSUE_GAMMA = makeIssue({ externalId: 'gamma-3', title: 'Gamma: improve performance', createdAt: new Date('2025-01-03').toISOString() });
 
 // ---------------------------------------------------------------------------
 // Setup helpers
@@ -123,6 +148,11 @@ async function openImportDialog(page: Page): Promise<void> {
   await expect(page.locator('[data-testid="import-loading"]')).toHaveCount(0, { timeout: 8000 });
 }
 
+/** Wait for any background page streaming to finish. */
+async function waitForStreamingSettled(page: Page): Promise<void> {
+  await expect(page.locator('[data-testid="import-loading-more"]')).toHaveCount(0, { timeout: 8000 });
+}
+
 /** Read the mock's importFetch call counter. Returns 0 if no calls have been made. */
 async function getFetchCallCount(page: Page): Promise<number> {
   return page.evaluate(() => {
@@ -134,150 +164,86 @@ async function getFetchCallCount(page: Page): Promise<number> {
 // Test suite
 // ---------------------------------------------------------------------------
 
-test.describe('ImportDialog - filter behaviour', () => {
+test.describe('ImportDialog - filter and streaming behaviour', () => {
   test.beforeEach(async ({ }, testInfo) => {
     testInfo.setTimeout(30000);
   });
 
-  test('server search empty result shows "No items match your filters" with Clear button', async () => {
+  test('typing a search term with no match shows "No items match your filters" with Clear button', async () => {
     const { browser, page } = await launchPage();
 
-    // importCheckCli returns available by default; seed the source
     await seedGitHubSource(page);
 
-    // Seed an issue for the initial load so the dialog opens with content.
-    // We switch to an empty response after the initial fetch by clearing the
-    // preset and relying on the default empty response in the mock.
-    await page.evaluate(() => {
+    await page.evaluate((issue) => {
       (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = {
-        issues: [
-          {
-            externalId: 'issue-100',
-            externalUrl: 'https://github.com/org/repo/issues/100',
-            title: 'Some real issue',
-            body: '',
-            labels: [],
-            assignee: null,
-            state: 'open',
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-            alreadyImported: false,
-            fileAttachments: [],
-            attachmentCount: 0,
-          },
-        ],
+        issues: [issue],
         totalCount: 1,
         hasNextPage: false,
       };
-    });
+    }, makeIssue({ externalId: 'issue-100', title: 'Some real issue' }));
 
     await createProject(page, 'import-empty-state-test');
     await openImportDialog(page);
 
-    // The initial issue should be visible after the first fetch
+    // The seeded issue should be visible after the first fetch
     await expect(page.locator('[data-testid="import-issue-issue-100"]')).toBeVisible({ timeout: 5000 });
 
-    // Switch the preset to empty so the next fetch (triggered by typing) returns nothing
-    await page.evaluate(() => {
-      (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = null;
-    });
-
-    // Type a search - for a non-Projects source this triggers a debounced refetch
+    // Type a search that matches nothing - purely client-side, no refetch
     await page.locator('[data-testid="import-search"]').fill('xyzzy-no-match');
 
-    // Wait for the debounced fetch to fire and the loading spinner to disappear
-    await expect(page.locator('[data-testid="import-loading"]')).toHaveCount(0, { timeout: 5000 });
-
-    // The empty-state message for active-filter path should appear.
-    // hasActiveFilters is true because serverSearchQuery is 'xyzzy-no-match'.
     await expect(page.locator('[data-testid="import-empty-state-message"]')).toBeVisible({ timeout: 3000 });
-
-    // The Clear filters button should be present
     await expect(page.locator('[data-testid="import-clear-filters-btn"]')).toBeVisible();
 
     await browser.close();
   });
 
-  test('clearFilters triggers a refetch with empty searchQuery when serverSearchQuery was set', async () => {
+  test('clearFilters clears the client-side filter without triggering a refetch', async () => {
     const { browser, page } = await launchPage();
 
     await seedGitHubSource(page);
 
-    // Reset the call counter before the dialog opens so we count accurately
-    // from mount. The initial fetch on mount will be call 1.
     await page.evaluate(() => {
       (window as unknown as { __mockImportFetchCallCount?: number }).__mockImportFetchCallCount = 0;
-      // All calls return one issue so the Clear button is always enabled after typing
+    });
+    await page.evaluate((issue) => {
       (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = {
-        issues: [
-          {
-            externalId: 'task-clear-test',
-            externalUrl: 'https://github.com/org/repo/issues/10',
-            title: 'Task that clears search',
-            body: '',
-            labels: [],
-            assignee: null,
-            state: 'open',
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-            alreadyImported: false,
-            fileAttachments: [],
-            attachmentCount: 0,
-          },
-        ],
+        issues: [issue],
         totalCount: 1,
         hasNextPage: false,
       };
-    });
+    }, makeIssue({ externalId: 'task-clear-test', title: 'Task that clears search' }));
 
     await createProject(page, 'import-clear-refetch-test');
     await openImportDialog(page);
 
-    // Verify the initial fetch happened (call 1)
     const countAfterOpen = await getFetchCallCount(page);
     expect(countAfterOpen).toBeGreaterThanOrEqual(1);
 
-    // Type a server search - this will trigger call 2 after the 200ms debounce
+    // Type a title filter - client-side only, no network call
     await page.locator('[data-testid="import-search"]').fill('search term');
-
-    // Wait for the debounced fetch to fire and settle
-    await expect.poll(() => getFetchCallCount(page), { timeout: 5000 }).toBeGreaterThanOrEqual(2);
-
-    // Wait for loading to finish
-    await expect(page.locator('[data-testid="import-loading"]')).toHaveCount(0, { timeout: 5000 });
+    await expect(page.locator('[data-testid="import-empty-state-message"]')).toBeVisible({ timeout: 3000 });
 
     const countAfterSearch = await getFetchCallCount(page);
+    expect(countAfterSearch).toBe(countAfterOpen);
 
     // Click Clear filters
     await page.locator('[data-testid="import-clear-filters-btn"]').click();
 
-    // Wait for the refetch triggered by clearFilters (call count should increment)
-    await expect.poll(() => getFetchCallCount(page), { timeout: 5000 }).toBeGreaterThan(countAfterSearch);
+    // The seeded row reappears once the filter clears
+    await expect(page.locator('[data-testid="import-issue-task-clear-test"]')).toBeVisible({ timeout: 3000 });
 
-    // Wait for loading to finish
-    await expect(page.locator('[data-testid="import-loading"]')).toHaveCount(0, { timeout: 5000 });
-
-    // Verify the last call used an empty searchQuery
-    const lastArgs = await page.evaluate(() => {
-      return (window as unknown as {
-        __mockImportFetchLastArgs?: { searchQuery?: string };
-      }).__mockImportFetchLastArgs;
-    });
-
-    expect(lastArgs).not.toBeNull();
-    // searchQuery should be undefined or empty string (importFetch passes undefined for empty search)
-    const searchQuery = lastArgs?.searchQuery;
-    expect(searchQuery == null || searchQuery === '').toBe(true);
+    // Clearing filters never refetches - it is purely client-side state.
+    const countAfterClear = await getFetchCallCount(page);
+    expect(countAfterClear).toBe(countAfterOpen);
 
     await browser.close();
   });
 
-  test('stale-prefilter narrows visible rows immediately before the debounced refetch', async () => {
+  test('typing narrows visible rows immediately with no server round-trip', async () => {
     const { browser, page } = await launchPage();
 
     await seedGitHubSource(page);
 
-    // Seed three issues with distinct title prefixes
     await page.evaluate(
       ([alpha, beta, gamma]) => {
         (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = {
@@ -289,26 +255,24 @@ test.describe('ImportDialog - filter behaviour', () => {
       [ISSUE_ALPHA, ISSUE_BETA, ISSUE_GAMMA],
     );
 
-    await createProject(page, 'import-stale-prefilter-test');
+    await createProject(page, 'import-live-filter-test');
     await openImportDialog(page);
 
-    // All three rows should be visible after the initial fetch
     await expect(page.locator('[data-testid="import-issue-alpha-1"]')).toBeVisible();
     await expect(page.locator('[data-testid="import-issue-beta-2"]')).toBeVisible();
     await expect(page.locator('[data-testid="import-issue-gamma-3"]')).toBeVisible();
 
-    // Type "alpha" into the search box. For a GitHub Issues (non-Projects) source
-    // this updates serverSearchQuery, which immediately drives the client-side
-    // titleSearchTerm filter via useDeferredValue - the visible list narrows
-    // before the 200ms-debounced remote refetch could even fire.
+    const countBeforeTyping = await getFetchCallCount(page);
+
     await page.locator('[data-testid="import-search"]').fill('alpha');
 
-    // The alpha row should remain visible; the others should disappear.
-    // We assert the positive row-removal invariant rather than "no refetch fired",
-    // because "no event occurred" is a negative-occurrence race (anti-pattern 6).
     await expect(page.locator('[data-testid="import-issue-alpha-1"]')).toBeVisible({ timeout: 3000 });
     await expect(page.locator('[data-testid="import-issue-beta-2"]')).toHaveCount(0, { timeout: 3000 });
     await expect(page.locator('[data-testid="import-issue-gamma-3"]')).toHaveCount(0, { timeout: 3000 });
+
+    // Filtering is purely client-side - no new fetch should have fired.
+    const countAfterTyping = await getFetchCallCount(page);
+    expect(countAfterTyping).toBe(countBeforeTyping);
 
     await browser.close();
   });
@@ -318,7 +282,6 @@ test.describe('ImportDialog - filter behaviour', () => {
 
     await seedGitHubSource(page);
 
-    // Seed two selectable issues
     await page.evaluate(
       ([alpha, beta]) => {
         (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = {
@@ -333,25 +296,452 @@ test.describe('ImportDialog - filter behaviour', () => {
     await createProject(page, 'import-toggle-signature-test');
     await openImportDialog(page);
 
-    // Wait for both rows to render
     await expect(page.locator('[data-testid="import-issue-alpha-1"]')).toBeVisible();
     await expect(page.locator('[data-testid="import-issue-beta-2"]')).toBeVisible();
 
-    // Click the checkbox inside the alpha row only
     const alphaRow = page.locator('[data-testid="import-issue-alpha-1"]');
     await alphaRow.locator('input[type="checkbox"]').click();
 
-    // Alpha's checkbox should now be checked
     await expect(alphaRow.locator('input[type="checkbox"]')).toBeChecked();
 
-    // Beta's checkbox must remain unchecked - this guards the onToggle(externalId)
-    // signature: if the callback received the wrong id (or no id), either both
-    // rows would be toggled or neither would.
     const betaRow = page.locator('[data-testid="import-issue-beta-2"]');
     await expect(betaRow.locator('input[type="checkbox"]')).not.toBeChecked();
 
-    // The import button should reflect exactly 1 selected item
     await expect(page.locator('[data-testid="import-execute-btn"]')).toContainText('Import (1)');
+
+    await browser.close();
+  });
+
+  test('filter facets populate as later pages stream in, with no manual load-more', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubSource(page);
+
+    await page.evaluate(
+      ([page1Issue, page2Issue]) => {
+        (window as unknown as { __mockImportFetchPages?: unknown }).__mockImportFetchPages = [
+          { issues: [page1Issue], totalCount: 2, hasNextPage: true },
+          { issues: [page2Issue], totalCount: 2, hasNextPage: false },
+        ];
+      },
+      [
+        makeIssue({ externalId: 'page1-issue', title: 'Page one issue', state: 'open' }),
+        makeIssue({ externalId: 'page2-issue', title: 'Page two issue', state: 'triaged' }),
+      ],
+    );
+
+    await createProject(page, 'import-streaming-facets-test');
+    await openImportDialog(page);
+
+    // Both rows should be present once streaming settles
+    await waitForStreamingSettled(page);
+    await expect(page.locator('[data-testid="import-issue-page1-issue"]')).toBeVisible();
+    await expect(page.locator('[data-testid="import-issue-page2-issue"]')).toBeVisible();
+
+    // The Status filter must show both statuses without any "Load more" click
+    await page.locator('button', { hasText: 'Status' }).click();
+    await expect(page.locator('[data-testid="filter-option-status-open"]')).toBeVisible();
+    await expect(page.locator('[data-testid="filter-option-status-triaged"]')).toBeVisible();
+
+    await browser.close();
+  });
+
+  test('a filter set while a later page is still loading keeps matching items that arrive after', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubSource(page);
+
+    await page.evaluate(
+      ([page1Issue, page2Issue]) => {
+        (window as unknown as { __mockImportFetchPageDelayMs?: number }).__mockImportFetchPageDelayMs = 2000;
+        (window as unknown as { __mockImportFetchPages?: unknown }).__mockImportFetchPages = [
+          { issues: [page1Issue], totalCount: 2, hasNextPage: true },
+          { issues: [page2Issue], totalCount: 2, hasNextPage: false },
+        ];
+      },
+      [
+        makeIssue({ externalId: 'early-issue', title: 'Loaded first' }),
+        makeIssue({ externalId: 'late-issue', title: 'Loaded later' }),
+      ],
+    );
+
+    await createProject(page, 'import-live-reeval-test');
+    await openImportDialog(page);
+
+    // Page 1 has landed (loading spinner gone); page 2 is still in flight.
+    await expect(page.locator('[data-testid="import-issue-early-issue"]')).toBeVisible();
+    await expect(page.locator('[data-testid="import-loading-more"]')).toBeVisible();
+
+    // Apply a title filter that matches only the item that hasn't arrived yet.
+    await page.locator('[data-testid="import-search"]').fill('Loaded later');
+
+    // The not-yet-loaded item cannot match yet, but once streaming settles it
+    // must appear - the filter must not have been frozen against page 1 only.
+    await waitForStreamingSettled(page);
+    await expect(page.locator('[data-testid="import-issue-late-issue"]')).toBeVisible({ timeout: 3000 });
+
+    await browser.close();
+  });
+
+  test('virtualization renders a windowed subset of a large list', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubSource(page);
+
+    // The dialog sorts newest-first, so index 0 gets the newest timestamp to
+    // land at the top of the (visible) list.
+    const issueCount = 60;
+    const manyIssues = Array.from({ length: issueCount }, (_, index) =>
+      makeIssue({
+        externalId: `bulk-${index}`,
+        title: `Bulk issue number ${index}`,
+        createdAt: new Date(2025, 0, 1, 0, issueCount - index).toISOString(),
+      }));
+
+    await page.evaluate((issues) => {
+      (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = {
+        issues,
+        totalCount: issues.length,
+        hasNextPage: false,
+      };
+    }, manyIssues);
+
+    await createProject(page, 'import-virtualization-test');
+    await openImportDialog(page);
+
+    await expect(page.locator('[data-testid="import-issue-bulk-0"]')).toBeVisible();
+
+    // The footer reports the full loaded count (hideImported defaults on, so
+    // with nothing imported yet the label reads "60 of 60 items")...
+    await expect(page.locator('text=/60 of 60 items/')).toBeVisible();
+
+    // ...but the DOM only renders a windowed subset of rows, not all 60.
+    const renderedRowCount = await page.locator('[data-testid^="import-issue-bulk-"]').count();
+    expect(renderedRowCount).toBeGreaterThan(0);
+    expect(renderedRowCount).toBeLessThan(issueCount);
+
+    await browser.close();
+  });
+
+  test('switching the state filter mid-stream cancels the previous filter\'s in-flight page', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubSource(page);
+
+    // A delay long enough that the "open" filter's page 2 is still in flight
+    // by the time we switch to "closed", but short enough to keep the test fast.
+    await page.evaluate(
+      ([openPageOneIssue, openPageTwoStaleIssue, closedIssue]) => {
+        (window as unknown as { __mockImportFetchPageDelayMs?: number }).__mockImportFetchPageDelayMs = 1500;
+        (window as unknown as { __mockImportFetchPagesByState?: unknown }).__mockImportFetchPagesByState = {
+          open: [
+            { issues: [openPageOneIssue], totalCount: 2, hasNextPage: true },
+            { issues: [openPageTwoStaleIssue], totalCount: 2, hasNextPage: false },
+          ],
+          closed: [
+            { issues: [closedIssue], totalCount: 1, hasNextPage: false },
+          ],
+        };
+      },
+      [
+        makeIssue({ externalId: 'open-page1-issue', title: 'Open page one issue', state: 'open' }),
+        makeIssue({ externalId: 'open-page2-stale-issue', title: 'Open page two STALE issue', state: 'open' }),
+        makeIssue({ externalId: 'closed-issue', title: 'Closed issue only', state: 'closed' }),
+      ],
+    );
+
+    await createProject(page, 'import-stale-state-cancel-test');
+    await openImportDialog(page);
+
+    // Page 1 of "open" has landed; page 2 of "open" is now in flight.
+    await expect(page.locator('[data-testid="import-issue-open-page1-issue"]')).toBeVisible();
+    await expect(page.locator('[data-testid="import-loading-more"]')).toBeVisible();
+
+    // Switch to "closed" before the stale "open" page 2 resolves.
+    const importDialog = page.locator('[data-testid="import-dialog"]');
+    await importDialog.getByRole('button', { name: 'Closed' }).click();
+
+    await waitForStreamingSettled(page);
+
+    // The "closed" filter's data lands, and the stale "open" page 2 item (whose
+    // fetch was already in flight when we switched away) is discarded by the
+    // fetchSequenceRef token guard - it can never leak into the final list,
+    // regardless of what the outgoing filter's already-loaded page 1 does.
+    await expect(page.locator('[data-testid="import-issue-closed-issue"]')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-testid="import-issue-open-page2-stale-issue"]')).toHaveCount(0);
+
+    // The outgoing filter's own already-loaded page 1 must also be fully
+    // replaced, not appended-to: "closed"'s first page should REPLACE the
+    // "open" filter's page 1 rather than accumulate alongside it.
+    await expect(page.locator('[data-testid="import-issue-open-page1-issue"]')).toHaveCount(0);
+
+    await browser.close();
+  });
+
+  test('closing the dialog mid-stream stops further fetches with no unmounted-component error', async () => {
+    const { browser, page } = await launchPage();
+
+    const consoleErrors: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') consoleErrors.push(message.text());
+    });
+    const getPageErrors = collectPageErrors(page);
+
+    await seedGitHubSource(page);
+
+    // Three pages, all delayed, so we can close the dialog while page 2 is
+    // in flight and prove page 3 is never requested afterward.
+    await page.evaluate(
+      ([pageOneIssue, pageTwoIssue, pageThreeIssue]) => {
+        (window as unknown as { __mockImportFetchPageDelayMs?: number }).__mockImportFetchPageDelayMs = 1000;
+        (window as unknown as { __mockImportFetchPages?: unknown }).__mockImportFetchPages = [
+          { issues: [pageOneIssue], totalCount: 3, hasNextPage: true },
+          { issues: [pageTwoIssue], totalCount: 3, hasNextPage: true },
+          { issues: [pageThreeIssue], totalCount: 3, hasNextPage: false },
+        ];
+      },
+      [
+        makeIssue({ externalId: 'unmount-page1', title: 'Unmount test page one' }),
+        makeIssue({ externalId: 'unmount-page2', title: 'Unmount test page two' }),
+        makeIssue({ externalId: 'unmount-page3', title: 'Unmount test page three' }),
+      ],
+    );
+
+    await createProject(page, 'import-unmount-cancel-test');
+    await openImportDialog(page);
+
+    // Page 1 landed; page 2's fetch has already been issued (loading-more visible
+    // means the page-2 importFetch call has started, per the dialog's loop).
+    // The exact call count is not asserted here: React StrictMode double-invokes
+    // the mount effect in dev, which can issue an extra superseded page-1 call
+    // before the "real" streaming loop begins. What matters is that the count
+    // does not grow further once we close mid-stream (asserted below).
+    await expect(page.locator('[data-testid="import-loading-more"]')).toBeVisible();
+    const callCountBeforeClose = await getFetchCallCount(page);
+    expect(callCountBeforeClose).toBeGreaterThanOrEqual(2);
+
+    await page.locator('[data-testid="import-dialog"]').getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.locator('[data-testid="import-dialog"]')).toHaveCount(0, { timeout: 3000 });
+
+    // Intentional fixed wait: this proves a negative (no further fetch call
+    // occurs after unmount), which cannot be expressed as a poll for a
+    // condition to become true. The wait comfortably exceeds the 1000ms
+    // per-page delay so page 2's in-flight promise has resolved and, if the
+    // fetchSequenceRef guard were broken, page 3 would have been requested.
+    await page.waitForTimeout(2000);
+
+    const callCountAfterWait = await getFetchCallCount(page);
+    expect(callCountAfterWait).toBe(callCountBeforeClose);
+
+    expect(getPageErrors()).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+
+    await browser.close();
+  });
+
+  test('a fetch failure mid-stream shows the error banner, and Retry clears it once it succeeds', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubSource(page);
+
+    await page.evaluate(() => {
+      (window as unknown as { __mockImportFetchFailUntilCleared?: boolean }).__mockImportFetchFailUntilCleared = true;
+    });
+
+    await createProject(page, 'import-error-retry-test');
+
+    // Open the dialog directly (not via openImportDialog, which assumes the
+    // first fetch succeeds): the forced failure resolves loading to false via
+    // the error path rather than the happy path.
+    await page.locator('[data-testid="view-toggle-backlog"]').click();
+    const importSourcesButton = page.locator('[data-testid="import-sources-btn"]').first();
+    await importSourcesButton.click();
+    await expect(page.locator('[data-testid="import-popover"]')).toBeVisible();
+    await page.getByText('org/repo GitHub Issues').click();
+    await page.locator('[data-testid="import-dialog"]').waitFor({ state: 'visible', timeout: 8000 });
+
+    const importDialog = page.locator('[data-testid="import-dialog"]');
+    const errorBanner = page.getByText('Mock import fetch failure');
+    await expect(errorBanner).toBeVisible({ timeout: 5000 });
+    const retryButton = importDialog.getByRole('button', { name: 'Retry' });
+    await expect(retryButton).toBeVisible();
+
+    // Switch the mock to succeed, then retry.
+    await page.evaluate((issue) => {
+      (window as unknown as { __mockImportFetchFailUntilCleared?: boolean }).__mockImportFetchFailUntilCleared = false;
+      (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = {
+        issues: [issue],
+        totalCount: 1,
+        hasNextPage: false,
+      };
+    }, makeIssue({ externalId: 'retry-success-issue', title: 'Recovered after retry' }));
+    await retryButton.click();
+
+    await expect(errorBanner).toHaveCount(0, { timeout: 5000 });
+    await expect(page.locator('[data-testid="import-issue-retry-success-issue"]')).toBeVisible({ timeout: 5000 });
+
+    await browser.close();
+  });
+
+  test('select-all becomes unchecked once a later page streams in more selectable items', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubSource(page);
+
+    await page.evaluate(
+      ([pageOneIssue, pageTwoIssue]) => {
+        (window as unknown as { __mockImportFetchPageDelayMs?: number }).__mockImportFetchPageDelayMs = 1500;
+        (window as unknown as { __mockImportFetchPages?: unknown }).__mockImportFetchPages = [
+          { issues: [pageOneIssue], totalCount: 2, hasNextPage: true },
+          { issues: [pageTwoIssue], totalCount: 2, hasNextPage: false },
+        ];
+      },
+      [
+        makeIssue({ externalId: 'select-all-page1', title: 'Select all page one issue' }),
+        makeIssue({ externalId: 'select-all-page2', title: 'Select all page two issue' }),
+      ],
+    );
+
+    await createProject(page, 'import-select-all-staleness-test');
+    await openImportDialog(page);
+
+    // Page 1 landed; page 2 is still in flight.
+    await expect(page.locator('[data-testid="import-issue-select-all-page1"]')).toBeVisible();
+    await expect(page.locator('[data-testid="import-loading-more"]')).toBeVisible();
+
+    const selectAllCheckbox = page.locator('[data-testid="import-select-all"]');
+    await selectAllCheckbox.click();
+
+    await expect(selectAllCheckbox).toBeChecked();
+    await expect(page.locator('[data-testid="import-execute-btn"]')).toContainText('Import (1)');
+
+    await waitForStreamingSettled(page);
+    await expect(page.locator('[data-testid="import-issue-select-all-page2"]')).toBeVisible();
+
+    // The page-1 selection is unchanged, but selectableIssues grew, so
+    // selectedIds.size (1) no longer equals selectableIssues.length (2).
+    await expect(selectAllCheckbox).not.toBeChecked();
+    await expect(page.locator('[data-testid="import-execute-btn"]')).toContainText('Import (1)');
+
+    await browser.close();
+  });
+
+  test('the all-imported empty state shows Refresh, and clicking it re-streams via loadAllIssues', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubSource(page);
+
+    await page.evaluate((issue) => {
+      (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = {
+        issues: [issue],
+        totalCount: 1,
+        hasNextPage: false,
+      };
+    }, makeIssue({ externalId: 'already-imported-1', title: 'Already imported issue', alreadyImported: true }));
+
+    await createProject(page, 'import-all-imported-test');
+    await openImportDialog(page);
+
+    // hideImported defaults to true, so the single (already-imported) issue is
+    // hidden from filteredIssues, leaving it empty - and every fetched issue
+    // being alreadyImported makes `allImported` true, so the dialog must show
+    // the all-imported branch rather than the generic "No items found" one.
+    await expect(page.getByText('All items have been imported')).toBeVisible({ timeout: 3000 });
+    const refreshButton = page.getByRole('button', { name: 'Refresh to check for new items' });
+    await expect(refreshButton).toBeVisible();
+
+    const countBeforeRefresh = await getFetchCallCount(page);
+    await refreshButton.click();
+
+    // Refresh must call loadAllIssues(stateFilter) again - a real re-stream,
+    // not a dead handler - so the fetch call count must increase.
+    await expect.poll(async () => getFetchCallCount(page), { timeout: 3000 }).toBeGreaterThan(countBeforeRefresh);
+
+    await browser.close();
+  });
+
+  test('the all-imported empty-state message is suppressed while a later page is still streaming', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubSource(page);
+
+    await page.evaluate(
+      ([page1Issue, page2Issue]) => {
+        (window as unknown as { __mockImportFetchPageDelayMs?: number }).__mockImportFetchPageDelayMs = 1500;
+        (window as unknown as { __mockImportFetchPages?: unknown }).__mockImportFetchPages = [
+          { issues: [page1Issue], totalCount: 2, hasNextPage: true },
+          { issues: [page2Issue], totalCount: 2, hasNextPage: false },
+        ];
+      },
+      [
+        makeIssue({ externalId: 'midstream-imported-1', title: 'Page one already-imported issue', alreadyImported: true }),
+        makeIssue({ externalId: 'midstream-fresh-2', title: 'Page two fresh issue', alreadyImported: false }),
+      ],
+    );
+
+    await createProject(page, 'import-allimported-midstream-test');
+    await openImportDialog(page);
+
+    // Page 1 has landed with only an already-imported item - hideImported
+    // hides it, so filteredIssues is momentarily empty - while page 2 is
+    // still in flight.
+    await expect(page.locator('[data-testid="import-loading-more"]')).toBeVisible();
+
+    // Non-occurrence check: this MUST be a single direct snapshot, not a
+    // web-first `expect(locator).toHaveCount(0)`. That assertion polls and
+    // retries for up to its timeout, so it would still pass once the message
+    // naturally disappears after streaming settles a moment later -
+    // silently proving nothing about this specific mid-stream instant (the
+    // exact bug the `!loadingMore` gate exists to prevent). See anti-pattern
+    // 6 in the test-builder catalogue: you cannot poll for "nothing happens".
+    const completionClaimedMidStream = await page.getByText('All items have been imported').count();
+    expect(completionClaimedMidStream).toBe(0);
+
+    await waitForStreamingSettled(page);
+    await expect(page.locator('[data-testid="import-issue-midstream-fresh-2"]')).toBeVisible({ timeout: 3000 });
+
+    await browser.close();
+  });
+
+  test('a malformed page response (non-array issues) shows the error banner with Retry', async () => {
+    const { browser, page } = await launchPage();
+
+    const getPageErrors = collectPageErrors(page);
+
+    await seedGitHubSource(page);
+
+    // A response whose `issues` field is not an array (e.g. a malformed
+    // adapter payload) makes sortByCreatedDesc(result.issues) throw inside
+    // loadAllIssues's processing step, after the fetch itself succeeded.
+    await page.evaluate(() => {
+      (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = {
+        issues: null,
+        totalCount: 0,
+        hasNextPage: false,
+      };
+    });
+
+    await createProject(page, 'import-malformed-response-test');
+
+    // Open the dialog directly (not via openImportDialog, which assumes the
+    // first fetch's happy path): the malformed payload resolves loading to
+    // false via the catch's error path instead.
+    await page.locator('[data-testid="view-toggle-backlog"]').click();
+    const importSourcesButton = page.locator('[data-testid="import-sources-btn"]').first();
+    await importSourcesButton.click();
+    await expect(page.locator('[data-testid="import-popover"]')).toBeVisible();
+    await page.getByText('org/repo GitHub Issues').click();
+    await page.locator('[data-testid="import-dialog"]').waitFor({ state: 'visible', timeout: 8000 });
+
+    const importDialog = page.locator('[data-testid="import-dialog"]');
+    const errorBanner = importDialog.locator('.text-danger').last();
+    await expect(errorBanner).toBeVisible({ timeout: 5000 });
+    await expect(importDialog.getByRole('button', { name: 'Retry' })).toBeVisible();
+
+    // Confirms the outer try/catch actually caught the malformed-payload
+    // throw rather than it surfacing as an unhandled rejection (the failure
+    // mode the catch exists to prevent, per the comment in loadAllIssues).
+    expect(getPageErrors()).toEqual([]);
 
     await browser.close();
   });

--- a/tests/ui/import-filter.spec.ts
+++ b/tests/ui/import-filter.spec.ts
@@ -60,6 +60,11 @@
  * 14. A malformed page response (a non-array `issues` field) is caught by
  *     loadAllIssues's outer try/catch and shows the error banner with Retry,
  *     instead of an unhandled rejection or a silently-stuck loading state.
+ *
+ * 15. An issue whose externalId reappears on a later streamed page (its
+ *     ordering shifted between sequential fetches) is deduped to a single
+ *     row instead of double-rendering it, and the footer's loaded count
+ *     reflects the deduped total, not the raw sum of both pages' arrays.
  */
 import { test, expect, type Page } from '@playwright/test';
 import { launchPage, createProject, collectPageErrors } from './helpers';
@@ -742,6 +747,47 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     // throw rather than it surfacing as an unhandled rejection (the failure
     // mode the catch exists to prevent, per the comment in loadAllIssues).
     expect(getPageErrors()).toEqual([]);
+
+    await browser.close();
+  });
+
+  test('a duplicate externalId across two streamed pages is deduped, not double-rendered', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubSource(page);
+
+    // A source can return the same item on two pages when its ordering shifts
+    // between sequential fetches (the exact scenario loadAllIssues's seenIds
+    // dedup exists to guard against - see the comment above setIssues in
+    // ImportDialog.tsx). Without it, the item would render twice (colliding
+    // the virtualizer's item key) and risk a double-submit on import.
+    await page.evaluate(
+      ([duplicateIssue, uniquePageOneIssue, uniquePageTwoIssue]) => {
+        (window as unknown as { __mockImportFetchPages?: unknown }).__mockImportFetchPages = [
+          { issues: [duplicateIssue, uniquePageOneIssue], totalCount: 3, hasNextPage: true },
+          { issues: [duplicateIssue, uniquePageTwoIssue], totalCount: 3, hasNextPage: false },
+        ];
+      },
+      [
+        makeIssue({ externalId: 'dup-shared', title: 'Item that shifted between pages' }),
+        makeIssue({ externalId: 'unique-page1', title: 'Unique page one issue' }),
+        makeIssue({ externalId: 'unique-page2', title: 'Unique page two issue' }),
+      ],
+    );
+
+    await createProject(page, 'import-dedupe-test');
+    await openImportDialog(page);
+
+    await waitForStreamingSettled(page);
+
+    // The duplicated item renders exactly once, not twice.
+    await expect(page.locator('[data-testid="import-issue-dup-shared"]')).toHaveCount(1);
+    await expect(page.locator('[data-testid="import-issue-unique-page1"]')).toBeVisible();
+    await expect(page.locator('[data-testid="import-issue-unique-page2"]')).toBeVisible();
+
+    // The footer's loaded count reflects the deduped total (3 unique issues),
+    // not the raw sum of both pages' issues arrays (4).
+    await expect(page.locator('text=/3 of 3 items/')).toBeVisible();
 
     await browser.close();
   });

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -2279,9 +2279,63 @@
         if (typeof window !== 'undefined') {
           window.__mockImportFetchCallCount = (window.__mockImportFetchCallCount || 0) + 1;
           window.__mockImportFetchLastArgs = input;
+          if (!window.__mockImportFetchCallLog) window.__mockImportFetchCallLog = [];
+          window.__mockImportFetchCallLog.push({ state: input && input.state, page: input && input.page });
+        }
+        // Persistent forced failure: window.__mockImportFetchFailUntilCleared = true
+        // makes EVERY call reject until a test explicitly sets it back to false.
+        // A one-shot flag is unsafe here because React StrictMode double-invokes
+        // the dialog's mount effect in dev, so more than one call can be issued
+        // before the "current" (non-superseded) one settles; a persistent flag
+        // guarantees whichever call ends up current still observes the failure.
+        // Checked before the artificial delay so a test does not have to wait
+        // through it to observe the failure.
+        if (typeof window !== 'undefined' && window.__mockImportFetchFailUntilCleared) {
+          throw new Error('Mock import fetch failure');
+        }
+        // Optional artificial delay so tests can interact with the dialog
+        // between page N landing and page N+1 resolving (streaming races).
+        var delayMs = (typeof window !== 'undefined' && window.__mockImportFetchPageDelayMs) || 0;
+        if (delayMs > 0) {
+          await new Promise(function (resolve) { setTimeout(resolve, delayMs); });
+        }
+        // Per-state multi-page preset: window.__mockImportFetchPagesByState is an
+        // object keyed by the request's state ('open' / 'closed' / 'all'), each
+        // value an array of { issues, totalCount, hasNextPage } page responses
+        // (1-indexed via input.page). Lets a test seed genuinely distinct data
+        // per state filter, so a stale in-flight page from the previous filter is
+        // distinguishable from the new filter's data.
+        var pagesByState = (typeof window !== 'undefined' && window.__mockImportFetchPagesByState) || null;
+        if (pagesByState) {
+          var stateKey = (input && input.state) || 'open';
+          var statePages = pagesByState[stateKey];
+          if (statePages) {
+            var statePageNumber = (input && input.page) || 1;
+            var stateResponse = statePages[statePageNumber - 1];
+            if (stateResponse) return stateResponse;
+          }
+          return { issues: [], totalCount: 0, hasNextPage: false };
+        }
+        // Multi-page preset: window.__mockImportFetchPages is an array of
+        // { issues, totalCount, hasNextPage } responses, one per page (1-indexed
+        // via input.page). Lets tests exercise the dialog's unbounded auto-paging.
+        var pages = (typeof window !== 'undefined' && window.__mockImportFetchPages) || null;
+        if (pages) {
+          var page = (input && input.page) || 1;
+          var response = pages[page - 1];
+          if (response) return response;
+          return { issues: [], totalCount: 0, hasNextPage: false };
         }
         var preset = (typeof window !== 'undefined' && window.__mockImportFetchPreset) || null;
-        if (preset) return preset;
+        if (preset) {
+          // The single preset returns the SAME response for every page. Since the
+          // dialog auto-pages unconditionally on hasNextPage, honoring a true
+          // value past page 1 here would loop forever. Use __mockImportFetchPages
+          // (below) to test real multi-page streaming instead.
+          var presetPage = (input && input.page) || 1;
+          if (presetPage > 1) return { issues: [], totalCount: preset.totalCount || 0, hasNextPage: false };
+          return preset;
+        }
         return { issues: [], totalCount: 0, hasNextPage: false };
       },
       importExecute: async function (input) {


### PR DESCRIPTION
## What

Fixes the Import Task modal's filter dropdowns (Status/Type/Assignee/Label) only showing values from the currently-loaded page of items, instead of every value across the whole source.

- Replaces manual "Load more" pagination with `loadAllIssues`, an unbounded background-streaming loader that auto-fetches every page of a source, using a sequence token (`fetchSequenceRef`) to cancel stale in-flight loops on a state-filter change or dialog unmount.
- Makes search, filtering, and sort fully client-side and live over the whole loaded set, so filter options and matching rows fill in progressively as pages stream in - a filter applied early keeps picking up matching items that arrive later.
- Adds virtual scrolling (`@tanstack/react-virtual`) so the full, unbounded set renders smoothly with no windowing tradeoff.
- `src/renderer/components/MultiSelectDropdown.tsx`: scopes the filter option `data-testid` by dropdown label to avoid collisions across the four dropdown instances.

## Why

The Status filter would show, for example, only "Backlog" at "30 of 30 items" loaded, and all 9 real statuses only once the user manually clicked "Load more" until every page had loaded.

## How

All changes are renderer-only (`ImportDialog.tsx`); no IPC, adapter, or type changes were needed since the existing `ImportFetchResult` shape already carries everything the streaming loop needs.

Trade-off: the loader has no page cap by design (explicit product requirement is "unbounded, no paging"), so a source with hundreds of pages does more total work than a capped loader would. This is judged acceptable for realistic import sizes; revisit only if it surfaces in practice.

A `/code-review` pass on this diff caught and fixed a real correctness bug along the way: the `setIssues` updater closed over a mutable `isFirstPage` variable by reference, and since React invokes the updater at flush time (after the very next line already mutated it to `false`), a state-filter switch mid-stream could silently append the new filter's data onto the outgoing filter's stale items instead of replacing them. Fixed by capturing the value into a per-iteration `const` before the mutation.

## Breaking changes

None.

## Tests

- `tests/ui/import-filter.spec.ts`: 15 UI-tier tests covering live client-side filtering/search, facets populating as pages stream in, a filter applied before a later page lands still catching it, virtualization windowing, state-filter-switch cancellation (which also pins the `isFirstPage` closure fix), unmount cancellation, error/retry mid-stream, select-all staleness once more items stream in, the all-imported empty state and its Refresh action, empty-state suppression mid-stream, a malformed-response error path, and externalId dedup across streamed pages.
- `tests/ui/mock-electron-api.js` extended to support multi-page presets (`__mockImportFetchPages`), an artificial per-page delay for exercising mid-stream races, and hardened against an accidental infinite loop if a single-preset test ever sets `hasNextPage: true` without the multi-page array.
- `npm run typecheck` and `npm run lint` pass locally; CI runs the full unit/UI/E2E tiers.

Generated with [Claude Code](https://claude.com/claude-code)
