### PR TITLE
feat(mcp): add Edit-style in-place description updates to kangentic_update_task

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -100,7 +100,7 @@ Create a task on the board (default: the To Do column on the active board) or in
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `title` | string | Yes | Task title (max 200 chars) |
-| `description` | string | No | Task description, supports markdown (max 10000 chars) |
+| `description` | string | No | Task description, supports markdown (max 50000 chars for a board task; a backlog item is capped at 10000 and an over-cap backlog description is rejected) |
 | `column` | string | No | Target column name (case-insensitive). Defaults to To Do. Pass `"Backlog"` to route to the backlog staging area instead of the board. |
 | `priority` | number | No | Priority: 0=none (default), 1=low, 2=medium, 3=high, 4=urgent. Applies to both board tasks and backlog items. |
 | `labels` | array | No | Labels for categorization. Each entry is a string or `{ name, color }` object with hex color. Applies to both board tasks and backlog items. |
@@ -208,13 +208,15 @@ Get detailed column configuration: description, auto-spawn, permission mode, pla
 
 ### kangentic_update_task
 
-Update a task's title, description, PR info, agent assignment, priority, labels, base branch, worktree toggle, or attachments. To move a task between columns, use `kangentic_move_task` instead.
+Update a task's title, description (full replace, in-place find/replace edits, or append), PR info, agent assignment, priority, labels, base branch, worktree toggle, or attachments. To move a task between columns, use `kangentic_move_task` instead.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `taskId` | string | Yes | Task ID (numeric display ID or full UUID) |
 | `title` | string | No | New title (max 200 chars) |
-| `description` | string | No | New description (max 10000 chars) |
+| `description` | string | No | New description, replaces the entire description (max 50000 chars). Mutually exclusive with `descriptionEdits` and `appendDescription`; for an incremental change to a long description, prefer those instead - they cost far fewer tokens and cannot silently drop untouched sections. |
+| `descriptionEdits` | array | No | Ordered exact-string replacements applied to the current description, like the file `Edit` tool: `[{ find: string, replace: string }]` (1-100 edits; each `find`/`replace` up to 50000 chars). Each `find` must be present and unique in the text as it stands after prior edits in the list, or the whole call fails and nothing is written. Mutually exclusive with `description`; may combine with `appendDescription` (edits apply first). |
+| `appendDescription` | string | No | Text appended to the end of the current description, exactly as given (no separator inserted, max 50000 chars). Mutually exclusive with `description`; may combine with `descriptionEdits` (edits apply first, then this append). |
 | `prUrl` | string | No | Pull request URL (e.g. `https://github.com/owner/repo/pull/123`) |
 | `prNumber` | number | No | Pull request number |
 | `agent` | string | No | Agent name to assign (e.g. `"claude"`, `"codex"`). Empty string clears. |
@@ -547,7 +549,7 @@ The committed `.claude/settings.json` `mcp__kangentic` entry remains for humans 
 - **DNS rebinding protection** - the Streamable HTTP transport enforces a host allowlist (`127.0.0.1`, `localhost`, `[::1]`) on top of the loopback bind.
 - **Project routing via URL path** - the URL embeds the project ID (`/mcp/<projectId>`). A stale `mcp.json` for a different project cannot be reused against the current launch.
 - **Runaway-loop safeguard** - task creations are capped at a fixed 500 per app launch, enforced atomically by the shared `TaskCounter`. This is an internal circuit breaker against a looping agent, not a user-tunable knob; the count resets on restart.
-- **Input validation** - Zod schemas enforce title (200 chars) and description (10000 chars) limits at the protocol level; the command handlers validate again.
+- **Input validation** - Zod schemas enforce title (200 chars) and description (50000 chars for tasks; 10000 chars for backlog item descriptions) limits at the protocol level, and the command handlers validate again. A backlog item created via `kangentic_create_task` shares the task 50000-char Zod schema, so `handleCreateTask` enforces the 10000 backlog cap itself and rejects an over-cap backlog description rather than truncating it.
 - **Column safety** - `kangentic_create_task` defaults to the To Do column; creating in an auto_spawn column intentionally triggers agent spawn.
 - **Destructive operations are explicit** - `kangentic_delete_task`, `kangentic_delete_backlog_item`, `kangentic_remove_task_attachment`, and `kangentic_move_task` mutate the board. Agents must invoke them by name; there is no implicit fallback.
 - **Honest mutating annotations** - mutating tools carry `readOnlyHint: false`, so the plan-mode auto-approval surface is exactly the read-only set. Deletes, moves, and creates always prompt while planning, even though the auto-allow injection pre-approves them in default mode.

--- a/src/main/agent/commands/backlog-commands.ts
+++ b/src/main/agent/commands/backlog-commands.ts
@@ -9,6 +9,12 @@ import { resolveColumn } from './column-resolver';
 import type { CommandContext, CommandHandler, CommandResponse } from './types';
 import type { BacklogTaskUpdateInput } from '../../../shared/types';
 
