### PR TITLE
fix(ui): portal label suggestions and fix suggestion click commit

### DIFF
--- a/src/renderer/components/LabelInput.tsx
+++ b/src/renderer/components/LabelInput.tsx
@@ -1,6 +1,8 @@
-import { useState, useRef, useEffect, useMemo } from 'react';
+import { useState, useRef, useEffect, useLayoutEffect, useMemo } from 'react';
 import { X } from 'lucide-react';
 import { Pill } from './Pill';
+import { OverlayPopover } from './OverlayPopover';
+import { usePopoverPosition } from '../hooks/usePopoverPosition';
 
 interface LabelInputProps {
   labels: string[];
@@ -18,7 +20,9 @@ interface LabelInputProps {
 export function LabelInput({ labels, setLabels, labelColors, allExistingLabels, testId }: LabelInputProps) {
   const [labelInput, setLabelInput] = useState('');
   const [showSuggestions, setShowSuggestions] = useState(false);
+  const [triggerWidth, setTriggerWidth] = useState<number>();
   const labelInputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const suggestionsRef = useRef<HTMLDivElement>(null);
 
   const filteredSuggestions = useMemo(() => {
@@ -28,13 +32,32 @@ export function LabelInput({ labels, setLabels, labelColors, allExistingLabels, 
     );
   }, [labelInput, allExistingLabels, labels]);
 
-  // Close suggestions on click outside
+  const suggestionsOpen = showSuggestions && filteredSuggestions.length > 0;
+
+  // Portaled to document.body (see render below), so measure and position against
+  // the visible field rather than relying on an in-flow absolute offset that would
+  // be clipped by an ancestor `overflow: hidden` / `overflow-y-auto`.
+  const { style: popoverStyle, placement } = usePopoverPosition(containerRef, suggestionsRef, suggestionsOpen, {
+    mode: 'dropdown',
+    strategy: 'fixed',
+    preferVertical: 'below',
+    preferRight: false,
+  });
+
+  useLayoutEffect(() => {
+    if (suggestionsOpen && containerRef.current) {
+      setTriggerWidth(containerRef.current.getBoundingClientRect().width);
+    }
+  }, [suggestionsOpen]);
+
+  // Close suggestions on click outside. The popover is portaled OUT of
+  // containerRef, so a click inside it must also count as "inside".
   useEffect(() => {
     if (!showSuggestions) return;
     const handleClick = (event: MouseEvent) => {
       if (
         suggestionsRef.current && !suggestionsRef.current.contains(event.target as Node) &&
-        labelInputRef.current && !labelInputRef.current.contains(event.target as Node)
+        containerRef.current && !containerRef.current.contains(event.target as Node)
       ) {
         setShowSuggestions(false);
       }
@@ -74,7 +97,10 @@ export function LabelInput({ labels, setLabels, labelColors, allExistingLabels, 
   return (
     <div className="flex-1 relative">
       <label className="text-xs text-fg-muted mb-1 block">Labels</label>
-      <div className="flex flex-wrap items-center gap-1 bg-surface border border-edge-input rounded px-2 py-1 min-h-[32px] focus-within:border-accent">
+      <div
+        ref={containerRef}
+        className="flex flex-wrap items-center gap-1 bg-surface border border-edge-input rounded px-2 py-1 min-h-[32px] focus-within:border-accent"
+      >
         {labels.map((label) => {
           const color = labelColors[label];
           return (
@@ -116,24 +142,30 @@ export function LabelInput({ labels, setLabels, labelColors, allExistingLabels, 
         />
       </div>
 
-      {/* Label suggestions dropdown */}
-      {showSuggestions && filteredSuggestions.length > 0 && (
-        <div
-          ref={suggestionsRef}
-          className="absolute z-50 left-0 right-0 mt-1 bg-surface-raised border border-edge rounded-lg shadow-xl py-1 max-h-[150px] overflow-y-auto"
-        >
-          {filteredSuggestions.map((suggestion) => (
-            <button
-              key={suggestion}
-              type="button"
-              onClick={() => addLabel(suggestion)}
-              className="w-full px-3 py-1.5 text-xs text-fg-secondary text-left hover:bg-surface-hover/40"
-            >
-              {suggestion}
-            </button>
-          ))}
-        </div>
-      )}
+      {/* Label suggestions dropdown - portaled to escape clipping ancestors (e.g. the
+          task-detail window's overflow-y-auto edit form) */}
+      <OverlayPopover
+        open={suggestionsOpen}
+        popoverRef={suggestionsRef}
+        style={{ ...popoverStyle, width: triggerWidth }}
+        portal
+        transformOrigin={placement.vertical === 'above' ? 'bottom center' : 'top center'}
+        className="fixed z-[2147483646] bg-surface-raised border border-edge rounded-lg shadow-xl py-1 max-h-[150px] overflow-y-auto"
+        data-testid="label-suggestions"
+      >
+        {filteredSuggestions.map((suggestion) => (
+          <button
+            key={suggestion}
+            type="button"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => addLabel(suggestion)}
+            className="w-full px-3 py-1.5 text-xs text-fg-secondary text-left hover:bg-surface-hover/40"
+            data-testid="label-suggestion"
+          >
+            {suggestion}
+          </button>
+        ))}
+      </OverlayPopover>
     </div>
   );
 }

--- a/tests/ui/label-input.spec.ts
+++ b/tests/ui/label-input.spec.ts
@@ -84,6 +84,55 @@ test('clicking a label suggestion commits the clicked label, not the typed text'
   }
 });
 
+test('clicking outside the field closes the suggestion dropdown', async () => {
+  const { browser, page } = await launchPage();
+  try {
+    await createProject(page, `LabelAutocompleteOutsideClick ${Date.now()}`);
+    await seedLabelColors(page, {
+      research: '#3b82f6',
+      'agent-adapter': '#8b5cf6',
+      'agent-context': '#06b6d4',
+    });
+
+    const todoColumn = page.locator('[data-swimlane-name="To Do"]');
+    await todoColumn.locator('text=Add task').click();
+
+    const newTaskDialog = page.locator('.fixed.inset-0');
+    const titleInput = newTaskDialog.locator('input[placeholder="Task title"]');
+    await titleInput.fill('Outside click test');
+
+    // Focus the (empty) Labels field. onFocus always opens the dropdown, and with
+    // an empty query every seeded label matches (String.includes('') is true), so
+    // the dropdown opens with no text typed.
+    const labelInput = newTaskDialog.locator('[data-testid="task-labels"]');
+    await labelInput.click();
+    const dropdown = page.locator('[data-testid="label-suggestions"]');
+    await expect(dropdown).toBeVisible({ timeout: 3000 });
+
+    // Click a sibling field that is outside both containerRef and the portaled
+    // suggestionsRef. Deliberately does NOT rely on onBlur's own close path:
+    // onBlur only calls addLabel/closes when labelInput has non-empty trimmed
+    // text (see handleLabelKeyDown's sibling onBlur in LabelInput.tsx), and this
+    // field is empty, so onBlur is a no-op here. Only the click-outside handler
+    // (now checking containerRef instead of the old labelInputRef, since the
+    // dropdown moved outside the DOM subtree via the portal) can close it.
+    await titleInput.click();
+    await expect(dropdown).not.toBeVisible({ timeout: 3000 });
+
+    // Confirm nothing was spuriously committed by the outside click.
+    const createButton = newTaskDialog.locator('button[type="submit"]:has-text("Create")');
+    await createButton.click();
+    await newTaskDialog.waitFor({ state: 'hidden', timeout: 3000 });
+
+    const taskData = await page.evaluate(() => window.electronAPI.tasks.list());
+    const task = taskData.find((t: { title: string }) => t.title === 'Outside click test');
+    expect(task).toBeDefined();
+    expect(task!.labels).toEqual([]);
+  } finally {
+    await browser.close();
+  }
+});
+
 const CLIP_PROJECT_ID = 'proj-label-input-clip';
 const CLIP_TASK_ID = 'task-label-input-clip';
 

--- a/tests/ui/label-input.spec.ts
+++ b/tests/ui/label-input.spec.ts
@@ -1,0 +1,227 @@
+/**
+ * UI tests for the shared label autocomplete (src/renderer/components/LabelInput.tsx),
+ * covering two bugs fixed together:
+ *
+ * 1. Clicking a suggestion committed the raw typed text instead of the clicked
+ *    suggestion, because the input's onBlur fired (and closed the dropdown) before
+ *    the suggestion button's onClick could land. Fixed with onMouseDown
+ *    preventDefault on each suggestion button.
+ * 2. The suggestion dropdown was position:absolute inside the task-detail window's
+ *    overflow-y-auto edit form / overflow-hidden window frame, so it was clipped.
+ *    Fixed by portaling it to document.body via OverlayPopover + usePopoverPosition
+ *    (the same pattern KebabMenu uses).
+ *
+ * Each test launches its own page (mode: 'parallel'), per the no-cross-test-state
+ * convention used across this suite (see pr-url.spec.ts, label-promotion.spec.ts).
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { launchPage, createProject, waitForViteReady } from './helpers';
+
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+/** The slice of the dev-only window.__zustandStores surface this spec drives. */
+type ConfigStoreHandle = {
+  config: {
+    getState: () => {
+      updateConfig: (partial: Record<string, unknown>) => Promise<void>;
+    };
+  };
+};
+
+/** Seed label suggestions via the real config-store action (mirrors LabelsPopover's own call). */
+async function seedLabelColors(page: Page, labelColors: Record<string, string>): Promise<void> {
+  await page.evaluate(async (colors) => {
+    const stores = (window as unknown as { __zustandStores?: ConfigStoreHandle }).__zustandStores;
+    if (!stores) throw new Error('window.__zustandStores not exposed');
+    await stores.config.getState().updateConfig({ backlog: { labelColors: colors } });
+  }, labelColors);
+}
+
+test('clicking a label suggestion commits the clicked label, not the typed text', async () => {
+  const { browser, page } = await launchPage();
+  try {
+    await createProject(page, `LabelAutocompleteClick ${Date.now()}`);
+    await seedLabelColors(page, {
+      research: '#3b82f6',
+      'agent-adapter': '#8b5cf6',
+      'agent-context': '#06b6d4',
+    });
+
+    const todoColumn = page.locator('[data-swimlane-name="To Do"]');
+    await todoColumn.locator('text=Add task').click();
+
+    const newTaskDialog = page.locator('.fixed.inset-0');
+    await newTaskDialog.locator('input[placeholder="Task title"]').fill('Autocomplete commit test');
+
+    const labelInput = newTaskDialog.locator('[data-testid="task-labels"]');
+    await labelInput.click();
+    await labelInput.fill('res');
+
+    const suggestion = page.locator('[data-testid="label-suggestion"]', { hasText: 'research' });
+    await expect(suggestion).toBeVisible({ timeout: 3000 });
+    await suggestion.click();
+
+    // Dropdown closes once the suggestion commits.
+    await expect(page.locator('[data-testid="label-suggestions"]')).not.toBeVisible({ timeout: 3000 });
+
+    const createButton = newTaskDialog.locator('button[type="submit"]:has-text("Create")');
+    await createButton.click();
+    await newTaskDialog.waitFor({ state: 'hidden', timeout: 3000 });
+
+    const taskData = await page.evaluate(() => window.electronAPI.tasks.list());
+    const task = taskData.find((t: { title: string }) => t.title === 'Autocomplete commit test');
+    expect(task).toBeDefined();
+    // Exact-array equality: pre-fix this would be ['res'] (the blur-committed
+    // partial text), not the clicked suggestion.
+    expect(task!.labels).toEqual(['research']);
+  } finally {
+    await browser.close();
+  }
+});
+
+const CLIP_PROJECT_ID = 'proj-label-input-clip';
+const CLIP_TASK_ID = 'task-label-input-clip';
+
+async function launchWithClipScenario(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1280, height: 700 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(`
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+
+      state.projects.push({
+        id: '${CLIP_PROJECT_ID}',
+        name: 'Label Input Clip Test',
+        path: '/mock/label-input-clip',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+
+      // Pre-merged into the effective config (config.get() deep-merges this
+      // in), so the Labels field has suggestions the moment the edit form mounts.
+      state.projectConfigs['/mock/label-input-clip'] = {
+        backlog: {
+          labelColors: {
+            research: '#3b82f6',
+            'agent-adapter': '#8b5cf6',
+            'agent-context': '#06b6d4',
+          },
+        },
+      };
+
+      var laneIds = {};
+      state.DEFAULT_SWIMLANES.forEach(function (swimlane, index) {
+        var id = 'lane-clip-' + swimlane.name.toLowerCase().replace(/\\s+/g, '-');
+        laneIds[swimlane.name] = id;
+        state.swimlanes.push(Object.assign({}, swimlane, { id: id, position: index, created_at: ts }));
+      });
+
+      // No session_id -> TaskCard opens this directly into the edit form on click.
+      state.tasks.push({
+        id: '${CLIP_TASK_ID}',
+        title: 'Label Dropdown Clip Task',
+        description: 'Task used to reproduce the clipped label suggestion dropdown.',
+        swimlane_id: laneIds['To Do'],
+        position: 0,
+        agent: 'claude',
+        session_id: null,
+        worktree_path: null,
+        branch_name: null,
+        pr_number: null,
+        pr_url: null,
+        pr_state: null,
+        base_branch: null,
+        use_worktree: 0,
+        labels: [],
+        priority: 0,
+        attachment_count: 0,
+        archived_at: null,
+        created_at: ts,
+        updated_at: ts,
+      });
+
+      return { currentProjectId: '${CLIP_PROJECT_ID}' };
+    });
+  `);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+  return { browser, page };
+}
+
+test('label suggestion dropdown escapes the task-detail edit form and stays within the viewport', async () => {
+  const { browser, page } = await launchWithClipScenario();
+  try {
+    await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+    await page.locator('[data-swimlane-name="To Do"]').locator('text=Label Dropdown Clip Task').first().click();
+
+    // Task has no session, so it opens directly into the edit form.
+    await page.locator('input[placeholder="Task title"]').waitFor({ state: 'visible', timeout: 5000 });
+
+    const labelInput = page.locator('[data-testid="task-labels"]');
+    await labelInput.click();
+
+    const dropdown = page.locator('[data-testid="label-suggestions"]');
+    await expect(dropdown).toBeVisible({ timeout: 3000 });
+
+    // Portal proof: the dropdown must not be a descendant of the task-detail
+    // window's clipping ancestor (data-testid="task-detail-dialog", which wraps
+    // the overflow-y-auto edit form in an overflow-hidden window frame).
+    const escapedClippingAncestor = await page.evaluate(() => {
+      const dialog = document.querySelector('[data-testid="task-detail-dialog"]');
+      const dropdownEl = document.querySelector('[data-testid="label-suggestions"]');
+      return !!dialog && !!dropdownEl && !dialog.contains(dropdownEl);
+    });
+    expect(escapedClippingAncestor).toBe(true);
+
+    // The portaled + flip-aware dropdown must stay fully within the viewport.
+    // Coarse containment bound, not a pixel-exact assertion, per the
+    // cross-platform-parity convention (font metrics differ across OSes).
+    const box = await dropdown.boundingBox();
+    expect(box).not.toBeNull();
+    const viewport = page.viewportSize();
+    expect(viewport).not.toBeNull();
+    expect(box!.y).toBeGreaterThanOrEqual(0);
+    expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height + 1);
+
+    // Width-match proof: the fixed-strategy popover lost the old `left-0
+    // right-0` in-flow stretch, so LabelInput measures the bordered input
+    // container (containerRef) via useLayoutEffect and applies it as an
+    // explicit `width` style on the portaled popover. Assert the two widths
+    // line up (both box-border, small tolerance per cross-platform-parity).
+    const container = labelInput.locator('xpath=ancestor::div[contains(@class,"border-edge-input")][1]');
+    await expect(container).toHaveCount(1);
+    const containerBox = await container.boundingBox();
+    expect(containerBox).not.toBeNull();
+    expect(containerBox!.width).toBeGreaterThan(0);
+    // OverlayPopover plays a scale-from-trigger entrance animation, so a
+    // boundingBox taken right after toBeVisible() can land mid-animation and
+    // read a visually-shrunk transformed rect even though the underlying
+    // layout width is already correct. Poll past the transform settle
+    // instead of a fixed wait (see anti-pattern 1 in the test-builder guide).
+    await expect
+      .poll(
+        async () => {
+          const currentBox = await dropdown.boundingBox();
+          return currentBox ? Math.abs(currentBox.width - containerBox!.width) : null;
+        },
+        { timeout: 2000, intervals: [100, 200, 300] },
+      )
+      .toBeLessThan(2);
+  } finally {
+    await browser.close();
+  }
+});


### PR DESCRIPTION
## What

Fixes two bugs in the shared label autocomplete (`src/renderer/components/LabelInput.tsx`), used by the task edit form, New Task dialog, and New Backlog Task dialog:

- The suggestion dropdown was clipped when the Labels field sat near the bottom of a scrollable dialog (most visibly in the task edit form), because it was `position: absolute` nested inside `overflow-y-auto` / `overflow-hidden` ancestors.
- Clicking a suggestion committed the raw typed text instead of the clicked suggestion, because the input's `onBlur` fired (committing the typed text and closing the dropdown) before the suggestion button's `onClick` could land.

## Why

Both bugs made the label autocomplete effectively unusable in the task edit form: users could not see most of the suggestion list, and clicking a suggestion silently applied the wrong label.

## How

- **Clipping:** the dropdown now portals to `document.body` via `OverlayPopover` + `usePopoverPosition({ strategy: 'fixed' })`, the same pattern already used by `KebabMenu.tsx`. It flips upward when there isn't room below and matches the field's width via a measured `containerRef`.
- **Mis-commit:** each suggestion button now sets `onMouseDown={(e) => e.preventDefault()}`, so clicking it never blurs the input, letting the button's `onClick` commit the correct label. The free-form Enter/comma/blur commit path for brand-new labels is unchanged.
- The click-outside-to-dismiss handler now checks `containerRef` (the visible field box) instead of the input element alone, since the dropdown no longer lives inside the field's DOM subtree.

The backlog Labels popover (`LabelsPopover.tsx`) does not use this shared component and has no autocomplete dropdown, so it is unaffected and out of scope.

## Breaking changes

None.

## Tests

Added `tests/ui/label-input.spec.ts` (3 UI-tier tests):
- Typing a partial label and clicking a suggestion commits the clicked suggestion, not the typed text (exact array assertion via `tasks.list()`).
- Clicking outside the field still closes the dropdown without committing anything, now that it's portaled outside the field's DOM subtree.
- The dropdown escapes the task-detail edit form's clipping ancestor (portal-escape proof), stays within the viewport, and matches the field's width.

All three were verified red-green (each fails when its corresponding fix is reverted) and pass consistently across repeated runs. `npm run typecheck` and `npm run lint` are clean.

Generated with [Claude Code](https://claude.com/claude-code)
