### PR TITLE
feat(conversation): smooth long transcripts, in-viewer search, open-at-position

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,7 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 | `dev:createEphemeralProject` | invoke | Clone the current worktree into an isolated, throwaway preview project (TestHarness "Create Project" button); fills its working tree in the background and returns the usable `Project` |
 | `dev:seedGitChanges` | invoke | Seed a realistic all-scopes / all-statuses git changeset (committed, staged, working) into each ephemeral preview repo (active task worktrees plus the project) so the Changes tab has content to exercise; silently skips any path outside the preview-projects root. Returns `DevSeedGitChangesResult` |
 | `dev:seedEmbeddingBacklog` | invoke | Seed synthetic pending chunks (`embedded_model = NULL`) into the current project's conversation-memory index via the real chunk-write path, then flag the project dirty (TestHarness "Seed Embedding Backlog" button) - a fast path to a realistic embedding backlog for exercising the central embedding engine's drain loop without needing that many real agent turns. Returns `DevSeedEmbeddingBacklogResult` |
+| `dev:seedLargeConversation` | invoke | Seed a throwaway task backed by a synthetic multi-thousand-turn Claude JSONL transcript (TestHarness "Seed Large Conversation" button; appends more turns on re-click) and open it in the Conversation viewer, for exercising the viewer's virtualization, in-viewer search, and open-at-position behavior against a realistic long transcript. Returns `DevSeedLargeConversationResult` |
 
 ### Project Groups (6 channels)
 | Channel | Pattern | Purpose |

--- a/src/devtools/main/seed-large-conversation.ts
+++ b/src/devtools/main/seed-large-conversation.ts
@@ -1,0 +1,323 @@
+/**
+ * Dev-only: seed a throwaway task + session backed by a REAL synthetic Claude
+ * Code session JSONL transcript file on disk, thousands of turns long, so a
+ * developer can open the Conversation viewer against a huge transcript and
+ * exercise scrolling/search/performance without hand-running an agent for
+ * hours to accumulate that much real history.
+ *
+ * The generated lines are shaped exactly like `parseClaudeTranscript`
+ * (`src/main/agent/adapters/claude/transcript-parser.ts`) expects: plain-text
+ * user turns, assistant text turns, assistant tool_use turns paired with a
+ * user-role tool_result turn, occasional extended-thinking turns (two lines
+ * sharing one `message.id`, usage attributed once), and occasional
+ * `compact_boundary` system entries - so the viewer renders a realistic,
+ * varied mix rather than a flat wall of identical lines.
+ *
+ * Re-clicking the harness button APPENDS more turns to the SAME file instead
+ * of starting a new one, continuing the sequence numbering from where the
+ * previous seed left off - this is deliberate: it gives the incremental-parse
+ * code path (built separately) a real growing file to parse against, not just
+ * a fresh one each time.
+ *
+ * Build-excluded from production: imported only behind `__KANGENTIC_DEV__`
+ * guards (src/main/index.ts), so esbuild dead-code elimination drops this
+ * module from prod bundles. See `.claude/rules/dev-tooling-build-exclusion.md`.
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { ipcMain } from 'electron';
+import { IPC } from '../../shared/ipc-channels';
+import { getProjectDb } from '../../main/db/database';
+import { TaskRepository } from '../../main/db/repositories/task-repository';
+import { SwimlaneRepository } from '../../main/db/repositories/swimlane-repository';
+import { SessionRepository } from '../../main/db/repositories/session-repository';
+import { locateClaudeTranscriptFile } from '../../main/agent/adapters/claude/transcript-parser';
+import type { DevSeedLargeConversationResult } from '../../shared/types';
+import type { IpcContext } from '../../main/ipc/ipc-context';
+
+// Word banks for varied, meaningless-but-plausible prompt/response text. Cycled
+// with the sequence number so nothing repeats exactly, without needing a real
+// language model to generate filler.
+const PROMPT_TOPICS = [
+  'the retry backoff logic', 'the session lifecycle state machine', 'the terminal scrollback buffer',
+  'the swimlane drag handler', 'the embedding backlog drain loop', 'the worktree cleanup path',
+  'the IPC channel for task moves', 'the transcript parser', 'the activity engine heuristics',
+  'the PTY resize debouncing', 'the board config round-trip', 'the settings panel tabs',
+];
+const PROMPT_ACTIONS = [
+  'Can you look into', 'Please investigate', 'I noticed an issue with', 'Take a pass at fixing',
+  'Can you refactor', 'Let us add a test for', 'Please review', 'I want to understand',
+];
+const RESPONSE_OPENERS = [
+  'I looked into this and found', 'Here is what I found:', 'After tracing through the code,',
+  'This turned out to be caused by', 'I made a small change to fix this:', 'The root cause was',
+  'I have updated the implementation so that', 'Digging into the logs,',
+];
+const RESPONSE_DETAILS = [
+  'a stale closure over the session id', 'a race between the resize handler and the reconnect path',
+  'an off-by-one in the pagination cursor', 'a missing null guard on the swimlane lookup',
+  'the debounce window firing before the last write flushed', 'a mismatched event name between the hook and the bridge',
+  'the cache not invalidating after the project switch', 'an unhandled rejection swallowed by the retry wrapper',
+];
+
+const BASH_COMMANDS = ['npm run typecheck', 'git status', 'npx vitest run tests/unit/session-lifecycle.test.ts', 'git diff --stat'];
+const EDIT_FILES = ['src/main/pty/session-manager.ts', 'src/renderer/stores/session-store.ts', 'src/main/transition-engine/engine.ts'];
+
+function pick<T>(pool: T[], seed: number): T {
+  return pool[seed % pool.length];
+}
+
+/** Deterministic, stable uuid-shaped id (the parser only requires a string). */
+function seedUuid(runIndex: number, seq: number, suffix: string): string {
+  return `dev-seed-${runIndex}-${seq}-${suffix}`;
+}
+
+/** ISO timestamp `secondsFromStart` seconds after `startMs`, backdated so the
+ *  whole run reads as having happened over a realistic span rather than all
+ *  landing in the same millisecond. */
+function tsAt(startMs: number, secondsFromStart: number): string {
+  return new Date(startMs + secondsFromStart * 1000).toISOString();
+}
+
+/**
+ * Generate `turnCount` JSONL line strings shaped like a real Claude Code
+ * session transcript, continuing sequence numbering from `startSeq` (so a
+ * re-click's appended lines read as a continuation, not a restart).
+ *
+ * Cycles through a repeating pattern: a user prompt, an assistant text reply,
+ * every third turn an assistant tool_use + a paired user tool_result, every
+ * ~40th turn an extended-thinking pair (two lines sharing one message id, one
+ * shared `usage`), and every ~200th turn a `system` compaction boundary.
+ */
+export function generateSyntheticClaudeJsonlLines(turnCount: number, runIndex: number, startSeq: number): string[] {
+  const lines: string[] = [];
+  // Backdate the whole run: turns land a few seconds apart, oldest first, so
+  // the run reads as having happened over minutes/hours rather than instantly.
+  const startMs = Date.now() - turnCount * 5000;
+
+  for (let turnOffset = 0; turnOffset < turnCount; turnOffset += 1) {
+    const seq = startSeq + turnOffset;
+    const secondsFromStart = turnOffset * 5;
+
+    if (seq > 0 && seq % 200 === 0) {
+      lines.push(JSON.stringify({
+        type: 'system',
+        subtype: 'compact_boundary',
+        uuid: seedUuid(runIndex, seq, 'compact'),
+        timestamp: tsAt(startMs, secondsFromStart),
+        content: 'Conversation compacted',
+        compactMetadata: { trigger: 'auto', preTokens: 150000 + seq },
+      }));
+      continue;
+    }
+
+    // User prompt.
+    const promptText = `${pick(PROMPT_ACTIONS, seq)} ${pick(PROMPT_TOPICS, seq + 1)} (turn ${seq}).`;
+    lines.push(JSON.stringify({
+      type: 'user',
+      uuid: seedUuid(runIndex, seq, 'user'),
+      timestamp: tsAt(startMs, secondsFromStart),
+      message: { role: 'user', content: promptText },
+    }));
+
+    if (seq > 0 && seq % 40 === 0) {
+      // Extended-thinking turn: a thinking-only line and the text line share one
+      // message.id; usage is attributed once, on the text line (the parser
+      // drops empty thinking blocks, so the thinking line itself yields no
+      // entry, but this still exercises the "one message id, two lines" path).
+      const messageId = `msg-${seedUuid(runIndex, seq, 'thinking')}`;
+      lines.push(JSON.stringify({
+        type: 'assistant',
+        uuid: seedUuid(runIndex, seq, 'thinking-block'),
+        timestamp: tsAt(startMs, secondsFromStart + 1),
+        message: {
+          id: messageId,
+          model: 'claude-opus-4-8',
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: `Weighing a few approaches to ${pick(PROMPT_TOPICS, seq)}.` }],
+        },
+      }));
+      const responseText = `${pick(RESPONSE_OPENERS, seq)} ${pick(RESPONSE_DETAILS, seq + 2)}.`;
+      lines.push(JSON.stringify({
+        type: 'assistant',
+        uuid: seedUuid(runIndex, seq, 'thinking-text'),
+        timestamp: tsAt(startMs, secondsFromStart + 2),
+        message: {
+          id: messageId,
+          model: 'claude-opus-4-8',
+          role: 'assistant',
+          content: [{ type: 'text', text: responseText }],
+          usage: { input_tokens: 1800 + seq, output_tokens: 260 + seq, cache_creation_input_tokens: 0, cache_read_input_tokens: 4200 },
+        },
+      }));
+      continue;
+    }
+
+    if (seq % 3 === 0) {
+      // Assistant tool_use turn, paired with a user-role tool_result turn.
+      const toolUseId = `toolu-${seedUuid(runIndex, seq, 'tool')}`;
+      const useBashTool = seq % 2 === 0;
+      const toolBlock = useBashTool
+        ? { type: 'tool_use', id: toolUseId, name: 'Bash', input: { command: pick(BASH_COMMANDS, seq) } }
+        : { type: 'tool_use', id: toolUseId, name: 'Edit', input: { file_path: pick(EDIT_FILES, seq), old_string: 'const previous = false;', new_string: 'const previous = true;' } };
+      lines.push(JSON.stringify({
+        type: 'assistant',
+        uuid: seedUuid(runIndex, seq, 'assistant-tool'),
+        timestamp: tsAt(startMs, secondsFromStart + 1),
+        message: {
+          id: `msg-${seedUuid(runIndex, seq, 'tool')}`,
+          model: 'claude-opus-4-8',
+          role: 'assistant',
+          content: [toolBlock],
+          usage: { input_tokens: 1200 + seq, output_tokens: 90 + seq, cache_creation_input_tokens: 0, cache_read_input_tokens: 3100 },
+        },
+      }));
+      const resultText = useBashTool
+        ? 'Command exited with code 0.'
+        : `Applied 1 edit to ${pick(EDIT_FILES, seq)}.`;
+      lines.push(JSON.stringify({
+        type: 'user',
+        uuid: seedUuid(runIndex, seq, 'tool-result'),
+        timestamp: tsAt(startMs, secondsFromStart + 2),
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: toolUseId, content: resultText, is_error: false }],
+        },
+      }));
+      continue;
+    }
+
+    // Plain assistant text reply.
+    const responseText = `${pick(RESPONSE_OPENERS, seq + 1)} ${pick(RESPONSE_DETAILS, seq)}.`;
+    lines.push(JSON.stringify({
+      type: 'assistant',
+      uuid: seedUuid(runIndex, seq, 'assistant-text'),
+      timestamp: tsAt(startMs, secondsFromStart + 1),
+      message: {
+        id: `msg-${seedUuid(runIndex, seq, 'text')}`,
+        model: 'claude-opus-4-8',
+        role: 'assistant',
+        content: [{ type: 'text', text: responseText }],
+        usage: { input_tokens: 900 + seq, output_tokens: 140 + seq, cache_creation_input_tokens: 0, cache_read_input_tokens: 2000 },
+      },
+    }));
+  }
+
+  return lines;
+}
+
+/** The task/session this process is currently seeding into, and how many
+ *  turns have been written so far - replaced whenever the caller's current
+ *  project changes, so a re-click after switching projects starts fresh
+ *  rather than appending into the wrong project's stale file path. */
+interface CurrentSeed {
+  projectId: string;
+  taskId: string;
+  sessionId: string;
+  agentSessionId: string;
+  filePath: string;
+  totalTurns: number;
+}
+
+let currentSeed: CurrentSeed | null = null;
+// Module state; resets when the main process restarts. Distinguishes a fresh
+// seed from a continuation so appended lines get non-colliding uuids/ids
+// (paired with `totalTurns` as the starting sequence number).
+let seedRunIndex = 0;
+
+/**
+ * Seed (or append to) a throwaway "[DEV SEED] Large conversation stress test"
+ * task/session in the current project, writing `turnCount` more synthetic
+ * transcript turns to its Claude JSONL file. Throws when no project is open.
+ */
+export async function seedLargeConversation(context: IpcContext, turnCount: number): Promise<DevSeedLargeConversationResult> {
+  const projectId = context.currentProjectId;
+  const projectPath = context.currentProjectPath;
+  if (!projectId || !projectPath) {
+    throw new Error('Open a project first to seed a large conversation');
+  }
+
+  const db = getProjectDb(projectId);
+
+  if (!currentSeed || currentSeed.projectId !== projectId) {
+    seedRunIndex += 1;
+    const todoSwimlane = new SwimlaneRepository(db).list().find((lane) => lane.role === 'todo');
+    if (!todoSwimlane) {
+      throw new Error('No To Do column to seed a large conversation task into');
+    }
+
+    const task = new TaskRepository(db).create({
+      title: '[DEV SEED] Large conversation stress test',
+      description: 'Throwaway task backing a synthetic multi-thousand-turn Claude transcript, for '
+        + 'exercising the Conversation viewer\'s scrolling/search/performance on a huge file. '
+        + 'Created by the Test Harness "Seed Large Conversation" button.',
+      swimlane_id: todoSwimlane.id,
+    });
+
+    const now = new Date().toISOString();
+    const sessionId = crypto.randomUUID();
+    const agentSessionId = crypto.randomUUID();
+    new SessionRepository(db).insert({
+      id: sessionId,
+      task_id: task.id,
+      session_type: 'claude_agent',
+      isolated_swimlane_id: null,
+      agent_session_id: agentSessionId,
+      command: '',
+      cwd: projectPath,
+      permission_mode: null,
+      prompt: null,
+      status: 'exited',
+      exit_code: 0,
+      started_at: now,
+      suspended_at: now,
+      exited_at: now,
+      suspended_by: null,
+    });
+
+    const filePath = locateClaudeTranscriptFile(agentSessionId, projectPath);
+    currentSeed = { projectId, taskId: task.id, sessionId, agentSessionId, filePath, totalTurns: 0 };
+  }
+
+  const seed = currentSeed;
+  const lines = generateSyntheticClaudeJsonlLines(turnCount, seedRunIndex, seed.totalTurns);
+  const jsonlPayload = `${lines.join('\n')}\n`;
+
+  await fs.promises.mkdir(path.dirname(seed.filePath), { recursive: true });
+  let existingContent = '';
+  try {
+    existingContent = await fs.promises.readFile(seed.filePath, 'utf-8');
+  } catch {
+    // First write for this file.
+  }
+  const needsLeadingNewline = existingContent.length > 0 && !existingContent.endsWith('\n');
+  await fs.promises.appendFile(seed.filePath, `${needsLeadingNewline ? '\n' : ''}${jsonlPayload}`, 'utf-8');
+
+  seed.totalTurns += turnCount;
+
+  return {
+    sessionId: seed.sessionId,
+    taskId: seed.taskId,
+    turnsAdded: turnCount,
+    totalTurns: seed.totalTurns,
+    filePath: seed.filePath,
+  };
+}
+
+let devIpcRegistered = false;
+
+/**
+ * Register the dev-only IPC behind the TestHarness "Seed Large Conversation"
+ * button. Idempotent.
+ */
+export function registerSeedLargeConversationDevIpc(getContext: () => IpcContext | null): void {
+  if (devIpcRegistered) return;
+  devIpcRegistered = true;
+  ipcMain.handle(IPC.DEV_SEED_LARGE_CONVERSATION, (_event, turnCount: number): Promise<DevSeedLargeConversationResult> => {
+    const context = getContext();
+    if (!context) throw new Error('IPC not initialized');
+    return seedLargeConversation(context, turnCount);
+  });
+}

--- a/src/devtools/renderer/TestHarness.tsx
+++ b/src/devtools/renderer/TestHarness.tsx
@@ -16,10 +16,11 @@
  */
 
 import { useState } from 'react';
-import { Plus, FolderPlus, FileDiff, Database } from 'lucide-react';
+import { Plus, FolderPlus, FileDiff, Database, MessagesSquare } from 'lucide-react';
 import { useBoardStore } from '../../renderer/stores/board-store';
 import { useProjectStore } from '../../renderer/stores/project-store';
 import { useToastStore } from '../../renderer/stores/toast-store';
+import { useSessionStore } from '../../renderer/stores/session-store';
 
 /** Default seed count for "Seed Embedding Backlog": large enough to force
  *  hundreds of real drain-loop round-robin iterations against the live embed
@@ -27,6 +28,11 @@ import { useToastStore } from '../../renderer/stores/toast-store';
  *  ballpark as a real one-time model-switch backfill, while staying well
  *  short of a full multi-hour history backfill. */
 const EMBEDDING_BACKLOG_SEED_COUNT = 3000;
+
+/** Turns written per click of "Seed Large Conversation": large enough to
+ *  stress the Conversation viewer's virtualization/scrolling/search on a
+ *  huge file, without hanging the UI for many seconds on a single click. */
+const LARGE_CONVERSATION_SEED_TURNS = 3000;
 
 // Lorem source. Titles/descriptions are deliberately meaningless so that
 // dragging a seeded task to an executing column gives the agent nothing real to
