### PR TITLE
ci(release): make publish-npm idempotent (skip if version already on npm)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,5 +231,15 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
+      # Idempotent: re-running an already-published tag (e.g. backfilling a green
+      # run after a transient failure) must not fail on npm's "cannot publish
+      # over the previously published version". Skip when the version is already
+      # on the registry so the re-run stays green.
       - name: Publish launcher to npm
-        run: npm publish --access public --provenance -w packages/launcher
+        run: |
+          PUBLISHED_VERSION=$(node -p "require('./packages/launcher/package.json').version")
+          if npm view "kangentic@$PUBLISHED_VERSION" version >/dev/null 2>&1; then
+            echo "kangentic@$PUBLISHED_VERSION is already on npm; skipping publish (idempotent re-run)."
+            exit 0
+          fi
+          npm publish --access public --provenance -w packages/launcher


### PR DESCRIPTION
## What

Make the `publish-npm` job in `.github/workflows/release.yml` idempotent: skip the publish when `kangentic@<version>` is already on the npm registry, instead of failing.

## Why

npm refuses to publish over an existing version. So re-running a release for a tag whose launcher was already published (backfilling a green run after a transient failure, or after an out-of-band manual publish) failed `publish-npm` with "cannot publish over the previously published version" and turned the whole Release run red. This is the follow-up to the Node 24 fix (#137): together they make the Release workflow safely re-runnable.

## How

Before publishing, resolve the launcher version and probe the registry with `npm view kangentic@<version>`. If it already exists, log and `exit 0`; otherwise publish as before. electron-builder already overwrites its own release assets on a re-run, so with this guard the entire workflow can be re-run green on an already-published tag.

## Breaking changes

None.

## Tests

The `publish-npm` job only runs on a tag push, so PR CI does not exercise it. The guard is a standard `npm view` existence check; correctness is by construction. Standard PR checks (lint, typecheck, unit, UI, E2E) still run and are unaffected by a workflow-only change. It gets its first live exercise on the v0.29.0 backfill re-run.

Generated with [Claude Code](https://claude.com/claude-code)
