### PR TITLE
ci(release): pin npm-publish job to Node 24, drop npm@latest self-upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,15 +219,17 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref }}
 
+      # Trusted publishing (OIDC) needs npm >= 11.5.1. Node 24 ships npm 11.16+,
+      # so this job pins Node 24 and skips the `npm install -g npm@latest`
+      # self-upgrade. That self-upgrade tracked whatever npm@latest shipped that
+      # day; a bad build pruned the bundled `sigstore` module and broke
+      # provenance publishing (the v0.29.0 release failure). This job builds no
+      # Electron, so it is isolated from the Node-22 pin the platform build jobs
+      # require.
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
-
-      # Trusted publishing (OIDC) needs npm >= 11.5.1; Node 22 ships 10.9.x.
-      # This job builds no Electron, so it is isolated from the Node-22 pin.
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
 
       - name: Publish launcher to npm
         run: npm publish --access public --provenance -w packages/launcher


### PR DESCRIPTION
## What

Pin the `publish-npm` job in `.github/workflows/release.yml` to Node 24 and remove the `npm install -g npm@latest` self-upgrade step.

## Why

The `publish-npm` job upgraded npm to `@latest` at runtime to reach npm >= 11.5.1 (required for OIDC trusted publishing), because Node 22 ships npm 10.9.x. That made every release depend on whatever `npm@latest` happened to be that day. On the v0.29.0 release a bad `npm@latest` build left the bundled `sigstore` module unresolvable, so `npm publish --provenance` crashed with `Cannot find module 'sigstore'` and the launcher never published. v0.28.0 published cleanly a day earlier with the identical step, confirming the floating dependency was at fault, not our package.

## How

Node 24 ships npm 11.16.0 (>= 11.5.1), so the job can use its bundled npm directly. Bump the job's `setup-node` from `node-version: 22` to `24` and delete the self-upgrade step. The `publish-npm` job builds no Electron and runs no `npm ci` for the app, so it is unaffected by the Node-22 pin the platform-build jobs require (rationale documented inline in the workflow).

## Breaking changes

None.

## Tests

The `publish-npm` job only runs on a tag push, so PR CI does not exercise it directly; correctness here is by construction (Node 24's bundled npm 11.16.0 clears the OIDC threshold, removing the runtime self-upgrade that was the sole failure point). The standard PR checks (lint, typecheck, unit, UI, E2E) still run and are unaffected by a workflow-only change. The fix gets its first live exercise on the next release (v0.30.0).

Generated with [Claude Code](https://claude.com/claude-code)
