### PR TITLE
fix(ui): remove redundant PR pill from task detail header

### DIFF
--- a/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
+++ b/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
@@ -6,7 +6,6 @@ import { useFormattedCombo } from '../../../hooks/useKeybinding';
 import { getSwimlaneIcon } from '../../../utils/swimlane-icons';
 import { ICON_REGISTRY } from '../../../utils/swimlane-icons';
 import { HeaderActionButton } from '../../HeaderActionButton';
-import { PrLink } from '../../PrLink';
 import { IsolatedBadge } from '../../IsolatedBadge';
 import { KebabMenu, KebabMenuItem, KebabMenuDivider } from '../../KebabMenu';
 import { CommandSearchList } from './CommandSearchList';
@@ -246,7 +245,7 @@ export function TaskDetailHeader({
   // Quick-access pills, highest priority collapses LAST. The title is reserved only
   // up to a ~50ch floor (useHeaderPillOverflow); these compete for whatever is left
   // above the floor. Among the built-in defaults the order is Conversation ->
-  // Browser -> PR -> Changes -> Folder (Conversation drops first). Custom header
+  // Browser -> Changes -> Folder (Conversation drops first). Custom header
   // shortcuts rank LOWEST (priority 10), so they fold BEFORE any built-in default -
   // an unbounded number of shortcuts can never bury the defaults. A folded pill /
   // header shortcut that is not already a menu item folds into the kebab (Commands,
@@ -256,14 +255,13 @@ export function TaskDetailHeader({
     const specs: HeaderPillSpec[] = [];
     if (task.worktree_path || projectPath) specs.push({ id: 'folder', priority: 40 });
     if (canShowChanges) specs.push({ id: 'changes', priority: 30 });
-    if (task.pr_url) specs.push({ id: 'pr', priority: 25 });
     if (canShowBrowser) specs.push({ id: 'browser', priority: 20 });
     specs.push({ id: 'conversation', priority: 18 });
     for (const action of headerShortcuts) {
       specs.push({ id: `shortcut:${action.id ?? action.label}`, priority: 10 });
     }
     return specs;
-  }, [task.worktree_path, task.pr_url, projectPath, canShowChanges, canShowBrowser, headerShortcuts]);
+  }, [task.worktree_path, projectPath, canShowChanges, canShowBrowser, headerShortcuts]);
 
   const hiddenPillIds = useHeaderPillOverflow(headerRef, leadingRef, trailingRef, titleSpanRef, pillsRef, pillSpecs);
   const showPill = (id: string) => !hiddenPillIds.has(id);
@@ -375,18 +373,6 @@ export function TaskDetailHeader({
                 title={task.worktree_path ? 'Open Worktree' : 'Open Folder'}
                 ariaLabel={task.worktree_path ? 'Open worktree folder' : 'Open project folder'}
                 testId="branch-pill"
-              />
-            </div>
-          )}
-
-          {/* PR pill */}
-          {showPill('pr') && task.pr_url && (
-            <div data-pill-id="pr" className="flex-shrink-0">
-              <PrLink
-                prUrl={task.pr_url}
-                prNumber={task.pr_number}
-                prState={task.pr_state}
-                testId="pr-pill"
               />
             </div>
           )}

--- a/tests/ui/pr-link-badge.spec.ts
+++ b/tests/ui/pr-link-badge.spec.ts
@@ -1,11 +1,14 @@
 /**
- * UI tests for the shared PR link affordance (PrLink / PrStateBadge).
+ * UI tests for the shared PR link affordance (PrLink / PrStateBadge) and its
+ * detail-header counterpart (the "View PR #N" kebab entry).
  *
  * Seeds a Code Review task with a linked, open PR and a running session (so the
- * detail dialog opens on TaskDetailHeader, not the edit form), then asserts both
- * surfaces that render the linked PR: the board card and the detail header. Each
- * must show the PR number, an `open` state badge (not inline text), a trailing
- * external-link icon, and an "Open PR #287 in browser" tooltip.
+ * detail dialog opens on TaskDetailHeader, not the edit form), then asserts the
+ * two surfaces that let a user open the linked PR: the board card's PrLink badge
+ * (PR number, an `open` state badge, a trailing external-link icon, and an "Open
+ * PR #287 in browser" tooltip) and the detail header's `...` kebab "View PR #287"
+ * entry (which opens the same URL). The header's compact icon bar itself has no
+ * PR pill - that affordance is intentionally only on the card and in the kebab.
  */
 import { test, expect } from '@playwright/test';
 import { chromium, type Browser, type Page } from '@playwright/test';
