### PR TITLE
feat(retrieval): central background embedding engine, duty-cycle throttled

### DIFF
--- a/.claude/rules/central-embedding-engine.md
+++ b/.claude/rules/central-embedding-engine.md
@@ -1,0 +1,62 @@
+---
+paths:
+  - "src/main/retrieval/**"
+  - "src/main/ipc/handlers/**"
+---
+# Rule: only the central embedding engine embeds
+
+Embedding inference used to be triggered by lifecycle/navigation events: `startForProject` ran
+an inline embed pass on every project open, and turn-boundary live-index, finalize, and a
+`getStatus`-polled heal each did the same. Switching back to a project whose active task was
+churning embedded the freshly-indexed chunks right at navigation time - a felt hardware spike
+(GPU power draw, or a multi-second CPU burn) correlated with the click, not with any real-time
+constraint. See the central-background-embedding task for the full history; commit `5eac2f93`
+(#352) fixed the *cold-load* spikes this rule's refactor could not (warm-holding the worker) -
+this rule is about the *residual*: the legitimate inference cost of embedding itself.
+
+## The rule
+
+`src/main/retrieval/embedder/embed-engine.ts` is the **only** place in the app that:
+
+1. Constructs an `EmbedClient` (`new EmbedClient(...)`).
+2. Calls `.embed(...)` on it to embed chunks in bulk.
+3. Decides *when* to embed (its own self-paced, duty-cycle-throttled drain loop).
+
+Everywhere else - lifecycle hooks (session finalize, live turn-boundary index, project open),
+IPC handlers (`src/main/ipc/handlers/**`), and config-change reconciliation - may only:
+
+- **Index** (a cheap diff-upsert via `ConversationIndexer`) and then call
+  `embedEngine.markDirty(projectId)` to flag that project has pending chunks. This must happen
+  unconditionally (regardless of whether semantic search is currently enabled) - the engine's own
+  gates decide whether to act on it, so a premature "semantic is off" check at the call site would
+  permanently drop the flag instead of deferring it.
+- **Query** through `retrievalService.getEmbedder(context)` (which delegates to
+  `embedEngine.getEmbedder`) for the interactive search / MCP recall path. A live user query
+  always takes priority over the background drain in the shared worker (see
+  `EmbedWorkerClient.waitForInteractiveIdle()` in `embed-client.ts`).
+- **Reconcile** via `retrievalService.reconcileEmbedWorker(context)` (warm-hold gate + dirty
+  re-mark on a semantic/model/acceleration change).
+
+A project switch must never perform synchronous embedding work. If you find yourself writing
+`await embedPass(...)` or `client.embed(...)` in a lifecycle hook or an IPC handler, that is the
+regression this rule exists to catch - route the chunk-producing event through `markDirty`
+instead and let the engine's drain loop pick it up in the background.
+
+## Enforcement (self-maintaining)
+
+- **Test:** `tests/unit/central-embedding-engine-boundary.test.ts` statically scans `src/main` and
+  fails if `new EmbedClient(` appears outside `embed-engine.ts`, if the deleted `embedPass`/
+  `scheduleEmbedHeal` functions ever reappear as a call/declaration, or if any file under
+  `src/main/ipc/handlers/**` calls `.embed(` directly. Runs in CI via `npm run test:unit`.
+- **Tests:** `tests/unit/embed-engine.test.ts` pins the drain loop's scheduling contract (the
+  duty-cycle pacer math, FIFO-within-a-project / round-robin-across-projects draining, and
+  crash/transient resume) via the engine's own DI seam (`createEmbedEngine(deps)`).
+- **Review:** `/code-review` should flag any new inline embed trigger during a change to
+  `src/main/retrieval/**` or `src/main/ipc/handlers/**`.
+
+## Scope
+
+`src/main/retrieval/**` (the retrieval/embedding subsystem) and `src/main/ipc/handlers/**` (the
+lifecycle/config call sites that produce chunks or toggle semantic search). Does not cover the
+renderer, which only ever reads `MemoryStatus` via `getStatus()` and never triggers embedding
+itself.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,7 @@ session; rules with one load when you touch matching files. Each rule names its 
 - `cross-platform-parity.md` - code and tests must behave identically on Windows/macOS/Linux/CI; no OS-specific paths, no cross-test state leakage or pixel-exact assertions (`tests/`, `src/main/` pty/agent/git).
 - `browser-automation-driver.md` - the shipped CDP driver is singular and ships; every `kangentic_browser_*` tool routes through `withGuest`; no `src/devtools/` import from shipped code (`src/main/browser/`).
 - `mcp-tool-list-parity.md` - every MCP tool registered under `src/main/agent/mcp-http/*-tools.ts` stays in sync with `MCP_TOOL_MANIFEST` (the settings panel's source) and `docs/mcp-server.md` (`src/main/agent/mcp-http/`, `src/shared/mcp-tool-manifest.ts`).
+- `central-embedding-engine.md` - only `embed-engine.ts` embeds; lifecycle/IPC call sites index and `markDirty()`, never embed inline (`src/main/retrieval/**`, `src/main/ipc/handlers/**`).
 
 **Local overrides:** there is no per-rule local file. Put machine-specific instruction
 overrides in a gitignored `CLAUDE.local.md` at the project root.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,6 +54,7 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 |---------|---------|---------|
 | `dev:createEphemeralProject` | invoke | Clone the current worktree into an isolated, throwaway preview project (TestHarness "Create Project" button); fills its working tree in the background and returns the usable `Project` |
 | `dev:seedGitChanges` | invoke | Seed a realistic all-scopes / all-statuses git changeset (committed, staged, working) into each ephemeral preview repo (active task worktrees plus the project) so the Changes tab has content to exercise; silently skips any path outside the preview-projects root. Returns `DevSeedGitChangesResult` |
+| `dev:seedEmbeddingBacklog` | invoke | Seed synthetic pending chunks (`embedded_model = NULL`) into the current project's conversation-memory index via the real chunk-write path, then flag the project dirty (TestHarness "Seed Embedding Backlog" button) - a fast path to a realistic embedding backlog for exercising the central embedding engine's drain loop without needing that many real agent turns. Returns `DevSeedEmbeddingBacklogResult` |
 
 ### Project Groups (6 channels)
 | Channel | Pattern | Purpose |

--- a/src/devtools/main/seed-embedding-backlog.ts
+++ b/src/devtools/main/seed-embedding-backlog.ts
@@ -1,0 +1,102 @@
+/**
+ * Dev-only: seed a realistic embedding backlog into the current project so
+ * the central embedding engine's drain loop can be exercised under sustained
+ * real-worker load without needing that many real agent turns.
+ *
+ * The engine only cares about `memory_chunks.embedded_model IS NULL` - it has
+ * no notion of where a chunk came from. So this writes synthetic chunks
+ * through the SAME `RetrievalStore.upsertDocument` path real conversation
+ * indexing uses (a distinct 'dev-seed' corpus, clearly labeled text), then
+ * flags the project dirty exactly the way `scheduleFinalizeIndex` /
+ * `scheduleLiveIndex` / `startForProject` do. From there the real drain loop,
+ * real EmbedClient, and real duty-cycle pacing take over - this seeds data,
+ * it does not shortcut the embedding path itself.
+ *
+ * Build-excluded from production: imported only behind `__KANGENTIC_DEV__`
+ * guards (src/main/index.ts), so esbuild dead-code elimination drops this
+ * module from prod bundles. See `.claude/rules/dev-tooling-build-exclusion.md`.
+ */
+
+import crypto from 'node:crypto';
+import { ipcMain } from 'electron';
+import { IPC } from '../../shared/ipc-channels';
+import { getProjectDb } from '../../main/db/database';
+import { RetrievalStore } from '../../main/retrieval/retrieval-store';
+import { embedEngine } from '../../main/retrieval/embedder/embed-engine';
+import type { ChunkInput } from '../../main/retrieval/types';
+import type { DevSeedEmbeddingBacklogResult } from '../../shared/types';
+import type { IpcContext } from '../../main/ipc/ipc-context';
+
+/** Distinct from the real 'conversation' corpus so seeded rows are easy to
+ *  identify (and, if ever needed, purge) without touching real history. */
+const CORPUS = 'dev-seed';
+
+function sha1(text: string): string {
+  return crypto.createHash('sha1').update(text).digest('hex');
+}
+
+// Module state; resets when the main process restarts. Each click uses a
+// fresh index so re-clicks land a new, non-colliding synthetic document.
+let seedRunIndex = 0;
+
+function makeSyntheticChunks(count: number, runIndex: number): ChunkInput[] {
+  const chunks: ChunkInput[] = [];
+  for (let seq = 0; seq < count; seq += 1) {
+    const text =
+      `[DEV SEED #${runIndex}] Synthetic embedding-backlog stress-test chunk ${seq + 1} of ${count}. ` +
+      'Throwaway text from the Test Harness "Seed Embedding Backlog" button - exercises the ' +
+      'background embedding engine\'s drain loop under a realistic backlog size, without needing ' +
+      'that many real agent turns to produce it.';
+    chunks.push({
+      seq,
+      text,
+      contentHash: sha1(text),
+      tokenEstimate: Math.ceil(text.length / 4),
+      role: 'user',
+      tsStart: null,
+      tsEnd: null,
+      turnUuidStart: null,
+      turnUuidEnd: null,
+    });
+  }
+  return chunks;
+}
+
+/** Seed `count` synthetic pending chunks into the current project and flag it
+ *  dirty. Throws when no project is open. */
+export function seedEmbeddingBacklog(context: IpcContext, count: number): DevSeedEmbeddingBacklogResult {
+  const projectId = context.currentProjectId;
+  if (!projectId) throw new Error('Open a project first to seed an embedding backlog');
+
+  seedRunIndex += 1;
+  const runIndex = seedRunIndex;
+  const docId = `dev-seed-embedding-backlog-${runIndex}`;
+
+  const db = getProjectDb(projectId);
+  const store = new RetrievalStore(db);
+  store.upsertDocument(
+    { corpus: CORPUS, docId, sessionId: null, taskId: null, agentSessionId: null, metaJson: null },
+    makeSyntheticChunks(count, runIndex),
+  );
+
+  // Flag the project dirty exactly the way a real chunk producer would - the
+  // engine's own drain loop, real EmbedClient, and duty-cycle pacer do
+  // everything else from here.
+  embedEngine.markDirty(projectId);
+
+  return { seeded: count, docId };
+}
+
+let devIpcRegistered = false;
+
+/** Register the dev-only IPC behind the TestHarness "Seed Embedding Backlog"
+ *  button. Idempotent. */
+export function registerSeedEmbeddingBacklogDevIpc(getContext: () => IpcContext | null): void {
+  if (devIpcRegistered) return;
+  devIpcRegistered = true;
+  ipcMain.handle(IPC.DEV_SEED_EMBEDDING_BACKLOG, (_event, count: number): DevSeedEmbeddingBacklogResult => {
+    const context = getContext();
+    if (!context) throw new Error('IPC not initialized');
+    return seedEmbeddingBacklog(context, count);
+  });
+}

--- a/src/devtools/renderer/TestHarness.tsx
+++ b/src/devtools/renderer/TestHarness.tsx
@@ -16,10 +16,17 @@
  */
 
 import { useState } from 'react';
-import { Plus, FolderPlus, FileDiff } from 'lucide-react';
+import { Plus, FolderPlus, FileDiff, Database } from 'lucide-react';
 import { useBoardStore } from '../../renderer/stores/board-store';
 import { useProjectStore } from '../../renderer/stores/project-store';
 import { useToastStore } from '../../renderer/stores/toast-store';
+
+/** Default seed count for "Seed Embedding Backlog": large enough to force
+ *  hundreds of real drain-loop round-robin iterations against the live embed
+ *  worker (a multi-minute soak test, not an instant no-op), in the same
+ *  ballpark as a real one-time model-switch backfill, while staying well
+ *  short of a full multi-hour history backfill. */
+const EMBEDDING_BACKLOG_SEED_COUNT = 3000;
 
 // Lorem source. Titles/descriptions are deliberately meaningless so that
 // dragging a seeded task to an executing column gives the agent nothing real to
@@ -118,6 +125,7 @@ export function TestHarness() {
   const [creating, setCreating] = useState(false);
   const [creatingProject, setCreatingProject] = useState(false);
   const [seeding, setSeeding] = useState(false);
+  const [seedingBacklog, setSeedingBacklog] = useState(false);
 
   const handleCreateTask = async () => {
     const todoSwimlane = useBoardStore.getState().swimlanes.find((lane) => lane.role === 'todo');
@@ -209,6 +217,38 @@ export function TestHarness() {
     }
   };
 
+  // Dev-only: seed a realistic embedding backlog (thousands of pending chunks)
+  // into the current project so the central embedding engine's drain loop can
+  // be exercised under sustained real-worker load. The engine only cares
+  // about memory_chunks.embedded_model IS NULL, not where the row came from,
+  // so this needs no real tasks or agent sessions to reach that scale.
+  const handleSeedEmbeddingBacklog = async () => {
+    const project = useProjectStore.getState().currentProject;
+    if (!project) {
+      useToastStore.getState().addToast({ message: 'Open a project first to seed an embedding backlog', variant: 'warning' });
+      return;
+    }
+    setSeedingBacklog(true);
+    try {
+      const result = await window.electronAPI.dev?.seedEmbeddingBacklog(EMBEDDING_BACKLOG_SEED_COUNT);
+      if (!result) {
+        useToastStore.getState().addToast({ message: 'Seeding an embedding backlog is dev-preview only', variant: 'warning' });
+        return;
+      }
+      useToastStore.getState().addToast({
+        message: `Seeded ${result.seeded} pending chunks - enable Semantic search (Settings > Memory) to watch the drain`,
+        variant: 'success',
+      });
+    } catch (error) {
+      useToastStore.getState().addToast({
+        message: `Failed to seed embedding backlog: ${error instanceof Error ? error.message : 'unknown error'}`,
+        variant: 'error',
+      });
+    } finally {
+      setSeedingBacklog(false);
+    }
+  };
+
   return (
     <div
       className="fixed left-6 top-1/2 -translate-y-1/2 z-[2147483600] flex flex-col gap-1.5 rounded-lg border border-edge bg-surface-raised/95 p-1.5 shadow-2xl backdrop-blur"
@@ -245,6 +285,17 @@ export function TestHarness() {
       >
         <FileDiff size={16} />
         {seeding ? 'Seeding...' : 'Seed File Changes'}
+      </button>
+      <button
+        type="button"
+        onClick={handleSeedEmbeddingBacklog}
+        disabled={seedingBacklog}
+        className="flex items-center gap-1.5 rounded-md border border-edge bg-surface-raised px-3.5 py-2 text-[13px] font-medium text-fg hover:bg-surface disabled:opacity-50 transition-colors"
+        data-testid="dev-seed-embedding-backlog"
+        title={`Seed ${EMBEDDING_BACKLOG_SEED_COUNT} synthetic pending chunks to stress-test the background embedding engine's drain loop`}
+      >
+        <Database size={16} />
+        {seedingBacklog ? 'Seeding...' : 'Seed Embedding Backlog'}
       </button>
     </div>
   );

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import { startEventLoopLagMonitor } from './diagnostics/event-loop-lag';
 import { createPreviewClone, fillPreviewClone, registerEphemeralProjectDevIpc } from '../devtools/main/ephemeral-projects';
 import { resolvePreviewTaskTitle } from '../devtools/main/preview-task-title';
 import { registerSeedGitChangesDevIpc } from '../devtools/main/seed-git-changes';
+import { registerSeedEmbeddingBacklogDevIpc } from '../devtools/main/seed-embedding-backlog';
 import { installDevtools } from '../devtools/install';
 import { startMcpHttpServer, type McpHttpServerHandle } from './agent/mcp-http-server';
 import { readBrowserAutomationConfig } from './browser/browser-automation-config';
@@ -81,10 +82,22 @@ function safeReadDeveloperFlag(
     // session and almost certainly wants the agent-driven inspection bridge
     // (including eval, inject-event, raw-PTY) available without flipping a
     // toggle each launch. Both are localhost-only and dropped from production
-    // builds via `__KANGENTIC_DEV__`. The other toggles (overlay, log mirror,
-    // IPC recorder) still default OFF because they have a visible/disk cost the
-    // user should opt into deliberately. An explicit stored value always wins.
+    // builds via `__KANGENTIC_DEV__`. An explicit stored value always wins.
     if (key === 'previewInspectionServer' || key === 'previewEvalEnabled') return __KANGENTIC_DEV__;
+    // Persistent console logs default ON in ANY dev build (npm start dogfooding
+    // AND /preview): the write path is already async-queued (queueAppend in
+    // log-mirror.ts defers the actual disk write to the next setImmediate turn,
+    // no per-call blocking appendFileSync/mkdirSync), so this has no measurable
+    // dogfooding performance cost, and having the trace already captured is far
+    // more useful than remembering to flip it before a debugging session starts.
+    if (key === 'persistConsoleLogs') return __KANGENTIC_DEV__;
+    // The IPC recorder is different: it has a real, documented disk-I/O cost per
+    // call ("non-trivial disk impact"). Default it ON only for the ephemeral
+    // `/preview` instance, whose entire data dir (including .kangentic/logs/) is
+    // wiped on close, bounding the growth. The regular npm start dogfooding
+    // session runs for days, so it stays opt-in there to avoid unbounded trace
+    // accumulation the user did not ask for.
+    if (key === 'recordIpcTraffic') return __KANGENTIC_DEV__ && isEphemeral;
     return false;
   } catch {
     return false;
@@ -611,6 +624,10 @@ const createWindow = () => {
           // registered in ephemeral preview, the one place its safety guard
           // (preview-projects root) has clones to operate on.
           registerSeedGitChangesDevIpc();
+          // Seed-embedding-backlog dev IPC for the TestHarness "Seed Embedding
+          // Backlog" button - a realistic pending-chunk count for exercising the
+          // central embedding engine's drain loop under sustained real-worker load.
+          registerSeedEmbeddingBacklogDevIpc(getOptionalIpcContext);
           // Adopt the two clones the /preview script pre-cloned (overlapping the
           // build); add more on demand via the TestHarness "Create Project" button.
           const project1 = await createPreviewClone(ephemeralContext, cwd); // adopts "Project 1"
@@ -642,6 +659,25 @@ const createWindow = () => {
       const project = await openProjectByPath(projectPath);
       endPhase('openProjectByPath');
       mark('project_opened');
+      // openProjectByPath is deliberately lighter than the project:open IPC
+      // handler (project:open is what fires on every manual sidebar switch)
+      // and does not start conversation-memory indexing or flag the project's
+      // embedding backlog dirty. Without this, a project auto-restored on cold
+      // boot would never resume an embedding backlog left mid-drain from a
+      // prior session - the engine's drain loop is alive but stays parked on
+      // an empty dirty-set until something marks this project dirty, and nothing
+      // else does for THIS specific path (getStatus()'s self-heal only fires if
+      // the user happens to open Quick Find or Settings -> Memory).
+      //
+      // This call site fires exactly ONCE per app launch (preloadPromise is a
+      // one-shot IIFE inside createWindow, structurally separate from the
+      // project:open handler that already handles every subsequent switch) -
+      // it does not run again on project switching, so it does not reintroduce
+      // navigation-triggered embedding. startForProject itself is switch-safe
+      // regardless (it only does a deferred sweep + markDirty, never inline
+      // embedding - the background engine alone decides when to actually embed).
+      const context = getOptionalIpcContext();
+      if (project && context) retrievalService.startForProject(context, project);
       return project;
     } catch (err) {
       endPhase('openProjectByPath');

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,6 +35,7 @@ import { loadVecExtension } from './retrieval/vec-extension';
 import { restoreShellEnv } from './shell-env';
 import { isFirstPartyPermissionAllowed } from './permission-policy';
 import { MIN_ZOOM, MAX_ZOOM } from '../shared/zoom-steps';
+import { defaultDeveloperFlag, type DeveloperFlagKey } from '../shared/developer-flag-defaults';
 
 initStartupTimer(PROCESS_START);
 mark('process_start');
@@ -63,42 +64,18 @@ installDiagnostics({
     safeReadDeveloperFlag('recordIpcTraffic'),
 });
 
-function safeReadDeveloperFlag(
-  key:
-    | 'activityDebugOverlay'
-    | 'persistConsoleLogs'
-    | 'recordIpcTraffic'
-    | 'previewInspectionServer'
-    | 'previewEvalEnabled',
-): boolean {
+function safeReadDeveloperFlag(key: DeveloperFlagKey): boolean {
   try {
     const ctx = getOptionalIpcContext();
     const manager = ctx?.configManager ?? windowConfigManager;
     const stored = manager.load().developer?.[key];
     if (stored !== undefined) return stored === true;
-    // Default values when the user has never touched the toggle. The
-    // inspection bridge AND its eval/unsafe gate default ON in dev builds:
-    // anyone running `npm start` / `/preview` is by definition a kangentic dev
-    // session and almost certainly wants the agent-driven inspection bridge
-    // (including eval, inject-event, raw-PTY) available without flipping a
-    // toggle each launch. Both are localhost-only and dropped from production
-    // builds via `__KANGENTIC_DEV__`. An explicit stored value always wins.
-    if (key === 'previewInspectionServer' || key === 'previewEvalEnabled') return __KANGENTIC_DEV__;
-    // Persistent console logs default ON in ANY dev build (npm start dogfooding
-    // AND /preview): the write path is already async-queued (queueAppend in
-    // log-mirror.ts defers the actual disk write to the next setImmediate turn,
-    // no per-call blocking appendFileSync/mkdirSync), so this has no measurable
-    // dogfooding performance cost, and having the trace already captured is far
-    // more useful than remembering to flip it before a debugging session starts.
-    if (key === 'persistConsoleLogs') return __KANGENTIC_DEV__;
-    // The IPC recorder is different: it has a real, documented disk-I/O cost per
-    // call ("non-trivial disk impact"). Default it ON only for the ephemeral
-    // `/preview` instance, whose entire data dir (including .kangentic/logs/) is
-    // wiped on close, bounding the growth. The regular npm start dogfooding
-    // session runs for days, so it stays opt-in there to avoid unbounded trace
-    // accumulation the user did not ask for.
-    if (key === 'recordIpcTraffic') return __KANGENTIC_DEV__ && isEphemeral;
-    return false;
+    // Default values when the user has never touched the toggle. An explicit
+    // stored value always wins (checked above). The decision logic itself
+    // lives in the dependency-free `defaultDeveloperFlag` (src/shared/) so it
+    // is unit-testable without importing this Electron entry-point module -
+    // see the doc comment there for the reasoning behind each key's default.
+    return defaultDeveloperFlag(key, __KANGENTIC_DEV__, isEphemeral);
   } catch {
     return false;
   }

--- a/src/main/ipc/register-all.ts
+++ b/src/main/ipc/register-all.ts
@@ -38,6 +38,7 @@ import { registerGitDiffHandlers } from './handlers/git-diff';
 import { registerBrowserHandlers } from './handlers/browser';
 import { registerSearchHandlers } from './handlers/search';
 import { registerTranscriptHandlers } from './handlers/transcripts';
+import { retrievalService } from '../retrieval/retrieval-service';
 import type { IpcContext } from './ipc-context';
 import type { McpHttpServerHandle } from '../agent/mcp-http-server';
 
@@ -140,6 +141,13 @@ export function registerAllIpc(mainWindow: BrowserWindow, mcpServerHandle: McpHt
   registerSearchHandlers(context);
   registerTranscriptHandlers(context);
   registerSystemHandlers(context);
+
+  // Start the central embedding engine's background drain loop at boot, not
+  // lazily on the first project:open. attach() is idempotent, so the later
+  // startForProject() call on project open just no-ops this part; what
+  // matters is the drain loop is alive even before any project is open (it
+  // parks on an empty dirty-set until markDirty wakes it).
+  retrievalService.attach(context);
 
   // Periodically flush live-session metrics so an app/OS kill mid-run doesn't
   // lose that run's cost/duration/compactions (stopped on before-quit).

--- a/src/main/retrieval/embedder/embed-client.ts
+++ b/src/main/retrieval/embedder/embed-client.ts
@@ -80,6 +80,17 @@ export class EmbedClient implements Embedder {
   /** True while an intentional teardown (idle recycle or dispose) is in flight,
    *  so the resulting 'exit' is not miscounted as a crash. */
   private intentionalShutdown = false;
+  /** Resolved (and cleared) whenever no interactive (non-background) request
+   *  is in flight. See waitForInteractiveIdle(). */
+  private interactiveIdleWaiters: Array<() => void> = [];
+  /** Count of interactive (non-background) embed() calls currently anywhere in
+   *  flight - INCLUDING the ensureReady() worker-spawn/init window, before the
+   *  request reaches `this.pending` in sendEmbed(). This is what
+   *  hasInteractiveInFlight() consults: scanning `pending` alone would miss a
+   *  live query still blocked in ensureReady() on a cold worker start, letting
+   *  the background drain post ahead of it and break the "a live query always
+   *  preempts the drain" invariant. */
+  private interactiveInFlightCount = 0;
 
   get crashed(): boolean {
     return this.crashCount >= MAX_CRASHES;
@@ -93,21 +104,64 @@ export class EmbedClient implements Embedder {
 
   async embed(
     texts: string[],
-    opts?: { timeoutMs?: number; isQuery?: boolean },
+    opts?: { timeoutMs?: number; isQuery?: boolean; background?: boolean },
   ): Promise<Float32Array[] | null> {
     if (texts.length === 0) return [];
     if (this.disposed || this.crashed) return null;
     if (this.pending.size >= QUEUE_CAP) return null;
 
-    const ready = await this.ensureReady();
-    if (!ready || this.disposed) return null;
-
-    this.clearIdleTimer();
+    const background = opts?.background ?? false;
+    // Track interactive intent BEFORE ensureReady() so a live query counts as
+    // in-flight during the cold-start worker-spawn window, not only once it
+    // reaches sendEmbed(). Cleared in the finally, which also wakes any waiters.
+    if (!background) this.interactiveInFlightCount += 1;
     try {
-      return await this.sendEmbed(texts, opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS, opts?.isQuery ?? false);
+      const ready = await this.ensureReady();
+      if (!ready || this.disposed) return null;
+
+      this.clearIdleTimer();
+      try {
+        return await this.sendEmbed(
+          texts,
+          opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          opts?.isQuery ?? false,
+        );
+      } finally {
+        this.armIdleShutdown();
+      }
     } finally {
-      this.armIdleShutdown();
+      if (!background) {
+        this.interactiveInFlightCount -= 1;
+        this.notifyInteractiveIdleIfClear();
+      }
     }
+  }
+
+  /** Resolves once no interactive (non-background) request is in flight.
+   *  The background drain (embed-engine) awaits this before every post so it
+   *  never sits in front of a live search / MCP recall query. Resolves
+   *  immediately when nothing interactive is pending. */
+  waitForInteractiveIdle(): Promise<void> {
+    if (!this.hasInteractiveInFlight()) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      this.interactiveIdleWaiters.push(resolve);
+    });
+  }
+
+  private hasInteractiveInFlight(): boolean {
+    // Counter, not a `pending` scan: it also covers the ensureReady() window
+    // before an interactive request is recorded in `pending`, and it spans the
+    // full embed() call for every non-background request, so it strictly
+    // subsumes the old scan.
+    return this.interactiveInFlightCount > 0;
+  }
+
+  private notifyInteractiveIdleIfClear(): void {
+    if (this.interactiveIdleWaiters.length === 0) return;
+    if (this.hasInteractiveInFlight()) return;
+    const waiters = this.interactiveIdleWaiters;
+    this.interactiveIdleWaiters = [];
+    for (const resolve of waiters) resolve();
   }
 
   /** Spawn + init the worker if needed. Memoized; returns false on failure. */
@@ -157,12 +211,17 @@ export class EmbedClient implements Embedder {
 
   private readyResolver: ((ok: boolean) => void) | null = null;
 
-  private sendEmbed(texts: string[], timeoutMs: number, isQuery: boolean): Promise<Float32Array[] | null> {
+  private sendEmbed(
+    texts: string[],
+    timeoutMs: number,
+    isQuery: boolean,
+  ): Promise<Float32Array[] | null> {
     if (!this.child) return Promise.resolve(null);
     const requestId = this.nextRequestId++;
     return new Promise<Float32Array[] | null>((resolve) => {
       const timer = setTimeout(() => {
         this.pending.delete(requestId);
+        this.notifyInteractiveIdleIfClear();
         resolve(null);
       }, timeoutMs);
       timer.unref();
@@ -194,6 +253,7 @@ export class EmbedClient implements Embedder {
       if (!entry) return;
       clearTimeout(entry.timer);
       this.pending.delete(record.id);
+      this.notifyInteractiveIdleIfClear();
       entry.resolve(record.type === 'result' ? record.vectors ?? null : null);
     }
   }
@@ -209,6 +269,7 @@ export class EmbedClient implements Embedder {
       entry.resolve(null);
     }
     this.pending.clear();
+    this.notifyInteractiveIdleIfClear();
     // An idle recycle or dispose is not a crash; only an unexpected exit counts.
     if (!this.disposed && !this.intentionalShutdown) this.crashCount += 1;
     this.intentionalShutdown = false;
@@ -262,6 +323,7 @@ export class EmbedClient implements Embedder {
       entry.resolve(null);
     }
     this.pending.clear();
+    this.notifyInteractiveIdleIfClear();
     this.killChild();
   }
 }

--- a/src/main/retrieval/embedder/embed-engine.ts
+++ b/src/main/retrieval/embedder/embed-engine.ts
@@ -1,0 +1,474 @@
+/**
+ * Central, project-agnostic background embedding engine. This is the ONLY
+ * embedder of chunks in the app - lifecycle/navigation events (project open,
+ * session finalize, live turn-boundary index) only INDEX (a cheap diff-upsert)
+ * and call `markDirty(projectId)`; they never embed inline. A project switch
+ * therefore performs zero synchronous embedding work, which is what makes the
+ * felt hardware spike on project switch impossible by construction.
+ *
+ * Owns the embed worker singleton (moved out of retrieval-service.ts), a
+ * dirty-set of project ids with pending chunks, and a single self-paced drain
+ * loop that:
+ *  - round-robins across dirty projects, FIFO within each (oldest chunk id
+ *    first, via RetrievalStore.chunksNeedingEmbedding),
+ *  - embeds one small batch at a time and paces itself with a measured
+ *    duty-cycle sleep (see computeEmbedSleepMs) so embedding's own
+ *    contribution to CPU/GPU never sustains a peg on any backend - this
+ *    applies identically to steady per-turn churn AND to a large first-run or
+ *    model-switch backfill, which is why those large one-time passes are
+ *    silent instead of a felt burn,
+ *  - always yields the shared worker to a live interactive query (search /
+ *    MCP recall) via `waitForInteractiveIdle()`, bounded so a continuous
+ *    stream of queries can slow but never permanently starve the drain.
+ *
+ * The DB is the durable queue (`chunksNeedingEmbedding` / `embedded_model`),
+ * so a crash mid-drain just leaves chunks pending; the next markDirty (or the
+ * getStatus safety-net re-mark) resumes them - nothing is lost.
+ */
+
+import type Database from 'better-sqlite3';
+import { getProjectDb } from '../../db/database';
+import { RetrievalStore } from '../retrieval-store';
+import { hasVecSupport } from '../vec-support';
+import { EmbedClient } from './embed-client';
+import { EMBED_DRAIN_BATCH, EMBED_DUTY_CYCLE, resolveEmbeddingModel, type EmbeddingModelDef } from './embedding-config';
+import { isEmbeddingModelPresent } from './embedding-model';
+import type { IpcContext } from '../../ipc/ipc-context';
+import type { Embedder, StoredChunk } from '../types';
+import type { MemoryAcceleration } from '../../../shared/types';
+
+/** The narrow slice of RetrievalStore the engine actually uses. Structural
+ *  (not the concrete class) so unit tests inject a plain fake object without
+ *  having to satisfy RetrievalStore's private fields. */
+export interface EmbedStore {
+  getMeta(key: string): string | undefined;
+  setMeta(key: string, value: string): void;
+  resetVec(dimensions: number): void;
+  ensureVecTable(dimensions: number): void;
+  readonly hasVec: boolean;
+  chunksNeedingEmbedding(modelTag: string, limit: number): StoredChunk[];
+  writeEmbeddings(rows: Array<{ chunkId: number; vector: Float32Array; contentHash: string }>, modelTag: string): void;
+}
+
+/** The narrow slice of EmbedClient the engine actually uses. Structural, for
+ *  the same reason as EmbedStore. Extends `Embedder` (dimensions/modelTag/
+ *  noiseFloor/embed) because resolveEmbedder hands this straight to the
+ *  interactive query path, which relies on those fields. */
+export interface EmbedWorkerClient extends Embedder {
+  embed(texts: string[], opts?: { timeoutMs?: number; isQuery?: boolean; background?: boolean }): Promise<Float32Array[] | null>;
+  setWarmHold(hold: boolean): void;
+  waitForInteractiveIdle(): Promise<void>;
+  dispose(): void;
+  readonly crashed: boolean;
+  readonly activeDevice: string | null;
+}
+
+/** How long a batch's transient failure (timeout / queue-full) backs off
+ *  before the project is retried. */
+const TRANSIENT_BACKOFF_MS = 2_000;
+/** Upper bound on how long the drain waits for the worker to go interactive-
+ *  idle before posting anyway. Keeps a continuous stream of live queries from
+ *  permanently starving the background drain. */
+const INTERACTIVE_IDLE_WAIT_CAP_MS = 300;
+
+/** Pure duty-cycle pacer: given the last batch's measured wall-time, how long
+ *  to sleep so the worker infers for at most `dutyCycle` of wall-time. This is
+ *  a machine-independent AVERAGE ceiling (not a wall-clock target): because it
+ *  is driven by the batch's REAL measured time, it self-adapts to any
+ *  backend/model with no per-device tuning table, and it self-throttles
+ *  GENTLER under contention (a busy machine inflates batchMs, which inflates
+ *  the sleep) - it can never make an already-busy machine busier. */
+export function computeEmbedSleepMs(lastBatchMs: number, dutyCycle: number): number {
+  if (dutyCycle <= 0) return 0;
+  return Math.max(0, lastBatchMs * (1 / dutyCycle - 1));
+}
+
+/** Wait for `promise` to settle, or fall through after `capMs` - whichever is
+ *  first. Used to bound the interactive-idle wait. */
+function raceWithCap(promise: Promise<void>, capMs: number, delay: (ms: number) => Promise<void>): Promise<void> {
+  return Promise.race([promise, delay(capMs)]);
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref();
+  });
+}
+
+export interface EmbedEngineDeps {
+  getDb: (projectId: string) => Database.Database;
+  createStore: (db: Database.Database) => EmbedStore;
+  createClient: (model: EmbeddingModelDef, acceleration: MemoryAcceleration) => EmbedWorkerClient;
+  delay: (ms: number) => Promise<void>;
+  dutyCycle: number;
+  drainBatchSize: number;
+  interactiveIdleWaitCapMs: number;
+  transientBackoffMs: number;
+}
+
+const defaultDeps: EmbedEngineDeps = {
+  getDb: getProjectDb,
+  createStore: (db) => new RetrievalStore(db),
+  createClient: (model, acceleration) => new EmbedClient(model, acceleration),
+  delay: defaultDelay,
+  dutyCycle: EMBED_DUTY_CYCLE,
+  drainBatchSize: EMBED_DRAIN_BATCH,
+  interactiveIdleWaitCapMs: INTERACTIVE_IDLE_WAIT_CAP_MS,
+  transientBackoffMs: TRANSIENT_BACKOFF_MS,
+};
+
+/** Config/model accessors the engine needs from an IpcContext. Kept as free
+ *  functions (mirroring retrieval-service.ts) rather than methods so the
+ *  engine has no dependency on the service module. */
+function isSemanticEnabled(context: IpcContext): boolean {
+  try {
+    return context.configManager.load().memory?.semanticEnabled === true;
+  } catch {
+    return false;
+  }
+}
+
+function selectedModel(context: IpcContext): EmbeddingModelDef {
+  try {
+    return resolveEmbeddingModel(context.configManager.load().memory?.embeddingModel);
+  } catch {
+    return resolveEmbeddingModel(undefined);
+  }
+}
+
+function selectedAcceleration(context: IpcContext): MemoryAcceleration {
+  try {
+    return context.configManager.load().memory?.acceleration ?? 'auto';
+  } catch {
+    return 'auto';
+  }
+}
+
+/** Whether the embed worker should stay warm (never idle-recycle): semantic
+ *  is enabled and a project is open. Gates every cold-load spike the same way
+ *  regardless of which path (task-detail open, Quick Find, MCP recall,
+ *  background drain) touches the worker next. */
+function shouldWarmHold(context: IpcContext, disposed: boolean): boolean {
+  return !disposed && isSemanticEnabled(context) && context.currentProjectId != null;
+}
+
+export function createEmbedEngine(overrides?: Partial<EmbedEngineDeps>) {
+  const deps: EmbedEngineDeps = { ...defaultDeps, ...overrides };
+
+  let attachedContext: IpcContext | null = null;
+  let disposed = false;
+  let started = false;
+
+  // Embed worker state, moved out of retrieval-service.ts. One client for the
+  // whole app: shared by the background drain AND the interactive query path.
+  let client: EmbedWorkerClient | null = null;
+  let activeModelId: string | null = null;
+  let activeAcceleration: MemoryAcceleration | null = null;
+
+  const dirty = new Set<string>();
+  let wakeResolve: (() => void) | null = null;
+  let wakePromise: Promise<void> | null = null;
+
+  /**
+   * Per-project drain-run metrics, for empirically tuning EMBED_DUTY_CYCLE /
+   * EMBED_DRAIN_BATCH on real hardware: a "run" starts at the first batch
+   * embedded after a project was idle (not merely when it was marked dirty -
+   * time spent parked with semantic disabled, or waiting for a crashed
+   * client, is deliberately excluded so the throughput number reflects only
+   * actual drain work) and ends when the project next has nothing pending.
+   * console.debug/info so the trace is always visible live in the terminal
+   * and captured to `.kangentic/logs/` only when
+   * Settings -> Developer -> Persist Console Logs is on (see log-mirror.ts) -
+   * no verbose logging cost for a user who never turns that on.
+   */
+  const drainRuns = new Map<string, { startedAt: number; chunks: number; batches: number }>();
+
+  function wake(): void {
+    if (wakeResolve) {
+      wakeResolve();
+      wakeResolve = null;
+      wakePromise = null;
+    }
+  }
+
+  function waitForWake(): Promise<void> {
+    if (!wakePromise) {
+      wakePromise = new Promise<void>((resolve) => {
+        wakeResolve = resolve;
+      });
+    }
+    return wakePromise;
+  }
+
+  /** The client for `model` + `acceleration`, recreating it when either the
+   *  selected model or the acceleration preference changed. Re-resolved on
+   *  every drain iteration (never cached across a model switch) and by the
+   *  query path. */
+  function getClientFor(model: EmbeddingModelDef, acceleration: MemoryAcceleration): EmbedWorkerClient {
+    if (client && (activeModelId !== model.id || activeAcceleration !== acceleration)) {
+      client.dispose();
+      client = null;
+    }
+    if (!client) {
+      client = deps.createClient(model, acceleration);
+      activeModelId = model.id;
+      activeAcceleration = acceleration;
+    }
+    return client;
+  }
+
+  /** The embedder for the interactive query path (search / MCP recall), or
+   *  null for lexical-only. Non-null only when semantic is enabled, the model
+   *  is present, and the worker has not crashed past its cap. */
+  function resolveEmbedder(context: IpcContext): Embedder | null {
+    if (disposed || !isSemanticEnabled(context)) return null;
+    const model = selectedModel(context);
+    if (!isEmbeddingModelPresent(model)) return null;
+    const resolved = getClientFor(model, selectedAcceleration(context));
+    resolved.setWarmHold(shouldWarmHold(context, disposed));
+    return resolved.crashed ? null : resolved;
+  }
+
+  /** Re-evaluate the warm-hold gate, and (when semantic just became viable)
+   *  mark the current project dirty. This subsumes the old
+   *  scheduleEmbedHeal: enabling semantic while the model is ALREADY on disk,
+   *  or switching model/acceleration, would otherwise never fire a fresh
+   *  embed trigger. */
+  function reconcileWarmHoldAndDirty(context: IpcContext): void {
+    if (shouldWarmHold(context, disposed)) {
+      client?.setWarmHold(true);
+    } else if (client) {
+      client.dispose();
+      client = null;
+      activeModelId = null;
+      activeAcceleration = null;
+    }
+    const projectId = context.currentProjectId;
+    if (projectId && isSemanticEnabled(context) && isEmbeddingModelPresent(selectedModel(context))) {
+      markDirty(projectId);
+    }
+  }
+
+  function markDirty(projectId: string): void {
+    if (disposed) return;
+    dirty.add(projectId);
+    wake();
+  }
+
+  /** Vec-table dimension sync for one project, moved verbatim from the old
+   *  embedPass. A dimension change (a different model) needs a full reset;
+   *  same-dimension model switches are handled by the model-tag re-embed in
+   *  chunksNeedingEmbedding. Returns false when the project has no usable vec
+   *  table (structurally lexical-only), so the drain should skip it. */
+  function syncVecTable(store: EmbedStore, model: EmbeddingModelDef): boolean {
+    const storedDims = store.getMeta('vec_dims');
+    if (storedDims !== String(model.dimensions)) {
+      store.resetVec(model.dimensions);
+      store.setMeta('vec_dims', String(model.dimensions));
+    } else {
+      store.ensureVecTable(model.dimensions);
+    }
+    return store.hasVec;
+  }
+
+  /** Pop the next dirty project in round-robin order (insertion order of a
+   *  Set). runLoop deletes the popped id before draining and re-adds it (at
+   *  the back) only when more work remains, which is what makes this an
+   *  actual round-robin across N dirty projects rather than draining one
+   *  project to completion before ever trying another. */
+  function nextDirtyProject(): string | undefined {
+    for (const projectId of dirty) return projectId;
+    return undefined;
+  }
+
+  type DrainResult = 'drained' | 'more-pending' | 'crashed' | 'transient';
+
+  /** Drain (at most) one small batch for one project. Never mutates `dirty`
+   *  itself - runLoop owns rotation based on the returned status, so a
+   *  project with more pending work moves to the BACK of the round-robin
+   *  instead of being drained to completion before any other project gets a
+   *  turn. */
+  async function drainOnce(context: IpcContext, projectId: string): Promise<DrainResult> {
+    // isSemanticEnabled is not re-checked here: runLoop only calls drainOnce
+    // once its own isSemanticEnabled gate has just passed, and treating a
+    // disabled semantic layer as 'drained' here would permanently drop a
+    // project's dirty flag even though real chunks remain pending.
+    const model = selectedModel(context);
+    if (!isEmbeddingModelPresent(model)) return 'drained';
+
+    let db;
+    try {
+      db = deps.getDb(projectId);
+    } catch {
+      return 'drained';
+    }
+    if (!hasVecSupport(db)) return 'drained';
+    const store = deps.createStore(db);
+    if (!syncVecTable(store, model)) return 'drained';
+
+    const resolvedClient = getClientFor(model, selectedAcceleration(context));
+    resolvedClient.setWarmHold(shouldWarmHold(context, disposed));
+
+    if (resolvedClient.crashed) {
+      // Terminal for this client instance (MAX_CRASHES reached): every
+      // project shares the one client, so there is nothing project-specific
+      // to retry here. runLoop parks the WHOLE loop on this result rather
+      // than busy-spinning through every dirty project against a dead
+      // worker. A model/acceleration change (via reconcile) creates a fresh
+      // client and wakes the loop; an app restart gets one too.
+      return 'crashed';
+    }
+
+    const batch = store.chunksNeedingEmbedding(model.modelTag, deps.drainBatchSize);
+    if (batch.length === 0) {
+      const run = drainRuns.get(projectId);
+      if (run) {
+        drainRuns.delete(projectId);
+        const elapsedMs = Date.now() - run.startedAt;
+        console.info('[embed-engine] drain complete', {
+          projectId,
+          modelId: model.id,
+          modelTag: model.modelTag,
+          chunksEmbedded: run.chunks,
+          batches: run.batches,
+          elapsedMs,
+          chunksPerMinute: elapsedMs > 0 ? Math.round((run.chunks / elapsedMs) * 60_000) : null,
+        });
+      }
+      return 'drained';
+    }
+
+    // Never let a background batch sit in front of a live interactive query.
+    // Bounded so a continuous query stream slows, but never permanently
+    // starves, the drain.
+    await raceWithCap(resolvedClient.waitForInteractiveIdle(), deps.interactiveIdleWaitCapMs, deps.delay);
+
+    if (!drainRuns.has(projectId)) {
+      drainRuns.set(projectId, { startedAt: Date.now(), chunks: 0, batches: 0 });
+    }
+
+    const startedAt = Date.now();
+    const vectors = await resolvedClient.embed(
+      batch.map((chunk) => chunk.text),
+      { isQuery: false, background: true },
+    );
+    const batchMs = Date.now() - startedAt;
+
+    if (!vectors) {
+      // Transient (timeout / queue full / worker mid-restart): keep the
+      // project dirty and back off a short fixed delay rather than busy-spin.
+      await deps.delay(deps.transientBackoffMs);
+      return 'transient';
+    }
+
+    store.writeEmbeddings(
+      batch.map((chunk, index) => ({ chunkId: chunk.id, vector: vectors[index], contentHash: chunk.contentHash })),
+      model.modelTag,
+    );
+
+    const sleepMs = computeEmbedSleepMs(batchMs, deps.dutyCycle);
+    const run = drainRuns.get(projectId);
+    if (run) {
+      run.chunks += batch.length;
+      run.batches += 1;
+    }
+    console.debug('[embed-engine] batch', {
+      projectId,
+      modelId: model.id,
+      batchSize: batch.length,
+      batchMs,
+      sleepMs,
+      dutyCycle: deps.dutyCycle,
+    });
+
+    await deps.delay(sleepMs);
+    return 'more-pending';
+  }
+
+  async function runLoop(): Promise<void> {
+    while (!disposed) {
+      try {
+        const context = attachedContext;
+        if (!context || !isSemanticEnabled(context) || dirty.size === 0) {
+          await waitForWake();
+          continue;
+        }
+        const projectId = nextDirtyProject();
+        if (projectId === undefined) {
+          await waitForWake();
+          continue;
+        }
+        // Pop for this turn; re-added below (at the back) only if more work
+        // remains, so a project with a deep backlog does not monopolize the
+        // loop ahead of other dirty projects.
+        dirty.delete(projectId);
+        const result = await drainOnce(context, projectId);
+        if (disposed) continue;
+        if (result === 'more-pending' || result === 'transient') {
+          dirty.add(projectId);
+        } else if (result === 'crashed') {
+          dirty.add(projectId);
+          // One shared client: every dirty project would hit the same
+          // 'crashed' result right now, so park the whole loop instead of
+          // thrashing through each of them. Woken by the next markDirty
+          // (e.g. reconcile() after a model/acceleration change).
+          await waitForWake();
+        }
+        // 'drained' -> leave popped; the project is fully caught up.
+      } catch (error) {
+        console.warn('[embed-engine] drain iteration failed:', error);
+      }
+    }
+  }
+
+  return {
+    /** Capture the stable process-global IpcContext and start the drain loop.
+     *  Idempotent; call once at startup. `markDirty` stays context-free
+     *  because this captured context carries all config/model/warm-hold
+     *  reads. */
+    attach(context: IpcContext): void {
+      attachedContext = context;
+      if (started || disposed) return;
+      started = true;
+      void runLoop();
+    },
+
+    markDirty,
+
+    getEmbedder(context: IpcContext): Embedder | null {
+      return resolveEmbedder(context);
+    },
+
+    reconcile(context: IpcContext): void {
+      reconcileWarmHoldAndDirty(context);
+    },
+
+    get activeDevice(): string | null {
+      return client?.activeDevice ?? null;
+    },
+
+    get workerCrashed(): boolean {
+      return client?.crashed ?? false;
+    },
+
+    /** Synchronous shutdown: mark disposed, resolve the wake deferred (so a
+     *  parked loop unblocks and exits its while(!disposed) check on the next
+     *  microtask instead of hanging forever), and dispose the worker
+     *  (EmbedClient.dispose is synchronous). In-flight work is abandoned; the
+     *  next open's markDirty resumes it. */
+    dispose(): void {
+      disposed = true;
+      wake();
+      client?.dispose();
+      client = null;
+      activeModelId = null;
+      activeAcceleration = null;
+      drainRuns.clear();
+    },
+  };
+}
+
+export type EmbedEngine = ReturnType<typeof createEmbedEngine>;
+
+export const embedEngine = createEmbedEngine();

--- a/src/main/retrieval/embedder/embedding-config.ts
+++ b/src/main/retrieval/embedder/embedding-config.ts
@@ -14,3 +14,21 @@ export {
 } from '../../../shared/embedding-models';
 
 export const EMBEDDING_MAX_BATCH = 16;
+
+/**
+ * The background drain's utilization ceiling: the embed worker infers for at
+ * most this fraction of wall-time, sleeping proportionally between batches
+ * (see computeEmbedSleepMs in embed-engine.ts). This is a machine-independent
+ * AVERAGE ceiling, not a wall-clock target - because the pacer measures each
+ * batch's real wall-time, it self-adapts to any backend/model with no
+ * per-device tuning table. A large first-run or model-switch backfill is
+ * therefore paced too, never pegged; it simply takes longer on slower
+ * hardware while holding the same ~20% average.
+ */
+export const EMBED_DUTY_CYCLE = 0.2;
+
+/** Chunks per background drain batch. Deliberately at or below
+ *  EMBEDDING_MAX_BATCH so each burst (the instantaneous spike, as opposed to
+ *  the time-averaged duty cycle) stays brief and a live interactive query
+ *  never waits behind more than one short in-flight background batch. */
+export const EMBED_DRAIN_BATCH = 8;

--- a/src/main/retrieval/retrieval-service.ts
+++ b/src/main/retrieval/retrieval-service.ts
@@ -7,10 +7,18 @@
  *  - a live turn-boundary hook (SessionManager 'activity' -> idle/permission) that
  *    re-indexes the active session so an in-progress conversation is searchable,
  *  - the per-open backfill sweep,
- *  - the embedding pass (Phase 2): local model download + embedding of chunks
- *    into the vec index, gated on memory.semanticEnabled + sqlite-vec,
- *  - a serial job chain (one indexing/embedding job in flight at a time),
- *  - config gating and synchronous shutdown (also disposes the embed worker).
+ *  - local model-file download orchestration,
+ *  - a serial job chain (one indexing job in flight at a time - INDEXING only;
+ *    embedding is owned entirely by `embedEngine`, see embedder/embed-engine.ts),
+ *  - config gating and synchronous shutdown (also disposes the embed worker,
+ *    via embedEngine.dispose()).
+ *
+ * Indexing (this file) and embedding (embed-engine.ts) are deliberately split:
+ * lifecycle/navigation events here only INDEX (a cheap diff-upsert) and flag a
+ * project dirty via `embedEngine.markDirty()`. They never embed inline, so a
+ * project switch performs zero synchronous embedding work - the felt hardware
+ * spike on switching back to a churning project is impossible by construction.
+ * The central engine alone drains pending embeddings, duty-cycle throttled.
  *
  * It reuses the existing SessionManager events rather than patching the four
  * PTY-layer finalize call sites, keeping all agent knowledge behind the adapter
@@ -22,13 +30,13 @@ import { RetrievalStore } from './retrieval-store';
 import { hasVecSupport } from './vec-support';
 import { lastVecLoadError } from './vec-extension';
 import { ConversationIndexer } from './conversation/conversation-indexer';
-import { EmbedClient } from './embedder/embed-client';
-import { EMBEDDING_MAX_BATCH, resolveEmbeddingModel, type EmbeddingModelDef } from './embedder/embedding-config';
+import { embedEngine } from './embedder/embed-engine';
+import { resolveEmbeddingModel, type EmbeddingModelDef } from './embedder/embedding-config';
 import { isEmbeddingModelPresent, downloadEmbeddingModel } from './embedder/embedding-model';
 import { requiresUserInteraction } from '../../shared/activity-state';
 import type { IpcContext } from '../ipc/ipc-context';
 import type { Embedder } from './types';
-import type { MemoryStatus, MemorySemanticState, MemoryModelState, MemoryAcceleration, Project, ActivityState } from '../../shared/types';
+import type { MemoryStatus, MemorySemanticState, MemoryModelState, Project, ActivityState } from '../../shared/types';
 
 /** Grace period after a finalize event before indexing, so the agent CLI has
  *  flushed its native history file. */
@@ -37,26 +45,22 @@ const FINALIZE_DEBOUNCE_MS = 2000;
  *  before a live re-index, so a burst of activity transitions within a turn
  *  coalesces into one index and the CLI has flushed the new turn to disk. */
 const LIVE_INDEX_DEBOUNCE_MS = 1500;
-/** Chunks fetched per embedding batch pass (each embed call is <= MAX_BATCH). */
-const EMBED_PASS_LIMIT = 128;
 
 const indexer = new ConversationIndexer();
 
 let attached = false;
 let disposed = false;
 let activeSweepProjectId: string | null = null;
-/** Serial job chain: one indexing/embedding job runs at a time. */
+/** Serial job chain: one INDEXING job runs at a time. Embedding is no longer
+ *  chained here - it is owned entirely by embedEngine's own drain loop. */
 let jobChain: Promise<void> = Promise.resolve();
 const pendingTimers = new Set<NodeJS.Timeout>();
 /** Per-session trailing-debounce timers for live (turn-boundary) re-indexing. */
 const liveIndexTimers = new Map<string, NodeJS.Timeout>();
 
-// Semantic layer state.
-let embedClient: EmbedClient | null = null;
-/** Which model id `embedClient` was created for (so a model switch recreates it). */
-let activeModelId: string | null = null;
-/** Which acceleration `embedClient` was created for (a change recreates it). */
-let activeAcceleration: MemoryAcceleration | null = null;
+// Model-file download state (downloading the local embedding model to disk).
+// The embed WORKER and its warm-hold / crash / device state live in
+// embedEngine, not here.
 let modelDownloadState: 'idle' | 'downloading' | 'error' = 'idle';
 let modelDownloadProgress = 0;
 /** Which model id is currently downloading (a switch mid-download retriggers). */
@@ -70,8 +74,8 @@ let downloadingModelId: string | null = null;
  * set by `startForProject`, which runs from the `project:open` IPC handler but NOT
  * from `openProjectByPath` (the lighter path used by cold start and the ephemeral
  * dev preview). On those paths the DB is vec-capable yet the flag stayed false, so
- * the status reported "unavailable" while the model downloaded fine. `embedPass`
- * and `resolveEmbedder` already gate on the live `hasVecSupport(db)`; this aligns
+ * the status reported "unavailable" while the model downloaded fine. embedEngine's
+ * drain and query paths already gate on the live `hasVecSupport(db)`; this aligns
  * the status surface with them.
  */
 function currentProjectHasVec(context: IpcContext): boolean {
@@ -100,28 +104,12 @@ function isSemanticEnabled(context: IpcContext): boolean {
   }
 }
 
-/** Whether the embed worker should stay warm (never idle-recycle): semantic is
- *  enabled and a project is open. Gates every cold-load spike - task-detail
- *  opens, Quick Find smart queries, and the MCP recall path - the same way. */
-function shouldWarmHoldEmbedWorker(context: IpcContext): boolean {
-  return !disposed && isSemanticEnabled(context) && context.currentProjectId != null;
-}
-
 /** The user-selected embedding model (or the default). */
 function selectedModel(context: IpcContext): EmbeddingModelDef {
   try {
     return resolveEmbeddingModel(context.configManager.load().memory?.embeddingModel);
   } catch {
     return resolveEmbeddingModel(undefined);
-  }
-}
-
-/** The user-selected embedding acceleration (or the default 'auto'). */
-function selectedAcceleration(context: IpcContext): MemoryAcceleration {
-  try {
-    return context.configManager.load().memory?.acceleration ?? 'auto';
-  } catch {
-    return 'auto';
   }
 }
 
@@ -135,21 +123,6 @@ function humanizeBackend(device: string | null | undefined): string | undefined 
   }
 }
 
-/** The embed client for `model` + `acceleration`, recreating it when either the
- *  selected model or the acceleration preference changed. */
-function getEmbedClientFor(model: EmbeddingModelDef, acceleration: MemoryAcceleration): EmbedClient {
-  if (embedClient && (activeModelId !== model.id || activeAcceleration !== acceleration)) {
-    embedClient.dispose();
-    embedClient = null;
-  }
-  if (!embedClient) {
-    embedClient = new EmbedClient(model, acceleration);
-    activeModelId = model.id;
-    activeAcceleration = acceleration;
-  }
-  return embedClient;
-}
-
 function chain(job: () => Promise<unknown>): void {
   jobChain = jobChain.then(() => job()).then(
     () => undefined,
@@ -157,36 +130,6 @@ function chain(job: () => Promise<unknown>): void {
       console.warn('[retrieval] job failed:', error);
     },
   );
-}
-
-/** The embedder the search path should use, or null for lexical-only. Non-null
- *  only when semantic is enabled, the selected model is present, and the worker
- *  has not crashed past its cap. */
-function resolveEmbedder(context: IpcContext): Embedder | null {
-  if (disposed || !isSemanticEnabled(context)) return null;
-  const model = selectedModel(context);
-  if (!isEmbeddingModelPresent(model)) return null;
-  const client = getEmbedClientFor(model, selectedAcceleration(context));
-  client.setWarmHold(shouldWarmHoldEmbedWorker(context));
-  return client.crashed ? null : client;
-}
-
-/** Re-evaluate the warm-hold gate: hold the resident worker when semantic is
- *  enabled and a project is open, otherwise dispose it so its ~100MB+ model and
- *  GPU backend are freed promptly. Called when either input changes -
- *  semantic toggled off, or the current project closes - since neither has its
- *  own embed() call to piggyback the gate check on. */
-function reconcileEmbedWorker(context: IpcContext): void {
-  if (shouldWarmHoldEmbedWorker(context)) {
-    embedClient?.setWarmHold(true);
-    return;
-  }
-  if (embedClient) {
-    embedClient.dispose();
-    embedClient = null;
-    activeModelId = null;
-    activeAcceleration = null;
-  }
 }
 
 function scheduleFinalizeIndex(context: IpcContext, sessionId: string): void {
@@ -200,8 +143,10 @@ function scheduleFinalizeIndex(context: IpcContext, sessionId: string): void {
     if (!projectId) return;
     chain(async () => {
       await indexer.indexSession(projectId, sessionId);
-      // Embed the freshly indexed chunks when the semantic layer is active.
-      if (isSemanticEnabled(context)) await embedPass(context, projectId);
+      // Flag the project dirty; embedEngine's own drain loop embeds the
+      // freshly indexed chunks in the background, duty-cycle throttled. This
+      // does NOT embed inline - that is the whole point of the split.
+      embedEngine.markDirty(projectId);
     });
   }, FINALIZE_DEBOUNCE_MS);
   timer.unref();
@@ -215,8 +160,9 @@ function scheduleFinalizeIndex(context: IpcContext, sessionId: string): void {
  * ~1.5s instead of only after the session finalizes. This is a per-session
  * TRAILING debounce: rapid transitions within one turn reset the timer, so an
  * active session is indexed once per settled turn, never per event. It stays
- * cheap because `indexSession` diff-upserts (an unchanged transcript is a no-op)
- * and `embedPass` only embeds the new chunks (off the main thread, in the worker).
+ * cheap because `indexSession` diff-upserts (an unchanged transcript is a
+ * no-op) and embedding the new chunks happens later, in the background, via
+ * embedEngine's own duty-cycle-throttled drain loop - never inline here.
  */
 function scheduleLiveIndex(context: IpcContext, sessionId: string): void {
   if (disposed || !isIndexingEnabled(context)) return;
@@ -231,60 +177,11 @@ function scheduleLiveIndex(context: IpcContext, sessionId: string): void {
     if (!projectId) return;
     chain(async () => {
       await indexer.indexSession(projectId, sessionId);
-      if (isSemanticEnabled(context)) await embedPass(context, projectId);
+      embedEngine.markDirty(projectId);
     });
   }, LIVE_INDEX_DEBOUNCE_MS);
   timer.unref();
   liveIndexTimers.set(sessionId, timer);
-}
-
-/** Embed any chunks in a project that still need an embedding for the selected
- *  model. Recreates the vec table at the model's dimension on a model switch.
- *  No-op unless semantic is enabled, the model is present, sqlite-vec loaded for
- *  this DB, and the worker is healthy. Passages embed WITHOUT a query prefix. */
-async function embedPass(context: IpcContext, projectId: string): Promise<void> {
-  if (disposed || !isSemanticEnabled(context)) return;
-  const model = selectedModel(context);
-  if (!isEmbeddingModelPresent(model)) return;
-  let db;
-  try {
-    db = getProjectDb(projectId);
-  } catch {
-    return;
-  }
-  if (!hasVecSupport(db)) return;
-  const store = new RetrievalStore(db);
-
-  // Sync the vec table to the selected model's dimension. A dimension change
-  // (e.g. bge-base's 768 vs 384) needs a full reset; same-dimension model
-  // switches are handled by the model-tag re-embed below.
-  const storedDims = store.getMeta('vec_dims');
-  if (storedDims !== String(model.dimensions)) {
-    store.resetVec(model.dimensions);
-    store.setMeta('vec_dims', String(model.dimensions));
-  } else {
-    store.ensureVecTable(model.dimensions);
-  }
-  if (!store.hasVec) return;
-
-  const client = getEmbedClientFor(model, selectedAcceleration(context));
-  client.setWarmHold(shouldWarmHoldEmbedWorker(context));
-  for (;;) {
-    if (disposed || client.crashed) return;
-    const chunks = store.chunksNeedingEmbedding(model.modelTag, EMBED_PASS_LIMIT);
-    if (chunks.length === 0) return;
-    for (let offset = 0; offset < chunks.length; offset += EMBEDDING_MAX_BATCH) {
-      if (disposed || client.crashed) return;
-      const batch = chunks.slice(offset, offset + EMBEDDING_MAX_BATCH);
-      const vectors = await client.embed(batch.map((chunk) => chunk.text), { isQuery: false });
-      if (!vectors) return; // embedder unavailable: retried on a later pass
-      store.writeEmbeddings(
-        batch.map((chunk, index) => ({ chunkId: chunk.id, vector: vectors[index] })),
-        model.modelTag,
-      );
-      await new Promise((resolve) => setImmediate(resolve));
-    }
-  }
 }
 
 /** Ensure the selected model is downloaded when semantic is enabled. Runs the
@@ -303,10 +200,12 @@ function ensureModelDownload(context: IpcContext): void {
     () => {
       modelDownloadState = 'idle';
       modelDownloadProgress = 1;
-      // The model just landed - embed the already-indexed chunks now so
-      // semantic search lights up without waiting for the next project open.
+      // The model just landed - flag the current project dirty so embedEngine's
+      // background drain embeds the already-indexed chunks without waiting for
+      // the next project open. This is a markDirty, not an inline embed: the
+      // drain is duty-cycle throttled, so even this one-time backfill is paced.
       const projectId = context.currentProjectId;
-      if (projectId) chain(() => embedPass(context, projectId));
+      if (projectId) embedEngine.markDirty(projectId);
     },
     (error) => {
       console.warn('[retrieval] embedding model download failed:', error);
@@ -315,32 +214,11 @@ function ensureModelDownload(context: IpcContext): void {
   );
 }
 
-let embedHealPending = false;
-
-/** Embed any already-indexed-but-unembedded chunks for the current project. This
- *  self-heals the case where semantic was enabled while the model was ALREADY on
- *  disk: the download-complete embed trigger never fires, so existing
- *  conversations would stay indexed-but-unembedded and semantic would find
- *  nothing. Polled from getStatus. embedPass no-ops once everything is embedded;
- *  a single pass runs at a time, and the next poll re-schedules if more remain. */
-function scheduleEmbedHeal(context: IpcContext): void {
-  if (embedHealPending || disposed) return;
-  const projectId = context.currentProjectId;
-  if (!projectId) return;
-  embedHealPending = true;
-  chain(async () => {
-    try {
-      await embedPass(context, projectId);
-    } finally {
-      embedHealPending = false;
-    }
-  });
-}
-
 export const retrievalService = {
-  /** Subscribe to session lifecycle + turn-boundary events. Idempotent; call
-   *  once at startup. */
+  /** Subscribe to session lifecycle + turn-boundary events, and start the
+   *  central embedding engine's drain loop. Idempotent; call once at startup. */
   attach(context: IpcContext): void {
+    embedEngine.attach(context);
     if (attached) return;
     attached = true;
     context.sessionManager.on('exit', (sessionId: string) => {
@@ -359,8 +237,9 @@ export const retrievalService = {
   },
 
   /** Run a deferred, project-switch-guarded backfill sweep for a project, then
-   *  (when semantic is enabled) ensure the model and embed its chunks. Called on
-   *  every PROJECT_OPEN and after a memory-config change. */
+   *  flag it dirty so embedEngine's background drain embeds its chunks. Called
+   *  on every PROJECT_OPEN and after a memory-config change. Never embeds
+   *  inline - a project open performs zero synchronous embedding work. */
   startForProject(context: IpcContext, project: Project): void {
     if (disposed) return;
     this.attach(context);
@@ -385,23 +264,30 @@ export const retrievalService = {
           project.id,
           () => !disposed && context.currentProjectId === project.id && activeSweepProjectId === project.id,
         );
-        if (isSemanticEnabled(context)) await embedPass(context, project.id);
+        // Covers project open, the startup backlog, AND crash-resume: the
+        // sweep re-indexed whatever changed, and this flags it for the
+        // background drain regardless of whether anything actually changed
+        // (markDirty is cheap and idempotent).
+        embedEngine.markDirty(project.id);
       });
     });
   },
 
   /** The embedder for the search path, or null for lexical-only. Consulted by
    *  the search IPC handler / MCP recall tool when the caller asks for semantic
-   *  or hybrid results. */
+   *  or hybrid results. Interactive queries through this path always preempt
+   *  the background drain in the shared worker. */
   getEmbedder(context: IpcContext): Embedder | null {
-    return resolveEmbedder(context);
+    return embedEngine.getEmbedder(context);
   },
 
-  /** Re-evaluate the embed-worker warm-hold. Call after a change to
-   *  `memory.semanticEnabled` or to the current project (open/close), since
-   *  those paths have no embed() call of their own to piggyback the gate on. */
+  /** Re-evaluate the embed-worker warm-hold, and (when semantic just became
+   *  viable) flag the current project dirty. Call after a change to
+   *  `memory.semanticEnabled`/model/acceleration or to the current project
+   *  (open/close), since those paths have no embed() call of their own to
+   *  piggyback the gate on. */
   reconcileEmbedWorker(context: IpcContext): void {
-    reconcileEmbedWorker(context);
+    embedEngine.reconcile(context);
   },
 
   /** Current conversation-memory status for the renderer's Smart-mode UI and
@@ -418,11 +304,15 @@ export const retrievalService = {
     // error (no retry spam - the user re-toggles to retry).
     if (indexingEnabled && semanticOn && !isEmbeddingModelPresent(model) && modelDownloadState !== 'error') {
       ensureModelDownload(context);
-    } else if (indexingEnabled && semanticOn && isEmbeddingModelPresent(model) && !embedClient?.crashed) {
-      // Model already on disk: self-heal the embeddings too, so enabling semantic
-      // (or switching model / acceleration) embeds the already-indexed chunks
-      // without waiting for a project re-open or a rebuild.
-      scheduleEmbedHeal(context);
+    } else if (indexingEnabled && semanticOn && isEmbeddingModelPresent(model) && !embedEngine.workerCrashed) {
+      // Model already on disk: flag the current project dirty too, so enabling
+      // semantic (or switching model / acceleration) drains the already-indexed
+      // chunks in the background without waiting for a project re-open or a
+      // rebuild. Cheap and idempotent - the engine self-clears a project from
+      // its dirty set once nothing remains, so this is a no-op safety net once
+      // caught up, continuously re-armed by every getStatus poll.
+      const projectId = context.currentProjectId;
+      if (projectId) embedEngine.markDirty(projectId);
     }
 
     const modelPresent = isEmbeddingModelPresent(model);
@@ -437,7 +327,7 @@ export const retrievalService = {
     } else if (isDownloadingThis || !modelPresent) {
       // Enabled, but the model is still downloading / not ready yet.
       semantic = 'downloading';
-    } else if (embedClient?.crashed) {
+    } else if (embedEngine.workerCrashed) {
       semantic = 'error';
     } else if (!currentProjectHasVec(context)) {
       semantic = 'lexical';
@@ -455,7 +345,7 @@ export const retrievalService = {
     return {
       indexingEnabled,
       semantic,
-      activeBackend: humanizeBackend(embedClient?.activeDevice),
+      activeBackend: humanizeBackend(embedEngine.activeDevice),
       modelProgress: showProgress ? modelDownloadProgress : undefined,
       vecError: semantic === 'lexical' ? lastVecLoadError() ?? undefined : undefined,
       model: {
@@ -492,8 +382,8 @@ export const retrievalService = {
    *  transcript while keeping the existing chunks as a fallback. A session whose
    *  transcript is gone or unparseable keeps its chunks (indexSession replaces a
    *  session's chunks only on a successful parse), so a rebuild can never drop a
-   *  past conversation. The re-sweep and, when semantic is on, the embed pass run
-   *  in the background via `startForProject`. */
+   *  past conversation. The re-sweep runs via `startForProject`, which flags the
+   *  project dirty so embedEngine's background drain embeds it afterward. */
   rebuildProjectIndex(context: IpcContext, project: Project): void {
     if (disposed) return;
     this.stop(project.id);
@@ -505,8 +395,9 @@ export const retrievalService = {
     this.startForProject(context, project);
   },
 
-  /** Synchronous shutdown: stop scheduling, drop pending timers, kill the embed
-   *  worker, mark disposed. In-flight work is abandoned; the next open recovers it. */
+  /** Synchronous shutdown: stop scheduling, drop pending timers, dispose the
+   *  embedding engine (which synchronously kills the embed worker), mark
+   *  disposed. In-flight work is abandoned; the next open recovers it. */
   dispose(): void {
     disposed = true;
     activeSweepProjectId = null;
@@ -514,8 +405,6 @@ export const retrievalService = {
     pendingTimers.clear();
     for (const timer of liveIndexTimers.values()) clearTimeout(timer);
     liveIndexTimers.clear();
-    embedClient?.dispose();
-    embedClient = null;
-    activeModelId = null;
+    embedEngine.dispose();
   },
 };

--- a/src/main/retrieval/retrieval-store.ts
+++ b/src/main/retrieval/retrieval-store.ts
@@ -404,8 +404,28 @@ export class RetrievalStore {
     this.vecReady = true;
   }
 
+  /**
+   * Write embedding vectors for chunks fetched earlier via
+   * `chunksNeedingEmbedding`. `contentHash` is each row's hash AT FETCH TIME;
+   * it is re-validated against the live row inside this same transaction
+   * before writing, and the row is skipped (left pending) on a mismatch or if
+   * the chunk no longer exists.
+   *
+   * This guard closes a race introduced by decoupling the background
+   * embedding drain from the indexer's serial job chain: `memory_chunks.id`
+   * is `INTEGER PRIMARY KEY` WITHOUT `AUTOINCREMENT`, so a concurrent
+   * `upsertDocument` that deletes-then-reinserts a churning chunk's row (e.g.
+   * a live session actively being re-indexed) can have SQLite reuse the freed
+   * rowid for a DIFFERENT chunk before this write lands. Without the guard,
+   * `writeEmbeddings` would stamp a stale vector onto that new chunk and mark
+   * it embedded - a silent, wrong embedding that never gets corrected. Because
+   * this whole method is one synchronous better-sqlite3 transaction and the
+   * only `await` in the drain loop happens before it is called, the
+   * check-and-write here is atomic with respect to any concurrent
+   * `upsertDocument`.
+   */
   writeEmbeddings(
-    rows: Array<{ chunkId: number; vector: Float32Array }>,
+    rows: Array<{ chunkId: number; vector: Float32Array; contentHash: string }>,
     modelTag: string,
   ): void {
     if (!this.vecReady || rows.length === 0) return;
@@ -415,10 +435,13 @@ export class RetrievalStore {
       // virtual table". Re-embedding a chunk (a model switch, or a rowid reused
       // after a content change) is therefore a DELETE followed by a plain
       // INSERT, which is sqlite-vec's documented update path.
+      const checkHash = this.db.prepare('SELECT content_hash FROM memory_chunks WHERE id = ?');
       const deleteVec = this.db.prepare('DELETE FROM memory_chunks_vec WHERE rowid = ?');
       const insertVec = this.db.prepare('INSERT INTO memory_chunks_vec(rowid, embedding) VALUES (?, ?)');
       const markChunk = this.db.prepare('UPDATE memory_chunks SET embedded_model = ? WHERE id = ?');
-      for (const { chunkId, vector } of rows) {
+      for (const { chunkId, vector, contentHash } of rows) {
+        const current = checkHash.get(chunkId) as { content_hash: string } | undefined;
+        if (!current || current.content_hash !== contentHash) continue;
         // vec0 rejects a JS number for its rowid ("Only integers are allowed
         // for primary key values") - it must be bound as a BigInt (verified
         // against sqlite-vec 0.1.9 under Electron).
@@ -456,6 +479,21 @@ export class RetrievalStore {
       )
       .all(modelTag, limit) as StoredChunkRow[];
     return rows.map(toStoredChunk);
+  }
+
+  /** Cheap count of chunks still pending embedding for `modelTag` (same WHERE
+   *  clause as `chunksNeedingEmbedding`, backed by `idx_memory_chunks_embedded`).
+   *  Not yet wired to a caller: exposed for a future embedding status/telemetry
+   *  surface that needs a pending count without fetching full rows. */
+  countChunksNeedingEmbedding(modelTag: string): number {
+    if (!this.vecReady) return 0;
+    const row = this.db
+      .prepare(
+        `SELECT COUNT(*) AS count FROM memory_chunks
+         WHERE embedded_model IS NULL OR embedded_model != ?`,
+      )
+      .get(modelTag) as { count: number };
+    return row.count;
   }
 
   /** Startup GC: drop vec rows whose chunk was removed while the extension was

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -471,6 +471,7 @@ if (__KANGENTIC_DEV__) {
   api.dev = {
     createEphemeralProject: () => ipcRenderer.invoke(IPC.DEV_CREATE_EPHEMERAL_PROJECT),
     seedGitChanges: (targetPaths: string[]) => ipcRenderer.invoke(IPC.DEV_SEED_GIT_CHANGES, targetPaths),
+    seedEmbeddingBacklog: (count: number) => ipcRenderer.invoke(IPC.DEV_SEED_EMBEDDING_BACKLOG, count),
     isEphemeralPreview,
     previewTaskTitle,
   };

--- a/src/renderer/components/settings/tabs/DeveloperTab.tsx
+++ b/src/renderer/components/settings/tabs/DeveloperTab.tsx
@@ -20,8 +20,18 @@ export function DeveloperTab({ globalConfig }: { globalConfig: AppConfig }) {
   const updateGlobal = useScopedUpdate('global');
   const developerConfig = globalConfig.developer ?? {};
   const overlayEnabled = developerConfig.activityDebugOverlay === true;
-  const persistConsoleLogsEnabled = developerConfig.persistConsoleLogs === true;
-  const recordIpcTrafficEnabled = developerConfig.recordIpcTraffic === true;
+  // Defaults ON in any dev build when the user has never touched the toggle
+  // (mirrors the Inspection Bridge / Allow Unsafe Operations default in
+  // DevToolsSections.tsx). `??` only falls through on null/undefined, so an
+  // explicit stored `false` is respected. Off (both `??` operands false) in
+  // production builds. Mirror of `safeReadDeveloperFlag` in src/main/index.ts
+  // so the displayed toggle state matches the actual persistence behavior.
+  const persistConsoleLogsEnabled = developerConfig.persistConsoleLogs ?? __KANGENTIC_DEV__;
+  // Narrower than persistConsoleLogs: the IPC recorder has a real disk-I/O cost,
+  // so it defaults on only for the ephemeral /preview instance (wiped on close,
+  // bounding growth), not the long-running npm start dogfooding session.
+  const recordIpcTrafficEnabled =
+    developerConfig.recordIpcTraffic ?? (__KANGENTIC_DEV__ && window.electronAPI.dev?.isEphemeralPreview === true);
 
   return (
     <div className="space-y-3">
@@ -56,6 +66,7 @@ export function DeveloperTab({ globalConfig }: { globalConfig: AppConfig }) {
           Errors and warnings are <strong>always</strong> persisted; this toggle additionally captures
           info / debug / log levels. NDJSON, one file per day at{' '}
           <Code>.kangentic/logs/&lt;YYYY-MM-DD&gt;.log</Code>. Read via <Code>kangentic_tail_logs</Code>.
+          {__KANGENTIC_DEV__ && ' On by default in dev builds (npm start / /preview) - the write path is async, so it has no measurable performance cost.'}
         </Description>
       </section>
 
@@ -86,8 +97,10 @@ export function DeveloperTab({ globalConfig }: { globalConfig: AppConfig }) {
         <Description>
           Records channel, args, result, durationMs, and any thrown errors. Mutating channels
           (settings writes, MCP config, attachments) are stored as{' '}
-          <Code>{'{ redacted: true, channel }'}</Code> to keep secrets out of disk logs. Off by default
-          (non-trivial disk impact). Read via <Code>kangentic_get_ipc_log</Code>.
+          <Code>{'{ redacted: true, channel }'}</Code> to keep secrets out of disk logs. Non-trivial
+          disk impact, so it is off by default - except in <Code>/preview</Code>, where it defaults
+          on since that instance's data (including its logs) is wiped on close. Read via{' '}
+          <Code>kangentic_get_ipc_log</Code>.
         </Description>
       </section>
 

--- a/src/shared/developer-flag-defaults.ts
+++ b/src/shared/developer-flag-defaults.ts
@@ -1,0 +1,55 @@
+/**
+ * The default value for a developer settings toggle when the user has never
+ * touched it (no stored value in `AppConfig.developer`). Extracted as a pure
+ * function so this decision logic is unit-testable in isolation: the main
+ * process's `safeReadDeveloperFlag` in `src/main/index.ts` cannot itself be
+ * imported by a test (it is an Electron entry-point module with top-level
+ * `electron` API calls that throw outside a running Electron process), and
+ * this module has zero dependencies so it also works from renderer code.
+ *
+ *   'previewInspectionServer' / 'previewEvalEnabled' -> ON in any dev build.
+ *     Anyone running `npm start` / `/preview` is by definition a Kangentic
+ *     dev session and almost certainly wants the agent-driven inspection
+ *     bridge (including eval, inject-event, raw-PTY) available without
+ *     flipping a toggle each launch. Both are localhost-only and dropped
+ *     from production builds via `__KANGENTIC_DEV__`.
+ *
+ *   'persistConsoleLogs' -> ON in any dev build (npm start dogfooding AND
+ *     /preview). The write path is already async-queued (queueAppend in
+ *     log-mirror.ts defers the actual disk write to the next setImmediate
+ *     turn, no per-call blocking appendFileSync/mkdirSync), so this has no
+ *     measurable dogfooding performance cost, and having the trace already
+ *     captured is far more useful than remembering to flip it before a
+ *     debugging session starts.
+ *
+ *   'recordIpcTraffic' -> ON only for the ephemeral `/preview` instance, in a
+ *     dev build. The IPC recorder has a real, documented disk-I/O cost per
+ *     call. `/preview`'s entire data dir (including `.kangentic/logs/`) is
+ *     wiped on close, bounding the growth. The regular npm start dogfooding
+ *     session runs for days, so it stays opt-in there to avoid unbounded
+ *     trace accumulation the user did not ask for.
+ *
+ *   'activityDebugOverlay' -> always OFF by default. It has a visible cost
+ *     the user should opt into deliberately.
+ *
+ * An explicit stored value in config always wins over this default; callers
+ * are responsible for checking that first (see `safeReadDeveloperFlag` in
+ * `src/main/index.ts` and the `??` fallbacks in `DeveloperTab.tsx`).
+ */
+export type DeveloperFlagKey =
+  | 'activityDebugOverlay'
+  | 'persistConsoleLogs'
+  | 'recordIpcTraffic'
+  | 'previewInspectionServer'
+  | 'previewEvalEnabled';
+
+export function defaultDeveloperFlag(
+  key: DeveloperFlagKey,
+  isDevBuild: boolean,
+  isEphemeralPreview: boolean,
+): boolean {
+  if (key === 'previewInspectionServer' || key === 'previewEvalEnabled') return isDevBuild;
+  if (key === 'persistConsoleLogs') return isDevBuild;
+  if (key === 'recordIpcTraffic') return isDevBuild && isEphemeralPreview;
+  return false;
+}

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -19,6 +19,7 @@ export const IPC = {
   // Dev-only (preview): build-excluded from production via __KANGENTIC_DEV__.
   DEV_CREATE_EPHEMERAL_PROJECT: 'dev:createEphemeralProject',
   DEV_SEED_GIT_CHANGES: 'dev:seedGitChanges',
+  DEV_SEED_EMBEDDING_BACKLOG: 'dev:seedEmbeddingBacklog',
 
   // Project Groups
   PROJECT_GROUP_LIST: 'projectGroup:list',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2828,6 +2828,14 @@ export interface DevSeedGitChangesResult {
   working: number;
 }
 
+/** Summary of a dev test-harness embedding-backlog seed (see DEV_SEED_EMBEDDING_BACKLOG). */
+export interface DevSeedEmbeddingBacklogResult {
+  /** Number of synthetic pending chunks inserted. */
+  seeded: number;
+  /** The synthetic document id the chunks were written under (e.g. 'dev-seed-embedding-backlog-3'). */
+  docId: string;
+}
+
 export interface ElectronAPI {
   // Dev-only (preview): present only when __KANGENTIC_DEV__ (build-excluded in prod).
   dev?: {
@@ -2840,6 +2848,15 @@ export interface ElectronAPI {
      * preview-projects root.
      */
     seedGitChanges: (targetPaths: string[]) => Promise<DevSeedGitChangesResult>;
+    /**
+     * Seed `count` synthetic pending chunks (embedded_model = NULL) into the
+     * current project's conversation-memory index via the real chunk-write
+     * path, then flag the project dirty - the fast path to a realistic
+     * embedding backlog (thousands of pending chunks) for exercising the
+     * central embedding engine's drain loop under sustained real-worker load,
+     * without needing that many real agent turns to produce it.
+     */
+    seedEmbeddingBacklog: (count: number) => Promise<DevSeedEmbeddingBacklogResult>;
     /** True only in dev-preview (`/preview`, `--ephemeral`); false in the regular dogfood. */
     isEphemeralPreview: boolean;
     /**

--- a/tests/ui/developer-tab-defaults.spec.ts
+++ b/tests/ui/developer-tab-defaults.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * UI tests for the Developer settings tab's default-value computation for
+ * `persistConsoleLogs` and `recordIpcTraffic` when the user has never touched
+ * either toggle (no stored value in `AppConfig.developer`).
+ *
+ * This pins the intent documented at the two call sites (DeveloperTab.tsx's
+ * inline `??` defaults and their mirror, `defaultDeveloperFlag` in
+ * src/shared/developer-flag-defaults.ts, consumed by src/main/index.ts's
+ * safeReadDeveloperFlag):
+ *   - Persistent Console Logs defaults ON in any dev build (regular npm start
+ *     dogfooding AND /preview) - its write path is async-queued, so it has no
+ *     measurable dogfooding cost.
+ *   - Record IPC Traffic defaults OFF for the regular (non-ephemeral) dev
+ *     session - it has a real per-call disk-I/O cost, so it stays opt-in
+ *     there - but defaults ON for the ephemeral `/preview` instance, whose
+ *     data dir (including its logs) is wiped on close, bounding the growth.
+ *
+ * The UI tier is correct here (not unit): the decision itself already has
+ * dedicated unit coverage on the shared pure function
+ * (tests/unit/developer-flag-defaults.test.ts); what is uniquely untested
+ * without a real DOM is that DeveloperTab.tsx's `??` expressions actually
+ * wire that decision to the rendered `<ToggleSwitch>`'s `aria-checked` state
+ * for a real user opening Settings -> Developer. No PTY or Electron main
+ * process is needed, so this stays out of tests/e2e/.
+ *
+ * The Playwright `ui` project serves Vite in dev mode (`npx vite`, no
+ * `--mode production`), so `__KANGENTIC_DEV__` is `true` for these tests -
+ * exercising the "dev build" branch, which is the branch relevant to a
+ * developer opening the app via `npm start` or `/preview`.
+ */
+import { test, expect } from '@playwright/test';
+import { launchPage, createProject } from './helpers';
+import type { Browser, Page } from '@playwright/test';
+
+let browser: Browser;
+let page: Page;
+
+test.beforeAll(async () => {
+  const result = await launchPage();
+  browser = result.browser;
+  page = result.page;
+  await createProject(page, `Developer Tab Defaults Test ${Date.now()}`);
+});
+
+test.afterAll(async () => {
+  await browser?.close();
+});
+
+/** Open Settings and switch to the Developer tab. */
+async function openDeveloperTab() {
+  await page.locator('[data-testid="settings-button"]').click();
+  await page.locator('h2:has-text("Settings")').waitFor({ state: 'visible', timeout: 3000 });
+  await page.getByRole('button', { name: 'Developer', exact: true }).click();
+}
+
+/** Close settings via Escape. */
+async function closeSettings() {
+  await page.keyboard.press('Escape');
+  await page.locator('h2:has-text("Settings")').waitFor({ state: 'hidden', timeout: 2000 });
+}
+
+/** Locate a ToggleRow's <button role="switch"> by its exact title text. The
+ *  title lives in a sibling div of the switch inside the row container, so
+ *  two `..` hops from the title element reach the row, which scopes the
+ *  `getByRole('switch')` query to that row alone. */
+function toggleForTitle(title: string) {
+  return page.getByText(title, { exact: true }).locator('..').locator('..').getByRole('switch');
+}
+
+test.describe('Developer Tab - persistConsoleLogs / recordIpcTraffic defaults', () => {
+  test('Persistent Console Logs defaults ON, Record IPC Traffic defaults OFF, for the regular (non-ephemeral) dev session', async () => {
+    // window.electronAPI.dev is undefined in the mock (mirrors a real,
+    // non-ephemeral dogfooding session, where `dev` is present but
+    // isEphemeralPreview is false) - DeveloperTab.tsx reads it via `?.`, so
+    // this exercises the "not ephemeral" branch without needing to stub it.
+    await openDeveloperTab();
+
+    await expect(toggleForTitle('Persistent Console Logs')).toHaveAttribute('aria-checked', 'true');
+    await expect(toggleForTitle('Record IPC Traffic')).toHaveAttribute('aria-checked', 'false');
+
+    await closeSettings();
+  });
+
+  test('Record IPC Traffic defaults ON when the session is the ephemeral /preview instance', async () => {
+    // Stub window.electronAPI.dev.isEphemeralPreview = true, then force the
+    // config store to reload so DeveloperTab re-renders with the new read.
+    // Cleaned up in `finally` so it does not leak into later tests on this
+    // shared page.
+    await page.evaluate(() => {
+      (window.electronAPI as unknown as { dev: { isEphemeralPreview: boolean } }).dev = {
+        isEphemeralPreview: true,
+      };
+    });
+
+    try {
+      await openDeveloperTab();
+
+      await expect(toggleForTitle('Record IPC Traffic')).toHaveAttribute('aria-checked', 'true');
+      // Persistent Console Logs does not depend on ephemeral state - still ON.
+      await expect(toggleForTitle('Persistent Console Logs')).toHaveAttribute('aria-checked', 'true');
+
+      await closeSettings();
+    } finally {
+      await page.evaluate(() => {
+        delete (window.electronAPI as unknown as { dev?: unknown }).dev;
+      });
+    }
+  });
+
+  // Deliberately last in this file: the mock's config.set() deep-merges and
+  // (like the real deepMergeConfig) SKIPS `undefined` values, so a stored
+  // `false` set here cannot be unset back to "never touched" afterward - only
+  // overwritten with another explicit value. Ordering this test last means no
+  // later test in this file depends on the developer config being unset.
+  test('an explicit stored false always wins over the dev-build default', async () => {
+    // Persist an explicit `false` for both toggles, then reload the config
+    // store so DeveloperTab picks it up. This is the `??` fallthrough guard:
+    // `??` only falls through on null/undefined, so a stored `false` must be
+    // respected rather than overridden by the dev-build default.
+    await page.evaluate(() => {
+      return window.electronAPI.config.set({
+        developer: { persistConsoleLogs: false, recordIpcTraffic: false },
+      });
+    });
+    await page.evaluate(() => {
+      const stores = (window as unknown as {
+        __zustandStores?: { config: { getState: () => { loadConfig: () => Promise<void> } } };
+      }).__zustandStores;
+      return stores?.config.getState().loadConfig();
+    });
+
+    await openDeveloperTab();
+
+    await expect(toggleForTitle('Persistent Console Logs')).toHaveAttribute('aria-checked', 'false');
+    await expect(toggleForTitle('Record IPC Traffic')).toHaveAttribute('aria-checked', 'false');
+
+    await closeSettings();
+  });
+});

--- a/tests/unit/central-embedding-engine-boundary.test.ts
+++ b/tests/unit/central-embedding-engine-boundary.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Enforces .claude/rules/central-embedding-engine.md: embedding work is
+ * triggered ONLY by embed-engine.ts's own duty-cycle-throttled drain loop,
+ * never inline from a lifecycle/IPC handler or a navigation event. This is
+ * the mechanical backstop for the core fix in the central-background-
+ * embedding refactor - a project switch must perform zero synchronous
+ * embedding, and that invariant only holds if nothing outside the engine can
+ * construct an EmbedClient or call embed() directly.
+ *
+ * Mirrors tests/unit/esbuild-cjs-imports.test.ts's scan-and-collect shape.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);
+/** The only file allowed to construct the embed worker or run the drain loop. */
+const ENGINE_FILE = 'src/main/retrieval/embedder/embed-engine.ts';
+
+function collectSourceFiles(directory: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath));
+    } else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function relativeLines(filePath: string): { relPath: string; lines: string[] } {
+  const relPath = path.relative(REPO_ROOT, filePath).replace(/\\/g, '/');
+  const lines = fs.readFileSync(filePath, 'utf-8').split('\n');
+  return { relPath, lines };
+}
+
+describe('central embedding engine boundary', () => {
+  it('constructs EmbedClient only from embed-engine.ts', () => {
+    const offenders: string[] = [];
+    const scanRoot = path.join(REPO_ROOT, 'src/main');
+    for (const filePath of collectSourceFiles(scanRoot)) {
+      const { relPath, lines } = relativeLines(filePath);
+      if (relPath === ENGINE_FILE) continue;
+      lines.forEach((line, index) => {
+        if (/\bnew EmbedClient\s*\(/.test(line)) {
+          offenders.push(`${relPath}:${index + 1}`);
+        }
+      });
+    }
+    expect(
+      offenders,
+      `Only embed-engine.ts may construct EmbedClient - the background drain and the interactive query path must share the ONE worker instance the engine owns. Offenders:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('never reintroduces an inline embed pass or heal poll outside the engine', () => {
+    // embedPass and scheduleEmbedHeal were the pre-refactor inline embedders,
+    // triggered by navigation/lifecycle events and a getStatus poll
+    // respectively. Both were deleted entirely - embedEngine.markDirty() is
+    // the only path a chunk-producing event may use. Their reappearance as a
+    // call or declaration anywhere signals the coupling has crept back in.
+    // Matches a call/declaration form (name immediately followed by '(') so a
+    // prose mention in a doc comment - e.g. explaining what this replaced -
+    // does not false-positive.
+    const offenders: string[] = [];
+    const scanRoot = path.join(REPO_ROOT, 'src/main');
+    for (const filePath of collectSourceFiles(scanRoot)) {
+      const { relPath, lines } = relativeLines(filePath);
+      lines.forEach((line, index) => {
+        if (/\b(embedPass|scheduleEmbedHeal)\s*\(/.test(line)) {
+          offenders.push(`${relPath}:${index + 1}`);
+        }
+      });
+    }
+    expect(
+      offenders,
+      `embedPass/scheduleEmbedHeal must not exist - embedding is driven ONLY by embedEngine's background drain loop (see embed-engine.ts). Offenders:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('never calls .embed( directly from an IPC handler', () => {
+    // Handlers may only reach the embed worker through the sanctioned facade
+    // (retrievalService.getEmbedder / reconcileEmbedWorker / startForProject,
+    // which all delegate to embedEngine) - never a direct `.embed(` call,
+    // which would bypass the engine's interactive-vs-background lane and duty
+    // cycle entirely.
+    const offenders: string[] = [];
+    const scanRoot = path.join(REPO_ROOT, 'src/main/ipc/handlers');
+    for (const filePath of collectSourceFiles(scanRoot)) {
+      const { relPath, lines } = relativeLines(filePath);
+      lines.forEach((line, index) => {
+        if (/\.embed\s*\(/.test(line)) {
+          offenders.push(`${relPath}:${index + 1}`);
+        }
+      });
+    }
+    expect(
+      offenders,
+      `IPC handlers must not call .embed( directly - go through retrievalService.getEmbedder()/embedEngine. Offenders:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/developer-flag-defaults.test.ts
+++ b/tests/unit/developer-flag-defaults.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for `defaultDeveloperFlag` (src/shared/developer-flag-defaults.ts).
+ *
+ * This is the decision logic behind `safeReadDeveloperFlag` in
+ * src/main/index.ts, extracted specifically because that file cannot itself
+ * be imported by a test: it is an Electron entry-point module with top-level
+ * `electron` API calls (`app`, `BrowserWindow`, ...) that throw outside a
+ * running Electron process, and vitest.config.ts pins `__KANGENTIC_DEV__` to
+ * `false` globally, so even an importable module could never observe the
+ * "true" branch of that build-time constant. Taking `isDevBuild` as a plain
+ * parameter here sidesteps both problems and lets every branch be exercised.
+ *
+ * Each case is anchored to the PR intent documented in the two call sites'
+ * comments (src/main/index.ts's safeReadDeveloperFlag and
+ * src/renderer/.../DeveloperTab.tsx), not reverse-engineered from the
+ * implementation:
+ *   - previewInspectionServer / previewEvalEnabled: ON in dev builds only.
+ *   - persistConsoleLogs: ON in ANY dev build (npm start AND /preview) -
+ *     the write path is async-queued, so there is no dogfooding cost.
+ *   - recordIpcTraffic: ON only for dev build AND ephemeral /preview - it has
+ *     a real per-call disk-I/O cost, bounded only in /preview by its data dir
+ *     being wiped on close.
+ *   - activityDebugOverlay (and any other/future key): always OFF by default -
+ *     it has a visible cost the user should opt into deliberately.
+ */
+import { describe, it, expect } from 'vitest';
+import { defaultDeveloperFlag, type DeveloperFlagKey } from '../../src/shared/developer-flag-defaults';
+
+describe('defaultDeveloperFlag - previewInspectionServer / previewEvalEnabled', () => {
+  it.each(['previewInspectionServer', 'previewEvalEnabled'] as const)(
+    '%s defaults ON in a dev build regardless of ephemeral state',
+    (key) => {
+      expect(defaultDeveloperFlag(key, true, false)).toBe(true);
+      expect(defaultDeveloperFlag(key, true, true)).toBe(true);
+    },
+  );
+
+  it.each(['previewInspectionServer', 'previewEvalEnabled'] as const)(
+    '%s defaults OFF in a production build regardless of ephemeral state',
+    (key) => {
+      expect(defaultDeveloperFlag(key, false, false)).toBe(false);
+      expect(defaultDeveloperFlag(key, false, true)).toBe(false);
+    },
+  );
+});
+
+describe('defaultDeveloperFlag - persistConsoleLogs', () => {
+  it('defaults ON in a dev build for the regular (non-ephemeral) npm start session', () => {
+    expect(defaultDeveloperFlag('persistConsoleLogs', true, false)).toBe(true);
+  });
+
+  it('defaults ON in a dev build for the ephemeral /preview session too', () => {
+    expect(defaultDeveloperFlag('persistConsoleLogs', true, true)).toBe(true);
+  });
+
+  it('defaults OFF in a production build even if somehow marked ephemeral', () => {
+    expect(defaultDeveloperFlag('persistConsoleLogs', false, false)).toBe(false);
+    expect(defaultDeveloperFlag('persistConsoleLogs', false, true)).toBe(false);
+  });
+});
+
+describe('defaultDeveloperFlag - recordIpcTraffic', () => {
+  it('defaults ON only for a dev build AND ephemeral /preview', () => {
+    expect(defaultDeveloperFlag('recordIpcTraffic', true, true)).toBe(true);
+  });
+
+  it('defaults OFF for a dev build that is NOT ephemeral (regular npm start dogfooding)', () => {
+    // This is the key distinction from persistConsoleLogs: the IPC recorder's
+    // real disk-I/O cost means the long-running dogfooding session must stay
+    // opt-in, even though it is a dev build.
+    expect(defaultDeveloperFlag('recordIpcTraffic', true, false)).toBe(false);
+  });
+
+  it('defaults OFF for a production build even if marked ephemeral', () => {
+    expect(defaultDeveloperFlag('recordIpcTraffic', false, true)).toBe(false);
+  });
+
+  it('defaults OFF for a production, non-ephemeral build', () => {
+    expect(defaultDeveloperFlag('recordIpcTraffic', false, false)).toBe(false);
+  });
+});
+
+describe('defaultDeveloperFlag - activityDebugOverlay', () => {
+  it('defaults OFF in every combination - it has a visible cost the user must opt into', () => {
+    expect(defaultDeveloperFlag('activityDebugOverlay', true, true)).toBe(false);
+    expect(defaultDeveloperFlag('activityDebugOverlay', true, false)).toBe(false);
+    expect(defaultDeveloperFlag('activityDebugOverlay', false, true)).toBe(false);
+    expect(defaultDeveloperFlag('activityDebugOverlay', false, false)).toBe(false);
+  });
+});
+
+describe('defaultDeveloperFlag - full table (pins every key x isDevBuild x isEphemeralPreview combination)', () => {
+  it('matches the documented default for every combination', () => {
+    const keys: DeveloperFlagKey[] = [
+      'activityDebugOverlay',
+      'persistConsoleLogs',
+      'recordIpcTraffic',
+      'previewInspectionServer',
+      'previewEvalEnabled',
+    ];
+    const booleans = [true, false];
+
+    const expectedFor = (key: DeveloperFlagKey, isDevBuild: boolean, isEphemeralPreview: boolean): boolean => {
+      if (key === 'previewInspectionServer' || key === 'previewEvalEnabled') return isDevBuild;
+      if (key === 'persistConsoleLogs') return isDevBuild;
+      if (key === 'recordIpcTraffic') return isDevBuild && isEphemeralPreview;
+      return false; // activityDebugOverlay
+    };
+
+    for (const key of keys) {
+      for (const isDevBuild of booleans) {
+        for (const isEphemeralPreview of booleans) {
+          expect(
+            defaultDeveloperFlag(key, isDevBuild, isEphemeralPreview),
+            `defaultDeveloperFlag('${key}', isDevBuild=${isDevBuild}, isEphemeralPreview=${isEphemeralPreview})`,
+          ).toBe(expectedFor(key, isDevBuild, isEphemeralPreview));
+        }
+      }
+    }
+  });
+});

--- a/tests/unit/embed-client.test.ts
+++ b/tests/unit/embed-client.test.ts
@@ -336,6 +336,105 @@ describe('EmbedClient', () => {
     }
   });
 
+  it('waitForInteractiveIdle resolves immediately when nothing is pending', async () => {
+    const client = new EmbedClient(TEST_MODEL);
+    await expect(client.waitForInteractiveIdle()).resolves.toBeUndefined();
+    client.dispose();
+  });
+
+  it('waitForInteractiveIdle resolves immediately when only background requests are pending', async () => {
+    const client = new EmbedClient(TEST_MODEL);
+    const promise = client.embed(['x'], { timeoutMs: 5000, background: true });
+    const child = lastChild();
+    child.emit('message', { type: 'ready' });
+    await flush();
+
+    // A background-only pending request must not block interactive idle -
+    // the whole point of the flag is that the background drain never counts
+    // as "the worker is busy with something interactive".
+    await expect(client.waitForInteractiveIdle()).resolves.toBeUndefined();
+
+    child.emit('message', { type: 'result', id: 1, vectors: [new Float32Array([0.1])] });
+    await promise;
+    client.dispose();
+  });
+
+  it('waitForInteractiveIdle waits until an in-flight interactive (non-background) request settles', async () => {
+    const client = new EmbedClient(TEST_MODEL);
+    const interactivePromise = client.embed(['query'], { timeoutMs: 5000 });
+    const child = lastChild();
+    child.emit('message', { type: 'ready' });
+    await flush();
+
+    let idleResolved = false;
+    const idlePromise = client.waitForInteractiveIdle().then(() => {
+      idleResolved = true;
+    });
+
+    // Still pending: the interactive request has not settled yet.
+    await flush();
+    expect(idleResolved).toBe(false);
+
+    child.emit('message', { type: 'result', id: 1, vectors: [new Float32Array([0.2])] });
+    await interactivePromise;
+    await idlePromise;
+    expect(idleResolved).toBe(true);
+
+    client.dispose();
+  });
+
+  it('does not resolve waitForInteractiveIdle while an interactive request is still inside the cold-start ensureReady() window (before ready)', async () => {
+    // Pins the interactiveInFlightCount fix: the counter increments BEFORE
+    // ensureReady() so a live query counts as in-flight during a cold worker
+    // spawn/init, not only once the request reaches `pending` in sendEmbed().
+    // If the counter were removed (falling back to a `pending`-only scan),
+    // hasInteractiveInFlight() would see an empty `pending` during this
+    // window and waitForInteractiveIdle() would resolve immediately here --
+    // exactly the regression this test catches. Unlike the other
+    // waitForInteractiveIdle tests, this one deliberately does NOT emit
+    // 'ready' before calling waitForInteractiveIdle(), so it actually
+    // exercises the cold-start window instead of the post-ready pending one.
+    const client = new EmbedClient(TEST_MODEL);
+    const interactivePromise = client.embed(['cold-query'], { timeoutMs: 5000 });
+
+    let idleResolved = false;
+    const idlePromise = client.waitForInteractiveIdle().then(() => {
+      idleResolved = true;
+    });
+
+    // No 'ready' emitted yet -- the request is still inside ensureReady().
+    await flush();
+    expect(idleResolved).toBe(false);
+
+    const child = lastChild();
+    child.emit('message', { type: 'ready' });
+    await flush();
+    // Ready fired, but the interactive request itself has not settled (no
+    // result reply yet), so idle must still not be resolved.
+    expect(idleResolved).toBe(false);
+
+    child.emit('message', { type: 'result', id: 1, vectors: [new Float32Array([0.3])] });
+    await interactivePromise;
+    await idlePromise;
+    expect(idleResolved).toBe(true);
+
+    client.dispose();
+  });
+
+  it('waitForInteractiveIdle resolves once an interactive request times out with no reply', async () => {
+    const client = new EmbedClient(TEST_MODEL);
+    const interactivePromise = client.embed(['query'], { timeoutMs: 10 });
+    const child = lastChild();
+    child.emit('message', { type: 'ready' });
+    await flush();
+    const idlePromise = client.waitForInteractiveIdle();
+
+    await expect(interactivePromise).resolves.toBeNull();
+    await expect(idlePromise).resolves.toBeUndefined();
+
+    client.dispose();
+  });
+
   it('degrades cleanly to null when the worker reports an init error before ready (no throw)', async () => {
     // An init/model-load failure surfaces as an 'error' message with no `id`,
     // before 'ready'. ensureReady()/embed() must degrade to null without

--- a/tests/unit/embed-engine.test.ts
+++ b/tests/unit/embed-engine.test.ts
@@ -1,0 +1,531 @@
+import { describe, it, expect, vi } from 'vitest';
+import type Database from 'better-sqlite3';
+
+// The real isEmbeddingModelPresent does fs.existsSync against PATHS.embeddingModelsDir;
+// these tests exercise the drain loop's scheduling logic, not on-disk model presence,
+// so it is stubbed to always report the model as available.
+vi.mock('../../src/main/retrieval/embedder/embedding-model', () => ({
+  isEmbeddingModelPresent: vi.fn(() => true),
+  downloadEmbeddingModel: vi.fn(),
+}));
+
+import {
+  createEmbedEngine,
+  computeEmbedSleepMs,
+  type EmbedStore,
+  type EmbedWorkerClient,
+} from '../../src/main/retrieval/embedder/embed-engine';
+import { markVecCapable } from '../../src/main/retrieval/vec-support';
+import { isEmbeddingModelPresent } from '../../src/main/retrieval/embedder/embedding-model';
+import type { IpcContext } from '../../src/main/ipc/ipc-context';
+import type { StoredChunk } from '../../src/main/retrieval/types';
+import type { EmbeddingModelDef } from '../../src/main/retrieval/embedder/embedding-config';
+import type { MemoryAcceleration } from '../../src/shared/types';
+
+/**
+ * The central embedding engine's scheduling contract: the duty-cycle pacer
+ * math, dirty-set round-robin draining across projects, and crash/transient
+ * resume. The embed worker and the store are both faked via the engine's DI
+ * seam (createEmbedEngine's deps) rather than the real EmbedClient/
+ * RetrievalStore - those are covered by embed-client.test.ts and
+ * retrieval-store-sql.test.ts respectively.
+ */
+
+function makeChunk(id: number, contentHash = `hash-${id}`): StoredChunk {
+  return {
+    id,
+    corpus: 'conversation',
+    docId: 'doc',
+    seq: id,
+    sessionId: null,
+    taskId: null,
+    agentSessionId: null,
+    role: 'user',
+    text: `text-${id}`,
+    contentHash,
+    tokenEstimate: 1,
+    tsStart: null,
+    tsEnd: null,
+    turnUuidStart: null,
+    turnUuidEnd: null,
+    embeddedModel: null,
+  };
+}
+
+/** A minimal in-memory EmbedStore. `chunksNeedingEmbedding` records a visit
+ *  (its project id) into the shared `visits` array on every call, so tests
+ *  can assert the drain's round-robin ordering across projects. */
+class FakeStore implements EmbedStore {
+  hasVec = true;
+  written: Array<{ chunkId: number; vector: Float32Array; contentHash: string }> = [];
+
+  constructor(
+    private readonly projectId: string,
+    private pending: StoredChunk[],
+    private readonly visits: string[],
+  ) {}
+
+  getMeta(): string | undefined {
+    return undefined;
+  }
+  setMeta(): void {}
+  resetVec(): void {}
+  ensureVecTable(): void {}
+
+  chunksNeedingEmbedding(_modelTag: string, limit: number): StoredChunk[] {
+    this.visits.push(this.projectId);
+    return this.pending.slice(0, limit);
+  }
+
+  writeEmbeddings(rows: Array<{ chunkId: number; vector: Float32Array; contentHash: string }>): void {
+    this.written.push(...rows);
+    const writtenIds = new Set(rows.map((row) => row.chunkId));
+    this.pending = this.pending.filter((chunk) => !writtenIds.has(chunk.id));
+  }
+
+  get remaining(): number {
+    return this.pending.length;
+  }
+}
+
+function makeFakeClient(overrides?: Partial<EmbedWorkerClient>): EmbedWorkerClient {
+  return {
+    embed: vi.fn(async (texts: string[]) => texts.map(() => new Float32Array([0.1]))),
+    setWarmHold: vi.fn(),
+    waitForInteractiveIdle: vi.fn(() => Promise.resolve()),
+    dispose: vi.fn(),
+    crashed: false,
+    activeDevice: 'cpu',
+    dimensions: 384,
+    modelTag: 'bge-base@q8-cls',
+    noiseFloor: 0.4,
+    ...overrides,
+  };
+}
+
+function makeContext(overrides?: { currentProjectId?: string | null; semanticEnabled?: boolean }): IpcContext {
+  return {
+    configManager: {
+      load: () => ({ memory: { semanticEnabled: overrides?.semanticEnabled ?? true } }),
+    },
+    currentProjectId: overrides?.currentProjectId ?? null,
+  } as unknown as IpcContext;
+}
+
+const immediateDelay = (): Promise<void> => Promise.resolve();
+
+describe('computeEmbedSleepMs (duty-cycle pacer)', () => {
+  it('scales the sleep proportionally to hold the duty-cycle average', () => {
+    // sleep = batchMs * (1/dutyCycle - 1): a 20% duty cycle sleeps 4x the batch.
+    expect(computeEmbedSleepMs(30, 0.2)).toBeCloseTo(120, 5);
+    expect(computeEmbedSleepMs(800, 0.2)).toBeCloseTo(3200, 5);
+  });
+
+  it('is machine-independent: the same duty cycle holds regardless of batch duration', () => {
+    expect(computeEmbedSleepMs(10, 0.2) / 10).toBeCloseTo(computeEmbedSleepMs(1000, 0.2) / 1000, 5);
+  });
+
+  it('floors at 0 and never returns a negative sleep', () => {
+    expect(computeEmbedSleepMs(0, 0.2)).toBe(0);
+  });
+
+  it('returns 0 for a duty cycle of 1 (no throttling) and for a non-positive duty cycle', () => {
+    expect(computeEmbedSleepMs(500, 1)).toBe(0);
+    expect(computeEmbedSleepMs(500, 0)).toBe(0);
+    expect(computeEmbedSleepMs(500, -1)).toBe(0);
+  });
+});
+
+describe('createEmbedEngine drain loop', () => {
+  it('drains each dirty project FIFO and round-robins across projects rather than draining one to completion first', async () => {
+    const visits: string[] = [];
+    const storeA = new FakeStore('proj-a', [makeChunk(1), makeChunk(2)], visits);
+    const storeB = new FakeStore('proj-b', [makeChunk(3), makeChunk(4)], visits);
+    const dbA = { __fakeProjectId: 'proj-a' } as unknown as Database.Database;
+    const dbB = { __fakeProjectId: 'proj-b' } as unknown as Database.Database;
+    markVecCapable(dbA);
+    markVecCapable(dbB);
+    const dbs = new Map<string, Database.Database>([
+      ['proj-a', dbA],
+      ['proj-b', dbB],
+    ]);
+    const stores = new Map<string, FakeStore>([
+      ['proj-a', storeA],
+      ['proj-b', storeB],
+    ]);
+
+    const engine = createEmbedEngine({
+      getDb: (projectId) => dbs.get(projectId)!,
+      createStore: (db) => stores.get((db as unknown as { __fakeProjectId: string }).__fakeProjectId)!,
+      createClient: () => makeFakeClient(),
+      delay: immediateDelay,
+      drainBatchSize: 1,
+    });
+
+    engine.attach(makeContext({ currentProjectId: 'proj-a' }));
+    engine.markDirty('proj-a');
+    engine.markDirty('proj-b');
+
+    await vi.waitFor(() => {
+      expect(storeA.remaining).toBe(0);
+      expect(storeB.remaining).toBe(0);
+    });
+
+    // Batch size 1, two chunks per project: a true round-robin alternates on
+    // every visit. If the loop instead drained proj-a to completion before
+    // ever trying proj-b, this would read ['proj-a','proj-a','proj-b','proj-b'].
+    expect(visits).toEqual(['proj-a', 'proj-b', 'proj-a', 'proj-b', 'proj-a', 'proj-b']);
+
+    engine.dispose();
+  });
+
+  it('FIFOs within a project: oldest chunk id embeds first', async () => {
+    const visits: string[] = [];
+    const store = new FakeStore('proj-fifo', [makeChunk(5), makeChunk(6), makeChunk(7)], visits);
+    const db = { name: 'proj-fifo' } as unknown as Database.Database;
+    markVecCapable(db);
+    const writtenOrder: number[] = [];
+    const client = makeFakeClient({
+      embed: vi.fn(async (texts: string[]) => {
+        writtenOrder.push(...texts.map((text) => Number(text.replace('text-', ''))));
+        return texts.map(() => new Float32Array([0.1]));
+      }),
+    });
+
+    const engine = createEmbedEngine({
+      getDb: () => db,
+      createStore: () => store,
+      createClient: () => client,
+      delay: immediateDelay,
+      drainBatchSize: 1,
+    });
+
+    engine.attach(makeContext({ currentProjectId: 'proj-fifo' }));
+    engine.markDirty('proj-fifo');
+
+    await vi.waitFor(() => expect(store.remaining).toBe(0));
+    expect(writtenOrder).toEqual([5, 6, 7]);
+
+    engine.dispose();
+  });
+
+  it('keeps a project dirty and retries after a transient embed failure, then finishes draining (crash-resume)', async () => {
+    const store = new FakeStore('proj-c', [makeChunk(10), makeChunk(11)], []);
+    const db = { name: 'proj-c' } as unknown as Database.Database;
+    markVecCapable(db);
+
+    let callCount = 0;
+    const client = makeFakeClient({
+      embed: vi.fn(async (texts: string[]) => {
+        callCount += 1;
+        // First attempt simulates a transient worker hiccup (timeout / queue
+        // full / mid-restart); subsequent attempts succeed.
+        if (callCount === 1) return null;
+        return texts.map(() => new Float32Array([0.5]));
+      }),
+    });
+
+    const engine = createEmbedEngine({
+      getDb: () => db,
+      createStore: () => store,
+      createClient: () => client,
+      delay: immediateDelay,
+      drainBatchSize: 2,
+      transientBackoffMs: 0,
+    });
+
+    engine.attach(makeContext({ currentProjectId: 'proj-c' }));
+    engine.markDirty('proj-c');
+
+    await vi.waitFor(() => expect(store.remaining).toBe(0));
+    expect(client.embed).toHaveBeenCalledTimes(2);
+
+    engine.dispose();
+  });
+
+  it('never busy-spins against a crashed client: it parks instead of calling embed', async () => {
+    const store = new FakeStore('proj-d', [makeChunk(20)], []);
+    const db = { name: 'proj-d' } as unknown as Database.Database;
+    markVecCapable(db);
+    const client = makeFakeClient({ crashed: true });
+
+    const engine = createEmbedEngine({
+      getDb: () => db,
+      createStore: () => store,
+      createClient: () => client,
+      delay: immediateDelay,
+    });
+
+    engine.attach(makeContext({ currentProjectId: 'proj-d' }));
+    engine.markDirty('proj-d');
+
+    // Let the loop run to the crashed branch and park; give it a generous
+    // window since parking must never be observed as continued embed() calls.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(client.embed).not.toHaveBeenCalled();
+
+    // dispose() must resolve the parked wake deferred synchronously so the
+    // loop actually exits rather than hanging forever - this is the
+    // load-bearing shutdown guarantee for a parked (crashed-client) loop.
+    expect(() => engine.dispose()).not.toThrow();
+  });
+
+  it('does not embed while semantic is disabled, even with a dirty project', async () => {
+    const store = new FakeStore('proj-e', [makeChunk(30)], []);
+    const db = { name: 'proj-e' } as unknown as Database.Database;
+    markVecCapable(db);
+    const client = makeFakeClient();
+
+    const engine = createEmbedEngine({
+      getDb: () => db,
+      createStore: () => store,
+      createClient: () => client,
+      delay: immediateDelay,
+    });
+
+    engine.attach(makeContext({ currentProjectId: 'proj-e', semanticEnabled: false }));
+    engine.markDirty('proj-e');
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(client.embed).not.toHaveBeenCalled();
+    expect(store.remaining).toBe(1);
+
+    engine.dispose();
+  });
+});
+
+describe('createEmbedEngine getEmbedder (resolveEmbedder)', () => {
+  it('returns null when semantic search is disabled, even with a project open', () => {
+    const engine = createEmbedEngine({
+      getDb: () => ({}) as unknown as Database.Database,
+      createStore: () => new FakeStore('proj-disabled', [], []),
+      createClient: () => makeFakeClient(),
+      delay: immediateDelay,
+    });
+
+    const context = makeContext({ currentProjectId: 'proj-disabled', semanticEnabled: false });
+    expect(engine.getEmbedder(context)).toBeNull();
+  });
+
+  it('returns null when the selected embedding model is not present on disk', () => {
+    vi.mocked(isEmbeddingModelPresent).mockReturnValueOnce(false);
+
+    const engine = createEmbedEngine({
+      getDb: () => ({}) as unknown as Database.Database,
+      createStore: () => new FakeStore('proj-missing-model', [], []),
+      createClient: () => makeFakeClient(),
+      delay: immediateDelay,
+    });
+
+    const context = makeContext({ currentProjectId: 'proj-missing-model', semanticEnabled: true });
+    expect(engine.getEmbedder(context)).toBeNull();
+  });
+
+  it('returns null when the shared client has crashed past MAX_CRASHES', () => {
+    const crashedClient = makeFakeClient({ crashed: true });
+    const engine = createEmbedEngine({
+      getDb: () => ({}) as unknown as Database.Database,
+      createStore: () => new FakeStore('proj-crashed', [], []),
+      createClient: () => crashedClient,
+      delay: immediateDelay,
+    });
+
+    const context = makeContext({ currentProjectId: 'proj-crashed', semanticEnabled: true });
+    expect(engine.getEmbedder(context)).toBeNull();
+  });
+
+  it('returns the shared client for the interactive query path when semantic is enabled, the model is present, and the client is healthy', () => {
+    const client = makeFakeClient();
+    const engine = createEmbedEngine({
+      getDb: () => ({}) as unknown as Database.Database,
+      createStore: () => new FakeStore('proj-healthy', [], []),
+      createClient: () => client,
+      delay: immediateDelay,
+    });
+
+    const context = makeContext({ currentProjectId: 'proj-healthy', semanticEnabled: true });
+    expect(engine.getEmbedder(context)).toBe(client);
+  });
+});
+
+describe('createEmbedEngine reconcile', () => {
+  it('holds the existing client warm without disposing it when semantic is enabled and a project is open', () => {
+    const client = makeFakeClient();
+    const engine = createEmbedEngine({
+      getDb: () => ({}) as unknown as Database.Database,
+      createStore: () => new FakeStore('proj-warm', [], []),
+      createClient: () => client,
+      delay: immediateDelay,
+    });
+
+    const context = makeContext({ currentProjectId: 'proj-warm', semanticEnabled: true });
+    // Seed the shared client via the query path first, so there is something
+    // for reconcile to hold warm. attach() is deliberately NOT called here:
+    // the warm-hold/dispose branch of reconcile is synchronous and does not
+    // depend on the drain loop being started.
+    engine.getEmbedder(context);
+    client.setWarmHold.mockClear();
+    client.dispose.mockClear();
+
+    engine.reconcile(context);
+
+    expect(client.setWarmHold).toHaveBeenCalledWith(true);
+    expect(client.dispose).not.toHaveBeenCalled();
+  });
+
+  it('disposes the cached client and drops it when semantic becomes disabled', () => {
+    const client = makeFakeClient();
+    const engine = createEmbedEngine({
+      getDb: () => ({}) as unknown as Database.Database,
+      createStore: () => new FakeStore('proj-cold', [], []),
+      createClient: () => client,
+      delay: immediateDelay,
+    });
+
+    const enabledContext = makeContext({ currentProjectId: 'proj-cold', semanticEnabled: true });
+    engine.getEmbedder(enabledContext);
+    expect(client.dispose).not.toHaveBeenCalled();
+
+    const disabledContext = makeContext({ currentProjectId: 'proj-cold', semanticEnabled: false });
+    engine.reconcile(disabledContext);
+
+    expect(client.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('disposes the cached client and drops it when no project is open, even with semantic enabled', () => {
+    const client = makeFakeClient();
+    const engine = createEmbedEngine({
+      getDb: () => ({}) as unknown as Database.Database,
+      createStore: () => new FakeStore('proj-none', [], []),
+      createClient: () => client,
+      delay: immediateDelay,
+    });
+
+    const openContext = makeContext({ currentProjectId: 'proj-none', semanticEnabled: true });
+    engine.getEmbedder(openContext);
+    expect(client.dispose).not.toHaveBeenCalled();
+
+    const noProjectContext = makeContext({ currentProjectId: null, semanticEnabled: true });
+    engine.reconcile(noProjectContext);
+
+    expect(client.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the current project dirty on reconcile itself (not just via markDirty) when semantic is enabled and the model is present, so a drain picks it up', async () => {
+    const visits: string[] = [];
+    const store = new FakeStore('proj-reconcile-dirty', [makeChunk(50)], visits);
+    const db = { name: 'proj-reconcile-dirty' } as unknown as Database.Database;
+    markVecCapable(db);
+    const client = makeFakeClient();
+
+    const engine = createEmbedEngine({
+      getDb: () => db,
+      createStore: () => store,
+      createClient: () => client,
+      delay: immediateDelay,
+    });
+
+    const context = makeContext({ currentProjectId: 'proj-reconcile-dirty', semanticEnabled: true });
+    engine.attach(context);
+
+    // No markDirty call here -- reconcile itself is what must flag the project.
+    engine.reconcile(context);
+
+    await vi.waitFor(() => expect(store.remaining).toBe(0));
+    expect(visits).toContain('proj-reconcile-dirty');
+
+    engine.dispose();
+  });
+});
+
+describe('createEmbedEngine getClientFor model/acceleration switch', () => {
+  function makeMutableContext(initial: {
+    currentProjectId?: string | null;
+    semanticEnabled?: boolean;
+    embeddingModel?: string;
+    acceleration?: MemoryAcceleration;
+  }): { context: IpcContext; state: typeof initial } {
+    const state = { ...initial };
+    const context = {
+      configManager: {
+        load: () => ({
+          memory: {
+            semanticEnabled: state.semanticEnabled ?? true,
+            embeddingModel: state.embeddingModel,
+            acceleration: state.acceleration,
+          },
+        }),
+      },
+      get currentProjectId() {
+        return state.currentProjectId ?? null;
+      },
+    } as unknown as IpcContext;
+    return { context, state };
+  }
+
+  it('disposes the old client and creates a fresh one when the selected model changes', () => {
+    const createdClients: EmbedWorkerClient[] = [];
+    const createClient = vi.fn((model: EmbeddingModelDef, _acceleration: MemoryAcceleration): EmbedWorkerClient => {
+      const instance = makeFakeClient({ modelTag: model.modelTag, dimensions: model.dimensions });
+      createdClients.push(instance);
+      return instance;
+    });
+
+    const engine = createEmbedEngine({
+      getDb: () => ({}) as unknown as Database.Database,
+      createStore: () => new FakeStore('proj-model-switch', [], []),
+      createClient,
+      delay: immediateDelay,
+    });
+
+    const { context, state } = makeMutableContext({
+      currentProjectId: 'proj-model-switch',
+      embeddingModel: 'bge-small',
+    });
+
+    const first = engine.getEmbedder(context);
+    expect(createClient).toHaveBeenCalledTimes(1);
+    expect(first).toBe(createdClients[0]);
+
+    state.embeddingModel = 'bge-large';
+    const second = engine.getEmbedder(context);
+
+    expect(createdClients[0].dispose).toHaveBeenCalledTimes(1);
+    expect(createClient).toHaveBeenCalledTimes(2);
+    expect(second).toBe(createdClients[1]);
+    expect(second).not.toBe(first);
+  });
+
+  it('disposes the old client and creates a fresh one when the acceleration preference changes', () => {
+    const createdClients: EmbedWorkerClient[] = [];
+    const createClient = vi.fn((_model: EmbeddingModelDef, _acceleration: MemoryAcceleration): EmbedWorkerClient => {
+      const instance = makeFakeClient();
+      createdClients.push(instance);
+      return instance;
+    });
+
+    const engine = createEmbedEngine({
+      getDb: () => ({}) as unknown as Database.Database,
+      createStore: () => new FakeStore('proj-accel-switch', [], []),
+      createClient,
+      delay: immediateDelay,
+    });
+
+    const { context, state } = makeMutableContext({
+      currentProjectId: 'proj-accel-switch',
+      acceleration: 'cpu',
+    });
+
+    const first = engine.getEmbedder(context);
+    expect(createClient).toHaveBeenCalledTimes(1);
+    expect(first).toBe(createdClients[0]);
+
+    state.acceleration = 'gpu';
+    const second = engine.getEmbedder(context);
+
+    expect(createdClients[0].dispose).toHaveBeenCalledTimes(1);
+    expect(createClient).toHaveBeenCalledTimes(2);
+    expect(second).toBe(createdClients[1]);
+    expect(second).not.toBe(first);
+  });
+});

--- a/tests/unit/register-all-idempotency.test.ts
+++ b/tests/unit/register-all-idempotency.test.ts
@@ -112,6 +112,27 @@ vi.mock('node-pty', () => ({ spawn: vi.fn() }));
 vi.mock('better-sqlite3', () => ({ default: vi.fn() }));
 vi.mock('simple-git', () => ({ default: vi.fn(() => ({})) }));
 
+// registerAllIpc calls retrievalService.attach(context) directly at startup
+// (so the central embedding engine's drain loop is alive from boot, not just
+// on the first project:open). Left unmocked, the real
+// retrievalService.attach() pulls in the full retrieval subsystem
+// (ConversationIndexer -> the real agent-registry -> every agent adapter) and
+// subscribes to context.sessionManager events - the same isolation problem
+// config-handler-wiring.test.ts hit and stubs away for the same reason.
+vi.mock('../../src/main/retrieval/retrieval-service', () => ({
+  retrievalService: {
+    attach: vi.fn(),
+    startForProject: vi.fn(),
+    reconcileEmbedWorker: vi.fn(),
+    getStatus: vi.fn(),
+    getEmbedder: vi.fn(),
+    stop: vi.fn(),
+    purgeProjectIndex: vi.fn(),
+    rebuildProjectIndex: vi.fn(),
+    dispose: vi.fn(),
+  },
+}));
+
 // Mock every handler-registration function that `registerAllIpc` imports.
 // If `register-all.ts` grows a new `registerXxxHandlers` call, add a mock
 // here - otherwise the real implementation runs, pulls its full dependency
@@ -189,6 +210,7 @@ describe('registerAllIpc idempotency', () => {
     const { registerTaskMoveHandlers } = await import('../../src/main/ipc/handlers/task-move');
     const { registerTaskBranchHandlers } = await import('../../src/main/ipc/handlers/task-branch');
     const { registerTaskRuntimeOverrideHandlers } = await import('../../src/main/ipc/handlers/task-runtime-override');
+    const { retrievalService } = await import('../../src/main/retrieval/retrieval-service');
 
     const window = makeMockWindow(1);
     registerAllIpc(window);
@@ -200,6 +222,11 @@ describe('registerAllIpc idempotency', () => {
     expect(registerTaskMoveHandlers).toHaveBeenCalledTimes(1);
     expect(registerTaskBranchHandlers).toHaveBeenCalledTimes(1);
     expect(registerTaskRuntimeOverrideHandlers).toHaveBeenCalledTimes(1);
+
+    // The central embedding engine's drain loop is started at boot (not just
+    // lazily on the first project:open), so the drain loop is already alive
+    // before any project is opened.
+    expect(retrievalService.attach).toHaveBeenCalledTimes(1);
 
     // Context is initialized (wrappers don't throw)
     expect(() => getSessionManager()).not.toThrow();
@@ -219,6 +246,7 @@ describe('registerAllIpc idempotency', () => {
     const { registerBacklogHandlers } = await import('../../src/main/ipc/handlers/backlog');
     const { registerGitDiffHandlers } = await import('../../src/main/ipc/handlers/git-diff');
     const { registerSystemHandlers } = await import('../../src/main/ipc/handlers/system');
+    const { retrievalService } = await import('../../src/main/retrieval/retrieval-service');
 
     const window1 = makeMockWindow(1);
     const window2 = makeMockWindow(2);
@@ -249,6 +277,10 @@ describe('registerAllIpc idempotency', () => {
     expect(registerBacklogHandlers).toHaveBeenCalledTimes(1);
     expect(registerGitDiffHandlers).toHaveBeenCalledTimes(1);
     expect(registerSystemHandlers).toHaveBeenCalledTimes(1);
+
+    // The second call short-circuits before reaching retrievalService.attach,
+    // so it stays called exactly once total across both registerAllIpc calls.
+    expect(retrievalService.attach).toHaveBeenCalledTimes(1);
   }, 30000);
 
   it('second call preserves existing services', async () => {

--- a/tests/unit/retrieval-store-sql.test.ts
+++ b/tests/unit/retrieval-store-sql.test.ts
@@ -171,12 +171,17 @@ describe('RetrievalStore.writeEmbeddings (vec0 has no UPSERT)', () => {
     // then INSERT. Force vecReady: mark the fake connection vec-capable and have
     // the constructor's sqlite_master probe report the table already exists.
     const { db, calls } = makeRecordingDb({
-      get: (sql) => (sql.includes('sqlite_master') ? { name: 'memory_chunks_vec' } : undefined),
+      get: (sql) =>
+        sql.includes('sqlite_master')
+          ? { name: 'memory_chunks_vec' }
+          : sql.includes('content_hash')
+            ? { content_hash: 'hash-7' }
+            : undefined,
     });
     markVecCapable(db);
 
     new RetrievalStore(db).writeEmbeddings(
-      [{ chunkId: 7, vector: new Float32Array([0.1, 0.2, 0.3]) }],
+      [{ chunkId: 7, vector: new Float32Array([0.1, 0.2, 0.3]), contentHash: 'hash-7' }],
       'bge-base@q8',
     );
 
@@ -197,6 +202,75 @@ describe('RetrievalStore.writeEmbeddings (vec0 has no UPSERT)', () => {
     // The chunk is marked embedded with the model tag.
     const markCall = findRun(calls, 'UPDATE memory_chunks SET embedded_model');
     expect(markCall?.args).toEqual(['bge-base@q8', 7]);
+  });
+
+  it('skips a chunk whose content_hash changed since it was fetched, without writing a stale vector', () => {
+    // Guards the concurrency-correctness fix for the background embedding
+    // drain: memory_chunks.id is INTEGER PRIMARY KEY WITHOUT AUTOINCREMENT, so
+    // a concurrent re-index (upsertDocument) can delete-then-reinsert a
+    // churning chunk's row and have SQLite reuse the freed rowid for a
+    // DIFFERENT chunk before this write lands. Re-validating content_hash
+    // inside the same transaction must skip the row rather than stamp a
+    // stale vector onto the new chunk's rowid.
+    const { db, calls } = makeRecordingDb({
+      get: (sql) =>
+        sql.includes('sqlite_master')
+          ? { name: 'memory_chunks_vec' }
+          : sql.includes('content_hash')
+            ? { content_hash: 'hash-NEW' } // the row changed after the fetch
+            : undefined,
+    });
+    markVecCapable(db);
+
+    new RetrievalStore(db).writeEmbeddings(
+      [{ chunkId: 7, vector: new Float32Array([0.1, 0.2, 0.3]), contentHash: 'hash-STALE' }],
+      'bge-base@q8',
+    );
+
+    expect(findRun(calls, 'DELETE FROM memory_chunks_vec')).toBeUndefined();
+    expect(findRun(calls, 'INSERT INTO memory_chunks_vec')).toBeUndefined();
+    expect(findRun(calls, 'UPDATE memory_chunks SET embedded_model')).toBeUndefined();
+  });
+
+  it('skips a chunk that no longer exists (deleted concurrently)', () => {
+    const { db, calls } = makeRecordingDb({
+      get: (sql) => (sql.includes('sqlite_master') ? { name: 'memory_chunks_vec' } : undefined),
+    });
+    markVecCapable(db);
+
+    new RetrievalStore(db).writeEmbeddings(
+      [{ chunkId: 7, vector: new Float32Array([0.1, 0.2, 0.3]), contentHash: 'hash-7' }],
+      'bge-base@q8',
+    );
+
+    expect(findRun(calls, 'INSERT INTO memory_chunks_vec')).toBeUndefined();
+    expect(findRun(calls, 'UPDATE memory_chunks SET embedded_model')).toBeUndefined();
+  });
+});
+
+describe('RetrievalStore.countChunksNeedingEmbedding', () => {
+  it('returns the COUNT(*) for the same WHERE clause as chunksNeedingEmbedding', () => {
+    const { db, calls } = makeRecordingDb({
+      get: (sql) =>
+        sql.includes('sqlite_master')
+          ? { name: 'memory_chunks_vec' }
+          : sql.includes('COUNT(*)')
+            ? { count: 3 }
+            : undefined,
+    });
+    markVecCapable(db);
+
+    const count = new RetrievalStore(db).countChunksNeedingEmbedding('bge-base@q8');
+
+    expect(count).toBe(3);
+    const countCall = calls.find((call) => call.method === 'get' && call.sql.includes('COUNT(*)'));
+    expect(countCall?.sql).toContain('embedded_model IS NULL OR embedded_model != ?');
+    expect(countCall?.args).toEqual(['bge-base@q8']);
+  });
+
+  it('returns 0 when the vec table is not ready', () => {
+    const { db } = makeRecordingDb({});
+    expect(new RetrievalStore(db).countChunksNeedingEmbedding('bge-base@q8')).toBe(0);
   });
 });
 


### PR DESCRIPTION
## What

Introduces a single, central, project-agnostic background embedding engine
(`src/main/retrieval/embedder/embed-engine.ts`) that is the sole embedder of
conversation chunks in the app. Every lifecycle/IPC call site that used to
embed inline now only indexes and flags a project dirty; the engine alone
decides when to actually embed, self-paced and duty-cycle throttled.

Also fixes a cold-start resume gap and adds a couple of related quality-of-life
changes to developer tooling defaults surfaced along the way.

## Why

Switching back to a project whose active task was churning produced a felt
hardware spike (GPU power draw, or a multi-second CPU burn) correlated with
the click, not with any real-time need. Root cause: `startForProject`,
session finalize/live-index, and a `getStatus`-polled heal each ran an
inline `embedPass` synchronously at navigation time. #352 already fixed the
*cold-load* spikes (warm-holding the worker); this closes the residual - the
legitimate inference cost of embedding itself, which #352 relocated but
could not remove.

## How

- **`embed-engine.ts`** owns the embed worker singleton, a dirty-set of
  project ids, and a self-paced drain loop: round-robins dirty projects,
  FIFO within each (oldest chunk id first), embeds one small batch at a
  time, and paces itself with a measured duty-cycle sleep
  (`sleep = batchMs * (1/dutyCycle - 1)`, default 20%) so a large first-run
  or model-switch backfill is paced too, never a sustained peg - not just
  steady per-turn churn. Live interactive queries (search / MCP recall)
  always preempt the background drain in the shared worker via a
  `background` flag + `waitForInteractiveIdle()` on `EmbedClient`.
- **`retrieval-service.ts`** is stripped down to indexing + status + model
  download orchestration; `embedPass` and `scheduleEmbedHeal` are deleted
  entirely. Lifecycle hooks now call `embedEngine.markDirty(projectId)`
  instead of embedding inline.
- **Concurrency correctness:** decoupling the drain from the indexer's
  serial job chain reintroduced a race - `memory_chunks.id` is
  `INTEGER PRIMARY KEY` without `AUTOINCREMENT`, so a concurrent re-index
  could have SQLite reuse a rowid mid-drain. `writeEmbeddings` now
  re-validates each chunk's `content_hash` inside its own transaction before
  writing, closing the window.
- **Cold-start resume fix:** `openProjectByPath` (the app's auto-restore-on-launch
  path, structurally separate from the per-switch `PROJECT_OPEN` handler)
  never flagged a project's backlog dirty, so a user who closed the app
  mid-drain and reopened later would not resume until they manually clicked
  into the sidebar. `main/index.ts`'s one-shot boot path now also calls
  `retrievalService.startForProject` once at startup. This does not
  reintroduce navigation-coupled embedding: it fires exactly once per app
  launch, and `startForProject` itself only does a deferred sweep +
  `markDirty` - never inline embedding.
- **Developer settings:** Persist Console Logs now defaults on for any dev
  build (`npm start` and `/preview` alike) - the write path is already
  async-queued, so this has no measurable dogfooding cost, and having the
  trace already captured beats remembering to flip a toggle. Record IPC
  Traffic defaults on only for `/preview` (its real disk-I/O cost stays
  opt-in for the long-running `npm start` session, whose data isn't wiped on
  close).
- **Test Harness:** a new dev-only "Seed Embedding Backlog" action
  (`src/devtools/main/seed-embedding-backlog.ts`) seeds synthetic pending
  chunks through the real chunk-write path, for exercising the drain loop at
  realistic backlog sizes without needing that many real agent turns.
- `.claude/rules/central-embedding-engine.md` plus a CI drift guard
  (`central-embedding-engine-boundary.test.ts`) pin the core invariant: only
  the engine embeds.

## Breaking changes

None. Purely a scheduling-layer change; the search path, model/vec-store
logic, and warm-hold gate are unchanged.

## Tests

- `tests/unit/embed-engine.test.ts` - duty-cycle pacer math, FIFO-within-a-
  project / round-robin-across-projects draining, crash/transient resume,
  no-busy-spin, semantic-disabled gating - via the engine's own DI seam.
- `tests/unit/embed-client.test.ts` - `waitForInteractiveIdle()` behavior
  (idle-resolves-immediately, background-does-not-block, interactive-blocks-
  until-settled, resolves-on-timeout).
- `tests/unit/retrieval-store-sql.test.ts` - the `writeEmbeddings`
  content-hash guard (stale hash skipped, deleted chunk skipped) and
  `countChunksNeedingEmbedding`.
- `tests/unit/central-embedding-engine-boundary.test.ts` - CI drift guard:
  only `embed-engine.ts` may construct `EmbedClient`; `embedPass`/
  `scheduleEmbedHeal` may never reappear; no IPC handler may call `.embed(`
  directly.
- `tests/unit/register-all-idempotency.test.ts` - updated to mock
  `retrieval-service` (the new explicit boot-time `attach()` call would
  otherwise pull in the real retrieval subsystem).
- `tests/unit/developer-flag-defaults.test.ts` + `tests/ui/developer-tab-defaults.spec.ts` -
  every key x isDevBuild x isEphemeralPreview combination for the extracted
  default-decision logic, and its wiring into the rendered Settings toggle.

**Manually verified** (not expressible as an automated test - no existing
harness for `main/index.ts`, an Electron entry-point module):
- Live, end-to-end on real hardware (RTX 5090): the duty-cycle math holds
  exactly (measured `batchMs * 4 = sleepMs` across a 376-batch trace), GPU
  power stayed within the same ~90-130W band across bge-base and bge-large
  despite a 2.1x wall-time difference, and live search/recall stayed instant
  during a backlog drain.
- Cold-start resume: built an isolated, non-ephemeral Electron instance
  (separate `KANGENTIC_DATA_DIR` + `--user-data-dir`, since `/preview`'s
  ephemeral mode has its own separate pre-existing fix and structurally
  can't exercise this code path), seeded a 4000-chunk backlog, hard-killed
  the process mid-drain at 3176 pending, relaunched with zero UI
  interaction, and confirmed it resumed automatically and drained exactly
  the 3176 remaining chunks - nothing lost, nothing duplicated.

Generated with [Claude Code](https://claude.com/claude-code)
