### PR TITLE
docs(skills): refresh board PR status via kangentic_link_pr after merge

### DIFF
--- a/.claude/skills/merge-pull-request/SKILL.md
+++ b/.claude/skills/merge-pull-request/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Merge an already-green PR (rebase merge, delete branch) and fast-forward the local main checkout for HMR. This is the Ship It column skill. It assumes the Tests column (/pull-request) already drove the PR to green. Not for creating a PR (use /pull-request) or a direct quick-push (use /merge-back).
-allowed-tools: Read, Glob, Grep, Edit, Write, Bash(git:*), Bash(npm:*), Bash(gh:*), Agent, mcp__kangentic__kangentic_get_current_task
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash(git:*), Bash(npm:*), Bash(gh:*), Agent, mcp__kangentic__kangentic_get_current_task, mcp__kangentic__kangentic_link_pr
 ---
 
 # Merge Pull Request
@@ -44,7 +44,9 @@ to the head branch only when there is no stored number.
    operations (the worktree realign), NEVER for `gh pr` lookups.
 2. Resolve the PR number `<pr>`:
    - Call `kangentic_get_current_task` (it reads the worktree's task) and take its `pr_number`. If
-     present, that is `<pr>` (the reliable, branch-independent path).
+     present, that is `<pr>` (the reliable, branch-independent path). Also record the returned
+     task's ID as `<taskId>` - it is reused in Step 3 to force an immediate board refresh after the
+     merge. If no task is found, `<taskId>` stays unset and that refresh is skipped.
    - If absent, fall back to the head branch: `gh pr list --head <branch> --state open --json number`
      (covers older PRs where the local branch IS the head); `<pr>` is the first match's number.
 3. Run `gh pr view <pr> --json number,url,state,mergeable,mergeStateStatus,statusCheckRollup,headRefName`.
@@ -113,6 +115,21 @@ Record `<mergeMethod>` (rebase or squash) - it selects the realign below.
 **If the merge fails** for any OTHER reason than the expected missing-review block (e.g. the branch
 is behind and needs a rebase first, or a required check actually went red), do NOT force past it -
 report the unmet requirement and stop.
+
+### Refresh the board's PR status
+
+The board caches each task's PR state and only re-resolves it on a background timer (default 5 min)
+or on project open, so the Ship It card would otherwise keep showing "PR #<pr> open" for minutes
+after this merge. Force an immediate re-resolve so the card flips to "merged" right away:
+
+- If Step 0 resolved a `<taskId>`, call `kangentic_link_pr` with that task ID. It re-resolves the PR
+  by number (branch-independent, so it works after `--delete-branch`), writes the fresh `merged`
+  state, and pushes the update so the board card re-renders at once.
+- If no `<taskId>` was resolved (the worktree has no linked task), skip this - there is no board card
+  tracking the PR, so nothing is stale.
+
+Run this right after the merge succeeds, before the realign below, so the board updates even if the
+realign later needs to stop for a conflict.
 
 ### Realign the worktree branch (so move-to-Done reads clean)
 


### PR DESCRIPTION
## What

`/merge-pull-request` now forces an immediate board refresh right after it merges a PR, so the Ship
It card flips to "merged" instead of showing "PR #N open" until the next background poll (default 5
min).

- Step 0 records the resolved task's ID (`<taskId>`) alongside the PR number it already extracts
  from `kangentic_get_current_task`.
- A new "Refresh the board's PR status" subsection in Step 3 (right after the merge succeeds, before
  the worktree realign) calls the existing `kangentic_link_pr` tool with `<taskId>`, forcing a fresh
  PR re-resolve. If no task was resolved in Step 0, this step is skipped (no card is tracking that PR).
- `allowed-tools` in the skill frontmatter now includes `mcp__kangentic__kangentic_link_pr`.

## Why

Kangentic's PR-status cache is only refreshed by a periodic timer (`prRefreshScheduler`) plus a
sweep on project open. Nothing forced a refresh at the moment a user just watched `/merge-pull-request`
merge a PR, so the board stayed cosmetically stale for up to 5 minutes right when the user was most
likely looking at it.

The task originally proposed a new `kangentic_refresh_pr_status` MCP tool wrapping
`refreshProjectPRs`. Investigation found the capability already exists: `kangentic_link_pr` already
force-refreshes a single task's PR state (`linkPRForTask(..., force: true)`), resolving by PR number
so it survives the merge's `--delete-branch`, and its `onLinked` callback already pushes
`TASK_UPDATED_BY_AGENT` so the board re-renders live. Since `/merge-pull-request` already resolves
the task in Step 0, reusing the existing tool closes the gap with a skill-only change - no new tool,
manifest entry, docs page, or IPC wiring.

## How

Three edits to `.claude/skills/merge-pull-request/SKILL.md`:
1. Add `mcp__kangentic__kangentic_link_pr` to `allowed-tools`.
2. Step 0: record `<taskId>` from the existing `kangentic_get_current_task` call.
3. Step 3: new "Refresh the board's PR status" subsection that calls `kangentic_link_pr` with
   `<taskId>` right after the merge, guarded to skip when no task was resolved.

No product code changed; `refreshProjectPRs`, the MCP tool manifest, and `docs/mcp-server.md` are
untouched since no new tool was registered.

## Breaking changes

None.

## Tests

Markdown-only skill change with no runtime surface to unit test. Verified:
- `npm run typecheck` and `npm run lint` pass (no source files touched).
- Read-through confirms `<taskId>` is captured in Step 0 and consumed in the new Step 3 subsection,
  the skip-guard is present, and the new tool is whitelisted in `allowed-tools`.
- The next real `/merge-pull-request` run will exercise the new call end-to-end (board card flips to
  "merged" immediately after the merge instead of after the poll interval).

Generated with [Claude Code](https://claude.com/claude-code)
