### PR TITLE
feat(mcp): support attaching and removing files on existing tasks

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -208,7 +208,7 @@ Get detailed column configuration: description, auto-spawn, permission mode, pla
 
 ### kangentic_update_task
 
-Update a task's title, description, PR info, agent assignment, priority, labels, base branch, or worktree toggle. To move a task between columns, use `kangentic_move_task` instead.
+Update a task's title, description, PR info, agent assignment, priority, labels, base branch, worktree toggle, or attachments. To move a task between columns, use `kangentic_move_task` instead.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -222,6 +222,7 @@ Update a task's title, description, PR info, agent assignment, priority, labels,
 | `labels` | string[] | No | Replace the task's label list. Pass `[]` to clear. |
 | `baseBranch` | string | No | Base branch the task's worktree branches from (e.g. `"main"`) |
 | `useWorktree` | boolean | No | Whether the task uses an isolated git worktree |
+| `attachments` | array | No | File attachments to ADD to the task: `[{ filePath: string, filename?: string }]`. Additive - existing attachments are kept, not replaced. Use `kangentic_remove_task_attachment` to remove one. |
 
 At least one updatable field is required.
 
@@ -277,6 +278,16 @@ Permanently delete a task from the board. Removes the task, its attachments, and
 
 Find task IDs with `kangentic_find_task` or `kangentic_search_tasks`.
 
+### kangentic_remove_task_attachment
+
+Remove one attachment by its attachment ID, from a board task or a backlog item - the ID alone determines which surface owns it. This cannot be undone.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `attachmentId` | string | Yes | Attachment UUID (board `task_attachments.id` or backlog `backlog_attachments.id`) |
+
+Find attachment IDs with `kangentic_query_db`, e.g. `SELECT id, filename, task_id FROM task_attachments` for board tasks, or `SELECT id, filename, backlog_task_id FROM backlog_attachments` for backlog items.
+
 ### kangentic_list_backlog
 
 List items in the backlog staging area. Items have priority levels and labels for organization.
@@ -312,7 +323,7 @@ Attachments on promoted backlog tasks are automatically copied to the new task. 
 
 ### kangentic_update_backlog_item
 
-Update a backlog item's title, description, priority, or labels. Only the fields you provide are changed; omitted fields are left as-is. The `labels` parameter is a full replacement (not additive) - pass the complete new label set.
+Update a backlog item's title, description, priority, labels, or attachments. Only the fields you provide are changed; omitted fields are left as-is. The `labels` parameter is a full replacement (not additive) - pass the complete new label set. `attachments` is additive - existing attachments are kept, not replaced.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -321,6 +332,7 @@ Update a backlog item's title, description, priority, or labels. Only the fields
 | `description` | string | No | New description (max 10,000 characters) |
 | `priority` | number | No | New priority: 0=none, 1=low, 2=medium, 3=high, 4=urgent |
 | `labels` | array | No | Full replacement label set. Strings, or `{name, color}` objects to also set the label color. |
+| `attachments` | array | No | File attachments to ADD to the item: `[{ filePath: string, filename?: string }]`. Additive - existing attachments are kept. Use `kangentic_remove_task_attachment` to remove one. |
 
 Find item IDs with `kangentic_list_backlog` or `kangentic_search_tasks` (with `scope: "backlog"`).
 
@@ -524,7 +536,7 @@ The committed `.claude/settings.json` `mcp__kangentic` entry remains for humans 
 - **Runaway-loop safeguard** - task creations are capped at a fixed 500 per app launch, enforced atomically by the shared `TaskCounter`. This is an internal circuit breaker against a looping agent, not a user-tunable knob; the count resets on restart.
 - **Input validation** - Zod schemas enforce title (200 chars) and description (10000 chars) limits at the protocol level; the command handlers validate again.
 - **Column safety** - `kangentic_create_task` defaults to the To Do column; creating in an auto_spawn column intentionally triggers agent spawn.
-- **Destructive operations are explicit** - `kangentic_delete_task`, `kangentic_delete_backlog_item`, and `kangentic_move_task` mutate the board. Agents must invoke them by name; there is no implicit fallback.
+- **Destructive operations are explicit** - `kangentic_delete_task`, `kangentic_delete_backlog_item`, `kangentic_remove_task_attachment`, and `kangentic_move_task` mutate the board. Agents must invoke them by name; there is no implicit fallback.
 - **Honest mutating annotations** - mutating tools carry `readOnlyHint: false`, so the plan-mode auto-approval surface is exactly the read-only set. Deletes, moves, and creates always prompt while planning, even though the auto-allow injection pre-approves them in default mode.
 
 ## Build

