### PR TITLE
fix(command-terminal): resolve dictation target by transient slot anchor

### DIFF
--- a/src/renderer/utils/dictation-target.ts
+++ b/src/renderer/utils/dictation-target.ts
@@ -2,6 +2,7 @@ import { boardWindowManager, commandWindowManager } from '../window-manager';
 import { useSessionStore } from '../stores/session-store';
 import { useProjectStore } from '../stores/project-store';
 import { derivePanelSessionId } from './focused-sessions';
+import { transientKey, type TransientSessionEntry } from '../stores/session-store/transient-session-slice';
 
 /**
  * Resolving the ONE terminal that dictated text should be injected into. The
@@ -50,6 +51,37 @@ function focusedWindowSessionId(manager: typeof boardWindowManager): string | nu
   return focusedWindow.sessionId ?? null;
 }
 
+/** Resolve the focused Command Terminal window's live session by its durable slot
+ *  anchor. Gated on layer visibility because hiding the layer keeps the window,
+ *  focusedWindowId, and PTY alive; a hidden terminal must never win injection over
+ *  a visible one. Resolved by anchor (not the window's stored sessionId, which is
+ *  always null for command windows - it is never written back on spawn/reattach/
+ *  respawn) so a branch-switch respawn is picked up. */
+export function resolveFocusedCommandSessionId(input: {
+  commandBarVisible: boolean;
+  focusedCommandAnchor: string | null;
+  currentProjectId: string | null;
+  transientSessions: Record<string, TransientSessionEntry>;
+}): string | null {
+  if (!input.commandBarVisible) return null;
+  if (!input.focusedCommandAnchor || !input.currentProjectId) return null;
+  const entry = input.transientSessions[transientKey(input.currentProjectId, input.focusedCommandAnchor)];
+  return entry?.sessionId ?? null;
+}
+
+function focusedCommandSessionId(): string | null {
+  const windowState = commandWindowManager.store.getState();
+  const focusedId = windowState.focusedWindowId;
+  const focusedWindow = focusedId ? windowState.windows[focusedId] : null;
+  const sessionState = useSessionStore.getState();
+  return resolveFocusedCommandSessionId({
+    commandBarVisible: sessionState.commandBarVisible,
+    focusedCommandAnchor: focusedWindow?.anchor ?? null,
+    currentProjectId: useProjectStore.getState().currentProject?.id ?? null,
+    transientSessions: sessionState.transientSessions,
+  });
+}
+
 /**
  * Resolve the single injection target via a priority chain. Returns null when
  * no live terminal can be determined, so the caller can refuse to commit rather
@@ -57,7 +89,7 @@ function focusedWindowSessionId(manager: typeof boardWindowManager): string | nu
  */
 export function resolveDictationTarget(): string | null {
   // 1. The focused Command Terminal window.
-  const commandTarget = focusedWindowSessionId(commandWindowManager);
+  const commandTarget = focusedCommandSessionId();
   if (isRunningSession(commandTarget)) return commandTarget;
 
   // 2. The focused task-detail (board) window.

--- a/tests/ui/changes-diff-scroll-memory.spec.ts
+++ b/tests/ui/changes-diff-scroll-memory.spec.ts
@@ -144,7 +144,13 @@ test.describe('Changes view: diff scroll memory', () => {
 
     // Open the Changes panel; alpha.ts is auto-selected (first file).
     await page.locator('[data-testid="changes-toggle"]').click();
-    await page.locator('[data-testid="diff-editor-area"]').waitFor({ state: 'visible', timeout: 5000 });
+    // 10s, matching every other visibility wait in this test (below) and the
+    // sibling commit-detail-selection.spec.ts: under CI worker contention the
+    // panel mount + Monaco diff-editor construction can take longer than a
+    // tight 5s budget (observed flake: failed at 6.5s, passed at 10.7s on
+    // retry), so a fixed 5000ms here was simply tighter than everywhere else
+    // that waits on the same locator.
+    await page.locator('[data-testid="diff-editor-area"]').waitFor({ state: 'visible', timeout: 10000 });
     // Wait for Monaco to render diff content (rendered line nodes exist).
     await page.locator('.view-line').first().waitFor({ state: 'visible', timeout: 10000 });
 

--- a/tests/unit/dictation-target.test.ts
+++ b/tests/unit/dictation-target.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Unit tests for `resolveFocusedCommandSessionId` in dictation-target.ts.
+ *
+ * Covers the fix for "Command Terminal voice dictation doesn't work": priority 1
+ * of `resolveDictationTarget()` used to read `focusedWindow.sessionId` from the
+ * command window-manager store, which is always null for Command Terminal
+ * windows (their live PTY id is never written back to the window store). The
+ * fix resolves the focused command window's session by its durable slot anchor
+ * through the transientSessions map instead, gated on the command layer
+ * actually being visible (hiding the layer keeps the window and its
+ * focusedWindowId alive, so an unguarded resolve would let a hidden terminal
+ * steal dictation from a visible board window).
+ */
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { resolveFocusedCommandSessionId, resolveDictationTarget } from '../../src/renderer/utils/dictation-target';
+import { commandWindowManager } from '../../src/renderer/window-manager';
+import { useSessionStore } from '../../src/renderer/stores/session-store';
+import { useProjectStore } from '../../src/renderer/stores/project-store';
+import { transientKey, type TransientSessionEntry } from '../../src/renderer/stores/session-store/transient-session-slice';
+import type { Project, Session } from '../../src/shared/types';
+
+function makeEntry(overrides: Partial<TransientSessionEntry> = {}): TransientSessionEntry {
+  return {
+    projectId: 'proj-1',
+    slot: 'slot-1',
+    sessionId: 'sess-transient-1',
+    branch: 'main',
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'sess-default',
+    taskId: 'task-default',
+    projectId: 'proj-default',
+    pid: 1000,
+    status: 'running',
+    shell: 'bash',
+    cwd: 'C:\\Users\\dev\\project',
+    startedAt: new Date().toISOString(),
+    exitCode: null,
+    resuming: false,
+    transient: false,
+    agentSessionId: null,
+    ...overrides,
+  };
+}
+
+function makeProject(id: string, overrides: Partial<Project> = {}): Project {
+  return {
+    id,
+    name: 'Test Project',
+    path: 'C:\\Users\\dev\\project',
+    github_url: null,
+    default_agent: 'claude',
+    default_model: null,
+    default_effort: null,
+    group_id: null,
+    position: 0,
+    last_opened: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+/**
+ * Blank the three real stores `resolveDictationTarget()` reads from directly
+ * (the command window-manager store, the session store, and the project
+ * store), so each integration test below starts from a clean slate and
+ * neither leaks into the other nor into the pure-function tests above (which
+ * never touch these stores, so they are unaffected either way).
+ */
+function resetIntegrationStores(): void {
+  commandWindowManager.store.setState({
+    windows: {},
+    order: [],
+    focusedWindowId: null,
+    zCounter: 0,
+    tileTree: null,
+    tileTreeRect: { x: 0, y: 0, w: 1, h: 1 },
+  });
+  useSessionStore.setState({
+    sessions: [],
+    commandBarVisible: false,
+    transientSessions: {},
+    activeSessionId: null,
+  });
+  useProjectStore.setState({ currentProject: null });
+}
+
+describe('resolveFocusedCommandSessionId', () => {
+  it('resolves the focused command window session when the layer is visible', () => {
+    const entry = makeEntry();
+    const result = resolveFocusedCommandSessionId({
+      commandBarVisible: true,
+      focusedCommandAnchor: 'slot-1',
+      currentProjectId: 'proj-1',
+      transientSessions: { 'proj-1::slot-1': entry },
+    });
+    expect(result).toBe('sess-transient-1');
+  });
+
+  it('returns null when the command layer is hidden, even with a focused window', () => {
+    // Regression guard: hiding the layer keeps the window and focusedWindowId
+    // alive in the store, so an unguarded resolve would let a hidden terminal
+    // steal dictation from a visible board window.
+    const entry = makeEntry();
+    const result = resolveFocusedCommandSessionId({
+      commandBarVisible: false,
+      focusedCommandAnchor: 'slot-1',
+      currentProjectId: 'proj-1',
+      transientSessions: { 'proj-1::slot-1': entry },
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no command window is focused', () => {
+    const entry = makeEntry();
+    const result = resolveFocusedCommandSessionId({
+      commandBarVisible: true,
+      focusedCommandAnchor: null,
+      currentProjectId: 'proj-1',
+      transientSessions: { 'proj-1::slot-1': entry },
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when there is no current project', () => {
+    const entry = makeEntry();
+    const result = resolveFocusedCommandSessionId({
+      commandBarVisible: true,
+      focusedCommandAnchor: 'slot-1',
+      currentProjectId: null,
+      transientSessions: { 'proj-1::slot-1': entry },
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the anchor is keyed under a different project', () => {
+    const entry = makeEntry({ projectId: 'proj-2' });
+    const result = resolveFocusedCommandSessionId({
+      commandBarVisible: true,
+      focusedCommandAnchor: 'slot-1',
+      currentProjectId: 'proj-1',
+      transientSessions: { 'proj-2::slot-1': entry },
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no transient entry exists yet for the slot (mid-spawn)', () => {
+    const result = resolveFocusedCommandSessionId({
+      commandBarVisible: true,
+      focusedCommandAnchor: 'slot-1',
+      currentProjectId: 'proj-1',
+      transientSessions: {},
+    });
+    expect(result).toBeNull();
+  });
+
+  it('resolves the correct slot when multiple Command Terminal windows are open', () => {
+    const result = resolveFocusedCommandSessionId({
+      commandBarVisible: true,
+      focusedCommandAnchor: 'slot-2',
+      currentProjectId: 'proj-1',
+      transientSessions: {
+        'proj-1::slot-1': makeEntry({ slot: 'slot-1', sessionId: 'sess-a' }),
+        'proj-1::slot-2': makeEntry({ slot: 'slot-2', sessionId: 'sess-b' }),
+      },
+    });
+    expect(result).toBe('sess-b');
+  });
+});
+
+/**
+ * Integration coverage for `resolveDictationTarget()`'s priority-1 leg
+ * (the private `focusedCommandSessionId()` wrapper), exercised against the
+ * REAL Zustand stores rather than a hand-built input object. This is the part
+ * `resolveFocusedCommandSessionId`'s unit tests above cannot reach: the
+ * wrapper's own store reads (`commandWindowManager.store.getState().windows[
+ * focusedWindowId].anchor`, `useSessionStore.getState().commandBarVisible` /
+ * `.transientSessions`, `useProjectStore.getState().currentProject?.id`) and
+ * the fact that `resolveDictationTarget()` actually calls this wrapper FIRST
+ * in its priority chain.
+ *
+ * Red condition (the bug this guards): revert priority 1 in
+ * `resolveDictationTarget()` back to `focusedWindowSessionId(commandWindowManager)`
+ * (reading `focusedWindow.sessionId`, which command windows never populate) and
+ * the "visible" test below fails because `resolveDictationTarget()` returns
+ * null instead of the seeded command session id.
+ */
+describe('resolveDictationTarget - Command Terminal priority (real stores)', () => {
+  beforeEach(resetIntegrationStores);
+  afterAll(resetIntegrationStores);
+
+  it('resolves the focused command-terminal window session when the command layer is visible', () => {
+    const projectId = 'proj-cmd-1';
+    const commandSessionId = 'sess-cmd-1';
+
+    useProjectStore.setState({ currentProject: makeProject(projectId) });
+
+    const windowId = commandWindowManager.store.getState().openWindow({
+      anchor: 'slot-1',
+      sessionId: null,
+      title: 'Command Terminal',
+    });
+    // openWindow focuses the window it just created, matching production:
+    // opening a Command Terminal window makes it the focused one.
+    expect(commandWindowManager.store.getState().focusedWindowId).toBe(windowId);
+
+    useSessionStore.setState({
+      commandBarVisible: true,
+      transientSessions: {
+        [transientKey(projectId, 'slot-1')]: {
+          projectId,
+          slot: 'slot-1',
+          sessionId: commandSessionId,
+          branch: 'main',
+        },
+      },
+      sessions: [
+        makeSession({ id: commandSessionId, projectId, transient: true, status: 'running' }),
+      ],
+    });
+
+    expect(resolveDictationTarget()).toBe(commandSessionId);
+  });
+
+  it('does not let a hidden command layer win priority 1, even with a focused window and a running session', () => {
+    const projectId = 'proj-cmd-2';
+    const commandSessionId = 'sess-cmd-2';
+
+    useProjectStore.setState({ currentProject: makeProject(projectId) });
+
+    commandWindowManager.store.getState().openWindow({
+      anchor: 'slot-1',
+      sessionId: null,
+      title: 'Command Terminal',
+    });
+
+    useSessionStore.setState({
+      // Layer hidden: priority 1 must not win, even though the window is
+      // focused and the transient session is running.
+      commandBarVisible: false,
+      transientSessions: {
+        [transientKey(projectId, 'slot-1')]: {
+          projectId,
+          slot: 'slot-1',
+          sessionId: commandSessionId,
+          branch: 'main',
+        },
+      },
+      sessions: [
+        makeSession({ id: commandSessionId, projectId, transient: true, status: 'running' }),
+      ],
+    });
+
+    const result = resolveDictationTarget();
+    expect(result).not.toBe(commandSessionId);
+    // No other priority has a candidate in this seeded state (no board window
+    // focused, no last-focused terminal, and the only running session is
+    // transient so it is excluded from the bottom-panel derivation), so the
+    // chain falls all the way through to null.
+    expect(result).toBeNull();
+  });
+});

--- a/tests/unit/dictation-target.test.ts
+++ b/tests/unit/dictation-target.test.ts
@@ -13,7 +13,7 @@
  */
 import { describe, it, expect, beforeEach, afterAll } from 'vitest';
 import { resolveFocusedCommandSessionId, resolveDictationTarget } from '../../src/renderer/utils/dictation-target';
-import { commandWindowManager } from '../../src/renderer/window-manager';
+import { boardWindowManager, commandWindowManager } from '../../src/renderer/window-manager';
 import { useSessionStore } from '../../src/renderer/stores/session-store';
 import { useProjectStore } from '../../src/renderer/stores/project-store';
 import { transientKey, type TransientSessionEntry } from '../../src/renderer/stores/session-store/transient-session-slice';
@@ -65,14 +65,23 @@ function makeProject(id: string, overrides: Partial<Project> = {}): Project {
 }
 
 /**
- * Blank the three real stores `resolveDictationTarget()` reads from directly
- * (the command window-manager store, the session store, and the project
- * store), so each integration test below starts from a clean slate and
- * neither leaks into the other nor into the pure-function tests above (which
- * never touch these stores, so they are unaffected either way).
+ * Blank the four real stores `resolveDictationTarget()` reads from directly
+ * (the command window-manager store, the board window-manager store, the
+ * session store, and the project store), so each integration test below
+ * starts from a clean slate and neither leaks into the other nor into the
+ * pure-function tests above (which never touch these stores, so they are
+ * unaffected either way).
  */
 function resetIntegrationStores(): void {
   commandWindowManager.store.setState({
+    windows: {},
+    order: [],
+    focusedWindowId: null,
+    zCounter: 0,
+    tileTree: null,
+    tileTreeRect: { x: 0, y: 0, w: 1, h: 1 },
+  });
+  boardWindowManager.store.setState({
     windows: {},
     order: [],
     focusedWindowId: null,
@@ -262,5 +271,84 @@ describe('resolveDictationTarget - Command Terminal priority (real stores)', () 
     // transient so it is excluded from the bottom-panel derivation), so the
     // chain falls all the way through to null.
     expect(result).toBeNull();
+  });
+
+  it('falls through to the focused board (task-detail) window when the command layer does not resolve', () => {
+    // Priority 2's positive path was entirely untested: every prior case here
+    // either had no board window open, or had the command layer win. This
+    // proves the board leg still resolves correctly on its own so the "both
+    // resolve" test below is meaningfully checking priority ORDER, not just
+    // that priority 2 happens to work.
+    const projectId = 'proj-board-1';
+    const boardSessionId = 'sess-board-1';
+
+    useProjectStore.setState({ currentProject: makeProject(projectId) });
+
+    boardWindowManager.store.getState().openWindow({
+      anchor: 'task-1',
+      sessionId: boardSessionId,
+      title: 'Task One',
+    });
+
+    // Command layer hidden: priority 1 must not resolve, so the chain falls
+    // through to priority 2.
+    useSessionStore.setState({
+      commandBarVisible: false,
+      sessions: [makeSession({ id: boardSessionId, projectId, taskId: 'task-1', status: 'running' })],
+    });
+
+    expect(resolveDictationTarget()).toBe(boardSessionId);
+  });
+
+  it('lets a focused Command Terminal window win priority 1 over a focused board window with a running session', () => {
+    // This is the exact regression scenario from the bug report: a task-detail
+    // window was focused (so priority 2 fully resolves), but the visible,
+    // focused Command Terminal is the one dictation should target. Before the
+    // fix, priority 1 read `focusedWindow.sessionId` off the command manager,
+    // which command windows never populate, so this case silently fell
+    // through to the board window instead of the terminal the user was
+    // actually dictating into.
+    const projectId = 'proj-both-1';
+    const commandSessionId = 'sess-cmd-both-1';
+    const boardSessionId = 'sess-board-both-1';
+
+    useProjectStore.setState({ currentProject: makeProject(projectId) });
+
+    // Board window is open and focused with a resolvable, running session -
+    // priority 2 alone would happily resolve to it.
+    boardWindowManager.store.getState().openWindow({
+      anchor: 'task-1',
+      sessionId: boardSessionId,
+      title: 'Task One',
+    });
+
+    // Each window layer tracks its own `focusedWindowId` independently, so
+    // opening the Command Terminal window afterward does not touch the board
+    // manager's focus - both managers report a focused window at once, which
+    // is the real shape of "task-detail window focused, Command Terminal also
+    // focused" that this scenario needs.
+    commandWindowManager.store.getState().openWindow({
+      anchor: 'slot-1',
+      sessionId: null,
+      title: 'Command Terminal',
+    });
+
+    useSessionStore.setState({
+      commandBarVisible: true,
+      transientSessions: {
+        [transientKey(projectId, 'slot-1')]: {
+          projectId,
+          slot: 'slot-1',
+          sessionId: commandSessionId,
+          branch: 'main',
+        },
+      },
+      sessions: [
+        makeSession({ id: commandSessionId, projectId, transient: true, status: 'running' }),
+        makeSession({ id: boardSessionId, projectId, taskId: 'task-1', status: 'running' }),
+      ],
+    });
+
+    expect(resolveDictationTarget()).toBe(commandSessionId);
   });
 });


### PR DESCRIPTION
## What

Fixes voice dictation not working in the Command Terminal (Ctrl+Shift+P). The fix is confined to `src/renderer/utils/dictation-target.ts`.

## Why

Kangentic's dictation is a fully custom in-app push-to-talk feature (local Whisper/Parakeet STT): transcribed text is injected over IPC to a single resolved PTY session id, never through OS/DOM typing. `resolveDictationTarget()`'s priority-1 leg resolved the focused Command Terminal window's session by reading `focusedWindow.sessionId` from the command window-manager store. Command Terminal windows are always opened with `sessionId: null`, and that field is never written back after the transient PTY spawns (the live id only ever lives in local React state and in the `transientSessions` map). So priority 1 always returned null, and dictated text either landed in a background focused task-detail terminal (priority 2) or fell through further.

## How

Resolve the focused Command Terminal window's session by its durable slot **anchor** through the `transientSessions` map instead of the window's stale stored `sessionId`, gated on `commandBarVisible`. The gate matters because the command layer is hideable while its windows and `focusedWindowId` stay alive in the store with the PTY still running in the background - without it, a hidden Command Terminal could steal dictation away from a visible board window.

Resolving by anchor (rather than adding a new window-store action to write a real `sessionId` back) reuses the `transientSessions` map that is already kept fresh across spawn, reattach, and branch-switch respawn, mirroring the durable-anchor approach `useWindowSessionClaims` already uses for board windows.

## Breaking changes

None.

## Tests

- `tests/unit/dictation-target.test.ts` (new): 11 tests covering the pure `resolveFocusedCommandSessionId` resolver (visible/hidden gating, missing anchor/project, wrong-project keying, mid-spawn absence, multi-slot resolution) and integration coverage against the real Zustand stores, including the core regression scenario - a focused board window and a focused, visible Command Terminal both resolving to a running session simultaneously, where priority 1 must still win.
- Red-green verified: reverting priority 1 to the old `focusedWindowSessionId(commandWindowManager)` call fails the new tests for the expected reason.
- `npm run typecheck` and `npm run lint` pass locally.

Generated with [Claude Code](https://claude.com/claude-code)