+// Backlog items keep a lower description cap than board tasks (whose cap is
+// TASK_DESCRIPTION_MAX_LENGTH in task-commands.ts). handleCreateTask enforces
+// this before routing a `column: "Backlog"` create here, so an over-cap
+// backlog description fails loudly instead of being silently truncated.
+export const BACKLOG_DESCRIPTION_MAX_LENGTH = 10_000;
+
 export const handleListBacklog: CommandHandler = (
   params: Record<string, unknown>,
   context: CommandContext,
@@ -64,7 +70,7 @@ export const handleCreateBacklogTask: CommandHandler = (
   context: CommandContext,
 ): CommandResponse => {
   const title = String(params.title ?? '').slice(0, 200);
-  const description = String(params.description ?? '').slice(0, 10_000);
+  const description = String(params.description ?? '').slice(0, BACKLOG_DESCRIPTION_MAX_LENGTH);
   const priority = (params.priority as number) ?? 0;
   const rawLabels = (params.labels as Array<string | { name: string; color: string }>) ?? [];
   const attachments = params.attachments as Array<{ filePath: string; filename?: string }> | null;
@@ -183,7 +189,7 @@ export const handleUpdateBacklogItem: CommandHandler = (
     changedFields.push('title');
   }
   if (newDescription !== null) {
-    updates.description = String(newDescription).slice(0, 10_000);
+    updates.description = String(newDescription).slice(0, BACKLOG_DESCRIPTION_MAX_LENGTH);
     changedFields.push('description');
   }
   if (newPriority !== null) {

--- a/src/main/agent/commands/task-commands.ts
+++ b/src/main/agent/commands/task-commands.ts
@@ -5,17 +5,82 @@ import { SessionRepository } from '../../db/repositories/session-repository';
 import { readFileAsAttachment } from '../../db/repositories/attachment-utils';
 import { resolveColumn } from './column-resolver';
 import { resolveTask } from './task-resolver';
-import { handleCreateBacklogTask } from './backlog-commands';
+import { handleCreateBacklogTask, BACKLOG_DESCRIPTION_MAX_LENGTH } from './backlog-commands';
 import { linkPRForTask } from '../../pr/pr-linking';
 import type { CommandContext, CommandHandler, CommandResponse } from './types';
 import type { TaskUpdateInput } from '../../../shared/types';
+
+export const TASK_DESCRIPTION_MAX_LENGTH = 50_000;
+
+export interface DescriptionEdit {
+  find: string;
+  replace: string;
+}
+
+export type DescriptionEditResult =
+  | { success: true; text: string }
+  | { success: false; error: string };
+
+/**
+ * Render a `find` value for an error message without echoing a huge string
+ * back to the caller (which would defeat the token-saving point of the edit
+ * modes). Long values are truncated with their full length reported.
+ */
+function describeFindValue(find: string): string {
+  const maxEchoLength = 200;
+  if (find.length <= maxEchoLength) return JSON.stringify(find);
+  return `${JSON.stringify(find.slice(0, maxEchoLength))} (truncated, ${find.length} chars total)`;
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  let index = haystack.indexOf(needle);
+  while (index !== -1) {
+    count += 1;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
+/**
+ * Apply Edit-tool-style exact-string replacements to a description, then an
+ * optional append, mirroring the file Edit tool's failure semantics: a `find`
+ * that is absent or not unique fails the whole call rather than a silent
+ * no-op or partial write. Edits apply sequentially against the evolving text.
+ */
+export function computeUpdatedDescription(
+  current: string,
+  options: { edits?: DescriptionEdit[] | null; append?: string | null },
+): DescriptionEditResult {
+  let text = current;
+  const edits = options.edits ?? [];
+  for (let index = 0; index < edits.length; index += 1) {
+    const { find, replace } = edits[index];
+    const occurrences = countOccurrences(text, find);
+    if (occurrences === 0) {
+      return { success: false, error: `descriptionEdits[${index}]: text to find was not present in the description: ${describeFindValue(find)}` };
+    }
+    if (occurrences > 1) {
+      return { success: false, error: `descriptionEdits[${index}]: text to find appears ${occurrences} times in the description; it must be unique: ${describeFindValue(find)}` };
+    }
+    text = text.split(find).join(replace);
+  }
+  if (options.append) {
+    text = text + options.append;
+  }
+  if (text.length > TASK_DESCRIPTION_MAX_LENGTH) {
+    return { success: false, error: `Resulting description would be ${text.length} characters, over the ${TASK_DESCRIPTION_MAX_LENGTH} character limit.` };
+  }
+  return { success: true, text };
+}
 
 export const handleCreateTask: CommandHandler = (
   params: Record<string, unknown>,
   context: CommandContext,
 ) => {
   const title = String(params.title ?? '').slice(0, 200);
-  const description = String(params.description ?? '').slice(0, 10_000);
+  const description = String(params.description ?? '').slice(0, TASK_DESCRIPTION_MAX_LENGTH);
   const columnName = params.column as string | null;
   const branchName = params.branchName as string | null;
   const baseBranch = params.baseBranch as string | null;
@@ -42,6 +107,17 @@ export const handleCreateTask: CommandHandler = (
   // item instead of a board task. The default (no column) always goes to the
   // To Do column on the active board, never the backlog.
   if (columnName && columnName.trim().toLowerCase() === 'backlog') {
+    // The create_task Zod cap (TASK_DESCRIPTION_MAX_LENGTH) covers board tasks;
+    // backlog items keep the lower BACKLOG_DESCRIPTION_MAX_LENGTH. Enforce it
+    // here so an over-cap backlog description fails loudly rather than being
+    // silently truncated by handleCreateBacklogTask's slice.
+    const backlogDescriptionLength = String(params.description ?? '').length;
+    if (backlogDescriptionLength > BACKLOG_DESCRIPTION_MAX_LENGTH) {
+      return {
+        success: false,
+        error: `Backlog item description is ${backlogDescriptionLength} characters, over the ${BACKLOG_DESCRIPTION_MAX_LENGTH} character limit for backlog items (board tasks allow up to ${TASK_DESCRIPTION_MAX_LENGTH}).`,
+      };
+    }
     return handleCreateBacklogTask({ ...params, priority: priority ?? 0 }, context);
   }
 
@@ -120,6 +196,8 @@ export const handleUpdateTask: CommandHandler = (
   const taskId = params.taskId as string;
   const newTitle = params.title as string | null;
   const newDescription = params.description as string | null;
+  const newDescriptionEdits = (params.descriptionEdits ?? null) as DescriptionEdit[] | null;
+  const newAppendDescription = (params.appendDescription ?? null) as string | null;
   const newPrUrl = params.prUrl as string | null;
   const newPrNumber = params.prNumber as number | null;
   const newAgent = params.agent as string | null;
@@ -133,6 +211,8 @@ export const handleUpdateTask: CommandHandler = (
   // (task #229). See the matching note in handleCreateTask.
   console.log('[update_task] received args:', {
     descriptionLength: typeof newDescription === 'string' ? newDescription.length : null,
+    descriptionEditsCount: newDescriptionEdits?.length ?? null,
+    appendLength: typeof newAppendDescription === 'string' ? newAppendDescription.length : null,
     labels: newLabels,
   });
 
@@ -149,7 +229,32 @@ export const handleUpdateTask: CommandHandler = (
 
   const updates: Record<string, unknown> = { id: task.id };
   if (newTitle !== null) updates.title = String(newTitle).slice(0, 200);
-  if (newDescription !== null) updates.description = String(newDescription).slice(0, 10_000);
+
+  // `description` (full replace) is mutually exclusive with `descriptionEdits`
+  // / `appendDescription`; the tool layer (task-tools.ts) rejects the two
+  // together, so this if/else never sees both from the MCP path.
+  let descriptionChanged = false;
+  if (newDescription !== null) {
+    updates.description = String(newDescription).slice(0, TASK_DESCRIPTION_MAX_LENGTH);
+    descriptionChanged = true;
+  } else if (newDescriptionEdits !== null || newAppendDescription !== null) {
+    const editResult = computeUpdatedDescription(task.description, {
+      edits: newDescriptionEdits,
+      append: newAppendDescription,
+    });
+    if (!editResult.success) {
+      return { success: false, error: editResult.error };
+    }
+    // Only treat this as a change when the text actually moved. An empty
+    // `appendDescription` or a no-op edit (e.g. find === replace) otherwise
+    // triggers a spurious DB write, an updated_at bump, and a misleading
+    // "description" in changedFields.
+    if (editResult.text !== task.description) {
+      updates.description = editResult.text;
+      descriptionChanged = true;
+    }
+  }
+
   if (newPrUrl !== null) updates.pr_url = String(newPrUrl);
   if (newPrNumber !== null) updates.pr_number = Number(newPrNumber);
   if (newAgent !== null) updates.agent = newAgent;
@@ -196,7 +301,7 @@ export const handleUpdateTask: CommandHandler = (
 
   const changedFields: string[] = [];
   if (newTitle !== null) changedFields.push('title');
-  if (newDescription !== null) changedFields.push('description');
+  if (descriptionChanged) changedFields.push('description');
   if (newPrUrl !== null) changedFields.push('prUrl');
   if (newPrNumber !== null) changedFields.push('prNumber');
   if (newAgent !== null) changedFields.push('agent');

--- a/src/main/agent/mcp-http/server-instructions.ts
+++ b/src/main/agent/mcp-http/server-instructions.ts
@@ -93,6 +93,9 @@ export function buildServerInstructions(
     '',
     'LABELS WITH A LONG DESCRIPTION (known limitation):',
     'When a kangentic_create_task or kangentic_update_task call carries both a long description (roughly 1KB or more) and labels, the labels can be dropped before they reach the server. To make labels stick, set them in a separate labels-only kangentic_update_task call after creating or updating the task with the long description.',
+    '',
+    'EDITING A LONG TASK DESCRIPTION:',
+    'For an incremental change to a long task description, prefer kangentic_update_task\'s `descriptionEdits` (exact find/replace, like the file Edit tool) or `appendDescription` over resending the whole `description`. They cost far fewer tokens and cannot silently drop or alter untouched sections. Reserve `description` for a genuine full rewrite.',
   ];
 
   if (browserAutomationEnabled) {

--- a/src/main/agent/mcp-http/task-tools.ts
+++ b/src/main/agent/mcp-http/task-tools.ts
@@ -4,6 +4,7 @@ import { callHandler, runHandler, withProject, detectCrossProjectMention, saniti
 import { READ_ONLY_ANNOTATIONS, MUTATING_ANNOTATIONS } from './annotations';
 import type { RequestResolver } from './project-resolver';
 import type { BoardHit, BacklogHit, SearchScope } from '../commands/search-commands';
+import { TASK_DESCRIPTION_MAX_LENGTH } from '../commands/task-commands';
 
 /**
  * Build the create_task routing-check refusal shown when the call
@@ -48,7 +49,7 @@ export function registerTaskTools(
       description: 'Create a task on the Kangentic board (default: the To Do column on the active board) or in the backlog. This is the only task-creation tool - use it whenever the user asks to "create a task", "add a todo", "add to backlog", or similar. ATTACHMENTS RULE: When the user\'s prompt references local files by absolute path (design handoffs, mockups, screenshots, specs, READMEs, transcripts), pass those paths in `attachments` on this same call. Default to attaching, not omitting. Do not require a second user request to add them. The only exception is files the user explicitly named as "for context only, don\'t attach." With no `column` argument, the task always lands in the active board\'s To Do column - never the backlog. Pass `column: "Backlog"` (case-insensitive) to create a backlog item instead. Pass any other column name (e.g. "Planning", "Code Review") to land directly in that board column. Board tasks get a git branch and are ready to work on immediately. If the user\'s prompt names a different Kangentic project, pass that name as `project` to route the task to that project instead of the active default - do not rely on the active default when the user clearly targeted another project. The name counts however it is phrased, not just the explicit "create a task in X" form: "create a task in X to fix ...", "the X to do board", "add a bug to the X board", "in X", and "X\'s backlog" all target project X. Use kangentic_list_projects to find valid selectors. LABELS WITH A LONG DESCRIPTION: due to a known large-payload limitation, when this call carries both a long description (roughly 1KB or more) and labels, the labels can be dropped before they reach the server. In that case create the task here (you may omit labels), then set labels with a separate labels-only kangentic_update_task call right after.',
       inputSchema: z.object({
         title: z.string().max(200).describe('Task title (max 200 characters)'),
-        description: z.string().max(10000).optional().describe('Task description. Supports markdown.'),
+        description: z.string().max(TASK_DESCRIPTION_MAX_LENGTH).optional().describe('Task description. Supports markdown.'),
         column: z.string().optional().describe('Target column name. Defaults to the To Do column on the active board. Use kangentic_list_columns to see board columns. Pass "Backlog" (case-insensitive) to create a backlog item instead of a board task. Only route to the backlog when the user explicitly asks for the backlog.'),
         priority: z.number().int().min(0).max(4).optional().describe('Priority: 0=none (default), 1=low, 2=medium, 3=high, 4=urgent. Applies to both board tasks and backlog items.'),
         labels: z.array(z.union([
@@ -355,11 +356,16 @@ export function registerTaskTools(
   server.registerTool(
     'kangentic_update_task',
     {
-      description: 'Update an existing task. Supports title, description, PR info, agent assignment, priority, labels, base branch, worktree toggle, and attaching files. To move a task between columns, use kangentic_move_task instead. Find the task ID first with kangentic_find_task. Pass `project` to update a task in a different project.',
+      description: 'Update an existing task. Supports title, description (full replace, in-place find/replace edits, or append), PR info, agent assignment, priority, labels, base branch, worktree toggle, and attaching files. To move a task between columns, use kangentic_move_task instead. Find the task ID first with kangentic_find_task. Pass `project` to update a task in a different project.',
       inputSchema: z.object({
         taskId: z.string().describe('Task ID (numeric display ID like "42" or full UUID).'),
         title: z.string().max(200).optional().describe('New task title (max 200 characters).'),
-        description: z.string().max(10000).optional().describe('New task description (markdown). Replaces the entire description.'),
+        description: z.string().max(TASK_DESCRIPTION_MAX_LENGTH).optional().describe('New task description (markdown). Replaces the entire description. For an incremental change to a long description, prefer descriptionEdits or appendDescription instead - they cost far fewer tokens and cannot silently drop untouched sections. Mutually exclusive with descriptionEdits and appendDescription.'),
+        descriptionEdits: z.array(z.object({
+          find: z.string().min(1).max(TASK_DESCRIPTION_MAX_LENGTH).describe('Exact text to find in the current description. Must appear exactly once.'),
+          replace: z.string().max(TASK_DESCRIPTION_MAX_LENGTH).describe('Text to replace it with.'),
+        })).min(1).max(100).describe('Ordered exact-string replacements applied to the current description, like the file Edit tool. Each edit\'s `find` must be present and unique in the text as it stands after the prior edits in the list; a missing or non-unique `find` fails the entire call and writes nothing. Mutually exclusive with `description`; may be combined with `appendDescription` (edits apply first, then the append).').optional(),
+        appendDescription: z.string().max(TASK_DESCRIPTION_MAX_LENGTH).optional().describe('Text appended to the end of the current description, exactly as given (no separator is inserted). Mutually exclusive with `description`; may be combined with `descriptionEdits` (edits apply first, then this append).'),
         prUrl: z.string().url().optional().describe('Pull request URL (e.g. https://github.com/owner/repo/pull/123).'),
         prNumber: z.number().int().positive().optional().describe('Pull request number.'),
         agent: z.string().optional().describe('Agent name to assign (e.g. "claude", "codex"). Pass empty string to clear.'),
@@ -375,18 +381,24 @@ export function registerTaskTools(
       }),
       annotations: MUTATING_ANNOTATIONS,
     },
-    async ({ taskId, title, description, prUrl, prNumber, agent, priority, labels, baseBranch, useWorktree, attachments, project }) => {
+    async ({ taskId, title, description, descriptionEdits, appendDescription, prUrl, prNumber, agent, priority, labels, baseBranch, useWorktree, attachments, project }) => {
       if (
-        title === undefined && description === undefined && prUrl === undefined && prNumber === undefined &&
+        title === undefined && description === undefined && descriptionEdits === undefined && appendDescription === undefined &&
+        prUrl === undefined && prNumber === undefined &&
         agent === undefined && priority === undefined && labels === undefined && baseBranch === undefined &&
         useWorktree === undefined && attachments === undefined
       ) {
         return { content: [{ type: 'text' as const, text: 'Provide at least one field to update.' }], isError: true };
       }
+      if (description !== undefined && (descriptionEdits !== undefined || appendDescription !== undefined)) {
+        return { content: [{ type: 'text' as const, text: 'Pass either `description` (full replace) or `descriptionEdits`/`appendDescription` (in-place edits), not both.' }], isError: true };
+      }
       return withProject(resolver, project, (ctx) => callHandler('update_task', {
         taskId,
         title: title ?? null,
         description: description ?? null,
+        descriptionEdits: descriptionEdits ?? null,
+        appendDescription: appendDescription ?? null,
         prUrl: prUrl ?? null,
         prNumber: prNumber ?? null,
         agent: agent ?? null,

--- a/src/shared/mcp-tool-manifest.ts
+++ b/src/shared/mcp-tool-manifest.ts
@@ -56,7 +56,7 @@ export const MCP_TOOL_MANIFEST: McpToolManifestEntry[] = [
   { name: 'kangentic_find_task', label: 'Find Task', blurb: 'look up a task by ID, branch, title, or PR number', category: 'tasks' },
   { name: 'kangentic_get_current_task', label: 'Current Task', blurb: 'resolve the task for the current directory or branch', category: 'tasks' },
   { name: 'kangentic_get_task_stats', label: 'Task Stats', blurb: 'token usage, cost, duration, and lines changed per task', category: 'tasks' },
-  { name: 'kangentic_update_task', label: 'Update Task', blurb: 'edit title, description, PR info, agent, priority, labels, base branch, worktree, and attachments', category: 'tasks' },
+  { name: 'kangentic_update_task', label: 'Update Task', blurb: 'edit title, description (full, in-place find/replace, or append), PR info, agent, priority, labels, base branch, worktree, and attachments', category: 'tasks' },
   { name: 'kangentic_move_task', label: 'Move Task', blurb: 'move a task between columns, running the same lifecycle as a drag', category: 'tasks' },
   { name: 'kangentic_link_pr', label: 'Link PR', blurb: 'resolve and attach a task pull request via the gh CLI', category: 'tasks' },
   { name: 'kangentic_delete_task', label: 'Delete Task', blurb: 'permanently remove a task, its attachments, and session records', category: 'tasks' },

--- a/tests/unit/mcp-create-task-labels.test.ts
+++ b/tests/unit/mcp-create-task-labels.test.ts
@@ -33,6 +33,7 @@ const mockTaskRepoUpdate = vi.fn();
 const mockTaskRepoGetById = vi.fn();
 const mockTaskRepoGetByDisplayId = vi.fn();
 const mockResolveColumn = vi.fn();
+const mockBacklogRepoCreate = vi.fn();
 
 vi.mock('../../src/main/db/repositories/task-repository', () => ({
   TaskRepository: class {
@@ -57,7 +58,7 @@ vi.mock('../../src/main/db/repositories/session-repository', () => ({
   SessionRepository: class {},
 }));
 vi.mock('../../src/main/db/repositories/backlog-repository', () => ({
-  BacklogRepository: class { create = vi.fn(); getById = vi.fn(); update = vi.fn(); list = vi.fn(() => []); },
+  BacklogRepository: class { create = mockBacklogRepoCreate; getById = vi.fn(); update = vi.fn(); list = vi.fn(() => []); },
 }));
 vi.mock('../../src/main/db/repositories/backlog-attachment-repository', () => ({
   BacklogAttachmentRepository: class { add = vi.fn(); list = vi.fn(() => []); deleteByTaskId = vi.fn(); },
@@ -74,6 +75,7 @@ vi.mock('../../src/main/pr/pr-linking', () => ({
 // ---------------------------------------------------------------------------
 
 import { handleCreateTask, handleUpdateTask } from '../../src/main/agent/commands/task-commands';
+import { BACKLOG_DESCRIPTION_MAX_LENGTH } from '../../src/main/agent/commands/backlog-commands';
 import type { CommandContext } from '../../src/main/agent/commands/types';
 
 // ---------------------------------------------------------------------------
@@ -176,5 +178,123 @@ describe('handleUpdateTask - labels survive a large description (round-trip guar
         labels: ['probe-a-v2'],
       }),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TASK_DESCRIPTION_MAX_LENGTH raised to 50,000 (from the prior 10,000 cap) -
+// a description in the 10,001-50,000 range must survive both the
+// handleCreateTask (board path) and handleUpdateTask (full-replace) slices
+// in full, not get truncated back down to the old cap.
+// ---------------------------------------------------------------------------
+
+// Comfortably past the old 10,000-character cap but well under the new
+// 50,000-character cap - proves the raise, not just "not truncated to zero".
+const DESCRIPTION_OVER_OLD_TASK_CAP = 'z'.repeat(BACKLOG_DESCRIPTION_MAX_LENGTH + 10_000);
+
+describe('handleCreateTask - persists the full description up to the raised 50,000 cap', () => {
+  let context: CommandContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    context = makeContext();
+    mockResolveColumn.mockReturnValue({ swimlane: { id: 'lane-1', name: 'To Do' } });
+    mockTaskRepoCreate.mockImplementation((input: { title: string; description: string }) => ({
+      id: 'task-uuid-1',
+      display_id: 1,
+      title: input.title,
+      description: input.description,
+    }));
+  });
+
+  it('persists a description well past the old 10,000-char cap in full (board task path, column omitted)', () => {
+    const result = handleCreateTask(
+      { title: 'Long description task', description: DESCRIPTION_OVER_OLD_TASK_CAP },
+      context,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockTaskRepoCreate).toHaveBeenCalledOnce();
+    const createInput = mockTaskRepoCreate.mock.calls[0][0] as { description: string };
+    expect(createInput.description).toHaveLength(DESCRIPTION_OVER_OLD_TASK_CAP.length);
+    expect(createInput.description).toBe(DESCRIPTION_OVER_OLD_TASK_CAP);
+  });
+});
+
+describe('handleUpdateTask - persists the full full-replace description up to the raised 50,000 cap', () => {
+  let context: CommandContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    context = makeContext();
+    mockTaskRepoGetById.mockReturnValue({ id: 'task-uuid-1', display_id: 1, title: 'Existing', description: 'old description' });
+    mockTaskRepoUpdate.mockImplementation((input: { description?: string }) => ({
+      id: 'task-uuid-1',
+      display_id: 1,
+      title: 'Existing',
+      description: input.description,
+    }));
+  });
+
+  it('persists a full-replace description well past the old 10,000-char cap in full', () => {
+    const result = handleUpdateTask(
+      { taskId: 'task-uuid-1', description: DESCRIPTION_OVER_OLD_TASK_CAP },
+      context,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockTaskRepoUpdate).toHaveBeenCalledOnce();
+    const updateInput = mockTaskRepoUpdate.mock.calls[0][0] as { description: string };
+    expect(updateInput.description).toHaveLength(DESCRIPTION_OVER_OLD_TASK_CAP.length);
+    expect(updateInput.description).toBe(DESCRIPTION_OVER_OLD_TASK_CAP);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Backlog items keep the lower BACKLOG_DESCRIPTION_MAX_LENGTH cap even though
+// board tasks were raised to 50,000. handleCreateTask must reject an
+// over-cap Backlog create with a structured error rather than silently
+// truncating (handleCreateBacklogTask's internal .slice() would otherwise
+// mask the overflow).
+// ---------------------------------------------------------------------------
+
+describe('handleCreateTask - Backlog column enforces its own lower description cap', () => {
+  let context: CommandContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    context = makeContext();
+    mockBacklogRepoCreate.mockImplementation((input: { title: string; description: string; priority: number; labels: string[] }) => ({
+      id: 'backlog-uuid-1',
+      title: input.title,
+      description: input.description,
+      priority: input.priority,
+      labels: input.labels,
+    }));
+  });
+
+  it('rejects a Backlog create whose description exceeds the backlog cap, and creates no row', () => {
+    const overBacklogCapDescription = 'x'.repeat(BACKLOG_DESCRIPTION_MAX_LENGTH + 5_000);
+
+    const result = handleCreateTask(
+      { title: 'Too-long backlog item', description: overBacklogCapDescription, column: 'Backlog' },
+      context,
+    );
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain(String(BACKLOG_DESCRIPTION_MAX_LENGTH));
+    expect(mockBacklogRepoCreate).not.toHaveBeenCalled();
+    expect(mockTaskRepoCreate).not.toHaveBeenCalled();
+  });
+
+  it('creates a backlog item normally when the description is within the backlog cap', () => {
+    const result = handleCreateTask(
+      { title: 'Short backlog item', description: 'A short description', column: 'Backlog' },
+      context,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockBacklogRepoCreate).toHaveBeenCalledOnce();
+    expect(mockTaskRepoCreate).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/mcp-task-session-tools.test.ts
+++ b/tests/unit/mcp-task-session-tools.test.ts
@@ -664,6 +664,92 @@ describe('kangentic_update_task descriptionEdits / appendDescription wiring', ()
 });
 
 // ---------------------------------------------------------------------------
+// kangentic_update_task descriptionEdits - Zod schema-level validation.
+//
+// The fake server harness above stubs `registerTool` itself, but the
+// `inputSchema` it captures is the REAL z.object(...) built by task-tools.ts -
+// only the SDK's server/transport is faked, not zod. In the real MCP server,
+// the SDK validates incoming args against this schema BEFORE the registered
+// handler ever runs; every wiring test above invokes the handler directly
+// with already-valid args, so none of them would catch a broken or dropped
+// Zod constraint (e.g. `.min(1)` silently removed from the array or the
+// `find` field). Exercise the schema directly via `.safeParse` to close that
+// protocol-level gap.
+// ---------------------------------------------------------------------------
+
+describe('kangentic_update_task descriptionEdits - Zod schema validation', () => {
+  let server: ReturnType<typeof makeFakeServer>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    server = makeFakeServer();
+    const resolver = makeResolver();
+    const taskCounter: TaskCounter = { tryReserve: vi.fn(() => true), limit: () => 50 };
+    registerTaskTools(server as never, resolver, taskCounter);
+  });
+
+  function updateTaskSchema(): { safeParse: (data: unknown) => { success: boolean } } {
+    const { inputSchema } = server.getConfig('kangentic_update_task');
+    return inputSchema as unknown as { safeParse: (data: unknown) => { success: boolean } };
+  }
+
+  it('rejects an empty descriptionEdits array (schema .min(1))', () => {
+    const result = updateTaskSchema().safeParse({ taskId: 'task-1', descriptionEdits: [] });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a descriptionEdits array beyond the 100-edit cap (schema .max(100))', () => {
+    const tooManyEdits = Array.from({ length: 101 }, (_, index) => ({
+      find: `find-${index}`,
+      replace: `replace-${index}`,
+    }));
+
+    const result = updateTaskSchema().safeParse({ taskId: 'task-1', descriptionEdits: tooManyEdits });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a descriptionEdits array at exactly the 100-edit cap boundary', () => {
+    const maxEdits = Array.from({ length: 100 }, (_, index) => ({
+      find: `find-${index}`,
+      replace: `replace-${index}`,
+    }));
+
+    const result = updateTaskSchema().safeParse({ taskId: 'task-1', descriptionEdits: maxEdits });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty-string find (schema .min(1) on the find field)', () => {
+    const result = updateTaskSchema().safeParse({
+      taskId: 'task-1',
+      descriptionEdits: [{ find: '', replace: 'anything' }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts an empty-string replace (deletion is valid at the schema level)', () => {
+    const result = updateTaskSchema().safeParse({
+      taskId: 'task-1',
+      descriptionEdits: [{ find: 'something', replace: '' }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a well-formed single-entry descriptionEdits array', () => {
+    const result = updateTaskSchema().safeParse({
+      taskId: 'task-1',
+      descriptionEdits: [{ find: 'old', replace: 'new' }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // kangentic_remove_task_attachment - tool registration and wiring at the
 // mcp-http layer (as opposed to handleRemoveAttachment's command-handler
 // logic, already covered in mcp-attachment-handlers.test.ts).

--- a/tests/unit/mcp-task-session-tools.test.ts
+++ b/tests/unit/mcp-task-session-tools.test.ts
@@ -577,6 +577,93 @@ describe('kangentic_update_task "at least one field" guard - attachments wiring'
 });
 
 // ---------------------------------------------------------------------------
+// kangentic_update_task descriptionEdits / appendDescription - tool-layer
+// wiring: the "at least one field" guard, the description mutual-exclusivity
+// guard, and forwarding to callHandler. handleUpdateTask's own apply/atomicity
+// logic is covered in mcp-update-task-description-edits.test.ts.
+// ---------------------------------------------------------------------------
+
+describe('kangentic_update_task descriptionEdits / appendDescription wiring', () => {
+  let server: ReturnType<typeof makeFakeServer>;
+  let resolver: RequestResolver;
+  let taskCounter: TaskCounter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    server = makeFakeServer();
+    resolver = makeResolver();
+    taskCounter = { tryReserve: vi.fn(() => true), limit: () => 50 };
+    registerTaskTools(server as never, resolver, taskCounter);
+  });
+
+  it('accepts a descriptionEdits-only call through the guard and forwards it to callHandler', async () => {
+    const result = await server.getHandler('kangentic_update_task')({
+      taskId: 'task-1',
+      descriptionEdits: [{ find: 'old text', replace: 'new text' }],
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockCallHandler).toHaveBeenCalledOnce();
+    const [handlerName, params] = mockCallHandler.mock.calls[0];
+    expect(handlerName).toBe('update_task');
+    const typedParams = params as Record<string, unknown>;
+    expect(typedParams.descriptionEdits).toEqual([{ find: 'old text', replace: 'new text' }]);
+    expect(typedParams.description).toBeNull();
+    expect(typedParams.appendDescription).toBeNull();
+  });
+
+  it('accepts an appendDescription-only call through the guard and forwards it to callHandler', async () => {
+    const result = await server.getHandler('kangentic_update_task')({
+      taskId: 'task-1',
+      appendDescription: '\n\nmore text',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockCallHandler).toHaveBeenCalledOnce();
+    const [, params] = mockCallHandler.mock.calls[0];
+    const typedParams = params as Record<string, unknown>;
+    expect(typedParams.appendDescription).toBe('\n\nmore text');
+    expect(typedParams.description).toBeNull();
+    expect(typedParams.descriptionEdits).toBeNull();
+  });
+
+  it('rejects description + descriptionEdits together without calling callHandler', async () => {
+    const result = await server.getHandler('kangentic_update_task')({
+      taskId: 'task-1',
+      description: 'full replacement',
+      descriptionEdits: [{ find: 'old text', replace: 'new text' }],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('not both');
+    expect(mockCallHandler).not.toHaveBeenCalled();
+  });
+
+  it('rejects description + appendDescription together without calling callHandler', async () => {
+    const result = await server.getHandler('kangentic_update_task')({
+      taskId: 'task-1',
+      description: 'full replacement',
+      appendDescription: '\n\nmore text',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('not both');
+    expect(mockCallHandler).not.toHaveBeenCalled();
+  });
+
+  it('allows descriptionEdits and appendDescription together (compose mode)', async () => {
+    const result = await server.getHandler('kangentic_update_task')({
+      taskId: 'task-1',
+      descriptionEdits: [{ find: 'old text', replace: 'new text' }],
+      appendDescription: '\n\nmore text',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockCallHandler).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // kangentic_remove_task_attachment - tool registration and wiring at the
 // mcp-http layer (as opposed to handleRemoveAttachment's command-handler
 // logic, already covered in mcp-attachment-handlers.test.ts).

--- a/tests/unit/mcp-update-task-description-edits.test.ts
+++ b/tests/unit/mcp-update-task-description-edits.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Unit tests for Edit-tool-style in-place description updates on
+ * kangentic_update_task: `descriptionEdits` (ordered exact-string
+ * find/replace, mirroring the file Edit tool) and `appendDescription`.
+ *
+ * Covers:
+ *   computeUpdatedDescription (src/main/agent/commands/task-commands.ts)
+ *     - pure find/replace, ordered multi-edit application, append, and
+ *       edits+append composition
+ *     - failure semantics: absent find, non-unique find, over-cap result
+ *
+ *   handleUpdateTask (src/main/agent/commands/task-commands.ts)
+ *     - a failing edit writes nothing (atomic - no TaskRepository.update call)
+ *     - a successful edit/append persists the computed description and
+ *       reports it in changedFields
+ *
+ * Strategy mirrors mcp-attachment-handlers.test.ts: mock the repositories so
+ * no better-sqlite3 binary is needed, and assert on captured repository calls.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks - must be registered before the import under test
+// ---------------------------------------------------------------------------
+
+const {
+  mockTaskRepoUpdate,
+  mockTaskRepoGetById,
+  mockTaskRepoGetByDisplayId,
+} = vi.hoisted(() => ({
+  mockTaskRepoUpdate: vi.fn(),
+  mockTaskRepoGetById: vi.fn(),
+  mockTaskRepoGetByDisplayId: vi.fn(),
+}));
+
+vi.mock('../../src/main/db/repositories/task-repository', () => ({
+  TaskRepository: class {
+    update = mockTaskRepoUpdate;
+    getById = mockTaskRepoGetById;
+    getByDisplayId = mockTaskRepoGetByDisplayId;
+  },
+}));
+
+vi.mock('../../src/main/db/repositories/attachment-repository', () => ({
+  AttachmentRepository: class {
+    add = vi.fn();
+    getById = vi.fn();
+    remove = vi.fn();
+  },
+}));
+
+vi.mock('../../src/main/db/repositories/backlog-attachment-repository', () => ({
+  BacklogAttachmentRepository: class {
+    getById = vi.fn();
+    remove = vi.fn();
+  },
+}));
+
+vi.mock('../../src/main/db/repositories/attachment-utils', () => ({
+  readFileAsAttachment: vi.fn(),
+}));
+
+// Defensive: transitively imported by task-commands.ts but unused by the
+// handler under test here.
+vi.mock('../../src/main/db/repositories/session-repository', () => ({
+  SessionRepository: class {},
+}));
+vi.mock('../../src/main/db/repositories/backlog-repository', () => ({
+  BacklogRepository: class {},
+}));
+vi.mock('../../src/main/pr/pr-linking', () => ({
+  linkPRForTask: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after all mocks are registered)
+// ---------------------------------------------------------------------------
+
+import { handleUpdateTask, computeUpdatedDescription, TASK_DESCRIPTION_MAX_LENGTH } from '../../src/main/agent/commands/task-commands';
+import type { CommandContext } from '../../src/main/agent/commands/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    getProjectDb: vi.fn(() => ({}) as never),
+    getProjectPath: vi.fn(() => '/mock/project'),
+    onBacklogChanged: vi.fn(),
+    onLabelColorsChanged: vi.fn(),
+    onTaskCreated: vi.fn(),
+    onTaskUpdated: vi.fn(),
+    onTaskDeleted: vi.fn(),
+    onTaskMove: vi.fn(async () => {}),
+    onSwimlaneUpdated: vi.fn(),
+    ...overrides,
+  };
+}
+
+/**
+ * The real kangentic_update_task tool (task-tools.ts) forwards every omitted
+ * field as an explicit `null`, not `undefined` - handleUpdateTask's
+ * `field !== null` checks depend on that. Mirror that shape.
+ */
+function updateTaskParams(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    taskId: 'task-uuid-1',
+    title: null,
+    description: null,
+    descriptionEdits: null,
+    appendDescription: null,
+    prUrl: null,
+    prNumber: null,
+    agent: null,
+    priority: null,
+    labels: null,
+    baseBranch: null,
+    useWorktree: null,
+    attachments: null,
+    ...overrides,
+  };
+}
+
+const ORIGINAL_DESCRIPTION = '## Section A\nfirst section text\n\n## Section B\nsecond section text\n';
+
+function existingTask(description: string = ORIGINAL_DESCRIPTION) {
+  return { id: 'task-uuid-1', display_id: 1, title: 'Existing', description, attachment_count: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// TASK_DESCRIPTION_MAX_LENGTH - the description cap was raised from 10,000 to
+// 50,000. Without this assertion, nothing in this suite fails if the cap
+// were reverted back to 10,000 (computeUpdatedDescription's own over-cap
+// tests use `TASK_DESCRIPTION_MAX_LENGTH` symbolically, so they pass either
+// way).
+// ---------------------------------------------------------------------------
+
+describe('TASK_DESCRIPTION_MAX_LENGTH', () => {
+  it('is 50,000 characters (raised from the prior 10,000 cap)', () => {
+    expect(TASK_DESCRIPTION_MAX_LENGTH).toBe(50_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeUpdatedDescription - pure helper
+// ---------------------------------------------------------------------------
+
+describe('computeUpdatedDescription', () => {
+  it('applies a single find/replace and leaves the rest of the description unchanged', () => {
+    const result = computeUpdatedDescription(ORIGINAL_DESCRIPTION, {
+      edits: [{ find: 'first section text', replace: 'updated first section' }],
+    });
+
+    expect(result).toEqual({
+      success: true,
+      text: '## Section A\nupdated first section\n\n## Section B\nsecond section text\n',
+    });
+  });
+
+  it('applies multiple edits in order against the evolving text', () => {
+    const result = computeUpdatedDescription('one two three', {
+      edits: [
+        { find: 'one', replace: 'ONE' },
+        { find: 'ONE two', replace: 'ONE-TWO' },
+      ],
+    });
+
+    expect(result).toEqual({ success: true, text: 'ONE-TWO three' });
+  });
+
+  it('appends to the end and preserves existing content exactly (no separator inserted)', () => {
+    const result = computeUpdatedDescription('existing content', { append: '\n\n## New Section\nmore text' });
+
+    expect(result).toEqual({ success: true, text: 'existing content\n\n## New Section\nmore text' });
+  });
+
+  it('composes edits then append', () => {
+    const result = computeUpdatedDescription(ORIGINAL_DESCRIPTION, {
+      edits: [{ find: 'second section text', replace: 'updated second section' }],
+      append: '\n\n## Section C\nnew section',
+    });
+
+    expect(result).toEqual({
+      success: true,
+      text: '## Section A\nfirst section text\n\n## Section B\nupdated second section\n\n\n## Section C\nnew section',
+    });
+  });
+
+  it('returns an error when find is absent from the description', () => {
+    const result = computeUpdatedDescription(ORIGINAL_DESCRIPTION, {
+      edits: [{ find: 'text that does not exist anywhere', replace: 'x' }],
+    });
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('not present');
+  });
+
+  it('returns an error when find is not unique', () => {
+    const result = computeUpdatedDescription('repeat repeat repeat', {
+      edits: [{ find: 'repeat', replace: 'once' }],
+    });
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('must be unique');
+  });
+
+  it('returns an error when the computed result exceeds the description cap', () => {
+    const result = computeUpdatedDescription('short', { append: 'x'.repeat(TASK_DESCRIPTION_MAX_LENGTH) });
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain(String(TASK_DESCRIPTION_MAX_LENGTH));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleUpdateTask - description edits/append (atomicity + persistence)
+// ---------------------------------------------------------------------------
+
+describe('handleUpdateTask - descriptionEdits / appendDescription', () => {
+  let context: CommandContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    context = makeContext();
+    mockTaskRepoGetById.mockReturnValue(existingTask());
+  });
+
+  it('a single successful edit persists the computed description and reports it in changedFields', () => {
+    mockTaskRepoUpdate.mockImplementation((input: { description?: string }) => ({ ...existingTask(), description: input.description }));
+
+    const result = handleUpdateTask(
+      updateTaskParams({ descriptionEdits: [{ find: 'first section text', replace: 'revised first section' }] }),
+      context,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockTaskRepoUpdate).toHaveBeenCalledOnce();
+    const updateInput = mockTaskRepoUpdate.mock.calls[0][0] as { description: string };
+    expect(updateInput.description).toBe('## Section A\nrevised first section\n\n## Section B\nsecond section text\n');
+    expect(result.message).toContain('description');
+  });
+
+  it('appendDescription persists the current description with the append concatenated', () => {
+    mockTaskRepoUpdate.mockImplementation((input: { description?: string }) => ({ ...existingTask(), description: input.description }));
+
+    const result = handleUpdateTask(
+      updateTaskParams({ appendDescription: '\n\n## Section C\nadded later' }),
+      context,
+    );
+
+    expect(result.success).toBe(true);
+    const updateInput = mockTaskRepoUpdate.mock.calls[0][0] as { description: string };
+    expect(updateInput.description).toBe(`${ORIGINAL_DESCRIPTION}\n\n## Section C\nadded later`);
+    // Guards against a regression that only sets descriptionChanged on the
+    // descriptionEdits path, not the append-only path.
+    expect(result.message).toContain('description');
+  });
+
+  it('an absent find fails the call and writes nothing', () => {
+    const result = handleUpdateTask(
+      updateTaskParams({ descriptionEdits: [{ find: 'text nowhere in the description', replace: 'x' }] }),
+      context,
+    );
+
+    expect(result.success).toBe(false);
+    expect(mockTaskRepoUpdate).not.toHaveBeenCalled();
+  });
+
+  it('a non-unique find fails the call and writes nothing', () => {
+    mockTaskRepoGetById.mockReturnValue(existingTask('repeat repeat repeat'));
+
+    const result = handleUpdateTask(
+      updateTaskParams({ descriptionEdits: [{ find: 'repeat', replace: 'once' }] }),
+      context,
+    );
+
+    expect(result.success).toBe(false);
+    expect(mockTaskRepoUpdate).not.toHaveBeenCalled();
+  });
+
+  it('a failing edit partway through a multi-edit batch writes nothing (atomic)', () => {
+    const result = handleUpdateTask(
+      updateTaskParams({
+        descriptionEdits: [
+          { find: 'first section text', replace: 'revised first section' },
+          { find: 'text nowhere in the description', replace: 'x' },
+        ],
+      }),
+      context,
+    );
+
+    expect(result.success).toBe(false);
+    expect(mockTaskRepoUpdate).not.toHaveBeenCalled();
+  });
+
+  it('an over-cap result fails the call and writes nothing', () => {
+    const result = handleUpdateTask(
+      updateTaskParams({ appendDescription: 'x'.repeat(TASK_DESCRIPTION_MAX_LENGTH) }),
+      context,
+    );
+
+    expect(result.success).toBe(false);
+    expect(mockTaskRepoUpdate).not.toHaveBeenCalled();
+  });
+
+  it('composes descriptionEdits and appendDescription: edits apply first, then the append', () => {
+    mockTaskRepoUpdate.mockImplementation((input: { description?: string }) => ({ ...existingTask(), description: input.description }));
+
+    const result = handleUpdateTask(
+      updateTaskParams({
+        descriptionEdits: [{ find: 'second section text', replace: 'revised second section' }],
+        appendDescription: '\n\n## Section C\nadded later',
+      }),
+      context,
+    );
+
+    expect(result.success).toBe(true);
+    const updateInput = mockTaskRepoUpdate.mock.calls[0][0] as { description: string };
+    expect(updateInput.description).toBe(
+      '## Section A\nfirst section text\n\n## Section B\nrevised second section\n\n\n## Section C\nadded later',
+    );
+    expect(result.message).toContain('description');
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty-string appendDescription / no-op descriptionEdits must NOT write.
+  // The handler only sets updates.description/descriptionChanged when the
+  // computed text actually moved (`editResult.text !== task.description`).
+  // Red-green: reverting to an unconditional write (dropping the !== guard)
+  // makes these fail by calling mockTaskRepoUpdate / reporting 'description'.
+  // -------------------------------------------------------------------------
+
+  it('an empty appendDescription alone is a no-op: writes nothing and fails with "No fields provided"', () => {
+    const result = handleUpdateTask(
+      updateTaskParams({ appendDescription: '' }),
+      context,
+    );
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('No fields provided to update');
+    expect(mockTaskRepoUpdate).not.toHaveBeenCalled();
+  });
+
+  it('a no-op descriptionEdits (find === replace) alone is a no-op: writes nothing', () => {
+    const result = handleUpdateTask(
+      updateTaskParams({ descriptionEdits: [{ find: 'first section text', replace: 'first section text' }] }),
+      context,
+    );
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('No fields provided to update');
+    expect(mockTaskRepoUpdate).not.toHaveBeenCalled();
+  });
+
+  it('a no-op appendDescription combined with a real field updates but omits description from changedFields', () => {
+    mockTaskRepoUpdate.mockImplementation((input: { title?: string }) => ({ ...existingTask(), title: input.title }));
+
+    const result = handleUpdateTask(
+      updateTaskParams({ title: 'New Title', appendDescription: '' }),
+      context,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockTaskRepoUpdate).toHaveBeenCalledOnce();
+    const updateInput = mockTaskRepoUpdate.mock.calls[0][0] as Record<string, unknown>;
+    expect(updateInput.description).toBeUndefined();
+    expect(result.message).not.toContain('description');
+    expect(result.message).toContain('title');
+  });
+});

--- a/tests/unit/mcp-update-task-description-edits.test.ts
+++ b/tests/unit/mcp-update-task-description-edits.test.ts
@@ -212,6 +212,59 @@ describe('computeUpdatedDescription', () => {
     expect(result.success).toBe(false);
     expect((result as { error: string }).error).toContain(String(TASK_DESCRIPTION_MAX_LENGTH));
   });
+
+  it('succeeds as a no-op when find and replace are identical', () => {
+    const result = computeUpdatedDescription(ORIGINAL_DESCRIPTION, {
+      edits: [{ find: 'first section text', replace: 'first section text' }],
+    });
+
+    expect(result).toEqual({ success: true, text: ORIGINAL_DESCRIPTION });
+  });
+
+  it('supports deletion via an empty-string replace', () => {
+    const result = computeUpdatedDescription('one two three', {
+      edits: [{ find: 'two ', replace: '' }],
+    });
+
+    expect(result).toEqual({ success: true, text: 'one three' });
+  });
+
+  it('accepts a result whose length lands exactly at the cap (boundary: > not >=)', () => {
+    const result = computeUpdatedDescription('short', {
+      append: 'x'.repeat(TASK_DESCRIPTION_MAX_LENGTH - 'short'.length),
+    });
+
+    expect(result.success).toBe(true);
+    expect((result as { text: string }).text).toHaveLength(TASK_DESCRIPTION_MAX_LENGTH);
+  });
+
+  it('rejects a result that lands exactly one character past the cap', () => {
+    const result = computeUpdatedDescription('short', {
+      append: 'x'.repeat(TASK_DESCRIPTION_MAX_LENGTH - 'short'.length + 1),
+    });
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain(String(TASK_DESCRIPTION_MAX_LENGTH + 1));
+  });
+
+  it('resolves overlapping-but-not-identical find strings across sequential edits (an earlier replace can make a later find unique)', () => {
+    // "section" alone appears twice (Section A / Section B headers), so it is
+    // non-unique against the ORIGINAL text. The first edit narrows the
+    // second edit's target to a string that only exists once in the
+    // POST-first-edit text, proving edits are matched against the evolving
+    // text, not the original.
+    const result = computeUpdatedDescription(ORIGINAL_DESCRIPTION, {
+      edits: [
+        { find: '## Section A\nfirst section text', replace: '## Section A\nfirst section CHANGED' },
+        { find: 'first section CHANGED', replace: 'first section FINAL' },
+      ],
+    });
+
+    expect(result).toEqual({
+      success: true,
+      text: '## Section A\nfirst section FINAL\n\n## Section B\nsecond section text\n',
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds Edit-tool-style in-place description updates to `kangentic_update_task`:

- `descriptionEdits`: ordered exact-string `{find, replace}` edits, mirroring the file `Edit` tool's failure semantics. A `find` that is absent or not unique fails the entire call atomically - nothing is written.
- `appendDescription`: appends text to the end of the current description, exactly as given.
- Both are mutually exclusive with the existing full-replace `description` param, but composable with each other (edits apply first, then the append).
- Raises the task description cap from 10,000 to 50,000 characters (`kangentic_create_task` and `kangentic_update_task`), so the feature's target use case - long, incrementally-growing descriptions - has real headroom.
- Backlog item descriptions intentionally keep the old 10,000-char cap: `handleCreateTask` now explicitly rejects an over-cap `column: "Backlog"`-routed create instead of silently truncating it via `handleCreateBacklogTask`'s internal slice.
- Updates the MCP tool manifest blurb, `docs/mcp-server.md`, and the MCP server instructions to steer agents toward the in-place edit path for incremental changes to long descriptions.

## Why

`kangentic_update_task`'s `description` param replaces the entire description. For a long, incrementally-edited task (e.g. a 7KB description where one section changes), an agent has to regenerate and resend the whole blob for every small change:

1. **Token cost** - the full description is regenerated and resent for a one-paragraph change; on a large task this is the dominant output-token cost of the edit.
2. **Drift risk** - regenerating a long document to change one section lets the model silently alter or drop unrelated parts. This mirrors why the file `Edit` tool uses exact-string replacement instead of "rewrite the whole file."

This adds a cheaper, safer path for surgical edits without replacing full-replace, which stays correct and unambiguous for creates and genuine rewrites.

## How

- `src/main/agent/mcp-http/task-tools.ts` - new Zod params, an imperative mutual-exclusivity guard (matching the codebase's existing imperative-validation convention, since there's no `.refine`/`.superRefine` precedent in this file), and forwarding to the command handler.
- `src/main/agent/commands/task-commands.ts` - new pure exported helper `computeUpdatedDescription` (sequential find/replace against evolving text, then append, then a cap check) called from `handleUpdateTask` before any DB write or attachment I/O, so a failure is atomic.
- `src/main/agent/commands/backlog-commands.ts` - new `BACKLOG_DESCRIPTION_MAX_LENGTH` constant to keep backlog items at the old 10,000 cap independently of the raised task cap.

Trade-off worth flagging: the mutual-exclusivity check is an imperative guard in the tool handler rather than a Zod-level `.refine`, consistent with how this file already handles cross-field validation (e.g. the "at least one field" guard).

## Breaking changes

None. `description` (full replace) is unchanged and still the default path; the new params are additive and optional.

## Tests

- New `tests/unit/mcp-update-task-description-edits.test.ts`: pure `computeUpdatedDescription` coverage (single/multi-edit, append, compose, absent/non-unique find, cap boundaries, no-op and deletion edits) plus `handleUpdateTask` atomicity (each failure mode writes nothing).
- `tests/unit/mcp-task-session-tools.test.ts`: tool-layer wiring (guard passes/rejects correctly, mutual exclusivity both directions, compose mode) plus direct Zod `inputSchema` validation (array size min/max, empty `find` rejection).
- `tests/unit/mcp-create-task-labels.test.ts`: the raised 50,000 cap persists in full via both `handleCreateTask` and `handleUpdateTask`, and a Backlog-routed create still rejects over the old 10,000 cap.
- CI: typecheck, lint, unit, UI, and Linux Electron E2E shards.

Generated with [Claude Code](https://claude.com/claude-code)