--- a/src/main/agent/commands/backlog-commands.ts
+++ b/src/main/agent/commands/backlog-commands.ts
@@ -147,6 +147,7 @@ export const handleUpdateBacklogItem: CommandHandler = (
   const newDescription = (params.description ?? null) as string | null;
   const newPriority = (params.priority ?? null) as number | null;
   const rawLabels = (params.labels ?? null) as Array<string | { name: string; color: string }> | null;
+  const newAttachments = (params.attachments ?? null) as Array<{ filePath: string; filename?: string }> | null;
 
   // Observability for the "labels dropped on a large description" bug
   // (task #229). See the matching note in handleCreateBacklogTask.
@@ -207,11 +208,40 @@ export const handleUpdateBacklogItem: CommandHandler = (
     changedFields.push('labels');
   }
 
-  if (changedFields.length === 0) {
-    return { success: false, error: 'No fields provided to update' };
+  // Attach files if provided (additive - existing attachments are untouched).
+  let attachmentsAdded = 0;
+  if (newAttachments && newAttachments.length > 0) {
+    const backlogAttachmentRepo = new BacklogAttachmentRepository(db);
+    const projectPath = context.getProjectPath();
+    for (const entry of newAttachments) {
+      try {
+        const fileData = readFileAsAttachment(entry.filePath, entry.filename);
+        backlogAttachmentRepo.add(projectPath, existing.id, fileData.filename, fileData.base64Data, fileData.mediaType);
+        attachmentsAdded += 1;
+      } catch (error) {
+        console.error(`[update_backlog_item] Failed to attach file "${entry.filePath}":`, error);
+      }
+    }
+    if (attachmentsAdded > 0) changedFields.push('attachments');
   }
 
-  const updated = backlogRepo.update(updates as unknown as BacklogTaskUpdateInput);
+  if (changedFields.length === 0) {
+    const attachmentsRequested = newAttachments?.length ?? 0;
+    return {
+      success: false,
+      error: attachmentsRequested > 0
+        ? `Failed to attach any of the ${attachmentsRequested} requested file(s); no other fields were updated.`
+        : 'No fields provided to update',
+    };
+  }
+
+  // The attach loop above must run BEFORE this update/getById: backlog
+  // attachment_count is a stored column synced inside BacklogAttachmentRepository.add,
+  // so re-reading the row here picks up the fresh count. (Contrast handleUpdateTask,
+  // where attachment_count is a computed JOIN aggregate, so its re-fetch happens
+  // after the loop instead.)
+  const hasScalarChange = Object.keys(updates).length > 1;
+  const updated = hasScalarChange ? backlogRepo.update(updates as unknown as BacklogTaskUpdateInput) : (backlogRepo.getById(existing.id) ?? existing);
 
   if (Object.keys(labelColorMap).length > 0) {
     context.onLabelColorsChanged(labelColorMap);
@@ -230,6 +260,7 @@ export const handleUpdateBacklogItem: CommandHandler = (
       priority: updated.priority,
       priorityLabel,
       labels: updated.labels,
+      ...(newAttachments !== null ? { attachmentCount: updated.attachment_count, attachmentsAdded } : {}),
     },
   };
 };

--- a/src/main/agent/commands/index.ts
+++ b/src/main/agent/commands/index.ts
@@ -1,7 +1,7 @@
 export type { CommandContext, CommandResponse, CommandHandler } from './types';
 export { resolveColumn, listActiveSwimlanes } from './column-resolver';
 
-import { handleCreateTask, handleUpdateTask, handleDeleteTask, handleMoveTask, handleLinkPr } from './task-commands';
+import { handleCreateTask, handleUpdateTask, handleDeleteTask, handleMoveTask, handleLinkPr, handleRemoveAttachment } from './task-commands';
 import { handleUpdateColumn } from './column-commands';
 import { handleListColumns, handleListTasks } from './inventory-commands';
 import { handleSearchTasks, handleFindTask, handleGetCurrentTask } from './search-commands';
@@ -23,6 +23,7 @@ export const commandHandlers: Record<string, CommandHandler> = {
   delete_task: handleDeleteTask,
   move_task: handleMoveTask,
   link_pr: handleLinkPr,
+  remove_attachment: handleRemoveAttachment,
   update_column: handleUpdateColumn,
   list_columns: handleListColumns,
   list_tasks: handleListTasks,

--- a/src/main/agent/commands/task-commands.ts
+++ b/src/main/agent/commands/task-commands.ts
@@ -1,5 +1,6 @@
 import { TaskRepository } from '../../db/repositories/task-repository';
 import { AttachmentRepository } from '../../db/repositories/attachment-repository';
+import { BacklogAttachmentRepository } from '../../db/repositories/backlog-attachment-repository';
 import { SessionRepository } from '../../db/repositories/session-repository';
 import { readFileAsAttachment } from '../../db/repositories/attachment-utils';
 import { resolveColumn } from './column-resolver';
@@ -126,6 +127,7 @@ export const handleUpdateTask: CommandHandler = (
   const newLabels = params.labels as string[] | null;
   const newBaseBranch = params.baseBranch as string | null;
   const newUseWorktree = params.useWorktree as boolean | null;
+  const newAttachments = params.attachments as Array<{ filePath: string; filename?: string }> | null;
 
   // Observability for the "labels dropped on a large description" bug
   // (task #229). See the matching note in handleCreateTask.
@@ -156,7 +158,39 @@ export const handleUpdateTask: CommandHandler = (
   if (newBaseBranch !== null) updates.base_branch = newBaseBranch;
   if (newUseWorktree !== null) updates.use_worktree = newUseWorktree ? 1 : 0;
 
-  const updated = taskRepo.update(updates as unknown as TaskUpdateInput);
+  const hasScalarChange = Object.keys(updates).length > 1;
+  let updated = hasScalarChange ? taskRepo.update(updates as unknown as TaskUpdateInput) : task;
+
+  // Attach files if provided (additive - existing attachments are untouched).
+  let attachmentsAdded = 0;
+  if (newAttachments && newAttachments.length > 0) {
+    const attachmentRepo = new AttachmentRepository(db);
+    const projectPath = context.getProjectPath();
+    for (const entry of newAttachments) {
+      try {
+        const fileData = readFileAsAttachment(entry.filePath, entry.filename);
+        attachmentRepo.add(projectPath, task.id, fileData.filename, fileData.base64Data, fileData.mediaType);
+        attachmentsAdded += 1;
+      } catch (error) {
+        console.error(`[update_task] Failed to attach file "${entry.filePath}":`, error);
+      }
+    }
+    // Re-fetch so the response and onTaskUpdated carry the fresh derived attachment_count.
+    updated = taskRepo.getById(task.id) ?? updated;
+  }
+
+  // If nothing actually changed (no scalar field set, and every requested
+  // attachment failed to read), surface a structured failure instead of a
+  // misleading success with an empty "Updated  for ..." message. Mirrors the
+  // equivalent guard in handleUpdateBacklogItem. Reachable only via attachments,
+  // since the tool layer forwards attachments past its "at least one field"
+  // gate while attachments contribute to changedFields only when one succeeds.
+  if (!hasScalarChange && attachmentsAdded === 0) {
+    const attachmentsRequested = newAttachments?.length ?? 0;
+    return attachmentsRequested > 0
+      ? { success: false, error: `Failed to attach any of the ${attachmentsRequested} requested file(s); no other fields were updated.` }
+      : { success: false, error: 'No fields provided to update' };
+  }
 
   context.onTaskUpdated(updated);
 
@@ -170,6 +204,7 @@ export const handleUpdateTask: CommandHandler = (
   if (newLabels !== null) changedFields.push('labels');
   if (newBaseBranch !== null) changedFields.push('baseBranch');
   if (newUseWorktree !== null) changedFields.push('useWorktree');
+  if (attachmentsAdded > 0) changedFields.push('attachments');
 
   return {
     success: true,
@@ -186,6 +221,7 @@ export const handleUpdateTask: CommandHandler = (
       labels: updated.labels,
       baseBranch: updated.base_branch,
       useWorktree: updated.use_worktree,
+      ...(newAttachments !== null ? { attachmentCount: updated.attachment_count, attachmentsAdded } : {}),
     },
   };
 };
@@ -351,4 +387,53 @@ export const handleDeleteTask: CommandHandler = (
     message: `Deleted task "${task.title}" (#${task.display_id}).`,
     data: { id: task.id, displayId: task.display_id, title: task.title },
   };
+};
+
+/**
+ * Remove a single attachment by ID from either surface. Tries the board
+ * `task_attachments` table first, then falls back to backlog
+ * `backlog_attachments` - the attachment UUID alone determines which surface
+ * owns it, so there is no separate board/backlog parameter to get wrong.
+ */
+export const handleRemoveAttachment: CommandHandler = (
+  params: Record<string, unknown>,
+  context: CommandContext,
+): CommandResponse => {
+  const attachmentId = params.attachmentId as string;
+
+  if (!attachmentId) {
+    return { success: false, error: 'attachmentId is required' };
+  }
+
+  const db = context.getProjectDb();
+
+  const attachmentRepo = new AttachmentRepository(db);
+  const boardAttachment = attachmentRepo.getById(attachmentId);
+  if (boardAttachment) {
+    attachmentRepo.remove(attachmentId);
+    const taskRepo = new TaskRepository(db);
+    const task = taskRepo.getById(boardAttachment.task_id);
+    if (task) {
+      context.onTaskUpdated(task);
+    }
+    return {
+      success: true,
+      message: `Removed attachment "${boardAttachment.filename}" from task ${task ? `"${task.title}" (#${task.display_id})` : boardAttachment.task_id}.`,
+      data: { attachmentId, taskId: boardAttachment.task_id, filename: boardAttachment.filename },
+    };
+  }
+
+  const backlogAttachmentRepo = new BacklogAttachmentRepository(db);
+  const backlogAttachment = backlogAttachmentRepo.getById(attachmentId);
+  if (backlogAttachment) {
+    backlogAttachmentRepo.remove(attachmentId);
+    context.onBacklogChanged();
+    return {
+      success: true,
+      message: `Removed attachment "${backlogAttachment.filename}" from backlog item ${backlogAttachment.backlog_task_id}.`,
+      data: { attachmentId, backlogItemId: backlogAttachment.backlog_task_id, filename: backlogAttachment.filename },
+    };
+  }
+
+  return { success: false, error: `Attachment "${attachmentId}" not found` };
 };

--- a/src/main/agent/mcp-http/session-tools.ts
+++ b/src/main/agent/mcp-http/session-tools.ts
@@ -97,7 +97,7 @@ export function registerSessionTools(server: McpServer, resolver: RequestResolve
   server.registerTool(
     'kangentic_update_backlog_item',
     {
-      description: 'Update a backlog item\'s title, description, priority, or labels. Only the fields you provide are changed; omitted fields are left as-is. Note that `labels` is a full replacement (not additive) - pass the complete new label set. Find item IDs with kangentic_list_backlog or kangentic_search_tasks (with `scope: "backlog"`). Pass `project` to update a backlog item in a different project.',
+      description: 'Update a backlog item\'s title, description, priority, labels, or attachments. Only the fields you provide are changed; omitted fields are left as-is. Note that `labels` is a full replacement (not additive) - pass the complete new label set; `attachments` is additive - existing attachments are kept. Find item IDs with kangentic_list_backlog or kangentic_search_tasks (with `scope: "backlog"`). Pass `project` to update a backlog item in a different project.',
       inputSchema: z.object({
         itemId: z.string().describe('Backlog item UUID (from kangentic_list_backlog or kangentic_search_tasks).'),
         title: z.string().max(200).optional().describe('New title (max 200 characters).'),
@@ -107,16 +107,21 @@ export function registerSessionTools(server: McpServer, resolver: RequestResolve
           z.string(),
           z.object({ name: z.string(), color: z.string() }),
         ])).optional().describe('Full replacement label set. Strings, or {name, color} objects to also set the label color.'),
+        attachments: z.array(z.object({
+          filePath: z.string().describe('Absolute path to the file to attach'),
+          filename: z.string().optional().describe('Override display filename'),
+        })).optional().describe('File attachments to ADD to the backlog item. This is additive - existing attachments are kept, not replaced. Each entry needs `filePath` (absolute) and may override the display `filename`. Use kangentic_remove_task_attachment to remove one.'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
       annotations: MUTATING_ANNOTATIONS,
     },
-    async ({ itemId, title, description, priority, labels, project }) => withProject(resolver, project, (ctx) => callHandler('update_backlog_item', {
+    async ({ itemId, title, description, priority, labels, attachments, project }) => withProject(resolver, project, (ctx) => callHandler('update_backlog_item', {
       itemId,
       title: title ?? null,
       description: description ?? null,
       priority: priority ?? null,
       labels: labels ?? null,
+      attachments: attachments ?? null,
     }, ctx, 'Failed to update backlog item')),
   );
 

--- a/src/main/agent/mcp-http/task-tools.ts
+++ b/src/main/agent/mcp-http/task-tools.ts
@@ -355,7 +355,7 @@ export function registerTaskTools(
   server.registerTool(
     'kangentic_update_task',
     {
-      description: 'Update an existing task. Supports title, description, PR info, agent assignment, priority, labels, base branch, and worktree toggle. To move a task between columns, use kangentic_move_task instead. Find the task ID first with kangentic_find_task. Pass `project` to update a task in a different project.',
+      description: 'Update an existing task. Supports title, description, PR info, agent assignment, priority, labels, base branch, worktree toggle, and attaching files. To move a task between columns, use kangentic_move_task instead. Find the task ID first with kangentic_find_task. Pass `project` to update a task in a different project.',
       inputSchema: z.object({
         taskId: z.string().describe('Task ID (numeric display ID like "42" or full UUID).'),
         title: z.string().max(200).optional().describe('New task title (max 200 characters).'),
@@ -367,14 +367,19 @@ export function registerTaskTools(
         labels: z.array(z.string()).optional().describe('Replace the task\'s label list. Pass [] to clear all labels. If this same call also sets a long description (roughly 1KB or more), set labels in a separate labels-only update instead, or they may be dropped before reaching the server.'),
         baseBranch: z.string().optional().describe('Base branch the task\'s worktree branches from (e.g. "main").'),
         useWorktree: z.boolean().optional().describe('Whether the task uses an isolated git worktree.'),
+        attachments: z.array(z.object({
+          filePath: z.string().describe('Absolute path to the file to attach'),
+          filename: z.string().optional().describe('Override display filename'),
+        })).optional().describe('File attachments to ADD to the task. This is additive - existing attachments are kept, not replaced. Each entry needs `filePath` (absolute) and may override the display `filename`. Use kangentic_remove_task_attachment to remove one.'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
       annotations: MUTATING_ANNOTATIONS,
     },
-    async ({ taskId, title, description, prUrl, prNumber, agent, priority, labels, baseBranch, useWorktree, project }) => {
+    async ({ taskId, title, description, prUrl, prNumber, agent, priority, labels, baseBranch, useWorktree, attachments, project }) => {
       if (
         title === undefined && description === undefined && prUrl === undefined && prNumber === undefined &&
-        agent === undefined && priority === undefined && labels === undefined && baseBranch === undefined && useWorktree === undefined
+        agent === undefined && priority === undefined && labels === undefined && baseBranch === undefined &&
+        useWorktree === undefined && attachments === undefined
       ) {
         return { content: [{ type: 'text' as const, text: 'Provide at least one field to update.' }], isError: true };
       }
@@ -389,6 +394,7 @@ export function registerTaskTools(
         labels: labels ?? null,
         baseBranch: baseBranch ?? null,
         useWorktree: useWorktree ?? null,
+        attachments: attachments ?? null,
       }, ctx, 'Failed to update task'));
     },
   );
@@ -474,5 +480,19 @@ export function registerTaskTools(
       annotations: MUTATING_ANNOTATIONS,
     },
     async ({ taskId, project }) => withProject(resolver, project, (ctx) => callHandler('delete_task', { taskId }, ctx, 'Failed to delete task')),
+  );
+
+  // --- kangentic_remove_task_attachment ---
+  server.registerTool(
+    'kangentic_remove_task_attachment',
+    {
+      description: 'Remove one attachment by its attachment ID, from a board task or a backlog item - the ID alone determines which. Find attachment IDs with kangentic_query_db (e.g. `SELECT id, filename, task_id FROM task_attachments` for board tasks, or `SELECT id, filename, backlog_task_id FROM backlog_attachments` for backlog items). Pass `project` to remove an attachment in a different project.',
+      inputSchema: z.object({
+        attachmentId: z.string().describe('Attachment UUID (board task_attachments.id or backlog backlog_attachments.id).'),
+        project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
+      }),
+      annotations: MUTATING_ANNOTATIONS,
+    },
+    async ({ attachmentId, project }) => withProject(resolver, project, (ctx) => callHandler('remove_attachment', { attachmentId }, ctx, 'Failed to remove attachment')),
   );
 }

--- a/src/shared/mcp-tool-manifest.ts
+++ b/src/shared/mcp-tool-manifest.ts
@@ -56,10 +56,11 @@ export const MCP_TOOL_MANIFEST: McpToolManifestEntry[] = [
   { name: 'kangentic_find_task', label: 'Find Task', blurb: 'look up a task by ID, branch, title, or PR number', category: 'tasks' },
   { name: 'kangentic_get_current_task', label: 'Current Task', blurb: 'resolve the task for the current directory or branch', category: 'tasks' },
   { name: 'kangentic_get_task_stats', label: 'Task Stats', blurb: 'token usage, cost, duration, and lines changed per task', category: 'tasks' },
-  { name: 'kangentic_update_task', label: 'Update Task', blurb: 'edit title, description, PR info, agent, priority, labels, base branch, and worktree', category: 'tasks' },
+  { name: 'kangentic_update_task', label: 'Update Task', blurb: 'edit title, description, PR info, agent, priority, labels, base branch, worktree, and attachments', category: 'tasks' },
   { name: 'kangentic_move_task', label: 'Move Task', blurb: 'move a task between columns, running the same lifecycle as a drag', category: 'tasks' },
   { name: 'kangentic_link_pr', label: 'Link PR', blurb: 'resolve and attach a task pull request via the gh CLI', category: 'tasks' },
   { name: 'kangentic_delete_task', label: 'Delete Task', blurb: 'permanently remove a task, its attachments, and session records', category: 'tasks' },
+  { name: 'kangentic_remove_task_attachment', label: 'Remove Attachment', blurb: 'detach a file from a board task or backlog item by attachment ID', category: 'tasks' },
 
   // ── Board (columns from task-tools.ts, backlog from session-tools.ts, projects/search from project-tools.ts + search-tools.ts) ──
   { name: 'kangentic_list_columns', label: 'List Columns', blurb: 'see every board column with its task counts', category: 'board' },
@@ -68,7 +69,7 @@ export const MCP_TOOL_MANIFEST: McpToolManifestEntry[] = [
   { name: 'kangentic_board_summary', label: 'Board Summary', blurb: 'counts, active sessions, and aggregate cost across the board', category: 'board' },
   { name: 'kangentic_list_backlog', label: 'List Backlog', blurb: 'see items staged in the backlog', category: 'board' },
   { name: 'kangentic_promote_backlog', label: 'Promote Backlog', blurb: 'move backlog items onto the board as tasks', category: 'board' },
-  { name: 'kangentic_update_backlog_item', label: 'Update Backlog Item', blurb: 'edit a backlog item title, description, priority, or labels', category: 'board' },
+  { name: 'kangentic_update_backlog_item', label: 'Update Backlog Item', blurb: 'edit a backlog item title, description, priority, labels, or attachments', category: 'board' },
   { name: 'kangentic_delete_backlog_item', label: 'Delete Backlog Item', blurb: 'permanently remove a backlog item and its attachments', category: 'board' },
   { name: 'kangentic_list_projects', label: 'List Projects', blurb: 'every Kangentic project registered on this machine', category: 'board' },
   { name: 'kangentic_search_everything', label: 'Search Everything', blurb: 'unified search across tasks, backlog, sessions, and projects', category: 'board' },

--- a/tests/unit/backlog-update-delete-handlers.test.ts
+++ b/tests/unit/backlog-update-delete-handlers.test.ts
@@ -31,16 +31,30 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Hoisted mocks - must be registered before any import under test
 // ---------------------------------------------------------------------------
 
-// Spy handles configured per test inside beforeEach
-const mockBacklogRepoGetById = vi.fn();
-const mockBacklogRepoUpdate = vi.fn();
-const mockBacklogRepoDelete = vi.fn();
-
-const mockBacklogAttachmentRepoDeleteByTaskId = vi.fn();
-const mockBacklogAttachmentRepoList = vi.fn(() => []);
-
-// Used by handlePromoteBacklog to create the promoted board task.
-const mockTaskRepoCreate = vi.fn();
+// Spy handles configured per test inside beforeEach. Wrapped in vi.hoisted
+// because vi.mock factories below reference them directly - vi.mock calls
+// are hoisted above plain top-level statements, so an un-hoisted const would
+// hit a TDZ ReferenceError the moment a factory is invoked.
+const {
+  mockBacklogRepoGetById,
+  mockBacklogRepoUpdate,
+  mockBacklogRepoDelete,
+  mockBacklogAttachmentRepoDeleteByTaskId,
+  mockBacklogAttachmentRepoList,
+  mockBacklogAttachmentRepoAdd,
+  mockReadFileAsAttachment,
+  mockTaskRepoCreate,
+} = vi.hoisted(() => ({
+  mockBacklogRepoGetById: vi.fn(),
+  mockBacklogRepoUpdate: vi.fn(),
+  mockBacklogRepoDelete: vi.fn(),
+  mockBacklogAttachmentRepoDeleteByTaskId: vi.fn(),
+  mockBacklogAttachmentRepoList: vi.fn(() => []),
+  mockBacklogAttachmentRepoAdd: vi.fn(),
+  mockReadFileAsAttachment: vi.fn(),
+  // Used by handlePromoteBacklog to create the promoted board task.
+  mockTaskRepoCreate: vi.fn(),
+}));
 
 vi.mock('../../src/main/db/repositories/backlog-repository', () => ({
   BacklogRepository: class {
@@ -56,13 +70,12 @@ vi.mock('../../src/main/db/repositories/backlog-attachment-repository', () => ({
   BacklogAttachmentRepository: class {
     deleteByTaskId = mockBacklogAttachmentRepoDeleteByTaskId;
     list = mockBacklogAttachmentRepoList;
-    add = vi.fn();
+    add = mockBacklogAttachmentRepoAdd;
   },
 }));
 
-// Silence the attachment-utils import (not used by update/delete handlers)
 vi.mock('../../src/main/db/repositories/attachment-utils', () => ({
-  readFileAsAttachment: vi.fn(),
+  readFileAsAttachment: mockReadFileAsAttachment,
 }));
 
 // Task repository - used by handlePromoteBacklog to create the promoted board task.
@@ -246,6 +259,105 @@ describe('handleUpdateBacklogItem', () => {
         labels: [],
       },
     });
+  });
+
+  it('attachments-only call does not touch BacklogRepository.update, but attaches and reports attachmentsAdded', () => {
+    const existing = makeBacklogItem({ id: 'item-001' });
+    mockBacklogRepoGetById.mockReturnValue(existing);
+    mockReadFileAsAttachment.mockReturnValue({
+      filename: 'notes.txt',
+      base64Data: 'ZmFrZS1kYXRh',
+      mediaType: 'text/plain',
+    });
+
+    const result = handleUpdateBacklogItem(
+      { itemId: 'item-001', attachments: [{ filePath: 'C:/mock/notes.txt' }] },
+      context,
+    );
+
+    expect(mockBacklogRepoUpdate).not.toHaveBeenCalled();
+    expect(mockBacklogAttachmentRepoAdd).toHaveBeenCalledOnce();
+    expect(mockBacklogAttachmentRepoAdd).toHaveBeenCalledWith(
+      '/mock/project', 'item-001', 'notes.txt', 'ZmFrZS1kYXRh', 'text/plain',
+    );
+    expect(context.onBacklogChanged).toHaveBeenCalledOnce();
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('attachments');
+    expect(result.data).toMatchObject({ attachmentsAdded: 1 });
+  });
+
+  it('combined title + attachments call updates both', () => {
+    const existing = makeBacklogItem({ id: 'item-001', title: 'Old title' });
+    mockBacklogRepoGetById.mockReturnValue(existing);
+    mockBacklogRepoUpdate.mockReturnValue({ ...existing, title: 'New title' });
+    mockReadFileAsAttachment.mockReturnValue({
+      filename: 'notes.txt',
+      base64Data: 'ZmFrZS1kYXRh',
+      mediaType: 'text/plain',
+    });
+
+    const result = handleUpdateBacklogItem(
+      { itemId: 'item-001', title: 'New title', attachments: [{ filePath: 'C:/mock/notes.txt' }] },
+      context,
+    );
+
+    expect(mockBacklogRepoUpdate).toHaveBeenCalledOnce();
+    expect(mockBacklogAttachmentRepoAdd).toHaveBeenCalledOnce();
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('title');
+    expect(result.message).toContain('attachments');
+  });
+
+  it('attachments-only call where every readFileAsAttachment throws returns a structured error and touches nothing else', () => {
+    const existing = makeBacklogItem({ id: 'item-001' });
+    mockBacklogRepoGetById.mockReturnValue(existing);
+    mockReadFileAsAttachment.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    const result = handleUpdateBacklogItem(
+      { itemId: 'item-001', attachments: [{ filePath: 'C:/mock/missing.txt' }] },
+      context,
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Failed to attach any of the 1 requested file(s); no other fields were updated.',
+    });
+    expect(mockBacklogAttachmentRepoAdd).not.toHaveBeenCalled();
+    expect(mockBacklogRepoUpdate).not.toHaveBeenCalled();
+    expect(context.onBacklogChanged).not.toHaveBeenCalled();
+  });
+
+  it('partial attachment failure: continues past a throwing entry and attaches the rest', () => {
+    const existing = makeBacklogItem({ id: 'item-001' });
+    mockBacklogRepoGetById.mockReturnValue(existing);
+    mockReadFileAsAttachment
+      .mockImplementationOnce(() => {
+        throw new Error('ENOENT');
+      })
+      .mockImplementationOnce(() => ({
+        filename: 'good.txt',
+        base64Data: 'Z29vZC1kYXRh',
+        mediaType: 'text/plain',
+      }));
+
+    const result = handleUpdateBacklogItem(
+      {
+        itemId: 'item-001',
+        attachments: [{ filePath: 'C:/mock/bad.txt' }, { filePath: 'C:/mock/good.txt' }],
+      },
+      context,
+    );
+
+    expect(mockBacklogAttachmentRepoAdd).toHaveBeenCalledOnce();
+    expect(mockBacklogAttachmentRepoAdd).toHaveBeenCalledWith(
+      '/mock/project', 'item-001', 'good.txt', 'Z29vZC1kYXRh', 'text/plain',
+    );
+    expect(context.onBacklogChanged).toHaveBeenCalledOnce();
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('attachments');
+    expect(result.data).toMatchObject({ attachmentsAdded: 1 });
   });
 
   it('fires onLabelColorsChanged with extracted color map when labels have {name, color} objects', () => {

--- a/tests/unit/mcp-attachment-handlers.test.ts
+++ b/tests/unit/mcp-attachment-handlers.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Unit tests for attaching/detaching files on an ALREADY-EXISTING task via
+ * MCP (as opposed to attachments passed at kangentic_create_task time, which
+ * mcp-create-task-labels.test.ts and existing create_task tests already
+ * cover).
+ *
+ * Covers:
+ *   handleUpdateTask (src/main/agent/commands/task-commands.ts)
+ *     - attachments-only call appends via AttachmentRepository.add without
+ *       calling TaskRepository.update (no gratuitous updated_at bump), and
+ *       re-fetches the task so the response reflects the fresh derived
+ *       attachment_count
+ *     - combined scalar field + attachments call updates both
+ *
+ *   handleRemoveAttachment (src/main/agent/commands/task-commands.ts)
+ *     - removes a board attachment by ID and notifies onTaskUpdated
+ *     - falls back to the backlog attachment repo and notifies onBacklogChanged
+ *     - returns a structured error when the ID matches neither surface
+ *
+ * Strategy mirrors mcp-create-task-labels.test.ts: mock the repositories so
+ * no better-sqlite3 binary is needed, and assert on captured repository calls.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks - must be registered before the import under test
+// ---------------------------------------------------------------------------
+
+const {
+  mockTaskRepoUpdate,
+  mockTaskRepoGetById,
+  mockTaskRepoGetByDisplayId,
+  mockAttachmentRepoAdd,
+  mockAttachmentRepoGetById,
+  mockAttachmentRepoRemove,
+  mockBacklogAttachmentRepoGetById,
+  mockBacklogAttachmentRepoRemove,
+  mockReadFileAsAttachment,
+} = vi.hoisted(() => ({
+  mockTaskRepoUpdate: vi.fn(),
+  mockTaskRepoGetById: vi.fn(),
+  mockTaskRepoGetByDisplayId: vi.fn(),
+  mockAttachmentRepoAdd: vi.fn(),
+  mockAttachmentRepoGetById: vi.fn(),
+  mockAttachmentRepoRemove: vi.fn(),
+  mockBacklogAttachmentRepoGetById: vi.fn(),
+  mockBacklogAttachmentRepoRemove: vi.fn(),
+  mockReadFileAsAttachment: vi.fn(),
+}));
+
+vi.mock('../../src/main/db/repositories/task-repository', () => ({
+  TaskRepository: class {
+    update = mockTaskRepoUpdate;
+    getById = mockTaskRepoGetById;
+    getByDisplayId = mockTaskRepoGetByDisplayId;
+  },
+}));
+
+vi.mock('../../src/main/db/repositories/attachment-repository', () => ({
+  AttachmentRepository: class {
+    add = mockAttachmentRepoAdd;
+    getById = mockAttachmentRepoGetById;
+    remove = mockAttachmentRepoRemove;
+  },
+}));
+
+vi.mock('../../src/main/db/repositories/backlog-attachment-repository', () => ({
+  BacklogAttachmentRepository: class {
+    getById = mockBacklogAttachmentRepoGetById;
+    remove = mockBacklogAttachmentRepoRemove;
+  },
+}));
+
+vi.mock('../../src/main/db/repositories/attachment-utils', () => ({
+  readFileAsAttachment: mockReadFileAsAttachment,
+}));
+
+// Defensive: transitively imported by task-commands.ts but unused by the
+// handlers under test here.
+vi.mock('../../src/main/db/repositories/session-repository', () => ({
+  SessionRepository: class {},
+}));
+vi.mock('../../src/main/db/repositories/backlog-repository', () => ({
+  BacklogRepository: class {},
+}));
+vi.mock('../../src/main/pr/pr-linking', () => ({
+  linkPRForTask: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after all mocks are registered)
+// ---------------------------------------------------------------------------
+
+import { handleUpdateTask, handleRemoveAttachment } from '../../src/main/agent/commands/task-commands';
+import type { CommandContext } from '../../src/main/agent/commands/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    getProjectDb: vi.fn(() => ({}) as never),
+    getProjectPath: vi.fn(() => '/mock/project'),
+    onBacklogChanged: vi.fn(),
+    onLabelColorsChanged: vi.fn(),
+    onTaskCreated: vi.fn(),
+    onTaskUpdated: vi.fn(),
+    onTaskDeleted: vi.fn(),
+    onTaskMove: vi.fn(async () => {}),
+    onSwimlaneUpdated: vi.fn(),
+    ...overrides,
+  };
+}
+
+const EXISTING_TASK = { id: 'task-uuid-1', display_id: 1, title: 'Existing', attachment_count: 0 };
+
+/**
+ * The real kangentic_update_task tool (task-tools.ts) forwards every
+ * omitted field as an explicit `null` (`title: title ?? null`, etc.), not
+ * `undefined` - handleUpdateTask's `field !== null` checks depend on that.
+ * Mirror that shape so calling the handler directly here matches production.
+ */
+function updateTaskParams(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    taskId: 'task-uuid-1',
+    title: null,
+    description: null,
+    prUrl: null,
+    prNumber: null,
+    agent: null,
+    priority: null,
+    labels: null,
+    baseBranch: null,
+    useWorktree: null,
+    attachments: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// handleUpdateTask - attachments
+// ---------------------------------------------------------------------------
+
+describe('handleUpdateTask - attachments (append to an existing task)', () => {
+  let context: CommandContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    context = makeContext();
+    mockTaskRepoGetById.mockReturnValue(EXISTING_TASK);
+    mockReadFileAsAttachment.mockReturnValue({
+      filename: 'screenshot.png',
+      base64Data: 'ZmFrZS1kYXRh',
+      mediaType: 'image/png',
+    });
+  });
+
+  it('attachments-only call does not touch TaskRepository.update, but attaches and re-fetches the task', () => {
+    mockTaskRepoGetById.mockReturnValueOnce(EXISTING_TASK).mockReturnValueOnce({ ...EXISTING_TASK, attachment_count: 1 });
+
+    const result = handleUpdateTask(
+      updateTaskParams({ attachments: [{ filePath: 'C:/mock/screenshot.png' }] }),
+      context,
+    );
+
+    expect(mockTaskRepoUpdate).not.toHaveBeenCalled();
+    expect(mockAttachmentRepoAdd).toHaveBeenCalledOnce();
+    expect(mockAttachmentRepoAdd).toHaveBeenCalledWith(
+      '/mock/project', 'task-uuid-1', 'screenshot.png', 'ZmFrZS1kYXRh', 'image/png',
+    );
+    expect(context.onTaskUpdated).toHaveBeenCalledWith(expect.objectContaining({ attachment_count: 1 }));
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('attachments');
+    expect(result.data).toMatchObject({ attachmentCount: 1, attachmentsAdded: 1 });
+  });
+
+  it('combined title + attachments call updates both', () => {
+    mockTaskRepoUpdate.mockReturnValue({ ...EXISTING_TASK, title: 'New title' });
+    mockTaskRepoGetById.mockReturnValueOnce(EXISTING_TASK).mockReturnValueOnce({ ...EXISTING_TASK, title: 'New title', attachment_count: 1 });
+
+    const result = handleUpdateTask(
+      updateTaskParams({
+        title: 'New title',
+        attachments: [{ filePath: 'C:/mock/screenshot.png' }],
+      }),
+      context,
+    );
+
+    expect(mockTaskRepoUpdate).toHaveBeenCalledOnce();
+    expect(mockAttachmentRepoAdd).toHaveBeenCalledOnce();
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('title');
+    expect(result.message).toContain('attachments');
+  });
+
+  it('a scalar-only update (no attachments field) omits attachmentCount/attachmentsAdded from the response', () => {
+    mockTaskRepoUpdate.mockReturnValue({ ...EXISTING_TASK, title: 'New title' });
+
+    const result = handleUpdateTask(updateTaskParams({ title: 'New title' }), context);
+
+    expect(mockAttachmentRepoAdd).not.toHaveBeenCalled();
+    expect(result.data).not.toHaveProperty('attachmentCount');
+    expect(result.data).not.toHaveProperty('attachmentsAdded');
+  });
+
+  it('attachments-only call where every readFileAsAttachment throws returns a structured error and touches nothing else', () => {
+    mockReadFileAsAttachment.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    const result = handleUpdateTask(
+      updateTaskParams({ attachments: [{ filePath: 'C:/mock/missing.png' }] }),
+      context,
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Failed to attach any of the 1 requested file(s); no other fields were updated.',
+    });
+    expect(mockAttachmentRepoAdd).not.toHaveBeenCalled();
+    expect(mockTaskRepoUpdate).not.toHaveBeenCalled();
+    expect(context.onTaskUpdated).not.toHaveBeenCalled();
+  });
+
+  it('attachments call with attachments: [] and no other field returns "No fields provided to update"', () => {
+    const result = handleUpdateTask(updateTaskParams({ attachments: [] }), context);
+
+    expect(result).toEqual({ success: false, error: 'No fields provided to update' });
+    expect(mockAttachmentRepoAdd).not.toHaveBeenCalled();
+    expect(context.onTaskUpdated).not.toHaveBeenCalled();
+  });
+
+  it('partial attachment failure: continues past a throwing entry and attaches the rest', () => {
+    mockReadFileAsAttachment
+      .mockImplementationOnce(() => {
+        throw new Error('ENOENT');
+      })
+      .mockImplementationOnce(() => ({
+        filename: 'good.png',
+        base64Data: 'Z29vZC1kYXRh',
+        mediaType: 'image/png',
+      }));
+    mockTaskRepoGetById.mockReturnValueOnce(EXISTING_TASK).mockReturnValueOnce({ ...EXISTING_TASK, attachment_count: 1 });
+
+    const result = handleUpdateTask(
+      updateTaskParams({
+        attachments: [{ filePath: 'C:/mock/bad.png' }, { filePath: 'C:/mock/good.png' }],
+      }),
+      context,
+    );
+
+    expect(mockAttachmentRepoAdd).toHaveBeenCalledOnce();
+    expect(mockAttachmentRepoAdd).toHaveBeenCalledWith(
+      '/mock/project', 'task-uuid-1', 'good.png', 'Z29vZC1kYXRh', 'image/png',
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('attachments');
+    expect(result.data).toMatchObject({ attachmentsAdded: 1 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleRemoveAttachment
+// ---------------------------------------------------------------------------
+
+describe('handleRemoveAttachment', () => {
+  let context: CommandContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    context = makeContext();
+  });
+
+  it('returns structured error when attachmentId is missing', () => {
+    const result = handleRemoveAttachment({}, context);
+
+    expect(result).toEqual({ success: false, error: 'attachmentId is required' });
+    expect(mockAttachmentRepoGetById).not.toHaveBeenCalled();
+  });
+
+  it('removes a board attachment and notifies onTaskUpdated with the refreshed task', () => {
+    mockAttachmentRepoGetById.mockReturnValue({ id: 'att-1', task_id: 'task-uuid-1', filename: 'shot.png' });
+    mockTaskRepoGetById.mockReturnValue({ ...EXISTING_TASK, attachment_count: 0 });
+
+    const result = handleRemoveAttachment({ attachmentId: 'att-1' }, context);
+
+    expect(mockAttachmentRepoRemove).toHaveBeenCalledWith('att-1');
+    expect(mockBacklogAttachmentRepoGetById).not.toHaveBeenCalled();
+    expect(context.onTaskUpdated).toHaveBeenCalledWith(expect.objectContaining({ id: 'task-uuid-1' }));
+    expect(result).toEqual({
+      success: true,
+      message: 'Removed attachment "shot.png" from task "Existing" (#1).',
+      data: { attachmentId: 'att-1', taskId: 'task-uuid-1', filename: 'shot.png' },
+    });
+  });
+
+  it('falls back to the backlog attachment repo and notifies onBacklogChanged', () => {
+    mockAttachmentRepoGetById.mockReturnValue(undefined);
+    mockBacklogAttachmentRepoGetById.mockReturnValue({ id: 'att-2', backlog_task_id: 'item-001', filename: 'notes.txt' });
+
+    const result = handleRemoveAttachment({ attachmentId: 'att-2' }, context);
+
+    expect(mockAttachmentRepoRemove).not.toHaveBeenCalled();
+    expect(mockBacklogAttachmentRepoRemove).toHaveBeenCalledWith('att-2');
+    expect(context.onBacklogChanged).toHaveBeenCalledOnce();
+    expect(context.onTaskUpdated).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: true,
+      message: 'Removed attachment "notes.txt" from backlog item item-001.',
+      data: { attachmentId: 'att-2', backlogItemId: 'item-001', filename: 'notes.txt' },
+    });
+  });
+
+  it('returns a structured error when the ID matches neither surface', () => {
+    mockAttachmentRepoGetById.mockReturnValue(undefined);
+    mockBacklogAttachmentRepoGetById.mockReturnValue(undefined);
+
+    const result = handleRemoveAttachment({ attachmentId: 'missing-id' }, context);
+
+    expect(result).toEqual({ success: false, error: 'Attachment "missing-id" not found' });
+    expect(context.onTaskUpdated).not.toHaveBeenCalled();
+    expect(context.onBacklogChanged).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/mcp-task-session-tools.test.ts
+++ b/tests/unit/mcp-task-session-tools.test.ts
@@ -519,3 +519,159 @@ describe('list_sessions project routing via withProject', () => {
     expect((params as Record<string, unknown>).taskId).toBe('task-uuid');
   });
 });
+
+// ---------------------------------------------------------------------------
+// kangentic_update_task - "at least one field" guard must accept an
+// attachments-only call (the guard is evaluated at the Zod-validated tool
+// handler in task-tools.ts, BEFORE callHandler/handleUpdateTask ever run -
+// mcp-attachment-handlers.test.ts only covers the command-handler layer
+// underneath, so this closes the tool-layer gap).
+// ---------------------------------------------------------------------------
+
+describe('kangentic_update_task "at least one field" guard - attachments wiring', () => {
+  let server: ReturnType<typeof makeFakeServer>;
+  let resolver: RequestResolver;
+  let taskCounter: TaskCounter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    server = makeFakeServer();
+    resolver = makeResolver();
+    taskCounter = { tryReserve: vi.fn(() => true), limit: () => 50 };
+    registerTaskTools(server as never, resolver, taskCounter);
+  });
+
+  it('accepts an attachments-only call through the guard and forwards attachments to callHandler', async () => {
+    const result = await server.getHandler('kangentic_update_task')({
+      taskId: 'task-1',
+      attachments: [{ filePath: '/mock/screenshot.png' }],
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockCallHandler).toHaveBeenCalledOnce();
+    const [handlerName, params] = mockCallHandler.mock.calls[0];
+    expect(handlerName).toBe('update_task');
+    const typedParams = params as Record<string, unknown>;
+    expect(typedParams.attachments).toEqual([{ filePath: '/mock/screenshot.png' }]);
+    // Every other field forwards as null, matching the "omitted -> null" contract
+    // handleUpdateTask's `field !== null` checks depend on.
+    expect(typedParams.title).toBeNull();
+    expect(typedParams.description).toBeNull();
+  });
+
+  it('still rejects when taskId is the only field (attachments and everything else omitted)', async () => {
+    const result = await server.getHandler('kangentic_update_task')({ taskId: 'task-1' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Provide at least one field to update.');
+    expect(mockCallHandler).not.toHaveBeenCalled();
+  });
+
+  it('forwards attachments: null when attachments is omitted but another field is present', async () => {
+    await server.getHandler('kangentic_update_task')({ taskId: 'task-1', title: 'New title' });
+
+    expect(mockCallHandler).toHaveBeenCalledOnce();
+    const [, params] = mockCallHandler.mock.calls[0];
+    expect((params as Record<string, unknown>).attachments).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// kangentic_remove_task_attachment - tool registration and wiring at the
+// mcp-http layer (as opposed to handleRemoveAttachment's command-handler
+// logic, already covered in mcp-attachment-handlers.test.ts).
+// ---------------------------------------------------------------------------
+
+describe('kangentic_remove_task_attachment wiring', () => {
+  let server: ReturnType<typeof makeFakeServer>;
+  let resolver: RequestResolver;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    server = makeFakeServer();
+    resolver = makeResolver();
+    const taskCounter: TaskCounter = { tryReserve: vi.fn(() => true), limit: () => 50 };
+    registerTaskTools(server as never, resolver, taskCounter);
+  });
+
+  it('is registered on the server', () => {
+    expect(() => server.getHandler('kangentic_remove_task_attachment')).not.toThrow();
+  });
+
+  it('routes attachmentId and the project selector through withProject to callHandler("remove_attachment", ...)', async () => {
+    await server.getHandler('kangentic_remove_task_attachment')({ attachmentId: 'att-1', project: 'Beta' });
+
+    expect(mockWithProject).toHaveBeenCalledOnce();
+    const [passedResolver, passedSelector] = mockWithProject.mock.calls[0];
+    expect(passedResolver).toBe(resolver);
+    expect(passedSelector).toBe('Beta');
+
+    expect(mockCallHandler).toHaveBeenCalledOnce();
+    const [handlerName, params] = mockCallHandler.mock.calls[0];
+    expect(handlerName).toBe('remove_attachment');
+    expect(params).toEqual({ attachmentId: 'att-1' });
+  });
+
+  it('returns an error result and does not call callHandler when the project selector is invalid', async () => {
+    mockCallHandler.mockClear();
+
+    const result = await server.getHandler('kangentic_remove_task_attachment')({
+      attachmentId: 'att-1',
+      project: 'INVALID_PROJECT',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('No project matching "INVALID_PROJECT"');
+    expect(mockCallHandler).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// kangentic_update_backlog_item - attachments wiring at the mcp-http layer
+// (session-tools.ts). backlog-update-delete-handlers.test.ts already covers
+// the command-handler behavior underneath; this closes the tool-layer gap.
+// ---------------------------------------------------------------------------
+
+describe('kangentic_update_backlog_item attachments wiring', () => {
+  let server: ReturnType<typeof makeFakeServer>;
+  let resolver: RequestResolver;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    server = makeFakeServer();
+    resolver = makeResolver();
+    registerSessionTools(server as never, resolver);
+  });
+
+  it('forwards the attachments array through to callHandler when provided', async () => {
+    await server.getHandler('kangentic_update_backlog_item')({
+      itemId: 'item-001',
+      attachments: [{ filePath: '/mock/notes.txt' }],
+    });
+
+    expect(mockCallHandler).toHaveBeenCalledOnce();
+    const [handlerName, params] = mockCallHandler.mock.calls[0];
+    expect(handlerName).toBe('update_backlog_item');
+    expect((params as Record<string, unknown>).attachments).toEqual([{ filePath: '/mock/notes.txt' }]);
+  });
+
+  it('forwards attachments: null when the attachments field is omitted', async () => {
+    await server.getHandler('kangentic_update_backlog_item')({ itemId: 'item-001', title: 'New title' });
+
+    expect(mockCallHandler).toHaveBeenCalledOnce();
+    const [, params] = mockCallHandler.mock.calls[0];
+    expect((params as Record<string, unknown>).attachments).toBeNull();
+  });
+
+  it('routes the project selector through withProject alongside attachments', async () => {
+    await server.getHandler('kangentic_update_backlog_item')({
+      itemId: 'item-001',
+      attachments: [{ filePath: '/mock/notes.txt' }],
+      project: 'Beta',
+    });
+
+    expect(mockWithProject).toHaveBeenCalledOnce();
+    const [, passedSelector] = mockWithProject.mock.calls[0];
+    expect(passedSelector).toBe('Beta');
+  });
+});

--- a/tests/unit/mcp-tool-list-parity.test.ts
+++ b/tests/unit/mcp-tool-list-parity.test.ts
@@ -102,6 +102,7 @@ const MUTATING_NAME_PREFIXES = [
   'kangentic_create_',
   'kangentic_update_',
   'kangentic_delete_',
+  'kangentic_remove_',
   'kangentic_move_',
   'kangentic_promote_',
   'kangentic_link_',


### PR DESCRIPTION
## What

Adds MCP support for attaching files to an already-existing board task or backlog item, and for removing an attachment:

- `kangentic_update_task` and `kangentic_update_backlog_item` gain an additive `attachments: [{ filePath, filename? }]` field (append semantics - existing attachments are kept).
- New `kangentic_remove_task_attachment` tool detaches one attachment by ID, resolving automatically to the board (`task_attachments`) or backlog (`backlog_attachments`) store.

## Why

`kangentic_create_task` could only attach files at creation time. There was no way to attach a file to a task after the fact, or to detach one, which made operations like folding one task into another lossy: a source task's attachments couldn't be carried to the target and were destroyed on delete.

## How

Both new attach paths reuse the exact `readFileAsAttachment` + `AttachmentRepository`/`BacklogAttachmentRepository` flow `create_task` already uses, so no new persistence logic was needed. The command handlers skip the scalar-field DB write when only attachments changed (avoiding a gratuitous `updated_at` bump), then re-fetch the task/item so the response carries a fresh `attachment_count`. The new detach tool tries the board attachment repo first, falls back to the backlog one, and returns a structured "not found" error if neither matches - the attachment UUID alone determines which surface owns it.

`MCP_TOOL_MANIFEST` and `docs/mcp-server.md` were updated for tool-list parity (`mcp-tool-list-parity.test.ts`).

## Breaking changes

None. All changes are additive to existing tool schemas, plus one new tool.

## Tests

- New `tests/unit/mcp-attachment-handlers.test.ts`: `handleUpdateTask` append/combined/scalar-only response shape, and all three `handleRemoveAttachment` branches (board hit, backlog fallback, not found).
- Extended `tests/unit/backlog-update-delete-handlers.test.ts`: backlog attachment append (attachments-only and combined with a scalar field).
- Extended `tests/unit/mcp-task-session-tools.test.ts`: tool-registration-layer wiring for the new `attachments` fields and the new tool's argument routing.
- `tests/unit/mcp-tool-list-parity.test.ts` passes with the new tool and manifest entry.
- `npm run typecheck`, `npm run lint`, and a full `npm run build` all pass locally.

Generated with [Claude Code](https://claude.com/claude-code)