@@ -127,7 +130,7 @@ test.describe('PR link: state badge and clickable affordance', () => {
     await expect(prLink).toHaveAttribute('title', 'Open PR #287 in browser');
   });
 
-  test('detail header shows the same PR badge and affordance', async () => {
+  test('detail header has no PR pill; the kebab "View PR" entry opens the same URL', async () => {
     const card = page
       .locator('[data-swimlane-name="Code Review"]')
       .locator('text=PR Link Task')
@@ -137,12 +140,33 @@ test.describe('PR link: state badge and clickable affordance', () => {
     const dialog = page.locator('[data-testid="task-detail-dialog"]');
     await dialog.waitFor({ state: 'visible', timeout: 5000 });
 
-    const prPill = page.locator('[data-testid="pr-pill"]');
-    await expect(prPill).toBeVisible();
-    await expect(prPill).toContainText('PR #287');
-    await expect(prPill.locator('[data-testid="pr-state-badge"]')).toHaveText('open');
-    await expect(prPill.locator('.lucide-external-link')).toBeVisible();
-    await expect(prPill).toHaveAttribute('title', 'Open PR #287 in browser');
+    // The compact icon bar itself has no PR pill; that affordance lives only on
+    // the card and in the overflow kebab.
+    await expect(page.locator('[data-testid="pr-pill"]')).toHaveCount(0);
+
+    await page.evaluate(() => {
+      window.__openedExternalUrls = [];
+      window.electronAPI.shell.openExternal = async (url: string) => {
+        window.__openedExternalUrls?.push(url);
+      };
+    });
+
+    await dialog.locator('[title="Actions"]').click();
+    const viewPrItem = page.getByRole('button', { name: 'View PR #287' });
+    await expect(viewPrItem).toBeVisible();
+    await viewPrItem.click();
+
+    await expect
+      .poll(() => page.evaluate(() => window.__openedExternalUrls))
+      .toEqual(['https://github.com/owner/repo/pull/287']);
+
+    // Restore the mock's default no-op so this patch does not leak into later
+    // tests on the shared page (matches mock-electron-api.js shell.openExternal).
+    await page.evaluate(() => {
+      window.electronAPI.shell.openExternal = async () => {
+        return;
+      };
+    });
 
     // Close the dialog so state does not leak to other tests.
     // Use Control+Shift+W (capture-phase) rather than Escape: the task-detail


### PR DESCRIPTION
## What

Removes the "PR #N open [external-link]" pill from the task-detail window's compact icon bar (the header row with folder/changes/browser/conversation pills). Touches `src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx` and its UI test coverage.

## Why

The pill no longer fits the compact icon bar's look/feel, and it's redundant: the exact same "open PR in browser" action is already available on the board card itself (the primary click point) and in the header's overflow `...` menu ("View PR #N").

## How

- Removed the PR pill's render block, its entry in the header's priority-plus pill-overflow spec (`pillSpecs` / `useHeaderPillOverflow`), and the now-unused `PrLink` import.
- Left the board card's PR badge (`task-card-pr-link`, via the same shared `PrLink` component) and the kebab menu's "View PR #N" item untouched - both still open the PR URL.

## Breaking changes

None. Purely a UI affordance removal with two equivalent affordances remaining.

## Tests

- `npm run typecheck`, `npm run lint`, `npm run build` all pass.
- Updated `tests/ui/pr-link-badge.spec.ts`: the header test now asserts the pill is gone (`[data-testid="pr-pill"]` count 0) and that the kebab "View PR #N" entry still triggers `shell.openExternal` with the PR URL. The board-card PR badge test is unchanged.
- Verified `tests/ui/task-detail-header-overflow.spec.ts` (pill overflow/priority suite) is unaffected - its fixtures never seed a PR URL.
- CI: lint, typecheck, unit, build, UI shards, and Linux Electron E2E shards.

Generated with [Claude Code](https://claude.com/claude-code)
