### PR TITLE
fix(terminal): fullscreen TUI select-prompt input/focus freeze

### DIFF
--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -275,6 +275,25 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   slow repaint can only delay a first paint, never hang the read. A resize that arrives before the
   PTY exists (the renderer mounts before the auto-resume spawn lands) is stashed and applied at
   spawn, so the PTY starts at the fitted size and no corrective resize is needed.
+- **DEC private mode and alt-screen re-assert on replay.** `xterm.reset()` on the renderer wipes
+  every DEC private mode xterm is tracking, and the original mode-set bytes usually scroll out of
+  the 512KB scrollback window on a long-running session. `PtyBufferManager` tracks DEC private
+  input/reporting modes (DECCKM, mouse tracking, bracketed paste, ...) from the live stream and
+  re-asserts them as a prefix on `getScrollback` (#313). Alt-screen (mode 1049/47/1047) is tracked
+  separately as `inAltScreen` and re-asserted with its own `\x1b[?1049h` prefix, gated on the
+  session currently being in the alt buffer - a classic (normal-buffer) session's replay is
+  unaffected, but a fullscreen-TUI session's replay now paints into the alt buffer instead of the
+  normal buffer (previously the cause of a cursor left visually disconnected from the TUI frame). A
+  synchronized-output frame (mode 2026) left open by a mid-frame sample is closed with a trailing
+  `\x1b[?2026l` so it cannot stall the renderer's ~1s safety timeout.
+- **Hold, not drop, live output across a renderer-side replay.** While a scrollback replay is in
+  flight (`scrollbackPendingRef`), the renderer's incoming-write queue HOLDS (retains, does not
+  ack) rather than drops live PTY bytes, and flushes them in order once the replay's `afterWrite`
+  completes. This closes a window where a live diff (e.g. a fullscreen TUI's selection-highlight
+  redraw) could be silently discarded during a reattach. Only the loading overlay continues to
+  drop-and-ack (its window can span the whole agent startup). A generation-aware `afterWrite` and a
+  bounded watchdog timer additionally guard against a stale or stuck replay leaving
+  `scrollbackPendingRef` true indefinitely, which would otherwise drop all live output forever.
 
 ## Key Constants
 

