### PR TITLE
fix(changes): make diff-viewer copy and select-all reliable

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -345,9 +345,14 @@ function getCwdArg(): string | null {
 export { resolveIconPath } from './window-utils';
 
 // Build and show the standard (non-image) right-click context menu with Copy,
-// Paste, and Select All. When the click lands inside a terminal, the actions are
-// dispatched as CustomEvents the renderer's terminal handlers act on; otherwise
-// they fall back to the document's native execCommand.
+// Paste, and Select All. When the click lands inside a terminal or a Monaco
+// diff editor, Copy and Select All are dispatched as CustomEvents the
+// renderer's own handlers act on: document.execCommand is unreliable for Copy
+// there (Menu.popup steals document focus before the click handler runs) and
+// simply does not work for Select All (Monaco keeps its own selection model
+// entirely outside the browser's native document Selection, so
+// execCommand('selectAll') is a no-op over it). Everywhere else falls back to
+// the document's native execCommand.
 function showTerminalAwareContextMenu(
   wc: Electron.WebContents,
   params: Electron.ContextMenuParams,
@@ -367,6 +372,8 @@ function showTerminalAwareContextMenu(
             var el = document.elementFromPoint(${x}, ${y});
             if (el && el.closest('.xterm')) {
               window.dispatchEvent(new CustomEvent('terminal-copy', { detail: { x: ${x}, y: ${y} } }));
+            } else if (el && el.closest('.monaco-diff-editor')) {
+              window.dispatchEvent(new CustomEvent('diff-copy', { detail: { x: ${x}, y: ${y} } }));
             } else {
               document.execCommand('copy');
             }
@@ -400,6 +407,8 @@ function showTerminalAwareContextMenu(
             var el = document.elementFromPoint(${x}, ${y});
             if (el && el.closest('.xterm')) {
               window.dispatchEvent(new CustomEvent('terminal-select-all', { detail: { x: ${x}, y: ${y} } }));
+            } else if (el && el.closest('.monaco-diff-editor')) {
+              window.dispatchEvent(new CustomEvent('diff-select-all', { detail: { x: ${x}, y: ${y} } }));
             } else {
               document.execCommand('selectAll');
             }

--- a/src/renderer/components/dialogs/task-detail/changes/DiffViewer.tsx
+++ b/src/renderer/components/dialogs/task-detail/changes/DiffViewer.tsx
@@ -15,6 +15,7 @@ import {
   resolveDiffScrollAction,
   saveDiffScroll,
 } from '../../../../utils/diff-scroll-memory';
+import { copyDiffSelection } from '../../../../utils/diff-clipboard';
 
 interface DiffViewerProps {
   original: string;
@@ -182,6 +183,7 @@ export function DiffViewer({
 
   const diffEditorRef = useRef<MonacoDiffEditor | null>(null);
   const monacoRef = useRef<Monaco | null>(null);
+  const editorContainerRef = useRef<HTMLDivElement | null>(null);
 
   // Live diff-rendering options derived from the global config. ignoreTrimWhitespace
   // is a diff-COMPUTATION option, so it applies when the diff loads. The diff
@@ -550,6 +552,97 @@ export function DiffViewer({
   useKeybinding('changes.nextChange', () => navigateChange('next'), { capture: true, enabled: isFocused && !previewActive });
   useKeybinding('changes.prevChange', () => navigateChange('prev'), { capture: true, enabled: isFocused && !previewActive });
 
+  // Reliable copy: Monaco's own Ctrl+C routes through the web clipboard, which
+  // rejects once the document loses focus. Capture ahead of Monaco (capture
+  // phase + default preventDefault) and write via the focus-independent
+  // main-process clipboard instead. Scoped to when a diff sub-editor actually
+  // holds focus so it never hijacks Ctrl+C elsewhere (e.g. the file filter).
+  useKeybinding('changes.copy', () => {
+    const diffEditor = diffEditorRef.current;
+    if (diffEditor) copyDiffSelection(diffEditor);
+  }, {
+    capture: true,
+    enabled: isFocused && !previewActive,
+    when: () => {
+      const diffEditor = diffEditorRef.current;
+      return !!diffEditor
+        && (diffEditor.getModifiedEditor().hasTextFocus() || diffEditor.getOriginalEditor().hasTextFocus());
+    },
+  });
+
+  // Right-click Copy / Select All: the main process's showTerminalAwareContextMenu
+  // shows the native OS Copy/Paste/Select All menu (same as everywhere else in
+  // the app - Monaco no longer preempts it now that contextmenu:false is set
+  // below). Its Copy and Select All items dispatch 'diff-copy' / 'diff-select-all'
+  // CustomEvents when the click lands over a '.monaco-diff-editor' rather than
+  // running document.execCommand, which is unreliable for Copy (focus loss) and
+  // a no-op for Select All (Monaco's selection model is outside the browser's
+  // native document Selection) - mirroring the terminal's 'terminal-copy' /
+  // 'terminal-select-all' handling in useTerminal.ts. Scope to THIS instance's
+  // container (isInside) so two co-mounted DiffViewers (two task windows open
+  // on Changes) don't both react to one right-click.
+  useEffect(() => {
+    // The click coordinates the main-process context menu forwarded, or null
+    // when the event carries no positional detail.
+    const pointOf = (event: Event): { x: number; y: number } | null => {
+      const { x, y } = (event as CustomEvent).detail || {};
+      if (x == null || y == null) return null;
+      return { x, y };
+    };
+    const isInside = (point: { x: number; y: number }): boolean => {
+      const el = editorContainerRef.current;
+      if (!el) return false;
+      const rect = el.getBoundingClientRect();
+      return point.x >= rect.left && point.x <= rect.right && point.y >= rect.top && point.y <= rect.bottom;
+    };
+    // Which sub-editor the user right-clicked in, resolved from the click POINT
+    // rather than hasTextFocus(): the native context menu (Menu.popup) steals
+    // document focus before this handler runs, so both sub-editors report no
+    // text focus and a focus-based check would always fall back to the modified
+    // pane (silently mistargeting the original pane in split view). The click
+    // point is reliable whether or not focus was restored. Falls back to the
+    // modified editor, which is the only pane laid out in inline view.
+    const subEditorAtPoint = (
+      diffEditor: MonacoDiffEditor,
+      point: { x: number; y: number },
+    ): MonacoEditorNamespace.ICodeEditor => {
+      const originalEditor = diffEditor.getOriginalEditor();
+      const originalNode = originalEditor.getDomNode();
+      if (originalNode) {
+        const rect = originalNode.getBoundingClientRect();
+        if (rect.width > 0
+          && point.x >= rect.left && point.x <= rect.right
+          && point.y >= rect.top && point.y <= rect.bottom) {
+          return originalEditor;
+        }
+      }
+      return diffEditor.getModifiedEditor();
+    };
+    const handleDiffCopy = (event: Event) => {
+      const point = pointOf(event);
+      if (!point || !isInside(point)) return;
+      const diffEditor = diffEditorRef.current;
+      if (diffEditor) copyDiffSelection(diffEditor, subEditorAtPoint(diffEditor, point));
+    };
+    const handleDiffSelectAll = (event: Event) => {
+      const point = pointOf(event);
+      if (!point || !isInside(point)) return;
+      const diffEditor = diffEditorRef.current;
+      if (!diffEditor) return;
+      const editor = subEditorAtPoint(diffEditor, point);
+      const model = editor.getModel();
+      if (!model) return;
+      editor.focus();
+      editor.setSelection(model.getFullModelRange());
+    };
+    window.addEventListener('diff-copy', handleDiffCopy);
+    window.addEventListener('diff-select-all', handleDiffSelectAll);
+    return () => {
+      window.removeEventListener('diff-copy', handleDiffCopy);
+      window.removeEventListener('diff-select-all', handleDiffSelectAll);
+    };
+  }, []);
+
   return (
     <div className="flex flex-col h-full">
       {/* Toolbar */}
@@ -697,36 +790,43 @@ export function DiffViewer({
           // list in src/shared/benign-renderer-errors.ts) so it no longer renders
           // red in the console, and the test harness filters the same message.
           // Upstream: https://github.com/suren-atoyan/monaco-react/issues/647
-          <DiffEditor
-            height="100%"
-            language={language}
-            original={original}
-            modified={modified}
-            theme={monacoTheme}
-            // Set the theme BEFORE the editor is created. Without this, Monaco
-            // creates the editor under its default light theme and only swaps to
-            // the prop theme afterwards, painting one white frame. A fade hid
-            // that frame; the slide-in reveal does not, so we prevent it here.
-            beforeMount={(monacoInstance) => monacoInstance.editor.setTheme(monacoTheme)}
-            onMount={handleEditorMount}
-            options={{
-              readOnly: true,
-              originalEditable: false,
-              renderSideBySide: viewMode === 'split',
-              automaticLayout: true,
-              scrollBeyondLastLine: false,
-              minimap: { enabled: false },
-              renderWhitespace: 'boundary',
-              fontSize: 12,
-              lineHeight: 18,
-              ...diffRenderOptions,
-            }}
-            loading={
-              <div className="flex items-center justify-center h-full">
-                <Loader2 size={20} className="animate-spin text-fg-muted" />
-              </div>
-            }
-          />
+          <div ref={editorContainerRef} className="h-full w-full">
+            <DiffEditor
+              height="100%"
+              language={language}
+              original={original}
+              modified={modified}
+              theme={monacoTheme}
+              // Set the theme BEFORE the editor is created. Without this, Monaco
+              // creates the editor under its default light theme and only swaps to
+              // the prop theme afterwards, painting one white frame. A fade hid
+              // that frame; the slide-in reveal does not, so we prevent it here.
+              beforeMount={(monacoInstance) => monacoInstance.editor.setTheme(monacoTheme)}
+              onMount={handleEditorMount}
+              options={{
+                readOnly: true,
+                originalEditable: false,
+                renderSideBySide: viewMode === 'split',
+                automaticLayout: true,
+                scrollBeyondLastLine: false,
+                minimap: { enabled: false },
+                renderWhitespace: 'boundary',
+                fontSize: 12,
+                lineHeight: 18,
+                // Monaco's default context menu also surfaces "Command Palette",
+                // which is meaningless on a read-only embedded diff, and its Copy
+                // action is unreliable (see copyDiffSelection). Disabling it lets
+                // the native contextmenu event through to showTerminalAwareContextMenu.
+                contextmenu: false,
+                ...diffRenderOptions,
+              }}
+              loading={
+                <div className="flex items-center justify-center h-full">
+                  <Loader2 size={20} className="animate-spin text-fg-muted" />
+                </div>
+              }
+            />
+          </div>
         )}
       </div>
     </div>

--- a/src/renderer/utils/diff-clipboard.ts
+++ b/src/renderer/utils/diff-clipboard.ts
@@ -1,0 +1,61 @@
+import type { editor as MonacoEditorNamespace } from 'monaco-editor';
+
+/** The subset of `@monaco-editor/react`'s `MonacoDiffEditor` this module needs,
+ *  kept structural (rather than importing the library) so this stays a plain,
+ *  monaco-runtime-free util that is trivial to stub in unit tests. */
+export interface DiffSelectionSource {
+  getModifiedEditor(): MonacoEditorNamespace.ICodeEditor;
+  getOriginalEditor(): MonacoEditorNamespace.ICodeEditor;
+}
+
+function selectedText(editor: MonacoEditorNamespace.ICodeEditor): string {
+  const selection = editor.getSelection();
+  if (!selection || selection.isEmpty()) return '';
+  return editor.getModel()?.getValueInRange(selection) ?? '';
+}
+
+/**
+ * Read the current selection out of whichever side of the diff (original or
+ * modified) holds it. A DiffEditor has two independent sub-editors, so a
+ * selection made in the left (original) pane never appears on the right
+ * (modified) pane's model.
+ *
+ * When `preferredEditor` is given (the pane the caller resolved from a
+ * right-click POINT), its selection wins if non-empty. This is the reliable
+ * signal for the context-menu path, because Menu.popup steals document focus,
+ * so hasTextFocus() reads false on both panes by the time this runs and both
+ * panes may still hold stale selections. Otherwise (the keyboard path, where
+ * focus is intact) prefer the side with text focus, then fall back to whichever
+ * side has a non-empty selection. Returns '' when nothing is selected.
+ */
+export function getDiffSelectionText(
+  diffEditor: DiffSelectionSource,
+  preferredEditor?: MonacoEditorNamespace.ICodeEditor,
+): string {
+  const modifiedEditor = diffEditor.getModifiedEditor();
+  const originalEditor = diffEditor.getOriginalEditor();
+  if (preferredEditor) {
+    const preferred = selectedText(preferredEditor);
+    if (preferred) return preferred;
+  }
+  if (modifiedEditor.hasTextFocus()) return selectedText(modifiedEditor);
+  if (originalEditor.hasTextFocus()) return selectedText(originalEditor);
+  return selectedText(modifiedEditor) || selectedText(originalEditor);
+}
+
+/**
+ * Copy the diff editor's current selection to the system clipboard. Writes via
+ * the main process (window.electronAPI.clipboard.writeText), which is focus-
+ * and permission-independent, rather than Monaco's default copy action (which
+ * routes through document.execCommand('copy') / navigator.clipboard.writeText
+ * and rejects with NotAllowedError once the document loses focus - exactly the
+ * state while a context menu is open). Best-effort: a failed write is
+ * swallowed. No-op when there is no selection.
+ */
+export function copyDiffSelection(
+  diffEditor: DiffSelectionSource,
+  preferredEditor?: MonacoEditorNamespace.ICodeEditor,
+): void {
+  const text = getDiffSelectionText(diffEditor, preferredEditor);
+  if (text) window.electronAPI.clipboard.writeText(text).catch(() => { /* best-effort */ });
+}

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -310,6 +310,20 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     defaultCombo: 'Alt+Shift+ArrowUp',
     rebindable: true,
   },
+  // Not rebindable: Mod+C is terminal-consumed (terminal.copy), and a rebindable
+  // entry on that combo would trip detectConflicts' terminal-warn. Mirrors
+  // terminal.copy's own non-rebindable treatment; NOT terminalUnsafe (this
+  // combo is handled by the diff editor, not the embedded terminal, so it must
+  // stay out of the terminalUnsafe set the "in sync" test locks).
+  {
+    id: 'changes.copy',
+    label: 'Copy Selection',
+    description: 'Copy the selected diff text to the clipboard.',
+    group: 'Git Changes',
+    scope: 'task-dialog',
+    defaultCombo: 'Mod+C',
+    rebindable: false,
+  },
 
   // ── Windows ──
   // Win11-style STATEFUL snap: each arrow's result depends on the window's current

--- a/tests/ui/changes-panel-diffviewer-copy.spec.ts
+++ b/tests/ui/changes-panel-diffviewer-copy.spec.ts
@@ -1,0 +1,455 @@
+/**
+ * UI tests for the DiffViewer copy / select-all behavior added to fix the
+ * Changes panel's Monaco diff viewer copy and context-menu handling
+ * (src/renderer/components/dialogs/task-detail/changes/DiffViewer.tsx).
+ *
+ * Two independent paths are covered:
+ *
+ *  1. The `changes.copy` keybinding (Mod+C), which calls copyDiffSelection()
+ *     directly when a diff sub-editor holds text focus. Scoped via a `when`
+ *     predicate so it never hijacks Ctrl+C elsewhere in the dialog.
+ *
+ *  2. The `window.addEventListener('diff-copy' | 'diff-select-all', ...)`
+ *     handlers that the main process's native context menu drives (see
+ *     showTerminalAwareContextMenu in src/main/index.ts). These resolve which
+ *     DiffViewer instance and which Monaco sub-editor (original vs modified) a
+ *     click point falls in, purely from the CustomEvent's `{ x, y }` detail -
+ *     there is no real Electron context menu in this headless-Chromium tier,
+ *     so the CustomEvent is dispatched directly, exactly mirroring what the
+ *     main process would send.
+ *
+ * A real @monaco-editor/react DiffEditor is mounted (via the __mockGitDiff
+ * hook), so selections are read and written through the actual monaco API
+ * (window.__monaco, a dev-only debug handle - see monacoConfig.ts), not
+ * simulated. Clipboard writes are asserted via the mock's
+ * window.electronAPI.clipboard.__writeTextCalls log (same pattern as
+ * tests/ui/terminal-osc52-copy.spec.ts).
+ *
+ * The `showTerminalAwareContextMenu` main-process wiring itself (which
+ * CustomEvent name fires for which click target) is not covered here - it is
+ * plain Electron.Menu template construction with no branch of its own logic
+ * worth a heavy Menu/webContents mock; see the test-builder report for that
+ * call.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const RUN_ID = Date.now();
+const PROJECT_ID = `proj-diffviewer-copy-${RUN_ID}`;
+const TASK_ID = `task-diffviewer-copy-${RUN_ID}`;
+const SESSION_ID = `sess-diffviewer-copy-${RUN_ID}`;
+const TASK_TITLE = `DiffViewer Copy Test ${RUN_ID}`;
+
+// Distinct original vs modified line 2 content so a test can prove WHICH pane
+// a click point resolved to, rather than merely that "some" text was copied.
+const ORIGINAL_LINE_2 = 'second original line';
+const MODIFIED_LINE_2 = 'SECOND MODIFIED LINE';
+const DIFF_FIXTURE = {
+  files: [
+    {
+      path: 'src/copy-test-file.ts',
+      status: 'M',
+      insertions: 1,
+      deletions: 1,
+      binary: false,
+      original: `first original line\n${ORIGINAL_LINE_2}\nthird original line\n`,
+      modified: `first original line\n${MODIFIED_LINE_2}\nthird original line\n`,
+      language: 'typescript',
+    },
+  ],
+};
+
+interface MonacoRangeLike {
+  startLineNumber: number;
+  startColumn: number;
+  endLineNumber: number;
+  endColumn: number;
+}
+interface MonacoModelHandle {
+  getFullModelRange(): MonacoRangeLike;
+  getLineMaxColumn(lineNumber: number): number;
+}
+interface MonacoSubEditorHandle {
+  getDomNode(): HTMLElement | null;
+  hasTextFocus(): boolean;
+  focus(): void;
+  setSelection(range: MonacoRangeLike): void;
+  getSelection(): MonacoRangeLike | null;
+  getModel(): MonacoModelHandle | null;
+}
+interface MonacoDiffEditorHandle {
+  getOriginalEditor(): MonacoSubEditorHandle;
+  getModifiedEditor(): MonacoSubEditorHandle;
+}
+type MonacoTestWindow = Window & {
+  __monaco?: { editor: { getDiffEditors(): MonacoDiffEditorHandle[] } };
+  electronAPI: { clipboard: { __writeTextCalls: string[]; writeText: (text: string) => Promise<void> } };
+};
+
+async function launchWithDiffTask(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(`
+    window.__mockGitDiff = ${JSON.stringify(DIFF_FIXTURE)};
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+
+      state.projects.push({
+        id: '${PROJECT_ID}',
+        name: 'DiffViewer Copy Test ${RUN_ID}',
+        path: '/mock/diffviewer-copy-${RUN_ID}',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+
+      var laneIds = {};
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        var id = 'lane-copy-' + s.name.toLowerCase().replace(/\\s+/g, '-') + '-${RUN_ID}';
+        laneIds[s.name] = id;
+        state.swimlanes.push(Object.assign({}, s, { id: id, position: i, created_at: ts }));
+      });
+
+      // Running session so TaskDetailBody renders the live body (with the
+      // Changes pill) rather than the edit form.
+      state.sessions.push({
+        id: '${SESSION_ID}',
+        taskId: '${TASK_ID}',
+        projectId: '${PROJECT_ID}',
+        pid: 8888,
+        status: 'running',
+        shell: 'bash',
+        cwd: '/mock/diffviewer-copy-${RUN_ID}',
+        startedAt: ts,
+        exitCode: null,
+      });
+
+      state.tasks.push({
+        id: '${TASK_ID}',
+        display_id: 1,
+        title: '${TASK_TITLE}',
+        description: 'Task used to exercise DiffViewer copy / select-all',
+        swimlane_id: laneIds['Code Review'],
+        position: 0,
+        agent: 'claude',
+        session_id: '${SESSION_ID}',
+        worktree_path: '/mock/worktrees/diffviewer-copy',
+        branch_name: 'feature/diffviewer-copy',
+        pr_number: null,
+        pr_url: null,
+        base_branch: 'main',
+        archived_at: null,
+        created_at: ts,
+        updated_at: ts,
+      });
+
+      return { currentProjectId: '${PROJECT_ID}' };
+    });
+  `);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  await page.locator('[data-swimlane-name="Code Review"]').waitFor({ state: 'visible', timeout: 10000 });
+
+  return { browser, page };
+}
+
+/** Open the task dialog and the Changes panel, and wait for the real Monaco
+ *  DiffEditor to finish mounting (a single diff editor registered with
+ *  monaco's global editor registry). */
+async function openDiffTask(page: Page): Promise<void> {
+  const card = page
+    .locator('[data-swimlane-name="Code Review"]')
+    .locator(`text=${TASK_TITLE}`)
+    .first();
+  await card.click();
+
+  const dialog = page.locator('[data-testid="task-detail-dialog"]');
+  await dialog.waitFor({ state: 'visible', timeout: 5000 });
+
+  const changesPill = page.locator('[data-testid="changes-toggle"]');
+  await expect(changesPill).toBeVisible();
+  await changesPill.click();
+
+  await page.locator('[data-testid="diff-editor-area"]').waitFor({ state: 'visible', timeout: 8000 });
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const monacoHandle = (window as unknown as MonacoTestWindow).__monaco;
+          return monacoHandle ? monacoHandle.editor.getDiffEditors().length : 0;
+        }),
+      { timeout: 8000 },
+    )
+    .toBe(1);
+}
+
+/** Close the Changes panel and the task dialog, mirroring the teardown used by
+ *  the sibling DiffViewer toolbar spec, so the next test starts from a clean,
+ *  fully-unmounted DiffEditor. */
+async function closeDiffTask(page: Page): Promise<void> {
+  const changesPill = page.locator('[data-testid="changes-toggle"]');
+  await changesPill.click();
+  await page.keyboard.press('Control+Shift+W');
+  await page.locator('[data-testid="task-detail-dialog"]').waitFor({ state: 'hidden', timeout: 8000 });
+}
+
+/** Read a point at the center of a sub-editor's real DOM node, computed inside
+ *  the page (no locator-index assumption about original-vs-modified DOM
+ *  order). */
+async function centerOf(page: Page, pane: 'original' | 'modified'): Promise<{ x: number; y: number }> {
+  return page.evaluate((which) => {
+    const monacoHandle = (window as unknown as MonacoTestWindow).__monaco;
+    if (!monacoHandle) throw new Error('monaco debug handle not present');
+    const diffEditor = monacoHandle.editor.getDiffEditors()[0];
+    const editor = which === 'original' ? diffEditor.getOriginalEditor() : diffEditor.getModifiedEditor();
+    const node = editor.getDomNode();
+    if (!node) throw new Error(`${which} editor has no DOM node`);
+    const rect = node.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  }, pane);
+}
+
+/** Select line 2 (the only differing line in the fixture) in full, on BOTH
+ *  sub-editors, so a test can prove which pane a click point resolved to by
+ *  which pane's line-2 text ends up in the clipboard. */
+async function selectLine2OnBothPanes(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const monacoHandle = (window as unknown as MonacoTestWindow).__monaco;
+    const diffEditor = monacoHandle!.editor.getDiffEditors()[0];
+    for (const editor of [diffEditor.getOriginalEditor(), diffEditor.getModifiedEditor()]) {
+      const model = editor.getModel()!;
+      editor.setSelection({ startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: model.getLineMaxColumn(2) });
+    }
+  });
+}
+
+test.describe('DiffViewer copy and select-all', () => {
+  let browser: Browser;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    ({ browser, page } = await launchWithDiffTask());
+  });
+
+  test.afterAll(async () => {
+    await page.evaluate(() => {
+      (window as unknown as Record<string, unknown>).__mockGitDiff = null;
+    });
+    await browser?.close();
+  });
+
+  test('Ctrl+C copies the selection from whichever sub-editor holds text focus', async () => {
+    await openDiffTask(page);
+
+    await page.evaluate(() => {
+      const monacoHandle = (window as unknown as MonacoTestWindow).__monaco;
+      const diffEditor = monacoHandle!.editor.getDiffEditors()[0];
+      const modifiedEditor = diffEditor.getModifiedEditor();
+      const model = modifiedEditor.getModel()!;
+      modifiedEditor.setSelection({
+        startLineNumber: 2,
+        startColumn: 1,
+        endLineNumber: 2,
+        endColumn: model.getLineMaxColumn(2),
+      });
+      modifiedEditor.focus();
+    });
+
+    await expect
+      .poll(() => page.evaluate(() => {
+        const monacoHandle = (window as unknown as MonacoTestWindow).__monaco;
+        return monacoHandle!.editor.getDiffEditors()[0].getModifiedEditor().hasTextFocus();
+      }))
+      .toBe(true);
+
+    await page.evaluate(() => {
+      (window as unknown as MonacoTestWindow).electronAPI.clipboard.__writeTextCalls.length = 0;
+    });
+
+    await page.keyboard.press('Control+c');
+
+    await expect
+      .poll(() => page.evaluate(() => (window as unknown as MonacoTestWindow).electronAPI.clipboard.__writeTextCalls.length))
+      .toBeGreaterThan(0);
+    const calls = await page.evaluate(() => (window as unknown as MonacoTestWindow).electronAPI.clipboard.__writeTextCalls);
+    expect(calls).toContain(MODIFIED_LINE_2);
+
+    await closeDiffTask(page);
+  });
+
+  test('Ctrl+C does nothing when no diff sub-editor holds text focus (does not hijack Ctrl+C elsewhere)', async () => {
+    await openDiffTask(page);
+
+    // A selection MUST exist (on the modified pane) without focus, so this
+    // proves the "when" focus gate itself blocks the fire - not merely that
+    // there was nothing to copy. getDiffSelectionText's no-preferredEditor
+    // fallback returns a non-focused pane's selection when NEITHER pane has
+    // focus, so if the gate were dropped, this selection would still reach
+    // the clipboard.
+    await selectLine2OnBothPanes(page);
+
+    // Blur whatever currently holds focus (a fresh dialog open, plus never
+    // having called .focus() on either editor above, already leaves nothing
+    // focused inside either sub-editor) without clicking any interactive
+    // control, so this test does not rely on a specific unrelated element
+    // being safely clickable.
+    await page.evaluate(() => {
+      (document.activeElement as HTMLElement | null)?.blur();
+    });
+    await expect
+      .poll(() => page.evaluate(() => {
+        const monacoHandle = (window as unknown as MonacoTestWindow).__monaco;
+        const diffEditor = monacoHandle!.editor.getDiffEditors()[0];
+        return diffEditor.getOriginalEditor().hasTextFocus() || diffEditor.getModifiedEditor().hasTextFocus();
+      }))
+      .toBe(false);
+
+    await page.evaluate(() => {
+      (window as unknown as MonacoTestWindow).electronAPI.clipboard.__writeTextCalls.length = 0;
+    });
+
+    await page.keyboard.press('Control+c');
+
+    // Intentional fixed wait - cannot poll for non-occurrence (test-builder
+    // anti-pattern 6). Mod+C's handler runs synchronously on keydown, so this
+    // budget is far more than enough for either the "when" gate to reject it
+    // or copyDiffSelection to have already pushed onto the mock's call log.
+    await page.waitForTimeout(500);
+
+    const count = await page.evaluate(() => (window as unknown as MonacoTestWindow).electronAPI.clipboard.__writeTextCalls.length);
+    expect(count).toBe(0);
+
+    await closeDiffTask(page);
+  });
+
+  test('a diff-copy event resolves the ORIGINAL pane by click point, not the modified pane', async () => {
+    await openDiffTask(page);
+
+    // Distinct selections on both panes (line 2 in each, the ONLY differing
+    // line between original and modified in this fixture).
+    await selectLine2OnBothPanes(page);
+
+    await page.evaluate(() => {
+      (window as unknown as MonacoTestWindow).electronAPI.clipboard.__writeTextCalls.length = 0;
+    });
+
+    const point = await centerOf(page, 'original');
+    const calls = await page.evaluate(({ x, y }) => {
+      window.dispatchEvent(new CustomEvent('diff-copy', { detail: { x, y } }));
+      return (window as unknown as MonacoTestWindow).electronAPI.clipboard.__writeTextCalls.slice();
+    }, point);
+
+    expect(calls).toEqual([ORIGINAL_LINE_2]);
+
+    await closeDiffTask(page);
+  });
+
+  test('a diff-copy event resolves the MODIFIED pane by click point', async () => {
+    await openDiffTask(page);
+
+    await selectLine2OnBothPanes(page);
+
+    await page.evaluate(() => {
+      (window as unknown as MonacoTestWindow).electronAPI.clipboard.__writeTextCalls.length = 0;
+    });
+
+    const point = await centerOf(page, 'modified');
+    const calls = await page.evaluate(({ x, y }) => {
+      window.dispatchEvent(new CustomEvent('diff-copy', { detail: { x, y } }));
+      return (window as unknown as MonacoTestWindow).electronAPI.clipboard.__writeTextCalls.slice();
+    }, point);
+
+    expect(calls).toEqual([MODIFIED_LINE_2]);
+
+    await closeDiffTask(page);
+  });
+
+  test('a diff-select-all event focuses and selects the full range of the resolved (original) pane', async () => {
+    await openDiffTask(page);
+
+    const point = await centerOf(page, 'original');
+    const result = await page.evaluate(({ x, y }) => {
+      window.dispatchEvent(new CustomEvent('diff-select-all', { detail: { x, y } }));
+      const monacoHandle = (window as unknown as MonacoTestWindow).__monaco;
+      const diffEditor = monacoHandle!.editor.getDiffEditors()[0];
+      const originalEditor = diffEditor.getOriginalEditor();
+      const modifiedEditor = diffEditor.getModifiedEditor();
+      // getSelection() returns a Selection (extends Range with cursor/anchor
+      // fields); narrow to the plain Range shape so this compares only what
+      // setSelection(model.getFullModelRange()) actually guarantees.
+      const selection = originalEditor.getSelection();
+      const fullRange = originalEditor.getModel()!.getFullModelRange();
+      return {
+        originalFocused: originalEditor.hasTextFocus(),
+        modifiedFocused: modifiedEditor.hasTextFocus(),
+        selectionRange: selection && {
+          startLineNumber: selection.startLineNumber,
+          startColumn: selection.startColumn,
+          endLineNumber: selection.endLineNumber,
+          endColumn: selection.endColumn,
+        },
+        fullRange,
+      };
+    }, point);
+
+    expect(result.originalFocused).toBe(true);
+    expect(result.modifiedFocused).toBe(false);
+    expect(result.selectionRange).toEqual(result.fullRange);
+
+    await closeDiffTask(page);
+  });
+
+  test('diff-copy and diff-select-all are ignored when the click point falls outside this DiffViewer instance', async () => {
+    await openDiffTask(page);
+
+    const editorArea = page.locator('[data-testid="diff-editor-area"]');
+    const areaBox = await editorArea.boundingBox();
+    if (!areaBox) throw new Error('diff-editor-area has no bounding box');
+    // A point above the editor area (in the toolbar row that sits directly
+    // above it in the same DiffViewer flex column) - real geometry, not a
+    // pixel-exact assumption, and clearly outside editorContainerRef's rect.
+    const outsidePoint = { x: areaBox.x + 10, y: Math.max(0, areaBox.y - 30) };
+
+    await page.evaluate(() => {
+      const monacoHandle = (window as unknown as MonacoTestWindow).__monaco;
+      const diffEditor = monacoHandle!.editor.getDiffEditors()[0];
+      diffEditor.getOriginalEditor().setSelection({ startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 3 });
+    });
+    await page.evaluate(() => {
+      (window as unknown as MonacoTestWindow).electronAPI.clipboard.__writeTextCalls.length = 0;
+    });
+
+    const before = await page.evaluate(() => {
+      const monacoHandle = (window as unknown as MonacoTestWindow).__monaco;
+      return monacoHandle!.editor.getDiffEditors()[0].getOriginalEditor().getSelection();
+    });
+
+    const result = await page.evaluate(({ x, y }) => {
+      window.dispatchEvent(new CustomEvent('diff-copy', { detail: { x, y } }));
+      window.dispatchEvent(new CustomEvent('diff-select-all', { detail: { x, y } }));
+      const monacoHandle = (window as unknown as MonacoTestWindow).__monaco;
+      const diffEditor = monacoHandle!.editor.getDiffEditors()[0];
+      return {
+        writeTextCalls: (window as unknown as MonacoTestWindow).electronAPI.clipboard.__writeTextCalls.slice(),
+        selectionAfter: diffEditor.getOriginalEditor().getSelection(),
+      };
+    }, outsidePoint);
+
+    expect(result.writeTextCalls).toEqual([]);
+    expect(result.selectionAfter).toEqual(before);
+
+    await closeDiffTask(page);
+  });
+});

--- a/tests/unit/diff-clipboard.test.ts
+++ b/tests/unit/diff-clipboard.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { editor as MonacoEditorNamespace } from 'monaco-editor';
+import {
+  getDiffSelectionText,
+  copyDiffSelection,
+  type DiffSelectionSource,
+} from '../../src/renderer/utils/diff-clipboard';
+
+/**
+ * Unit coverage for the diff-editor copy path added to fix Copy / Ctrl+C in the
+ * Changes panel's Monaco diff viewer. Monaco's own copy routes through the web
+ * clipboard, which rejects once the document loses focus (exactly the state
+ * while a context menu is open); this module reads the selection directly off
+ * the diff editor's two sub-editors and writes it via the focus-independent
+ * main-process clipboard.
+ */
+
+type StubCodeEditor = MonacoEditorNamespace.ICodeEditor;
+
+/** `selectionText` of `null` means no selection object at all (getSelection()
+ *  returns null); an empty string means a selection object with isEmpty() true. */
+function makeEditorStub(focused: boolean, selectionText: string | null): StubCodeEditor {
+  return {
+    hasTextFocus: () => focused,
+    getSelection: () => {
+      if (selectionText === null) return null;
+      return { isEmpty: () => selectionText.length === 0 };
+    },
+    getModel: () => ({
+      getValueInRange: () => selectionText ?? '',
+    }),
+  } as unknown as StubCodeEditor;
+}
+
+function makeDiffEditorStub(modified: StubCodeEditor, original: StubCodeEditor): DiffSelectionSource {
+  return {
+    getModifiedEditor: () => modified,
+    getOriginalEditor: () => original,
+  };
+}
+
+describe('getDiffSelectionText', () => {
+  it('reads the modified side selection when it holds text focus', () => {
+    const diffEditor = makeDiffEditorStub(
+      makeEditorStub(true, 'modified selection'),
+      makeEditorStub(false, null),
+    );
+
+    expect(getDiffSelectionText(diffEditor)).toBe('modified selection');
+  });
+
+  it('reads the original side selection when it holds text focus', () => {
+    const diffEditor = makeDiffEditorStub(
+      makeEditorStub(false, null),
+      makeEditorStub(true, 'original selection'),
+    );
+
+    expect(getDiffSelectionText(diffEditor)).toBe('original selection');
+  });
+
+  it('prefers the focused side even when the other side also has a selection', () => {
+    const diffEditor = makeDiffEditorStub(
+      makeEditorStub(true, 'modified selection'),
+      makeEditorStub(false, 'stale original selection'),
+    );
+
+    expect(getDiffSelectionText(diffEditor)).toBe('modified selection');
+  });
+
+  it('falls back to the modified side when neither side has text focus', () => {
+    const diffEditor = makeDiffEditorStub(
+      makeEditorStub(false, 'modified selection'),
+      makeEditorStub(false, null),
+    );
+
+    expect(getDiffSelectionText(diffEditor)).toBe('modified selection');
+  });
+
+  it('falls back to the original side when neither side has text focus and only it has a selection', () => {
+    const diffEditor = makeDiffEditorStub(
+      makeEditorStub(false, null),
+      makeEditorStub(false, 'original selection'),
+    );
+
+    expect(getDiffSelectionText(diffEditor)).toBe('original selection');
+  });
+
+  it('returns an empty string when neither side has a selection', () => {
+    const diffEditor = makeDiffEditorStub(
+      makeEditorStub(true, null),
+      makeEditorStub(false, null),
+    );
+
+    expect(getDiffSelectionText(diffEditor)).toBe('');
+  });
+
+  it('returns an empty string for a collapsed (empty) selection', () => {
+    const diffEditor = makeDiffEditorStub(
+      makeEditorStub(true, ''),
+      makeEditorStub(false, null),
+    );
+
+    expect(getDiffSelectionText(diffEditor)).toBe('');
+  });
+
+  it('prefers a non-empty preferredEditor selection over both sides, even when neither has focus (context-menu path)', () => {
+    const originalEditor = makeEditorStub(false, 'original selection');
+    const diffEditor = makeDiffEditorStub(
+      makeEditorStub(false, 'stale modified selection'),
+      originalEditor,
+    );
+
+    expect(getDiffSelectionText(diffEditor, originalEditor)).toBe('original selection');
+  });
+
+  it('falls back to the focused/content selection when preferredEditor has an empty selection', () => {
+    const preferredEditor = makeEditorStub(false, '');
+    const diffEditor = makeDiffEditorStub(
+      makeEditorStub(true, 'modified selection'),
+      makeEditorStub(false, null),
+    );
+
+    expect(getDiffSelectionText(diffEditor, preferredEditor)).toBe('modified selection');
+  });
+});
+
+describe('copyDiffSelection', () => {
+  const originalWindow = globalThis.window;
+
+  afterEach(() => {
+    globalThis.window = originalWindow;
+  });
+
+  function stubWindowClipboard(): ReturnType<typeof vi.fn> {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    // @ts-expect-error -- minimal window stub for the write call
+    globalThis.window = { electronAPI: { clipboard: { writeText } } };
+    return writeText;
+  }
+
+  it('writes the selection via window.electronAPI.clipboard.writeText (focus-independent main-process write)', () => {
+    const writeText = stubWindowClipboard();
+    const diffEditor = makeDiffEditorStub(
+      makeEditorStub(true, 'copy me'),
+      makeEditorStub(false, null),
+    );
+
+    copyDiffSelection(diffEditor);
+
+    expect(writeText).toHaveBeenCalledWith('copy me');
+  });
+
+  it('is a no-op when there is no selection', () => {
+    const writeText = stubWindowClipboard();
+    const diffEditor = makeDiffEditorStub(
+      makeEditorStub(true, null),
+      makeEditorStub(false, null),
+    );
+
+    copyDiffSelection(diffEditor);
+
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('swallows a rejected clipboard write instead of throwing (best-effort write)', async () => {
+    // A plain (non-vi.fn) function, deliberately not a mock: vitest's spy
+    // wrapper internally chains its own .then()/.catch() onto a mocked
+    // async function's return value to populate `mock.results`, which
+    // would mask a missing .catch() in the source under test.
+    let callCount = 0;
+    let lastArg: string | undefined;
+    const writeText = (text: string): Promise<void> => {
+      callCount += 1;
+      lastArg = text;
+      return Promise.reject(new Error('denied'));
+    };
+    // @ts-expect-error -- minimal window stub for the write call
+    globalThis.window = { electronAPI: { clipboard: { writeText } } };
+    const diffEditor = makeDiffEditorStub(
+      makeEditorStub(true, 'copy me'),
+      makeEditorStub(false, null),
+    );
+
+    // A rejected promise only surfaces as `process.on('unhandledRejection')`
+    // if nothing calls .catch() on it by the end of the microtask queue, so
+    // synchronous expect(...).not.toThrow() can't detect a missing .catch():
+    // install a listener and give the rejection a full macrotask to surface.
+    let unhandled: unknown;
+    const onUnhandledRejection = (reason: unknown): void => {
+      unhandled = reason;
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+    try {
+      expect(() => copyDiffSelection(diffEditor)).not.toThrow();
+      expect(callCount).toBe(1);
+      expect(lastArg).toBe('copy me');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandled).toBeUndefined();
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
+  it('writes the preferredEditor selection when passed explicitly (right-click path)', () => {
+    const writeText = stubWindowClipboard();
+    const originalEditor = makeEditorStub(false, 'original selection');
+    const diffEditor = makeDiffEditorStub(
+      makeEditorStub(false, 'stale modified selection'),
+      originalEditor,
+    );
+
+    copyDiffSelection(diffEditor, originalEditor);
+
+    expect(writeText).toHaveBeenCalledWith('original selection');
+  });
+});


### PR DESCRIPTION
## What

Fixes copy in the Changes panel's Monaco diff viewer and removes the irrelevant "Command Palette" context-menu item.

- Disables Monaco's built-in context menu (`contextmenu: false`) on the diff editor, so the app's native OS Copy/Paste/Select All menu shows instead. This removes the Command Palette item in one move.
- Adds `src/renderer/utils/diff-clipboard.ts`: reads the current selection off whichever diff sub-editor (original or modified) holds it, and writes it via the focus-independent main-process clipboard (`window.electronAPI.clipboard.writeText`).
- Binds Ctrl+C / Cmd+C through the central keybinding registry (`changes.copy`), gated so it only fires when a diff sub-editor holds text focus.
- Extends `showTerminalAwareContextMenu` (main process) so a right-click landing on a Monaco diff editor dispatches `diff-copy` / `diff-select-all` CustomEvents (mirroring the existing `.xterm` handling) instead of falling through to `document.execCommand`, which is unreliable for Copy (the popup steals document focus) and a no-op for Select All (Monaco keeps its own selection model outside the browser's native document Selection).
- Resolves which sub-editor (original vs modified) a right-click landed in from the click's coordinates rather than `hasTextFocus()`, since `Menu.popup()` steals document focus before the click handler runs.

## Why

Right-clicking a text selection in the diff viewer showed Monaco's own context menu with a "Copy" that did not actually put the selection on the system clipboard, plus a "Command Palette (F1)" item that does nothing useful in a read-only embedded diff.

## How

Mirrors the existing terminal clipboard pattern (`src/renderer/utils/terminal-clipboard.ts`, `useTerminal.ts`'s `terminal-copy`/`terminal-select-all` CustomEvent handling) rather than introducing a new mechanism: the main process dispatches a CustomEvent carrying the click coordinates when the click lands on the relevant element, and the renderer resolves the rest. An earlier iteration used a bespoke on-page context menu; that was replaced with this approach so right-click still shows the app's one native OS menu everywhere, matching existing conventions.

## Breaking changes

None.

## Tests

- `tests/unit/diff-clipboard.test.ts` (new): unit coverage for `getDiffSelectionText` / `copyDiffSelection`, including the `preferredEditor` precedence used by the context-menu path and clipboard-write-rejection handling.
- `tests/ui/changes-panel-diffviewer-copy.spec.ts` (new): UI-tier coverage driving a real Monaco `DiffEditor` - Ctrl+C copy and its focus gate, `diff-copy`/`diff-select-all` resolving the correct pane by click point, and scoping to the correct `DiffViewer` instance.
- `tests/unit/keybindings-registry.test.ts`: existing suite confirms the new `changes.copy` entry (non-rebindable) introduces no conflicts.
- CI: typecheck, lint, unit, UI, and E2E checks below.

Generated with [Claude Code](https://claude.com/claude-code)