@@ -126,6 +132,7 @@ export function TestHarness() {
   const [creatingProject, setCreatingProject] = useState(false);
   const [seeding, setSeeding] = useState(false);
   const [seedingBacklog, setSeedingBacklog] = useState(false);
+  const [seedingConversation, setSeedingConversation] = useState(false);
 
   const handleCreateTask = async () => {
     const todoSwimlane = useBoardStore.getState().swimlanes.find((lane) => lane.role === 'todo');
@@ -249,6 +256,40 @@ export function TestHarness() {
     }
   };
 
+  // Dev-only: seed (or, on a re-click for the same project, append to) a
+  // throwaway task + session backed by a real synthetic multi-thousand-turn
+  // Claude session JSONL transcript file, so the Conversation viewer can be
+  // exercised on a huge transcript without running a real agent for hours.
+  // Opens the seeded conversation immediately so there is no need to hunt
+  // for the throwaway task on the board.
+  const handleSeedLargeConversation = async () => {
+    const project = useProjectStore.getState().currentProject;
+    if (!project) {
+      useToastStore.getState().addToast({ message: 'Open a project first to seed a large conversation', variant: 'warning' });
+      return;
+    }
+    setSeedingConversation(true);
+    try {
+      const result = await window.electronAPI.dev?.seedLargeConversation(LARGE_CONVERSATION_SEED_TURNS);
+      if (!result) {
+        useToastStore.getState().addToast({ message: 'Seeding a large conversation is dev-preview only', variant: 'warning' });
+        return;
+      }
+      useSessionStore.getState().setConversationSessionId(result.sessionId);
+      useToastStore.getState().addToast({
+        message: `Seeded ${result.turnsAdded} turns (${result.totalTurns} total) into ${result.filePath}`,
+        variant: 'success',
+      });
+    } catch (error) {
+      useToastStore.getState().addToast({
+        message: `Failed to seed large conversation: ${error instanceof Error ? error.message : 'unknown error'}`,
+        variant: 'error',
+      });
+    } finally {
+      setSeedingConversation(false);
+    }
+  };
+
   return (
     <div
       className="fixed left-6 top-1/2 -translate-y-1/2 z-[2147483600] flex flex-col gap-1.5 rounded-lg border border-edge bg-surface-raised/95 p-1.5 shadow-2xl backdrop-blur"
@@ -296,6 +337,17 @@ export function TestHarness() {
       >
         <Database size={16} />
         {seedingBacklog ? 'Seeding...' : 'Seed Embedding Backlog'}
+      </button>
+      <button
+        type="button"
+        onClick={handleSeedLargeConversation}
+        disabled={seedingConversation}
+        className="flex items-center gap-1.5 rounded-md border border-edge bg-surface-raised px-3.5 py-2 text-[13px] font-medium text-fg hover:bg-surface disabled:opacity-50 transition-colors"
+        data-testid="dev-seed-large-conversation"
+        title={`Seed ${LARGE_CONVERSATION_SEED_TURNS} synthetic transcript turns (append on re-click) and open it in the Conversation viewer`}
+      >
+        <MessagesSquare size={16} />
+        {seedingConversation ? 'Seeding...' : 'Seed Large Conversation'}
       </button>
     </div>
   );

--- a/src/main/agent/adapters/claude/transcript-parser.ts
+++ b/src/main/agent/adapters/claude/transcript-parser.ts
@@ -49,188 +49,368 @@ export function claudeProjectSlug(cwd: string): string {
 }
 
 /**
+ * Parse one JSONL line into zero or more transcript entries, appending to
+ * `entries` and mutating `usageAttributedMessageIds` in place. Extracted so
+ * both the full-file parse and the incremental append parse below share
+ * IDENTICAL per-line semantics - the only difference between them is which
+ * bytes get fed to this function and whether `entries`/`usageAttributedMessageIds`
+ * start fresh or carry over from a prior increment.
+ */
+function parseTranscriptLine(
+  line: string,
+  entries: TranscriptEntry[],
+  usageAttributedMessageIds: Set<string>,
+): void {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (!isRecord(raw)) return;
+
+  const uuid = typeof raw.uuid === 'string' ? raw.uuid : '';
+  const ts = parseTimestamp(raw.timestamp);
+  const type = raw.type;
+
+  // Conversation-compaction boundary: a system entry Claude writes when it
+  // compacts the context. Surface it explicitly so the post-compaction
+  // summary that follows is not read as a fresh start.
+  if (type === 'system' && raw.subtype === 'compact_boundary') {
+    entries.push({
+      kind: 'system',
+      uuid,
+      ts,
+      subtype: 'compaction',
+      text: describeCompactBoundary(raw),
+    });
+    return;
+  }
+
+  if (type === 'user') {
+    // Skip Claude's own meta injections (skill preambles, queued-message
+    // bookkeeping). They are not real user turns and otherwise render as
+    // "## User" noise.
+    if (raw.isMeta === true) return;
+
+    const message = raw.message;
+    if (!isRecord(message)) return;
+    const messageContent = message.content;
+
+    // Collect the user-authored text (string shorthand or text blocks) and
+    // emit any tool_result blocks the SDK injected as synthetic user turns.
+    let userText = '';
+    if (typeof messageContent === 'string') {
+      userText = messageContent;
+    } else if (Array.isArray(messageContent)) {
+      const textParts: string[] = [];
+      for (const block of messageContent) {
+        if (!isRecord(block)) continue;
+        if (block.type === 'tool_result') {
+          entries.push({
+            kind: 'tool_result',
+            uuid,
+            ts,
+            toolUseId: typeof block.tool_use_id === 'string' ? block.tool_use_id : '',
+            content: stringifyToolResultContent(block.content),
+            isError: block.is_error === true,
+          });
+        } else if (block.type === 'text' && typeof block.text === 'string') {
+          textParts.push(block.text);
+        }
+      }
+      userText = textParts.join('\n');
+    }
+
+    // Compaction summary: Claude writes the post-compaction recap as a
+    // single user entry flagged isCompactSummary. Surface it as a
+    // compaction system entry, not a "## User" turn.
+    if (raw.isCompactSummary === true) {
+      if (userText.length > 0) {
+        entries.push({ kind: 'system', uuid, ts, subtype: 'compaction', text: userText });
+      }
+      return;
+    }
+
+    if (userText.length === 0) return;
+
+    // Slash-command invocations: when the ENTIRE message is command XML,
+    // collapse it to a compact marker (or drop empty local stdout) instead
+    // of rendering raw <command-name>/<local-command-stdout> tags.
+    const commandEntry = parseCommandEntry(userText, uuid, ts);
+    if (commandEntry !== null) {
+      if (commandEntry !== 'drop') entries.push(commandEntry);
+      return;
+    }
+
+    // Strip <system-reminder> spans from real user text; drop the entry
+    // entirely if nothing meaningful remains (a reminder-only injection).
+    const stripped = stripSystemReminders(userText);
+    if (stripped.length === 0) return;
+    entries.push({ kind: 'user', uuid, ts, text: stripped });
+    return;
+  }
+
+  if (type === 'assistant') {
+    const message = raw.message;
+    if (!isRecord(message)) return;
+    const model = typeof message.model === 'string' ? message.model : undefined;
+    const messageId = typeof message.id === 'string' ? message.id : null;
+
+    const blocks: TranscriptBlock[] = [];
+
+    const messageContent = message.content;
+    if (Array.isArray(messageContent)) {
+      for (const block of messageContent) {
+        if (!isRecord(block)) continue;
+        if (block.type === 'text' && typeof block.text === 'string') {
+          blocks.push({ type: 'text', text: block.text });
+        } else if (block.type === 'thinking') {
+          // Real Claude Code session JSONL never persists thinking text
+          // (it stores only an encrypted `signature`). Empty thinking
+          // blocks would render as useless empty disclosures, so skip
+          // them. Kept the branch in case a future Claude version starts
+          // persisting plaintext thinking - then it will be captured.
+          if (typeof block.thinking === 'string' && block.thinking.length > 0) {
+            blocks.push({ type: 'thinking', text: block.thinking });
+          }
+        } else if (block.type === 'tool_use') {
+          blocks.push({
+            type: 'tool_use',
+            id: typeof block.id === 'string' ? block.id : '',
+            name: typeof block.name === 'string' ? block.name : 'tool',
+            input: block.input,
+          });
+        }
+      }
+    }
+
+    // A line that yields no blocks produces no entry, so skip it BEFORE
+    // claiming this message's usage. With extended thinking, Claude writes a
+    // turn as two lines under one message id - a thinking-only line (which we
+    // drop, since persisted thinking is empty) followed by the text line. If
+    // usage were claimed on the dropped thinking line, the message id would be
+    // marked "attributed" and the following text entry (same id) would be
+    // deduped out of its own usage, silently losing the whole turn's per-turn
+    // tokens. Claiming usage only when an entry is actually emitted keeps it on
+    // the first VISIBLE line of each message id.
+    if (blocks.length === 0) return;
+
+    // Attribute this turn's usage to exactly one emitted entry per message id
+    // (a single message can still span several emitted lines, e.g. text +
+    // tool_use); the first emitted line claims it so a burn-rate sum never
+    // double-counts a turn. Persisted on `usageAttributedMessageIds` across
+    // incremental append calls (not just within one parse), so a turn split
+    // across TWO SEPARATE poll ticks (the thinking-only line landing in one
+    // increment, the text line in the next) still attributes usage exactly
+    // once.
+    let usage: TranscriptTurnUsage | undefined;
+    if (!messageId || !usageAttributedMessageIds.has(messageId)) {
+      usage = extractTurnUsage(message);
+      if (usage && messageId) usageAttributedMessageIds.add(messageId);
+    }
+
+    entries.push(
+      usage
+        ? { kind: 'assistant', uuid, ts, model, usage, blocks }
+        : { kind: 'assistant', uuid, ts, model, blocks },
+    );
+  }
+}
+
+/** Per-file incremental-append parse state, keyed by the transcript's
+ *  absolute path. A resume replay writes to a NEW path (a fresh agent session
+ *  id), so its state starts clean and never mixes with its parent's. */
+interface IncrementalParseState {
+  mtimeMs: number;
+  size: number;
+  /** Bytes fully consumed (parsed or explicitly carried) as of this state. */
+  byteOffset: number;
+  /** Trailing bytes after the last complete `\n` seen so far, not yet part
+   *  of a complete line - re-prepended to the next increment's read. */
+  carry: Buffer;
+  entries: TranscriptEntry[];
+  usageAttributedMessageIds: Set<string>;
+}
+
+const incrementalStateByPath = new Map<string, IncrementalParseState>();
+
+/** Cap on the number of distinct transcript files whose incremental-parse
+ *  state is retained, mirroring the LRU caps on the sibling caches introduced
+ *  alongside this one (`CACHE_LIMIT` in `transcript-cache.ts`,
+ *  `STITCH_MEMO_LIMIT` in `transcript-service.ts`). Each record holds a full
+ *  `entries` array, so an uncapped map would grow with every distinct session
+ *  ever parsed over the process lifetime (conversation viewer, Transcript tab,
+ *  MCP `get_transcript`). */
+const INCREMENTAL_STATE_LIMIT = 32;
+
+/** Re-insert `state` at the most-recently-used end and evict the oldest past
+ *  the cap. Map iteration order is insertion order, so a delete-then-set is
+ *  enough for LRU without a separate list (same idiom as `transcript-cache`'s
+ *  `touch`). Called on every parse of a path so an actively-growing session
+ *  stays hot and is never evicted out from under its own live poll. */
+function touchIncrementalState(filePath: string, state: IncrementalParseState): void {
+  incrementalStateByPath.delete(filePath);
+  incrementalStateByPath.set(filePath, state);
+  while (incrementalStateByPath.size > INCREMENTAL_STATE_LIMIT) {
+    const oldestPath = incrementalStateByPath.keys().next().value;
+    if (oldestPath === undefined) break;
+    incrementalStateByPath.delete(oldestPath);
+  }
+}
+
+/** Splits `buffer` at the LAST `\n` byte (0x0A) it contains. UTF-8 continuation
+ *  bytes are always >= 0x80, so 0x0A can only ever be a genuine newline,
+ *  never the tail of a multi-byte character - a byte-level split is safe.
+ *  `completeLinesText` retains any `\r` immediately preceding a `\n` (a CRLF
+ *  file, possible on Windows where the team dogfoods); downstream
+ *  `parseTranscriptLine` runs `JSON.parse`, which tolerates the trailing `\r`
+ *  as insignificant whitespace, so the byte-level split needs no `\r` strip to
+ *  match the full-parse path's `split(/\r?\n/)`. */
+function splitCompleteLines(buffer: Buffer): { completeLinesText: string; carry: Buffer } {
+  let lastNewlineIndex = -1;
+  for (let index = buffer.length - 1; index >= 0; index -= 1) {
+    if (buffer[index] === 0x0a) {
+      lastNewlineIndex = index;
+      break;
+    }
+  }
+  if (lastNewlineIndex === -1) {
+    return { completeLinesText: '', carry: Buffer.from(buffer) };
+  }
+  return {
+    completeLinesText: buffer.subarray(0, lastNewlineIndex + 1).toString('utf-8'),
+    carry: Buffer.from(buffer.subarray(lastNewlineIndex + 1)),
+  };
+}
+
+/** Reads exactly the bytes in `[start, end)` from `filePath` via a single
+ *  positioned read, so an append-parse never re-reads bytes already consumed
+ *  by a prior call. */
+async function readByteRange(filePath: string, start: number, end: number): Promise<Buffer> {
+  const length = end - start;
+  if (length <= 0) return Buffer.alloc(0);
+  const handle = await fs.open(filePath, 'r');
+  try {
+    const buffer = Buffer.alloc(length);
+    const { bytesRead } = await handle.read(buffer, 0, length, start);
+    if (bytesRead < length) {
+      // The file was truncated/rewritten between the caller's fs.stat and this
+      // positioned read (a concurrent rotate). The unread tail of `buffer`
+      // stays zero-filled and would corrupt the next increment's carry, so
+      // throw to trigger the caller's fall-through to a full reparse rather
+      // than silently returning NUL bytes.
+      throw new Error(`short read on ${filePath}: expected ${length} bytes, got ${bytesRead}`);
+    }
+    return buffer;
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
  * Parse Claude Code's native session JSONL into a list of full transcript
  * entries (user prompts, assistant turns with text/thinking/tool_use blocks,
- * and tool results). Runs on demand from the renderer's Transcript tab.
+ * and tool results). Runs on demand from the renderer's Transcript tab and
+ * (wrapped in the stat-validated cache) the conversation viewer's live poll.
  *
  * Claude's authoritative live telemetry comes from the hook-driven
  * `statusFile` pipeline (status.json + events.jsonl). The native session
  * JSONL is a secondary source: read on demand here (Transcript tab,
  * lifetime-token refinement) and tailed as a background-session fallback by
  * `session-history-parser.ts` until status.json starts flowing.
+ *
+ * Incremental append: when this path's size GREW and its mtime did not go
+ * backwards since the last call, only the new bytes `[byteOffset, size)` are
+ * read and parsed, appended onto the SAME `entries` array reference from last
+ * time - the file-level cache in `transcript-cache.ts` relies on this array
+ * staying referentially append-only so its own stat-validated cache and the
+ * task-level stitch memo both see a stable identity for unrelated sessions.
+ * Any other case (first call for this path, a shrink, mtime going backwards,
+ * or a failed incremental read) falls back to a full re-parse of the whole
+ * file, which also resets the incremental state.
  */
 export async function parseClaudeTranscript(filePath: string): Promise<TranscriptEntry[]> {
+  let stat: { mtimeMs: number; size: number };
+  try {
+    stat = await fs.stat(filePath);
+  } catch {
+    incrementalStateByPath.delete(filePath);
+    return [];
+  }
+
+  const previous = incrementalStateByPath.get(filePath);
+  const canIncrement = !!previous && stat.size > previous.size && stat.mtimeMs >= previous.mtimeMs;
+
+  if (canIncrement && previous) {
+    try {
+      // `previous.byteOffset` tracks how much of the file has been READ so
+      // far (not how much has been fully consumed into complete lines) -
+      // `previous.carry` already holds whatever trailing partial bytes that
+      // last read did not complete, so reading starts strictly AFTER it,
+      // never re-reading (and thereby duplicating) those carried bytes.
+      const appended = await readByteRange(filePath, previous.byteOffset, stat.size);
+      const combined = Buffer.concat([previous.carry, appended]);
+      const { completeLinesText, carry } = splitCompleteLines(combined);
+      if (completeLinesText.length > 0) {
+        for (const line of completeLinesText.split('\n')) {
+          if (line.length === 0) continue;
+          parseTranscriptLine(line, previous.entries, previous.usageAttributedMessageIds);
+        }
+      }
+      previous.mtimeMs = stat.mtimeMs;
+      previous.size = stat.size;
+      previous.byteOffset = stat.size;
+      previous.carry = carry;
+      touchIncrementalState(filePath, previous);
+      return previous.entries;
+    } catch {
+      // Tolerate a read race (a concurrent truncate/rotate between the stat
+      // and the read) by falling through to a full reparse below.
+    }
+  }
+
+  // Full (re)parse: first call for this path, a shrink/rewind, or a
+  // just-failed incremental read.
   let content: string;
   try {
     content = await fs.readFile(filePath, 'utf-8');
   } catch {
+    incrementalStateByPath.delete(filePath);
     return [];
   }
 
   const entries: TranscriptEntry[] = [];
-  const lines = content.split(/\r?\n/);
-  // A single assistant message (one `message.id`) can be written across several
-  // JSONL lines; its `usage` must be attributed to exactly one turn, not every
-  // line, or per-turn burn analysis double-counts it. Track which message ids
-  // have already carried their usage onto an entry.
   const usageAttributedMessageIds = new Set<string>();
-
-  for (const line of lines) {
+  for (const line of content.split(/\r?\n/)) {
     if (line.length === 0) continue;
-    let raw: unknown;
-    try {
-      raw = JSON.parse(line);
-    } catch {
-      continue;
-    }
-    if (!isRecord(raw)) continue;
-
-    const uuid = typeof raw.uuid === 'string' ? raw.uuid : '';
-    const ts = parseTimestamp(raw.timestamp);
-    const type = raw.type;
-
-    // Conversation-compaction boundary: a system entry Claude writes when it
-    // compacts the context. Surface it explicitly so the post-compaction
-    // summary that follows is not read as a fresh start.
-    if (type === 'system' && raw.subtype === 'compact_boundary') {
-      entries.push({
-        kind: 'system',
-        uuid,
-        ts,
-        subtype: 'compaction',
-        text: describeCompactBoundary(raw),
-      });
-      continue;
-    }
-
-    if (type === 'user') {
-      // Skip Claude's own meta injections (skill preambles, queued-message
-      // bookkeeping). They are not real user turns and otherwise render as
-      // "## User" noise.
-      if (raw.isMeta === true) continue;
-
-      const message = raw.message;
-      if (!isRecord(message)) continue;
-      const messageContent = message.content;
-
-      // Collect the user-authored text (string shorthand or text blocks) and
-      // emit any tool_result blocks the SDK injected as synthetic user turns.
-      let userText = '';
-      if (typeof messageContent === 'string') {
-        userText = messageContent;
-      } else if (Array.isArray(messageContent)) {
-        const textParts: string[] = [];
-        for (const block of messageContent) {
-          if (!isRecord(block)) continue;
-          if (block.type === 'tool_result') {
-            entries.push({
-              kind: 'tool_result',
-              uuid,
-              ts,
-              toolUseId: typeof block.tool_use_id === 'string' ? block.tool_use_id : '',
-              content: stringifyToolResultContent(block.content),
-              isError: block.is_error === true,
-            });
-          } else if (block.type === 'text' && typeof block.text === 'string') {
-            textParts.push(block.text);
-          }
-        }
-        userText = textParts.join('\n');
-      }
-
-      // Compaction summary: Claude writes the post-compaction recap as a
-      // single user entry flagged isCompactSummary. Surface it as a
-      // compaction system entry, not a "## User" turn.
-      if (raw.isCompactSummary === true) {
-        if (userText.length > 0) {
-          entries.push({ kind: 'system', uuid, ts, subtype: 'compaction', text: userText });
-        }
-        continue;
-      }
-
-      if (userText.length === 0) continue;
-
-      // Slash-command invocations: when the ENTIRE message is command XML,
-      // collapse it to a compact marker (or drop empty local stdout) instead
-      // of rendering raw <command-name>/<local-command-stdout> tags.
-      const commandEntry = parseCommandEntry(userText, uuid, ts);
-      if (commandEntry !== null) {
-        if (commandEntry !== 'drop') entries.push(commandEntry);
-        continue;
-      }
-
-      // Strip <system-reminder> spans from real user text; drop the entry
-      // entirely if nothing meaningful remains (a reminder-only injection).
-      const stripped = stripSystemReminders(userText);
-      if (stripped.length === 0) continue;
-      entries.push({ kind: 'user', uuid, ts, text: stripped });
-      continue;
-    }
-
-    if (type === 'assistant') {
-      const message = raw.message;
-      if (!isRecord(message)) continue;
-      const model = typeof message.model === 'string' ? message.model : undefined;
-      const messageId = typeof message.id === 'string' ? message.id : null;
-
-      const blocks: TranscriptBlock[] = [];
-
-      const messageContent = message.content;
-      if (Array.isArray(messageContent)) {
-        for (const block of messageContent) {
-          if (!isRecord(block)) continue;
-          if (block.type === 'text' && typeof block.text === 'string') {
-            blocks.push({ type: 'text', text: block.text });
-          } else if (block.type === 'thinking') {
-            // Real Claude Code session JSONL never persists thinking text
-            // (it stores only an encrypted `signature`). Empty thinking
-            // blocks would render as useless empty disclosures, so skip
-            // them. Kept the branch in case a future Claude version starts
-            // persisting plaintext thinking - then it will be captured.
-            if (typeof block.thinking === 'string' && block.thinking.length > 0) {
-              blocks.push({ type: 'thinking', text: block.thinking });
-            }
-          } else if (block.type === 'tool_use') {
-            blocks.push({
-              type: 'tool_use',
-              id: typeof block.id === 'string' ? block.id : '',
-              name: typeof block.name === 'string' ? block.name : 'tool',
-              input: block.input,
-            });
-          }
-        }
-      }
-
-      // A line that yields no blocks produces no entry, so skip it BEFORE
-      // claiming this message's usage. With extended thinking, Claude writes a
-      // turn as two lines under one message id - a thinking-only line (which we
-      // drop, since persisted thinking is empty) followed by the text line. If
-      // usage were claimed on the dropped thinking line, the message id would be
-      // marked "attributed" and the following text entry (same id) would be
-      // deduped out of its own usage, silently losing the whole turn's per-turn
-      // tokens. Claiming usage only when an entry is actually emitted keeps it on
-      // the first VISIBLE line of each message id.
-      if (blocks.length === 0) continue;
-
-      // Attribute this turn's usage to exactly one emitted entry per message id
-      // (a single message can still span several emitted lines, e.g. text +
-      // tool_use); the first emitted line claims it so a burn-rate sum never
-      // double-counts a turn.
-      let usage: TranscriptTurnUsage | undefined;
-      if (!messageId || !usageAttributedMessageIds.has(messageId)) {
-        usage = extractTurnUsage(message);
-        if (usage && messageId) usageAttributedMessageIds.add(messageId);
-      }
-
-      entries.push(
-        usage
-          ? { kind: 'assistant', uuid, ts, model, usage, blocks }
-          : { kind: 'assistant', uuid, ts, model, blocks },
-      );
-    }
+    parseTranscriptLine(line, entries, usageAttributedMessageIds);
   }
 
+  // A full parse just consumed everything available in the read, INCLUDING a
+  // trailing line with no final newline (content.split above parses it like
+  // any other segment) - so the next increment starts from the current size
+  // with no carry, regardless of whether the file physically ends in `\n`.
+  touchIncrementalState(filePath, {
+    mtimeMs: stat.mtimeMs,
+    size: stat.size,
+    byteOffset: stat.size,
+    carry: Buffer.alloc(0),
+    entries,
+    usageAttributedMessageIds,
+  });
   return entries;
+}
+
+/** Test-only: clear the module-scope incremental-parse cache between test cases. */
+export function resetIncrementalParseStateForTests(): void {
+  incrementalStateByPath.clear();
+}
+
+/** Test-only: current number of distinct paths retained in the incremental-parse
+ *  cache, so a test can assert the `INCREMENTAL_STATE_LIMIT` LRU cap holds. */
+export function incrementalStateSizeForTests(): number {
+  return incrementalStateByPath.size;
 }
 
 /**

--- a/src/main/agent/transcript-cache.ts
+++ b/src/main/agent/transcript-cache.ts
@@ -1,0 +1,130 @@
+import fs from 'node:fs/promises';
+import type { TranscriptEntry } from '../../shared/types';
+
+/** Per-block/content clamp so a multi-MB transcript never ships whole over IPC
+ *  into React state. Individual spans over this are truncated with a marker.
+ *  Exported so the index-fallback path in `transcript-service.ts` clamps by the
+ *  identical rule instead of maintaining a second copy that could drift. */
+export const MAX_SPAN_CHARS = 20_000;
+
+/** Cached results are keyed by `(sessionType, agentSessionId)`; cap the number
+ *  of distinct sessions held so a long-running app with many opened
+ *  conversations does not grow this map unbounded. */
+const CACHE_LIMIT = 16;
+
+export function clampSpan(text: string): string {
+  if (text.length <= MAX_SPAN_CHARS) return text;
+  return `${text.slice(0, MAX_SPAN_CHARS)}\n[truncated ${text.length - MAX_SPAN_CHARS} chars]`;
+}
+
+/** Apply the per-span clamp across every entry's text/blocks/content. A
+ *  tool_use block's `input` is deliberately left untouched (the diff/tool-use
+ *  renderer needs it intact). */
+export function truncateEntries(entries: TranscriptEntry[]): TranscriptEntry[] {
+  return entries.map((entry) => {
+    switch (entry.kind) {
+      case 'user':
+        return { ...entry, text: clampSpan(entry.text) };
+      case 'assistant':
+        return {
+          ...entry,
+          blocks: entry.blocks.map((block) =>
+            block.type === 'tool_use' ? block : { ...block, text: clampSpan(block.text) },
+          ),
+        };
+      case 'tool_result':
+        return { ...entry, content: clampSpan(entry.content) };
+      case 'system':
+        return { ...entry, text: clampSpan(entry.text) };
+    }
+  });
+}
+
+interface CacheRecord {
+  sourcePath: string;
+  mtimeMs: number;
+  size: number;
+  truncatedEntries: TranscriptEntry[];
+}
+
+const cache = new Map<string, CacheRecord>();
+
+/** Move `key` to the most-recently-used end and evict the oldest entry past
+ *  the cap. Map iteration order is insertion order, so re-inserting after a
+ *  delete is enough to implement LRU without a separate linked list. */
+function touch(key: string, record: CacheRecord): void {
+  cache.delete(key);
+  cache.set(key, record);
+  while (cache.size > CACHE_LIMIT) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey === undefined) break;
+    cache.delete(oldestKey);
+  }
+}
+
+export interface ParsedTranscriptResult {
+  entries: TranscriptEntry[];
+  sourcePath: string | null;
+}
+
+/**
+ * Stat-validated per-file result cache wrapping an adapter's `parseTranscript`
+ * call. On a cache hit (the previously-parsed file's path/mtime/size are
+ * unchanged), returns the SAME `truncatedEntries` array reference with zero
+ * parsing - this is what lets the task-level stitch memo (see
+ * `transcript-service.ts`) and the renderer's row reconciler skip their own
+ * re-work when a live-poll tick finds nothing new.
+ *
+ * Deliberately does not require a separate "locate" call: the cache
+ * remembers the sourcePath the last successful parse returned and re-stats
+ * THAT path directly on the next call, so a session whose file is genuinely
+ * unchanged never has to ask the adapter to parse at all. The first call for
+ * a session (or a call after the remembered path stops matching) always
+ * parses once to (re)learn the current path.
+ */
+export async function getCachedTranscript(
+  sessionType: string,
+  agentSessionId: string,
+  parse: () => Promise<ParsedTranscriptResult>,
+): Promise<ParsedTranscriptResult> {
+  const key = `${sessionType}:${agentSessionId}`;
+  const cached = cache.get(key);
+
+  if (cached) {
+    let stat: { mtimeMs: number; size: number } | null = null;
+    try {
+      stat = await fs.stat(cached.sourcePath);
+    } catch {
+      stat = null;
+    }
+    if (stat && stat.mtimeMs === cached.mtimeMs && stat.size === cached.size) {
+      touch(key, cached);
+      return { entries: cached.truncatedEntries, sourcePath: cached.sourcePath };
+    }
+  }
+
+  const parsed = await parse();
+  const truncatedEntries = truncateEntries(parsed.entries);
+
+  if (parsed.sourcePath) {
+    try {
+      const stat = await fs.stat(parsed.sourcePath);
+      touch(key, { sourcePath: parsed.sourcePath, mtimeMs: stat.mtimeMs, size: stat.size, truncatedEntries });
+    } catch {
+      // File disappeared between the parse and this stat (a genuine race, or
+      // the parser located a path that does not actually exist): nothing
+      // stable to cache against, so leave any prior entry in place rather
+      // than caching a record we cannot validate next time.
+      cache.delete(key);
+    }
+  } else {
+    cache.delete(key);
+  }
+
+  return { entries: truncatedEntries, sourcePath: parsed.sourcePath };
+}
+
+/** Test-only: clear the module-scope cache between test cases. */
+export function resetForTests(): void {
+  cache.clear();
+}

--- a/src/main/agent/transcript-service.ts
+++ b/src/main/agent/transcript-service.ts
@@ -2,6 +2,11 @@ import type Database from 'better-sqlite3';
 import { SessionRepository } from '../db/repositories/session-repository';
 import { agentRegistry } from './agent-registry';
 import { RetrievalStore } from '../retrieval/retrieval-store';
+import {
+  clampSpan,
+  getCachedTranscript,
+  resetForTests as resetTranscriptCacheForTests,
+} from './transcript-cache';
 import type {
   ConversationSessionMeta,
   SessionRecord,
@@ -9,10 +14,6 @@ import type {
   TranscriptSource,
   TranscriptUnavailableReason,
 } from '../../shared/types';
-
-/** Per-block/content clamp so a multi-MB transcript never ships whole over IPC
- *  into React state. Individual spans over this are truncated with a marker. */
-const MAX_SPAN_CHARS = 20_000;
 
 export interface ResolvedTranscript {
   record: SessionRecord;
@@ -28,7 +29,10 @@ export interface ResolvedTranscript {
 /** A task's entire lifecycle, stitched from every session it has ever
  *  accumulated. The "latest" fields (record/agentName/source/sourcePath)
  *  describe the newest contributing session, since that is the one live
- *  polling watches; `entries` and `sessions` span all of them. */
+ *  polling watches; `entries` and `sessions` span all of them. `revision`
+ *  bumps only when the stitched `entries` array actually changes content
+ *  (see the stitch memo below), letting the IPC layer short-circuit an idle
+ *  poll. */
 export interface ResolvedTaskTranscript {
   record: SessionRecord;
   taskTitle: string;
@@ -39,32 +43,7 @@ export interface ResolvedTaskTranscript {
   degraded: boolean;
   unavailableReason?: TranscriptUnavailableReason;
   sessions: ConversationSessionMeta[];
-}
-
-function clampSpan(text: string): string {
-  if (text.length <= MAX_SPAN_CHARS) return text;
-  return `${text.slice(0, MAX_SPAN_CHARS)}\n[truncated ${text.length - MAX_SPAN_CHARS} chars]`;
-}
-
-/** Apply the per-span clamp across every entry's text/blocks/content. */
-function truncateEntries(entries: TranscriptEntry[]): TranscriptEntry[] {
-  return entries.map((entry) => {
-    switch (entry.kind) {
-      case 'user':
-        return { ...entry, text: clampSpan(entry.text) };
-      case 'assistant':
-        return {
-          ...entry,
-          blocks: entry.blocks.map((block) =>
-            block.type === 'tool_use' ? block : { ...block, text: clampSpan(block.text) },
-          ),
-        };
-      case 'tool_result':
-        return { ...entry, content: clampSpan(entry.content) };
-      case 'system':
-        return { ...entry, text: clampSpan(entry.text) };
-    }
-  });
+  revision: number;
 }
 
 /** Reconstruct lossy display entries from indexed chunks when the native
@@ -119,23 +98,31 @@ export async function resolveSessionTranscript(
     agentName,
   };
 
-  // Live parse via the adapter's structured-parse capability.
+  // Live parse via the adapter's structured-parse capability, wrapped in the
+  // stat-validated cache so an unchanged file costs one fs.stat instead of a
+  // full re-parse.
   if (adapter?.parseTranscript && record.agent_session_id) {
+    const agentSessionId = record.agent_session_id;
     let entries: TranscriptEntry[] = [];
     let sourcePath: string | null = null;
     try {
-      const parsed = await adapter.parseTranscript(record.agent_session_id, record.cwd);
-      entries = parsed.entries;
-      sourcePath = parsed.sourcePath;
+      const cached = await getCachedTranscript(
+        record.session_type,
+        agentSessionId,
+        () => adapter.parseTranscript!(agentSessionId, record.cwd),
+      );
+      entries = cached.entries;
+      sourcePath = cached.sourcePath;
     } catch (error) {
       // A genuine parser failure (permission error, corrupt JSONL, adapter
       // regression) must not look identical to "session has no transcript yet":
       // log it, then fall through to the index fallback.
-      console.warn(`transcript live-parse failed for session ${record.agent_session_id}:`, error);
+      console.warn(`transcript live-parse failed for session ${agentSessionId}:`, error);
       entries = [];
     }
     if (entries.length > 0) {
-      return { ...base, source: 'live', sourcePath, entries: truncateEntries(entries), degraded: false };
+      // Already truncated inside the cache.
+      return { ...base, source: 'live', sourcePath, entries, degraded: false };
     }
     // Native file located but empty/pruned: try the index fallback.
     const indexed = entriesFromIndex(db, record.agent_session_id ?? record.id);
@@ -165,6 +152,58 @@ export async function resolveSessionTranscript(
     degraded: false,
     unavailableReason: adapter?.parseTranscript ? 'no_agent_session_id' : 'unsupported_agent',
   };
+}
+
+/**
+ * Identity token for a resolved session's `entries` array, used to build the
+ * task-level stitch memo's dependency fingerprint below. `getCachedTranscript`
+ * returns the SAME array reference across calls when the underlying file is
+ * unchanged, so tokening by reference (not content) is both cheap and exact
+ * for the 'live' source - a genuine content change always produces a new
+ * array from the cache. The index/none sources build a fresh array on every
+ * call (no file-level cache backs them), so their token changes every poll;
+ * that is an acceptable cost since a degraded session's entries are rare and
+ * few.
+ */
+const entriesArrayTokens = new WeakMap<TranscriptEntry[], number>();
+let nextEntriesArrayToken = 1;
+function tokenForEntries(entries: TranscriptEntry[]): number {
+  let token = entriesArrayTokens.get(entries);
+  if (token === undefined) {
+    token = nextEntriesArrayToken;
+    nextEntriesArrayToken += 1;
+    entriesArrayTokens.set(entries, token);
+  }
+  return token;
+}
+
+interface StitchMemoRecord {
+  depsFingerprint: string;
+  revision: number;
+  entries: TranscriptEntry[];
+}
+
+/** Task-level stitch memo, capped so a long-running app does not grow this
+ *  unbounded across many opened tasks. */
+const STITCH_MEMO_LIMIT = 64;
+const stitchMemoByTaskId = new Map<string, StitchMemoRecord>();
+
+function touchStitchMemo(taskId: string, record: StitchMemoRecord): void {
+  stitchMemoByTaskId.delete(taskId);
+  stitchMemoByTaskId.set(taskId, record);
+  while (stitchMemoByTaskId.size > STITCH_MEMO_LIMIT) {
+    const oldestTaskId = stitchMemoByTaskId.keys().next().value;
+    if (oldestTaskId === undefined) break;
+    stitchMemoByTaskId.delete(oldestTaskId);
+  }
+}
+
+/** Test-only: clear both the file-level transcript cache and the task-level
+ *  stitch memo between test cases. */
+export function resetForTests(): void {
+  resetTranscriptCacheForTests();
+  stitchMemoByTaskId.clear();
+  nextEntriesArrayToken = 1;
 }
 
 function toSessionMeta(record: SessionRecord, agentName: string): ConversationSessionMeta {
@@ -226,15 +265,9 @@ export async function resolveTaskTranscript(
     ? sessionRepo.listForTaskNewestFirst(anchor.task_id).reverse() // oldest first
     : [anchor];
 
-  // Collect every deduped turn, tagged with the session that first contributed
-  // it (for the chronological merge + transition boundaries below).
-  interface TaggedEntry {
-    entry: TranscriptEntry;
-    sessionId: string;
-  }
-  const tagged: TaggedEntry[] = [];
   const sessionMetas: ConversationSessionMeta[] = [];
-  const seenUuids = new Set<string>();
+  const depsParts: string[] = [];
+  const resolvedBySession: Array<{ session: SessionRecord; resolved: ResolvedTranscript }> = [];
   let anyDegraded = false;
   let latest: ResolvedTranscript | null = null;
 
@@ -244,7 +277,49 @@ export async function resolveTaskTranscript(
     latest = resolved;
     anyDegraded = anyDegraded || resolved.degraded;
     sessionMetas.push(toSessionMeta(session, resolved.agentName));
+    resolvedBySession.push({ session, resolved });
+    depsParts.push(`${session.id}:${tokenForEntries(resolved.entries)}`);
+  }
 
+  if (!latest) return null;
+
+  const taskId = anchor.task_id;
+  const depsFingerprint = depsParts.join('|');
+
+  // The expensive part (dedup by uuid, chronological sort, boundary-divider
+  // insertion) is memoized per task: when every contributing session's
+  // entries array is unchanged (same reference, per the token above), skip
+  // straight to the SAME stitched `entries` array and `revision` - this is
+  // what keeps `entries` referentially stable across an idle live-poll tick,
+  // letting both the IPC revision short-circuit and the renderer's row
+  // reconciler bail out cheaply.
+  if (taskId) {
+    const memo = stitchMemoByTaskId.get(taskId);
+    if (memo && memo.depsFingerprint === depsFingerprint) {
+      return {
+        record: latest.record,
+        taskTitle: latest.taskTitle,
+        agentName: latest.agentName,
+        source: latest.source,
+        sourcePath: latest.sourcePath,
+        entries: memo.entries,
+        degraded: anyDegraded,
+        unavailableReason: latest.unavailableReason,
+        sessions: sessionMetas,
+        revision: memo.revision,
+      };
+    }
+  }
+
+  // Collect every deduped turn, tagged with the session that first contributed
+  // it (for the chronological merge + transition boundaries below).
+  interface TaggedEntry {
+    entry: TranscriptEntry;
+    sessionId: string;
+  }
+  const tagged: TaggedEntry[] = [];
+  const seenUuids = new Set<string>();
+  for (const { session, resolved } of resolvedBySession) {
     for (const entry of resolved.entries) {
       if (seenUuids.has(entry.uuid)) continue; // a resume replays parent turns verbatim
       seenUuids.add(entry.uuid);
@@ -254,8 +329,6 @@ export async function resolveTaskTranscript(
       });
     }
   }
-
-  if (!latest) return null;
 
   // Merge chronologically by each turn's own ts (stable: equal-ts turns keep
   // oldest-session-first order via the index tiebreaker), then walk the sorted
@@ -289,6 +362,11 @@ export async function resolveTaskTranscript(
     previousSessionId = item.sessionId;
   }
 
+  const revision = taskId ? (stitchMemoByTaskId.get(taskId)?.revision ?? 0) + 1 : 0;
+  if (taskId) {
+    touchStitchMemo(taskId, { depsFingerprint, revision, entries });
+  }
+
   return {
     record: latest.record,
     taskTitle: latest.taskTitle,
@@ -299,5 +377,6 @@ export async function resolveTaskTranscript(
     degraded: anyDegraded,
     unavailableReason: latest.unavailableReason,
     sessions: sessionMetas,
+    revision,
   };
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ import { createPreviewClone, fillPreviewClone, registerEphemeralProjectDevIpc } 
 import { resolvePreviewTaskTitle } from '../devtools/main/preview-task-title';
 import { registerSeedGitChangesDevIpc } from '../devtools/main/seed-git-changes';
 import { registerSeedEmbeddingBacklogDevIpc } from '../devtools/main/seed-embedding-backlog';
+import { registerSeedLargeConversationDevIpc } from '../devtools/main/seed-large-conversation';
 import { installDevtools } from '../devtools/install';
 import { startMcpHttpServer, type McpHttpServerHandle } from './agent/mcp-http-server';
 import { readBrowserAutomationConfig } from './browser/browser-automation-config';
@@ -614,6 +615,11 @@ const createWindow = () => {
           // Backlog" button - a realistic pending-chunk count for exercising the
           // central embedding engine's drain loop under sustained real-worker load.
           registerSeedEmbeddingBacklogDevIpc(getOptionalIpcContext);
+          // Seed-large-conversation dev IPC for the TestHarness "Seed Large
+          // Conversation" button - a throwaway task/session backed by a real
+          // synthetic multi-thousand-turn Claude transcript file, for
+          // exercising the Conversation viewer on a huge transcript.
+          registerSeedLargeConversationDevIpc(getOptionalIpcContext);
           // Adopt the two clones the /preview script pre-cloned (overlapping the
           // build); add more on demand via the TestHarness "Create Project" button.
           const project1 = await createPreviewClone(ephemeralContext, cwd); // adopts "Project 1"

--- a/src/main/ipc/handlers/transcripts.ts
+++ b/src/main/ipc/handlers/transcripts.ts
@@ -8,6 +8,7 @@ import type {
   ConversationSessionMeta,
   TranscriptGetRequest,
   TranscriptGetResponse,
+  TranscriptUnchangedResponse,
 } from '../../../shared/types';
 import type { IpcContext } from '../ipc-context';
 
@@ -26,7 +27,10 @@ import type { IpcContext } from '../ipc-context';
 export function registerTranscriptHandlers(context: IpcContext): void {
   ipcMain.handle(
     IPC.TRANSCRIPT_GET,
-    async (_event, request: TranscriptGetRequest): Promise<TranscriptGetResponse> => {
+    async (
+      _event,
+      request: TranscriptGetRequest,
+    ): Promise<TranscriptGetResponse | TranscriptUnchangedResponse> => {
       const projectId = request.projectId ?? context.currentProjectId;
       const emptyResponse: TranscriptGetResponse = {
         sessionId: request.sessionId,
@@ -41,12 +45,20 @@ export function registerTranscriptHandlers(context: IpcContext): void {
         degraded: false,
         unavailableReason: 'file_missing',
         sessions: [],
+        revision: 0,
       };
       if (!projectId) return emptyResponse;
 
       const db = getProjectDb(projectId);
       const resolved = await resolveTaskTranscript(db, request.sessionId);
       if (!resolved) return emptyResponse;
+
+      // Nothing changed since the caller's last fetch: skip the full
+      // structured clone (the common case for an idle live-poll tick on a
+      // long transcript).
+      if (request.knownRevision !== undefined && request.knownRevision === resolved.revision) {
+        return { unchanged: true, revision: resolved.revision };
+      }
 
       return {
         sessionId: resolved.record.id,
@@ -61,6 +73,7 @@ export function registerTranscriptHandlers(context: IpcContext): void {
         degraded: resolved.degraded,
         unavailableReason: resolved.unavailableReason,
         sessions: resolved.sessions,
+        revision: resolved.revision,
       };
     },
   );

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -476,6 +476,7 @@ if (__KANGENTIC_DEV__) {
     createEphemeralProject: () => ipcRenderer.invoke(IPC.DEV_CREATE_EPHEMERAL_PROJECT),
     seedGitChanges: (targetPaths: string[]) => ipcRenderer.invoke(IPC.DEV_SEED_GIT_CHANGES, targetPaths),
     seedEmbeddingBacklog: (count: number) => ipcRenderer.invoke(IPC.DEV_SEED_EMBEDDING_BACKLOG, count),
+    seedLargeConversation: (count: number) => ipcRenderer.invoke(IPC.DEV_SEED_LARGE_CONVERSATION, count),
     isEphemeralPreview,
     previewTaskTitle,
   };

--- a/src/renderer/components/conversation/ConversationScrollbar.tsx
+++ b/src/renderer/components/conversation/ConversationScrollbar.tsx
@@ -1,0 +1,240 @@
+/**
+ * Custom overlay scrollbar rail for the conversation viewer, replacing the
+ * native scrollbar on the scroll container ONLY (see the
+ * `.conversation-scroll-hide-native` rule in index.css - every other surface keeps the
+ * global 8px scrollbar). At 10k+ messages a purely proportional native thumb
+ * collapses to an ungrabbable sliver; this rail enforces a minimum thumb size
+ * (`scrollbar-math.ts`) and stays fat and always visible instead of
+ * hover-only, so it never competes with the panel's own resize handle for the
+ * same few pixels at the window edge.
+ *
+ * Also renders the "jump to latest" pill (bottom-center, appears once the
+ * user has scrolled away from the tail) as the explicit way back, since
+ * auto-follow is gated off while the window is focused or hovered.
+ *
+ * Reads the container's native `scrollTop`/`scrollHeight`/`clientHeight`
+ * rather than the virtualizer's own reactive fields - the virtualizer sets
+ * those same DOM properties under the hood, so this stays fully decoupled
+ * from @tanstack/react-virtual's API surface while remaining exact.
+ */
+
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+import { ArrowDown, Hash } from 'lucide-react';
+import { formatTime } from '../../lib/datetime';
+import { computeThumbGeometry, thumbPositionToOffset, FAR_FROM_BOTTOM_PX } from './scrollbar-math';
+import type { DisplayRow } from './display-rows';
+
+interface ConversationScrollbarProps {
+  containerRef: RefObject<HTMLDivElement | null>;
+  rows: DisplayRow[];
+  onJumpToLatest: () => void;
+  /** Reports whether the rail is currently showing (content overflows the
+   *  viewport), so ConversationView can reclaim the row's extra right-side
+   *  clearance when there's no scrollbar to clear. */
+  onShowRailChange?: (showRail: boolean) => void;
+}
+
+/** Flush to the window's right edge (no inset gap) with a visible track
+ *  background, so it reads as a traditional vertical scrollbar rather than a
+ *  floating pill. The thumb sits inside the track with a small fixed margin. */
+const RAIL_WIDTH_PX = 14;
+const THUMB_MARGIN_PX = 3;
+
+/** Matches ConversationView's row wrapper `pl-3` (12px) - the message box's
+ *  own left inset from the window's left edge. Exported (not just inline in
+ *  ConversationView) because CONTENT_RIGHT_CLEARANCE_PX reproduces it on the
+ *  right side too, and ConversationView reuses it as the row's right padding
+ *  when there is no scrollbar to clear (reclaiming the extra clearance). */
+export const ROW_LEFT_INSET_PX = 12;
+
+/** How far a message row's own right edge must sit from the window's right
+ *  edge so the gap between the message border and the thumb's LEFT edge
+ *  matches the message's own left inset (ROW_LEFT_INSET_PX) - the same
+ *  breathing room a message keeps from the window's left edge, mirrored on
+ *  the right. The thumb's left edge sits THUMB_MARGIN_PX in from the rail's
+ *  own left edge (RAIL_WIDTH_PX = thumb width + a THUMB_MARGIN_PX margin on
+ *  each side), so the message border needs to clear that PLUS the desired
+ *  gap. Exported so ConversationView can size its row padding against it
+ *  instead of duplicating the rail's own geometry as a second magic number. */
+export const CONTENT_RIGHT_CLEARANCE_PX = (RAIL_WIDTH_PX - THUMB_MARGIN_PX) + ROW_LEFT_INSET_PX;
+const BOTTOM_EPSILON_PX = 4;
+
+interface ScrollGeometry {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+export function ConversationScrollbar({ containerRef, rows, onJumpToLatest, onShowRailChange }: ConversationScrollbarProps) {
+  const [geometry, setGeometry] = useState<ScrollGeometry>({ scrollTop: 0, scrollHeight: 0, clientHeight: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const [isHoveringRail, setIsHoveringRail] = useState(false);
+  const dragStateRef = useRef<{ pointerId: number; startClientY: number; startThumbTop: number } | null>(null);
+  const scrollReadRafRef = useRef<number | null>(null);
+  const dragApplyRafRef = useRef<number | null>(null);
+  const pendingDragOffsetRef = useRef<number | null>(null);
+
+  const readGeometry = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    setGeometry({ scrollTop: container.scrollTop, scrollHeight: container.scrollHeight, clientHeight: container.clientHeight });
+  }, [containerRef]);
+
+  useEffect(() => {
+    readGeometry();
+    const container = containerRef.current;
+    if (!container) return undefined;
+    const handleScroll = () => {
+      if (scrollReadRafRef.current !== null) return;
+      scrollReadRafRef.current = requestAnimationFrame(() => {
+        scrollReadRafRef.current = null;
+        readGeometry();
+      });
+    };
+    container.addEventListener('scroll', handleScroll, { passive: true });
+    const resizeObserver = new ResizeObserver(readGeometry);
+    resizeObserver.observe(container);
+    return () => {
+      container.removeEventListener('scroll', handleScroll);
+      resizeObserver.disconnect();
+      if (scrollReadRafRef.current !== null) cancelAnimationFrame(scrollReadRafRef.current);
+    };
+    // Re-observe when the row count changes (a live append can grow
+    // scrollHeight without firing a 'scroll' event).
+  }, [containerRef, readGeometry, rows.length]);
+
+  const railSize = geometry.clientHeight;
+  const { thumbTop, thumbSize } = computeThumbGeometry({
+    scrollOffset: geometry.scrollTop,
+    totalSize: geometry.scrollHeight,
+    viewportSize: railSize,
+    railSize,
+  });
+
+  const flushDragOffset = useCallback(() => {
+    dragApplyRafRef.current = null;
+    const container = containerRef.current;
+    if (container && pendingDragOffsetRef.current !== null) {
+      container.scrollTop = pendingDragOffsetRef.current;
+    }
+  }, [containerRef]);
+
+  const handlePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    dragStateRef.current = { pointerId: event.pointerId, startClientY: event.clientY, startThumbTop: thumbTop };
+    setIsDragging(true);
+  }, [thumbTop]);
+
+  const handlePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const dragState = dragStateRef.current;
+    if (!dragState || dragState.pointerId !== event.pointerId) return;
+    const deltaY = event.clientY - dragState.startClientY;
+    const offset = thumbPositionToOffset({
+      thumbTop: dragState.startThumbTop + deltaY,
+      thumbSize,
+      totalSize: geometry.scrollHeight,
+      viewportSize: railSize,
+      railSize,
+    });
+    pendingDragOffsetRef.current = offset;
+    if (dragApplyRafRef.current === null) {
+      dragApplyRafRef.current = requestAnimationFrame(flushDragOffset);
+    }
+  }, [thumbSize, geometry.scrollHeight, railSize, flushDragOffset]);
+
+  const handlePointerUp = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (dragStateRef.current?.pointerId !== event.pointerId) return;
+    dragStateRef.current = null;
+    setIsDragging(false);
+    if (dragApplyRafRef.current !== null) {
+      cancelAnimationFrame(dragApplyRafRef.current);
+      flushDragOffset();
+    }
+  }, [flushDragOffset]);
+
+  useEffect(() => {
+    return () => {
+      if (scrollReadRafRef.current !== null) cancelAnimationFrame(scrollReadRafRef.current);
+      if (dragApplyRafRef.current !== null) cancelAnimationFrame(dragApplyRafRef.current);
+    };
+  }, []);
+
+  const distanceFromBottom = geometry.scrollHeight - (geometry.scrollTop + geometry.clientHeight);
+  const isAtBottom = distanceFromBottom <= BOTTOM_EPSILON_PX;
+  const showRail = geometry.scrollHeight > railSize && railSize > 0;
+
+  useEffect(() => {
+    onShowRailChange?.(showRail);
+  }, [showRail, onShowRailChange]);
+
+  const handleJumpClick = useCallback(() => {
+    onJumpToLatest();
+  }, [onJumpToLatest]);
+
+  // Scrub bubble: approximate which row is under the thumb, using scroll
+  // PROGRESS against the row count as a proxy - close enough for a live label
+  // while dragging (not a precision requirement; the real destination is
+  // whatever offset the drag lands on).
+  const progress = geometry.scrollHeight > railSize
+    ? geometry.scrollTop / (geometry.scrollHeight - railSize)
+    : 0;
+  const anchoredIndex = rows.length > 0
+    ? Math.min(rows.length - 1, Math.max(0, Math.round(progress * (rows.length - 1))))
+    : 0;
+  const anchoredRow = rows[anchoredIndex];
+  const showExpandedThumb = isDragging || isHoveringRail;
+
+  return (
+    <>
+      {showRail && (
+        <div
+          className={`absolute top-0 bottom-0 right-0 select-none transition-colors duration-150 ${
+            showExpandedThumb ? 'bg-fg/[0.05]' : 'bg-fg/[0.02]'
+          }`}
+          style={{ width: RAIL_WIDTH_PX }}
+          onMouseEnter={() => setIsHoveringRail(true)}
+          onMouseLeave={() => setIsHoveringRail(false)}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+          data-testid="conversation-scrollbar-rail"
+        >
+          <div
+            className={`absolute w-2 rounded-sm transition-colors duration-150 ${
+              showExpandedThumb ? 'bg-[var(--kng-edge-input)]' : 'bg-[var(--kng-edge)]'
+            }`}
+            style={{ top: thumbTop, height: thumbSize, right: THUMB_MARGIN_PX }}
+            data-testid="conversation-scrollbar-thumb"
+          />
+          {isDragging && anchoredRow && (
+            <div
+              className="absolute right-full mr-2 whitespace-nowrap rounded-md border border-edge bg-surface-raised px-2 py-1.5 text-[11px] text-fg shadow-lg flex flex-col gap-1"
+              style={{ top: Math.max(0, thumbTop) }}
+              data-testid="conversation-scrollbar-bubble"
+            >
+              {anchoredRow.entry.ts > 0 && <span>{formatTime(anchoredRow.entry.ts)}</span>}
+              <span className="flex items-center gap-1 text-fg-muted">
+                <Hash size={11} className="flex-shrink-0" />
+                {anchoredIndex + 1} of {rows.length}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+      {!isAtBottom && geometry.scrollHeight > 0 && (
+        <button
+          type="button"
+          onClick={handleJumpClick}
+          className="absolute bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-1.5 rounded-full border border-edge bg-surface-raised px-3 py-1.5 text-xs text-fg-secondary shadow-lg hover:bg-surface-hover transition-colors"
+          data-testid="conversation-jump-to-latest"
+          data-far={distanceFromBottom > FAR_FROM_BOTTOM_PX ? 'true' : undefined}
+        >
+          <ArrowDown size={13} />
+          Jump to latest
+        </button>
+      )}
+    </>
+  );
+}

--- a/src/renderer/components/conversation/ConversationSearchBar.tsx
+++ b/src/renderer/components/conversation/ConversationSearchBar.tsx
@@ -1,0 +1,218 @@
+/**
+ * In-viewer search bar hosted by ConversationView. Always visible (no
+ * open/close state - Mod+F focuses it rather than toggling it) - client-side
+ * lexical substring search over the reconciled rows' `searchText` (see
+ * `display-rows.ts`). No semantic matching (SearchPalette owns that) and no
+ * inline markdown highlight injection; navigating to a hit reuses
+ * ConversationView's existing amber row-flash instead.
+ *
+ * Standard find-bar cursor model: `currentMatchIndex` starts at -1 (nothing
+ * active yet). Next/Enter and Prev/Shift+Enter both wrap and always land on a
+ * real match; clicking a specific result row jumps straight to it.
+ */
+
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import { Search, ChevronUp, ChevronDown } from 'lucide-react';
+import { HeaderActionButton } from '../HeaderActionButton';
+import type { DisplayRow } from './display-rows';
+
+interface ConversationSearchBarProps {
+  rows: DisplayRow[];
+  onNavigate: (uuid: string, options?: { flash?: boolean }) => boolean;
+}
+
+/** Imperative handle so the owning window's Mod+F keybinding can focus the
+ *  (already-visible) input without this component owning any open/close state. */
+export interface ConversationSearchBarHandle {
+  focus: () => void;
+}
+
+interface SearchMatch {
+  uuid: string;
+  snippet: string;
+  snippetMatchStart: number;
+  snippetMatchEnd: number;
+}
+
+const DEBOUNCE_MS = 120;
+const MAX_RESULTS = 200;
+const SNIPPET_RADIUS = 40;
+
+function buildSnippet(text: string, matchStart: number, matchEnd: number): { snippet: string; snippetMatchStart: number; snippetMatchEnd: number } {
+  const start = Math.max(0, matchStart - SNIPPET_RADIUS);
+  const end = Math.min(text.length, matchEnd + SNIPPET_RADIUS);
+  const prefix = start > 0 ? '...' : '';
+  const suffix = end < text.length ? '...' : '';
+  return {
+    snippet: `${prefix}${text.slice(start, end)}${suffix}`,
+    snippetMatchStart: matchStart - start + prefix.length,
+    snippetMatchEnd: matchEnd - start + prefix.length,
+  };
+}
+
+export const ConversationSearchBar = forwardRef<ConversationSearchBarHandle, ConversationSearchBarProps>(
+  function ConversationSearchBar({ rows, onNavigate }, ref) {
+    const [query, setQuery] = useState('');
+    const [debouncedQuery, setDebouncedQuery] = useState('');
+    const [currentMatchIndex, setCurrentMatchIndex] = useState(-1);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      },
+    }), []);
+
+    useEffect(() => {
+      const timer = setTimeout(() => setDebouncedQuery(query), DEBOUNCE_MS);
+      return () => clearTimeout(timer);
+    }, [query]);
+
+    const matches = useMemo<SearchMatch[]>(() => {
+      const needle = debouncedQuery.trim().toLowerCase();
+      if (needle.length === 0) return [];
+      const results: SearchMatch[] = [];
+      for (const row of rows) {
+        const haystack = row.searchText.toLowerCase();
+        const matchIndex = haystack.indexOf(needle);
+        if (matchIndex < 0) continue;
+        const { snippet, snippetMatchStart, snippetMatchEnd } = buildSnippet(
+          row.searchText,
+          matchIndex,
+          matchIndex + needle.length,
+        );
+        results.push({ uuid: row.uuid, snippet, snippetMatchStart, snippetMatchEnd });
+        if (results.length >= MAX_RESULTS) break;
+      }
+      return results;
+    }, [rows, debouncedQuery]);
+
+    useEffect(() => {
+      setCurrentMatchIndex(-1);
+    }, [debouncedQuery]);
+
+    const goToMatchIndex = useCallback(
+      (index: number) => {
+        setCurrentMatchIndex(index);
+        onNavigate(matches[index].uuid);
+      },
+      [matches, onNavigate],
+    );
+
+    const goToNext = useCallback(() => {
+      if (matches.length === 0) return;
+      goToMatchIndex(currentMatchIndex < 0 ? 0 : (currentMatchIndex + 1) % matches.length);
+    }, [matches.length, currentMatchIndex, goToMatchIndex]);
+
+    const goToPrevious = useCallback(() => {
+      if (matches.length === 0) return;
+      goToMatchIndex(currentMatchIndex < 0 ? matches.length - 1 : (currentMatchIndex - 1 + matches.length) % matches.length);
+    }, [matches.length, currentMatchIndex, goToMatchIndex]);
+
+    const handleInputKeyDown = useCallback(
+      (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          // Dismiss focus (not the bar itself - it has no closed state) and
+          // keep this from also reaching the window's structural Escape
+          // handler, which would otherwise close the whole conversation window.
+          event.stopPropagation();
+          inputRef.current?.blur();
+          return;
+        }
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          if (event.shiftKey) goToPrevious();
+          else goToNext();
+        }
+      },
+      [goToNext, goToPrevious],
+    );
+
+    const countLabel = matches.length === 0
+      ? (debouncedQuery.trim().length > 0 ? 'No results' : '')
+      : `${currentMatchIndex >= 0 ? currentMatchIndex + 1 : 0} of ${matches.length}`;
+
+    return (
+      <div
+        className="flex flex-col border-b border-edge bg-surface-raised flex-shrink-0"
+        data-testid="conversation-search-bar"
+      >
+        <div className="flex items-center gap-2 px-3 py-2">
+          <Search size={14} className="flex-shrink-0 text-fg-muted" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleInputKeyDown}
+            placeholder="Search this conversation"
+            className="flex-1 min-w-0 bg-transparent text-sm text-fg placeholder:text-fg-faint focus:outline-none"
+            data-testid="conversation-search-input"
+          />
+          {countLabel.length > 0 && (
+            <span className="text-[11px] text-fg-muted whitespace-nowrap" data-testid="conversation-search-count">
+              {countLabel}
+            </span>
+          )}
+          <HeaderActionButton
+            icon={ChevronUp}
+            onClick={goToPrevious}
+            disabled={matches.length === 0}
+            title="Previous match"
+            ariaLabel="Previous match"
+            size="small"
+            testId="conversation-search-previous"
+          />
+          <HeaderActionButton
+            icon={ChevronDown}
+            onClick={goToNext}
+            disabled={matches.length === 0}
+            title="Next match"
+            ariaLabel="Next match"
+            size="small"
+            testId="conversation-search-next"
+          />
+        </div>
+        {matches.length > 0 && (
+          <div className="max-h-48 overflow-y-auto border-t border-edge/60" data-testid="conversation-search-results">
+            {matches.map((match, index) => (
+              <button
+                key={`${match.uuid}-${index}`}
+                type="button"
+                onClick={() => goToMatchIndex(index)}
+                data-testid="conversation-search-result"
+                data-highlighted={index === currentMatchIndex ? 'true' : undefined}
+                className={`block w-full truncate px-3 py-1.5 text-left text-xs transition-colors ${
+                  index === currentMatchIndex
+                    ? 'bg-accent/15 text-fg'
+                    : 'text-fg-muted hover:bg-surface-hover hover:text-fg-secondary'
+                }`}
+              >
+                <SnippetText
+                  text={match.snippet}
+                  highlightStart={match.snippetMatchStart}
+                  highlightEnd={match.snippetMatchEnd}
+                />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+function SnippetText({ text, highlightStart, highlightEnd }: { text: string; highlightStart: number; highlightEnd: number }) {
+  const before = text.slice(0, highlightStart);
+  const match = text.slice(highlightStart, highlightEnd);
+  const after = text.slice(highlightEnd);
+  return (
+    <>
+      {before}
+      <mark className="bg-amber-400/30 text-inherit rounded-sm">{match}</mark>
+      {after}
+    </>
+  );
+}

--- a/src/renderer/components/conversation/ConversationView.tsx
+++ b/src/renderer/components/conversation/ConversationView.tsx
@@ -34,6 +34,7 @@ import { ConversationSearchBar, type ConversationSearchBarHandle } from './Conve
 import { ConversationScrollbar, CONTENT_RIGHT_CLEARANCE_PX, ROW_LEFT_INSET_PX } from './ConversationScrollbar';
 import { reconcileDisplayRows, isSlashCommandRow, speakerGroup, type DisplayRow, type DisplayRowResult } from './display-rows';
 import { FAR_FROM_BOTTOM_PX } from './scrollbar-math';
+import { ESTIMATED_ROW_HEIGHT, computeSettleScrollTop, type SettleVirtualItem } from './settle-scroll';
 import { renderAssistantBlocksMarkdown } from '../../../shared/transcript-format';
 import { sanitizeTranscriptText } from '../../../shared/ansi-strip';
 import { humanizeModelId } from '../../../shared/model-id';
@@ -49,7 +50,6 @@ import type {
 /** Result bodies longer than this are clamped with a "Show all" toggle. */
 const RESULT_CLAMP_CHARS = 4000;
 const HIGHLIGHT_DURATION_MS = 4000;
-const ESTIMATED_ROW_HEIGHT = 96;
 
 /** Where the viewer opens by default (no `scrollToTurnUuid`): the latest
  *  message, or centered on the row matching the terminal's visible
@@ -80,49 +80,26 @@ interface ConversationViewProps {
   isFocused: boolean;
 }
 
-/** Sum of `rows[0..index)`'s estimated heights - the row's approximate
- *  offset from the top of the virtual content, independent of the
- *  virtualizer's own (asynchronous, reconcile-driven) internal scroll state.
- *  Used only as a bootstrap guess before the target row has ever been
- *  rendered (see `useScrollSettle`'s `getVirtualItems` fallback below) - the
- *  per-row heuristic in `display-rows.ts` is a rough line-count estimate, so
- *  a target many rows deep can accumulate a large enough error that this
- *  alone is not a reliable final position. */
-function estimatedOffsetForIndex(rows: DisplayRow[], index: number): number {
-  let offset = 0;
-  for (let rowIndex = 0; rowIndex < index && rowIndex < rows.length; rowIndex += 1) {
-    offset += rows[rowIndex]?.estimatedHeight ?? ESTIMATED_ROW_HEIGHT;
-  }
-  return offset;
-}
-
-/** The subset of `@tanstack/react-virtual`'s `VirtualItem` this settle loop
- *  needs - narrowed so the hook does not have to import the virtualizer's
- *  full generic type. */
-interface SettleVirtualItem {
-  index: number;
-  start: number;
-  size: number;
-}
-
 /**
  * Bounded settle loop that drives the scroll container's `scrollTop`
  * DIRECTLY (never through `virtualizer.scrollToIndex`/`scrollToEnd`) until it
  * stabilizes across two ticks (or a tick cap is hit).
  *
- * For `align: 'center' | 'start'`, each tick first checks whether the target
- * row is currently among the virtualizer's OWN rendered `getVirtualItems()` -
- * if so, its `start`/`size` are real, measured values (accurate regardless of
- * how far off the row's static `estimatedHeight` heuristic was), and this
- * loop uses them directly instead of the heuristic. A target far from the
- * current scroll position is not yet rendered on tick 1, so that tick falls
- * back to the heuristic-summed estimate purely to get CLOSE - close enough
- * that the browser's own scrollTop clamping settles near the target's real
- * rows, which the virtualizer then renders, which the NEXT tick picks up via
- * getVirtualItems(). This is what actually fulfills convergence: the
- * heuristic alone never improves across retries (it is static per row), so
- * without this real-measurement readback the loop would just rewrite the
- * same wrong value every tick and call it "stable".
+ * For `align: 'center' | 'start'`, each tick delegates the actual scrollTop
+ * math to `computeSettleScrollTop` (settle-scroll.ts, unit-tested there),
+ * which first checks whether the target row is currently among the
+ * virtualizer's OWN rendered `getVirtualItems()` - if so, its `start`/`size`
+ * are real, measured values (accurate regardless of how far off the row's
+ * static `estimatedHeight` heuristic was), and it uses them directly instead
+ * of the heuristic. A target far from the current scroll position is not yet
+ * rendered on tick 1, so that tick falls back to the heuristic-summed
+ * estimate purely to get CLOSE - close enough that the browser's own
+ * scrollTop clamping settles near the target's real rows, which the
+ * virtualizer then renders, which the NEXT tick picks up via a fresh
+ * `virtualItem`. This is what actually fulfills convergence: the heuristic
+ * alone never improves across retries (it is static per row), so without
+ * this real-measurement readback the loop would just rewrite the same wrong
+ * value every tick and call it "stable".
  *
  * This bypasses `@tanstack/virtual-core`'s own scroll-to + reconcile
  * machinery on purpose: that reconcile path schedules its OWN
@@ -203,14 +180,9 @@ function useScrollSettle(
           // typically ready by the NEXT tick) - at that point start/size flip
           // to real values and this converges to the true position, which the
           // static heuristic alone never would (see this function's doc
-          // comment above).
+          // comment above and computeSettleScrollTop's in settle-scroll.ts).
           const virtualItem = getVirtualItems().find((item) => item.index === index);
-          const rowOffset = virtualItem ? virtualItem.start : estimatedOffsetForIndex(rows, index);
-          const rowHeight = virtualItem ? virtualItem.size : (rows[index]?.estimatedHeight ?? ESTIMATED_ROW_HEIGHT);
-          const targetOffset = align === 'center'
-            ? rowOffset - Math.max(0, (container.clientHeight - rowHeight) / 2)
-            : rowOffset;
-          container.scrollTop = Math.max(0, Math.round(targetOffset));
+          container.scrollTop = computeSettleScrollTop({ align, index, rows, virtualItem, clientHeight: container.clientHeight });
         }
 
         // `instant` (search-result navigation) skips the retry loop entirely:
@@ -563,7 +535,7 @@ export function ConversationView({
                   }}
                 >
                   {isSystem ? (
-                    <div className={gapClass} style={rowStyle}>
+                    <div className={gapClass} style={rowStyle} data-testid="conversation-row-gap">
                       <MemoConversationRow
                         row={row}
                         agentName={agentName}
@@ -572,7 +544,7 @@ export function ConversationView({
                       />
                     </div>
                   ) : (
-                    <div className={gapClass} style={rowStyle}>
+                    <div className={gapClass} style={rowStyle} data-testid="conversation-row-gap">
                       <div
                         data-highlighted={isHighlighted ? 'true' : undefined}
                         className={`group/message rounded-lg border px-3 py-2 transition-colors duration-700 ${

--- a/src/renderer/components/conversation/ConversationView.tsx
+++ b/src/renderer/components/conversation/ConversationView.tsx
@@ -3,23 +3,38 @@
  *
  * Renders the structured `TranscriptEntry[]` (agent-agnostic) with dynamic row
  * measurement (turn heights vary, unlike the fixed-row ActivityLog). tool_result
- * entries are folded into their owning tool_use card via `buildResultsByUseId`;
- * a tool_result with no owning tool_use in this parse (an orphan, e.g. after a
- * resume) renders as its own standalone row.
+ * entries are folded into their owning tool_use card via `reconcileDisplayRows`
+ * (`display-rows.ts`); a tool_result with no owning tool_use in this parse (an
+ * orphan, e.g. after a resume) renders as its own standalone row.
  *
  * Stateless with respect to fetching: the owning ConversationWindow fetches and
- * passes the loaded entries down. Scroll-to-turn mirrors ActivityLog: map
- * `scrollToTurnUuid` to a display-row index, scroll it to center, flash a 4s
- * amber highlight, auto-expand a folded card containing the target, then clear
- * the one-shot signal via `onConsumedScroll`.
+ * passes the loaded entries down. `reconcileDisplayRows` reuses a previous
+ * row's object identity whenever its uuid and content are unchanged, which is
+ * what lets `MemoConversationRow`'s default shallow-compare skip re-rendering
+ * (and re-parsing markdown) rows a live-poll tick did not actually change.
+ *
+ * Three things can move the scroll position, coordinated through one bounded
+ * rAF "settle loop" (`useScrollSettle`) so they never fight each other:
+ *   1. Mount-time initial positioning (`initialPosition` / `scrollToTurnUuid`
+ *      already set at open) - the container stays `visibility: hidden` for the
+ *      few settle frames so the viewer opens already positioned, no top-flash.
+ *   2. A later `scrollToTurnUuid` (search palette, or the in-viewer search bar
+ *      via `navigateToUuid`) - centers + flashes the target for 4s.
+ *   3. Auto-follow-to-bottom on a live-poll append - suppressed while a settle
+ *      loop is active, and cancelled itself by any user wheel/pointerdown.
  */
 
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from 'react';
 import { ChevronRight, ChevronDown, Wrench, MessageSquareWarning, Bot, User, Terminal, Copy, Check } from 'lucide-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { HeaderActionButton } from '../HeaderActionButton';
-import { buildResultsByUseId, renderAssistantBlocksMarkdown } from '../../../shared/transcript-format';
+import { useKeybinding } from '../../hooks/useKeybinding';
+import { ConversationSearchBar, type ConversationSearchBarHandle } from './ConversationSearchBar';
+import { ConversationScrollbar, CONTENT_RIGHT_CLEARANCE_PX, ROW_LEFT_INSET_PX } from './ConversationScrollbar';
+import { reconcileDisplayRows, isSlashCommandRow, speakerGroup, type DisplayRow, type DisplayRowResult } from './display-rows';
+import { FAR_FROM_BOTTOM_PX } from './scrollbar-math';
+import { renderAssistantBlocksMarkdown } from '../../../shared/transcript-format';
 import { sanitizeTranscriptText } from '../../../shared/ansi-strip';
 import { humanizeModelId } from '../../../shared/model-id';
 import { parseFileEditTool, computeLineDiff, diffStats, type FileEdit } from '../../../shared/tool-diff';
@@ -36,36 +51,10 @@ const RESULT_CLAMP_CHARS = 4000;
 const HIGHLIGHT_DURATION_MS = 4000;
 const ESTIMATED_ROW_HEIGHT = 96;
 
-type ToolResultEntry = Extract<TranscriptEntry, { kind: 'tool_result' }>;
-
-interface DisplayRow {
-  /** The TranscriptEntry uuid; used as the React key AND the scroll-to target. */
-  uuid: string;
-  entry: TranscriptEntry;
-}
-
-/** A user turn that is nothing but a slash-command invocation (e.g. "/code-review",
- *  "/model opus"). These are legitimate messages but low-signal as a search
- *  scroll ANCHOR - a chunk match that starts on one should skip to the real
- *  content it precedes. Requires whitespace/end after the command word so a
- *  path like "/usr/bin/foo" is not mistaken for a command. */
-function isSlashCommandRow(entry: TranscriptEntry): boolean {
-  return entry.kind === 'user' && /^\/[a-zA-Z][\w-]*(?:\s|$)/.test(entry.text.trim());
-}
-
-/** Classifies an entry's speaker for the row box color / system divider. */
-function speakerGroup(entry: TranscriptEntry): 'user' | 'agent' | 'tool' | 'system' {
-  switch (entry.kind) {
-    case 'user':
-      return 'user';
-    case 'system':
-      return 'system';
-    case 'tool_result':
-      return 'tool';
-    default:
-      return 'agent';
-  }
-}
+/** Where the viewer opens by default (no `scrollToTurnUuid`): the latest
+ *  message, or centered on the row matching the terminal's visible
+ *  scrollback (see `tui-anchor.ts`). Computed by `ConversationWindow`. */
+export type InitialPosition = { kind: 'bottom' } | { kind: 'uuid'; uuid: string };
 
 interface ConversationViewProps {
   entries: TranscriptEntry[];
@@ -84,6 +73,183 @@ interface ConversationViewProps {
    *  user NOT focusing or hovering it, so reading an earlier part of the
    *  transcript is never yanked out from under them. */
   autoFollowNewMessages: boolean;
+  /** Where to position on first paint, when no `scrollToTurnUuid` wins first. */
+  initialPosition: InitialPosition;
+  /** Whether the owning window is focused - gates the Mod+F keybinding that
+   *  focuses the (always-visible) in-viewer search bar. */
+  isFocused: boolean;
+}
+
+/** Sum of `rows[0..index)`'s estimated heights - the row's approximate
+ *  offset from the top of the virtual content, independent of the
+ *  virtualizer's own (asynchronous, reconcile-driven) internal scroll state.
+ *  Used only as a bootstrap guess before the target row has ever been
+ *  rendered (see `useScrollSettle`'s `getVirtualItems` fallback below) - the
+ *  per-row heuristic in `display-rows.ts` is a rough line-count estimate, so
+ *  a target many rows deep can accumulate a large enough error that this
+ *  alone is not a reliable final position. */
+function estimatedOffsetForIndex(rows: DisplayRow[], index: number): number {
+  let offset = 0;
+  for (let rowIndex = 0; rowIndex < index && rowIndex < rows.length; rowIndex += 1) {
+    offset += rows[rowIndex]?.estimatedHeight ?? ESTIMATED_ROW_HEIGHT;
+  }
+  return offset;
+}
+
+/** The subset of `@tanstack/react-virtual`'s `VirtualItem` this settle loop
+ *  needs - narrowed so the hook does not have to import the virtualizer's
+ *  full generic type. */
+interface SettleVirtualItem {
+  index: number;
+  start: number;
+  size: number;
+}
+
+/**
+ * Bounded settle loop that drives the scroll container's `scrollTop`
+ * DIRECTLY (never through `virtualizer.scrollToIndex`/`scrollToEnd`) until it
+ * stabilizes across two ticks (or a tick cap is hit).
+ *
+ * For `align: 'center' | 'start'`, each tick first checks whether the target
+ * row is currently among the virtualizer's OWN rendered `getVirtualItems()` -
+ * if so, its `start`/`size` are real, measured values (accurate regardless of
+ * how far off the row's static `estimatedHeight` heuristic was), and this
+ * loop uses them directly instead of the heuristic. A target far from the
+ * current scroll position is not yet rendered on tick 1, so that tick falls
+ * back to the heuristic-summed estimate purely to get CLOSE - close enough
+ * that the browser's own scrollTop clamping settles near the target's real
+ * rows, which the virtualizer then renders, which the NEXT tick picks up via
+ * getVirtualItems(). This is what actually fulfills convergence: the
+ * heuristic alone never improves across retries (it is static per row), so
+ * without this real-measurement readback the loop would just rewrite the
+ * same wrong value every tick and call it "stable".
+ *
+ * This bypasses `@tanstack/virtual-core`'s own scroll-to + reconcile
+ * machinery on purpose: that reconcile path schedules its OWN
+ * `requestAnimationFrame`-driven correction keyed off asynchronous
+ * scroll/resize-observer callbacks, and on a freshly-mounted virtualizer (no
+ * prior real measurements yet) that correction can race the browser's own
+ * scroll-offset reporting and silently reset `scrollTop` back to 0 - exactly
+ * the "opens at the top instead of the bottom" bug this feature exists to
+ * fix. A raw, self-computed `scrollTop` write plus a `setTimeout`-based retry
+ * (never `requestAnimationFrame`, which is throttled or never fires for a
+ * backgrounded / not-yet-visible window) sidesteps that path entirely while
+ * still converging on the real, measured position within a few ticks.
+ * Cancelled by any user wheel/pointerdown on the scroll container.
+ */
+function useScrollSettle(
+  containerRef: RefObject<HTMLDivElement | null>,
+  rows: DisplayRow[],
+  getVirtualItems: () => SettleVirtualItem[],
+) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isSettlingRef = useRef(false);
+
+  const cancel = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    isSettlingRef.current = false;
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return undefined;
+    const handleUserScroll = () => cancel();
+    container.addEventListener('wheel', handleUserScroll, { passive: true });
+    container.addEventListener('pointerdown', handleUserScroll);
+    return () => {
+      container.removeEventListener('wheel', handleUserScroll);
+      container.removeEventListener('pointerdown', handleUserScroll);
+    };
+  }, [containerRef, cancel]);
+
+  // Deliberately NO unmount-cleanup effect calling cancel() here. React
+  // StrictMode's development-only double-invoke simulates an unmount+remount
+  // of every effect immediately after mount (synchronously, within the same
+  // task) - an unmount-cleanup effect here would cancel the settle loop's
+  // pending correction tick before it ever fires, permanently leaving the
+  // FIRST (imprecise, pre-measurement) position on screen. A genuinely
+  // unmounted component already makes this safe without an explicit cancel:
+  // React clears `containerRef.current` to null on unmount, and `step()`
+  // below bails immediately when the container is gone.
+  const settleToIndex = useCallback(
+    (index: number, options?: { align?: 'center' | 'start' | 'end'; onSettled?: () => void; instant?: boolean }) => {
+      cancel();
+      isSettlingRef.current = true;
+      const align = options?.align ?? 'center';
+      const MAX_TICKS = 12;
+      const TICK_MS = 16;
+      const STABLE_TICKS_NEEDED = 2;
+      let previousScrollTop: number | null = null;
+      let stableTicks = 0;
+      let tick = 0;
+
+      const step = () => {
+        const container = containerRef.current;
+        if (!container) return;
+        if (align === 'end') {
+          // Browsers clamp an over-large scrollTop assignment to the real
+          // max automatically, so this always lands exactly at the tail
+          // regardless of how precise the estimate is.
+          container.scrollTop = container.scrollHeight;
+        } else {
+          // Prefer the virtualizer's OWN item for this index when available.
+          // The item exists from the first tick if the target is already
+          // within the render range, but its start/size are only the static
+          // estimateSize() substitutes until @tanstack/react-virtual's
+          // ResizeObserver actually measures the rendered row (asynchronous,
+          // typically ready by the NEXT tick) - at that point start/size flip
+          // to real values and this converges to the true position, which the
+          // static heuristic alone never would (see this function's doc
+          // comment above).
+          const virtualItem = getVirtualItems().find((item) => item.index === index);
+          const rowOffset = virtualItem ? virtualItem.start : estimatedOffsetForIndex(rows, index);
+          const rowHeight = virtualItem ? virtualItem.size : (rows[index]?.estimatedHeight ?? ESTIMATED_ROW_HEIGHT);
+          const targetOffset = align === 'center'
+            ? rowOffset - Math.max(0, (container.clientHeight - rowHeight) / 2)
+            : rowOffset;
+          container.scrollTop = Math.max(0, Math.round(targetOffset));
+        }
+
+        // `instant` (search-result navigation) skips the retry loop entirely:
+        // a single synchronous jump, no visible multi-tick correction. This is
+        // safe here specifically because it targets an already-mounted,
+        // already-measured virtualizer (unlike the mount-time positioning this
+        // loop also drives, which genuinely needs the retries - see the loop's
+        // own doc comment above).
+        if (options?.instant) {
+          isSettlingRef.current = false;
+          options?.onSettled?.();
+          return;
+        }
+
+        const currentScrollTop = container.scrollTop;
+        if (previousScrollTop !== null && Math.abs(currentScrollTop - previousScrollTop) < 1) {
+          stableTicks += 1;
+        } else {
+          stableTicks = 0;
+        }
+        previousScrollTop = currentScrollTop;
+        tick += 1;
+        if (stableTicks >= STABLE_TICKS_NEEDED || tick >= MAX_TICKS) {
+          isSettlingRef.current = false;
+          timerRef.current = null;
+          options?.onSettled?.();
+          return;
+        }
+        timerRef.current = setTimeout(step, TICK_MS);
+      };
+      // The first step runs SYNCHRONOUSLY so the target is positioned
+      // immediately in the common case; the timer-based retries correct it
+      // once the container's real (measured) dimensions have settled.
+      step();
+    },
+    [containerRef, rows, cancel, getVirtualItems],
+  );
+
+  return { settleToIndex, isSettlingRef };
 }
 
 export function ConversationView({
@@ -95,10 +261,17 @@ export function ConversationView({
   scrollToTurnUuid,
   onConsumedScroll,
   autoFollowNewMessages,
+  initialPosition,
+  isFocused,
 }: ConversationViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const searchBarRef = useRef<ConversationSearchBarHandle>(null);
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(() => new Set());
   const [highlightedUuid, setHighlightedUuid] = useState<string | null>(null);
+  // Whether the custom scrollbar rail is currently showing (content
+  // overflows the viewport) - reported by ConversationScrollbar so rows can
+  // reclaim their extra right-side clearance when there's no rail to clear.
+  const [hasScrollbar, setHasScrollbar] = useState(false);
   const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const toggleExpanded = useCallback((key: string) => {
@@ -110,51 +283,22 @@ export function ConversationView({
     });
   }, []);
 
-  // Map tool_use id -> its tool_result, so cards can inline their result.
-  const resultsByUseId = useMemo(() => buildResultsByUseId(entries), [entries]);
-
-  // The set of tool_use ids actually produced by an assistant turn: a tool_result
-  // whose owner is in this set is FOLDED (inlined under the card); one without an
-  // owner is a standalone orphan row.
-  const ownedToolUseIds = useMemo(() => {
-    const ids = new Set<string>();
-    for (const entry of entries) {
-      if (entry.kind !== 'assistant') continue;
-      for (const block of entry.blocks) {
-        if (block.type === 'tool_use') ids.add(block.id);
-      }
-    }
-    return ids;
+  // Reuses row object identity across renders whenever a row's uuid + content
+  // are unchanged (see display-rows.ts) - this is what lets MemoConversationRow
+  // bail out of re-rendering. Mutating a ref during render to "remember last
+  // result" is the same pattern React's own memoization guidance uses; it
+  // never schedules a render itself, only caches for the NEXT call.
+  const previousRowsRef = useRef<DisplayRow[]>([]);
+  const rows = useMemo(() => {
+    const next = reconcileDisplayRows(previousRowsRef.current, entries);
+    previousRowsRef.current = next;
+    return next;
   }, [entries]);
 
-  // Display rows = every entry except tool_results folded into a card.
-  const displayRows = useMemo<DisplayRow[]>(() => {
-    const rows: DisplayRow[] = [];
-    // Defense in depth: the uuid is the React key AND the virtualizer's
-    // measurement-cache key, so a duplicate collapses reconciliation (stale
-    // rows pile up, boxes overlap). resolveTaskTranscript already dedups the
-    // stitched multi-session timeline, but guard here too so no upstream source
-    // (a resume replay, an index-fallback collision) can ever break the render.
-    const seenUuids = new Set<string>();
-    for (const entry of entries) {
-      if (
-        entry.kind === 'tool_result'
-        && entry.toolUseId
-        && ownedToolUseIds.has(entry.toolUseId)
-      ) {
-        continue; // folded into its owning tool_use card
-      }
-      if (seenUuids.has(entry.uuid)) continue;
-      seenUuids.add(entry.uuid);
-      rows.push({ uuid: entry.uuid, entry });
-    }
-    return rows;
-  }, [entries, ownedToolUseIds]);
-
   const virtualizer = useVirtualizer({
-    count: displayRows.length,
+    count: rows.length,
     getScrollElement: () => containerRef.current,
-    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    estimateSize: (index) => rows[index]?.estimatedHeight ?? ESTIMATED_ROW_HEIGHT,
     // Key the virtualizer's measurement cache by the entry's stable uuid, not
     // the default raw index. The live-poll can stitch new rows into the
     // MIDDLE of this array (a session_boundary divider plus a newly-live
@@ -162,86 +306,146 @@ export function ConversationView({
     // the cache keeps applying an earlier row's already-measured height to
     // whatever new content now sits at that index, which visibly overlaps
     // rendered text until a scroll forces a full remeasure.
-    getItemKey: (index) => displayRows[index].uuid,
+    getItemKey: (index) => rows[index].uuid,
     overscan: 8,
   });
 
-  // Scroll-to-turn: map the one-shot uuid to a display-row index (or the owning
-  // assistant row for a folded tool_result), scroll it into view, flash the
-  // highlight, and clear the signal. Mirrors ActivityLog.tsx:188-213.
+  const getVirtualItems = useCallback(() => virtualizer.getVirtualItems(), [virtualizer]);
+  const { settleToIndex, isSettlingRef } = useScrollSettle(containerRef, rows, getVirtualItems);
+
+  // Core navigate-to-turn logic, shared by the scrollToTurnUuid prop effect,
+  // the mount-time initial-position effect, and the in-viewer search bar's
+  // result-click / prev-next navigation. Mirrors ActivityLog.tsx:188-213.
+  const navigateToUuid = useCallback(
+    (targetUuid: string, options?: { flash?: boolean; onSettled?: () => void; instant?: boolean }): boolean => {
+      const flash = options?.flash ?? true;
+      let index = rows.findIndex((row) => row.uuid === targetUuid);
+      let expandKey: string | null = null;
+      if (index < 0) {
+        // The target may be a folded tool_result: scroll to its owning
+        // assistant row and auto-expand the card that holds it.
+        const target = entries.find((entry) => entry.uuid === targetUuid);
+        if (target && target.kind === 'tool_result' && target.toolUseId) {
+          const ownerToolUseId = target.toolUseId;
+          index = rows.findIndex(
+            (row) =>
+              row.entry.kind === 'assistant'
+              && row.entry.blocks.some(
+                (block) => block.type === 'tool_use' && block.id === ownerToolUseId,
+              ),
+          );
+          if (index >= 0) expandKey = ownerToolUseId;
+        }
+      }
+      if (index < 0) return false;
+
+      // A conversation search hit anchors on its matched chunk's FIRST turn,
+      // which can be a bare slash-command. Landing on the command instead of
+      // the content that actually matched is confusing, so advance past any
+      // leading command turns to the first substantive one. Bounded and never
+      // targets a folded tool_result redirect (expandKey), which is already
+      // the right row.
+      if (!expandKey) {
+        let skip = 0;
+        while (index + 1 < rows.length && isSlashCommandRow(rows[index].entry) && skip < 4) {
+          index += 1;
+          skip += 1;
+        }
+      }
+
+      if (expandKey) {
+        const key = expandKey;
+        setExpandedKeys((previous) => new Set(previous).add(key));
+      }
+      settleToIndex(index, { align: 'center', onSettled: options?.onSettled, instant: options?.instant });
+      if (flash) {
+        const targetRowUuid = rows[index].uuid;
+        setHighlightedUuid(targetRowUuid);
+        if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
+        highlightTimerRef.current = setTimeout(() => {
+          highlightTimerRef.current = undefined;
+          setHighlightedUuid(null);
+        }, HIGHLIGHT_DURATION_MS);
+      }
+      return true;
+    },
+    [rows, entries, settleToIndex],
+  );
+
+  // The in-viewer search bar's own navigation (result click / prev / next)
+  // always snaps instantly - no multi-tick settle animation. Distinct from
+  // navigateToUuid's other callers (mount-time positioning, the search
+  // palette's scrollToTurnUuid), which keep the settle loop's retries.
+  const navigateToUuidFromSearch = useCallback(
+    (targetUuid: string) => navigateToUuid(targetUuid, { flash: true, instant: true }),
+    [navigateToUuid],
+  );
+
+  // Mod+F focuses the always-visible search bar (it has no open/close state
+  // to toggle - see conversation.find's registry comment for the deliberate
+  // scope shadow over the board's global Mod+F).
+  useKeybinding(
+    'conversation.find',
+    () => searchBarRef.current?.focus(),
+    { capture: true, enabled: isFocused, stopPropagation: true },
+  );
+
+  // Mount-time positioning: applied once on the first render with non-empty
+  // rows. Runs in a LAYOUT effect (synchronously after DOM mutation, before
+  // the browser paints) and the settle loop's first jump is itself
+  // synchronous (see useScrollSettle above), so the very first paint already
+  // shows the target position - no separate "hide the container" step is
+  // needed to avoid a top-flash. Precedence: an already-set `scrollToTurnUuid`
+  // (opened from the search palette) wins, WITH the flash; else
+  // `initialPosition` (the TUI-anchor match or bottom), with no flash - a
+  // quiet open.
+  const hasAppliedInitialPositionRef = useRef(false);
+  const initialScrollHandledUuidRef = useRef<string | null>(null);
+
+  useLayoutEffect(() => {
+    if (hasAppliedInitialPositionRef.current) return;
+    if (rows.length === 0) return;
+    hasAppliedInitialPositionRef.current = true;
+
+    if (scrollToTurnUuid) {
+      initialScrollHandledUuidRef.current = scrollToTurnUuid;
+      const found = navigateToUuid(scrollToTurnUuid, { flash: true });
+      onConsumedScroll();
+      if (found) return;
+    }
+    if (initialPosition.kind === 'uuid') {
+      const found = navigateToUuid(initialPosition.uuid, { flash: false });
+      if (found) return;
+    }
+    settleToIndex(rows.length - 1, { align: 'end' });
+  }, [rows.length, scrollToTurnUuid, initialPosition, navigateToUuid, onConsumedScroll, settleToIndex]);
+
+  // Post-mount scrollToTurnUuid changes (a search-palette navigate while this
+  // window is already open). Skips the value the mount effect already
+  // consumed this tick, so the two never double-navigate on open.
   useEffect(() => {
     if (!scrollToTurnUuid) return;
-
-    let index = displayRows.findIndex((row) => row.uuid === scrollToTurnUuid);
-    let expandKey: string | null = null;
-    if (index < 0) {
-      // The target may be a folded tool_result: scroll to its owning assistant
-      // row and auto-expand the card that holds it.
-      const target = entries.find((entry) => entry.uuid === scrollToTurnUuid);
-      if (target && target.kind === 'tool_result' && target.toolUseId) {
-        const ownerToolUseId = target.toolUseId;
-        index = displayRows.findIndex(
-          (row) =>
-            row.entry.kind === 'assistant'
-            && row.entry.blocks.some(
-              (block) => block.type === 'tool_use' && block.id === ownerToolUseId,
-            ),
-        );
-        if (index >= 0) expandKey = ownerToolUseId;
-      }
-    }
-
-    if (index < 0) {
-      // Not present in this transcript: clear so a later render doesn't re-try.
-      onConsumedScroll();
-      return;
-    }
-
-    // A conversation search hit anchors on its matched chunk's FIRST turn, which
-    // can be a bare slash-command (a chunk that opens with "/code-review" then
-    // covers the exchange after it). Landing on the command instead of the
-    // content that actually matched is confusing, so advance past any leading
-    // command turns to the first substantive one. Bounded and never targets a
-    // folded tool_result redirect (expandKey), which is already the right row.
-    if (!expandKey) {
-      let skip = 0;
-      while (index + 1 < displayRows.length && isSlashCommandRow(displayRows[index].entry) && skip < 4) {
-        index += 1;
-        skip += 1;
-      }
-    }
-
-    if (expandKey) {
-      const key = expandKey;
-      setExpandedKeys((previous) => new Set(previous).add(key));
-    }
-    virtualizer.scrollToIndex(index, { align: 'center' });
-    setHighlightedUuid(displayRows[index].uuid);
-    if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
-    highlightTimerRef.current = setTimeout(() => {
-      highlightTimerRef.current = undefined;
-      setHighlightedUuid(null);
-    }, HIGHLIGHT_DURATION_MS);
+    if (scrollToTurnUuid === initialScrollHandledUuidRef.current) return;
+    navigateToUuid(scrollToTurnUuid, { flash: true });
     onConsumedScroll();
-  }, [scrollToTurnUuid, displayRows, entries, virtualizer, onConsumedScroll]);
+  }, [scrollToTurnUuid, navigateToUuid, onConsumedScroll]);
 
-  // Auto-follow: while the window isn't focused/hovered, smoothly scroll to the
-  // bottom whenever the live-refresh poll grows the transcript, so the newest
-  // turn stays in view. Tracks the previous row count in a ref rather than
-  // state so this never fires on the initial load (previousCount starts null)
-  // - only on a genuine append after the view is already showing something.
-  // Declared after the scrollToTurnUuid effect so an explicit turn-navigation
-  // (rare same-tick coincidence with a live append) wins the final scroll
-  // position - effects run in declaration order.
+  // Auto-follow: while the window isn't focused/hovered AND no settle loop is
+  // active, smoothly scroll to the bottom whenever the live-refresh poll grows
+  // the transcript, so the newest turn stays in view. Tracks the previous row
+  // count in a ref rather than state so this never fires on the initial load
+  // (previousCount starts null) - only on a genuine append after the view is
+  // already showing something.
   const previousRowCountRef = useRef<number | null>(null);
   useEffect(() => {
     const previousCount = previousRowCountRef.current;
-    previousRowCountRef.current = displayRows.length;
+    previousRowCountRef.current = rows.length;
     if (previousCount === null) return;
-    if (displayRows.length <= previousCount) return;
+    if (rows.length <= previousCount) return;
     if (!autoFollowNewMessages) return;
+    if (isSettlingRef.current) return;
     virtualizer.scrollToEnd({ behavior: 'smooth' });
-  }, [displayRows.length, autoFollowNewMessages, virtualizer]);
+  }, [rows.length, autoFollowNewMessages, virtualizer, isSettlingRef]);
 
   useEffect(() => {
     return () => {
@@ -261,6 +465,16 @@ export function ConversationView({
     event.preventDefault();
     event.clipboardData.setData('text/plain', text.replace(/\n{3,}/g, '\n\n').trim());
   }, []);
+
+  // "Jump to latest" pill: near the tail, a smooth scroll reads as a natural
+  // continuation; far away, smooth-scrolling the whole distance takes an
+  // uncomfortably long time, so snap instantly instead.
+  const handleJumpToLatest = useCallback(() => {
+    const container = containerRef.current;
+    const totalSize = virtualizer.getTotalSize();
+    const distanceFromBottom = container ? totalSize - (container.scrollTop + container.clientHeight) : 0;
+    virtualizer.scrollToEnd({ behavior: distanceFromBottom > FAR_FROM_BOTTOM_PX ? 'auto' : 'smooth' });
+  }, [virtualizer]);
 
   // source === 'none': no content at all. Explain why per unavailable reason.
   if (source === 'none') {
@@ -292,15 +506,21 @@ export function ConversationView({
           <span>Original transcript file is gone - showing indexed text.</span>
         </div>
       )}
-      {displayRows.length === 0 ? (
+      <ConversationSearchBar ref={searchBarRef} rows={rows} onNavigate={navigateToUuidFromSearch} />
+      {rows.length === 0 ? (
         <div className="flex-1 min-h-0 flex items-center justify-center text-sm text-fg-muted">
           This conversation has no messages yet.
         </div>
       ) : (
-        <div ref={containerRef} className="flex-1 min-h-0 overflow-y-auto">
+        <div className="relative flex-1 min-h-0">
+        <div
+          ref={containerRef}
+          className="conversation-scroll-hide-native h-full overflow-y-auto"
+          data-testid="conversation-scroll-container"
+        >
           <div style={{ height: totalSize, position: 'relative', width: '100%' }}>
             {virtualItems.map((virtualRow) => {
-              const row = displayRows[virtualRow.index];
+              const row = rows[virtualRow.index];
               const isHighlighted = highlightedUuid === row.uuid;
               // Each message is a discrete rounded box, filled AND bordered in a
               // theme-adaptive role color (accent for you, neutral for the agent),
@@ -312,12 +532,22 @@ export function ConversationView({
               const boxClass = speaker === 'user'
                 ? 'border-accent/40 bg-accent/10'
                 : 'border-edge bg-fg/[0.05]';
-              // 12px sides; 6px top/bottom per row so adjacent rows sum to a 12px
-              // gap; the first/last rows get the full 12px so the top and bottom
-              // edges match that rhythm.
-              const gapClass = `px-3 ${virtualRow.index === 0 ? 'pt-3' : 'pt-1.5'} ${
-                virtualRow.index === displayRows.length - 1 ? 'pb-3' : 'pb-1.5'
+              // 12px on the left; 6px top/bottom per row so adjacent rows sum to a
+              // 12px gap, with the first/last rows getting the full 12px so the top
+              // and bottom edges match that rhythm. The right side is handled
+              // separately (see rowStyle below) - it must clear the overlaid
+              // scrollbar rail, not just match the left inset.
+              const gapClass = `pl-3 ${virtualRow.index === 0 ? 'pt-3' : 'pt-1.5'} ${
+                virtualRow.index === rows.length - 1 ? 'pb-3' : 'pb-1.5'
               }`;
+              // Right padding clears the overlaid scrollbar rail with the same
+              // visual gap the thumb keeps from the window's own right edge, so
+              // the thumb reads as evenly inset from the message content on one
+              // side and the window edge on the other (see
+              // CONTENT_RIGHT_CLEARANCE_PX's doc comment in ConversationScrollbar).
+              // When there's no rail (content doesn't overflow), that extra
+              // clearance is reclaimed back down to the plain left-matching inset.
+              const rowStyle = { paddingRight: hasScrollbar ? CONTENT_RIGHT_CLEARANCE_PX : ROW_LEFT_INSET_PX };
               return (
                 <div
                   key={row.uuid}
@@ -333,17 +563,16 @@ export function ConversationView({
                   }}
                 >
                   {isSystem ? (
-                    <div className={gapClass}>
+                    <div className={gapClass} style={rowStyle}>
                       <MemoConversationRow
-                        entry={row.entry}
+                        row={row}
                         agentName={agentName}
-                        resultsByUseId={resultsByUseId}
                         expandedKeys={expandedKeys}
                         toggleExpanded={toggleExpanded}
                       />
                     </div>
                   ) : (
-                    <div className={gapClass}>
+                    <div className={gapClass} style={rowStyle}>
                       <div
                         data-highlighted={isHighlighted ? 'true' : undefined}
                         className={`group/message rounded-lg border px-3 py-2 transition-colors duration-700 ${
@@ -351,9 +580,8 @@ export function ConversationView({
                         }`}
                       >
                         <MemoConversationRow
-                          entry={row.entry}
+                          row={row}
                           agentName={agentName}
-                          resultsByUseId={resultsByUseId}
                           expandedKeys={expandedKeys}
                           toggleExpanded={toggleExpanded}
                         />
@@ -364,6 +592,13 @@ export function ConversationView({
               );
             })}
           </div>
+        </div>
+        <ConversationScrollbar
+          containerRef={containerRef}
+          rows={rows}
+          onJumpToLatest={handleJumpToLatest}
+          onShowRailChange={setHasScrollbar}
+        />
         </div>
       )}
     </div>
@@ -386,14 +621,14 @@ function emptyReasonText(reason: TranscriptUnavailableReason | undefined): strin
 /* ── Per-kind rows ── */
 
 interface ConversationRowProps {
-  entry: TranscriptEntry;
+  row: DisplayRow;
   agentName?: string;
-  resultsByUseId: Map<string, { content: string; isError: boolean }>;
   expandedKeys: Set<string>;
   toggleExpanded: (key: string) => void;
 }
 
-function ConversationRow({ entry, agentName, resultsByUseId, expandedKeys, toggleExpanded }: ConversationRowProps) {
+function ConversationRow({ row, agentName, expandedKeys, toggleExpanded }: ConversationRowProps) {
+  const { entry, results } = row;
   if (entry.kind === 'user') return <UserRow text={entry.text} ts={entry.ts} />;
   if (entry.kind === 'system') return <SystemRow subtype={entry.subtype} text={entry.text} />;
   if (entry.kind === 'tool_result') return <OrphanToolResultRow entry={entry} expandedKeys={expandedKeys} toggleExpanded={toggleExpanded} />;
@@ -408,7 +643,7 @@ function ConversationRow({ entry, agentName, resultsByUseId, expandedKeys, toggl
       // single-session transcript where entries don't carry their own.
       agentName={entry.agentName ?? agentName}
       ts={entry.ts}
-      resultsByUseId={resultsByUseId}
+      resultsByUseId={results}
       expandedKeys={expandedKeys}
       toggleExpanded={toggleExpanded}
     />
@@ -419,12 +654,14 @@ function ConversationRow({ entry, agentName, resultsByUseId, expandedKeys, toggl
  * Memoized row. `useVirtualizer` re-renders the whole list on every scroll
  * frame; without this, each visible row re-runs its body (markdown sanitize,
  * the eager copy-text serialization, JSX construction) on every frame - the
- * jank that shows up on long transcripts. All five props are referentially
- * stable while scrolling (the entries array, `resultsByUseId`, and
- * `expandedKeys` only change on a poll that grows the transcript or on a toggle,
- * never on scroll), so the default shallow compare bails the entire subtree out
- * of scroll re-renders. `isHighlighted` deliberately lives on the OUTER box, not
- * here, so a highlight flash never busts this memo.
+ * jank that shows up on long transcripts. All four props are referentially
+ * stable while scrolling AND while a live-poll tick does not touch this
+ * particular row: `row` is reused by `reconcileDisplayRows` whenever its uuid
+ * and content (including its OWN folded tool results) are unchanged, and
+ * `expandedKeys` only changes on a toggle. So the default shallow compare
+ * bails the entire subtree out of both scroll re-renders and poll re-renders
+ * for every row a tick did not actually change. `isHighlighted` deliberately
+ * lives on the OUTER box, not here, so a highlight flash never busts this memo.
  */
 const MemoConversationRow = memo(ConversationRow);
 
@@ -575,7 +812,7 @@ interface AssistantRowProps {
   /** Agent CLI display name for the role pill; falls back to "Agent". */
   agentName?: string;
   ts: number;
-  resultsByUseId: Map<string, { content: string; isError: boolean }>;
+  resultsByUseId: Map<string, DisplayRowResult>;
   expandedKeys: Set<string>;
   toggleExpanded: (key: string) => void;
 }
@@ -658,7 +895,7 @@ function ThinkingBlock({ text, expanded, onToggle }: { text: string; expanded: b
 interface ToolCallCardProps {
   name: string;
   input: unknown;
-  result: { content: string; isError: boolean } | null;
+  result: DisplayRowResult | null;
   expanded: boolean;
   onToggle: () => void;
 }
@@ -771,7 +1008,7 @@ function DiffView({ fileEdit }: { fileEdit: FileEdit }) {
                 <span className="select-none opacity-50">
                   {line.type === 'add' ? '+ ' : line.type === 'remove' ? '- ' : '  '}
                 </span>
-                {line.text.length > 0 ? line.text : ' '}
+                {line.text.length > 0 ? line.text : ' '}
               </div>
             ))}
           </div>
@@ -786,7 +1023,7 @@ function OrphanToolResultRow({
   expandedKeys,
   toggleExpanded,
 }: {
-  entry: ToolResultEntry;
+  entry: Extract<TranscriptEntry, { kind: 'tool_result' }>;
   expandedKeys: Set<string>;
   toggleExpanded: (key: string) => void;
 }) {

--- a/src/renderer/components/conversation/display-rows.ts
+++ b/src/renderer/components/conversation/display-rows.ts
@@ -125,6 +125,7 @@ function estimateRowHeight(entry: TranscriptEntry): number {
       for (const block of entry.blocks) {
         if (block.type === 'text') {
           height += estimateTextLines(block.text) * LINE_HEIGHT;
+        // activity-state-ok: this is TranscriptBlock.type, not an ActivityState bucket.
         } else if (block.type === 'thinking') {
           height += THINKING_TOGGLE_HEIGHT;
         } else {
@@ -177,6 +178,7 @@ function buildSearchIndex(
       entry.blocks.forEach((block, index) => {
         if (block.type === 'text') {
           appendSegment(builder, sanitizeTranscriptText(block.text), null);
+        // activity-state-ok: this is TranscriptBlock.type, not an ActivityState bucket.
         } else if (block.type === 'thinking') {
           appendSegment(builder, sanitizeTranscriptText(block.text), `${entry.uuid}:think:${index}`);
         } else {

--- a/src/renderer/components/conversation/display-rows.ts
+++ b/src/renderer/components/conversation/display-rows.ts
@@ -1,0 +1,313 @@
+/**
+ * Pure entry-to-row transformation for the conversation viewer, shared by
+ * scrolling, in-viewer search, and the open-at-position TUI-anchor match.
+ *
+ * A `DisplayRow` folds a tool_result into its owning tool_use card (moved
+ * here from ConversationView's inline memos) and additionally carries:
+ *   - `results`: a ROW-SCOPED map (only this row's own tool_use ids), not the
+ *     whole-transcript map. This is what lets `MemoConversationRow`'s default
+ *     shallow-compare bail during a live-poll tick that only changed a
+ *     DIFFERENT row's tool result - passing the shared whole-transcript map
+ *     busts every row's memo on every append.
+ *   - `estimatedHeight`: precomputed here (not in the virtualizer's
+ *     `estimateSize`) so it can be text-length-aware instead of a flat
+ *     constant, cutting scrollbar jump and imprecise `scrollToIndex`.
+ *   - `searchText` / `searchSegments`: a lexical index for the in-viewer
+ *     search bar and the TUI-anchor match, with enough structure to
+ *     auto-expand a folded card when a hit lands inside it.
+ *
+ * `reconcileDisplayRows` reuses a previous row's object reference (identity)
+ * whenever its uuid and a cheap content signature both match, which is what
+ * lets `MemoConversationRow` skip re-rendering (and re-parsing markdown) for
+ * every row a live-poll tick did not actually change - only a genuinely new
+ * or changed row gets a new object.
+ */
+
+import type { TranscriptEntry } from '../../../shared/types';
+import { buildResultsByUseId } from '../../../shared/transcript-format';
+import { sanitizeTranscriptText } from '../../../shared/ansi-strip';
+
+export interface DisplayRowResult {
+  content: string;
+  isError: boolean;
+}
+
+/** A span of `searchText` that came from a specific renderable part of the
+ *  row. `expandKey` is the same key `ConversationView`'s `expandedKeys` set
+ *  uses for that part (a tool_use id, an orphan `orphan:<uuid>` key, or a
+ *  thinking-block `<uuid>:think:<index>` key) - `null` for text that is
+ *  always visible (a user turn, a system divider, an assistant text block),
+ *  so a hit there needs no auto-expand. */
+export interface SearchSegment {
+  start: number;
+  end: number;
+  expandKey: string | null;
+}
+
+export interface DisplayRow {
+  /** The TranscriptEntry uuid; used as the React key AND the scroll-to target. */
+  uuid: string;
+  entry: TranscriptEntry;
+  /** This row's own tool_use results only (see file doc comment). */
+  results: Map<string, DisplayRowResult>;
+  estimatedHeight: number;
+  searchText: string;
+  searchSegments: SearchSegment[];
+  /** Cheap content fingerprint used only by `reconcileDisplayRows` to decide
+   *  whether a previous row object can be reused. Not meant to be read by
+   *  renderer code. */
+  signature: string;
+}
+
+/** A user turn that is nothing but a slash-command invocation (e.g.
+ *  "/code-review", "/model opus"). Requires whitespace/end after the command
+ *  word so a path like "/usr/bin/foo" is not mistaken for a command. */
+export function isSlashCommandRow(entry: TranscriptEntry): boolean {
+  return entry.kind === 'user' && /^\/[a-zA-Z][\w-]*(?:\s|$)/.test(entry.text.trim());
+}
+
+/** Classifies an entry's speaker for the row box color / system divider. */
+export function speakerGroup(entry: TranscriptEntry): 'user' | 'agent' | 'tool' | 'system' {
+  switch (entry.kind) {
+    case 'user':
+      return 'user';
+    case 'system':
+      return 'system';
+    case 'tool_result':
+      return 'tool';
+    default:
+      return 'agent';
+  }
+}
+
+const MAX_SEARCH_TEXT_CHARS = 16_000;
+
+const BASE_HEIGHT = 56;
+const LINE_HEIGHT = 20;
+const TOOL_CARD_HEIGHT = 34;
+const THINKING_TOGGLE_HEIGHT = 24;
+const MIN_HEIGHT = 64;
+const MAX_HEIGHT = 900;
+/** Rough characters-per-wrapped-line at the viewer's default width, used only
+ *  to estimate row height before the real DOM measurement lands. */
+const CHARS_PER_LINE = 80;
+
+function estimateTextLines(text: string): number {
+  if (text.length === 0) return 0;
+  let lines = 0;
+  for (const line of text.split('\n')) {
+    lines += Math.max(1, Math.ceil(line.length / CHARS_PER_LINE));
+  }
+  return lines;
+}
+
+function summarizeToolInputForSearch(input: unknown): string {
+  if (input === null || input === undefined) return '';
+  if (typeof input === 'string') return input;
+  try {
+    return JSON.stringify(input);
+  } catch {
+    return String(input);
+  }
+}
+
+function estimateRowHeight(entry: TranscriptEntry): number {
+  let height = BASE_HEIGHT;
+  switch (entry.kind) {
+    case 'user':
+    case 'system':
+      height += estimateTextLines(entry.text) * LINE_HEIGHT;
+      break;
+    case 'tool_result':
+      height += TOOL_CARD_HEIGHT;
+      break;
+    case 'assistant':
+      for (const block of entry.blocks) {
+        if (block.type === 'text') {
+          height += estimateTextLines(block.text) * LINE_HEIGHT;
+        } else if (block.type === 'thinking') {
+          height += THINKING_TOGGLE_HEIGHT;
+        } else {
+          height += TOOL_CARD_HEIGHT;
+        }
+      }
+      break;
+  }
+  return Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, height));
+}
+
+interface SearchIndexBuilder {
+  parts: string[];
+  segments: SearchSegment[];
+  offset: number;
+}
+
+function appendSegment(builder: SearchIndexBuilder, text: string, expandKey: string | null): void {
+  if (text.length === 0) return;
+  if (builder.offset > 0) {
+    builder.parts.push(' ');
+    builder.offset += 1;
+  }
+  if (builder.offset >= MAX_SEARCH_TEXT_CHARS) return;
+  const remaining = MAX_SEARCH_TEXT_CHARS - builder.offset;
+  const clipped = text.length > remaining ? text.slice(0, remaining) : text;
+  const start = builder.offset;
+  builder.parts.push(clipped);
+  builder.offset += clipped.length;
+  builder.segments.push({ start, end: builder.offset, expandKey });
+}
+
+function buildSearchIndex(
+  entry: TranscriptEntry,
+  results: Map<string, DisplayRowResult>,
+): { searchText: string; searchSegments: SearchSegment[] } {
+  const builder: SearchIndexBuilder = { parts: [], segments: [], offset: 0 };
+
+  switch (entry.kind) {
+    case 'user':
+      appendSegment(builder, sanitizeTranscriptText(entry.text), null);
+      break;
+    case 'system':
+      appendSegment(builder, sanitizeTranscriptText(entry.text), null);
+      break;
+    case 'tool_result':
+      appendSegment(builder, sanitizeTranscriptText(entry.content), `orphan:${entry.uuid}`);
+      break;
+    case 'assistant':
+      entry.blocks.forEach((block, index) => {
+        if (block.type === 'text') {
+          appendSegment(builder, sanitizeTranscriptText(block.text), null);
+        } else if (block.type === 'thinking') {
+          appendSegment(builder, sanitizeTranscriptText(block.text), `${entry.uuid}:think:${index}`);
+        } else {
+          appendSegment(builder, block.name, block.id);
+          appendSegment(builder, summarizeToolInputForSearch(block.input), block.id);
+          const result = results.get(block.id);
+          if (result) appendSegment(builder, sanitizeTranscriptText(result.content), block.id);
+        }
+      });
+      break;
+  }
+
+  return { searchText: builder.parts.join(''), searchSegments: builder.segments };
+}
+
+/** Cheap content fingerprint: everything a row RENDERS, so a change to any of
+ *  it (including a late tool_result landing on this row, or the stamped
+ *  agentName) busts reuse - but nothing else (e.g. scroll position) does. */
+function computeSignature(entry: TranscriptEntry, results: Map<string, DisplayRowResult>): string {
+  const parts: string[] = [entry.kind, String(entry.ts)];
+  switch (entry.kind) {
+    case 'user':
+      parts.push(String(entry.text.length));
+      break;
+    case 'system':
+      parts.push(entry.subtype, String(entry.text.length));
+      break;
+    case 'tool_result':
+      parts.push(entry.toolUseId, String(entry.content.length), entry.isError ? '1' : '0');
+      break;
+    case 'assistant':
+      parts.push(entry.model ?? '', entry.agentName ?? '');
+      for (const block of entry.blocks) {
+        if (block.type === 'tool_use') {
+          const result = results.get(block.id);
+          parts.push(
+            `tool:${block.id}:${block.name}:${summarizeToolInputForSearch(block.input).length}`
+            + (result ? `:${result.content.length}:${result.isError ? '1' : '0'}` : ':none'),
+          );
+        } else {
+          parts.push(`${block.type}:${block.text.length}`);
+        }
+      }
+      break;
+  }
+  return parts.join('|');
+}
+
+/** This entry's own tool_use results, scoped out of the whole-transcript
+ *  `resultsByUseId` map (see the file doc comment for why row-scoping is the
+ *  memo-bail win). */
+function rowResultsFor(entry: TranscriptEntry, resultsByUseId: Map<string, DisplayRowResult>): Map<string, DisplayRowResult> {
+  const results = new Map<string, DisplayRowResult>();
+  if (entry.kind === 'assistant') {
+    for (const block of entry.blocks) {
+      if (block.type !== 'tool_use') continue;
+      const result = resultsByUseId.get(block.id);
+      if (result) results.set(block.id, result);
+    }
+  }
+  return results;
+}
+
+function buildRow(entry: TranscriptEntry, results: Map<string, DisplayRowResult>): DisplayRow {
+  const signature = computeSignature(entry, results);
+  const { searchText, searchSegments } = buildSearchIndex(entry, results);
+  return {
+    uuid: entry.uuid,
+    entry,
+    results,
+    estimatedHeight: estimateRowHeight(entry),
+    searchText,
+    searchSegments,
+    signature,
+  };
+}
+
+/**
+ * Fold `entries` into display rows, reusing a previous row's OBJECT
+ * REFERENCE whenever its uuid and content signature both match a row from
+ * `previousRows`. A tool_result entry whose owning tool_use appeared in an
+ * assistant turn is folded into that turn's row (not emitted as its own
+ * row); an unowned one (e.g. after a resume) renders standalone.
+ */
+export function reconcileDisplayRows(previousRows: DisplayRow[], entries: TranscriptEntry[]): DisplayRow[] {
+  const previousByUuid = new Map<string, DisplayRow>();
+  for (const row of previousRows) previousByUuid.set(row.uuid, row);
+
+  const resultsByUseId = buildResultsByUseId(entries);
+
+  const ownedToolUseIds = new Set<string>();
+  for (const entry of entries) {
+    if (entry.kind !== 'assistant') continue;
+    for (const block of entry.blocks) {
+      if (block.type === 'tool_use') ownedToolUseIds.add(block.id);
+    }
+  }
+
+  const rows: DisplayRow[] = [];
+  // Defense in depth: the uuid is the React key AND the virtualizer's
+  // measurement-cache key, so a duplicate collapses reconciliation (stale
+  // rows pile up, boxes overlap). resolveTaskTranscript already dedups the
+  // stitched multi-session timeline, but guard here too so no upstream
+  // source (a resume replay, an index-fallback collision) can ever break
+  // the render.
+  const seenUuids = new Set<string>();
+  for (const entry of entries) {
+    if (
+      entry.kind === 'tool_result'
+      && entry.toolUseId
+      && ownedToolUseIds.has(entry.toolUseId)
+    ) {
+      continue; // folded into its owning tool_use card
+    }
+    if (seenUuids.has(entry.uuid)) continue;
+    seenUuids.add(entry.uuid);
+
+    const previous = previousByUuid.get(entry.uuid);
+    // Always compute against the CURRENT resultsByUseId - entry-reference
+    // equality alone is not enough to prove a row is unchanged, since an
+    // assistant entry's folded results come from a SEPARATE tool_result
+    // entry elsewhere in the array; that tool_result landing (or changing)
+    // must still bust this row even though the assistant entry object itself
+    // never changed.
+    const currentResults = rowResultsFor(entry, resultsByUseId);
+    const candidateSignature = computeSignature(entry, currentResults);
+    if (previous && previous.signature === candidateSignature) {
+      rows.push(previous);
+      continue;
+    }
+    rows.push(buildRow(entry, currentResults));
+  }
+  return rows;
+}

--- a/src/renderer/components/conversation/scrollbar-math.ts
+++ b/src/renderer/components/conversation/scrollbar-math.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure geometry helpers for the conversation viewer's custom scrollbar rail
+ * (`ConversationScrollbar.tsx`). Kept separate from the component so the
+ * offset<->thumb-position mapping is unit-testable without mounting React or
+ * touching the DOM.
+ */
+
+export interface ThumbGeometry {
+  /** Distance from the top of the rail to the top of the thumb, in px. */
+  thumbTop: number;
+  /** Thumb height, in px - never below `MIN_THUMB_SIZE_PX`. */
+  thumbSize: number;
+}
+
+/** Below this, a purely proportional thumb becomes an ungrabbable sliver on a
+ *  very long transcript - the whole reason this custom rail exists. */
+export const MIN_THUMB_SIZE_PX = 48;
+
+/** Beyond this distance (px) from the tail, a "Jump to latest" snaps instantly
+ *  instead of smooth-scrolling, which would otherwise take uncomfortably long to
+ *  visually cross a very long transcript. Shared by `ConversationView` (which
+ *  decides the scroll behavior) and `ConversationScrollbar` (which labels the
+ *  jump pill's `data-far`) so the two can never disagree. */
+export const FAR_FROM_BOTTOM_PX = 4000;
+
+function clamp01(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+/** Maps a scroll offset to where the thumb should sit on the rail. When the
+ *  proportional size (`viewportSize / totalSize * railSize`) would fall below
+ *  the floor, the thumb is pinned to `MIN_THUMB_SIZE_PX` and its travel range
+ *  is correspondingly reduced, so it still reaches both rail ends exactly at
+ *  the scroll extremes. */
+export function computeThumbGeometry(params: {
+  scrollOffset: number;
+  totalSize: number;
+  viewportSize: number;
+  railSize: number;
+}): ThumbGeometry {
+  const { scrollOffset, totalSize, viewportSize, railSize } = params;
+  if (totalSize <= 0 || viewportSize <= 0 || railSize <= 0) {
+    return { thumbTop: 0, thumbSize: Math.max(0, railSize) };
+  }
+  const proportionalSize = (viewportSize / totalSize) * railSize;
+  const thumbSize = Math.min(railSize, Math.max(MIN_THUMB_SIZE_PX, proportionalSize));
+  const scrollableDistance = Math.max(0, totalSize - viewportSize);
+  const progress = scrollableDistance > 0 ? clamp01(scrollOffset / scrollableDistance) : 0;
+  const thumbTravel = Math.max(0, railSize - thumbSize);
+  return { thumbTop: progress * thumbTravel, thumbSize };
+}
+
+/** Inverse of `computeThumbGeometry`'s position half: given where the user
+ *  dragged the thumb to, returns the scroll offset that should produce it. */
+export function thumbPositionToOffset(params: {
+  thumbTop: number;
+  thumbSize: number;
+  totalSize: number;
+  viewportSize: number;
+  railSize: number;
+}): number {
+  const { thumbTop, thumbSize, totalSize, viewportSize, railSize } = params;
+  const thumbTravel = Math.max(0, railSize - thumbSize);
+  const progress = thumbTravel > 0 ? clamp01(thumbTop / thumbTravel) : 0;
+  const scrollableDistance = Math.max(0, totalSize - viewportSize);
+  return progress * scrollableDistance;
+}

--- a/src/renderer/components/conversation/settle-scroll.ts
+++ b/src/renderer/components/conversation/settle-scroll.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure scrollTop computation behind ConversationView's `useScrollSettle` loop
+ * (open-at-position, search/palette navigation). Extracted from
+ * ConversationView.tsx so the "prefer the virtualizer's own real measurement
+ * over the static per-row estimate" correction - the fix for the
+ * open-at-position centering bug - is unit-testable without mounting React or
+ * a `@tanstack/react-virtual` instance (mirrors `scrollbar-math.ts`,
+ * `display-rows.ts`, and `tui-anchor.ts`, which extract this component's
+ * other DOM-adjacent pure logic for the same reason).
+ */
+
+import type { DisplayRow } from './display-rows';
+
+/** Row height fallback when a row is missing from `rows` (should not happen
+ *  in practice) or has no estimate of its own yet. */
+export const ESTIMATED_ROW_HEIGHT = 96;
+
+/** The subset of `@tanstack/react-virtual`'s `VirtualItem` the settle loop
+ *  needs - narrowed so callers do not have to import the virtualizer's full
+ *  generic type. */
+export interface SettleVirtualItem {
+  index: number;
+  start: number;
+  size: number;
+}
+
+/** Sum of `rows[0..index)`'s estimated heights - the row's approximate
+ *  offset from the top of the virtual content, independent of the
+ *  virtualizer's own (asynchronous, reconcile-driven) internal scroll state.
+ *  Used only as a bootstrap guess before the target row has ever been
+ *  rendered (see `computeSettleScrollTop`'s doc comment) - the per-row
+ *  heuristic in `display-rows.ts` is a rough line-count estimate, so a
+ *  target many rows deep can accumulate a large enough error that this alone
+ *  is not a reliable final position. */
+export function estimatedOffsetForIndex(rows: DisplayRow[], index: number): number {
+  let offset = 0;
+  for (let rowIndex = 0; rowIndex < index && rowIndex < rows.length; rowIndex += 1) {
+    offset += rows[rowIndex]?.estimatedHeight ?? ESTIMATED_ROW_HEIGHT;
+  }
+  return offset;
+}
+
+/**
+ * Computes the `scrollTop` to write for one settle-loop tick with
+ * `align: 'center' | 'start'` (see `useScrollSettle` in ConversationView.tsx
+ * for the `'end'` case, which just clamps to `scrollHeight` and needs no
+ * per-row math).
+ *
+ * Prefers the virtualizer's OWN rendered item for this index when one is
+ * passed in (`virtualItem`) - its `start`/`size` are REAL, measured values,
+ * accurate regardless of how far off the row's static `estimatedHeight`
+ * heuristic was. Only when the target isn't currently rendered (`virtualItem`
+ * is `undefined` - not yet within the virtualizer's own render range) does
+ * this fall back to the static per-row estimate, purely to land the
+ * container CLOSE to the target - close enough that the browser's own
+ * scrollTop clamping settles near the target's real rows, which the
+ * virtualizer then renders, which the caller's NEXT tick can pick up via a
+ * fresh `virtualItem`. This is what actually fulfills convergence: the
+ * static heuristic alone never improves across retries (it is a pure
+ * function of `rows`, unaffected by anything the virtualizer has since
+ * measured), so a settle loop that never reads the real `virtualItem` would
+ * just recompute the identical wrong value every tick and call it "stable" -
+ * this was the open-at-position centering bug this function's callers fix.
+ */
+export function computeSettleScrollTop(params: {
+  align: 'center' | 'start';
+  index: number;
+  rows: DisplayRow[];
+  virtualItem: SettleVirtualItem | undefined;
+  clientHeight: number;
+}): number {
+  const { align, index, rows, virtualItem, clientHeight } = params;
+  const rowOffset = virtualItem ? virtualItem.start : estimatedOffsetForIndex(rows, index);
+  const rowHeight = virtualItem ? virtualItem.size : (rows[index]?.estimatedHeight ?? ESTIMATED_ROW_HEIGHT);
+  const targetOffset = align === 'center'
+    ? rowOffset - Math.max(0, (clientHeight - rowHeight) / 2)
+    : rowOffset;
+  return Math.max(0, Math.round(targetOffset));
+}

--- a/src/renderer/components/conversation/tui-anchor.ts
+++ b/src/renderer/components/conversation/tui-anchor.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure matcher: given the terminal's visible scrollback lines at the moment
+ * the user opened the conversation viewer, find which display row that
+ * viewport was showing, so the viewer can open centered on it instead of
+ * always at the bottom. Deliberately simple - exact substring matching on a
+ * handful of center lines, no fuzzy scoring, no proportional position
+ * mapping (a TUI's rendering does not correspond 1:1 with transcript byte
+ * position, so a proportional guess would frequently be wrong).
+ */
+
+import type { DisplayRow } from './display-rows';
+
+/** The sample window scales with the CAPTURED terminal's own row count
+ *  (`visibleLines.length`), not a fixed line count - the task-detail
+ *  terminal and a docked bottom-panel terminal are routinely different
+ *  heights, and a fixed sample would be most of a short terminal's viewport
+ *  but a narrow, unrepresentative sliver of a tall one. */
+const CENTER_SAMPLE_FRACTION = 0.3;
+const CENTER_SAMPLE_MIN = 6;
+const CENTER_SAMPLE_MAX = 20;
+const MIN_NORMALIZED_LINE_LENGTH = 16;
+
+/** Sample window size for a terminal with this many visible lines - a
+ *  fraction of the viewport, clamped to [min, max] and to the viewport's own
+ *  line count (never larger than what was actually captured). */
+function sampleSizeFor(visibleLineCount: number): number {
+  const scaled = Math.round(visibleLineCount * CENTER_SAMPLE_FRACTION);
+  const clamped = Math.max(CENTER_SAMPLE_MIN, Math.min(CENTER_SAMPLE_MAX, scaled));
+  return Math.min(visibleLineCount, clamped);
+}
+
+/** Lowercase, collapse everything non-alphanumeric to single spaces, trim.
+ *  Strips ANSI-adjacent box-drawing/padding noise and makes whitespace
+ *  differences between the TUI's rendering and the transcript's stored text
+ *  (wrapping, indentation) irrelevant to the match. */
+function normalizeForMatch(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Returns the uuid of the row whose `searchText` best contains the terminal's
+ * visible-center lines, or `null` when nothing scores (too little signal in
+ * the sampled lines, or no row contains any of them). Ties break toward the
+ * LATEST row, since a TUI's visible scrollback most often reflects the most
+ * recent occurrence of repeated text (e.g. the same tool run twice).
+ */
+export function matchTuiViewportToRow(visibleLines: string[], rows: DisplayRow[]): string | null {
+  if (visibleLines.length === 0 || rows.length === 0) return null;
+
+  // Sample lines around the viewport's vertical center: the top/bottom edges
+  // of a captured viewport are more likely truncated or boundary artifacts,
+  // and centering the sample keeps the matched turn roughly centered too,
+  // matching how the caller then scrolls to it. The sample size itself scales
+  // with THIS capture's own line count (sampleSizeFor), since the terminal
+  // panel that was captured (task-detail dialog vs. docked bottom panel) can
+  // be a very different height from capture to capture.
+  const sampleSize = sampleSizeFor(visibleLines.length);
+  const center = Math.floor(visibleLines.length / 2);
+  const half = Math.floor(sampleSize / 2);
+  const start = Math.max(0, Math.min(Math.max(0, visibleLines.length - sampleSize), center - half));
+  const sampleLines = visibleLines.slice(start, start + sampleSize);
+
+  const normalizedLines = sampleLines
+    .map(normalizeForMatch)
+    .filter((line) => line.length >= MIN_NORMALIZED_LINE_LENGTH);
+  if (normalizedLines.length === 0) return null;
+
+  let bestUuid: string | null = null;
+  let bestScore = 0;
+
+  for (const row of rows) {
+    const normalizedSearchText = normalizeForMatch(row.searchText);
+    if (normalizedSearchText.length === 0) continue;
+    let score = 0;
+    for (const line of normalizedLines) {
+      if (normalizedSearchText.includes(line)) score += 1;
+    }
+    if (score === 0) continue;
+    // >= (not >) so a later row with an equal score wins the tie-break.
+    if (score >= bestScore) {
+      bestScore = score;
+      bestUuid = row.uuid;
+    }
+  }
+
+  return bestUuid;
+}

--- a/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
+++ b/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
@@ -15,6 +15,7 @@ import { PriorityBadge } from '../../backlog/PriorityBadge';
 import { useToastStore } from '../../../stores/toast-store';
 import { useProjectStore } from '../../../stores/project-store';
 import { useSessionStore } from '../../../stores/session-store';
+import { captureTerminalScrollback } from '../../../utils/terminal-capture-registry';
 import type { Task, AgentCommand, ShortcutConfig, Swimlane } from '../../../../shared/types';
 import { type TilePreset } from '../../../window-manager/tiling/presets';
 import { WindowLayoutMenu } from '../WindowLayoutMenu';
@@ -156,6 +157,13 @@ interface TaskDetailHeaderProps {
 async function openTaskConversation(taskId: string): Promise<void> {
   const projectId = useProjectStore.getState().currentProject?.id ?? null;
   let sessionId = useSessionStore.getState()._sessionByTaskId.get(taskId)?.id ?? null;
+  // Capture the terminal's visible scrollback NOW, at click time, before the
+  // async listSessions() gap below (during which live output could keep
+  // scrolling it) - open-at-position needs the viewport exactly as the user
+  // was looking at it. A no-terminal / no-live-session task simply has
+  // nothing to capture (capture is null), and the viewer falls back to
+  // opening at the bottom.
+  const capture = captureTerminalScrollback(sessionId);
   if (!sessionId) {
     try {
       const list = await window.electronAPI.transcripts.listSessions(taskId, projectId);
@@ -166,6 +174,13 @@ async function openTaskConversation(taskId: string): Promise<void> {
     }
   }
   if (sessionId) {
+    if (capture) {
+      useSessionStore.getState().setPendingTuiAnchor({
+        sessionId,
+        visibleLines: capture.visibleLines,
+        atBottom: capture.atBottom,
+      });
+    }
     useSessionStore.getState().setConversationSessionId(sessionId);
   } else {
     useToastStore.getState().addToast({ message: 'No conversation history for this task yet', variant: 'info' });

--- a/src/renderer/hooks/useProjectSwitchEffect.ts
+++ b/src/renderer/hooks/useProjectSwitchEffect.ts
@@ -188,6 +188,7 @@ export function useProjectSwitchEffect(currentProject: Project | null): void {
           // signal via `_pendingOpenConversation` below.
           conversationSessionId: null,
           scrollToTurnUuid: null,
+          pendingTuiAnchor: null,
         });
 
         // Re-derive the active tab from config rather than the live
@@ -282,6 +283,7 @@ export function useProjectSwitchEffect(currentProject: Project | null): void {
           detailTaskId: null,
           conversationSessionId: null,
           scrollToTurnUuid: null,
+          pendingTuiAnchor: null,
           sessionEvents: preservedEvents,
         });
 
@@ -372,6 +374,7 @@ export function useProjectSwitchEffect(currentProject: Project | null): void {
         detailTaskId: null,
         conversationSessionId: null,
         scrollToTurnUuid: null,
+        pendingTuiAnchor: null,
         pendingDetailWindowsProjectId: null,
       });
       // Reset effective config to global defaults (no project overrides)

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -7,6 +7,7 @@ import { createWriteBatcher, type WriteBatcher } from '../utils/write-batcher';
 import { createIncomingWriteQueue, writeChunkedToTerminal } from '../utils/incoming-write-queue';
 import { isBoardDragActive, onBoardDragEnd } from '../lib/session-update-coalescer';
 import { noteTerminalFocus } from '../utils/dictation-target';
+import { registerTerminalCapture, unregisterTerminalCapture, type TerminalCaptureReader } from '../utils/terminal-capture-registry';
 import '@xterm/xterm/css/xterm.css';
 
 /** Delay before forwarding a resize to the PTY. Coalesces rapid resizes
@@ -418,6 +419,40 @@ export function useTerminal(options: UseTerminalOptions) {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- unmount-only teardown; adding options.sessionId would dispose and recreate the xterm on every session switch. The scroll-save reads sessionId from the disposing render, which is correct because the component remounts per session (terminal ownership handoff)
   }, []);
+
+  // Register a scrollback-viewport reader for the open-at-position feature:
+  // captured at the moment a conversation viewer is opened from the task
+  // header, so it can match the visible lines to a transcript turn (see
+  // tui-anchor.ts). Deliberately its OWN effect, keyed only on sessionId -
+  // NOT folded into initTerminal's one-shot creation, which guards itself
+  // with `if (xtermRef.current) return` and so would only ever attempt this
+  // once per component instance. A session-owning terminal's dimensions can
+  // still be 0x0 on the first initTerminal() attempt (a task-detail dialog
+  // that isn't laid out yet), in which case initTerminal defers its real
+  // creation to a later ResizeObserver-driven retry - by which point
+  // initTerminal's own registration attempt would already have been skipped
+  // for good. Reading `xtermRef.current` lazily (inside the reader, not at
+  // registration time) means this effect only needs sessionId to be known,
+  // not the terminal to already exist yet.
+  useEffect(() => {
+    if (!options.sessionId) return undefined;
+    const captureSessionId = options.sessionId;
+    const reader: TerminalCaptureReader = () => {
+      const terminal = xtermRef.current;
+      if (!terminal) return { visibleLines: [], atBottom: true };
+      const buffer = terminal.buffer.active;
+      const visibleLines: string[] = [];
+      for (let row = 0; row < terminal.rows; row += 1) {
+        const line = buffer.getLine(buffer.viewportY + row);
+        visibleLines.push(line ? line.translateToString(true) : '');
+      }
+      return { visibleLines, atBottom: buffer.viewportY >= buffer.baseY };
+    };
+    registerTerminalCapture(captureSessionId, reader);
+    return () => {
+      unregisterTerminalCapture(captureSessionId, reader);
+    };
+  }, [options.sessionId]);
 
   // fit() only refits xterm visually. The debounced onResize callback
   // forwards dimensions to the PTY automatically when cols/rows change.

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -269,6 +269,16 @@
   background: var(--kng-edge-input);
 }
 
+/* Conversation viewer scroll container: replaces the native scrollbar with a
+   custom overlay rail (ConversationScrollbar.tsx) so a 10k+ message transcript
+   gets a substantial, always-grabbable thumb instead of the global 8px
+   thumb's ungrabbable sliver at that length. Scoped to this one class - every
+   other scrollable surface keeps the global scrollbar above untouched. */
+.conversation-scroll-hide-native::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
 /* Drag overlay styling. The FlyingCard's frame 0 (KanbanBoard.tsx) mirrors
    these exact values so the overlay->fly handoff on a Done drop is seamless;
    keep opacity and rotation in sync across both. */

--- a/src/renderer/stores/session-store.ts
+++ b/src/renderer/stores/session-store.ts
@@ -3,7 +3,7 @@ import { ACTIVITY_TAB, type Session, type SessionUsage, type SessionEvent } from
 import { requiresUserInteraction, isActive } from '../../shared/activity-state';
 import { useProjectStore } from './project-store';
 import { useConfigStore } from './config-store';
-import type { SessionStore } from './session-store/types';
+import type { SessionStore, PendingTuiAnchor } from './session-store/types';
 import { buildSessionByTaskId } from './session-store/session-index';
 import { createTaskChangesPanelSlice } from './session-store/task-changes-panel-slice';
 import { createUsagePeriodSlice } from './session-store/usage-period-slice';
@@ -172,6 +172,8 @@ const preservedPendingCommandLabel: Record<string, string> = import.meta.hot?.da
 const preservedConversationSessionId: string | null = import.meta.hot?.data?.conversationSessionId ?? null;
 // @ts-expect-error -- Vite handles import.meta.hot
 const preservedScrollToTurnUuid: string | null = import.meta.hot?.data?.scrollToTurnUuid ?? null;
+// @ts-expect-error -- Vite handles import.meta.hot
+const preservedPendingTuiAnchor: PendingTuiAnchor | null = import.meta.hot?.data?.pendingTuiAnchor ?? null;
 
 // @ts-expect-error -- Vite handles import.meta.hot
 if (import.meta.hot) {
@@ -186,6 +188,7 @@ if (import.meta.hot) {
     data.pendingCommandLabel = state.pendingCommandLabel;
     data.conversationSessionId = state.conversationSessionId;
     data.scrollToTurnUuid = state.scrollToTurnUuid;
+    data.pendingTuiAnchor = state.pendingTuiAnchor;
   });
 }
 
@@ -230,6 +233,7 @@ export const useSessionStore = create<SessionStore>((set, get, api) => ({
   // switch; dropping it on a coincident HMR only skips an auto-open, no visible close.
   _pendingOpenConversation: null,
   _pendingScrollToTurnUuid: null,
+  pendingTuiAnchor: preservedPendingTuiAnchor,
   sessionUsage: {},
   latestRateLimits: null,
   sessionFirstOutput: {},
@@ -590,6 +594,7 @@ export const useSessionStore = create<SessionStore>((set, get, api) => ({
   setScrollToTurnUuid: (uuid) => set({ scrollToTurnUuid: uuid }),
   setPendingOpenConversation: (id) => set({ _pendingOpenConversation: id }),
   setPendingScrollToTurnUuid: (uuid) => set({ _pendingScrollToTurnUuid: uuid }),
+  setPendingTuiAnchor: (anchor) => set({ pendingTuiAnchor: anchor }),
 
   upsertSession: (session) => {
     set((state) => {

--- a/src/renderer/stores/session-store/types.ts
+++ b/src/renderer/stores/session-store/types.ts
@@ -11,6 +11,18 @@ import type { UsagePeriodSlice } from './usage-period-slice';
 import type { TransientSessionSlice } from './transient-session-slice';
 import type { RateLimitSnapshot } from '../../utils/rate-limit-window';
 
+/** A one-shot capture of a task's terminal scrollback viewport at the moment
+ *  its conversation viewer was opened. See `pendingTuiAnchor` below. */
+export interface PendingTuiAnchor {
+  sessionId: string;
+  visibleLines: string[];
+  /** Do NOT gate the anchor's scroll position on this; see the anti-gate note
+   *  on `TerminalScrollbackCapture.atBottom` (Claude's alt-screen TUI never
+   *  moves real xterm scroll, so this is unreliable as a "user is at the tail"
+   *  signal). */
+  atBottom: boolean;
+}
+
 /**
  * The "core" session store state: every key that lives on the main
  * session-store.ts file (sessions, usage/activity/events, CRUD
@@ -71,6 +83,15 @@ export interface CoreSessionSlice {
    *  scroll to once the destination project has loaded. Kept separate because the
    *  project switch resets `scrollToTurnUuid`, which would otherwise drop it. */
   _pendingScrollToTurnUuid: string | null;
+  /** One-shot: captured at `TaskDetailHeader.openTaskConversation` click time
+   *  from the task's terminal (if any) - the visible scrollback lines and
+   *  whether it was at the live tail. `ConversationWindow` matches this to a
+   *  transcript turn (`tui-anchor.ts`) so the viewer opens centered there
+   *  instead of always at the bottom, when the user had scrolled up in the
+   *  TUI. Consumed only by the window whose anchor matches
+   *  `conversationSessionId`; cleared on project switch; loses to an explicit
+   *  `scrollToTurnUuid` navigation. */
+  pendingTuiAnchor: PendingTuiAnchor | null;
   sessionUsage: Record<string, SessionUsage>;
   /**
    * Shared account-wide rate-limit snapshot. Rate limits are an account-wide
@@ -149,6 +170,7 @@ export interface CoreSessionSlice {
   setScrollToTurnUuid: (uuid: string | null) => void;
   setPendingOpenConversation: (id: string | null) => void;
   setPendingScrollToTurnUuid: (uuid: string | null) => void;
+  setPendingTuiAnchor: (anchor: PendingTuiAnchor | null) => void;
   upsertSession: (session: Session) => void;
   updateSessionStatus: (id: string, updates: Partial<Session>) => void;
   updateUsage: (sessionId: string, data: SessionUsage) => void;

--- a/src/renderer/utils/terminal-capture-registry.ts
+++ b/src/renderer/utils/terminal-capture-registry.ts
@@ -1,0 +1,68 @@
+/**
+ * Module-scope registry mapping a live session id to a reader that captures
+ * ITS terminal's currently visible scrollback lines (not the full buffer).
+ * Used only at the moment a conversation viewer opens, to find which
+ * transcript turn the terminal was showing (see `tui-anchor.ts`) - this is
+ * NOT a general-purpose terminal-content API.
+ *
+ * Preserved across HMR (Pattern A, mirroring `useTerminal.ts`'s
+ * `savedScrollPositions`) so a Fast Refresh of `useTerminal.ts` does not drop
+ * a capture reader for a session whose terminal instance survives the reload.
+ */
+
+export interface TerminalScrollbackCapture {
+  /** The lines currently visible in the terminal's viewport, top to bottom. */
+  visibleLines: string[];
+  /** True when the viewport is scrolled to the live tail. Captured for
+   *  completeness, but do NOT gate the anchor's scroll position on it: Claude
+   *  Code's alt-screen TUI never moves real xterm scroll position, so this
+   *  reads "at bottom" even when the user is looking at an earlier turn. The
+   *  anchor match (`tui-anchor.ts`) is deliberately unconditional and degrades
+   *  to the tail on no match; see the consuming note in `ConversationWindow`. */
+  atBottom: boolean;
+}
+
+export type TerminalCaptureReader = () => TerminalScrollbackCapture;
+
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+const readers: Map<string, TerminalCaptureReader> = import.meta.hot?.data?.terminalCaptureReaders ?? new Map();
+
+// @ts-expect-error -- Vite handles import.meta.hot
+if (import.meta.hot) {
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.dispose((data: Record<string, unknown>) => {
+    data.terminalCaptureReaders = readers;
+  });
+}
+
+export function registerTerminalCapture(sessionId: string, reader: TerminalCaptureReader): void {
+  readers.set(sessionId, reader);
+}
+
+/**
+ * Unregisters a capture reader. When `reader` is passed, the entry is only
+ * removed if it is STILL the same reader that registered it - a stale
+ * unmount cleanup (e.g. the bottom-panel/task-dialog terminal ownership
+ * handoff tearing down the LOSING side, or React StrictMode's dev-only
+ * double-invoke cleanup) can otherwise fire after a newer mount has already
+ * registered its own reader for the same session id, silently deleting the
+ * live registration. Callers that don't have a reader reference (rare) fall
+ * back to the unconditional delete.
+ */
+export function unregisterTerminalCapture(sessionId: string, reader?: TerminalCaptureReader): void {
+  if (reader !== undefined && readers.get(sessionId) !== reader) return;
+  readers.delete(sessionId);
+}
+
+/** Reads the given session's terminal, or null when no session id is given,
+ *  no terminal is registered for it, or the read itself throws. */
+export function captureTerminalScrollback(sessionId: string | null): TerminalScrollbackCapture | null {
+  if (!sessionId) return null;
+  const reader = readers.get(sessionId);
+  if (!reader) return null;
+  try {
+    return reader();
+  } catch {
+    return null;
+  }
+}

--- a/src/renderer/window-manager/components/ConversationWindow.tsx
+++ b/src/renderer/window-manager/components/ConversationWindow.tsx
@@ -12,12 +12,21 @@
  * "Copy as Markdown" export.
  *
  * The title bar reuses the same panel.* keybindings + structural-Escape pattern
- * as TaskDetailWindow (gated on `isFocused`); it adds no new KEYBINDINGS entries.
- * Close routes through the frame's animated `requestClose`; the conversation
- * window bridge mirrors the closure back to clearing `conversationSessionId`.
+ * as TaskDetailWindow (gated on `isFocused`). The in-viewer search bar is
+ * always visible (ConversationView owns it, including the `conversation.find`
+ * Mod+F binding that focuses it - there is no open/close state to toggle
+ * here). Close routes through the frame's animated `requestClose`; the
+ * conversation window bridge mirrors the closure back to clearing
+ * `conversationSessionId`.
+ *
+ * Open-at-position: computes `initialPosition` once, synchronously, the moment
+ * the transcript first loads - precedence is an already-set `scrollToTurnUuid`
+ * (handled inside ConversationView itself, since it wins there too), then a
+ * `pendingTuiAnchor` match (the task's terminal viewport at the moment the
+ * user clicked "open conversation" - see `tui-anchor.ts`), then the bottom.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { MessageSquare, X, SquareTerminal, Copy, Check, Loader2, PictureInPicture2 } from 'lucide-react';
 import { useSessionStore } from '../../stores/session-store';
 import { useProjectStore } from '../../stores/project-store';
@@ -26,11 +35,13 @@ import { MaximizeToggleButton } from '../../components/dialogs/dialog-maximize';
 import { WindowLayoutMenu } from '../../components/dialogs/WindowLayoutMenu';
 import { KebabMenu, KebabMenuItem } from '../../components/KebabMenu';
 import { HeaderActionButton } from '../../components/HeaderActionButton';
-import { ConversationView } from '../../components/conversation/ConversationView';
+import { ConversationView, type InitialPosition } from '../../components/conversation/ConversationView';
+import { reconcileDisplayRows } from '../../components/conversation/display-rows';
+import { matchTuiViewportToRow } from '../../components/conversation/tui-anchor';
 import { transcriptToMarkdown } from '../../../shared/transcript-format';
 import { useLayerStore } from '../context';
 import type { ManagedWindow } from '../store/types';
-import type { TranscriptGetResponse } from '../../../shared/types';
+import type { TranscriptGetResponse, TranscriptUnchangedResponse } from '../../../shared/types';
 
 interface ConversationWindowProps {
   managedWindow: ManagedWindow;
@@ -44,15 +55,22 @@ interface ConversationWindowProps {
  *  open viewer follows new turns as the agent produces them. */
 const LIVE_REFRESH_MS = 2500;
 
+function isUnchangedResponse(
+  value: TranscriptGetResponse | TranscriptUnchangedResponse,
+): value is TranscriptUnchangedResponse {
+  return (value as TranscriptUnchangedResponse).unchanged === true;
+}
+
 /**
  * Cheap fingerprint of a transcript response, so a live poll that returns
  * identical content skips the state update entirely (the common case between
- * actual new turns). Without this, every 2.5s tick replaces the whole entries
- * array, re-runs the viewer's O(n) memos, and re-renders the visible rows -
- * a periodic hitch that fights smooth scrolling on a long transcript. Captures
- * appends (entry count), a streaming last turn (its content length grows in
- * place), and status/degraded/source flips - the changes that actually warrant
- * a repaint. A mid-transcript edit with an unchanged length is not detected,
+ * actual new turns). This is a client-side complement to the IPC-layer
+ * revision short-circuit (`knownRevision` below), which already skips the
+ * full structured clone on an idle poll - kept as defense in depth in case a
+ * genuinely new revision ever ships with an unchanged tail. Captures appends
+ * (entry count), a streaming last turn (its content length grows in place),
+ * and status/degraded/source flips - the changes that actually warrant a
+ * repaint. A mid-transcript edit with an unchanged length is not detected,
  * but transcripts are append-and-stream, so that does not occur in practice. */
 function transcriptSignature(response: TranscriptGetResponse | null): string {
   if (!response) return 'null';
@@ -100,6 +118,8 @@ export function ConversationWindow({
   const scrollToTurnUuid = useSessionStore((state) => state.scrollToTurnUuid);
   const setScrollToTurnUuid = useSessionStore((state) => state.setScrollToTurnUuid);
   const conversationSessionId = useSessionStore((state) => state.conversationSessionId);
+  const pendingTuiAnchor = useSessionStore((state) => state.pendingTuiAnchor);
+  const setPendingTuiAnchor = useSessionStore((state) => state.setPendingTuiAnchor);
   const sessions = useSessionStore((state) => state.sessions);
 
   const useStore = useLayerStore();
@@ -119,8 +139,18 @@ export function ConversationWindow({
   // whatever part of the transcript they are reading.
   const autoFollowNewMessages = !isFocused && !isHovering;
 
+  // Mirrors `response` so the live-poll interval (armed once per live window,
+  // not re-armed on every response update) can read the CURRENT revision at
+  // each tick without stale-closure risk.
+  const responseRef = useRef<TranscriptGetResponse | null>(null);
+  useEffect(() => {
+    responseRef.current = response;
+  }, [response]);
+
   // Fetch the transcript on mount. The anchor only resolves WHICH task to
-  // show - the response always spans that task's entire lifecycle.
+  // show - the response always spans that task's entire lifecycle. No
+  // knownRevision on this first fetch (nothing to compare against yet), so
+  // the handler always returns the full payload here.
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
@@ -128,6 +158,10 @@ export function ConversationWindow({
       .get({ sessionId: managedWindow.anchor, projectId: currentProjectId })
       .then((result) => {
         if (cancelled) return;
+        if (isUnchangedResponse(result)) {
+          setLoading(false);
+          return;
+        }
         setResponse(result);
         setLoading(false);
       })
@@ -164,9 +198,16 @@ export function ConversationWindow({
     let cancelled = false;
     const interval = setInterval(() => {
       window.electronAPI.transcripts
-        .get({ sessionId: managedWindow.anchor, projectId: currentProjectId })
+        .get({
+          sessionId: managedWindow.anchor,
+          projectId: currentProjectId,
+          knownRevision: responseRef.current?.revision,
+        })
         .then((result) => {
           if (cancelled) return;
+          // Nothing changed server-side: the handler already skipped the full
+          // structured clone, so there is nothing further to do here.
+          if (isUnchangedResponse(result)) return;
           // Returning the SAME reference when nothing changed makes React bail
           // out of the re-render, so an idle live session does not repaint the
           // viewer every 2.5s.
@@ -208,12 +249,17 @@ export function ConversationWindow({
   const handleUndock = useCallback(() => untileWindow(managedWindow.id), [untileWindow, managedWindow.id]);
 
   // Task-detail parity keybindings (capture phase, gated on focus). No new
-  // registry entries: reuse panel.maximize / panel.close.
+  // registry entries for maximize/close: reuse panel.maximize / panel.close.
+  // conversation.find is registered inside ConversationView itself, which
+  // owns the always-visible search bar it focuses.
   useKeybinding('panel.maximize', handleToggleMaximized, { capture: true, enabled: isFocused });
   useKeybinding('panel.close', requestClose, { capture: true, enabled: isFocused });
 
   // Structural Escape (keybindings-registry exception, like BaseDialog /
-  // TaskDetailWindow): bubble-phase, gated on focus.
+  // TaskDetailWindow): bubble-phase, gated on focus. The search bar has no
+  // open/close state to special-case here - Escape always closes the window
+  // (the search input's own Escape handler stops propagation before this
+  // listener sees it, so typing Escape while focused in search just blurs it).
   useEffect(() => {
     if (!isFocused) return;
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -240,6 +286,46 @@ export function ConversationWindow({
   // so a second open conversation window never races to clear it.
   const activeScrollUuid = managedWindow.anchor === conversationSessionId ? scrollToTurnUuid : null;
 
+  // Open-at-position: computed ONCE, synchronously, on the render where
+  // `response` first becomes available - so it is ready before ConversationView
+  // even mounts (avoiding the top-flash the settle-loop's visibility gate is
+  // built to prevent). Mutating a ref during render to cache a one-time
+  // derived value (never scheduling a render itself) is the same pattern
+  // ConversationView's own row reconciler uses.
+  const initialPositionRef = useRef<InitialPosition | null>(null);
+  if (initialPositionRef.current === null && response) {
+    const anchor =
+      pendingTuiAnchor && pendingTuiAnchor.sessionId === managedWindow.anchor ? pendingTuiAnchor : null;
+    // Deliberately NOT gated on anchor.atBottom: Claude Code's TUI manages
+    // in-session scrollback internally (redrawing text at a fixed cursor
+    // position, printing its own "N new messages (ctrl+End)" hint) rather
+    // than moving the real terminal scroll position, so xterm's own
+    // viewportY/baseY reads as "at bottom" even while the user is looking at
+    // an earlier turn. Matching unconditionally is safe: when the terminal
+    // truly is caught up, the sampled center lines are themselves the latest
+    // turn, so the match naturally lands on (or very near) the last row
+    // anyway; a genuine miss (no signal in the sample) still falls back to
+    // bottom exactly as before.
+    if (anchor) {
+      const rowsForMatch = reconcileDisplayRows([], response.entries);
+      const matchedUuid = matchTuiViewportToRow(anchor.visibleLines, rowsForMatch);
+      initialPositionRef.current = matchedUuid ? { kind: 'uuid', uuid: matchedUuid } : { kind: 'bottom' };
+    } else {
+      initialPositionRef.current = { kind: 'bottom' };
+    }
+  }
+  const initialPosition = initialPositionRef.current ?? { kind: 'bottom' };
+
+  // Consume the one-shot pendingTuiAnchor exactly once, after the above has
+  // had a chance to read it (a store update never invalidates the ref already
+  // computed this render).
+  useEffect(() => {
+    if (!response) return;
+    const anchor =
+      pendingTuiAnchor && pendingTuiAnchor.sessionId === managedWindow.anchor ? pendingTuiAnchor : null;
+    if (anchor) setPendingTuiAnchor(null);
+  }, [response, pendingTuiAnchor, managedWindow.anchor, setPendingTuiAnchor]);
+
   return (
     <div
       className="flex h-full w-full flex-col overflow-hidden"
@@ -264,10 +350,11 @@ export function ConversationWindow({
           </div>
 
           {/* Promoted from kebab-only to visible icon buttons (shared component,
-              matching TaskDetailHeader's header row): both are common enough in a
+              matching TaskDetailHeader's header row): common enough in a
               read-only viewer to earn a one-tap affordance rather than living only
               behind "...". The kebab entries stay too (same pill+kebab redundancy
-              TaskDetailHeader uses for "View conversation"). */}
+              TaskDetailHeader uses for "View conversation"). Search has no toggle
+              button here - it is always visible inside ConversationView. */}
           {taskId && (
             <HeaderActionButton
               icon={SquareTerminal}
@@ -360,6 +447,8 @@ export function ConversationWindow({
           scrollToTurnUuid={activeScrollUuid}
           onConsumedScroll={consumeScroll}
           autoFollowNewMessages={autoFollowNewMessages}
+          initialPosition={initialPosition}
+          isFocused={isFocused}
         />
       )}
     </div>

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -22,6 +22,7 @@ export const IPC = {
   DEV_CREATE_EPHEMERAL_PROJECT: 'dev:createEphemeralProject',
   DEV_SEED_GIT_CHANGES: 'dev:seedGitChanges',
   DEV_SEED_EMBEDDING_BACKLOG: 'dev:seedEmbeddingBacklog',
+  DEV_SEED_LARGE_CONVERSATION: 'dev:seedLargeConversation',
 
   // Project Groups
   PROJECT_GROUP_LIST: 'projectGroup:list',

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -34,7 +34,8 @@ export type KeyScope =
   | 'panel' // a maximizable dialog/overlay panel (command terminal or task detail)
   | 'browser-pane' // BrowserPane visible inside a task dialog
   | 'terminal' // xterm-owned combos; display-only
-  | 'dialog'; // generic dialog-local keys (Escape dismissal, Board Manager save)
+  | 'dialog' // generic dialog-local keys (Escape dismissal, Board Manager save)
+  | 'conversation'; // a focused Conversation viewer window (capture phase, deliberately does NOT overlap 'global' - see conversation.find)
 
 /** Display grouping in the settings panel. Cosmetic, independent of scope. */
 export type KeyGroup =
@@ -159,6 +160,20 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     description: 'Focus the board search, or open Quick Find if not on the board.',
     group: 'General',
     scope: 'global',
+    defaultCombo: 'Mod+F',
+    rebindable: true,
+  },
+  {
+    id: 'conversation.find',
+    label: 'Find in Conversation',
+    description: 'Open in-viewer search inside the focused Conversation window.',
+    group: 'General',
+    // Deliberately shares Mod+F with search.plainFind: 'conversation' is NOT
+    // in scopesOverlap's overlapping list, so this intentionally shadows the
+    // global binding (same pattern as the documented task-dialog shadow) -
+    // bound capture-phase + focus-gated, it wins over the board's bubble-phase
+    // Mod+F while a Conversation window is focused, without a registry conflict.
+    scope: 'conversation',
     defaultCombo: 'Mod+F',
     rebindable: true,
   },

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2956,6 +2956,20 @@ export interface DevSeedEmbeddingBacklogResult {
   docId: string;
 }
 
+/** Summary of a dev test-harness large-conversation seed (see DEV_SEED_LARGE_CONVERSATION). */
+export interface DevSeedLargeConversationResult {
+  /** The throwaway task's Kangentic session record id. */
+  sessionId: string;
+  /** The throwaway task's id. */
+  taskId: string;
+  /** Turns written by this click. */
+  turnsAdded: number;
+  /** Running total of turns written to the transcript file across every click for this seed. */
+  totalTurns: number;
+  /** The Claude session JSONL file the turns were written to. */
+  filePath: string;
+}
+
 export interface ElectronAPI {
   // Dev-only (preview): present only when __KANGENTIC_DEV__ (build-excluded in prod).
   dev?: {
@@ -2977,6 +2991,14 @@ export interface ElectronAPI {
      * without needing that many real agent turns to produce it.
      */
     seedEmbeddingBacklog: (count: number) => Promise<DevSeedEmbeddingBacklogResult>;
+    /**
+     * Seed (or, on a re-click for the same project, append to) a throwaway
+     * task + session backed by a real synthetic Claude session JSONL
+     * transcript file, `count` turns long - the fast path to a huge realistic
+     * transcript for exercising the Conversation viewer's
+     * scrolling/search/performance, without running a real agent for hours.
+     */
+    seedLargeConversation: (count: number) => Promise<DevSeedLargeConversationResult>;
     /** True only in dev-preview (`/preview`, `--ephemeral`); false in the regular dogfood. */
     isEphemeralPreview: boolean;
     /**
@@ -3428,7 +3450,7 @@ export interface ElectronAPI {
 
   // Conversation viewer (structured transcripts)
   transcripts: {
-    get: (input: TranscriptGetRequest) => Promise<TranscriptGetResponse>;
+    get: (input: TranscriptGetRequest) => Promise<TranscriptGetResponse | TranscriptUnchangedResponse>;
     listSessions: (
       taskId: string,
       projectId?: string | null,
@@ -3654,6 +3676,12 @@ export interface TranscriptGetRequest {
   /** Interaction-time project id. Read-only, but preferred over the ambient
    *  current project (a conversation hit can target another project). */
   projectId?: string | null;
+  /** The `revision` of the last `TranscriptGetResponse` this caller received
+   *  for this task. When it matches the task's CURRENT revision, the handler
+   *  returns a `TranscriptUnchangedResponse` instead of the full payload,
+   *  skipping the multi-MB structured clone on an idle live-poll tick. Omit
+   *  on the first fetch for a session (nothing to compare against yet). */
+  knownRevision?: number;
 }
 
 /** Where a rendered conversation's content came from. `none` = neither the
@@ -3695,6 +3723,19 @@ export interface TranscriptGetResponse {
   /** Every session that contributed entries, oldest first - lets the viewer's
    *  session picker jump to where each one begins in the unified scroll. */
   sessions: ConversationSessionMeta[];
+  /** Bumps only when `entries` actually changed content (see
+   *  `resolveTaskTranscript`'s stitch memo). Round-trip this as the next
+   *  request's `knownRevision` to get a `TranscriptUnchangedResponse` on an
+   *  idle poll instead of the full payload. */
+  revision: number;
+}
+
+/** Returned by `transcripts.get` instead of a full `TranscriptGetResponse`
+ *  when the caller's `knownRevision` matches the task's current revision -
+ *  nothing has changed, so there is nothing to ship over IPC. */
+export interface TranscriptUnchangedResponse {
+  unchanged: true;
+  revision: number;
 }
 
 /** One selectable session in the conversation viewer's session picker. */

--- a/tests/ui/conversation-open-position.spec.ts
+++ b/tests/ui/conversation-open-position.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * UI tests for the conversation viewer's open-at-position behavior: with no
+ * `scrollToTurnUuid` signal, the viewer opens already positioned at the
+ * LATEST message (not the top, the historical default) - and an explicit
+ * `scrollToTurnUuid` (the search-palette path) still wins over that default.
+ *
+ * The TUI-anchor-match path (pendingTuiAnchor -> a centered open) is covered
+ * at the unit level by tui-anchor-match.test.ts; driving a real xterm
+ * scrollback capture end-to-end is out of scope for this UI-tier spec.
+ *
+ * Cross-platform: no pixel assertions, no bare waitForTimeout - every check
+ * polls for a condition (data attribute / testid / text) or uses Playwright's
+ * built-in visibility auto-waiting.
+ */
+import { test, expect, chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-conv-openpos';
+const TASK_ID = 'task-conv-openpos-1';
+const SESSION_ID = 'sess-conv-openpos-a';
+const ENTRY_COUNT = 60;
+
+function preConfig(): string {
+  return `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+      var nowMs = Date.now();
+
+      state.projects.push({
+        id: '${PROJECT_ID}', name: 'Open Position Project', path: '/mock/convopenpos',
+        github_url: null, default_agent: 'claude', last_opened: ts, created_at: ts,
+      });
+
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        state.swimlanes.push(Object.assign({}, s, { id: 'lane-convopenpos-' + i, position: i, created_at: ts }));
+      });
+
+      state.tasks.push({
+        id: '${TASK_ID}', title: 'Open position fixture task', description: '',
+        swimlane_id: 'lane-convopenpos-0', position: 0, agent: null, session_id: null,
+        worktree_path: null, branch_name: null, pr_number: null, pr_url: null,
+        base_branch: null, archived_at: null, created_at: ts, updated_at: ts,
+      });
+
+      var entries = [];
+      for (var i = 0; i < ${ENTRY_COUNT}; i++) {
+        entries.push({
+          kind: i % 2 === 0 ? 'user' : 'assistant',
+          uuid: 'turn-openpos-' + i,
+          ts: nowMs + i,
+          text: i % 2 === 0 ? undefined : undefined,
+        });
+        var entry = entries[entries.length - 1];
+        if (i === 0) entry.text = 'FIRST_ENTRY_MARKER';
+        else if (i === ${ENTRY_COUNT} - 1) {
+          if (entry.kind === 'user') { entry.text = 'LAST_ENTRY_MARKER'; }
+          else { entry.blocks = [{ type: 'text', text: 'LAST_ENTRY_MARKER' }]; delete entry.text; }
+        } else if (entry.kind === 'user') {
+          entry.text = 'filler user turn number ' + i;
+        } else {
+          entry.blocks = [{ type: 'text', text: 'filler assistant reply number ' + i }];
+          delete entry.text;
+        }
+      }
+
+      var transcriptSeeds = {};
+      transcriptSeeds['${SESSION_ID}'] = {
+        sessionId: '${SESSION_ID}', taskId: '${TASK_ID}', taskTitle: 'Open position fixture task',
+        agentName: 'Claude Code', startedAt: ts, sessionStatus: 'exited',
+        source: 'live', sourcePath: '/mock/convopenpos.jsonl',
+        entries: entries,
+        degraded: false,
+        sessions: [
+          { sessionId: '${SESSION_ID}', agentName: 'Claude Code', startedAt: ts, exitedAt: ts, isolatedSwimlaneId: null, status: 'exited' },
+        ],
+      };
+
+      return {
+        currentProjectId: '${PROJECT_ID}',
+        transcriptSeeds: transcriptSeeds,
+      };
+    });
+  `;
+}
+
+async function launch(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady();
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(preConfig());
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+  return { browser, page };
+}
+
+test.describe('Conversation Viewer - open-at-position', () => {
+  test('opening with no scrollToTurnUuid shows the LATEST message immediately, not the top of the transcript', async () => {
+    const { browser, page } = await launch();
+    try {
+      await page.evaluate((sid) => {
+        const stores = (window as unknown as {
+          __zustandStores?: { session: { getState: () => { setConversationSessionId: (id: string) => void } } };
+        }).__zustandStores;
+        stores?.session.getState().setConversationSessionId(sid);
+      }, SESSION_ID);
+      await expect(page.getByTestId('conversation-view')).toBeVisible({ timeout: 5000 });
+
+      // The last message is visible right away, with no manual scroll.
+      await expect(page.getByText('LAST_ENTRY_MARKER')).toBeVisible();
+      // The first message is NOT in the initial viewport - it only exists
+      // once the user scrolls up (still mounted-on-demand by the virtualizer).
+      await expect(page.getByText('FIRST_ENTRY_MARKER')).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('an explicit scrollToTurnUuid still wins over the default bottom-open position', async () => {
+    const { browser, page } = await launch();
+    try {
+      await page.evaluate((sid) => {
+        const stores = (window as unknown as {
+          __zustandStores?: {
+            session: {
+              getState: () => {
+                setScrollToTurnUuid: (id: string) => void;
+                setConversationSessionId: (id: string) => void;
+              };
+            };
+          };
+        }).__zustandStores;
+        stores?.session.getState().setScrollToTurnUuid('turn-openpos-0');
+        stores?.session.getState().setConversationSessionId(sid);
+      }, SESSION_ID);
+      await expect(page.getByTestId('conversation-view')).toBeVisible({ timeout: 5000 });
+
+      // The FIRST entry (the explicit scroll target) is what's shown, not
+      // the default bottom.
+      await expect(page.getByText('FIRST_ENTRY_MARKER')).toBeVisible();
+      await expect
+        .poll(async () => page.locator('[data-turn-uuid="turn-openpos-0"] [data-highlighted="true"]').count())
+        .toBeGreaterThan(0);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/ui/conversation-scrollbar.spec.ts
+++ b/tests/ui/conversation-scrollbar.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * UI tests for the conversation viewer's custom scrollbar rail's overflow
+ * detection and the row padding it drives (ConversationScrollbar.tsx's
+ * `onShowRailChange` callback, consumed by ConversationView.tsx as
+ * `hasScrollbar` to size each row's right padding).
+ *
+ * When content fits the viewport there is no rail to clear, so rows reclaim
+ * the extra right-side clearance back down to the plain left-matching inset
+ * (ROW_LEFT_INSET_PX). When content overflows, the rail shows and rows widen
+ * their right padding to CONTENT_RIGHT_CLEARANCE_PX so the message border
+ * stays evenly inset from the thumb. Both constants are exported from
+ * ConversationScrollbar.tsx; the values below (12 / 23) mirror them
+ * (RAIL_WIDTH_PX 14 - THUMB_MARGIN_PX 3 + ROW_LEFT_INSET_PX 12 = 23) - not a
+ * pixel-exact LAYOUT assertion (font metrics, scrollbar width), since these
+ * are explicit inline-style px values this component sets itself, not
+ * anything the browser/OS derives from rendering.
+ *
+ * Cross-platform: no bare waitForTimeout - every check polls for a condition
+ * (data-testid presence/count) or uses Playwright's built-in auto-waiting.
+ */
+import { test, expect, chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-conv-scrollbar';
+const TASK_ID = 'task-conv-scrollbar-1';
+const SHORT_SESSION_ID = 'sess-conv-scrollbar-short';
+const LONG_SESSION_ID = 'sess-conv-scrollbar-long';
+const LONG_ENTRY_COUNT = 60;
+
+// Mirrors ConversationScrollbar.tsx's exported constants.
+const ROW_LEFT_INSET_PX = 12;
+const CONTENT_RIGHT_CLEARANCE_PX = 23;
+
+function preConfig(): string {
+  return `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+      var nowMs = Date.now();
+
+      state.projects.push({
+        id: '${PROJECT_ID}', name: 'Scrollbar Project', path: '/mock/convscrollbar',
+        github_url: null, default_agent: 'claude', last_opened: ts, created_at: ts,
+      });
+
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        state.swimlanes.push(Object.assign({}, s, { id: 'lane-convscrollbar-' + i, position: i, created_at: ts }));
+      });
+
+      state.tasks.push({
+        id: '${TASK_ID}', title: 'Scrollbar fixture task', description: '',
+        swimlane_id: 'lane-convscrollbar-0', position: 0, agent: null, session_id: null,
+        worktree_path: null, branch_name: null, pr_number: null, pr_url: null,
+        base_branch: null, archived_at: null, created_at: ts, updated_at: ts,
+      });
+
+      // A single short turn - well under the viewport height, so the rail
+      // never shows.
+      var transcriptShort = {
+        sessionId: '${SHORT_SESSION_ID}', taskId: '${TASK_ID}', taskTitle: 'Scrollbar fixture task',
+        agentName: 'Claude Code', startedAt: ts, sessionStatus: 'exited',
+        source: 'live', sourcePath: '/mock/convscrollbar-short.jsonl',
+        entries: [
+          { kind: 'user', uuid: 'turn-scrollbar-short', ts: nowMs, text: 'SHORT_CONTENT_MARKER' },
+        ],
+        degraded: false,
+        sessions: [
+          { sessionId: '${SHORT_SESSION_ID}', agentName: 'Claude Code', startedAt: ts, exitedAt: ts, isolatedSwimlaneId: null, status: 'exited' },
+        ],
+      };
+
+      // Many short turns - well past the viewport height, so the rail shows.
+      var longEntries = [];
+      for (var i = 0; i < ${LONG_ENTRY_COUNT}; i++) {
+        longEntries.push({
+          kind: i % 2 === 0 ? 'user' : 'assistant',
+          uuid: 'turn-scrollbar-long-' + i,
+          ts: nowMs + i,
+        });
+        var entry = longEntries[longEntries.length - 1];
+        if (entry.kind === 'user') {
+          entry.text = 'LONG_CONTENT_MARKER filler user turn number ' + i;
+        } else {
+          entry.blocks = [{ type: 'text', text: 'LONG_CONTENT_MARKER filler assistant reply number ' + i }];
+        }
+      }
+      var transcriptLong = {
+        sessionId: '${LONG_SESSION_ID}', taskId: '${TASK_ID}', taskTitle: 'Scrollbar fixture task',
+        agentName: 'Claude Code', startedAt: ts, sessionStatus: 'exited',
+        source: 'live', sourcePath: '/mock/convscrollbar-long.jsonl',
+        entries: longEntries,
+        degraded: false,
+        sessions: [
+          { sessionId: '${LONG_SESSION_ID}', agentName: 'Claude Code', startedAt: ts, exitedAt: ts, isolatedSwimlaneId: null, status: 'exited' },
+        ],
+      };
+
+      var transcriptSeeds = {};
+      transcriptSeeds['${SHORT_SESSION_ID}'] = transcriptShort;
+      transcriptSeeds['${LONG_SESSION_ID}'] = transcriptLong;
+
+      return {
+        currentProjectId: '${PROJECT_ID}',
+        transcriptSeeds: transcriptSeeds,
+      };
+    });
+  `;
+}
+
+async function launch(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady();
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(preConfig());
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+  return { browser, page };
+}
+
+async function openConversation(page: Page, sessionId: string): Promise<void> {
+  await page.evaluate((sid) => {
+    const stores = (window as unknown as {
+      __zustandStores?: { session: { getState: () => { setConversationSessionId: (id: string) => void } } };
+    }).__zustandStores;
+    stores?.session.getState().setConversationSessionId(sid);
+  }, sessionId);
+  await expect(page.getByTestId('conversation-view')).toBeVisible({ timeout: 5000 });
+}
+
+test.describe('Conversation Viewer - scrollbar rail and row padding reclaim', () => {
+  test('content that fits the viewport hides the rail and rows use the plain left-matching right padding', async () => {
+    const { browser, page } = await launch();
+    try {
+      await openConversation(page, SHORT_SESSION_ID);
+      await expect(page.getByText('SHORT_CONTENT_MARKER')).toBeVisible();
+
+      // No rail: onShowRailChange(false) - the rendered content is far
+      // shorter than the viewport.
+      await expect(page.getByTestId('conversation-scrollbar-rail')).toHaveCount(0);
+
+      // hasScrollbar stays false, so the row's right padding is reclaimed
+      // back to match the left inset - not the wider scrollbar clearance.
+      await expect
+        .poll(async () =>
+          page.getByTestId('conversation-row-gap').first().evaluate((el) => (el as HTMLElement).style.paddingRight),
+        )
+        .toBe(`${ROW_LEFT_INSET_PX}px`);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('content taller than the viewport shows the rail and rows widen their right padding to clear it', async () => {
+    const { browser, page } = await launch();
+    try {
+      await openConversation(page, LONG_SESSION_ID);
+      await expect(page.getByText('LONG_CONTENT_MARKER', { exact: false }).first()).toBeVisible();
+
+      // Rail shows: onShowRailChange(true) - 60 turns overflow the viewport.
+      await expect(page.getByTestId('conversation-scrollbar-rail')).toBeVisible();
+
+      // hasScrollbar flips true, so rows widen their right padding to clear
+      // the rail/thumb instead of the plain left-matching inset.
+      await expect
+        .poll(async () =>
+          page.getByTestId('conversation-row-gap').first().evaluate((el) => (el as HTMLElement).style.paddingRight),
+        )
+        .toBe(`${CONTENT_RIGHT_CLEARANCE_PX}px`);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/ui/conversation-search.spec.ts
+++ b/tests/ui/conversation-search.spec.ts
@@ -1,0 +1,237 @@
+/**
+ * UI tests for the conversation viewer's in-viewer search bar
+ * (ConversationSearchBar.tsx): always visible by default (no header toggle
+ * button), Mod+F focuses it, navigating to a result by click and via
+ * prev/next, the match count, a hit inside a folded tool card auto-expanding
+ * it, Escape blurring the input without closing the window (a second Escape
+ * then closes it), and that the board's own Mod+F does not also fire.
+ *
+ * Cross-platform: no pixel assertions, no bare waitForTimeout - every check
+ * polls for a condition (data attribute / testid / text).
+ */
+import { test, expect, chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-conv-search';
+const TASK_ID = 'task-conv-search-1';
+const SESSION_ID = 'sess-conv-search-a';
+
+function preConfig(): string {
+  return `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+      var nowMs = Date.now();
+
+      state.projects.push({
+        id: '${PROJECT_ID}', name: 'Conversation Search Project', path: '/mock/convsearch',
+        github_url: null, default_agent: 'claude', last_opened: ts, created_at: ts,
+      });
+
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        state.swimlanes.push(Object.assign({}, s, { id: 'lane-convsearch-' + i, position: i, created_at: ts }));
+      });
+
+      state.tasks.push({
+        id: '${TASK_ID}', title: 'Search fixture task', description: '',
+        swimlane_id: 'lane-convsearch-0', position: 0, agent: null, session_id: null,
+        worktree_path: null, branch_name: null, pr_number: null, pr_url: null,
+        base_branch: null, archived_at: null, created_at: ts, updated_at: ts,
+      });
+
+      var transcriptSeeds = {};
+      transcriptSeeds['${SESSION_ID}'] = {
+        sessionId: '${SESSION_ID}', taskId: '${TASK_ID}', taskTitle: 'Search fixture task',
+        agentName: 'Claude Code', startedAt: ts, sessionStatus: 'exited',
+        source: 'live', sourcePath: '/mock/convsearch.jsonl',
+        entries: [
+          { kind: 'user', uuid: 'turn-1', ts: nowMs, text: 'Please look at the retry backoff logic' },
+          { kind: 'assistant', uuid: 'turn-2', ts: nowMs + 1, model: 'claude-opus-4-8',
+            blocks: [{ type: 'text', text: 'I looked at the retry backoff logic and found the bug' }] },
+          { kind: 'user', uuid: 'turn-3', ts: nowMs + 2, text: 'Thanks, what about the worktree cleanup path' },
+          { kind: 'assistant', uuid: 'turn-4', ts: nowMs + 3, model: 'claude-opus-4-8',
+            blocks: [
+              { type: 'text', text: 'Checking the worktree cleanup path now' },
+              { type: 'tool_use', id: 'tool-search-1', name: 'Bash', input: { command: 'git worktree list' } },
+            ] },
+          { kind: 'tool_result', uuid: 'turn-5', ts: nowMs + 4, toolUseId: 'tool-search-1',
+            content: 'FOLDED_RESULT_MARKER worktree list output here', isError: false },
+          { kind: 'user', uuid: 'turn-6', ts: nowMs + 5, text: 'One more unrelated turn with no matches at all' },
+        ],
+        degraded: false,
+        sessions: [
+          { sessionId: '${SESSION_ID}', agentName: 'Claude Code', startedAt: ts, exitedAt: ts, isolatedSwimlaneId: null, status: 'exited' },
+        ],
+      };
+
+      return {
+        currentProjectId: '${PROJECT_ID}',
+        transcriptSeeds: transcriptSeeds,
+      };
+    });
+  `;
+}
+
+async function launch(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady();
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(preConfig());
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+  return { browser, page };
+}
+
+async function openConversation(page: Page): Promise<void> {
+  await page.evaluate((sid) => {
+    const stores = (window as unknown as {
+      __zustandStores?: { session: { getState: () => { setConversationSessionId: (id: string) => void } } };
+    }).__zustandStores;
+    stores?.session.getState().setConversationSessionId(sid);
+  }, SESSION_ID);
+  await expect(page.getByTestId('conversation-window')).toBeVisible({ timeout: 5000 });
+  await expect(page.getByTestId('conversation-view')).toBeVisible({ timeout: 5000 });
+}
+
+/** The conversation window must be FOCUSED for its Mod+F binding to win over
+ *  the board's global one - click its title bar to focus it. */
+async function focusConversationWindow(page: Page): Promise<void> {
+  await page.getByTestId('conversation-titlebar').click({ position: { x: 200, y: 10 } });
+}
+
+test.describe('Conversation Viewer - in-viewer search', () => {
+  test('the search bar is visible by default, with no header toggle button', async () => {
+    const { browser, page } = await launch();
+    try {
+      await openConversation(page);
+      await expect(page.getByTestId('conversation-search-bar')).toBeVisible();
+      await expect(page.getByTestId('conversation-search-input')).toBeVisible();
+      await expect(page.getByTestId('conversation-search-button')).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('Mod+F focuses the search input while the conversation window is focused, without also triggering board find', async () => {
+    const { browser, page } = await launch();
+    try {
+      await openConversation(page);
+      await focusConversationWindow(page);
+
+      await page.keyboard.press('ControlOrMeta+F');
+      await expect(page.getByTestId('conversation-search-input')).toBeFocused();
+      // The board's own find/search palette must not also have opened.
+      await expect(page.getByTestId('search-palette-input')).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('typing a query lists matching turns with a count, and clicking a result navigates and flashes it', async () => {
+    const { browser, page } = await launch();
+    try {
+      await openConversation(page);
+
+      await page.getByTestId('conversation-search-input').fill('retry backoff');
+      await expect(page.getByTestId('conversation-search-results')).toBeVisible();
+      const results = page.getByTestId('conversation-search-result');
+      // Both turn-1 (user) and turn-2 (assistant) mention "retry backoff".
+      await expect(results).toHaveCount(2);
+
+      await results.first().click();
+      await expect
+        .poll(async () => page.locator('[data-highlighted="true"]').count())
+        .toBeGreaterThan(0);
+      await expect(page.getByTestId('conversation-search-count')).toHaveText('1 of 2');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('prev/next navigation cycles through matches and wraps, updating the count', async () => {
+    const { browser, page } = await launch();
+    try {
+      await openConversation(page);
+      await page.getByTestId('conversation-search-input').fill('retry backoff');
+      await expect(page.getByTestId('conversation-search-results')).toBeVisible();
+
+      await page.getByTestId('conversation-search-next').click();
+      await expect(page.getByTestId('conversation-search-count')).toHaveText('1 of 2');
+      await page.getByTestId('conversation-search-next').click();
+      await expect(page.getByTestId('conversation-search-count')).toHaveText('2 of 2');
+      // Wraps back to the first match.
+      await page.getByTestId('conversation-search-next').click();
+      await expect(page.getByTestId('conversation-search-count')).toHaveText('1 of 2');
+
+      // Enter/Shift+Enter drive the same navigation from the input.
+      await page.getByTestId('conversation-search-input').press('Shift+Enter');
+      await expect(page.getByTestId('conversation-search-count')).toHaveText('2 of 2');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('a hit inside a folded tool result auto-expands the owning tool card on navigate', async () => {
+    const { browser, page } = await launch();
+    try {
+      await openConversation(page);
+
+      await page.getByTestId('conversation-search-input').fill('FOLDED_RESULT_MARKER');
+      const result = page.getByTestId('conversation-search-result').first();
+      await expect(result).toBeVisible();
+      await result.click();
+
+      // The tool card the result folded into must expand and show the
+      // matched text, which is otherwise hidden until toggled open.
+      await expect(page.getByText('FOLDED_RESULT_MARKER', { exact: false })).toBeVisible();
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('Escape blurs the search input without closing the window; a second Escape then closes it', async () => {
+    const { browser, page } = await launch();
+    try {
+      await openConversation(page);
+      await focusConversationWindow(page);
+      const input = page.getByTestId('conversation-search-input');
+      await input.click();
+      await expect(input).toBeFocused();
+
+      await input.press('Escape');
+      await expect(input).not.toBeFocused();
+      // The bar itself has no closed state - it stays mounted and visible.
+      await expect(page.getByTestId('conversation-search-bar')).toBeVisible();
+      await expect(page.getByTestId('conversation-window')).toBeVisible();
+
+      await page.keyboard.press('Escape');
+      await expect(page.getByTestId('conversation-window')).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('a query with no matches shows "No results" and disables prev/next', async () => {
+    const { browser, page } = await launch();
+    try {
+      await openConversation(page);
+
+      await page.getByTestId('conversation-search-input').fill('nothing matches this string anywhere');
+      await expect(page.getByTestId('conversation-search-count')).toHaveText('No results');
+      await expect(page.getByTestId('conversation-search-next')).toBeDisabled();
+      await expect(page.getByTestId('conversation-search-previous')).toBeDisabled();
+      await expect(page.getByTestId('conversation-search-results')).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/ui/conversation-viewer.spec.ts
+++ b/tests/ui/conversation-viewer.spec.ts
@@ -682,6 +682,59 @@ test.describe('Conversation Viewer', () => {
     }
   });
 
+  test('a live poll reporting { unchanged: true } (the IPC revision short-circuit) leaves the rendered content untouched across several ticks', async () => {
+    const { browser, page } = await launch(undefined, liveSessionPreConfig());
+    try {
+      await openConversation(page, 'sess-conv-liveswitch-old');
+      await expect(page.getByText('LIVESWITCH_INITIAL_TEXT')).toBeVisible();
+
+      // First override call returns full content WITH an explicit revision;
+      // every call after that reports unchanged for the SAME revision - the
+      // shape `transcripts.get` returns once main's stitch-memo revision has
+      // not moved since the caller's last-known revision.
+      await page.evaluate(() => {
+        (window as unknown as { __unchangedPollCallCount?: number }).__unchangedPollCallCount = 0;
+        window.__mockTranscriptsGetOverride = (input) => {
+          if (input.sessionId !== 'sess-conv-liveswitch-old') return undefined;
+          const state = window as unknown as { __unchangedPollCallCount: number };
+          state.__unchangedPollCallCount += 1;
+          if (state.__unchangedPollCallCount === 1) {
+            return {
+              sessionId: 'sess-conv-liveswitch-old',
+              taskId: 'task-conv-liveswitch',
+              taskTitle: 'Live session switch',
+              agentName: 'Claude Code',
+              startedAt: new Date().toISOString(),
+              sessionStatus: 'suspended',
+              source: 'live',
+              sourcePath: '/mock/liveswitch-old.jsonl',
+              entries: [{ kind: 'user', uuid: 'turn-liveswitch-1', ts: Date.now(), text: 'LIVESWITCH_INITIAL_TEXT' }],
+              degraded: false,
+              sessions: [
+                { sessionId: 'sess-conv-liveswitch-old', agentName: 'Claude Code', startedAt: new Date().toISOString(), exitedAt: new Date().toISOString(), isolatedSwimlaneId: null, status: 'suspended' },
+                { sessionId: 'sess-conv-liveswitch-new', agentName: 'Claude Code', startedAt: new Date().toISOString(), exitedAt: null, isolatedSwimlaneId: null, status: 'running' },
+              ],
+              revision: 7,
+            };
+          }
+          return { unchanged: true, revision: 7 };
+        };
+      });
+
+      // Let several poll ticks (2500ms interval) land on the unchanged branch.
+      await expect
+        .poll(async () => page.evaluate(() => (window as unknown as { __unchangedPollCallCount: number }).__unchangedPollCallCount), { timeout: 12_000 })
+        .toBeGreaterThanOrEqual(3);
+
+      // The viewer never blanked, errored, or lost its content across those
+      // unchanged ticks.
+      await expect(page.getByText('LIVESWITCH_INITIAL_TEXT')).toBeVisible();
+      await expect(page.getByTestId('conversation-view')).toBeVisible();
+    } finally {
+      await browser.close();
+    }
+  });
+
   test('a duplicate uuid in the transcript is rendered once, not piled up as a stale overlapping row', async () => {
     const { browser, page } = await launch();
     try {

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -2547,30 +2547,50 @@
 
     transcripts: {
       get: function (input) {
+        var response = null;
         // Test hook: window.__mockTranscriptsGetOverride(input) => response | undefined,
         // for a live-poll test where later calls must return different content
         // than the first (a static transcriptSeeds entry can't vary per call).
+        // The override may itself return an explicit `{ unchanged: true, revision }`
+        // shape to drive the revision-short-circuit path directly.
         if (typeof window !== 'undefined' && typeof window.__mockTranscriptsGetOverride === 'function') {
           var overridden = window.__mockTranscriptsGetOverride(input);
-          if (overridden) return Promise.resolve(overridden);
+          if (overridden) response = overridden;
         }
-        var seed = transcriptSeeds[input.sessionId];
-        if (seed) return Promise.resolve(seed);
-        // Default: nothing indexed / no native file for this session.
-        return Promise.resolve({
-          sessionId: input.sessionId,
-          taskId: null,
-          taskTitle: '',
-          agentName: '',
-          startedAt: new Date().toISOString(),
-          sessionStatus: null,
-          source: 'none',
-          sourcePath: null,
-          entries: [],
-          degraded: false,
-          unavailableReason: 'file_missing',
-          sessions: [],
-        });
+        if (!response) {
+          var seed = transcriptSeeds[input.sessionId];
+          response = seed || {
+            // Default: nothing indexed / no native file for this session.
+            sessionId: input.sessionId,
+            taskId: null,
+            taskTitle: '',
+            agentName: '',
+            startedAt: new Date().toISOString(),
+            sessionStatus: null,
+            source: 'none',
+            sourcePath: null,
+            entries: [],
+            degraded: false,
+            unavailableReason: 'file_missing',
+            sessions: [],
+            revision: 0,
+          };
+        }
+        if (response.unchanged === true) return Promise.resolve(response);
+        // Only apply the knownRevision short-circuit when the seed/override
+        // EXPLICITLY set a numeric revision - most fixtures (and the
+        // pre-revision override tests) don't manage revision at all and
+        // expect every call to return the full current content, relying on
+        // the real client-side transcriptSignature dedup instead. Defaulting
+        // an implicit revision to a fixed value would incorrectly make a
+        // later poll with a matching knownRevision look "unchanged" forever.
+        if (typeof response.revision === 'number') {
+          if (input.knownRevision !== undefined && input.knownRevision === response.revision) {
+            return Promise.resolve({ unchanged: true, revision: response.revision });
+          }
+          return Promise.resolve(response);
+        }
+        return Promise.resolve(Object.assign({}, response, { revision: 0 }));
       },
       listSessions: function (taskId, _projectId) {
         var list = transcriptSessionsByTask[taskId];

--- a/tests/unit/claude-transcript-parser-incremental.test.ts
+++ b/tests/unit/claude-transcript-parser-incremental.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  parseClaudeTranscript,
+  resetIncrementalParseStateForTests,
+  incrementalStateSizeForTests,
+} from '../../src/main/agent/adapters/claude/transcript-parser';
+
+/**
+ * Covers the incremental-append parse path in `parseClaudeTranscript`: when a
+ * transcript file's size grows and its mtime does not go backwards, only the
+ * NEW bytes are read and parsed, appended onto the entries array from the
+ * prior call - instead of re-reading and re-parsing the whole file. All
+ * cases reuse the SAME path across multiple `parseClaudeTranscript` calls
+ * (unlike claude-transcript-parser.test.ts's fresh-path-per-test convention),
+ * which is exactly what exercises this path, so each test resets the
+ * module-scope incremental state first for isolation.
+ */
+
+function line(record: Record<string, unknown>): string {
+  return `${JSON.stringify(record)}\n`;
+}
+
+function crlfLine(record: Record<string, unknown>): string {
+  return `${JSON.stringify(record)}\r\n`;
+}
+
+function userLineRecord(uuid: string, text: string, ts: string): Record<string, unknown> {
+  return { type: 'user', uuid, timestamp: ts, message: { role: 'user', content: text } };
+}
+
+function userLine(uuid: string, text: string, ts = '2026-06-01T00:00:00Z'): string {
+  return line({ type: 'user', uuid, timestamp: ts, message: { role: 'user', content: text } });
+}
+
+function assistantTextLine(
+  uuid: string,
+  messageId: string,
+  text: string,
+  usage: Record<string, number> | null,
+  ts = '2026-06-01T00:00:01Z',
+): string {
+  const message: Record<string, unknown> = {
+    id: messageId,
+    role: 'assistant',
+    model: 'claude-opus-4-8',
+    content: [{ type: 'text', text }],
+  };
+  if (usage) message.usage = usage;
+  return line({ type: 'assistant', uuid, timestamp: ts, message });
+}
+
+describe('parseClaudeTranscript incremental append', () => {
+  let tmpDir: string;
+  let file: string;
+
+  beforeEach(() => {
+    resetIncrementalParseStateForTests();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'transcript-incremental-test-'));
+    file = path.join(tmpDir, 'session.jsonl');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('append round-trip: parsing after N appends equals a single full parse of the final content', async () => {
+    fs.writeFileSync(file, userLine('u1', 'first prompt'));
+    const afterFirst = await parseClaudeTranscript(file);
+    expect(afterFirst).toHaveLength(1);
+
+    fs.appendFileSync(file, assistantTextLine('a1', 'm1', 'first reply', { input_tokens: 10, output_tokens: 5 }));
+    const afterSecond = await parseClaudeTranscript(file);
+    expect(afterSecond).toHaveLength(2);
+
+    fs.appendFileSync(file, userLine('u2', 'second prompt'));
+    const afterThird = await parseClaudeTranscript(file);
+    expect(afterThird).toHaveLength(3);
+
+    // Cross-check against a single full parse of the same final content from
+    // a fresh (never-incrementally-touched) path.
+    const fullPath = path.join(tmpDir, 'session-full.jsonl');
+    fs.writeFileSync(fullPath, fs.readFileSync(file));
+    const fullParse = await parseClaudeTranscript(fullPath);
+
+    expect(afterThird.map((entry) => entry.uuid)).toEqual(fullParse.map((entry) => entry.uuid));
+  });
+
+  it('holds a partial (no trailing newline) line as carry until it completes, never parsing it early', async () => {
+    fs.writeFileSync(file, userLine('u1', 'first prompt'));
+    await parseClaudeTranscript(file);
+
+    // Simulate a write-in-progress: append a line's bytes WITHOUT its
+    // terminating newline yet.
+    const partial = JSON.stringify({ type: 'user', uuid: 'u2', timestamp: '2026-06-01T00:00:02Z', message: { role: 'user', content: 'second prompt' } });
+    fs.appendFileSync(file, partial);
+    const whilePartial = await parseClaudeTranscript(file);
+    expect(whilePartial).toHaveLength(1); // the partial line must NOT appear yet
+
+    // Now the writer finishes the line.
+    fs.appendFileSync(file, '\n');
+    const afterComplete = await parseClaudeTranscript(file);
+    expect(afterComplete).toHaveLength(2);
+    expect(afterComplete[1]).toMatchObject({ kind: 'user', uuid: 'u2', text: 'second prompt' });
+  });
+
+  it('falls back to a full reparse when the file shrinks (rotation/truncation), never reading stale byte offsets', async () => {
+    fs.writeFileSync(file, userLine('u1', 'first prompt') + assistantTextLine('a1', 'm1', 'first reply', null));
+    const before = await parseClaudeTranscript(file);
+    expect(before).toHaveLength(2);
+
+    // Truncate to a single, DIFFERENT line (simulating log rotation).
+    fs.writeFileSync(file, userLine('u-new', 'after rotation'));
+    const after = await parseClaudeTranscript(file);
+
+    expect(after).toHaveLength(1);
+    expect(after[0]).toMatchObject({ kind: 'user', uuid: 'u-new', text: 'after rotation' });
+  });
+
+  it('attributes usage exactly once for a turn split across two SEPARATE parse calls (thinking-only line, then the text line in a later increment)', async () => {
+    // The thinking block is EMPTY (real Claude JSONL never persists plaintext
+    // thinking), so this line produces NO entry and must NOT claim message
+    // m1's usage - if it did, the text line's usage below would be dropped.
+    fs.writeFileSync(
+      file,
+      line({
+        type: 'assistant',
+        uuid: 'think-1',
+        timestamp: '2026-06-01T00:00:00Z',
+        message: { id: 'm1', role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'thinking', thinking: '' }] },
+      }),
+    );
+    const afterThinkingOnly = await parseClaudeTranscript(file);
+    expect(afterThinkingOnly).toHaveLength(0);
+
+    // The text line for the SAME message id lands in a LATER increment.
+    fs.appendFileSync(file, assistantTextLine('text-1', 'm1', 'the actual reply', { input_tokens: 100, output_tokens: 40 }));
+    const afterText = await parseClaudeTranscript(file);
+
+    expect(afterText).toHaveLength(1);
+    const [entry] = afterText;
+    expect(entry.kind).toBe('assistant');
+    if (entry.kind === 'assistant') {
+      expect(entry.usage).toEqual({
+        inputTokens: 100,
+        outputTokens: 40,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+      });
+    }
+  });
+
+  it('does not re-read already-consumed bytes: a second call with no file change returns entries without touching the filesystem again', async () => {
+    fs.writeFileSync(file, userLine('u1', 'first prompt'));
+    const first = await parseClaudeTranscript(file);
+    const second = await parseClaudeTranscript(file);
+
+    // Same content, same result (identity is the transcript-cache layer's
+    // concern, not this function's - this only asserts correctness holds).
+    expect(second).toEqual(first);
+  });
+
+  it('caps incrementalStateByPath at INCREMENTAL_STATE_LIMIT (32) and evicts the oldest path on overflow', async () => {
+    const totalDistinctPaths = 40;
+    const parsedPaths: string[] = [];
+    for (let pathIndex = 0; pathIndex < totalDistinctPaths; pathIndex += 1) {
+      const distinctPath = path.join(tmpDir, `session-${pathIndex}.jsonl`);
+      fs.writeFileSync(distinctPath, userLine(`u${pathIndex}`, `prompt ${pathIndex}`));
+      parsedPaths.push(distinctPath);
+      await parseClaudeTranscript(distinctPath);
+    }
+
+    // Crisp red-green anchor: reverting the eviction loop in
+    // `touchIncrementalState` leaves every one of the 40 distinct paths
+    // resident, so this assertion fails at 40 without the cap in place.
+    expect(incrementalStateSizeForTests()).toBeLessThanOrEqual(32);
+
+    // Observable eviction: the FIRST (oldest, now-evicted) path's state is
+    // gone, so appending to it and re-parsing takes the full-reparse
+    // fallback rather than an incremental append. The fallback is
+    // transparent to correctness, so this still parses correctly - proving
+    // the cap evicted state without corrupting a later parse of that path.
+    const oldestPath = parsedPaths[0];
+    fs.appendFileSync(oldestPath, userLine('u-oldest-appended', 'appended after eviction'));
+    const oldestReparsed = await parseClaudeTranscript(oldestPath);
+    expect(oldestReparsed).toHaveLength(2);
+    expect(oldestReparsed[1]).toMatchObject({
+      kind: 'user',
+      uuid: 'u-oldest-appended',
+      text: 'appended after eviction',
+    });
+
+    // One of the LAST 32 touched paths should still be cached (reused
+    // incremental state), and the cap continues to hold after this parse.
+    const mostRecentPath = parsedPaths[totalDistinctPaths - 1];
+    fs.appendFileSync(mostRecentPath, userLine('u-recent-appended', 'appended while cached'));
+    const recentReparsed = await parseClaudeTranscript(mostRecentPath);
+    expect(recentReparsed).toHaveLength(2);
+    expect(recentReparsed[1]).toMatchObject({
+      kind: 'user',
+      uuid: 'u-recent-appended',
+      text: 'appended while cached',
+    });
+    expect(incrementalStateSizeForTests()).toBeLessThanOrEqual(32);
+  });
+
+  it('parses a CRLF-terminated line appended incrementally to a CRLF-terminated transcript', async () => {
+    fs.writeFileSync(file, crlfLine(userLineRecord('u1', 'first prompt', '2026-06-01T00:00:00Z')));
+    const afterFirst = await parseClaudeTranscript(file);
+    expect(afterFirst).toHaveLength(1);
+    expect(afterFirst[0]).toMatchObject({ kind: 'user', uuid: 'u1', text: 'first prompt' });
+
+    fs.appendFileSync(file, crlfLine(userLineRecord('u2', 'second prompt', '2026-06-01T00:00:01Z')));
+    const afterSecond = await parseClaudeTranscript(file);
+
+    expect(afterSecond).toHaveLength(2);
+    expect(afterSecond[1]).toMatchObject({ kind: 'user', uuid: 'u2', text: 'second prompt' });
+  });
+});

--- a/tests/unit/display-rows-reconcile.test.ts
+++ b/tests/unit/display-rows-reconcile.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { reconcileDisplayRows } from '../../src/renderer/components/conversation/display-rows';
+import type { TranscriptEntry } from '../../src/shared/types';
+
+/**
+ * `reconcileDisplayRows` is what lets `MemoConversationRow`'s default
+ * shallow-compare skip re-rendering rows a live-poll tick did not actually
+ * change - it reuses a previous row's OBJECT REFERENCE whenever the row's
+ * uuid and content signature both match. Covers: identity preservation
+ * across an unchanged append, a growing last row NOT busting earlier rows, a
+ * late tool_result busting only its OWNING assistant row, and basic
+ * searchText/searchSegments construction.
+ */
+
+function userEntry(uuid: string, text: string, ts = 1): TranscriptEntry {
+  return { kind: 'user', uuid, ts, text };
+}
+
+function assistantTextEntry(uuid: string, text: string, ts = 2): TranscriptEntry {
+  return { kind: 'assistant', uuid, ts, blocks: [{ type: 'text', text }] };
+}
+
+function assistantToolUseEntry(uuid: string, toolUseId: string, ts = 3): TranscriptEntry {
+  return {
+    kind: 'assistant',
+    uuid,
+    ts,
+    blocks: [{ type: 'tool_use', id: toolUseId, name: 'Bash', input: { command: 'ls' } }],
+  };
+}
+
+function toolResultEntry(uuid: string, toolUseId: string, content: string, ts = 4): TranscriptEntry {
+  return { kind: 'tool_result', uuid, ts, toolUseId, content };
+}
+
+describe('reconcileDisplayRows', () => {
+  it('reuses row object references when entries are unchanged (identity preservation)', () => {
+    const entries: TranscriptEntry[] = [userEntry('u1', 'hello'), assistantTextEntry('a1', 'hi there')];
+    const first = reconcileDisplayRows([], entries);
+    const second = reconcileDisplayRows(first, entries);
+
+    expect(second[0]).toBe(first[0]);
+    expect(second[1]).toBe(first[1]);
+  });
+
+  it('a genuine content change to one entry produces a NEW row for it, but does not disturb other unchanged rows', () => {
+    const entries: TranscriptEntry[] = [userEntry('u1', 'hello'), assistantTextEntry('a1', 'hi there')];
+    const first = reconcileDisplayRows([], entries);
+
+    const changed: TranscriptEntry[] = [userEntry('u1', 'hello'), assistantTextEntry('a1', 'hi there - edited')];
+    const second = reconcileDisplayRows(first, changed);
+
+    expect(second[0]).toBe(first[0]); // u1 unchanged
+    expect(second[1]).not.toBe(first[1]); // a1 changed
+  });
+
+  it('appending a new last entry produces a new row for it while ALL earlier rows keep their identity', () => {
+    const entries: TranscriptEntry[] = [
+      userEntry('u1', 'first'),
+      assistantTextEntry('a1', 'reply one'),
+      userEntry('u2', 'second'),
+    ];
+    const first = reconcileDisplayRows([], entries);
+
+    const grown: TranscriptEntry[] = [...entries, assistantTextEntry('a2', 'reply two')];
+    const second = reconcileDisplayRows(first, grown);
+
+    expect(second).toHaveLength(4);
+    expect(second[0]).toBe(first[0]);
+    expect(second[1]).toBe(first[1]);
+    expect(second[2]).toBe(first[2]);
+    expect(second[3]).not.toBe(first[2]); // the new row, obviously distinct
+  });
+
+  it('a late tool_result landing for an existing tool_use busts ONLY the owning assistant row, not sibling rows', () => {
+    const entries: TranscriptEntry[] = [
+      userEntry('u1', 'run ls'),
+      assistantToolUseEntry('a1', 'tool-1'),
+      userEntry('u2', 'unrelated turn'),
+    ];
+    const first = reconcileDisplayRows([], entries);
+    // Before the result lands, the tool_use row folds no result.
+    expect(first[1].results.size).toBe(0);
+
+    const withResult: TranscriptEntry[] = [
+      ...entries,
+      toolResultEntry('r1', 'tool-1', 'file1.txt\nfile2.txt'),
+    ];
+    const second = reconcileDisplayRows(first, withResult);
+
+    // The tool_result entry is folded into its owner, not its own row.
+    expect(second).toHaveLength(3);
+    expect(second[0]).toBe(first[0]); // untouched
+    expect(second[1]).not.toBe(first[1]); // owning row busted - now carries the result
+    expect(second[1].results.get('tool-1')).toMatchObject({ content: 'file1.txt\nfile2.txt', isError: false });
+    expect(second[2]).toBe(first[2]); // sibling row untouched
+  });
+
+  it('folds an owned tool_result into its owner and never emits it as a standalone row', () => {
+    const entries: TranscriptEntry[] = [
+      assistantToolUseEntry('a1', 'tool-1'),
+      toolResultEntry('r1', 'tool-1', 'result body'),
+    ];
+    const rows = reconcileDisplayRows([], entries);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].uuid).toBe('a1');
+  });
+
+  it('renders an UNOWNED tool_result (no matching tool_use in this parse) as its own standalone row', () => {
+    const entries: TranscriptEntry[] = [toolResultEntry('r1', 'orphan-tool', 'orphaned output')];
+    const rows = reconcileDisplayRows([], entries);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].uuid).toBe('r1');
+    expect(rows[0].entry.kind).toBe('tool_result');
+  });
+
+  it('dedupes a duplicate uuid, keeping only the first occurrence', () => {
+    const entries: TranscriptEntry[] = [userEntry('u1', 'first'), userEntry('u1', 'duplicate')];
+    const rows = reconcileDisplayRows([], entries);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].entry.kind === 'user' && rows[0].entry.text).toBe('first');
+  });
+
+  it('builds searchText covering user text and assistant text blocks', () => {
+    const entries: TranscriptEntry[] = [userEntry('u1', 'find this keyword')];
+    const rows = reconcileDisplayRows([], entries);
+
+    expect(rows[0].searchText.toLowerCase()).toContain('find this keyword');
+    expect(rows[0].searchSegments.length).toBeGreaterThan(0);
+    // A user turn's text is always visible - no fold key needed.
+    expect(rows[0].searchSegments[0].expandKey).toBeNull();
+  });
+
+  it('gives a tool_use block segment an expandKey matching the id ConversationView uses to toggle it', () => {
+    const entries: TranscriptEntry[] = [assistantToolUseEntry('a1', 'tool-xyz')];
+    const rows = reconcileDisplayRows([], entries);
+
+    const toolSegment = rows[0].searchSegments.find((segment) => segment.expandKey === 'tool-xyz');
+    expect(toolSegment).toBeDefined();
+  });
+
+  it('gives a thinking block segment an expandKey in the "<uuid>:think:<index>" format ConversationView uses', () => {
+    const entries: TranscriptEntry[] = [
+      { kind: 'assistant', uuid: 'a1', ts: 1, blocks: [{ type: 'thinking', text: 'pondering the problem' }] },
+    ];
+    const rows = reconcileDisplayRows([], entries);
+
+    const thinkingSegment = rows[0].searchSegments.find((segment) => segment.expandKey === 'a1:think:0');
+    expect(thinkingSegment).toBeDefined();
+  });
+
+  it('estimates a taller row for longer text content than a short one', () => {
+    const shortEntries: TranscriptEntry[] = [userEntry('u1', 'short')];
+    const longEntries: TranscriptEntry[] = [userEntry('u1', 'x'.repeat(2000))];
+
+    const shortRows = reconcileDisplayRows([], shortEntries);
+    const longRows = reconcileDisplayRows([], longEntries);
+
+    expect(longRows[0].estimatedHeight).toBeGreaterThan(shortRows[0].estimatedHeight);
+  });
+});

--- a/tests/unit/keybindings-registry.test.ts
+++ b/tests/unit/keybindings-registry.test.ts
@@ -116,6 +116,9 @@ describe('scopesOverlap', () => {
   it('does NOT overlap intentional-shadow scope pairs', () => {
     expect(scopesOverlap('board', 'task-dialog')).toBe(false);
     expect(scopesOverlap('task-dialog', 'command-bar')).toBe(false);
+    // conversation.find intentionally shadows search.plainFind's Mod+F while a
+    // Conversation window is focused - see the id's registry comment.
+    expect(scopesOverlap('conversation', 'global')).toBe(false);
   });
 });
 

--- a/tests/unit/scrollbar-math.test.ts
+++ b/tests/unit/scrollbar-math.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { computeThumbGeometry, thumbPositionToOffset, MIN_THUMB_SIZE_PX } from '../../src/renderer/components/conversation/scrollbar-math';
+
+/**
+ * Pure geometry helpers behind ConversationScrollbar.tsx. Covers: the
+ * offset<->thumb-position round trip, the minimum-thumb clamp engaging on a
+ * very long transcript, and both scroll extremes pinning the thumb to the
+ * rail ends.
+ */
+
+describe('computeThumbGeometry', () => {
+  it('sizes the thumb proportionally when the proportional size is above the floor', () => {
+    // viewport is half the total content -> thumb should be ~half the rail.
+    const { thumbSize } = computeThumbGeometry({ scrollOffset: 0, totalSize: 2000, viewportSize: 500, railSize: 500 });
+    expect(thumbSize).toBeCloseTo(125, 0);
+  });
+
+  it('clamps the thumb to MIN_THUMB_SIZE_PX on a very long transcript', () => {
+    const { thumbSize } = computeThumbGeometry({ scrollOffset: 0, totalSize: 500_000, viewportSize: 600, railSize: 600 });
+    expect(thumbSize).toBe(MIN_THUMB_SIZE_PX);
+  });
+
+  it('pins the thumb to the TOP of the rail at scrollOffset 0', () => {
+    const { thumbTop } = computeThumbGeometry({ scrollOffset: 0, totalSize: 500_000, viewportSize: 600, railSize: 600 });
+    expect(thumbTop).toBe(0);
+  });
+
+  it('pins the thumb to the BOTTOM of the rail at the maximum scroll offset', () => {
+    const totalSize = 500_000;
+    const viewportSize = 600;
+    const railSize = 600;
+    const maxOffset = totalSize - viewportSize;
+    const { thumbTop, thumbSize } = computeThumbGeometry({ scrollOffset: maxOffset, totalSize, viewportSize, railSize });
+    expect(thumbTop + thumbSize).toBeCloseTo(railSize, 0);
+  });
+
+  it('handles a zero/negative-size input gracefully (no NaN, no throw)', () => {
+    const result = computeThumbGeometry({ scrollOffset: 0, totalSize: 0, viewportSize: 0, railSize: 600 });
+    expect(Number.isNaN(result.thumbTop)).toBe(false);
+    expect(Number.isNaN(result.thumbSize)).toBe(false);
+  });
+});
+
+describe('thumbPositionToOffset <-> computeThumbGeometry round trip', () => {
+  it('round-trips a mid-scroll position through thumbTop -> offset -> thumbTop', () => {
+    const totalSize = 500_000;
+    const viewportSize = 600;
+    const railSize = 600;
+    const originalOffset = 120_000;
+
+    const { thumbTop, thumbSize } = computeThumbGeometry({ scrollOffset: originalOffset, totalSize, viewportSize, railSize });
+    const recoveredOffset = thumbPositionToOffset({ thumbTop, thumbSize, totalSize, viewportSize, railSize });
+    const { thumbTop: recoveredThumbTop } = computeThumbGeometry({ scrollOffset: recoveredOffset, totalSize, viewportSize, railSize });
+
+    expect(recoveredThumbTop).toBeCloseTo(thumbTop, 1);
+  });
+
+  it('dragging the thumb to the very top of the rail maps back to offset 0', () => {
+    const offset = thumbPositionToOffset({ thumbTop: 0, thumbSize: MIN_THUMB_SIZE_PX, totalSize: 500_000, viewportSize: 600, railSize: 600 });
+    expect(offset).toBe(0);
+  });
+
+  it('dragging the thumb to the very bottom of the rail maps back to the maximum scroll offset', () => {
+    const totalSize = 500_000;
+    const viewportSize = 600;
+    const railSize = 600;
+    const thumbSize = MIN_THUMB_SIZE_PX;
+    const thumbTravel = railSize - thumbSize;
+
+    const offset = thumbPositionToOffset({ thumbTop: thumbTravel, thumbSize, totalSize, viewportSize, railSize });
+
+    expect(offset).toBeCloseTo(totalSize - viewportSize, 0);
+  });
+});

--- a/tests/unit/settle-scroll.test.ts
+++ b/tests/unit/settle-scroll.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { computeSettleScrollTop, estimatedOffsetForIndex, ESTIMATED_ROW_HEIGHT, type SettleVirtualItem } from '../../src/renderer/components/conversation/settle-scroll';
+import type { DisplayRow } from '../../src/renderer/components/conversation/display-rows';
+
+/**
+ * Pure scrollTop math behind ConversationView's open-at-position settle
+ * loop. The load-bearing behavior under test: `computeSettleScrollTop`
+ * PREFERS a real, measured `virtualItem` (the virtualizer's own rendered
+ * item for the target index) over the static per-row `estimatedHeight`
+ * heuristic, no matter how far the two diverge - this is the exact
+ * regression fix for the open-at-position centering bug (see
+ * settle-scroll.ts's doc comment: without this, a settle loop that only
+ * ever trusted the static estimate would recompute the identical wrong
+ * value every tick and falsely report "stable").
+ */
+
+function fakeRow(uuid: string, estimatedHeight: number): DisplayRow {
+  return {
+    uuid,
+    entry: { kind: 'user', uuid, ts: 0, text: '' },
+    results: new Map(),
+    estimatedHeight,
+    searchText: '',
+    searchSegments: [],
+    signature: uuid,
+  };
+}
+
+describe('estimatedOffsetForIndex', () => {
+  it('sums the estimated heights of every row BEFORE the given index (exclusive)', () => {
+    const rows = [fakeRow('r0', 100), fakeRow('r1', 200), fakeRow('r2', 300)];
+    expect(estimatedOffsetForIndex(rows, 2)).toBe(300); // 100 + 200
+  });
+
+  it('returns 0 for index 0 (nothing before the first row)', () => {
+    const rows = [fakeRow('r0', 100)];
+    expect(estimatedOffsetForIndex(rows, 0)).toBe(0);
+  });
+
+  it('sums all rows when index is past the end of the array', () => {
+    const rows = [fakeRow('r0', 100), fakeRow('r1', 200)];
+    expect(estimatedOffsetForIndex(rows, 10)).toBe(300);
+  });
+
+  it('falls back to ESTIMATED_ROW_HEIGHT for a row missing its own estimate', () => {
+    const rows = [{ ...fakeRow('r0', 100), estimatedHeight: undefined as unknown as number }];
+    expect(estimatedOffsetForIndex(rows, 1)).toBe(ESTIMATED_ROW_HEIGHT);
+  });
+});
+
+describe('computeSettleScrollTop', () => {
+  it('falls back to the static per-row estimate sum when no virtualItem is rendered yet', () => {
+    const rows = [fakeRow('r0', 100), fakeRow('r1', 200), fakeRow('r2', 300), fakeRow('r3', 400)];
+    const result = computeSettleScrollTop({
+      align: 'start',
+      index: 3,
+      rows,
+      virtualItem: undefined,
+      clientHeight: 600,
+    });
+    // estimatedOffsetForIndex(rows, 3) = 100 + 200 + 300 = 600.
+    expect(result).toBe(600);
+  });
+
+  it('PREFERS the real, measured virtualItem over the static estimate, even when they wildly diverge (the regression fix)', () => {
+    // Mirrors display-rows.ts's MAX_HEIGHT clamp: every row's STATIC estimate
+    // is small, but the virtualizer's OWN measurement of the target row
+    // reports a real position thousands of px further down (simulating an
+    // earlier row - e.g. a huge markdown block - whose real rendered height
+    // was clamped to a much smaller static estimate).
+    const rows = [fakeRow('r0', 100), fakeRow('r1', 100), fakeRow('r2', 100), fakeRow('r3', 100)];
+    const staticEstimate = estimatedOffsetForIndex(rows, 3); // 300 - what a static-only loop would compute
+    const virtualItem: SettleVirtualItem = { index: 3, start: 9000, size: 120 };
+
+    const result = computeSettleScrollTop({
+      align: 'start',
+      index: 3,
+      rows,
+      virtualItem,
+      clientHeight: 600,
+    });
+
+    expect(result).toBe(9000); // virtualItem.start, not the static estimate
+    expect(result).not.toBe(staticEstimate);
+  });
+
+  it('align: "center" subtracts half the (clientHeight - rowHeight) gap from the row offset', () => {
+    const rows = [fakeRow('r0', 100), fakeRow('r1', 100)];
+    const virtualItem: SettleVirtualItem = { index: 1, start: 1000, size: 80 };
+    const result = computeSettleScrollTop({
+      align: 'center',
+      index: 1,
+      rows,
+      virtualItem,
+      clientHeight: 600,
+    });
+    // 1000 - max(0, (600 - 80) / 2) = 1000 - 260 = 740.
+    expect(result).toBe(740);
+  });
+
+  it('align: "center" never subtracts a NEGATIVE gap when the row is taller than the viewport', () => {
+    const rows = [fakeRow('r0', 100)];
+    const virtualItem: SettleVirtualItem = { index: 0, start: 500, size: 900 };
+    const result = computeSettleScrollTop({
+      align: 'center',
+      index: 0,
+      rows,
+      virtualItem,
+      clientHeight: 300, // rowHeight (900) > clientHeight (300)
+    });
+    // max(0, (300 - 900) / 2) clamps to 0, so the result is just the raw offset.
+    expect(result).toBe(500);
+  });
+
+  it('clamps the final result to a minimum of 0', () => {
+    const rows = [fakeRow('r0', 100)];
+    const virtualItem: SettleVirtualItem = { index: 0, start: 10, size: 50 };
+    const result = computeSettleScrollTop({
+      align: 'center',
+      index: 0,
+      rows,
+      virtualItem,
+      clientHeight: 600, // a large centering subtraction would otherwise go negative
+    });
+    expect(result).toBe(0);
+  });
+
+  it('rounds the result to the nearest integer pixel', () => {
+    const rows = [fakeRow('r0', 100)];
+    const virtualItem: SettleVirtualItem = { index: 0, start: 100, size: 51 };
+    const result = computeSettleScrollTop({
+      align: 'center',
+      index: 0,
+      rows,
+      virtualItem,
+      clientHeight: 200,
+    });
+    // 100 - (200 - 51) / 2 = 100 - 74.5 = 25.5 -> rounds to 26.
+    expect(result).toBe(26);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+});

--- a/tests/unit/terminal-capture-registry.test.ts
+++ b/tests/unit/terminal-capture-registry.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  registerTerminalCapture,
+  unregisterTerminalCapture,
+  captureTerminalScrollback,
+} from '../../src/renderer/utils/terminal-capture-registry';
+
+/**
+ * `unregisterTerminalCapture` must be safe against a STALE unmount cleanup
+ * firing after a newer mount has already registered its own reader for the
+ * same session id - the exact race that let the open-at-TUI-position feature
+ * silently end up with no reader registered at all (see the bottom-panel /
+ * task-dialog terminal ownership handoff, and React StrictMode's dev-only
+ * double-invoke cleanup).
+ */
+describe('terminal-capture-registry identity-guarded unregister', () => {
+  const sessionId = 'sess-registry-test';
+
+  beforeEach(() => {
+    unregisterTerminalCapture(sessionId);
+  });
+
+  it('captures the registered reader for a session', () => {
+    const reader = () => ({ visibleLines: ['hello'], atBottom: false });
+    registerTerminalCapture(sessionId, reader);
+
+    expect(captureTerminalScrollback(sessionId)).toEqual({ visibleLines: ['hello'], atBottom: false });
+  });
+
+  it('unregisters by identity: a stale reader does not clobber a newer registration', () => {
+    const staleReader = () => ({ visibleLines: ['stale'], atBottom: true });
+    const freshReader = () => ({ visibleLines: ['fresh'], atBottom: false });
+
+    registerTerminalCapture(sessionId, staleReader);
+    registerTerminalCapture(sessionId, freshReader);
+
+    // The stale mount's cleanup fires AFTER the fresh mount already
+    // registered - it must not delete the fresh registration.
+    unregisterTerminalCapture(sessionId, staleReader);
+
+    expect(captureTerminalScrollback(sessionId)).toEqual({ visibleLines: ['fresh'], atBottom: false });
+  });
+
+  it('unregisters normally when the identity matches the current reader', () => {
+    const reader = () => ({ visibleLines: ['only'], atBottom: true });
+    registerTerminalCapture(sessionId, reader);
+
+    unregisterTerminalCapture(sessionId, reader);
+
+    expect(captureTerminalScrollback(sessionId)).toBeNull();
+  });
+
+  it('falls back to an unconditional delete when no reader is passed', () => {
+    const reader = () => ({ visibleLines: ['x'], atBottom: false });
+    registerTerminalCapture(sessionId, reader);
+
+    unregisterTerminalCapture(sessionId);
+
+    expect(captureTerminalScrollback(sessionId)).toBeNull();
+  });
+
+  it('returns null for a session with no registered reader, or when the reader itself throws', () => {
+    expect(captureTerminalScrollback('sess-never-registered')).toBeNull();
+    expect(captureTerminalScrollback(null)).toBeNull();
+
+    registerTerminalCapture(sessionId, () => {
+      throw new Error('boom');
+    });
+    expect(captureTerminalScrollback(sessionId)).toBeNull();
+  });
+});

--- a/tests/unit/transcript-cache.test.ts
+++ b/tests/unit/transcript-cache.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getCachedTranscript, truncateEntries, resetForTests } from '../../src/main/agent/transcript-cache';
+import type { TranscriptEntry } from '../../src/shared/types';
+
+/**
+ * `getCachedTranscript` is the stat-validated per-file cache the conversation
+ * viewer's live poll relies on to avoid re-parsing an unchanged transcript
+ * file on every tick. Covers: same-reference on an unchanged stat, a fresh
+ * parse on a real content change, and LRU eviction past the cap.
+ */
+
+function writeFile(dir: string, name: string, content: string): string {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+describe('getCachedTranscript', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    resetForTests();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'transcript-cache-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns the SAME entries array reference on a second call with an unchanged file', async () => {
+    const file = writeFile(tmpDir, 'session.jsonl', 'line-one\n');
+    let parseCalls = 0;
+    const parse = async () => {
+      parseCalls += 1;
+      return { entries: [{ kind: 'user', uuid: 'u1', ts: 1, text: 'hello' }] as TranscriptEntry[], sourcePath: file };
+    };
+
+    const first = await getCachedTranscript('claude_agent', 'agent-1', parse);
+    const second = await getCachedTranscript('claude_agent', 'agent-1', parse);
+
+    expect(parseCalls).toBe(1);
+    expect(second.entries).toBe(first.entries);
+    expect(second.sourcePath).toBe(file);
+  });
+
+  it('re-parses and returns a NEW array when the file content actually changes', async () => {
+    const file = writeFile(tmpDir, 'session.jsonl', 'line-one\n');
+    let parseCalls = 0;
+    const parse = async () => {
+      parseCalls += 1;
+      const text = fs.readFileSync(file, 'utf-8');
+      return {
+        entries: [{ kind: 'user', uuid: `u${parseCalls}`, ts: parseCalls, text }] as TranscriptEntry[],
+        sourcePath: file,
+      };
+    };
+
+    const first = await getCachedTranscript('claude_agent', 'agent-1', parse);
+    // Force a distinct mtime/size: append more content.
+    fs.appendFileSync(file, 'line-two\n');
+    const second = await getCachedTranscript('claude_agent', 'agent-1', parse);
+
+    expect(parseCalls).toBe(2);
+    expect(second.entries).not.toBe(first.entries);
+  });
+
+  it('applies the 20k-char span clamp to the cached (truncated) entries', async () => {
+    const file = writeFile(tmpDir, 'session.jsonl', 'x');
+    const longText = 'A'.repeat(20_010);
+    const parse = async () => ({
+      entries: [{ kind: 'user', uuid: 'u1', ts: 1, text: longText }] as TranscriptEntry[],
+      sourcePath: file,
+    });
+
+    const result = await getCachedTranscript('claude_agent', 'agent-1', parse);
+
+    const [entry] = result.entries;
+    expect(entry.kind).toBe('user');
+    if (entry.kind === 'user') {
+      expect(entry.text).not.toBe(longText);
+      expect(entry.text).toContain('[truncated 10 chars]');
+    }
+  });
+
+  it('invalidates the cache entry when the file disappears', async () => {
+    const file = writeFile(tmpDir, 'session.jsonl', 'line-one\n');
+    const parse = async () => ({
+      entries: [{ kind: 'user', uuid: 'u1', ts: 1, text: 'hi' }] as TranscriptEntry[],
+      sourcePath: file,
+    });
+    await getCachedTranscript('claude_agent', 'agent-1', parse);
+
+    fs.rmSync(file, { force: true });
+    let secondParseCalled = false;
+    const secondParse = async () => {
+      secondParseCalled = true;
+      return { entries: [] as TranscriptEntry[], sourcePath: null };
+    };
+    const result = await getCachedTranscript('claude_agent', 'agent-1', secondParse);
+
+    expect(secondParseCalled).toBe(true);
+    expect(result.entries).toEqual([]);
+  });
+
+  it('evicts the least-recently-used entry once the cache grows past its cap', async () => {
+    // The cache is capped at 16; fill it with 17 distinct sessions and verify
+    // the FIRST (oldest, never re-touched) session re-parses on next access.
+    const files: string[] = [];
+    for (let index = 0; index < 17; index += 1) {
+      const file = writeFile(tmpDir, `session-${index}.jsonl`, `content-${index}\n`);
+      files.push(file);
+      await getCachedTranscript('claude_agent', `agent-${index}`, async () => ({
+        entries: [{ kind: 'user', uuid: `u${index}`, ts: index, text: `t${index}` }] as TranscriptEntry[],
+        sourcePath: file,
+      }));
+    }
+
+    let reparsed = false;
+    await getCachedTranscript('claude_agent', 'agent-0', async () => {
+      reparsed = true;
+      return {
+        entries: [{ kind: 'user', uuid: 'u0-again', ts: 0, text: 't0-again' }] as TranscriptEntry[],
+        sourcePath: files[0],
+      };
+    });
+
+    expect(reparsed).toBe(true);
+  });
+});
+
+describe('truncateEntries', () => {
+  it('clamps assistant text/thinking blocks and tool_result content, leaving tool_use input untouched', () => {
+    const longText = 'A'.repeat(20_100);
+    const entries: TranscriptEntry[] = [
+      {
+        kind: 'assistant',
+        uuid: 'a1',
+        ts: 1,
+        blocks: [
+          { type: 'text', text: longText },
+          { type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'X'.repeat(30_000) } },
+        ],
+      },
+      { kind: 'tool_result', uuid: 'r1', ts: 2, toolUseId: 't1', content: longText },
+      { kind: 'system', uuid: 's1', ts: 3, subtype: 'command', text: longText },
+    ];
+
+    const [assistant, toolResult, system] = truncateEntries(entries);
+
+    if (assistant.kind === 'assistant') {
+      const [textBlock, toolUseBlock] = assistant.blocks;
+      expect(textBlock.type === 'text' && textBlock.text.split('\n[truncated')[0].length).toBe(20_000);
+      expect(textBlock.type === 'text' && textBlock.text).toContain('[truncated 100 chars]');
+      expect(toolUseBlock.type === 'tool_use' && (toolUseBlock.input as { command: string }).command.length).toBe(30_000);
+    }
+    if (toolResult.kind === 'tool_result') {
+      expect(toolResult.content.split('\n[truncated')[0].length).toBe(20_000);
+    }
+    if (system.kind === 'system') {
+      expect(system.text.split('\n[truncated')[0].length).toBe(20_000);
+    }
+  });
+});

--- a/tests/unit/transcript-get-handler-revision-shortcircuit.test.ts
+++ b/tests/unit/transcript-get-handler-revision-shortcircuit.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for the TRANSCRIPT_GET IPC handler's `knownRevision`
+ * short-circuit in src/main/ipc/handlers/transcripts.ts.
+ *
+ * When the caller's `request.knownRevision` matches the task's current
+ * `resolved.revision`, the handler must skip the full structured-clone
+ * payload and return only `{ unchanged: true, revision }`. Any other case
+ * (a differing revision, or no `knownRevision` at all - the first fetch)
+ * must return the full `TranscriptGetResponse`, including `entries`.
+ *
+ * Strategy mirrors agent-summarize-handler.test.ts: capture the handler via
+ * a mocked `ipcMain.handle`, and stub `resolveTaskTranscript` (the service
+ * this handler delegates to) so the test controls the resolved revision
+ * directly rather than driving it through real DB/file state.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { TranscriptGetResponse, TranscriptUnchangedResponse } from '../../src/shared/types';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const capturedHandlers = new Map<string, (...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      capturedHandlers.set(channel, handler);
+    }),
+  },
+}));
+
+vi.mock('../../src/main/db/database', () => ({
+  getProjectDb: vi.fn(() => ({})),
+}));
+
+const resolveTaskTranscript = vi.fn();
+vi.mock('../../src/main/agent/transcript-service', () => ({
+  resolveTaskTranscript: (...args: unknown[]) => resolveTaskTranscript(...args),
+}));
+
+vi.mock('../../src/main/agent/agent-registry', () => ({
+  agentRegistry: { getBySessionType: vi.fn() },
+}));
+
+import { registerTranscriptHandlers } from '../../src/main/ipc/handlers/transcripts';
+import { IPC } from '../../src/shared/ipc-channels';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(currentProjectId: string | null) {
+  return { currentProjectId } as Parameters<typeof registerTranscriptHandlers>[0];
+}
+
+async function invokeTranscriptGet(request: {
+  sessionId: string;
+  projectId?: string | null;
+  knownRevision?: number;
+}): Promise<TranscriptGetResponse | TranscriptUnchangedResponse> {
+  const handler = capturedHandlers.get(IPC.TRANSCRIPT_GET);
+  if (!handler) throw new Error(`${IPC.TRANSCRIPT_GET} handler not registered`);
+  return handler(undefined, request) as Promise<TranscriptGetResponse | TranscriptUnchangedResponse>;
+}
+
+function makeResolved(revision: number) {
+  return {
+    record: {
+      id: 'session-1',
+      task_id: 'task-1',
+      started_at: '2026-06-01T10:00:00Z',
+      status: 'running',
+    },
+    taskTitle: 'Wire the auth flow',
+    agentName: 'Claude Code',
+    source: 'live' as const,
+    sourcePath: '/history/x.jsonl',
+    entries: [{ kind: 'user' as const, uuid: 'u1', ts: 1, text: 'hi' }],
+    degraded: false,
+    sessions: [],
+    revision,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TRANSCRIPT_GET IPC handler knownRevision short-circuit', () => {
+  beforeEach(() => {
+    capturedHandlers.clear();
+    resolveTaskTranscript.mockReset();
+    registerTranscriptHandlers(makeContext('proj-1'));
+  });
+
+  it('returns { unchanged: true, revision } with no entries when knownRevision matches the resolved revision', async () => {
+    resolveTaskTranscript.mockResolvedValue(makeResolved(4));
+
+    const result = await invokeTranscriptGet({ sessionId: 'session-1', knownRevision: 4 });
+
+    expect(result).toEqual({ unchanged: true, revision: 4 });
+    expect('entries' in result).toBe(false);
+  });
+
+  it('returns the full response including entries when knownRevision differs from the resolved revision', async () => {
+    resolveTaskTranscript.mockResolvedValue(makeResolved(5));
+
+    const result = await invokeTranscriptGet({ sessionId: 'session-1', knownRevision: 4 });
+
+    expect('unchanged' in result).toBe(false);
+    if (!('unchanged' in result)) {
+      expect(result.entries).toEqual([{ kind: 'user', uuid: 'u1', ts: 1, text: 'hi' }]);
+      expect(result.revision).toBe(5);
+      expect(result.taskTitle).toBe('Wire the auth flow');
+    }
+  });
+
+  it('returns the full response including entries when knownRevision is omitted (the first fetch for a session)', async () => {
+    resolveTaskTranscript.mockResolvedValue(makeResolved(1));
+
+    const result = await invokeTranscriptGet({ sessionId: 'session-1' });
+
+    expect('unchanged' in result).toBe(false);
+    if (!('unchanged' in result)) {
+      expect(result.entries).toEqual([{ kind: 'user', uuid: 'u1', ts: 1, text: 'hi' }]);
+      expect(result.revision).toBe(1);
+    }
+  });
+});

--- a/tests/unit/transcript-service-revision-memo.test.ts
+++ b/tests/unit/transcript-service-revision-memo.test.ts
@@ -1,0 +1,151 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import type { SessionRecord } from '../../src/shared/types';
+
+/**
+ * `resolveTaskTranscript` memoizes its expensive per-task stitch (dedup by
+ * uuid, chronological sort, boundary-divider insertion) keyed on a
+ * fingerprint of every contributing session's `entries` array IDENTITY (see
+ * `tokenForEntries`'s WeakMap in transcript-service.ts). That identity is
+ * governed by `getCachedTranscript`'s real stat-validated file cache
+ * (transcript-cache.ts): the SAME array reference comes back when a
+ * session's native transcript file is byte-for-byte unchanged (mtime+size
+ * match), and a genuinely NEW array reference comes back the moment the file
+ * changes. These tests exercise that real file cache (via `os.tmpdir()`
+ * fixtures) rather than mocking array identity directly, so they prove the
+ * actual dependency the memo relies on, not an assumption about it.
+ *
+ * Covers the two NEW, currently-untested cases: an idle poll (nothing on
+ * disk changed) must short-circuit to the SAME `entries` reference and SAME
+ * `revision`; a genuine change must bump `revision` and re-stitch.
+ */
+
+vi.mock('../../src/main/agent/agent-registry', () => ({
+  agentRegistry: { getBySessionType: vi.fn() },
+}));
+
+import { resolveTaskTranscript, resetForTests } from '../../src/main/agent/transcript-service';
+import { agentRegistry } from '../../src/main/agent/agent-registry';
+
+function makeRecord(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    id: 'session-1',
+    task_id: 'task-1',
+    session_type: 'claude_agent',
+    isolated_swimlane_id: null,
+    agent_session_id: 'agent-1',
+    cwd: '/work/project',
+    started_at: '2026-06-01T12:00:00Z',
+    exited_at: null,
+    status: 'running',
+    ...overrides,
+  } as unknown as SessionRecord;
+}
+
+function makeFakeDb(record: SessionRecord): Database.Database {
+  return {
+    prepare(sql: string) {
+      return {
+        get: (...args: unknown[]) => {
+          if (sql.includes('FROM sessions WHERE id = ? OR agent_session_id = ?')) {
+            const requestedId = args[0] as string;
+            return requestedId === record.id || requestedId === record.agent_session_id
+              ? record
+              : undefined;
+          }
+          if (sql.includes('SELECT title FROM tasks WHERE id = ?')) {
+            return { title: 'Revision Memo Task' };
+          }
+          throw new Error(`unexpected get SQL: ${sql}`);
+        },
+        all: (...args: unknown[]) => {
+          if (sql.includes('FROM sessions WHERE task_id = ?')) {
+            return [record];
+          }
+          throw new Error(`unexpected all SQL: ${sql}`);
+        },
+      };
+    },
+  } as unknown as Database.Database;
+}
+
+const getBySessionType = vi.mocked(agentRegistry.getBySessionType);
+
+describe('resolveTaskTranscript revision stitch memo', () => {
+  let tmpDir: string;
+  let transcriptFilePath: string;
+  let parseTranscript: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    resetForTests();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kangentic-transcript-revision-'));
+    transcriptFilePath = path.join(tmpDir, 'transcript.jsonl');
+    fs.writeFileSync(transcriptFilePath, JSON.stringify({ turn: 'first' }));
+    parseTranscript = vi.fn(async () => ({
+      entries: [{ kind: 'user' as const, uuid: 'turn-1', ts: 1, text: 'hello' }],
+      sourcePath: transcriptFilePath,
+    }));
+    getBySessionType.mockReturnValue({
+      displayName: 'Claude Code',
+      parseTranscript,
+    } as unknown as ReturnType<typeof agentRegistry.getBySessionType>);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns a real entries array and revision >= 1 on the first call for a task', async () => {
+    const db = makeFakeDb(makeRecord());
+
+    const result = await resolveTaskTranscript(db, 'session-1');
+
+    expect(result).not.toBeNull();
+    expect(result!.entries.length).toBeGreaterThan(0);
+    expect(result!.revision).toBeGreaterThanOrEqual(1);
+  });
+
+  it('short-circuits to the SAME entries reference and SAME revision when every contributing session file is unchanged', async () => {
+    const db = makeFakeDb(makeRecord());
+
+    const first = await resolveTaskTranscript(db, 'session-1');
+    const second = await resolveTaskTranscript(db, 'session-1');
+
+    expect(second!.entries).toBe(first!.entries);
+    expect(second!.revision).toBe(first!.revision);
+    // The file-level cache itself should also have short-circuited the
+    // adapter call on the second poll, which is what gives the stitched
+    // entries array its stable identity in the first place.
+    expect(parseTranscript).toHaveBeenCalledTimes(1);
+  });
+
+  it('bumps revision and returns a freshly-stitched entries array when an underlying session file genuinely changes', async () => {
+    const db = makeFakeDb(makeRecord());
+
+    const first = await resolveTaskTranscript(db, 'session-1');
+
+    // Grow the file's byte size so the stat-validated file cache misses on
+    // the next read, forcing a genuine re-parse (and thus a new entries
+    // array reference for that session).
+    fs.writeFileSync(
+      transcriptFilePath,
+      JSON.stringify({ turn: 'first-and-then-a-second-turn-that-changed-the-file-size' }),
+    );
+    parseTranscript.mockResolvedValueOnce({
+      entries: [
+        { kind: 'user' as const, uuid: 'turn-1', ts: 1, text: 'hello' },
+        { kind: 'user' as const, uuid: 'turn-2', ts: 2, text: 'a genuinely new turn' },
+      ],
+      sourcePath: transcriptFilePath,
+    });
+
+    const second = await resolveTaskTranscript(db, 'session-1');
+
+    expect(second!.revision).toBe(first!.revision + 1);
+    expect(second!.entries).not.toBe(first!.entries);
+    expect(second!.entries.some((entry) => entry.uuid === 'turn-2')).toBe(true);
+  });
+});

--- a/tests/unit/tui-anchor-match.test.ts
+++ b/tests/unit/tui-anchor-match.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { matchTuiViewportToRow } from '../../src/renderer/components/conversation/tui-anchor';
+import { reconcileDisplayRows } from '../../src/renderer/components/conversation/display-rows';
+import type { TranscriptEntry } from '../../src/shared/types';
+
+/**
+ * `matchTuiViewportToRow` maps a terminal's visible scrollback lines (at the
+ * moment a conversation viewer was opened) to the transcript row it was most
+ * likely showing, so the viewer can open centered there. Covers: an exact
+ * match, a match despite whitespace/formatting noise, a tie broken toward
+ * the LATEST occurrence, pure noise producing no match, and the zero-match
+ * fallback.
+ */
+
+function rowsFrom(entries: TranscriptEntry[]) {
+  return reconcileDisplayRows([], entries);
+}
+
+/** A line long enough (>= 16 normalized chars) to count as real signal. */
+function longLine(text: string): string {
+  return text.padEnd(20, ' filler');
+}
+
+describe('matchTuiViewportToRow', () => {
+  it('matches the row whose text exactly contains the sampled viewport lines', () => {
+    const rows = rowsFrom([
+      { kind: 'user', uuid: 'u1', ts: 1, text: 'run the failing test suite please' },
+      { kind: 'assistant', uuid: 'a1', ts: 2, blocks: [{ type: 'text', text: 'Running the full test suite now to reproduce the failure' }] },
+    ]);
+    const visibleLines = [
+      '  some terminal chrome  ',
+      'Running the full test suite now to reproduce the failure',
+      '  more chrome  ',
+    ];
+
+    const matched = matchTuiViewportToRow(visibleLines, rows);
+
+    expect(matched).toBe('a1');
+  });
+
+  it('matches despite ANSI-adjacent formatting noise (box-drawing chars, extra spaces, case differences)', () => {
+    const rows = rowsFrom([
+      { kind: 'assistant', uuid: 'a1', ts: 1, blocks: [{ type: 'text', text: 'Editing the config file to add the new option' }] },
+    ]);
+    const visibleLines = ['│ EDITING   the    config--file to add the NEW option │'];
+
+    const matched = matchTuiViewportToRow(visibleLines, rows);
+
+    expect(matched).toBe('a1');
+  });
+
+  it('breaks a tie between two equally-matching rows toward the LATEST one', () => {
+    const rows = rowsFrom([
+      { kind: 'assistant', uuid: 'a1', ts: 1, blocks: [{ type: 'text', text: longLine('running the exact same command again here') }] },
+      { kind: 'user', uuid: 'u2', ts: 2, text: 'unrelated middle turn with its own filler text' },
+      { kind: 'assistant', uuid: 'a3', ts: 3, blocks: [{ type: 'text', text: longLine('running the exact same command again here') }] },
+    ]);
+    const visibleLines = ['running the exact same command again here'];
+
+    const matched = matchTuiViewportToRow(visibleLines, rows);
+
+    expect(matched).toBe('a3');
+  });
+
+  it('returns null when the visible lines are pure noise (too short to count as signal)', () => {
+    const rows = rowsFrom([
+      { kind: 'user', uuid: 'u1', ts: 1, text: 'a substantial user turn with real content in it' },
+    ]);
+    const visibleLines = ['$', '>', '---', 'ok', ''];
+
+    const matched = matchTuiViewportToRow(visibleLines, rows);
+
+    expect(matched).toBeNull();
+  });
+
+  it('returns null when no row contains any of the sampled lines', () => {
+    const rows = rowsFrom([
+      { kind: 'user', uuid: 'u1', ts: 1, text: 'a substantial user turn with real content in it' },
+    ]);
+    const visibleLines = ['this text appears nowhere in the transcript at all'];
+
+    const matched = matchTuiViewportToRow(visibleLines, rows);
+
+    expect(matched).toBeNull();
+  });
+
+  it('returns null for an empty viewport or an empty row list', () => {
+    const rows = rowsFrom([{ kind: 'user', uuid: 'u1', ts: 1, text: 'some real content here for the row' }]);
+
+    expect(matchTuiViewportToRow([], rows)).toBeNull();
+    expect(matchTuiViewportToRow(['a real line of terminal content here'], [])).toBeNull();
+  });
+
+  it('samples lines from the CENTER of a long viewport, not the edges', () => {
+    const rows = rowsFrom([
+      { kind: 'assistant', uuid: 'edge', ts: 1, blocks: [{ type: 'text', text: 'this text only appears at the very edge of the viewport sample' }] },
+      { kind: 'assistant', uuid: 'center', ts: 2, blocks: [{ type: 'text', text: 'this text only appears in the vertical center of the viewport' }] },
+    ]);
+    // 40 lines: edge-matching content at index 0 (far outside the ~10-line
+    // center sample), center-matching content around the middle.
+    const visibleLines = Array.from({ length: 40 }, (_, index) => {
+      if (index === 0) return 'this text only appears at the very edge of the viewport sample';
+      if (index === 20) return 'this text only appears in the vertical center of the viewport';
+      return `filler line number ${index} with enough characters to pass the length floor`;
+    });
+
+    const matched = matchTuiViewportToRow(visibleLines, rows);
+
+    expect(matched).toBe('center');
+  });
+
+  it('scales the sample window to the captured terminal\'s own height, not a fixed line count', () => {
+    const rows = rowsFrom([
+      { kind: 'assistant', uuid: 'a1', ts: 1, blocks: [{ type: 'text', text: longLine('the only substantive line in a short terminal capture') }] },
+    ]);
+    // A short (12-line) capture: the fixed-10-line sample used to nearly
+    // consume the whole thing anyway, but scaling (30%, floored at 6) must
+    // still land squarely on center content in a viewport this small.
+    const shortCapture = [
+      'chrome', 'chrome', 'chrome', 'chrome',
+      'the only substantive line in a short terminal capture',
+      'chrome', 'chrome', 'chrome', 'chrome', 'chrome', 'chrome', 'chrome',
+    ];
+
+    expect(matchTuiViewportToRow(shortCapture, rows)).toBe('a1');
+  });
+
+  it('samples a wider window from a much taller terminal capture than from a short one', () => {
+    const rows = rowsFrom([
+      { kind: 'assistant', uuid: 'far', ts: 1, blocks: [{ type: 'text', text: longLine('content sitting further out from dead center') }] },
+    ]);
+    // 80 lines tall: content 8 lines off center (outside the old fixed
+    // 10-line sample [35,45), but within the scaled sample - clamped at the
+    // 20-line max - which spans [30,50)).
+    const tallCapture = Array.from({ length: 80 }, (_, index) => {
+      if (index === 48) return 'content sitting further out from dead center';
+      return `filler line number ${index} with enough characters to pass the length floor`;
+    });
+
+    expect(matchTuiViewportToRow(tallCapture, rows)).toBe('far');
+  });
+});


### PR DESCRIPTION
## What

Makes the Conversation viewer the fast path for reading and searching agent transcripts instead of relying on TUI copy buttons: smooth performance on very long transcripts, an always-visible in-viewer search bar, and the viewer opening already positioned at the right spot instead of always at the top.

## Why

The Conversation viewer janked on long transcripts (a live poll rebuilt every entry and reshipped the whole array over IPC every 2.5s), had no way to search within a conversation, and always opened scrolled to the top regardless of where the user actually was in the terminal. This made the terminal's own TUI copy buttons the faster way to grab text, defeating the point of having a dedicated viewer.

## How

**Performance**
- Main-process transcript caching: a stat-validated per-file cache (`transcript-cache.ts`), Claude-adapter incremental byte-offset append parsing (only the new tail of a growing JSONL file is parsed), and a task-level stitch memo keyed by a revision counter so an unchanged transcript returns the same `entries` array reference.
- An IPC revision short-circuit: `transcripts.get` accepts a `knownRevision` and returns `{ unchanged: true }` to skip the full structured clone on idle polls.
- Renderer row reconciliation (`display-rows.ts`) reuses row object identity across polls so `MemoConversationRow` bails out of re-rendering unchanged rows, with per-row height estimates feeding the virtualizer.

**In-viewer search**
- An always-visible `ConversationSearchBar` (no header toggle button) with debounced substring search, snippet results, prev/next navigation, and instant (no settle-animation) navigation on a result click.
- Mod+F focuses the search input via a `conversation.find` keybinding, scoped so it doesn't overlap the board's global find.

**Open-at-position**
- The viewer opens positioned at the latest message by default, or centered on the transcript turn matching the terminal's visible scrollback when the user had scrolled up in the TUI (`tui-anchor.ts` + `terminal-capture-registry.ts`).
- This surfaced three compounding bugs during live testing against a real running preview, all fixed here: a terminal-capture-reader registration lifecycle gap (moved registration into its own effect, identity-guarded unregister so a stale cleanup can't clobber a fresher registration), Claude Code's TUI not using real terminal scrollback for in-session paging (removed the unreliable `atBottom` gate - always attempt the match, fall back to bottom only when nothing matches), and the scroll settle loop being permanently locked to static per-row height estimates instead of the virtualizer's real measurements (now reads `virtualizer.getVirtualItems()` for real `start`/`size` once available, self-correcting within a couple of retry ticks).

**Scrollbar**
- A custom overlay scrollbar (`ConversationScrollbar.tsx`) for 10k+ message transcripts: a minimum thumb size so it never collapses to an ungrabbable sliver, flush-to-edge traditional track styling with symmetric padding against the message content, a two-row scrub bubble while dragging, and a "jump to latest" pill.

**Dev tooling**
- A "Seed Large Conversation" Test Harness button (`seed-large-conversation.ts`) that seeds a throwaway task backed by a synthetic multi-thousand-turn Claude JSONL transcript (appending more turns on re-click), for exercising the viewer's virtualization, search, and open-at-position behavior against realistic long-conversation content.

Trade-offs reviewers may want to look at: the settle loop still uses a bounded multi-tick retry (`setTimeout`, never `requestAnimationFrame`) rather than `@tanstack/react-virtual`'s own `scrollToIndex` - deliberate, since that path raced the browser's own scroll-offset reporting on a freshly-mounted virtualizer (documented in the code and covered by `settle-scroll.test.ts`).

## Breaking changes

None.

## Tests

- Unit: `transcript-cache.test.ts`, `claude-transcript-parser-incremental.test.ts`, `transcript-service-revision-memo.test.ts`, `transcript-get-handler-revision-shortcircuit.test.ts`, `display-rows-reconcile.test.ts`, `scrollbar-math.test.ts`, `tui-anchor-match.test.ts`, `terminal-capture-registry.test.ts`, `settle-scroll.test.ts`, plus an extension to `keybindings-registry.test.ts` for the `conversation.find` scope shadow.
- UI: `conversation-viewer.spec.ts` (extended), `conversation-open-position.spec.ts`, `conversation-search.spec.ts`, `conversation-scrollbar.spec.ts`.
- Verified live end-to-end against a running preview via direct devtools driving: open-at-position matching a real terminal scrollback position, search + navigate + highlight, Mod+F scope-shadowing, scrollbar drag-to-precise-offset and minimum-thumb clamping, and the incremental-append-then-reopen path.

Generated with [Claude Code](https://claude.com/claude-code)