--- a/src/main/pty/buffer/pty-buffer-manager.ts
+++ b/src/main/pty/buffer/pty-buffer-manager.ts
@@ -59,11 +59,22 @@ function surrogateSafeFlushEnd(buffer: string, max: number): number {
 
 // DEC private input/reporting modes to re-assert on a scrollback replay. These
 // are invisible to restore: they change what xterm SENDS on later input, not
-// what it draws, so the replayed frame is unchanged. Display modes (alt-screen
-// 1049/47, origin 6, autowrap 7, cursor 25, ...) are excluded on purpose. #313.
-// Note: re-asserting 1004 (focus reporting) means the post-replay xterm.focus()
-// in useTerminal's afterWrite now emits a benign \x1b[I (FocusIn) to the PTY,
-// which Claude handles as a normal focus event.
+// what it draws, so the replayed frame is unchanged. Most display modes
+// (origin 6, autowrap 7, cursor 25, ...) are excluded on purpose: re-asserting
+// them for a NORMAL-buffer (classic-renderer) session could corrupt its
+// restore. #313. Note: re-asserting 1004 (focus reporting) means the
+// post-replay xterm.focus() in useTerminal's afterWrite now emits a benign
+// \x1b[I (FocusIn) to the PTY, which Claude handles as a normal focus event.
+//
+// Alt-screen (1049/47/1047) is the one display mode re-asserted, but NOT via
+// this set: it is tracked separately as BufferState.inAltScreen and emitted
+// only when the session is CURRENTLY in the alt buffer (see getScrollback).
+// That gate is what keeps it safe alongside the #313 exclusion above - a
+// classic normal-buffer session never sets inAltScreen, so its replay is
+// byte-for-byte unchanged; a fullscreen-TUI session's captured frame genuinely
+// belongs in the alt buffer, so replaying it there (instead of the normal
+// buffer, where it previously landed and desynced the cursor from the frame)
+// is the correct restore, not a corruption risk.
 const RESTORABLE_DEC_PRIVATE_MODES = new Set<number>([
   1,                 // DECCKM application cursor keys (the arrow-key bug)
   1000, 1002, 1003,  // mouse tracking
@@ -72,29 +83,54 @@ const RESTORABLE_DEC_PRIVATE_MODES = new Set<number>([
   2004,              // bracketed paste
 ]);
 
+// Alt-screen enter/exit variants, tracked into BufferState.inAltScreen (not
+// RESTORABLE_DEC_PRIVATE_MODES - see the comment above). 1049 is the modern
+// combined form (save cursor + switch + clear); 47/1047 are older variants
+// without the cursor save. All three flip the same boolean.
+const ALT_SCREEN_MODES = new Set<number>([47, 1047, 1049]);
+
+// DEC synchronized-output framing (mode 2026). Tracked so getScrollback can
+// close a frame left open by a mid-frame sample, which would otherwise stall
+// xterm's renderer for its ~1s safety timeout.
+const SYNCHRONIZED_OUTPUT_MODE = 2026;
+
 // Upper bound on a partial mode sequence carried across a PTY chunk boundary.
-// Larger than the longest combined restorable DECSET (all modes in one set is
-// ~45 chars: `\x1b[?1;1000;1002;1003;1004;1006;1015;1016;2004`), so a real split
-// is always preserved while a lone trailing ESC cannot grow modeParseCarry
-// without limit. Adding a mode to RESTORABLE_DEC_PRIVATE_MODES that pushes the
-// combined set past this must bump it too.
+// The carry must preserve a split of any tracked DECSET: the restorable input
+// modes, the alt-screen modes (47/1047/1049), and synchronized output (2026).
+// A single DECSET folding in every restorable mode alone is ~45 chars
+// (`\x1b[?1;1000;1002;1003;1004;1006;1015;1016;2004`); one that also folded in
+// 47/1047/1049/2026 would come to ~64, so a real split is always preserved
+// while a lone trailing ESC cannot grow modeParseCarry without limit. Adding a
+// mode to any of the three tracked sets that pushes a combined DECSET past this
+// must bump the constant too.
 const MODE_CARRY_MAX_LENGTH = 64;
 
-function updateDecPrivateModes(activeModes: Set<number>, text: string): void {
+/** Mutable mode-tracking fields of BufferState that updateModeState mutates. */
+type ModeState = Pick<BufferState, 'decPrivateModes' | 'inAltScreen' | 'synchronizedOpen'>;
+
+function updateModeState(state: ModeState, text: string): void {
   // One alternation matches a DECSET/DECRST set (\x1b[?<params>h|l) OR a full
   // reset (RIS \x1bc / DECSTR \x1b[!p) that returns every private mode to its
   // default. matchAll yields matches in stream order, so an interleaved
   // set-then-reset resolves correctly. A reset match has no capture groups.
   for (const match of text.matchAll(/\x1b\[\?([\d;]+)([hl])|\x1bc|\x1b\[!p/g)) {
     if (match[1] === undefined) {
-      for (const privateMode of RESTORABLE_DEC_PRIVATE_MODES) activeModes.delete(privateMode);
+      // RIS (\x1bc) returns to the normal buffer, so clear inAltScreen too;
+      // DECSTR (\x1b[!p) does not switch buffers per spec, so it leaves
+      // inAltScreen untouched. Both clear a dangling synchronized frame.
+      for (const privateMode of RESTORABLE_DEC_PRIVATE_MODES) state.decPrivateModes.delete(privateMode);
+      state.synchronizedOpen = false;
+      if (match[0] === '\x1bc') state.inAltScreen = false;
       continue;
     }
     const isSet = match[2] === 'h';
     for (const parameter of match[1].split(';')) {
       const privateMode = Number(parameter);
-      if (!RESTORABLE_DEC_PRIVATE_MODES.has(privateMode)) continue;
-      if (isSet) activeModes.add(privateMode); else activeModes.delete(privateMode);
+      if (RESTORABLE_DEC_PRIVATE_MODES.has(privateMode)) {
+        if (isSet) state.decPrivateModes.add(privateMode); else state.decPrivateModes.delete(privateMode);
+      }
+      if (ALT_SCREEN_MODES.has(privateMode)) state.inAltScreen = isSet;
+      if (privateMode === SYNCHRONIZED_OUTPUT_MODE) state.synchronizedOpen = isSet;
     }
   }
 }
@@ -131,6 +167,17 @@ interface BufferState {
    *  tracked from the live stream so getScrollback() can re-assert them after
    *  xterm.reset() wipes them on replay. Survives scrollback trimming. #313. */
   decPrivateModes: Set<number>;
+  /** Whether the session is currently in the alt screen buffer (DEC mode
+   *  47/1047/1049), tracked so getScrollback() can re-assert it after
+   *  xterm.reset() wipes it on replay - otherwise a fullscreen TUI's replayed
+   *  frame paints into the wrong (normal) buffer. Survives scrollback
+   *  trimming; reset on respawn like decPrivateModes. */
+  inAltScreen: boolean;
+  /** Whether a DEC synchronized-output frame (mode 2026) is currently open,
+   *  tracked so getScrollback() can close a frame left dangling by a
+   *  mid-frame sample - otherwise xterm stalls rendering for its ~1s safety
+   *  timeout. */
+  synchronizedOpen: boolean;
   /** Trailing partial escape sequence stitched onto the next chunk so a mode
    *  set split across two PTY chunks is parsed whole. Bounded in onData(). */
   modeParseCarry: string;
@@ -159,8 +206,10 @@ export class PtyBufferManager {
       pendingRepaintAt: null,
       lastDataAt: null,
       tuiStartIndex: previousScrollback ? 0 : -1,
-      // Start empty even on carry-over: the new process re-emits its own modes.
+      // Start empty/false even on carry-over: the new process re-emits its own modes.
       decPrivateModes: new Set<number>(),
+      inAltScreen: false,
+      synchronizedOpen: false,
       modeParseCarry: '',
     });
   }
@@ -169,22 +218,23 @@ export class PtyBufferManager {
     const state = this.buffers.get(sessionId);
     if (!state) return;
 
-    // Track sticky DEC private input modes (DECCKM, mouse, paste) from the live
-    // stream so the scrollback replay can re-assert them after xterm.reset()
-    // wipes them - the original mode-set bytes usually scroll out of the 512KB
-    // window (#313). modeParseCarry stitches a set split across two PTY chunks,
-    // bounded by MODE_CARRY_MAX_LENGTH so a lone ESC cannot grow it. Skip the
-    // scan for ESC-free bulk output unless a partial set is pending. Parse
-    // `combined` only; append the original `data` below so the carry never
-    // duplicates bytes into buffer/scrollback.
+    // Track sticky DEC private input modes (DECCKM, mouse, paste), alt-screen,
+    // and synchronized-output framing from the live stream so the scrollback
+    // replay can re-assert/close them after xterm.reset() wipes them - the
+    // original mode-set bytes usually scroll out of the 512KB window (#313).
+    // modeParseCarry stitches a set split across two PTY chunks, bounded by
+    // MODE_CARRY_MAX_LENGTH so a lone ESC cannot grow it. Skip the scan for
+    // ESC-free bulk output unless a partial set is pending. Parse `combined`
+    // only; append the original `data` below so the carry never duplicates
+    // bytes into buffer/scrollback.
     if (state.modeParseCarry || data.includes('\x1b')) {
       const combined = state.modeParseCarry + data;
-      updateDecPrivateModes(state.decPrivateModes, combined);
+      updateModeState(state, combined);
       // A carry can only be a partial sequence at the very END of `combined`,
       // and it is bounded to MODE_CARRY_MAX_LENGTH, so scan just the trailing
       // window - a full-chunk scan here is redundant on the hot path. The `!?`
       // admits a partial DECSTR (\x1b[!) split at \x1b[! | p, matching the
-      // DECSTR arm of updateDecPrivateModes so the soft reset is not lost.
+      // DECSTR arm of updateModeState so the soft reset is not lost.
       const trailingWindow = combined.slice(-(MODE_CARRY_MAX_LENGTH + 1));
       const partialEscapeMatch = trailingWindow.match(/\x1b(?:\[[\d?;]*!?)?$/);
       state.modeParseCarry =
@@ -366,7 +416,18 @@ export class PtyBufferManager {
       }
     }
 
-    return buildDecPrivateModePrefix(state.decPrivateModes) + '\x1b[0m' + scrollback;
+    // Alt-screen enter goes first: it (re-)clears the alt buffer and switches
+    // into it, so the input-mode reassert and the replayed frame land where
+    // the session actually is. Gated on inAltScreen so a classic normal-buffer
+    // session's replay is byte-for-byte unchanged (see the #313 comment on
+    // RESTORABLE_DEC_PRIVATE_MODES). A dangling synchronized-output frame is
+    // closed at the very end so a mid-frame sample can't stall xterm's
+    // renderer for its ~1s safety timeout.
+    return (state.inAltScreen ? '\x1b[?1049h' : '')
+      + buildDecPrivateModePrefix(state.decPrivateModes)
+      + '\x1b[0m'
+      + scrollback
+      + (state.synchronizedOpen ? '\x1b[?2026l' : '');
   }
 
   /**

--- a/src/renderer/components/LaunchOverlay.tsx
+++ b/src/renderer/components/LaunchOverlay.tsx
@@ -13,7 +13,7 @@ interface LaunchOverlayProps {
  */
 export function LaunchOverlay({ label }: LaunchOverlayProps) {
   return (
-    <div className="absolute inset-0 z-10 flex items-center justify-center bg-surface">
+    <div data-testid="launch-overlay" className="absolute inset-0 z-10 flex items-center justify-center bg-surface">
       <span className="flex items-center gap-2 text-sm text-fg-muted">
         <Loader2 size={14} className="animate-spin" />
         {label}

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -14,6 +14,13 @@ import '@xterm/xterm/css/xterm.css';
  *  (Claude Code) only redraws once and scrollback isn't churned. */
 const PTY_RESIZE_DEBOUNCE_MS = 200;
 
+/** Backstop for a scrollback replay whose chunked write never completes (e.g.
+ *  a dropped xterm.write callback). Force-clears scrollbackPendingRef and
+ *  resumes the incoming queue so live output isn't dropped indefinitely.
+ *  Comfortably above a healthy replay (repaint-settle caps at 400ms, plus a
+ *  512KB chunked write) and far below a pathological hang. */
+const SCROLLBACK_WATCHDOG_MS = 5000;
+
 /** Scroll positions saved before xterm dispose, keyed by session ID.
  *  Preserved across HMR via import.meta.hot.data so terminals restore
  *  the user's viewport position instead of jumping to the bottom. */
@@ -102,6 +109,14 @@ export function useTerminal(options: UseTerminalOptions) {
   /** Monotonic counter to abandon stale scrollback operations when a newer
    *  one starts (e.g. initTerminal and reloadScrollback racing). */
   const scrollbackGenerationRef = useRef(0);
+  /** Backstop timer for a stuck replay (see SCROLLBACK_WATCHDOG_MS). Arming a
+   *  new one clears any prior timer, so at most one is ever live - the one
+   *  for the most recently started replay. */
+  const scrollbackWatchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Resumes the incoming-write queue's held drain (set by the queue effect
+   *  below). Used by the watchdog to flush replay-held live bytes when a
+   *  stuck replay is force-cleared. */
+  const incomingResumeRef = useRef<(() => void) | null>(null);
   const isAtBottomRef = useRef(true);
   /** When true, onData writes are suppressed. Controlled by the caller
    *  (e.g. TerminalTab) to gate PTY output while a loading overlay is shown. */
@@ -198,6 +213,18 @@ export function useTerminal(options: UseTerminalOptions) {
       scrollbackPendingRef.current = true;
       const scrollbackGeneration = ++scrollbackGenerationRef.current;
       const suppressScrollback = suppressDataRef.current;
+      if (scrollbackWatchdogRef.current) clearTimeout(scrollbackWatchdogRef.current);
+      scrollbackWatchdogRef.current = setTimeout(() => {
+        scrollbackWatchdogRef.current = null;
+        if (scrollbackGenerationRef.current === scrollbackGeneration && scrollbackPendingRef.current) {
+          // Invalidate the generation so a merely-delayed (not dropped) afterWrite
+          // or catch for this replay bails at its generation guard instead of
+          // re-running fit / scroll / focus after we already force-recovered.
+          scrollbackGenerationRef.current += 1;
+          scrollbackPendingRef.current = false;
+          incomingResumeRef.current?.();
+        }
+      }, SCROLLBACK_WATCHDOG_MS);
 
       // Fit immediately to calculate actual container cols/rows
       fitAddon.fit();
@@ -219,13 +246,21 @@ export function useTerminal(options: UseTerminalOptions) {
 
       Promise.all([resizePromise, scrollbackPromise])
         .then(([, scrollback]) => {
-          // A newer scrollback operation has started; abandon this one.
-          if (scrollbackGenerationRef.current !== scrollbackGeneration) {
-            scrollbackPendingRef.current = false;
-            return;
-          }
+          // A newer scrollback operation has started; it owns clearing pending
+          // (and the watchdog it armed), so this stale resolve must not touch
+          // either - clearing them here would open the drop/hold gate early
+          // for the newer replay still in flight.
+          if (scrollbackGenerationRef.current !== scrollbackGeneration) return;
 
           const afterWrite = () => {
+            // A newer replay may have started (and armed its own watchdog,
+            // which already canceled ours) while this chunked write was in
+            // flight; abandon so we don't clobber its pending/fit/focus.
+            if (scrollbackGenerationRef.current !== scrollbackGeneration) return;
+            if (scrollbackWatchdogRef.current) {
+              clearTimeout(scrollbackWatchdogRef.current);
+              scrollbackWatchdogRef.current = null;
+            }
             // Re-fit to handle any layout shifts during the async gap
             if (fitAddonRef.current) {
               fitAddonRef.current.fit();
@@ -235,6 +270,10 @@ export function useTerminal(options: UseTerminalOptions) {
               isAtBottomRef.current = restoreScrollPosition(xtermRef.current, options.sessionId);
             }
             scrollbackPendingRef.current = false;
+            // Flush any live bytes the incoming queue held during the replay
+            // (see shouldHold in the queue effect below) now that the replay
+            // frame is fully painted, so they apply strictly after it.
+            incomingResumeRef.current?.();
             // Focus the terminal after the full init chain completes. No
             // corrective resize: main already sampled the settled frame at the
             // fitted width, and a same-dims resize is a documented no-op (POSIX
@@ -255,6 +294,10 @@ export function useTerminal(options: UseTerminalOptions) {
           // IPC may reject if session was killed during the async gap.
           // Unblock onData so the terminal isn't permanently silenced.
           if (scrollbackGenerationRef.current !== scrollbackGeneration) return;
+          if (scrollbackWatchdogRef.current) {
+            clearTimeout(scrollbackWatchdogRef.current);
+            scrollbackWatchdogRef.current = null;
+          }
           scrollbackPendingRef.current = false;
         });
     } else {
@@ -274,18 +317,24 @@ export function useTerminal(options: UseTerminalOptions) {
 
     const queue = createIncomingWriteQueue({
       getTerminal: () => xtermRef.current,
-      // While scrollback is loading (or an overlay is up), drop onData -- it's
-      // duplicate data already included in the scrollback replay. The
-      // server-side getScrollback() drains the pending buffer, so this is
-      // defense-in-depth. Dropped slices are still acked inside the queue.
-      shouldDrop: () => scrollbackPendingRef.current || suppressDataRef.current,
-      // While a board drag is active, HOLD (not drop) inbound writes so xterm
-      // parsing doesn't compete with the drag on the renderer thread. Held bytes
-      // are retained and resumed on drag end; the coalescer's 30s watchdog
-      // bounds the hold if a drag end is ever missed.
-      shouldHold: () => isBoardDragActive(),
+      // Only an overlay (agent startup) drops onData - it can last many
+      // seconds and is recovered by the overlay-lift reloadScrollback, so
+      // holding it would pause the PTY for the whole startup. Dropped slices
+      // are still acked inside the queue.
+      shouldDrop: () => suppressDataRef.current,
+      // While a board drag OR a scrollback replay is in flight, HOLD (not
+      // drop) inbound writes. For a replay, getScrollback() drains the
+      // server-side pending buffer, so anything still arriving here is either
+      // an in-flight duplicate of the replay (harmless to re-apply) or
+      // genuinely new live output (e.g. a diff frame) that must not be lost -
+      // dropping it (the prior behavior) could silently discard a selection
+      // highlight in a fullscreen TUI. Held bytes are retained and resumed via
+      // kick() on drag end, at the end of afterWrite, or by the stuck-replay
+      // watchdog.
+      shouldHold: () => isBoardDragActive() || scrollbackPendingRef.current,
       ack: (bytes) => window.electronAPI.sessions.ackData(sessionId, bytes),
     });
+    incomingResumeRef.current = () => queue.kick();
 
     const cleanup = window.electronAPI.sessions.onData((incomingSessionId, data) => {
       if (incomingSessionId !== sessionId) return;
@@ -299,6 +348,7 @@ export function useTerminal(options: UseTerminalOptions) {
     return () => {
       cleanup();
       cleanupRef.current = null;
+      incomingResumeRef.current = null;
       unsubscribeDragEnd();
       queue.reset();
     };
@@ -346,6 +396,7 @@ export function useTerminal(options: UseTerminalOptions) {
   useEffect(() => {
     return () => {
       if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
+      if (scrollbackWatchdogRef.current) clearTimeout(scrollbackWatchdogRef.current);
       // Flush any pending batched writes synchronously so keystrokes queued
       // just before unmount (sessionId change, HMR dispose) aren't dropped.
       writeBatcherRef.current?.flush();
@@ -408,6 +459,18 @@ export function useTerminal(options: UseTerminalOptions) {
     const skipResize = reloadOptions?.skipResize ?? false;
     scrollbackPendingRef.current = true;
     const scrollbackGeneration = ++scrollbackGenerationRef.current;
+    if (scrollbackWatchdogRef.current) clearTimeout(scrollbackWatchdogRef.current);
+    scrollbackWatchdogRef.current = setTimeout(() => {
+      scrollbackWatchdogRef.current = null;
+      if (scrollbackGenerationRef.current === scrollbackGeneration && scrollbackPendingRef.current) {
+        // Invalidate the generation so a merely-delayed (not dropped) afterWrite
+        // or catch for this replay bails at its generation guard instead of
+        // re-running fit / scroll / focus after we already force-recovered.
+        scrollbackGenerationRef.current += 1;
+        scrollbackPendingRef.current = false;
+        incomingResumeRef.current?.();
+      }
+    }, SCROLLBACK_WATCHDOG_MS);
     xtermRef.current.reset();
 
     // Resize-first: fit to container, then sync PTY dimensions before
@@ -431,19 +494,31 @@ export function useTerminal(options: UseTerminalOptions) {
 
     Promise.all([resizePromise, scrollbackPromise])
       .then(([, scrollback]) => {
-        // A newer scrollback operation has started; abandon this one.
-        if (scrollbackGenerationRef.current !== scrollbackGeneration) {
-          scrollbackPendingRef.current = false;
-          return;
-        }
+        // A newer scrollback operation has started; it owns clearing pending
+        // (and the watchdog it armed), so this stale resolve must not touch
+        // either - clearing them here would open the drop/hold gate early
+        // for the newer replay still in flight.
+        if (scrollbackGenerationRef.current !== scrollbackGeneration) return;
 
         const afterWrite = () => {
+          // A newer replay may have started (and armed its own watchdog,
+          // which already canceled ours) while this chunked write was in
+          // flight; abandon so we don't clobber its pending/fit/focus.
+          if (scrollbackGenerationRef.current !== scrollbackGeneration) return;
+          if (scrollbackWatchdogRef.current) {
+            clearTimeout(scrollbackWatchdogRef.current);
+            scrollbackWatchdogRef.current = null;
+          }
           if (fitAddonRef.current) fitAddonRef.current.fit();
           // Restore saved scroll position (HMR) or pin to bottom
           if (xtermRef.current) {
             isAtBottomRef.current = restoreScrollPosition(xtermRef.current, options.sessionId);
           }
           scrollbackPendingRef.current = false;
+          // Flush any live bytes the incoming queue held during the reload
+          // (see shouldHold in the queue effect below) now that the replay
+          // frame is fully painted, so they apply strictly after it.
+          incomingResumeRef.current?.();
           // Focus after the reload completes. No corrective resize: when a
           // resize was sent above, main sampled the settled frame; a same-dims
           // resize is a no-op either way.
@@ -464,6 +539,10 @@ export function useTerminal(options: UseTerminalOptions) {
         // IPC may reject if session was killed during the async gap.
         // Unblock onData so the terminal isn't permanently silenced.
         if (scrollbackGenerationRef.current !== scrollbackGeneration) return;
+        if (scrollbackWatchdogRef.current) {
+          clearTimeout(scrollbackWatchdogRef.current);
+          scrollbackWatchdogRef.current = null;
+        }
         scrollbackPendingRef.current = false;
       });
   }, [options.sessionId]);

--- a/tests/e2e/terminal-fullscreen-select-replay-focus.spec.ts
+++ b/tests/e2e/terminal-fullscreen-select-replay-focus.spec.ts
@@ -1,0 +1,244 @@
+/**
+ * E2E regression guard: terminal input/focus disconnect at a fullscreen-TUI
+ * select prompt across a scrollback replay.
+ *
+ * Reported live on task #290 (2026-07-08): at an interactive select prompt
+ * (AskUserQuestion / plan approval) in Claude's default fullscreen (alt-screen)
+ * TUI renderer, arrow keys and Enter appeared to do nothing. Clicking the
+ * terminal instantly unfroze it, proving keys were never reaching the PTY
+ * (the xterm textarea had lost DOM focus) rather than the display being
+ * frozen. A second symptom - the real xterm cursor parked bottom-right,
+ * disconnected from the TUI frame - showed the replay had painted into
+ * xterm's NORMAL buffer instead of the alt buffer.
+ *
+ * Root cause (two coupled defects):
+ *   1. A stale/overlapping scrollback replay's afterWrite callback could
+ *      clobber a newer replay's pending flag before the newer one's own
+ *      focus() ever ran (no generation guard inside afterWrite itself).
+ *   2. getScrollback() re-asserted DEC private INPUT modes (#313) but never
+ *      alt-screen (1049), so a fullscreen session's replay always landed in
+ *      the normal buffer.
+ *
+ * `tests/fixtures/mock-claude.js` normally emits plain marker lines with no
+ * terminal escape sequences at all, so it cannot reproduce a bug that only
+ * exists in the alt-screen replay path. Setting MOCK_CLAUDE_FULLSCREEN_SELECT=1
+ * switches it to a small interactive select-prompt harness: it enters the alt
+ * screen buffer, turns on DECCKM, draws a 3-option menu, and moves the
+ * highlight via a cursor-addressed, synchronized-output DIFF on arrow input --
+ * never a full repaint - so a lost keystroke or a misplaced replay is
+ * directly observable in the scrollback (the highlighted-option marker for
+ * the NEXT option only ever appears if the keystroke actually reached the PTY).
+ *
+ * This spec drives real, focused Playwright keyboard events into the xterm
+ * DOM (not a `sessions.write` IPC bypass), because the bug is specifically
+ * about whether DOM focus lands - an IPC-direct write would pass regardless
+ * of whether the fix is present.
+ *
+ * Manual ground-truth reproduction against the real Claude CLI:
+ *   1. Launch Kangentic dev build. Start a task, park it at any interactive
+ *      select prompt (AskUserQuestion, plan approval).
+ *   2. Open/close the task-detail dialog (or resize the panel) to force a
+ *      scrollback replay.
+ *   3. Confirm arrow keys move the highlight and Enter selects, without
+ *      needing to click the terminal first.
+ */
+import { test, expect } from '@playwright/test';
+import {
+  launchApp,
+  createProject,
+  createTask,
+  createTempProject,
+  cleanupTempProject,
+  getTestDataDir,
+  cleanupTestDataDir,
+  closeApp,
+  mockAgentPath,
+  getTaskIdByTitle,
+  moveTaskIpc,
+} from './helpers';
+import type { ElectronApplication, Page } from '@playwright/test';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const TEST_NAME = 'terminal-fullscreen-select-replay-focus';
+const runId = Date.now();
+const PROJECT_NAME = `Fullscreen Select ${runId}`;
+
+// Text mock-claude.js's fullscreen-select harness writes for the
+// currently-highlighted option (a "> " marker; unhighlighted rows get "  ").
+// Matched as plain text, not the surrounding SGR reverse-video codes: a real
+// PTY (Windows ConPTY in particular) can re-serialize style sequences it
+// relays (observed \x1b[27m in place of the \x1b[0m the mock wrote), so
+// asserting on exact escape bytes is fragile. The marker text itself is
+// unique per option, so its appearance in scrollback still unambiguously
+// proves the corresponding arrow key reached the PTY and moved the highlight.
+const HIGHLIGHT_FIRST = '> First option';
+const HIGHLIGHT_SECOND = '> Second option';
+const HIGHLIGHT_THIRD = '> Third option';
+
+function writeTestConfig(dataDir: string): void {
+  fs.writeFileSync(
+    path.join(dataDir, 'config.json'),
+    JSON.stringify({
+      claude: {
+        cliPath: mockAgentPath('claude'),
+        permissionMode: 'default',
+        maxConcurrentSessions: 5,
+        queueOverflow: 'queue',
+      },
+      git: { worktreesEnabled: false },
+    }),
+  );
+}
+
+async function getSwimlaneByName(page: Page, name: string): Promise<string> {
+  const swimlaneId = await page.evaluate(async (laneName) => {
+    const swimlanes: Array<{ id: string; name: string }> =
+      await window.electronAPI.swimlanes.list();
+    return swimlanes.find((swimlane) => swimlane.name === laneName)?.id ?? null;
+  }, name);
+  if (!swimlaneId) throw new Error(`Swimlane "${name}" not found`);
+  return swimlaneId;
+}
+
+/** Current raw scrollback for this task's session (any status - the mock
+ *  exits on Enter, so the session may already be 'exited' by the last read). */
+async function scrollbackForTask(page: Page, taskId: string): Promise<string> {
+  return page.evaluate(async (tid) => {
+    const sessions: Array<{ id: string; taskId: string }> = await window.electronAPI.sessions.list();
+    const session = sessions.find((sessionEntry) => sessionEntry.taskId === tid);
+    if (!session) return '';
+    return window.electronAPI.sessions.getScrollback(session.id);
+  }, taskId);
+}
+
+async function openTaskWindow(page: Page, taskTitle: string): Promise<void> {
+  const card = page.locator(`text=${taskTitle}`).first();
+  await card.click();
+  await page
+    .locator('[data-testid="task-detail-dialog"]')
+    .first()
+    .waitFor({ state: 'visible', timeout: 5000 });
+}
+
+/** Dispatch Escape directly on `document` to close the dialog, bypassing
+ *  xterm's own key capture (xterm intercepts Escape as an ANSI sequence when
+ *  its textarea has focus, so page.keyboard.press('Escape') would not reach
+ *  the dialog's listener). */
+async function closeTaskWindow(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+  });
+  await page
+    .locator('[data-testid="task-detail-dialog"]')
+    .first()
+    .waitFor({ state: 'detached', timeout: 5000 });
+}
+
+test.describe('Fullscreen TUI select prompt - input/focus survives a scrollback replay', () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let tmpDir: string;
+  let dataDir: string;
+
+  test.beforeAll(async () => {
+    tmpDir = createTempProject(TEST_NAME);
+    dataDir = getTestDataDir(TEST_NAME);
+    writeTestConfig(dataDir);
+
+    const result = await launchApp({
+      dataDir,
+      extraEnv: { MOCK_CLAUDE_FULLSCREEN_SELECT: '1' },
+    });
+    app = result.app;
+    page = result.page;
+    await createProject(page, PROJECT_NAME, tmpDir);
+  });
+
+  test.afterAll(async () => {
+    await closeApp(app);
+    cleanupTempProject(TEST_NAME);
+    cleanupTestDataDir(TEST_NAME);
+  });
+
+  test('arrow-key navigation reaches the PTY and tracks the highlight, including immediately after a dialog reattach with no manual re-focus', async () => {
+    // Session spawn + two replay cycles + several polls comfortably exceeds
+    // the 30s Electron default.
+    test.slow();
+
+    const taskTitle = `Fullscreen Select ${runId}`;
+    await createTask(page, taskTitle, 'Fullscreen select-prompt input/focus regression guard');
+
+    const executingId = await getSwimlaneByName(page, 'Executing');
+    const taskId = await getTaskIdByTitle(page, taskTitle);
+    await moveTaskIpc(page, taskId, executingId);
+
+    // Wait for the mock's initial fullscreen frame: option 0 highlighted.
+    await expect
+      .poll(() => scrollbackForTask(page, taskId), {
+        timeout: 15000,
+        message: 'Expected the fullscreen select prompt to render with option 1 highlighted',
+      })
+      .toContain(HIGHLIGHT_FIRST);
+
+    // Open the task-detail window and focus its terminal with a real click,
+    // targeting xterm's own focusable textarea directly (not the outer
+    // container) so the click is guaranteed to land on the focusable element.
+    await openTaskWindow(page, taskTitle);
+    const dialog = page.locator('[data-testid="task-detail-dialog"]').first();
+    const textarea = dialog.locator('.xterm-helper-textarea').first();
+    await textarea.click();
+    await expect
+      .poll(() => page.evaluate(() => document.activeElement?.className ?? null), {
+        timeout: 5000,
+        message: 'Expected the click to focus the xterm textarea',
+      })
+      .toContain('xterm-helper-textarea');
+
+    // First arrow-down: highlight moves option 1 -> 2. A real, focused
+    // keyboard event through xterm's own key handler - the exact path the
+    // bug broke.
+    await page.keyboard.press('ArrowDown');
+    await expect
+      .poll(() => scrollbackForTask(page, taskId), {
+        timeout: 10000,
+        message: 'Expected the highlight to advance to option 2 after the first ArrowDown',
+      })
+      .toContain(HIGHLIGHT_SECOND);
+
+    // Close and reopen the task-detail window. TerminalTab is keyed by
+    // sessionId, so this remounts it and re-runs the scrollback replay path
+    // (initTerminal) this fix hardens - the exact trigger from the reported
+    // freeze (task #290): a dialog open/close.
+    await closeTaskWindow(page);
+    await openTaskWindow(page, taskTitle);
+
+    // The freshly re-fetched scrollback must lead with the alt-screen
+    // re-assert, so the replay paints into the alt buffer, not the normal
+    // buffer (the secondary defect: the cursor left disconnected from the
+    // TUI frame).
+    const freshScrollback = await scrollbackForTask(page, taskId);
+    expect(freshScrollback.startsWith('\x1b[?1049h')).toBe(true);
+
+    // Second arrow-down WITHOUT an explicit click: proves focus landed
+    // automatically after the replay (the primary defect - previously, keys
+    // only reached the PTY again after a manual click to re-focus the
+    // terminal).
+    await page.keyboard.press('ArrowDown');
+    await expect
+      .poll(() => scrollbackForTask(page, taskId), {
+        timeout: 10000,
+        message: 'Expected the highlight to advance to option 3 after a post-replay ArrowDown with no manual re-focus',
+      })
+      .toContain(HIGHLIGHT_THIRD);
+
+    // Enter still reaches the PTY and completes the prompt at the final option.
+    await page.keyboard.press('Enter');
+    await expect
+      .poll(() => scrollbackForTask(page, taskId), {
+        timeout: 10000,
+        message: 'Expected Enter to select the currently-highlighted option (index 2)',
+      })
+      .toContain('MOCK_CLAUDE_SELECTED:2');
+  });
+});

--- a/tests/e2e/terminal-fullscreen-select-replay-focus.spec.ts
+++ b/tests/e2e/terminal-fullscreen-select-replay-focus.spec.ts
@@ -190,6 +190,14 @@ test.describe('Fullscreen TUI select prompt - input/focus survives a scrollback 
     // particularly under CI's headless Linux/xvfb renderer.
     await openTaskWindow(page, taskTitle);
     const dialog = page.locator('[data-testid="task-detail-dialog"]').first();
+    // The LaunchOverlay (a z-10 shimmer covering the terminal until
+    // terminalReady) can still be up here even though scrollback already has
+    // the marker: overlay-lift is a separate renderer-side race (live
+    // 'data'-driven first-output detection), not tied to the getScrollback
+    // poll above. Wait for it to clear so the click isn't racing it -
+    // otherwise Playwright's own click-retry loop absorbs the wait and can
+    // exceed its 30s action timeout under CI's slower, contended runners.
+    await dialog.locator('[data-testid="launch-overlay"]').waitFor({ state: 'hidden', timeout: 15000 });
     await dialog.locator('.xterm').first().click();
     await expect
       .poll(() => page.evaluate(() => document.activeElement?.className ?? null), {

--- a/tests/e2e/terminal-fullscreen-select-replay-focus.spec.ts
+++ b/tests/e2e/terminal-fullscreen-select-replay-focus.spec.ts
@@ -181,13 +181,16 @@ test.describe('Fullscreen TUI select prompt - input/focus survives a scrollback 
       })
       .toContain(HIGHLIGHT_FIRST);
 
-    // Open the task-detail window and focus its terminal with a real click,
-    // targeting xterm's own focusable textarea directly (not the outer
-    // container) so the click is guaranteed to land on the focusable element.
+    // Open the task-detail window and focus its terminal with a real click on
+    // the OUTER xterm container, mirroring an actual user click. xterm's own
+    // mousedown handler then focuses its hidden helper textarea. Clicking the
+    // textarea directly is not viable here: xterm deliberately renders it
+    // near-invisible (it exists only to capture keystrokes), so Playwright's
+    // actionability check ("element is not visible") can time out on it,
+    // particularly under CI's headless Linux/xvfb renderer.
     await openTaskWindow(page, taskTitle);
     const dialog = page.locator('[data-testid="task-detail-dialog"]').first();
-    const textarea = dialog.locator('.xterm-helper-textarea').first();
-    await textarea.click();
+    await dialog.locator('.xterm').first().click();
     await expect
       .poll(() => page.evaluate(() => document.activeElement?.className ?? null), {
         timeout: 5000,

--- a/tests/fixtures/mock-claude.js
+++ b/tests/fixtures/mock-claude.js
@@ -283,21 +283,126 @@ if (process.env.MOCK_CLAUDE_BACKGROUND_BASH === '1' && sessionId && !settingsPat
   }
 }
 
-// Stay alive to simulate a running session (30s gives tests time to interact)
-const timeout = setTimeout(() => process.exit(0), 30000);
+// Fullscreen-TUI interactive select-prompt harness for the terminal
+// input/focus-disconnect regression (fullscreen select-prompt freeze fix).
+//
+// mock-claude normally emits plain console.log marker lines with no terminal
+// escape sequences at all, so it cannot reproduce a bug that only exists in
+// the alt-screen (fullscreen renderer) replay path. When
+// MOCK_CLAUDE_FULLSCREEN_SELECT=1 is set, this branch instead behaves like a
+// real Claude Code fullscreen TUI parked at an AskUserQuestion-style select
+// prompt: it enters the alt screen buffer (1049h), turns on application
+// cursor keys (DECCKM, 1h), draws a 3-option menu, and reacts to arrow-key
+// input by moving the highlight via a cursor-addressed, synchronized-output
+// (2026h/2026l) DIFF - never a full repaint - exactly like the fix this
+// harness verifies (a dropped diff, or a replay landing in the wrong xterm
+// buffer, must not go unnoticed).
+const FULLSCREEN_SELECT_OPTIONS = ['First option', 'Second option', 'Third option'];
 
-// Exit cleanly on SIGTERM/SIGINT
-process.on('SIGTERM', () => { clearTimeout(timeout); process.exit(0); });
-process.on('SIGINT', () => { clearTimeout(timeout); process.exit(0); });
+if (process.env.MOCK_CLAUDE_FULLSCREEN_SELECT === '1') {
+  let selectedIndex = 0;
 
-// Keep stdin open so PTY doesn't close
-process.stdin.resume();
+  const cursorTo = (row, col) => '\x1b[' + row + ';' + col + 'H';
 
-// Listen for /exit command on stdin (graceful shutdown)
-process.stdin.setEncoding('utf8');
-process.stdin.on('data', (data) => {
-  if (data.includes('/exit')) {
-    clearTimeout(timeout);
-    process.exit(0);
-  }
-});
+  const renderOptionRow = (index) => {
+    const row = 3 + index;
+    const marker = index === selectedIndex ? '> ' : '  ';
+    const text = marker + FULLSCREEN_SELECT_OPTIONS[index];
+    const styled = index === selectedIndex ? '\x1b[7m' + text + '\x1b[0m' : text;
+    return cursorTo(row, 1) + styled + '\x1b[K';
+  };
+
+  const drawFullScreen = () => {
+    let out = '\x1b[?1049h'; // enter the alt screen buffer
+    out += '\x1b[?1h'; // DECCKM: application cursor keys
+    out += '\x1b[2J'; // clear screen - marks where the TUI takes over
+    out += cursorTo(1, 1) + 'Select an option:';
+    for (let i = 0; i < FULLSCREEN_SELECT_OPTIONS.length; i++) {
+      out += renderOptionRow(i);
+    }
+    process.stdout.write(out);
+  };
+
+  const moveHighlight = (delta) => {
+    const previousIndex = selectedIndex;
+    const nextIndex = Math.min(
+      FULLSCREEN_SELECT_OPTIONS.length - 1,
+      Math.max(0, selectedIndex + delta),
+    );
+    if (nextIndex === previousIndex) return;
+    selectedIndex = nextIndex;
+    // A real diff, not a full repaint: only the two affected rows redraw,
+    // bracketed in a synchronized-output frame like Claude's real renderer.
+    const diff = '\x1b[?2026h' + renderOptionRow(previousIndex) + renderOptionRow(selectedIndex) + '\x1b[?2026l';
+    process.stdout.write(diff);
+  };
+
+  // A real interactive TUI reads its stdin in RAW mode: on a real TTY/PTY,
+  // stdin otherwise stays in the OS's cooked/line-buffered mode, which both
+  // locally echoes typed characters AND withholds every keystroke from the
+  // 'data' event until a newline is typed - so a single arrow-key press
+  // (never followed by Enter) would never be delivered at all. Guarded on
+  // isTTY: a plain pipe (e.g. a direct child_process spawn in a unit-style
+  // probe) has no raw/cooked mode and setRawMode does not exist there.
+  if (process.stdin.isTTY) process.stdin.setRawMode(true);
+
+  drawFullScreen();
+
+  // Bounded lifetime safety net in case a test never sends Enter/exit
+  // (mirrors the 30s cap on the default branch below).
+  const timeout = setTimeout(() => process.exit(0), 30000);
+  process.on('SIGTERM', () => { clearTimeout(timeout); process.exit(0); });
+  process.on('SIGINT', () => { clearTimeout(timeout); process.exit(0); });
+
+  // Substring matching (not exact equality) on an accumulated buffer: a real
+  // PTY can deliver a 3-byte arrow-key escape sequence split across two
+  // 'data' events, or coalesce several keystrokes into one. inputCarry keeps
+  // a short trailing partial escape for the next chunk, mirroring the
+  // cross-chunk mode-carry pattern in pty-buffer-manager.ts.
+  let inputCarry = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (data) => {
+    const combined = inputCarry + data;
+    inputCarry = '';
+    if (combined.includes('\r') || combined.includes('\n')) {
+      clearTimeout(timeout);
+      process.stdout.write('\x1b[?1049l'); // leave the alt screen buffer
+      console.log('MOCK_CLAUDE_SELECTED:' + selectedIndex);
+      process.exit(0);
+      return;
+    }
+    if (combined.includes('/exit')) {
+      clearTimeout(timeout);
+      process.exit(0);
+      return;
+    }
+    if (combined.includes('\x1bOA') || combined.includes('\x1b[A')) {
+      moveHighlight(-1);
+    }
+    if (combined.includes('\x1bOB') || combined.includes('\x1b[B')) {
+      moveHighlight(1);
+    }
+    const partialEscapeMatch = combined.match(/\x1b(?:O|\[)?$/);
+    if (partialEscapeMatch) inputCarry = partialEscapeMatch[0];
+  });
+  process.stdin.resume();
+} else {
+  // Stay alive to simulate a running session (30s gives tests time to interact)
+  const timeout = setTimeout(() => process.exit(0), 30000);
+
+  // Exit cleanly on SIGTERM/SIGINT
+  process.on('SIGTERM', () => { clearTimeout(timeout); process.exit(0); });
+  process.on('SIGINT', () => { clearTimeout(timeout); process.exit(0); });
+
+  // Keep stdin open so PTY doesn't close
+  process.stdin.resume();
+
+  // Listen for /exit command on stdin (graceful shutdown)
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (data) => {
+    if (data.includes('/exit')) {
+      clearTimeout(timeout);
+      process.exit(0);
+    }
+  });
+}

--- a/tests/fixtures/mock-claude.js
+++ b/tests/fixtures/mock-claude.js
@@ -315,6 +315,12 @@ if (process.env.MOCK_CLAUDE_FULLSCREEN_SELECT === '1') {
   const drawFullScreen = () => {
     let out = '\x1b[?1049h'; // enter the alt screen buffer
     out += '\x1b[?1h'; // DECCKM: application cursor keys
+    // Hide the cursor while the TUI manages its own visual indicators. This
+    // is also Kangentic's detectFirstOutput heuristic for Claude (see
+    // src/main/agent/adapters/claude/claude-adapter.ts) -- without it the
+    // renderer's launch overlay never lifts and the terminal stays hidden
+    // behind the shimmer indefinitely.
+    out += '\x1b[?25l';
     out += '\x1b[2J'; // clear screen - marks where the TUI takes over
     out += cursorTo(1, 1) + 'Select an option:';
     for (let i = 0; i < FULLSCREEN_SELECT_OPTIONS.length; i++) {

--- a/tests/unit/incoming-write-queue.test.ts
+++ b/tests/unit/incoming-write-queue.test.ts
@@ -180,6 +180,70 @@ describe('createIncomingWriteQueue', () => {
     queue.reset();
     expect(ack).toHaveBeenCalledWith(6);
   });
+
+  // ---------------------------------------------------------------------
+  // useTerminal.ts wiring: shouldDrop: () => suppressDataRef.current,
+  // shouldHold: () => isBoardDragActive() || scrollbackPendingRef.current.
+  // A scrollback replay now HOLDS (not drops) live bytes, so a fullscreen
+  // TUI's selection-highlight diff arriving during a replay is never
+  // silently discarded - it applies strictly after the replayed frame.
+  // ---------------------------------------------------------------------
+  it('a scrollback replay holds live bytes and flushes them in order once it clears (no byte lost across the replay)', async () => {
+    const { term, writes } = fakeTerminal();
+    const ack = vi.fn();
+    const scrollbackPendingRef = { current: true };
+    const suppressDataRef = { current: false };
+    const queue = createIncomingWriteQueue({
+      getTerminal: () => term,
+      shouldDrop: () => suppressDataRef.current,
+      shouldHold: () => scrollbackPendingRef.current,
+      ack,
+      chunkSize: 4,
+    });
+
+    // A live diff frame arrives while the replay is still in flight.
+    queue.push('diff-frame-1');
+    await flush();
+    expect(writes).toEqual([]);
+    expect(ack).not.toHaveBeenCalled();
+
+    // More live bytes arrive before the replay finishes.
+    queue.push('-diff-frame-2');
+    await flush();
+    expect(writes).toEqual([]);
+    expect(ack).not.toHaveBeenCalled();
+
+    // The replay's afterWrite clears pending and kicks the queue.
+    scrollbackPendingRef.current = false;
+    queue.kick();
+    await flush();
+
+    // Every held byte was written, in order, strictly after the replay -
+    // nothing pushed during the window was silently dropped.
+    const expected = 'diff-frame-1-diff-frame-2';
+    expect(writes.join('')).toBe(expected);
+    const totalAcked = ack.mock.calls.reduce((sum, call) => sum + call[0], 0);
+    expect(totalAcked).toBe(expected.length);
+  });
+
+  it('an overlay with no active replay still drops-and-acks immediately (unaffected by the replay-hold change)', async () => {
+    const { term, writes } = fakeTerminal();
+    const ack = vi.fn();
+    const scrollbackPendingRef = { current: false };
+    const suppressDataRef = { current: true };
+    const queue = createIncomingWriteQueue({
+      getTerminal: () => term,
+      shouldDrop: () => suppressDataRef.current,
+      shouldHold: () => scrollbackPendingRef.current,
+      ack,
+    });
+
+    queue.push('startup noise');
+    await flush();
+
+    expect(writes).toEqual([]);
+    expect(ack).toHaveBeenCalledWith('startup noise'.length);
+  });
 });
 
 describe('writeChunkedToTerminal', () => {

--- a/tests/unit/pty-buffer-manager.test.ts
+++ b/tests/unit/pty-buffer-manager.test.ts
@@ -877,5 +877,38 @@ describe('PtyBufferManager', () => {
       vi.advanceTimersByTime(20);
       vi.useRealTimers();
     });
+
+    it('a full reset (RIS) clears a dangling synchronized-output frame (no spurious 2026l after the reset)', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      // 2026h opens with no matching 2026l, then RIS resets everything. RIS
+      // itself wipes terminal state, so getScrollback must not append a
+      // trailing 2026l on top of it - state.synchronizedOpen has to be
+      // cleared by the reset arm of updateModeState, same as decPrivateModes.
+      manager.onData(SESSION, '\x1b[?2026hpartial diff, no closing 2026l');
+      manager.onData(SESSION, '\x1bc');
+
+      expect(manager.getScrollback(SESSION).endsWith('\x1b[?2026l')).toBe(false);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('a soft reset (DECSTR) clears a dangling synchronized-output frame (no spurious 2026l after the reset)', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      // Mirrors the RIS case above for the DECSTR reset arm: DECSTR does not
+      // switch buffers, but it still returns private modes to default, which
+      // must include closing a dangling synchronized-output frame.
+      manager.onData(SESSION, '\x1b[?2026hpartial diff, no closing 2026l');
+      manager.onData(SESSION, '\x1b[!p');
+
+      expect(manager.getScrollback(SESSION).endsWith('\x1b[?2026l')).toBe(false);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
   });
 });

--- a/tests/unit/pty-buffer-manager.test.ts
+++ b/tests/unit/pty-buffer-manager.test.ts
@@ -501,15 +501,18 @@ describe('PtyBufferManager', () => {
       vi.useRealTimers();
     });
 
-    it('does not re-assert display modes (alt-screen 1049)', () => {
+    it('does not re-assert display modes as INPUT modes (alt-screen 1049 is not in the input-mode prefix)', () => {
       vi.useFakeTimers();
       const { manager } = createManager();
 
       manager.onData(SESSION, '\x1b[?1049h');
       manager.onData(SESSION, 'tui frame');
 
-      // 1049 is a display mode, excluded from the restore set -> empty prefix.
-      expect(modePrefixOf(manager.getScrollback(SESSION))).toBe('');
+      // 1049 is excluded from RESTORABLE_DEC_PRIVATE_MODES (the #313 input-mode
+      // set), so it never appears merged into the coalesced input-mode DECSET.
+      // It is re-asserted separately as alt-screen - see the "alt-screen
+      // re-assert" block below.
+      expect(modePrefixOf(manager.getScrollback(SESSION))).toBe('\x1b[?1049h');
 
       vi.advanceTimersByTime(20);
       vi.useRealTimers();
@@ -567,7 +570,7 @@ describe('PtyBufferManager', () => {
       // One combined DECSET with params in non-sorted order (1, 2004, 1000).
       manager.onData(SESSION, '\x1b[?1;2004;1000h');
 
-      // updateDecPrivateModes splits on ';' and registers each param; the prefix
+      // updateModeState splits on ';' and registers each param; the prefix
       // must contain all three, sorted. Would fail if multi-param splitting was broken.
       expect(modePrefixOf(manager.getScrollback(SESSION))).toBe('\x1b[?1;1000;2004h');
 
@@ -584,7 +587,7 @@ describe('PtyBufferManager', () => {
 
       // DECSTR resets every private mode -> no mode re-asserted in the prefix.
       // Mirrors the RIS (\x1bc) test; independently red-greens the |\x1b\[!p
-      // arm of the updateDecPrivateModes regex.
+      // arm of the updateModeState regex.
       expect(modePrefixOf(manager.getScrollback(SESSION))).toBe('');
 
       vi.advanceTimersByTime(20);
@@ -634,18 +637,21 @@ describe('PtyBufferManager', () => {
       vi.useRealTimers();
     });
 
-    it('filters out non-restorable params from a combined DECSET, tracking only restorable ones', () => {
+    it('filters out non-restorable params from a combined DECSET, tracking 1049 separately as alt-screen', () => {
       vi.useFakeTimers();
       const { manager } = createManager();
 
-      // One DECSET with restorable mouse-tracking modes 1000, 1002 and non-restorable
-      // display mode 1049 (alt-screen) mixed in between them. The per-param guard
-      // `if (!RESTORABLE_DEC_PRIVATE_MODES.has(privateMode)) continue` inside
-      // updateDecPrivateModes must skip 1049 while tracking the others.
-      // Would fail (producing '\x1b[?1000;1002;1049h') if the guard were removed.
+      // One DECSET with restorable mouse-tracking modes 1000, 1002 and the
+      // alt-screen mode 1049 mixed in between them. The per-param guard inside
+      // updateModeState must keep 1049 OUT of the coalesced input-mode DECSET
+      // (it tracks inAltScreen separately instead) while still tracking 1000/1002.
       manager.onData(SESSION, '\x1b[?1000;1049;1002h');
 
-      expect(modePrefixOf(manager.getScrollback(SESSION))).toBe('\x1b[?1000;1002h');
+      const scrollback = manager.getScrollback(SESSION);
+      // Alt-screen leads, then the coalesced (sorted, 1049-free) input-mode
+      // DECSET, then the reset.
+      expect(scrollback.startsWith('\x1b[?1049h\x1b[?1000;1002h\x1b[0m')).toBe(true);
+      expect(modePrefixOf(scrollback)).toBe('\x1b[?1049h\x1b[?1000;1002h');
 
       vi.advanceTimersByTime(20);
       vi.useRealTimers();
@@ -667,6 +673,206 @@ describe('PtyBufferManager', () => {
       // read" refactor), which would make the second call return an empty prefix.
       const secondPrefix = modePrefixOf(manager.getScrollback(SESSION));
       expect(secondPrefix).toBe('\x1b[?1h');
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+  });
+
+  describe('alt-screen re-assert and synchronized-output safety (fullscreen TUI freeze fix)', () => {
+    it('re-asserts alt-screen (1049) when the session is currently in the alt buffer', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      manager.onData(SESSION, '\x1b[?1049h');
+      manager.onData(SESSION, '\x1b[2Jtui frame');
+
+      const scrollback = manager.getScrollback(SESSION);
+      // Alt-screen enter goes first (re-clearing/switching into the alt
+      // buffer), then the (empty here) input-mode prefix, then the reset,
+      // then the replayed frame.
+      expect(scrollback.startsWith('\x1b[?1049h\x1b[0m')).toBe(true);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('leaves a classic (normal-buffer) session byte-for-byte unchanged (#313 safety guard)', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      // Input modes only, no alt-screen - a classic-renderer session.
+      manager.onData(SESSION, '\x1b[?1h\x1b[?2004h');
+      manager.onData(SESSION, 'plain scrollback');
+
+      const scrollback = manager.getScrollback(SESSION);
+      expect(scrollback).not.toContain('\x1b[?1049h');
+      expect(scrollback.startsWith('\x1b[?1;2004h\x1b[0m')).toBe(true);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('drops the re-assert after leaving alt-screen (1049l)', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      manager.onData(SESSION, '\x1b[?1049h');
+      manager.onData(SESSION, 'tui frame');
+      manager.onData(SESSION, '\x1b[?1049l');
+      manager.onData(SESSION, 'back in the shell');
+
+      // The raw body still legitimately contains the original 1049h/1049l
+      // bytes (recorded content); what must NOT happen is a re-assert PREFIX
+      // in front of it, since the session is no longer in the alt buffer.
+      expect(manager.getScrollback(SESSION).startsWith('\x1b[?1049h')).toBe(false);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('restores an alt-screen enter split across two PTY chunks', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      manager.onData(SESSION, '\x1b[?104');
+      manager.onData(SESSION, '9h');
+
+      expect(manager.getScrollback(SESSION).startsWith('\x1b[?1049h')).toBe(true);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('a full reset (RIS) exits alt-screen', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      manager.onData(SESSION, '\x1b[?1049h');
+      manager.onData(SESSION, '\x1bc');
+
+      // The raw body still legitimately contains the original 1049h bytes;
+      // what must NOT happen is a re-assert prefix, since RIS returned the
+      // session to the normal buffer.
+      expect(manager.getScrollback(SESSION).startsWith('\x1b[?1049h')).toBe(false);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('a soft reset (DECSTR) does not exit alt-screen (DECSTR does not switch buffers per spec)', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      manager.onData(SESSION, '\x1b[?1049h');
+      manager.onData(SESSION, '\x1b[!p');
+
+      expect(manager.getScrollback(SESSION).startsWith('\x1b[?1049h')).toBe(true);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('orders alt-screen before the input-mode prefix, and the replay frame after the reset', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      manager.onData(SESSION, '\x1b[?1049h\x1b[?1h');
+      manager.onData(SESSION, '\x1b[2Jthe frame');
+
+      const scrollback = manager.getScrollback(SESSION);
+      expect(scrollback.startsWith('\x1b[?1049h\x1b[?1h\x1b[0m')).toBe(true);
+      expect(scrollback.indexOf('\x1b[2J')).toBeGreaterThan(scrollback.indexOf('\x1b[0m'));
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('closes a synchronized-output frame left dangling by the sample (2026h with no matching 2026l)', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      manager.onData(SESSION, '\x1b[2Jframe');
+      manager.onData(SESSION, '\x1b[?2026hpartial diff, no closing 2026l');
+
+      expect(manager.getScrollback(SESSION).endsWith('\x1b[?2026l')).toBe(true);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('does not append a spurious 2026l when the synchronized-output frame is already balanced', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      manager.onData(SESSION, '\x1b[2Jframe');
+      manager.onData(SESSION, '\x1b[?2026hdiff\x1b[?2026l');
+
+      // The raw body already ends with a balanced 2026l; getScrollback must
+      // not append a second one on top of it.
+      const scrollback = manager.getScrollback(SESSION);
+      const occurrences = scrollback.split('\x1b[?2026l').length - 1;
+      expect(occurrences).toBe(1);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('tracks alt-screen via the older 47 and 1047 variants, not just 1049', () => {
+      vi.useFakeTimers();
+
+      // 47 (oldest variant, no cursor save) must flip inAltScreen the same
+      // way 1049 does. Would fail if ALT_SCREEN_MODES were narrowed to {1049}.
+      const managerFor47 = createManager().manager;
+      managerFor47.onData(SESSION, '\x1b[?47h');
+      managerFor47.onData(SESSION, '\x1b[2Jtui frame');
+      expect(managerFor47.getScrollback(SESSION).startsWith('\x1b[?1049h')).toBe(true);
+
+      // 1047 (intermediate variant) must do the same.
+      const managerFor1047 = createManager().manager;
+      managerFor1047.onData(SESSION, '\x1b[?1047h');
+      managerFor1047.onData(SESSION, '\x1b[2Jtui frame');
+      expect(managerFor1047.getScrollback(SESSION).startsWith('\x1b[?1049h')).toBe(true);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('routes a single combined DECSET spanning all three trackers (input-mode + alt-screen + synchronized-output)', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      // One DECSET carrying a restorable input mode (1000), the alt-screen
+      // mode (1049), and synchronized-output (2026) together. Each param must
+      // route independently to its own tracker.
+      manager.onData(SESSION, '\x1b[?1000;1049;2026h');
+      manager.onData(SESSION, '\x1b[2Jframe');
+
+      const scrollback = manager.getScrollback(SESSION);
+      // Alt-screen prefix leads (inAltScreen tracked separately from 1000).
+      expect(scrollback.startsWith('\x1b[?1049h')).toBe(true);
+      // 1000 lands in the coalesced input-mode DECSET, not the alt-screen or
+      // synchronized-output trackers.
+      const modePrefix = scrollback.slice(0, scrollback.indexOf('\x1b[0m'));
+      expect(modePrefix).toBe('\x1b[?1049h\x1b[?1000h');
+      // 2026 stayed open (never closed in this stream), so getScrollback
+      // closes the dangling frame at the very end.
+      expect(scrollback.endsWith('\x1b[?2026l')).toBe(true);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('closes a synchronized-output frame whose 2026h open is split across two PTY chunks', () => {
+      vi.useFakeTimers();
+      const { manager } = createManager();
+
+      // \x1b[?2026h split at the chunk boundary: '\x1b[?202' then '6h...'.
+      // modeParseCarry must stitch the two pieces so the open is not missed.
+      manager.onData(SESSION, '\x1b[?202');
+      manager.onData(SESSION, '6hframe');
+
+      expect(manager.getScrollback(SESSION).endsWith('\x1b[?2026l')).toBe(true);
 
       vi.advanceTimersByTime(20);
       vi.useRealTimers();

--- a/tests/unit/use-terminal-scrollback.test.ts
+++ b/tests/unit/use-terminal-scrollback.test.ts
@@ -1,23 +1,29 @@
 /**
- * Unit tests for the three behavioral gaps exposed by the parallel-IPC
- * refactor in useTerminal.ts (initTerminal + reloadScrollback paths).
+ * Unit tests for the behavioral gaps in useTerminal.ts's scrollback replay
+ * orchestration (initTerminal + reloadScrollback paths).
  *
  * These tests exercise the orchestration logic directly - no React, no xterm,
- * no DOM - because all three behaviors are purely about Promise sequencing,
- * ref mutation, and generation-guard arithmetic. The hook extracts cleanly
- * into a standalone helper for testing.
+ * no DOM - because all of it is purely about Promise sequencing, ref
+ * mutation, and generation-guard arithmetic. The hook extracts cleanly into a
+ * standalone helper for testing.
  *
  * Gaps covered:
  *   1. reloadScrollback overlay-lift: always calls getScrollback (no suppressScrollback
  *      gate), writes result to xterm, and clears scrollbackPendingRef.
- *   2. Stale-generation guard: when a second call fires before the first
- *      Promise.all resolves, the first call bails at the generation check
- *      without clobbering the pending flag.
+ *   2. Stale-generation guard (outer .then): when a second call fires before
+ *      the first Promise.all resolves, the first call bails at the generation
+ *      check without clobbering pending owned by the newer call.
  *   3. IPC rejection path: when either IPC rejects, scrollbackPendingRef
  *      clears so onData is unblocked.
+ *   4. afterWrite generation guard: a stale generation's deferred afterWrite
+ *      (the chunked-write completion callback) is a no-op, so an abandoned
+ *      replay can never clobber a newer one's pending/fit/focus.
+ *   5. Stuck-replay watchdog: if the chunked write's completion callback never
+ *      fires, a backstop timer force-clears pending and resumes the incoming
+ *      queue so live output isn't dropped indefinitely.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Minimal ref emulation (mirrors useRef semantics without React)
@@ -31,19 +37,25 @@ function makeRef<T>(initial: T): { current: T } {
 // The orchestration logic extracted verbatim from useTerminal.ts.
 //
 // initTerminal and reloadScrollback share the same Promise.all pattern.
-// We replicate only the observable contract:
+// We replicate the observable contract:
 //   - scrollbackPendingRef starts true on entry
 //   - getScrollback is / is not called based on suppressScrollback
-//   - scrollbackPendingRef clears to false after completion (happy or catch)
-//   - stale generation increments cause early exit without clearing pending
+//   - a stale generation's outer resolve bails WITHOUT touching pending
+//     (bare return - the newer generation owns clearing it)
+//   - afterWrite (the chunked-write completion) itself re-checks the
+//     generation before running any side effect or clearing pending
+//   - a watchdog timer force-clears a stuck replay and resumes the queue
 //
-// The xterm.write(scrollback, afterWrite) callback is synchronous in tests
-// (mock calls afterWrite immediately) so we don't need requestAnimationFrame.
+// onWrite mirrors writeChunkedToTerminal(term, scrollback, afterWrite): the
+// test controls exactly when (or whether) afterWrite fires.
 // ---------------------------------------------------------------------------
+
+const SCROLLBACK_WATCHDOG_MS = 5000;
 
 interface Refs {
   scrollbackPendingRef: { current: boolean };
   scrollbackGenerationRef: { current: number };
+  scrollbackWatchdogRef: { current: ReturnType<typeof setTimeout> | null };
 }
 
 interface MockIpc {
@@ -51,18 +63,87 @@ interface MockIpc {
   getScrollback: () => Promise<string | null>;
 }
 
-/**
- * Mirrors the initTerminal scrollback path.
- * suppressScrollback=true fast-paths getScrollback to null (shimmer path).
- */
+interface PathHooks {
+  onWrite: (scrollback: string, afterWrite: () => void) => void;
+  /** Represents the fit/restoreScroll/focus side effects, run only when the
+   *  generation guard passes. */
+  onEffects?: () => void;
+  /** Represents incomingResumeRef.current?.() - the incoming queue's kick(). */
+  onResume?: () => void;
+}
+
+function armWatchdog(refs: Refs, scrollbackGeneration: number, onResume: () => void): void {
+  if (refs.scrollbackWatchdogRef.current) clearTimeout(refs.scrollbackWatchdogRef.current);
+  refs.scrollbackWatchdogRef.current = setTimeout(() => {
+    refs.scrollbackWatchdogRef.current = null;
+    if (refs.scrollbackGenerationRef.current === scrollbackGeneration && refs.scrollbackPendingRef.current) {
+      // Invalidate the generation so a merely-delayed (not dropped) afterWrite
+      // for this replay bails at its generation guard instead of re-running its
+      // side effects after the watchdog already force-recovered.
+      refs.scrollbackGenerationRef.current += 1;
+      refs.scrollbackPendingRef.current = false;
+      onResume();
+    }
+  }, SCROLLBACK_WATCHDOG_MS);
+}
+
+function clearWatchdog(refs: Refs): void {
+  if (refs.scrollbackWatchdogRef.current) {
+    clearTimeout(refs.scrollbackWatchdogRef.current);
+    refs.scrollbackWatchdogRef.current = null;
+  }
+}
+
+/** Mirrors the reloadScrollback path (no suppressScrollback gate). */
+async function runReloadScrollbackPath(refs: Refs, ipc: MockIpc, hooks: PathHooks): Promise<void> {
+  const onResume = hooks.onResume ?? (() => {});
+  refs.scrollbackPendingRef.current = true;
+  const scrollbackGeneration = ++refs.scrollbackGenerationRef.current;
+  armWatchdog(refs, scrollbackGeneration, onResume);
+
+  const resizePromise = ipc.resize();
+  const scrollbackPromise = ipc.getScrollback();
+
+  return Promise.all([resizePromise, scrollbackPromise])
+    .then(([, scrollback]) => {
+      // A newer scrollback operation has started; it owns clearing pending
+      // (and the watchdog it armed), so this stale resolve must not touch
+      // either.
+      if (refs.scrollbackGenerationRef.current !== scrollbackGeneration) return;
+
+      const afterWrite = () => {
+        // A newer replay may have started while this chunked write was in
+        // flight; abandon so we don't clobber its pending/fit/focus.
+        if (refs.scrollbackGenerationRef.current !== scrollbackGeneration) return;
+        clearWatchdog(refs);
+        hooks.onEffects?.();
+        refs.scrollbackPendingRef.current = false;
+        onResume();
+      };
+      if (scrollback) {
+        hooks.onWrite(scrollback, afterWrite);
+      } else {
+        afterWrite();
+      }
+    })
+    .catch(() => {
+      if (refs.scrollbackGenerationRef.current !== scrollbackGeneration) return;
+      clearWatchdog(refs);
+      refs.scrollbackPendingRef.current = false;
+    });
+}
+
+/** Mirrors the initTerminal scrollback path (suppressScrollback fast-path to null). */
 async function runInitScrollbackPath(
   refs: Refs,
   ipc: MockIpc,
   suppressScrollback: boolean,
-  onWrite: (scrollback: string) => void,
+  hooks: PathHooks,
 ): Promise<void> {
+  const onResume = hooks.onResume ?? (() => {});
   refs.scrollbackPendingRef.current = true;
   const scrollbackGeneration = ++refs.scrollbackGenerationRef.current;
+  armWatchdog(refs, scrollbackGeneration, onResume);
 
   const resizePromise = ipc.resize();
   const scrollbackPromise = suppressScrollback
@@ -71,60 +152,35 @@ async function runInitScrollbackPath(
 
   return Promise.all([resizePromise, scrollbackPromise])
     .then(([, scrollback]) => {
-      if (refs.scrollbackGenerationRef.current !== scrollbackGeneration) {
-        refs.scrollbackPendingRef.current = false;
-        return;
-      }
+      if (refs.scrollbackGenerationRef.current !== scrollbackGeneration) return;
+
       const afterWrite = () => {
+        if (refs.scrollbackGenerationRef.current !== scrollbackGeneration) return;
+        clearWatchdog(refs);
+        hooks.onEffects?.();
         refs.scrollbackPendingRef.current = false;
+        onResume();
       };
       if (scrollback) {
-        onWrite(scrollback);
-        afterWrite();
+        hooks.onWrite(scrollback, afterWrite);
       } else {
         afterWrite();
       }
     })
     .catch(() => {
       if (refs.scrollbackGenerationRef.current !== scrollbackGeneration) return;
+      clearWatchdog(refs);
       refs.scrollbackPendingRef.current = false;
     });
 }
 
-/**
- * Mirrors the reloadScrollback path (no suppressScrollback gate).
- */
-async function runReloadScrollbackPath(
-  refs: Refs,
-  ipc: MockIpc,
-  onWrite: (scrollback: string) => void,
-): Promise<void> {
-  refs.scrollbackPendingRef.current = true;
-  const scrollbackGeneration = ++refs.scrollbackGenerationRef.current;
-
-  const resizePromise = ipc.resize();
-  const scrollbackPromise = ipc.getScrollback();
-
-  return Promise.all([resizePromise, scrollbackPromise])
-    .then(([, scrollback]) => {
-      if (refs.scrollbackGenerationRef.current !== scrollbackGeneration) {
-        refs.scrollbackPendingRef.current = false;
-        return;
-      }
-      const afterWrite = () => {
-        refs.scrollbackPendingRef.current = false;
-      };
-      if (scrollback) {
-        onWrite(scrollback);
-        afterWrite();
-      } else {
-        afterWrite();
-      }
-    })
-    .catch(() => {
-      if (refs.scrollbackGenerationRef.current !== scrollbackGeneration) return;
-      refs.scrollbackPendingRef.current = false;
-    });
+/** A synchronous chunked-write stand-in: calls afterWrite immediately, and
+ *  (optionally) records the written scrollback. */
+function syncWrite(onWritten?: (scrollback: string) => void): PathHooks['onWrite'] {
+  return (scrollback, afterWrite) => {
+    onWritten?.(scrollback);
+    afterWrite();
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -138,6 +194,7 @@ describe('useTerminal scrollback orchestration', () => {
     refs = {
       scrollbackPendingRef: makeRef(false),
       scrollbackGenerationRef: makeRef(0),
+      scrollbackWatchdogRef: makeRef(null),
     };
   });
 
@@ -150,9 +207,8 @@ describe('useTerminal scrollback orchestration', () => {
         resize: vi.fn().mockResolvedValue(undefined),
         getScrollback: vi.fn().mockResolvedValue('previous output'),
       };
-      const onWrite = vi.fn();
 
-      await runReloadScrollbackPath(refs, ipc, onWrite);
+      await runReloadScrollbackPath(refs, ipc, { onWrite: syncWrite() });
 
       expect(ipc.getScrollback).toHaveBeenCalledOnce();
     });
@@ -162,11 +218,11 @@ describe('useTerminal scrollback orchestration', () => {
         resize: vi.fn().mockResolvedValue(undefined),
         getScrollback: vi.fn().mockResolvedValue('line1\r\nline2'),
       };
-      const onWrite = vi.fn();
+      const written: string[] = [];
 
-      await runReloadScrollbackPath(refs, ipc, onWrite);
+      await runReloadScrollbackPath(refs, ipc, { onWrite: syncWrite((s) => written.push(s)) });
 
-      expect(onWrite).toHaveBeenCalledWith('line1\r\nline2');
+      expect(written).toEqual(['line1\r\nline2']);
     });
 
     it('clears scrollbackPendingRef after successful write', async () => {
@@ -175,7 +231,7 @@ describe('useTerminal scrollback orchestration', () => {
         getScrollback: vi.fn().mockResolvedValue('some output'),
       };
 
-      await runReloadScrollbackPath(refs, ipc, vi.fn());
+      await runReloadScrollbackPath(refs, ipc, { onWrite: syncWrite() });
 
       expect(refs.scrollbackPendingRef.current).toBe(false);
     });
@@ -187,7 +243,7 @@ describe('useTerminal scrollback orchestration', () => {
       };
       const onWrite = vi.fn();
 
-      await runReloadScrollbackPath(refs, ipc, onWrite);
+      await runReloadScrollbackPath(refs, ipc, { onWrite });
 
       expect(onWrite).not.toHaveBeenCalled();
       expect(refs.scrollbackPendingRef.current).toBe(false);
@@ -209,7 +265,7 @@ describe('useTerminal scrollback orchestration', () => {
         }),
       };
 
-      const pathPromise = runReloadScrollbackPath(refs, ipc, vi.fn());
+      const pathPromise = runReloadScrollbackPath(refs, ipc, { onWrite: syncWrite() });
 
       // Both must have been invoked before either resolved
       expect(callOrder).toEqual(['resize-called', 'getScrollback-called']);
@@ -230,7 +286,7 @@ describe('useTerminal scrollback orchestration', () => {
         getScrollback: vi.fn().mockResolvedValue('should not appear'),
       };
 
-      await runInitScrollbackPath(refs, ipc, true, vi.fn());
+      await runInitScrollbackPath(refs, ipc, true, { onWrite: syncWrite() });
 
       expect(ipc.getScrollback).not.toHaveBeenCalled();
     });
@@ -241,7 +297,7 @@ describe('useTerminal scrollback orchestration', () => {
         getScrollback: vi.fn().mockResolvedValue(null),
       };
 
-      await runInitScrollbackPath(refs, ipc, true, vi.fn());
+      await runInitScrollbackPath(refs, ipc, true, { onWrite: syncWrite() });
 
       expect(refs.scrollbackPendingRef.current).toBe(false);
     });
@@ -251,46 +307,45 @@ describe('useTerminal scrollback orchestration', () => {
         resize: vi.fn().mockResolvedValue(undefined),
         getScrollback: vi.fn().mockResolvedValue('terminal content'),
       };
-      const onWrite = vi.fn();
+      const written: string[] = [];
 
-      await runInitScrollbackPath(refs, ipc, false, onWrite);
+      await runInitScrollbackPath(refs, ipc, false, { onWrite: syncWrite((s) => written.push(s)) });
 
       expect(ipc.getScrollback).toHaveBeenCalledOnce();
-      expect(onWrite).toHaveBeenCalledWith('terminal content');
+      expect(written).toEqual(['terminal content']);
     });
   });
 
   // -------------------------------------------------------------------------
-  // Gap 2: Stale-generation guard
+  // Gap 2: Stale-generation guard (outer .then)
   // -------------------------------------------------------------------------
-  describe('stale-generation guard', () => {
+  describe('stale-generation guard (outer resolve)', () => {
     it('bails out when generation increments before Promise.all resolves', async () => {
       let resolveFirst!: () => void;
+      const written: string[] = [];
       const ipc: MockIpc = {
         resize: vi.fn().mockImplementation(() =>
           new Promise<void>((resolve) => { resolveFirst = resolve; })
         ),
         getScrollback: vi.fn().mockResolvedValue('first scrollback'),
       };
-      const onWrite = vi.fn();
 
       // Start first path - it's pending on resize
-      const firstPath = runReloadScrollbackPath(refs, ipc, onWrite);
+      const firstPath = runReloadScrollbackPath(refs, ipc, { onWrite: syncWrite((s) => written.push(s)) });
 
       // A second path fires and increments the generation counter
       const secondIpc: MockIpc = {
         resize: vi.fn().mockResolvedValue(undefined),
         getScrollback: vi.fn().mockResolvedValue('second scrollback'),
       };
-      await runReloadScrollbackPath(refs, secondIpc, onWrite);
+      await runReloadScrollbackPath(refs, secondIpc, { onWrite: syncWrite((s) => written.push(s)) });
 
       // Now resolve the first path's resize - it should bail at generation check
       resolveFirst();
       await firstPath;
 
-      // onWrite was called once (for the second path), not twice
-      expect(onWrite).toHaveBeenCalledTimes(1);
-      expect(onWrite).toHaveBeenCalledWith('second scrollback');
+      // Written once (for the second path), not twice
+      expect(written).toEqual(['second scrollback']);
     });
 
     it('leaves scrollbackPendingRef=false after stale bail-out (second path cleared it)', async () => {
@@ -302,19 +357,19 @@ describe('useTerminal scrollback orchestration', () => {
         getScrollback: vi.fn().mockResolvedValue('stale output'),
       };
 
-      const firstPath = runReloadScrollbackPath(refs, ipc, vi.fn());
+      const firstPath = runReloadScrollbackPath(refs, ipc, { onWrite: syncWrite() });
 
       const secondIpc: MockIpc = {
         resize: vi.fn().mockResolvedValue(undefined),
         getScrollback: vi.fn().mockResolvedValue('fresh output'),
       };
-      await runReloadScrollbackPath(refs, secondIpc, vi.fn());
+      await runReloadScrollbackPath(refs, secondIpc, { onWrite: syncWrite() });
 
       resolveFirst();
       await firstPath;
 
       // The second path already cleared the flag; the stale bail-out must not
-      // set it back to true
+      // set it back to true (nor re-clear it, though false->false is moot).
       expect(refs.scrollbackPendingRef.current).toBe(false);
     });
 
@@ -323,11 +378,97 @@ describe('useTerminal scrollback orchestration', () => {
         resize: vi.fn().mockResolvedValue(undefined),
         getScrollback: vi.fn().mockResolvedValue('the output'),
       };
-      const onWrite = vi.fn();
+      const written: string[] = [];
 
-      await runReloadScrollbackPath(refs, ipc, onWrite);
+      await runReloadScrollbackPath(refs, ipc, { onWrite: syncWrite((s) => written.push(s)) });
 
-      expect(onWrite).toHaveBeenCalledWith('the output');
+      expect(written).toEqual(['the output']);
+      expect(refs.scrollbackPendingRef.current).toBe(false);
+    });
+
+    it('a stale outer resolve does NOT clear pending while a newer replay is still in flight (regression: the resolve-path clobber)', async () => {
+      let resolveFirstScrollback!: (value: string | null) => void;
+      const ipcA: MockIpc = {
+        resize: vi.fn().mockResolvedValue(undefined),
+        getScrollback: vi.fn().mockImplementation(() =>
+          new Promise<string | null>((resolve) => { resolveFirstScrollback = resolve; })
+        ),
+      };
+      const pathA = runReloadScrollbackPath(refs, ipcA, { onWrite: syncWrite() });
+
+      // Path B starts before A's IPC resolves (bumping the generation) and
+      // itself stays pending - its own IPC has not resolved either.
+      let resolveSecondScrollback!: (value: string | null) => void;
+      const ipcB: MockIpc = {
+        resize: vi.fn().mockResolvedValue(undefined),
+        getScrollback: vi.fn().mockImplementation(() =>
+          new Promise<string | null>((resolve) => { resolveSecondScrollback = resolve; })
+        ),
+      };
+      const pathB = runReloadScrollbackPath(refs, ipcB, { onWrite: syncWrite() });
+
+      // A's IPC now resolves (a stale generation). Its outer .then must bail
+      // without touching pending - B still owns it and hasn't finished.
+      resolveFirstScrollback('stale frame');
+      await pathA;
+      expect(refs.scrollbackPendingRef.current).toBe(true);
+
+      // B finishes and clears it.
+      resolveSecondScrollback('fresh frame');
+      await pathB;
+      expect(refs.scrollbackPendingRef.current).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Gap 4: afterWrite generation guard (the chunked-write completion callback)
+  // -------------------------------------------------------------------------
+  describe('afterWrite generation guard', () => {
+    it('a stale generation\'s deferred afterWrite is a no-op and cannot clobber a newer in-flight replay', async () => {
+      let capturedAfterWriteA!: () => void;
+      const effectsA = vi.fn();
+      const resumeA = vi.fn();
+
+      const ipcA: MockIpc = {
+        resize: vi.fn().mockResolvedValue(undefined),
+        getScrollback: vi.fn().mockResolvedValue('stale frame'),
+      };
+
+      // Path A's IPC resolves and its outer .then body runs (capturing
+      // afterWrite), but the chunked write's completion is held by the test --
+      // simulating an in-flight xterm.write callback that hasn't fired yet.
+      await runReloadScrollbackPath(refs, ipcA, {
+        onWrite: (_scrollback, afterWrite) => { capturedAfterWriteA = afterWrite; },
+        onEffects: effectsA,
+        onResume: resumeA,
+      });
+      expect(refs.scrollbackPendingRef.current).toBe(true);
+
+      // Path B starts (bumps the generation) while A's write is still pending.
+      const effectsB = vi.fn();
+      const resumeB = vi.fn();
+      const ipcB: MockIpc = {
+        resize: vi.fn().mockResolvedValue(undefined),
+        getScrollback: vi.fn().mockResolvedValue('fresh frame'),
+      };
+      const pathB = runReloadScrollbackPath(refs, ipcB, {
+        onWrite: syncWrite(),
+        onEffects: effectsB,
+        onResume: resumeB,
+      });
+
+      // A's write finally "completes" - its afterWrite must be a no-op now:
+      // no fit/scroll/focus side effect, no queue resume, no pending clear.
+      capturedAfterWriteA();
+      expect(effectsA).not.toHaveBeenCalled();
+      expect(resumeA).not.toHaveBeenCalled();
+      expect(refs.scrollbackPendingRef.current).toBe(true);
+
+      await pathB;
+
+      // B owns clearing it.
+      expect(effectsB).toHaveBeenCalledOnce();
+      expect(resumeB).toHaveBeenCalledOnce();
       expect(refs.scrollbackPendingRef.current).toBe(false);
     });
   });
@@ -342,7 +483,7 @@ describe('useTerminal scrollback orchestration', () => {
         getScrollback: vi.fn().mockResolvedValue('output'),
       };
 
-      await runReloadScrollbackPath(refs, ipc, vi.fn());
+      await runReloadScrollbackPath(refs, ipc, { onWrite: syncWrite() });
 
       expect(refs.scrollbackPendingRef.current).toBe(false);
     });
@@ -353,7 +494,7 @@ describe('useTerminal scrollback orchestration', () => {
         getScrollback: vi.fn().mockRejectedValue(new Error('ipc error')),
       };
 
-      await runReloadScrollbackPath(refs, ipc, vi.fn());
+      await runReloadScrollbackPath(refs, ipc, { onWrite: syncWrite() });
 
       expect(refs.scrollbackPendingRef.current).toBe(false);
     });
@@ -364,7 +505,7 @@ describe('useTerminal scrollback orchestration', () => {
         getScrollback: vi.fn().mockRejectedValue(new Error('scrollback failed')),
       };
 
-      await runReloadScrollbackPath(refs, ipc, vi.fn());
+      await runReloadScrollbackPath(refs, ipc, { onWrite: syncWrite() });
 
       expect(refs.scrollbackPendingRef.current).toBe(false);
     });
@@ -376,7 +517,7 @@ describe('useTerminal scrollback orchestration', () => {
       };
       const onWrite = vi.fn();
 
-      await runReloadScrollbackPath(refs, ipc, onWrite);
+      await runReloadScrollbackPath(refs, ipc, { onWrite });
 
       expect(onWrite).not.toHaveBeenCalled();
     });
@@ -392,20 +533,138 @@ describe('useTerminal scrollback orchestration', () => {
       };
 
       // Start stale path
-      const firstPath = runReloadScrollbackPath(refs, ipc, vi.fn());
+      const firstPath = runReloadScrollbackPath(refs, ipc, { onWrite: syncWrite() });
 
       // Fresh second path completes and sets pending=false
       const secondIpc: MockIpc = {
         resize: vi.fn().mockResolvedValue(undefined),
         getScrollback: vi.fn().mockResolvedValue('fresh'),
       };
-      await runReloadScrollbackPath(refs, secondIpc, vi.fn());
+      await runReloadScrollbackPath(refs, secondIpc, { onWrite: syncWrite() });
 
       // Reject the stale first path - the catch guard checks generation mismatch
       rejectFirst(new Error('killed after second started'));
       await firstPath;
 
       // Still false - the stale rejection should not have re-set the flag
+      expect(refs.scrollbackPendingRef.current).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Gap 5: stuck-replay watchdog
+  // -------------------------------------------------------------------------
+  describe('scrollback watchdog', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('force-clears pending and resumes the queue if the chunked write never completes', async () => {
+      const resume = vi.fn();
+      const ipc: MockIpc = {
+        resize: vi.fn().mockResolvedValue(undefined),
+        getScrollback: vi.fn().mockResolvedValue('stuck frame'),
+      };
+
+      await runReloadScrollbackPath(refs, ipc, {
+        // Never invokes afterWrite - simulates a dropped xterm.write callback.
+        onWrite: () => {},
+        onResume: resume,
+      });
+      expect(refs.scrollbackPendingRef.current).toBe(true);
+      expect(resume).not.toHaveBeenCalled();
+
+      vi.runAllTimers();
+
+      expect(refs.scrollbackPendingRef.current).toBe(false);
+      expect(resume).toHaveBeenCalledOnce();
+    });
+
+    it('does not fire for a generation that has already been superseded', async () => {
+      const resumeA = vi.fn();
+      const ipcA: MockIpc = {
+        resize: vi.fn().mockResolvedValue(undefined),
+        getScrollback: vi.fn().mockResolvedValue('stuck frame'),
+      };
+      await runReloadScrollbackPath(refs, ipcA, {
+        onWrite: () => {},
+        onResume: resumeA,
+      });
+
+      // A newer replay starts and arms its own watchdog, canceling A's timer.
+      const resumeB = vi.fn();
+      const ipcB: MockIpc = {
+        resize: vi.fn().mockResolvedValue(undefined),
+        getScrollback: vi.fn().mockResolvedValue('fresh frame'),
+      };
+      await runReloadScrollbackPath(refs, ipcB, {
+        onWrite: syncWrite(),
+        onResume: resumeB,
+      });
+      expect(refs.scrollbackPendingRef.current).toBe(false);
+
+      // Advancing time must not touch anything: B already completed and
+      // cleared its own timer, and A's timer was canceled when B armed.
+      vi.runAllTimers();
+      expect(resumeA).not.toHaveBeenCalled();
+      expect(refs.scrollbackPendingRef.current).toBe(false);
+    });
+
+    it('a healthy replay clears its own watchdog before it can fire', async () => {
+      const resume = vi.fn();
+      const ipc: MockIpc = {
+        resize: vi.fn().mockResolvedValue(undefined),
+        getScrollback: vi.fn().mockResolvedValue('normal frame'),
+      };
+
+      await runReloadScrollbackPath(refs, ipc, { onWrite: syncWrite(), onResume: resume });
+      expect(refs.scrollbackPendingRef.current).toBe(false);
+
+      vi.runAllTimers();
+
+      // The watchdog was already canceled by afterWrite; running timers must
+      // not invoke the resume callback a second time.
+      expect(resume).toHaveBeenCalledOnce();
+    });
+
+    it('a later-arriving afterWrite for a force-recovered generation is a no-op (does not re-run effects/resume or re-clear pending)', async () => {
+      const effects = vi.fn();
+      const resume = vi.fn();
+      let capturedAfterWrite!: () => void;
+      const ipc: MockIpc = {
+        resize: vi.fn().mockResolvedValue(undefined),
+        getScrollback: vi.fn().mockResolvedValue('stuck frame'),
+      };
+
+      // The chunked write captures afterWrite but never calls it - the
+      // watchdog's "never completes" case, except this write eventually DOES
+      // complete, just after the watchdog already force-recovered.
+      await runReloadScrollbackPath(refs, ipc, {
+        onWrite: (_scrollback, afterWrite) => { capturedAfterWrite = afterWrite; },
+        onEffects: effects,
+        onResume: resume,
+      });
+      expect(refs.scrollbackPendingRef.current).toBe(true);
+      expect(effects).not.toHaveBeenCalled();
+      expect(resume).not.toHaveBeenCalled();
+
+      // The watchdog fires: force-recovers and bumps the generation.
+      vi.runAllTimers();
+      expect(refs.scrollbackPendingRef.current).toBe(false);
+      expect(resume).toHaveBeenCalledOnce();
+      expect(effects).not.toHaveBeenCalled();
+
+      // The delayed (not dropped) write finally completes. Its afterWrite
+      // must be a no-op: the watchdog already bumped scrollbackGenerationRef,
+      // so afterWrite's own generation guard bails before running effects,
+      // resuming the queue again, or touching pending a second time.
+      capturedAfterWrite();
+      expect(effects).not.toHaveBeenCalled();
+      expect(resume).toHaveBeenCalledOnce();
       expect(refs.scrollbackPendingRef.current).toBe(false);
     });
   });


### PR DESCRIPTION
## What

Fixes a terminal input/focus disconnect at interactive select prompts (AskUserQuestion, plan
approval) in Claude's default fullscreen (alt-screen) TUI renderer. Reported live on task #290
and confirmed with a click-to-unfocus/refocus repro. Two coupled fixes:

- **`src/renderer/hooks/useTerminal.ts`** - `initTerminal` and `reloadScrollback`'s `afterWrite`
  callback now re-checks the scrollback generation before running any side effect (fit, scroll
  restore, focus, incoming-queue resume), and the outer `Promise.all` resolve for a stale
  generation is now a bare bail instead of clearing `scrollbackPendingRef` on behalf of a newer,
  still-in-flight replay. A bounded watchdog force-recovers a stuck replay (and bumps the
  generation so a merely-delayed, not truly dropped, `afterWrite` cannot re-fire and steal focus
  later). The incoming-write queue now HOLDS (not drops) live PTY bytes during a replay window and
  flushes them in order once the replay completes, so a live diff frame can no longer be silently
  discarded.
- **`src/main/pty/buffer/pty-buffer-manager.ts`** - alt-screen (DEC mode 1049/47/1047) is now
  tracked separately from the existing `#313` input-mode set and re-asserted on `getScrollback()`
  only when the session is currently in the alt buffer, so a fullscreen session's replay paints
  into the alt buffer instead of the normal buffer. A dangling synchronized-output frame (mode
  2026) left open by a mid-frame sample is closed with a trailing `\x1b[?2026l`.

## Why

At a select prompt in fullscreen, a scrollback replay (dialog open/close, tab reattach, project
switch) could leave the terminal visibly frozen: arrow keys and Enter reached nothing until the
user clicked to re-focus, and the xterm cursor could end up parked disconnected from the TUI
frame. Root cause was two defects in the replay path - a missing generation guard inside
`afterWrite` that let a stale replay clobber a newer one's focus/fit, and `getScrollback()` never
re-asserting alt-screen, so a fullscreen session's replay always landed in xterm's normal buffer.

## How

Empirical-first: the design was validated against the user's own live repro (click instantly
unfroze the terminal, proving it was a focus/input issue, not a render freeze) before any code was
written. `tests/fixtures/mock-claude.js` gained a new `MOCK_CLAUDE_FULLSCREEN_SELECT=1` harness
mode (it previously emitted no escape sequences at all, so it could not reproduce an alt-screen
bug) that behaves like a real Claude fullscreen select prompt: alt-screen, DECCKM, a 3-option menu,
and cursor-addressed synchronized-output diffs on arrow input.

Trade-off: a self-counted renderer-side sequence watermark was considered for exact duplicate-byte
dedup across a replay, but rejected - it would reset to 0 on every remount (the primary replay
trigger) while main's counter climbs, so it would itself drop live data. The simpler, correct fix
is hold-not-drop: reuse the existing board-drag `shouldHold` retain-and-resume mechanism for the
replay window too, so nothing is lost and any residual duplicate frame re-applies idempotently.

## Breaking changes

None.

## Tests

- `tests/unit/pty-buffer-manager.test.ts` - new "alt-screen re-assert and synchronized-output
  safety" coverage (re-assert only when in the alt buffer, unchanged for classic sessions, mode
  exit, cross-chunk split, RIS/DECSTR reset behavior including a dangling-2026-frame edge case,
  ordering, no-double-append).
- `tests/unit/use-terminal-scrollback.test.ts` - extracted-verbatim orchestration tests for the
  `afterWrite` generation guard, the resolve-path generation guard (the exact regression this PR
  fixes), and the stuck-replay watchdog.
- `tests/unit/incoming-write-queue.test.ts` - hold-not-drop across a replay window (no byte lost,
  flushed in order after the replay), overlay-drop behavior unaffected.
- `tests/e2e/terminal-fullscreen-select-replay-focus.spec.ts` (new) - spawns a real fullscreen
  select prompt via the new mock harness, drives real Playwright keyboard events through a forced
  task-detail dialog close/reopen (a genuine scrollback replay), and asserts arrow keys keep
  working with no manual re-focus click, plus the alt-screen re-assert prefix and Enter completing
  the prompt. Ran stable across 3 local runs.
- Manually verified in `/preview` against a real Claude session parked at a live
  `AskUserQuestion` prompt.

CI runs the full unit/UI/E2E suite as PR checks.

Generated with [Claude Code](https://claude.com/claude-code)
