### PR TITLE
feat(mobile-bridge): add protocol package, device pairing, and secure relay transport

### DIFF
--- a/.claude/skills/release-protocol/SKILL.md
+++ b/.claude/skills/release-protocol/SKILL.md
@@ -1,0 +1,135 @@
+---
+description: Version bump, changelog, tag, and push a @kangentic/protocol release, independent of the Kangentic desktop release
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash(git:*), Bash(npm:*), Bash(npx:*)
+argument-hint: [patch|minor|major]
+---
+
+# Release Protocol
+
+Publishes a new version of `@kangentic/protocol` independently of Kangentic's own release cycle
+(`/release`). `@kangentic/protocol`'s version (`packages/protocol/package.json`) is deliberately
+decoupled from root's -- this pipeline exists so the protocol package can ship on its own
+cadence, including while the mobile bridge feature is still being built out, without requiring
+or triggering a full Kangentic desktop release. The publish side lives in
+`.github/workflows/publish-protocol.yml`.
+
+**Usage:** `/release-protocol [patch|minor|major]`
+
+- `/release-protocol` -- auto-suggests bump type from commit history scoped to `packages/protocol/`, asks for confirmation
+- `/release-protocol patch` -- bump 0.1.0 to 0.1.1
+- `/release-protocol minor` -- bump 0.1.0 to 0.2.0
+- `/release-protocol major` -- bump 0.1.0 to 1.0.0
+
+**Release type (optional):** $ARGUMENTS
+
+This is NOT `/release`. It never touches root's `package.json` version or `packages/launcher`,
+never triggers `release.yml`, and tags on the `protocol-v*` namespace instead of `v*` so the two
+tag sequences never collide.
+
+## Step 0 -- Determine Bump Type
+
+1. **Find the previous protocol tag:** Run `git describe --tags --abbrev=0 --match "protocol-v*"`. Note whether this succeeds or fails (no matching tags = first protocol release).
+2. **Collect commits since the last protocol tag, scoped to the package:** Run `git log <previousTag>..HEAD --oneline --no-decorate -- packages/protocol/` (or `git log --oneline --no-decorate -- packages/protocol/` if no previous tag).
+3. **Analyze conventional commit prefixes to suggest a bump type** (same rules as `/release`):
+   - Any commit with `!` after the type or containing `BREAKING CHANGE` -- suggest **major**
+   - Any `feat:` commit -- suggest **minor**
+   - Only `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `style:`, `perf:`, `ci:`, `build:` -- suggest **patch**
+   - No conventional prefixes found -- fall back to keyword analysis: "Add"/"Implement"/"Create" = minor, "Fix" = patch, otherwise patch
+4. **If `$ARGUMENTS` is `patch`, `minor`, or `major`:** use it directly, skip the suggestion prompt.
+5. **First-release check:** If no previous `protocol-v*` tags exist and `$ARGUMENTS` is empty, read the current version from `packages/protocol/package.json`. Ask the user: "No previous protocol releases found. Release current version as protocol-v{version}? [confirm/override]". If confirmed, skip the version bump in Step 2 (tag the current version as-is).
+6. **Otherwise:** report the suggestion with reasoning and wait for confirmation, same format as `/release`:
+   ```
+   Suggested bump: minor
+   Reason: 2 feat: commits found since protocol-v0.1.0 (scoped to packages/protocol/)
+   Commits: feat: add capability revocation, feat: add relay reconnect backoff
+
+   Proceed with minor bump (0.1.0 -> 0.2.0)? [confirm/override]
+   ```
+
+## Pre-flight Checks
+
+1. **Verify branch:** Run `git rev-parse --abbrev-ref HEAD`. Must be `main`. If not, stop with an error: "Release must run from the main branch."
+2. **Verify clean tree:** Run `git status --porcelain`. Must be empty. If not, stop.
+3. **Fetch latest:** Run `git fetch origin main`.
+4. **Verify up-to-date:** Run `git diff HEAD origin/main --stat`. Must be empty. If not, stop with: "Local main is behind origin/main. Run `git pull` first."
+5. **Install dependencies:** Run `npm ci`.
+
+Report the current protocol version, the bump type, and the new version before proceeding.
+
+## Step 1 -- Validate
+
+Scoped to the protocol package only -- do NOT run the full Kangentic app test suite (that is
+`/test`'s job, and this release does not touch the desktop app).
+
+1. Run `npx tsc --noEmit`. If it fails, report type errors and stop. (Full-repo typecheck, since `packages/protocol/src` is included in the root tsconfig.)
+2. Run `npx eslint packages/protocol/src/ --max-warnings 0`. If it fails, stop.
+3. Run `npx vitest run tests/unit/protocol/`. If it fails, stop.
+4. Run `npm run build -w packages/protocol` to confirm the package actually builds (dual CJS/ESM bundle + `.d.ts` declarations). If it fails, stop -- a release must never ship a package that fails its own build.
+
+## Step 2 -- Version Bump
+
+**Skip this step entirely if this is a first release** (no previous `protocol-v*` tags and the user confirmed releasing the current version).
+
+Run: `npm version <patch|minor|major> --no-git-tag-version -w packages/protocol`
+
+Read the new version from `packages/protocol/package.json` to confirm it matches expectations.
+
+## Step 3 -- Changelog
+
+1. Read `packages/protocol/CHANGELOG.md`. If it does not exist, create it via the Write tool with:
+   ```markdown
+   # @kangentic/protocol Changelog
+
+   <!-- releases -->
+   ```
+2. Group the commits collected in Step 0 the same way `/release`'s Step 3 does: Breaking Changes / Features / Fixes / Other, stripping conventional prefixes, one bullet per commit with its short hash.
+3. Use the **Edit tool** to insert the new entry after the `<!-- releases -->` marker:
+   ```markdown
+   ## [protocol-vX.Y.Z] - YYYY-MM-DD
+
+   ### Features
+   - Commit message here (abc1234)
+   ```
+   Omit any category with no entries.
+4. Stage `packages/protocol/CHANGELOG.md` (done in Step 4, not here).
+
+## Step 4 -- Commit
+
+1. Check `git status --porcelain` for what actually changed (Step 2's `npm version -w` touches `packages/protocol/package.json` and the root `package-lock.json`).
+2. Stage: `git add packages/protocol/package.json packages/protocol/CHANGELOG.md package-lock.json`
+   (If this is a first release with no version bump, only stage `packages/protocol/CHANGELOG.md`.)
+3. Write the commit message using the **Write tool** to `.kangentic/COMMIT_MSG.tmp`:
+   ```
+   chore(protocol-release): protocol-vX.Y.Z
+   ```
+4. Commit: `git commit -F .kangentic/COMMIT_MSG.tmp`
+
+## Step 5 -- Tag
+
+Run: `git tag -a protocol-vX.Y.Z -m "Release @kangentic/protocol vX.Y.Z"`
+
+## Step 6 -- Push
+
+Run these sequentially:
+
+1. `git push origin main` -- push the release commit
+2. `git push origin protocol-vX.Y.Z` -- push the tag (triggers `publish-protocol.yml`)
+
+**If either push fails**, report the error and stop. Do not force-push.
+
+## Step 7 -- Report
+
+Summarize the release:
+
+- Version: `@kangentic/protocol` vX.Y.Z
+- Tag: `protocol-vX.Y.Z`
+- Commits included: N
+- Changelog entry: show the generated entry
+- GitHub Actions: link to `https://github.com/Kangentic/kangentic/actions` -- the tag push triggers the "Publish @kangentic/protocol" workflow.
+- **First publish only:** if this is the very first time `@kangentic/protocol` is being published, warn the user explicitly: npm cannot link an OIDC Trusted Publisher to a package that has never been published, so this workflow run will likely fail on the `npm publish` step with an authentication error. Tell them to run `npm login` then `npm publish --access public -w packages/protocol` locally once from an authenticated maintainer machine, then configure Trusted Publishing for `@kangentic/protocol` on npmjs.com (pointing at this repo and the `publish-protocol.yml` workflow file), then re-trigger the workflow (re-push the tag, or use `workflow_dispatch`) for every publish after that.
+
+## Allowed Tools
+
+Use `Read`, `Glob`, `Grep`, `Bash` (for `git`, `npm`, and `npx` commands), `Write` (for the commit message temp file and a new CHANGELOG.md), and `Edit` (for an existing CHANGELOG.md).
+
+**CRITICAL: No chained commands.** Every Bash call must contain exactly ONE command. Never use `&&`, `||`, `|`, or `;`. Use `git -C <path>` for git commands in another directory -- never `cd <path> && git ...`.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -88,6 +88,10 @@ Run: `npm version <new-version> --no-git-tag-version -w packages/launcher`
 
 Read the new version from `package.json` and `packages/launcher/package.json` to confirm both match.
 
+**Do not bump `packages/protocol`.** `@kangentic/protocol`'s version is deliberately decoupled
+from Kangentic's own -- it ships on its own cadence via the separate `/release-protocol` skill
+and `publish-protocol.yml` workflow, not this one. See that skill for details.
+
 ## Step 3 -- Generate Changelog
 
 1. **Find the previous tag:** Run `git describe --tags --abbrev=0`. If no tags exist, use the root commit as the starting point (this is the first release).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,15 @@ jobs:
         run: npm ci
       - name: Build (production bundle)
         run: npm run build
+      # @kangentic/protocol publishes through its own independent workflow
+      # (publish-protocol.yml), not this one -- but that workflow only runs
+      # at publish time (a protocol-v* tag push), so without this step a
+      # broken package build (a declaration-emit error, an esbuild config
+      # regression) would go undetected until an actual release attempt.
+      # This proves `npm run build -w packages/protocol` still succeeds on
+      # every PR, same as the app bundle above.
+      - name: Build @kangentic/protocol package
+        run: npm run build -w packages/protocol
 
   # UI tier, sharded across parallel ubuntu runners (Playwright `--shard`). Each
   # shard prints its own per-test results via the `list` reporter (visible in the

--- a/.github/workflows/publish-protocol.yml
+++ b/.github/workflows/publish-protocol.yml
@@ -1,0 +1,78 @@
+name: Publish @kangentic/protocol
+
+# Independent of the main Kangentic release pipeline (release.yml) BY DESIGN.
+# @kangentic/protocol's version (packages/protocol/package.json) is
+# deliberately decoupled from Kangentic's own root version -- this lets the
+# protocol package ship on its own cadence, including while the mobile
+# bridge feature is still being actively built out, without requiring (or
+# triggering) a full Kangentic desktop release. Cut a protocol release with
+# the `/release-protocol` skill, which tags on the `protocol-v*` namespace
+# (never colliding with Kangentic's own `v*` release tags) and pushes that
+# tag to trigger this workflow. `workflow_dispatch` is also available for an
+# ad hoc manual publish (e.g. re-running after a transient npm failure).
+#
+# Revisit merging this back into release.yml's publish-npm job once the
+# protocol API stabilizes and kangentic-mobile's release cadence wants to
+# track Kangentic's own releases more closely -- see the comment left in
+# release.yml's publish-npm job.
+
+on:
+  push:
+    tags:
+      - 'protocol-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-protocol:
+    # Distinct from (and shorter than) the workflow name above, since GitHub
+    # concatenates them as "Publish @kangentic/protocol / <job name>" in the
+    # checks list and run summary -- repeating the package name in both
+    # would read redundantly.
+    name: Build & publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      # Trusted publishing (OIDC) needs npm >= 11.5.1, which Node 24 ships
+      # (11.16+). See release.yml's publish-npm job for why this pins Node 24
+      # instead of self-upgrading npm.
+      #
+      # IMPORTANT (one-time bootstrap): npm cannot link an OIDC Trusted
+      # Publisher to a package that has never been published. The very
+      # first @kangentic/protocol release must be published manually
+      # (`npm login` then `npm publish --access public -w packages/protocol`
+      # from an authenticated maintainer machine) BEFORE Trusted Publishing
+      # can be configured on npmjs.com for this repo + workflow file. Every
+      # publish after that first one goes through this workflow via OIDC,
+      # with no stored npm token.
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Install dependencies (npm ci)
+        run: npm ci
+
+      - name: Build protocol package
+        run: npm run build -w packages/protocol
+
+      # Idempotent: re-running an already-published version (a workflow_dispatch
+      # retry, or backfilling a green run after a transient failure) must not
+      # fail on npm's "cannot publish over the previously published version".
+      # npm view on a scoped package still resolves by "<name>@<version>".
+      - name: Publish @kangentic/protocol to npm
+        run: |
+          PUBLISHED_VERSION=$(node -p "require('./packages/protocol/package.json').version")
+          if npm view "@kangentic/protocol@$PUBLISHED_VERSION" version >/dev/null 2>&1; then
+            echo "@kangentic/protocol@$PUBLISHED_VERSION is already on npm; skipping publish (idempotent re-run)."
+            exit 0
+          fi
+          npm publish --access public --provenance -w packages/protocol

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,3 +243,12 @@ jobs:
             exit 0
           fi
           npm publish --access public --provenance -w packages/launcher
+
+  # @kangentic/protocol is published by its OWN independent workflow
+  # (publish-protocol.yml), NOT here. Its version is deliberately decoupled
+  # from Kangentic's own version (see that workflow's header comment) so the
+  # protocol package can ship on its own cadence -- including while the
+  # mobile bridge feature is still being built out -- without requiring or
+  # triggering a full Kangentic desktop release. Do not re-add a protocol
+  # publish step to this job; that reintroduces the lockstep coupling this
+  # split was built to remove.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ config/           # Vite configs (renderer, used by scripts/dev.js)
 packages/
   launcher/       # Public npm package ("kangentic") - thin npx installer
     bin/          # kangentic.js launcher script
+  protocol/       # Public npm package ("@kangentic/protocol") - shared mobile bridge
+                  #   wire schema, Noise crypto, capability verbs (desktop + future mobile app)
 src/
   main/           # Electron main process
     agent/        # Agent adapter system
@@ -33,6 +35,8 @@ src/
     transition-engine/  # Transition engine (action execution)
     git/          # Worktree manager
     ipc/          # IPC handler registration
+    mobile-bridge/  # Mobile companion app bridge: identity, signed roster, QR pairing,
+                    #   capability router, relay transport client (consumes @kangentic/protocol)
     pr/           # PR subsystem (mirrors agent/boards): shared/ contract + errors,
                   #   adapters/github/ connector, pr-registry, linking, refresh, scheduler
     pty/          # PTY session manager, shell resolver

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Kangentic is a cross-platform desktop Kanban for AI coding agents. Drag tasks be
 - [Command Injection](command-injection.md) -- Per-column auto-commands and model/effort injection, verifier contract, retry semantics
 - [Board Integration](board-integration.md) -- BoardAdapter interface, registry, GitHub/Azure DevOps/Jira/Linear/etc., how to add a new provider
 - [PR Integration](pr-integration.md) - PRConnector interface, registry, GitHub connector, the confidence-ladder linker, background refresh, where PR state is stored
+- [Mobile Bridge](mobile-bridge.md) - Desktop half of the mobile companion app: `@kangentic/protocol` package, pairing ceremony, signed device roster, capability verbs, relay transport
 - [Handoff](handoff.md) -- Cross-agent context transfer: extraction, packaging, markdown rendering, prompt delivery
 - [MCP Server](mcp-server.md) -- Board management tools for agents, file-based command queue, .mcp.json safety
 - [Embedded Browser](embedded-browser.md) - Browser pane architecture: webview capture, draw and inspect modes, the paste engine, multi-modal prompt submission

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -243,6 +243,21 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 | `boardConfig:shortcutsChanged` | on | Event: shortcuts file changed |
 | `boardConfig:setDefaultBaseBranch` | invoke | Set the team-shared default base branch in `kangentic.json` |
 
+### Mobile Bridge (10 channels)
+Machine-global (like Config), not project-scoped - backs the Mobile Devices settings tab. See [Mobile Bridge](mobile-bridge.md) for the pairing ceremony, roster, capability verbs, and relay transport this group fronts.
+| Channel | Pattern | Purpose |
+|---------|---------|---------|
+| `mobile:getStatus` | invoke | Report bridge status: enabled, secure-storage availability, identity fingerprint, relay URL, paired device count, pairing-in-progress |
+| `mobile:startPairing` | invoke | Mint a pairing token, connect the pairing relay slot, and return the QR payload URI |
+| `mobile:confirmPairing` | invoke | Confirm the SAS matched; signs the phone's static key into the roster with the given display name and capabilities |
+| `mobile:cancelPairing` | invoke | Cancel an in-progress pairing ceremony |
+| `mobile:listDevices` | invoke | List paired devices (id, display name, capabilities, paired-at) |
+| `mobile:revokeDevice` | invoke | Revoke a paired device: drop it from the signed roster and tear down its session |
+| `mobile:setDeviceCapabilities` | invoke | Update a paired device's granted capability verbs (re-signs the roster entry) |
+| `mobile:pairingSas` | on | Event: the SAS (digits + emoji) to display for the current pairing ceremony |
+| `mobile:pairingEnded` | on | Event: pairing cancelled or failed, with a reason |
+| `mobile:stateChanged` | on | Event: status or device list changed (confirm/revoke/capability update) |
+
 ### Notifications (2 channels)
 | Channel | Pattern | Purpose |
 |---------|---------|---------|
@@ -708,11 +723,20 @@ Backlog Import group (6 channels): `backlog:importCheckCli`, `backlog:importFetc
 
 Asana ships an additional `boards:asana:*` group (3 channels: `authStatus`, `setPat`, `clearCredential`) for its Personal Access Token lifecycle. Handlers live in `src/main/boards/adapters/asana/ipc-handlers.ts` and are registered by `registerAsanaIpcHandlers()` from the backlog handler. Keeping the surface adapter-local means Asana specifics never leak into the generic backlog handler.
 
+## Mobile Bridge
+
+`src/main/mobile-bridge/`
+
+Desktop half of the mobile companion app's secure pairing/transport link, consuming the shared `@kangentic/protocol` package (`packages/protocol/`). Owns the device identity, signed device roster, QR pairing ceremony, capability-verb router, and the outbound relay transport client. Constructed in `src/main/ipc/register-all.ts`, torn down synchronously in `src/main/index.ts`'s `clearPendingTimers`. Machine-global (not project-scoped), backing the Mobile Devices settings tab via the `mobile:*` IPC group above.
+
+Phase 1 (shipped) covers identity/roster/pairing/transport and the deny-by-default capability router with no verb handlers registered yet; capability data feeds, notifications, and a direct P2P transport upgrade are later phases. See [Mobile Bridge](mobile-bridge.md) for the full pairing ceremony, SAS confirmation, roster revocation model, capability verb list, ongoing-session crypto, relay transport contract, and phase scope.
+
 ## See Also
 
 - [Session Lifecycle](session-lifecycle.md) -- Full state machine, spawn flow, queue, crash recovery
 - [Agent Integration](agent-integration.md) -- Adapter interface, per-agent CLI details, permission modes, hooks, trust
 - [Board Integration](board-integration.md) -- BoardAdapter interface, registry, how to add a new provider
+- [Mobile Bridge](mobile-bridge.md) - Pairing ceremony, signed device roster, capability verbs, relay transport
 - [Transition Engine](transition-engine.md) -- Action types, templates, priority rules
 - [Database](database.md) -- Full schema reference, migrations, repository pattern
 - [Configuration](configuration.md) -- Config cascade, all settings keys

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ The config directory (`<configDir>`) is platform-specific:
 
 Both panels use a VS Code-style layout: a sidebar with tab navigation on the left and the active settings pane on the right. A search bar at the top filters settings by keyword. Search uses multi-token matching (all tokens must appear in the setting name or description). Results are grouped by tab with match count badges on the sidebar; tabs with zero matches are dimmed. Press Ctrl+F (Cmd+F on macOS) to focus the search bar, Escape to clear the filter.
 
-- **Settings Panel** -- opened via the titlebar gear icon or the gear icon on each project row in the sidebar. A project switcher dropdown in the header allows switching between projects. Sidebar tabs: General, Theme, Terminal, Agent, Git, Browser, Shortcuts, Layout, Behavior, Dictation, Memory, Hotkeys, MCP Server, Agent Browser, Notifications, Privacy, Developer. The first seven tabs (above the separator) are per-project settings. Five of them (Theme, Terminal, Agent, Git, Browser) save to `.kangentic/config.json`, Shortcuts saves to the board config files (`kangentic.json` and `kangentic.local.json`), and the General tab edits the project record in the global index database. The General tab exposes the `project.location` setting -- the folder on disk the project points at -- with a "Change..." button to re-point the project after its folder is moved or renamed; because tasks and history are keyed by project id, they are preserved across a relocation. The Agent tab exposes the `project.defaultAgent` setting (the "Agent" combobox) -- the agent CLI used for new sessions in this project -- along with `project.defaultModel` and `project.defaultEffort` (the "Model" and "Effort" comboboxes), the project-level model and reasoning-effort defaults applied when no column or task override is set. Like `project.location`, all three are stored on the project record in the global index database rather than in `AppConfig`. The last ten (Layout, Behavior, Dictation, Memory, Hotkeys, MCP Server, Agent Browser, Notifications, Privacy, Developer) are shared settings that apply across all projects, saved to the global config. When no project is open, only the 10 shared tabs appear. Changes save immediately. New projects inherit only the seeded settings subset (`theme`, `terminal.*`, `agent.permissionMode`, `git.*`) from the most recently configured project, falling back to defaults if none exist. Project-specific data such as `browser.defaultUrl` and `importSources` is stored per-project and is never cloned into a new project.
+- **Settings Panel** -- opened via the titlebar gear icon or the gear icon on each project row in the sidebar. A project switcher dropdown in the header allows switching between projects. Sidebar tabs: General, Theme, Terminal, Agent, Git, Browser, Shortcuts, Layout, Behavior, Dictation, Memory, Hotkeys, MCP Server, Agent Browser, Notifications, Mobile Devices, Privacy, Developer. The first seven tabs (above the separator) are per-project settings. Five of them (Theme, Terminal, Agent, Git, Browser) save to `.kangentic/config.json`, Shortcuts saves to the board config files (`kangentic.json` and `kangentic.local.json`), and the General tab edits the project record in the global index database. The General tab exposes the `project.location` setting -- the folder on disk the project points at -- with a "Change..." button to re-point the project after its folder is moved or renamed; because tasks and history are keyed by project id, they are preserved across a relocation. The Agent tab exposes the `project.defaultAgent` setting (the "Agent" combobox) -- the agent CLI used for new sessions in this project -- along with `project.defaultModel` and `project.defaultEffort` (the "Model" and "Effort" comboboxes), the project-level model and reasoning-effort defaults applied when no column or task override is set. Like `project.location`, all three are stored on the project record in the global index database rather than in `AppConfig`. The last eleven (Layout, Behavior, Dictation, Memory, Hotkeys, MCP Server, Agent Browser, Notifications, Mobile Devices, Privacy, Developer) are shared settings that apply across all projects, saved to the global config. When no project is open, only the 11 shared tabs appear. Changes save immediately. New projects inherit only the seeded settings subset (`theme`, `terminal.*`, `agent.permissionMode`, `git.*`) from the most recently configured project, falling back to defaults if none exist. Project-specific data such as `browser.defaultUrl` and `importSources` is stored per-project and is never cloned into a new project.
 
 ### App-Only Settings
 
@@ -42,6 +42,7 @@ These settings appear only in App Settings and cannot be overridden per-project:
 - `browserAutomation.enabled`, `browserAutomation.allowInteraction`, `browserAutomation.allowNavigation`, `browserAutomation.allowEval`, `browserAutomation.restrictNavigationToLocalhost`
 - `dictation.*` (all voice dictation settings)
 - `memory.*` (conversation search + recall, in the Memory tab)
+- `mobileBridge.*` (mobile companion app pairing/relay, in the Mobile Devices tab)
 - `hotkeyOverrides`
 
 ### Per-Project Overridable Settings
@@ -291,6 +292,17 @@ from `memory.semanticEnabled` (Smart/hybrid when on, keyword when off), so there
 is no per-search toggle. The Memory tab also offers a "Rebuild index" action that
 purges and re-runs the backfill sweep for the current project (recovery from a
 stale or corrupt index).
+
+### Mobile Bridge
+
+The Mobile Devices tab hosts the desktop half of the mobile companion app's pairing/transport link (`src/main/mobile-bridge/`, see [Mobile Bridge](mobile-bridge.md)). Global-only (per-machine) - the identity, roster, and relay connection represent this desktop installation, not any one project.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `mobileBridge.enabled` | boolean | `false` | Master switch. When `false`, no relay connection is held and pairing is unavailable; the relay URL input and pairing controls are disabled in the UI. |
+| `mobileBridge.relayUrl` | string | `''` | The relay address to dial (self-hosted or Kangentic's hosted relay), e.g. `wss://relay.kangentic.com`. |
+
+**Actions (not config keys):** the Mobile Devices tab also exposes two settings-registry entries that are UI surfaces, not `AppConfig` keys: **Pair a Device** (registry id `mobileBridge.pairing`) starts the QR pairing ceremony described in [Mobile Bridge](mobile-bridge.md#pairing-ceremony), and **Paired Devices** (registry id `mobileBridge.devices`) lists currently paired phones with their granted capabilities and a revoke action. Both are backed by the `mobile:*` IPC channels and the signed device roster (`src/main/mobile-bridge/roster-store.ts`), not persisted in `AppConfig`.
 
 ### Privacy
 

--- a/docs/mobile-bridge.md
+++ b/docs/mobile-bridge.md
@@ -1,0 +1,141 @@
+# Mobile Bridge
+
+Kangentic's mobile companion app (`kangentic-mobile`, a separate repo) pairs with the desktop over an end-to-end encrypted connection so a user can walk away from their PC while agents run, then get notified, read the live conversation, see code changes, send messages back, and move tasks from their phone. The full product rationale and architecture research live in [docs/research/mobile-companion-app.md](research/mobile-companion-app.md); this doc covers what actually shipped in the desktop bridge and the shared protocol package.
+
+This doc covers **Phase 1: Protocol, pairing & secure relay transport** - the identity, pairing ceremony, signed device roster, capability-verb envelope, ongoing session crypto, and outbound relay transport client. See [Scope](#scope) at the bottom for what is explicitly deferred to later phases.
+
+## Layout
+
+```
+packages/protocol/src/       # @kangentic/protocol - shared wire schema + crypto, desktop and mobile
+  crypto/
+    primitives.ts            # X25519/Ed25519 keypairs, random bytes, hex helpers
+    noise/                   # Noise Protocol Framework: handshake state, cipher state, KK + IKpsk0 patterns
+    pairing-handshake.ts     # Noise_IKpsk0_25519_ChaChaPoly_BLAKE2s driver for pairing
+    sas.ts                   # Short Authentication String derivation
+    secretstream.ts          # libsodium-style secretstream framing for ongoing session traffic
+  wire/
+    messages.ts              # BridgeMessage envelope (heartbeat, capability request/response, event)
+    framing.ts                # length-prefixed message encode/decode
+    session-frame.ts          # handshake-vs-application frame tagging
+  pairing/qr.ts               # PairingQrPayload encode/decode (kangentic-pair:// URI)
+  roster/roster.ts            # signed device roster entry sign/verify
+  capabilities/verbs.ts       # CAPABILITY_VERBS - the full verb allowlist
+  events/event.ts             # BridgeEvent union (transcript/board/activity)
+  transport/transport.ts      # Transport interface (swap point for relay vs future P2P)
+  version.ts                  # PROTOCOL_VERSION, prologue encoding
+
+src/main/mobile-bridge/       # desktop implementation, consumes @kangentic/protocol
+  identity.ts                 # device keypair (X25519 + Ed25519), encrypted at rest
+  roster-store.ts             # signed device roster persistence
+  pairing/
+    pairing-token.ts          # single-use, ~10min pairing token
+    pairing-service.ts        # one pairing ceremony: handshake -> SAS -> confirm
+  transport/
+    relay-client.ts           # outbound WebSocket relay client with reconnect/backoff
+    transport-factory.ts      # Transport swap point (relay today, P2P later)
+  session/bridge-session.ts   # one connected device's Noise KK session + re-handshake timer
+  capability-router.ts        # deny-by-default verb dispatch (no handlers yet - Phase 2)
+  mobile-bridge-service.ts    # top-level service: identity, roster, pairing, sessions
+```
+
+The desktop service is constructed in `src/main/ipc/register-all.ts` and torn down synchronously in `src/main/index.ts`'s `clearPendingTimers` (see [Synchronous Shutdown](../.claude/rules/synchronous-shutdown.md)). It is wired to the renderer through the full 7-layer IPC bridge - channels in `src/shared/ipc-channels.ts` (`MOBILE_*`, see [Architecture > Mobile Bridge](architecture.md#mobile-bridge-10-channels)), types in `src/shared/types.ts` ("Mobile Bridge" section), the `mobile:` namespace in `src/preload/preload.ts`, the handler in `src/main/ipc/handlers/mobile-bridge.ts`, the `useMobileStore` renderer store, and the Mobile Devices settings tab.
+
+## Why a separate package
+
+`@kangentic/protocol` is a local npm workspace (`packages/protocol/`), built independently (`npm run build -w packages/protocol`) and published as its own npm package. It is dependency-free of anything Electron- or Node-specific in its public surface (only `@noble/ciphers`, `@noble/curves`, `@noble/hashes` - pure JS, portable to React Native), so the same wire schema, Noise implementation, and capability-verb list are shared verbatim between the desktop and the future mobile app, with no risk of the two drifting.
+
+Its version and release cadence are **deliberately decoupled from Kangentic's own** - `packages/protocol/package.json` carries its own semver line, bumped and tagged (`protocol-vX.Y.Z`, a separate namespace from Kangentic's `vX.Y.Z` release tags) by the `/release-protocol` skill, published by its own workflow (`.github/workflows/publish-protocol.yml`), independent of the `kangentic` launcher's publish step in `release.yml`. This lets the protocol package ship on its own schedule while the mobile bridge feature is still being built out, without requiring or triggering a full Kangentic desktop release. In-repo, the desktop still consumes the package's TypeScript source directly via the `@kangentic/protocol` alias (see Layout above) - only the external, published npm artifact follows the separate versioning.
+
+## Pairing Ceremony
+
+Direction: **the desktop displays a QR code, the phone scans it.** The desktop is the trust root.
+
+1. The user clicks "Pair a device" in the Mobile Devices settings tab. This mints a single-use `PairingToken` (32 random bytes, ~10 minute TTL - `PAIRING_TOKEN_TTL_MS` in `pairing-token.ts`) and opens a relay connection on a slot keyed by the token's hex encoding.
+2. The QR payload (`PairingQrPayload`, encoded as a `kangentic-pair://...` URI by `packages/protocol/src/pairing/qr.ts`) carries: the desktop's static X25519 public key, the pairing token, the relay address, an expiry timestamp, and the protocol version. It is a pairing *bootstrap*, not a long-lived secret.
+3. The phone scans the QR and runs the initiator side of a **Noise_IKpsk0_25519_ChaChaPoly_BLAKE2s** handshake (`packages/protocol/src/crypto/pairing-handshake.ts`), with the pairing token mixed in as the Noise PSK.
+
+### Design decision: token-bound Noise PSK instead of SPAKE2
+
+The original research doc considered a PAKE (SPAKE2) for the pairing exchange so two devices could authenticate from a short, human-typed code. What actually shipped uses a **high-entropy, machine-generated token as a Noise PSK** instead. The reasoning, documented in `pairing-handshake.ts`'s module comment: a PAKE's real value is defending a *low-entropy, human-typed* code against offline dictionary attacks. A 32-byte token scanned from a QR is already high-entropy, so an online-guess-only, single-use property (the same property a PAKE would give a short code) falls out of the token itself - no PAKE is needed to get it. Avoiding SPAKE2 also sidesteps a real practical gap: there is no maintained, audited JavaScript SPAKE2 implementation (the one npm package is years-stale, draft-08, and Node-only, which would have broken React Native parity). Using PSK-mode Noise instead keeps exactly **one** audited crypto primitive (Noise) across both pairing and ongoing sessions, rather than two.
+
+### SAS confirmation
+
+After the handshake completes, both sides derive a **Short Authentication String** (`packages/protocol/src/crypto/sas.ts`, `deriveShortAuthenticationString`) from the handshake transcript hash - a 6-digit code plus a short emoji sequence, Matrix-style commitment-before-reveal. The desktop's settings UI shows this alongside a device-name field and two buttons: "Codes match" and "Codes don't match." The user visually compares the code against what the phone displays. This step defeats a photographed or relayed QR: an attacker who intercepts the QR cannot also make both sides' SAS values agree, because the SAS is derived from a live handshake transcript involving both parties' ephemeral keys, not from anything printed on the QR.
+
+Confirming ("Codes match") signs the phone's static public key into the device roster with a display name and an initial capability grant (`DEFAULT_PAIRING_CAPABILITIES` - `read-stream`, `read-board`, `read-diff`; write/control verbs are granted explicitly afterward, not by default). Rejecting ("Codes don't match") or cancelling tears down the pairing ceremony without touching the roster.
+
+## Signed Device Roster
+
+`src/main/mobile-bridge/roster-store.ts` persists a `DeviceRoster` (one JSON file, globally scoped - like the identity, this represents the desktop installation, not any one project). Every entry (`RosterDeviceEntry`: device id, static public key, display name, capabilities, paired-at, expiry, signature) is signed with the desktop's Ed25519 master signing key at pairing time and **re-verified against that same key every time the roster is loaded from disk**. A corrupted or hand-edited roster file degrades to "that device drops out," not "an unverified entry is silently trusted" - the roster, not the relay, is the source of truth for who is paired.
+
+### Revocation is drop-plus-rekey
+
+Revoking a device (`revokeDevice()`) removes its entry from the roster **and** is intended to rotate the desktop's own static identity key. Dropping the roster entry alone is not sufficient: Noise KK's mutual authentication only proves possession of a static keypair, so a revoked device that already completed a handshake could still authenticate against a future session as long as the desktop's static key is unchanged. Phase 1 ships the roster-side "drop" half (`roster-store.ts`'s `revokeDevice`) plus session teardown for that device; a full key-rotation-and-re-provisioning flow for any *other* still-paired devices is Phase 2/3 scope, since Phase 1 typically has at most one paired device to reason about in practice.
+
+## Capability Verbs
+
+`packages/protocol/src/capabilities/verbs.ts` defines the complete allowlist a paired device can be granted:
+
+- `read-stream`
+- `read-board`
+- `read-diff`
+- `send-user-message`
+- `move-task`
+- `answer-permission-prompt`
+
+There is **deliberately no shell, file-read, or arbitrary-command verb** - absent from the protocol entirely, not filtered at runtime. This mirrors the lesson from SSH forced-command escapes and is the counter-example to Chrome Remote Desktop / VS Code tunnels, which are identity-gated but capability-unscoped. Adding a verb to this list is a protocol change; it does not by itself grant anything to a device - a device's roster entry still has to include the verb in its `CapabilitySet`, and the desktop's `CapabilityRouter` still has to have a handler registered for it.
+
+`src/main/mobile-bridge/capability-router.ts` is the desktop-side dispatch point: it checks the requesting session's `CapabilitySet` (bound at pairing time, adjustable per-device afterward) before even looking up a handler, so an unauthorized verb is rejected before any handler code runs. **Phase 1 ships the router and the deny-by-default authorization check only - no verb has a registered handler yet.** An authorized-but-unregistered verb fails closed with an explicit "no handler registered" error rather than doing nothing silently. Wiring real handlers (SessionManager output tap, transcript service, repositories, DiffService, activity engine, the PTY write path) is Phase 2.
+
+## Ongoing Session: Noise KK + Re-handshake + Secretstream
+
+Once a device is paired, `src/main/mobile-bridge/session/bridge-session.ts` manages its live connection:
+
+- The desktop always **initiates** a `Noise_KK_25519_ChaChaPoly_BLAKE2s` handshake (both statics are already known from the roster/pairing, so this is mutual authentication by construction - neither identity ever travels on the wire). The desktop is the always-on, source-of-truth side, so it owns the handshake timing rather than waiting on the phone.
+- **Re-handshake every ~2 minutes** (`REHANDSHAKE_INTERVAL_MS`, WireGuard's `REKEY_AFTER_TIME`), for bounded post-compromise security - not just initial forward secrecy.
+- Once established, application traffic (the `BridgeMessage` envelope from `wire/messages.ts`) is sealed with **libsodium-style secretstream framing** (`crypto/secretstream.ts`, `deriveSecretstreamPair`) keyed off the Noise session's chaining key. Secretstream framing gives truncation, reorder, and replay detection out of the box, distinct per direction (`SecretstreamDirectionPair`).
+- No Double Ratchet: it solves offline-queued asynchronous messaging, which this interactive, always-connected link does not have.
+
+`src/main/mobile-bridge/wire/session-frame.ts` (re-exported from the protocol package) tags every frame as either a `Handshake` frame (routed to the in-progress `HandshakeState`) or an `Application` frame (routed to the established secretstream pair), so handshake and application traffic can share one transport connection without ambiguity.
+
+## Relay Transport
+
+`src/main/mobile-bridge/transport/relay-client.ts` is the desktop's **outbound-only** WebSocket client to a blind relay (self-hostable, or Kangentic's hosted instance). The relay forwards opaque ciphertext frames only - it authenticates nothing and reads nothing, because every frame is already Noise-encrypted (or, during pairing, is itself a Noise handshake message the relay cannot decrypt).
+
+- **Wire contract:** connect to `${relayUrl}?slot=<hex-encoded-slot-id>`. During pairing, the slot id is the pairing token (so the relay rendezvouses the phone and desktop connections that present the *same* token); for an ongoing session, it is a value derived from the paired device's static key. The relay never interprets the slot id's cryptographic meaning, only its bytes. **The relay server itself is a separate, not-yet-built repo/task** - this client-side contract is the assumed shape until that server lands.
+- **Reconnect with capped exponential backoff:** starts at 500ms, doubles up to a 30s ceiling, resets on a successful connect.
+- **Per-session byte cap** (`maxBytesPerSession`, default 256MB) as defense-in-depth against a runaway send loop on either end.
+- **Accountless:** no Kangentic account/entitlement coupling in this client. Any such gate belongs only on the hosted relay's own connection-acceptance policy (open-core design - see the research doc section 10); this client behaves identically against a self-hosted or Kangentic-hosted relay.
+- `src/main/mobile-bridge/transport/transport-factory.ts` is the deliberate swap point: pairing service, bridge sessions, and the capability router only ever see the `Transport` interface (`packages/protocol/src/transport/transport.ts`). A future WebRTC data-channel implementation (Phase 4) slots in at `createTransport()` with nothing above it changing.
+
+### Honest relay-metadata statement
+
+Even a correctly-implemented blind relay is not metadata-invisible. A relay operator (including a self-hoster, or Kangentic operating the hosted instance) can observe: source and destination IPs, connection timing, frame sizes and frequency, and the pairing graph (which slot ids co-occur). None of that is message *content* - the relay cannot decrypt anything - but it is real, observable metadata. Mitigations available today: self-hosting the relay, single-use pairing tokens, and (once the relay server exists) relay-slot tokens so only paired devices can consume relay capacity at all. This statement should stay in any user-facing security documentation rather than being implied away.
+
+## Scope
+
+**Shipped in this phase (Bridge Phase 1):**
+
+- `@kangentic/protocol` package: wire schema, Noise KK + IKpsk0 implementations, secretstream framing, capability verb list, roster signing, QR payload encode/decode, transport interface.
+- Device identity (encrypted at rest via Electron `safeStorage`, refuses to persist unprotected).
+- Signed device roster with revoke-drop (rekey-on-revoke is scaffolded but the full multi-device re-provisioning flow is deferred).
+- QR pairing ceremony (token-bound Noise PSK + SAS confirmation) with desktop settings UI.
+- The desktop's outbound relay CLIENT connection with reconnect/backoff.
+- `CapabilityRouter` with the deny-by-default authorization check (no verb handlers registered).
+- Mobile Devices settings tab: enable toggle, relay URL, pairing flow, paired-device list, revoke.
+
+**Explicitly out of scope for this phase:**
+
+- **Bridge Phase 2 (data feeds, interactive control & capabilities):** actual capability-verb handlers wired to `SessionManager`'s output tap, the transcript service, repositories, `DiffService`, and the activity engine; the PTY write path for phone-originated input, including `answer-permission-prompt` bound to a specific outstanding prompt id; a consolidated main-side board event stream; the MCP tool surface exposed to paired devices.
+- **Bridge Phase 3 (notifications & push sender):** moving the notification should-fire policy into main; an Expo push sender; presence suppression; the paired-devices capability-editing UI beyond revoke.
+- **Bridge Phase 4 (direct P2P + IPv6 speed upgrade):** WebRTC data channels (`node-datachannel` desktop / `react-native-webrtc` mobile), signaling over the already-secure channel, DTLS fingerprint pinning, IPv6-first candidate ordering, Tailscale detection.
+- **The relay SERVER.** This doc describes the desktop's client-side contract against a relay; the relay itself (a tiny stateless blind byte-forwarder) is planned as a separate `kangentic-relay` repo and is not part of this codebase.
+- The mobile app itself (`kangentic-mobile`, a separate repo).
+
+## See Also
+
+- [Mobile Companion App Research](research/mobile-companion-app.md) - Full product rationale, transport decision (relay-first), security architecture, notification design, and phasing this doc summarizes.
+- [Architecture > Mobile Bridge](architecture.md#mobile-bridge-10-channels) - IPC channel table.
+- [Configuration](configuration.md) - `AppConfig.mobileBridge` (`enabled`, `relayUrl`).
+- [Board Integration](board-integration.md) - The analogous per-provider adapter pattern this bridge's `Transport` swap point mirrors in spirit.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -330,7 +330,7 @@ Settings are accessed from two entry points:
 - **App Settings** - click the gear icon in the title bar. This is the main settings panel with all app-wide and project-default settings.
 - **Project Settings** - click the gear icon on a project row in the sidebar. This shows only the per-project overridable subset.
 
-Both panels use a VS Code-style layout: a sidebar with tab navigation on the left, and the active settings pane on the right. In App Settings, tabs above the separator (General, Theme, Terminal, Agent, Git, Browser, Shortcuts) are per-project settings; tabs below the separator (Layout, Behavior, Dictation, Memory, Hotkeys, MCP Server, Agent Browser, Notifications, Privacy, Developer) are shared across all projects. The General tab shows the project's location on disk with a "Move..." button (see [Moving a project](#moving-a-project)). When no project is open, only the shared tabs appear. Project Settings shows inherited defaults as hints, with reset buttons on any overridden value and a "Reset All" footer when overrides exist.
+Both panels use a VS Code-style layout: a sidebar with tab navigation on the left, and the active settings pane on the right. In App Settings, tabs above the separator (General, Theme, Terminal, Agent, Git, Browser, Shortcuts) are per-project settings; tabs below the separator (Layout, Behavior, Dictation, Memory, Hotkeys, MCP Server, Agent Browser, Notifications, Mobile Devices, Privacy, Developer) are shared across all projects. The General tab shows the project's location on disk with a "Move..." button (see [Moving a project](#moving-a-project)). When no project is open, only the shared tabs appear. Project Settings shows inherited defaults as hints, with reset buttons on any overridden value and a "Reset All" footer when overrides exist.
 
 ### Moving a project
 
@@ -513,6 +513,14 @@ When an agent goes idle (waiting for input or stopped) on a non-active project, 
 Desktop and toast notifications fire when an agent needs attention and the user can't already see it - either the window is minimized/unfocused, or a different project is active. Notification events: agent idle, permission-blocked idle (body shows "Needs permission"), session crash (non-zero exit), and plan-completion auto-moves. The task name is the title and the project name is the body. Clicking a desktop notification brings the window to the foreground, switches to the correct project, and opens the task detail dialog. The taskbar also flashes on Windows. A 10-second per-session cooldown prevents repeated desktop notifications from the same agent.
 
 The Settings > Notifications panel exposes three configurable events: **Agent Idle**, **Plan Complete**, and **Spawn Stalled** (a task spawn that waits too long on the git queue while preparing). Each can be set to Desktop & Toast, Desktop Only, Toast Only, or Off. Toast duration and max visible count are also configurable. The **Agent Crash** notification (non-zero exit) is always on and not exposed in the settings UI.
+
+### Mobile Devices
+
+The Mobile Devices tab is the desktop half of the mobile companion app's pairing link - global (applies to this desktop installation, not any one project) and off by default. Enable the **Mobile Bridge** toggle and set a **Relay Address** (a self-hosted or Kangentic-hosted relay) before pairing.
+
+Click **Pair a Device** to display a QR code; scanning it with the Kangentic mobile app starts an end-to-end encrypted pairing handshake. Once the handshake completes, both the desktop and the phone show a short code and emoji sequence - confirm they match on both screens before tapping "Codes match" to finish pairing. This catches a photographed or relayed QR, since an attacker cannot make both sides show the same code. If the codes don't match, or you want to back out, cancel and start over.
+
+Paired devices appear in a list below, each with its granted capabilities. Revoking a device removes it from the desktop's signed roster immediately; a revoked phone must be paired again from scratch to reconnect. See [Mobile Bridge](mobile-bridge.md) for the underlying protocol, pairing ceremony, and security design.
 
 ### Privacy
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,11 +6,15 @@ import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import globals from 'globals';
 
 export default tseslint.config(
-  { ignores: ['node_modules/', '.vite/', '.kangentic/', 'dist/', 'build/', 'packages/'] },
+  // packages/launcher is deliberately zero-dep plain CommonJS with no build
+  // step; packages/protocol IS linted under the same strict rules as src/
+  // and tests/ below (see the `packages/protocol/src/**` entry in the next
+  // block's `files`), so it is NOT in this ignore list.
+  { ignores: ['node_modules/', '.vite/', '.kangentic/', 'dist/', 'build/', 'packages/launcher/'] },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    files: ['src/**/*.{ts,tsx}', 'tests/**/*.{ts,tsx}'],
+    files: ['src/**/*.{ts,tsx}', 'tests/**/*.{ts,tsx}', 'packages/protocol/src/**/*.ts'],
     plugins: {
       'react-hooks': reactHooksPlugin,
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [
-        "packages/launcher"
+        "packages/launcher",
+        "packages/protocol"
       ],
       "dependencies": {
         "@aptabase/electron": "^0.3.1",
@@ -44,11 +45,13 @@
         "@tailwindcss/postcss": "^4.3.0",
         "@tailwindcss/vite": "^4.3.0",
         "@types/better-sqlite3": "^7.6.13",
+        "@types/qrcode": "^1.5.6",
         "@types/react": "^19.2.16",
         "@types/react-dom": "^19.2.3",
         "@types/remove-markdown": "^0.3.4",
         "@types/uuid": "^10.0.0",
         "@types/which": "^3.0.4",
+        "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^6.0.2",
         "@xterm/addon-serialize": "^0.14.0",
         "@xterm/addon-unicode11": "^0.9.0",
@@ -69,6 +72,7 @@
         "lucide-react": "^1.17.0",
         "playwright": "^1.60.0",
         "postcss": "^8.5.15",
+        "qrcode": "^1.5.4",
         "react": "^19.2.7",
         "react-colorful": "^5.7.0",
         "react-dom": "^19.2.7",
@@ -80,6 +84,7 @@
         "vite": "^8.0.16",
         "vitest": "^4.1.8",
         "which": "^7.0.0",
+        "ws": "^8.21.0",
         "zod": "^4.4.3",
         "zustand": "^5.0.14"
       }
@@ -2743,6 +2748,10 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kangentic/protocol": {
+      "resolved": "packages/protocol",
+      "link": true
+    },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
@@ -2919,6 +2928,45 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@npmcli/agent": {
@@ -3888,6 +3936,16 @@
         "xmlbuilder": ">=11.0.1"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
@@ -3957,6 +4015,16 @@
       "integrity": "sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -5552,6 +5620,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001784",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
@@ -6144,6 +6222,16 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -6312,6 +6400,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dir-compare": {
       "version": "4.2.0",
@@ -11860,6 +11955,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -12122,6 +12227,16 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -12389,6 +12504,151 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.0",
@@ -12719,6 +12979,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/resedit": {
       "version": "1.7.2",
@@ -13084,6 +13351,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -15002,6 +15276,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -15093,6 +15374,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
@@ -15259,6 +15562,23 @@
       "license": "AGPL-3.0-only",
       "bin": {
         "kangentic": "bin/kangentic.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/protocol": {
+      "name": "@kangentic/protocol",
+      "version": "0.1.0",
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0"
+      },
+      "devDependencies": {
+        "esbuild": "^0.28.0",
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "repository": "https://github.com/Kangentic/kangentic",
   "private": true,
   "workspaces": [
-    "packages/launcher"
+    "packages/launcher",
+    "packages/protocol"
   ],
   "scripts": {
     "start": "node scripts/dev.js",
@@ -19,7 +20,7 @@
     "publish": "npm run rebuild && npm run build && electron-builder --publish always",
     "postinstall": "node scripts/rebuild-native.js",
     "rebuild": "node scripts/rebuild-native.js",
-    "lint": "eslint src/ --max-warnings 0",
+    "lint": "eslint src/ packages/protocol/src/ --max-warnings 0",
     "test": "npx playwright test --project=ui --project=electron",
     "test:headed": "HEADED=1 npx playwright test --project=ui --project=electron",
     "capture": "npx playwright test --project=captures",
@@ -59,11 +60,13 @@
     "@tailwindcss/postcss": "^4.3.0",
     "@tailwindcss/vite": "^4.3.0",
     "@types/better-sqlite3": "^7.6.13",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "@types/remove-markdown": "^0.3.4",
     "@types/uuid": "^10.0.0",
     "@types/which": "^3.0.4",
+    "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^6.0.2",
     "@xterm/addon-serialize": "^0.14.0",
     "@xterm/addon-unicode11": "^0.9.0",
@@ -84,6 +87,7 @@
     "lucide-react": "^1.17.0",
     "playwright": "^1.60.0",
     "postcss": "^8.5.15",
+    "qrcode": "^1.5.4",
     "react": "^19.2.7",
     "react-colorful": "^5.7.0",
     "react-dom": "^19.2.7",
@@ -95,6 +99,7 @@
     "vite": "^8.0.16",
     "vitest": "^4.1.8",
     "which": "^7.0.0",
+    "ws": "^8.21.0",
     "zod": "^4.4.3",
     "zustand": "^5.0.14"
   },

--- a/packages/protocol/LICENSE
+++ b/packages/protocol/LICENSE
@@ -1,0 +1,5 @@
+See the LICENSE file in the root of this repository:
+https://github.com/Kangentic/kangentic/blob/main/LICENSE
+
+SPDX-License-Identifier: AGPL-3.0-only
+Copyright (C) 2025-2026 VORPAHL LLC. All rights reserved.

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -1,0 +1,27 @@
+# @kangentic/protocol
+
+Shared wire protocol for the Kangentic mobile bridge: frame encoding, the Noise-based pairing
+and session handshakes, secretstream-style AEAD framing, the signed device roster, capability
+verbs, and the transcript/board/activity event contract types the mobile app consumes.
+
+This package is the single source of truth for the desktop (`src/main/mobile-bridge/`) and
+`kangentic-mobile` implementations of the protocol. It is pure TypeScript on top of
+[`@noble/curves`](https://github.com/paulmillr/noble-curves),
+[`@noble/hashes`](https://github.com/paulmillr/noble-hashes), and
+[`@noble/ciphers`](https://github.com/paulmillr/noble-ciphers) so the exact same handshake code
+runs on Node (Electron main) and React Native (via the same pure-JS primitives), with no native
+module coupling.
+
+See `docs/mobile-bridge.md` in the main repository for the pairing ceremony, roster/revocation
+model, and the honest relay-metadata statement.
+
+## Security
+
+- `Noise_KK_25519_ChaChaPoly_BLAKE2s` for ongoing sessions (mutual authentication by construction,
+  no trust-on-first-use).
+- A token-bound Noise PSK handshake for the one-time pairing ceremony, confirmed by a Matrix-style
+  short authentication string (SAS) on both screens.
+- No shell, file, or arbitrary-command verb exists in the protocol.
+
+This package has not undergone a third-party security audit. Report suspected vulnerabilities
+per the repository's security policy rather than filing a public issue.

--- a/packages/protocol/build.mjs
+++ b/packages/protocol/build.mjs
@@ -1,0 +1,33 @@
+// Bundles the package into dual CJS/ESM outputs. @noble/curves, @noble/hashes,
+// and @noble/ciphers ship ESM-only (no "require" export condition), so a plain
+// `tsc`-emitted CommonJS build would call require() on an ESM-only package and
+// throw ERR_REQUIRE_ESM at runtime for any CJS consumer. Bundling the noble
+// dependencies directly into both outputs (instead of leaving them external)
+// sidesteps that: neither dist file does a runtime resolve of `@noble/*`.
+// `tsconfig.build.json` (run separately, see package.json's `build` script)
+// handles the `.d.ts` declaration emit; this script only produces runtime JS.
+import esbuild from 'esbuild';
+
+const common = {
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  sourcemap: false,
+  minify: false,
+};
+
+await Promise.all([
+  esbuild.build({
+    ...common,
+    platform: 'neutral',
+    format: 'esm',
+    outfile: 'dist/index.mjs',
+  }),
+  esbuild.build({
+    ...common,
+    platform: 'node',
+    format: 'cjs',
+    outfile: 'dist/index.cjs',
+  }),
+]);
+
+console.log('[protocol build] Wrote dist/index.mjs and dist/index.cjs');

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@kangentic/protocol",
+  "version": "0.1.0",
+  "description": "Kangentic mobile bridge wire protocol: framing, Noise-based pairing and session handshakes, signed device roster, and capability verbs shared between desktop and mobile.",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Kangentic/kangentic.git"
+  },
+  "keywords": [
+    "kangentic",
+    "protocol",
+    "noise-protocol",
+    "e2ee",
+    "mobile"
+  ],
+  "author": {
+    "name": "Kangentic",
+    "url": "https://github.com/Kangentic"
+  },
+  "license": "AGPL-3.0-only",
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "dist/",
+    "LICENSE",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "node build.mjs && tsc -p tsconfig.build.json"
+  },
+  "dependencies": {
+    "@noble/ciphers": "^2.2.0",
+    "@noble/curves": "^2.2.0",
+    "@noble/hashes": "^2.2.0"
+  },
+  "devDependencies": {
+    "esbuild": "^0.28.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/protocol/src/capabilities/verbs.ts
+++ b/packages/protocol/src/capabilities/verbs.ts
@@ -1,0 +1,40 @@
+/**
+ * The complete set of capability verbs a paired device may be granted.
+ * There is deliberately NO shell, file-read, or arbitrary-command verb --
+ * absent from the protocol entirely, not filtered at runtime (the SSH
+ * forced-command lesson: Chrome Remote Desktop and VS Code tunnels are the
+ * counter-examples, identity-gated but capability-unscoped). Adding a new
+ * verb here is a protocol change; it does not, by itself, grant anything --
+ * the desktop's capability router (Phase 2) still has to implement and
+ * wire a handler, and a device's roster entry still has to include it in
+ * its CapabilitySet.
+ */
+export const CAPABILITY_VERBS = [
+  'read-stream',
+  'read-board',
+  'read-diff',
+  'send-user-message',
+  'move-task',
+  'answer-permission-prompt',
+] as const;
+
+export type CapabilityVerb = (typeof CAPABILITY_VERBS)[number];
+
+export function isCapabilityVerb(value: string): value is CapabilityVerb {
+  return (CAPABILITY_VERBS as readonly string[]).includes(value);
+}
+
+/** Deny-by-default: a verb absent from the set is not authorized. */
+export type CapabilitySet = ReadonlySet<CapabilityVerb>;
+
+export function capabilitySetFromArray(verbs: readonly string[]): CapabilitySet {
+  const set = new Set<CapabilityVerb>();
+  for (const verb of verbs) {
+    if (isCapabilityVerb(verb)) set.add(verb);
+  }
+  return set;
+}
+
+export function capabilitySetToArray(capabilities: CapabilitySet): CapabilityVerb[] {
+  return Array.from(capabilities);
+}

--- a/packages/protocol/src/crypto/noise/cipher-state.ts
+++ b/packages/protocol/src/crypto/noise/cipher-state.ts
@@ -1,0 +1,40 @@
+/**
+ * Noise Protocol Framework section 5.1: the CipherState object. `k` is
+ * either null (no key set yet, EncryptWithAd/DecryptWithAd are the
+ * identity function) or a 32-byte ChaCha20-Poly1305 key; `n` is the
+ * 64-bit nonce counter, reset to 0 every time the key changes.
+ */
+import { aeadDecrypt, aeadEncrypt } from '../primitives';
+
+const MAX_NONCE = 0xffffffffffffffffn;
+
+export class CipherState {
+  private key: Uint8Array | null = null;
+  private nonce = 0n;
+
+  initializeKey(key: Uint8Array | null): void {
+    this.key = key;
+    this.nonce = 0n;
+  }
+
+  hasKey(): boolean {
+    return this.key !== null;
+  }
+
+  encryptWithAd(associatedData: Uint8Array, plaintext: Uint8Array): Uint8Array {
+    if (this.key === null) return plaintext;
+    if (this.nonce >= MAX_NONCE) throw new Error('Noise CipherState nonce space exhausted');
+    const ciphertext = aeadEncrypt(this.key, this.nonce, associatedData, plaintext);
+    this.nonce += 1n;
+    return ciphertext;
+  }
+
+  /** Nonce is only advanced on a SUCCESSFUL decrypt; aeadDecrypt throws on tag failure. */
+  decryptWithAd(associatedData: Uint8Array, ciphertext: Uint8Array): Uint8Array {
+    if (this.key === null) return ciphertext;
+    if (this.nonce >= MAX_NONCE) throw new Error('Noise CipherState nonce space exhausted');
+    const plaintext = aeadDecrypt(this.key, this.nonce, associatedData, ciphertext);
+    this.nonce += 1n;
+    return plaintext;
+  }
+}

--- a/packages/protocol/src/crypto/noise/handshake-state.ts
+++ b/packages/protocol/src/crypto/noise/handshake-state.ts
@@ -1,0 +1,222 @@
+/**
+ * Noise Protocol Framework section 5.3: the HandshakeState object. A
+ * generic token interpreter driven by a NoisePattern, so both the ongoing
+ * session pattern (KK) and the pairing pattern (IKpsk0) share this exact
+ * code - only the pattern table and the supplied key material differ.
+ */
+import { X25519_KEY_LENGTH, AEAD_TAG_LENGTH, concatBytes, generateX25519KeyPair, x25519SharedSecret, type X25519KeyPair } from '../primitives';
+import { CipherState } from './cipher-state';
+import { SymmetricState } from './symmetric-state';
+import type { NoisePattern, NoiseToken } from './patterns';
+
+export interface HandshakeStateOptions {
+  pattern: NoisePattern;
+  initiator: boolean;
+  /** Bound into the transcript before any key material - kills downgrade attacks when it encodes the negotiated protocol version. */
+  prologue: Uint8Array;
+  /** Local static keypair. Required whenever the pattern's local role sends or has pre-shared an "s" token. */
+  s?: X25519KeyPair;
+  /** Local ephemeral keypair. Only ever set by a test harness; production code always lets writeMessage() generate it. */
+  e?: X25519KeyPair;
+  /** Remote static public key. Required whenever the pattern's local role receives an "s" pre-message (e.g. KK) or already knows it out-of-band (e.g. IK's responder key from a QR). */
+  rs?: Uint8Array;
+  re?: Uint8Array;
+  /** 32-byte pre-shared key. Required by patterns with a "psk" token. */
+  psk?: Uint8Array;
+  /** Test-only override for ephemeral keypair generation, to replay a fixed test vector. */
+  generateEphemeral?: () => X25519KeyPair;
+}
+
+export interface HandshakeWriteResult {
+  message: Uint8Array;
+  /** Present once the pattern's last message has been written. */
+  split?: [CipherState, CipherState];
+}
+
+export interface HandshakeReadResult {
+  payload: Uint8Array;
+  /** Present once the pattern's last message has been read. */
+  split?: [CipherState, CipherState];
+}
+
+export class HandshakeState {
+  private readonly symmetricState: SymmetricState;
+  private readonly pattern: NoisePattern;
+  private readonly initiator: boolean;
+  private readonly generateEphemeral: () => X25519KeyPair;
+  private readonly psk?: Uint8Array;
+  private s?: X25519KeyPair;
+  private e?: X25519KeyPair;
+  private rs?: Uint8Array;
+  private re?: Uint8Array;
+  private messageIndex = 0;
+
+  constructor(options: HandshakeStateOptions) {
+    this.pattern = options.pattern;
+    this.initiator = options.initiator;
+    this.s = options.s;
+    this.e = options.e;
+    this.rs = options.rs;
+    this.re = options.re;
+    this.psk = options.psk;
+    this.generateEphemeral = options.generateEphemeral ?? generateX25519KeyPair;
+
+    const protocolName = new TextEncoder().encode(`Noise_${this.pattern.name}_25519_ChaChaPoly_BLAKE2s`);
+    this.symmetricState = new SymmetricState(protocolName);
+    this.symmetricState.mixHash(options.prologue);
+
+    // Initiator's pre-message keys are ALWAYS mixed before the responder's,
+    // regardless of which role this instance is playing locally.
+    for (const token of this.pattern.initiatorPreMessage) {
+      this.symmetricState.mixHash(this.resolvePreMessageKey(token, true));
+    }
+    for (const token of this.pattern.responderPreMessage) {
+      this.symmetricState.mixHash(this.resolvePreMessageKey(token, false));
+    }
+  }
+
+  private resolvePreMessageKey(token: NoiseToken, isInitiatorSide: boolean): Uint8Array {
+    if (token !== 's') throw new Error(`Unsupported pre-message token: ${token}`);
+    const isLocalSide = isInitiatorSide === this.initiator;
+    if (isLocalSide) {
+      if (!this.s) throw new Error('Local static key required by this pattern but not provided');
+      return this.s.publicKey;
+    }
+    if (!this.rs) throw new Error('Remote static key required by this pattern but not provided');
+    return this.rs;
+  }
+
+  private requireLocalKeyPair(which: 'e' | 's'): X25519KeyPair {
+    const keyPair = which === 'e' ? this.e : this.s;
+    if (!keyPair) throw new Error(`Local "${which}" key required for this token but not available`);
+    return keyPair;
+  }
+
+  private requireRemoteKey(which: 're' | 'rs'): Uint8Array {
+    const publicKey = which === 're' ? this.re : this.rs;
+    if (!publicKey) throw new Error(`Remote "${which}" key required for this token but not available`);
+    return publicKey;
+  }
+
+  private requirePsk(): Uint8Array {
+    if (!this.psk) throw new Error('PSK required by this pattern but not provided');
+    return this.psk;
+  }
+
+  private dh(local: X25519KeyPair, remotePublicKey: Uint8Array): Uint8Array {
+    return x25519SharedSecret(local.secretKey, remotePublicKey);
+  }
+
+  private mixDhToken(token: 'ee' | 'es' | 'se' | 'ss'): void {
+    switch (token) {
+      case 'ee':
+        this.symmetricState.mixKey(this.dh(this.requireLocalKeyPair('e'), this.requireRemoteKey('re')));
+        return;
+      case 'es':
+        this.symmetricState.mixKey(
+          this.initiator
+            ? this.dh(this.requireLocalKeyPair('e'), this.requireRemoteKey('rs'))
+            : this.dh(this.requireLocalKeyPair('s'), this.requireRemoteKey('re')),
+        );
+        return;
+      case 'se':
+        this.symmetricState.mixKey(
+          this.initiator
+            ? this.dh(this.requireLocalKeyPair('s'), this.requireRemoteKey('re'))
+            : this.dh(this.requireLocalKeyPair('e'), this.requireRemoteKey('rs')),
+        );
+        return;
+      case 'ss':
+        this.symmetricState.mixKey(this.dh(this.requireLocalKeyPair('s'), this.requireRemoteKey('rs')));
+        return;
+    }
+  }
+
+  private nextTokens(): readonly NoiseToken[] {
+    const tokens = this.pattern.messages[this.messageIndex];
+    if (!tokens) throw new Error('No more messages remain in this handshake pattern');
+    this.messageIndex += 1;
+    return tokens;
+  }
+
+  private maybeSplit(): [CipherState, CipherState] | undefined {
+    return this.messageIndex >= this.pattern.messages.length ? this.symmetricState.split() : undefined;
+  }
+
+  writeMessage(payload: Uint8Array): HandshakeWriteResult {
+    const tokens = this.nextTokens();
+    const buffers: Uint8Array[] = [];
+
+    for (const token of tokens) {
+      switch (token) {
+        case 'e': {
+          this.e = this.generateEphemeral();
+          buffers.push(this.e.publicKey);
+          this.symmetricState.mixHash(this.e.publicKey);
+          // Section 9.2: in a PSK handshake, every "e" token ALSO calls
+          // MixKey(e.public_key), not just MixHash. Non-PSK patterns skip this.
+          if (this.pattern.usesPsk) this.symmetricState.mixKey(this.e.publicKey);
+          break;
+        }
+        case 's': {
+          buffers.push(this.symmetricState.encryptAndHash(this.requireLocalKeyPair('s').publicKey));
+          break;
+        }
+        case 'psk':
+          this.symmetricState.mixKeyAndHash(this.requirePsk());
+          break;
+        default:
+          this.mixDhToken(token);
+      }
+    }
+
+    buffers.push(this.symmetricState.encryptAndHash(payload));
+    return { message: concatBytes(...buffers), split: this.maybeSplit() };
+  }
+
+  readMessage(message: Uint8Array): HandshakeReadResult {
+    const tokens = this.nextTokens();
+    let offset = 0;
+
+    for (const token of tokens) {
+      switch (token) {
+        case 'e': {
+          this.re = message.subarray(offset, offset + X25519_KEY_LENGTH);
+          offset += X25519_KEY_LENGTH;
+          this.symmetricState.mixHash(this.re);
+          if (this.pattern.usesPsk) this.symmetricState.mixKey(this.re);
+          break;
+        }
+        case 's': {
+          const fieldLength = this.symmetricState.hasKey() ? X25519_KEY_LENGTH + AEAD_TAG_LENGTH : X25519_KEY_LENGTH;
+          const field = message.subarray(offset, offset + fieldLength);
+          offset += fieldLength;
+          this.rs = this.symmetricState.decryptAndHash(field);
+          break;
+        }
+        case 'psk':
+          this.symmetricState.mixKeyAndHash(this.requirePsk());
+          break;
+        default:
+          this.mixDhToken(token);
+      }
+    }
+
+    const payload = this.symmetricState.decryptAndHash(message.subarray(offset));
+    return { payload, split: this.maybeSplit() };
+  }
+
+  getHandshakeHash(): Uint8Array {
+    return this.symmetricState.getHandshakeHash();
+  }
+
+  /** See SymmetricState.getChainingKey(): only meaningful once split() has occurred. */
+  getChainingKey(): Uint8Array {
+    return this.symmetricState.getChainingKey();
+  }
+
+  /** The remote static public key, once learned (pre-shared or received via an "s" token). */
+  getRemoteStaticKey(): Uint8Array | undefined {
+    return this.rs;
+  }
+}

--- a/packages/protocol/src/crypto/noise/kk.ts
+++ b/packages/protocol/src/crypto/noise/kk.ts
@@ -1,0 +1,24 @@
+/** Driver for the ongoing bridge session handshake: Noise_KK_25519_ChaChaPoly_BLAKE2s. */
+import { encodeProtocolVersion } from '../../version';
+import type { X25519KeyPair } from '../primitives';
+import { HandshakeState } from './handshake-state';
+import { KK_PATTERN } from './patterns';
+
+export interface KKHandshakeOptions {
+  initiator: boolean;
+  /** Local device's static identity keypair. */
+  localStatic: X25519KeyPair;
+  /** Peer's static public key, already pinned in the signed device roster. */
+  remoteStatic: Uint8Array;
+  protocolVersion?: string;
+}
+
+export function createKKHandshake(options: KKHandshakeOptions): HandshakeState {
+  return new HandshakeState({
+    pattern: KK_PATTERN,
+    initiator: options.initiator,
+    prologue: encodeProtocolVersion(options.protocolVersion),
+    s: options.localStatic,
+    rs: options.remoteStatic,
+  });
+}

--- a/packages/protocol/src/crypto/noise/patterns.ts
+++ b/packages/protocol/src/crypto/noise/patterns.ts
@@ -1,0 +1,69 @@
+/** Noise message-pattern tokens (section 5.3, plus "psk" from section 9). */
+export type NoiseToken = 'e' | 's' | 'ee' | 'es' | 'se' | 'ss' | 'psk';
+
+export interface NoisePattern {
+  /** Used to construct the protocol name, e.g. "KK" -> Noise_KK_25519_ChaChaPoly_BLAKE2s. */
+  readonly name: string;
+  readonly initiatorPreMessage: readonly NoiseToken[];
+  readonly responderPreMessage: readonly NoiseToken[];
+  readonly messages: readonly (readonly NoiseToken[])[];
+  /**
+   * Noise section 9.2: in a PSK handshake every "e" token calls
+   * MixKey(e.public_key) in addition to the MixHash(e.public_key) a
+   * non-PSK handshake always does. This must be a property of the
+   * PATTERN (not inferred from "was a psk option passed"), since it
+   * changes how the "e" token itself is processed, independent of
+   * whether the pattern's own "psk" token has been reached yet.
+   */
+  readonly usesPsk: boolean;
+}
+
+/**
+ * Both parties' static keys are known in advance (mutual authentication by
+ * construction, no trust-on-first-use). Used for ongoing bridge sessions
+ * once a device is in the signed roster.
+ *
+ *   KK:
+ *     -> s
+ *     <- s
+ *     ...
+ *     -> e, es, ss
+ *     <- e, ee, se
+ */
+export const KK_PATTERN: NoisePattern = {
+  name: 'KK',
+  initiatorPreMessage: ['s'],
+  responderPreMessage: ['s'],
+  messages: [
+    ['e', 'es', 'ss'],
+    ['e', 'ee', 'se'],
+  ],
+  usesPsk: false,
+};
+
+/**
+ * The initiator (phone) knows the responder's (desktop's) static key from
+ * the QR in advance; the responder learns the initiator's static key from
+ * the "s" token in message 1, which is exactly how the desktop learns the
+ * phone's identity key during pairing. The "psk0" modifier mixes the
+ * pairing token in before any Diffie-Hellman step, so message 1 only
+ * decrypts (and the "s"/payload fields inside it only authenticate) for a
+ * peer that has the same token - a wrong guess fails at DecryptAndHash
+ * with no oracle beyond "handshake failed".
+ *
+ *   IKpsk0:
+ *     <- s
+ *     ...
+ *     -> psk, e, es, s, ss
+ *     <- e, ee, se
+ */
+export const IKPSK0_PATTERN: NoisePattern = {
+  name: 'IKpsk0',
+  initiatorPreMessage: [],
+  responderPreMessage: ['s'],
+  messages: [
+    ['psk', 'e', 'es', 's', 'ss'],
+    ['e', 'ee', 'se'],
+  ],
+  usesPsk: true,
+};

--- a/packages/protocol/src/crypto/noise/symmetric-state.ts
+++ b/packages/protocol/src/crypto/noise/symmetric-state.ts
@@ -1,0 +1,84 @@
+/**
+ * Noise Protocol Framework section 5.2: the SymmetricState object. Wraps a
+ * CipherState plus the chaining key `ck` and running transcript hash `h`.
+ */
+import { concatBytes, hashBlake2s, noiseHkdf, HASH_LENGTH } from '../primitives';
+import { CipherState } from './cipher-state';
+
+export class SymmetricState {
+  private readonly cipherState = new CipherState();
+  private chainingKey: Uint8Array;
+  private hash: Uint8Array;
+
+  constructor(protocolName: Uint8Array) {
+    if (protocolName.length <= HASH_LENGTH) {
+      this.hash = concatBytes(protocolName, new Uint8Array(HASH_LENGTH - protocolName.length));
+    } else {
+      this.hash = hashBlake2s(protocolName);
+    }
+    this.chainingKey = this.hash;
+    this.cipherState.initializeKey(null);
+  }
+
+  mixKey(inputKeyMaterial: Uint8Array): void {
+    const [nextChainingKey, tempKey] = noiseHkdf(this.chainingKey, inputKeyMaterial, 2);
+    this.chainingKey = nextChainingKey;
+    this.cipherState.initializeKey(tempKey);
+  }
+
+  mixHash(data: Uint8Array): void {
+    this.hash = hashBlake2s(concatBytes(this.hash, data));
+  }
+
+  /** Processes a "psk" token: MixKeyAndHash(psk) per Noise section 9. */
+  mixKeyAndHash(inputKeyMaterial: Uint8Array): void {
+    const [nextChainingKey, tempHash, tempKey] = noiseHkdf(this.chainingKey, inputKeyMaterial, 3);
+    this.chainingKey = nextChainingKey;
+    this.mixHash(tempHash);
+    this.cipherState.initializeKey(tempKey);
+  }
+
+  getHandshakeHash(): Uint8Array {
+    return this.hash;
+  }
+
+  /**
+   * The raw chaining key, meaningful only after the handshake's message
+   * patterns are exhausted (alongside split()). Exposed so a caller can
+   * derive ADDITIONAL independent key material (e.g. secretstream framing
+   * keys) via its own domain-separated HKDF label - see
+   * crypto/secretstream.ts's deriveTransportKey. This is standard KDF
+   * practice (TLS 1.3's key schedule does the same): reusing one secret
+   * for multiple purposes via distinct labels is safe; Split()'s own
+   * derivation (empty info) and a labeled derivation never collide.
+   */
+  getChainingKey(): Uint8Array {
+    return this.chainingKey;
+  }
+
+  encryptAndHash(plaintext: Uint8Array): Uint8Array {
+    const ciphertext = this.cipherState.encryptWithAd(this.hash, plaintext);
+    this.mixHash(ciphertext);
+    return ciphertext;
+  }
+
+  decryptAndHash(ciphertext: Uint8Array): Uint8Array {
+    const plaintext = this.cipherState.decryptWithAd(this.hash, ciphertext);
+    this.mixHash(ciphertext);
+    return plaintext;
+  }
+
+  hasKey(): boolean {
+    return this.cipherState.hasKey();
+  }
+
+  /** Only valid once every message pattern has been processed. */
+  split(): [CipherState, CipherState] {
+    const [tempKey1, tempKey2] = noiseHkdf(this.chainingKey, new Uint8Array(0), 2);
+    const c1 = new CipherState();
+    const c2 = new CipherState();
+    c1.initializeKey(tempKey1);
+    c2.initializeKey(tempKey2);
+    return [c1, c2];
+  }
+}

--- a/packages/protocol/src/crypto/pairing-handshake.ts
+++ b/packages/protocol/src/crypto/pairing-handshake.ts
@@ -1,0 +1,53 @@
+/**
+ * Driver for the one-time pairing handshake: Noise_IKpsk0_25519_ChaChaPoly_BLAKE2s.
+ *
+ * The phone (initiator) already knows the desktop's (responder's) static
+ * public key from the QR, and sends its own static key authenticated
+ * within message 1. The pairing token is mixed in as a PSK before any
+ * Diffie-Hellman step, so a peer without the token cannot produce a
+ * transcript that decrypts on the other side - see patterns.ts for the
+ * full token trace.
+ */
+import { encodeProtocolVersion } from '../version';
+import type { X25519KeyPair } from './primitives';
+import { HandshakeState } from './noise/handshake-state';
+import { IKPSK0_PATTERN } from './noise/patterns';
+
+export interface PairingInitiatorOptions {
+  /** The phone's own static identity keypair. */
+  localStatic: X25519KeyPair;
+  /** The desktop's static public key, read from the QR payload. */
+  remoteStatic: Uint8Array;
+  /** The 32-byte single-use pairing token from the QR payload, used as the Noise PSK. */
+  pairingToken: Uint8Array;
+  protocolVersion?: string;
+}
+
+export function createPairingInitiatorHandshake(options: PairingInitiatorOptions): HandshakeState {
+  return new HandshakeState({
+    pattern: IKPSK0_PATTERN,
+    initiator: true,
+    prologue: encodeProtocolVersion(options.protocolVersion),
+    s: options.localStatic,
+    rs: options.remoteStatic,
+    psk: options.pairingToken,
+  });
+}
+
+export interface PairingResponderOptions {
+  /** The desktop's own static identity keypair (the one published in the QR). */
+  localStatic: X25519KeyPair;
+  /** The same 32-byte single-use pairing token minted for this QR. */
+  pairingToken: Uint8Array;
+  protocolVersion?: string;
+}
+
+export function createPairingResponderHandshake(options: PairingResponderOptions): HandshakeState {
+  return new HandshakeState({
+    pattern: IKPSK0_PATTERN,
+    initiator: false,
+    prologue: encodeProtocolVersion(options.protocolVersion),
+    s: options.localStatic,
+    psk: options.pairingToken,
+  });
+}

--- a/packages/protocol/src/crypto/primitives.ts
+++ b/packages/protocol/src/crypto/primitives.ts
@@ -1,0 +1,167 @@
+/**
+ * Thin wrappers over @noble/curves, @noble/hashes, and @noble/ciphers - the
+ * only place in this package that imports noble directly. Everything above
+ * this module (Noise state machine, secretstream, SAS, roster signing) goes
+ * through these functions so the primitive choice stays swappable in one
+ * place and every byte length is asserted at the boundary.
+ */
+import { x25519, ed25519 } from '@noble/curves/ed25519.js';
+import { blake2s } from '@noble/hashes/blake2.js';
+import { hkdf as nobleHkdf } from '@noble/hashes/hkdf.js';
+import { randomBytes as nobleRandomBytes, hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
+import { chacha20poly1305, xchacha20poly1305 } from '@noble/ciphers/chacha.js';
+
+export const X25519_KEY_LENGTH = 32;
+export const ED25519_KEY_LENGTH = 32;
+export const ED25519_SIGNATURE_LENGTH = 64;
+export const HASH_LENGTH = 32;
+export const AEAD_KEY_LENGTH = 32;
+export const CHACHA_NONCE_LENGTH = 12;
+export const XCHACHA_NONCE_LENGTH = 24;
+export const AEAD_TAG_LENGTH = 16;
+
+function assertLength(bytes: Uint8Array, expected: number, label: string): void {
+  if (bytes.length !== expected) {
+    throw new Error(`${label} must be ${expected} bytes, got ${bytes.length}`);
+  }
+}
+
+export function randomBytes(length: number): Uint8Array {
+  return nobleRandomBytes(length);
+}
+
+export { hexToBytes, bytesToHex };
+
+export interface X25519KeyPair {
+  secretKey: Uint8Array;
+  publicKey: Uint8Array;
+}
+
+export function generateX25519KeyPair(): X25519KeyPair {
+  return x25519.keygen();
+}
+
+export function x25519PublicKeyFrom(secretKey: Uint8Array): Uint8Array {
+  assertLength(secretKey, X25519_KEY_LENGTH, 'x25519 secret key');
+  return x25519.getPublicKey(secretKey);
+}
+
+/** Diffie-Hellman: DH(localSecretKey, remotePublicKey). Throws on a low-order/invalid peer key. */
+export function x25519SharedSecret(secretKey: Uint8Array, publicKey: Uint8Array): Uint8Array {
+  assertLength(secretKey, X25519_KEY_LENGTH, 'x25519 secret key');
+  assertLength(publicKey, X25519_KEY_LENGTH, 'x25519 public key');
+  return x25519.getSharedSecret(secretKey, publicKey);
+}
+
+export interface Ed25519KeyPair {
+  secretKey: Uint8Array;
+  publicKey: Uint8Array;
+}
+
+export function generateEd25519KeyPair(): Ed25519KeyPair {
+  return ed25519.keygen();
+}
+
+export function ed25519Sign(message: Uint8Array, secretKey: Uint8Array): Uint8Array {
+  assertLength(secretKey, ED25519_KEY_LENGTH, 'ed25519 secret key');
+  return ed25519.sign(message, secretKey);
+}
+
+export function ed25519Verify(signature: Uint8Array, message: Uint8Array, publicKey: Uint8Array): boolean {
+  assertLength(signature, ED25519_SIGNATURE_LENGTH, 'ed25519 signature');
+  assertLength(publicKey, ED25519_KEY_LENGTH, 'ed25519 public key');
+  return ed25519.verify(signature, message, publicKey);
+}
+
+export function hashBlake2s(data: Uint8Array): Uint8Array {
+  return blake2s(data);
+}
+
+/**
+ * Noise's HKDF(chaining_key, input_key_material, num_outputs): HKDF-Extract
+ * with salt=chaining_key, ikm=input_key_material, then HKDF-Expand with an
+ * empty info, chunked into num_outputs HASH_LENGTH-byte blocks. This is
+ * exactly RFC 5869 HKDF with a zero-length info string, so the noble
+ * convenience function (extract+expand combined) is used directly rather
+ * than hand-rolling the counter loop.
+ */
+export function noiseHkdf(chainingKey: Uint8Array, inputKeyMaterial: Uint8Array, numOutputs: 2 | 3): Uint8Array[] {
+  const output = nobleHkdf(blake2s, inputKeyMaterial, chainingKey, new Uint8Array(0), numOutputs * HASH_LENGTH);
+  const chunks: Uint8Array[] = [];
+  for (let i = 0; i < numOutputs; i++) {
+    chunks.push(output.subarray(i * HASH_LENGTH, (i + 1) * HASH_LENGTH));
+  }
+  return chunks;
+}
+
+/**
+ * Independent, domain-separated key derivation from a Noise chaining key,
+ * for material that is NOT part of the Noise handshake itself (e.g. the
+ * secretstream framing keys derived once a session's split() has run).
+ * Reusing one secret for multiple purposes via distinct labels is safe
+ * KDF practice as long as every purpose gets its own label; this is a
+ * plain HKDF-Expand-style derivation (salt=chainingKey, ikm=empty,
+ * info=label), independent of noiseHkdf's own empty-info convention.
+ */
+export function deriveLabeledKey(chainingKey: Uint8Array, label: string, length: number): Uint8Array {
+  return nobleHkdf(blake2s, new Uint8Array(0), chainingKey, new TextEncoder().encode(label), length);
+}
+
+/**
+ * AEAD_ENCRYPT/AEAD_DECRYPT per Noise section 12.3: ChaCha20-Poly1305 (RFC
+ * 7539) with the 96-bit nonce formed as 32 zero bits followed by the
+ * little-endian encoding of the 64-bit counter `n`.
+ */
+function chachaNonce(counter: bigint): Uint8Array {
+  const nonce = new Uint8Array(CHACHA_NONCE_LENGTH);
+  const view = new DataView(nonce.buffer);
+  view.setBigUint64(4, counter, true);
+  return nonce;
+}
+
+export function aeadEncrypt(key: Uint8Array, counter: bigint, associatedData: Uint8Array, plaintext: Uint8Array): Uint8Array {
+  assertLength(key, AEAD_KEY_LENGTH, 'AEAD key');
+  const cipher = chacha20poly1305(key, chachaNonce(counter), associatedData);
+  return cipher.encrypt(plaintext);
+}
+
+export function aeadDecrypt(key: Uint8Array, counter: bigint, associatedData: Uint8Array, ciphertext: Uint8Array): Uint8Array {
+  assertLength(key, AEAD_KEY_LENGTH, 'AEAD key');
+  const cipher = chacha20poly1305(key, chachaNonce(counter), associatedData);
+  return cipher.decrypt(ciphertext);
+}
+
+/** XChaCha20-Poly1305 with a 24-byte nonce - used by the secretstream framing, not the Noise handshake. */
+export function xaeadEncrypt(key: Uint8Array, nonce: Uint8Array, associatedData: Uint8Array, plaintext: Uint8Array): Uint8Array {
+  assertLength(key, AEAD_KEY_LENGTH, 'XAEAD key');
+  assertLength(nonce, XCHACHA_NONCE_LENGTH, 'XAEAD nonce');
+  const cipher = xchacha20poly1305(key, nonce, associatedData);
+  return cipher.encrypt(plaintext);
+}
+
+export function xaeadDecrypt(key: Uint8Array, nonce: Uint8Array, associatedData: Uint8Array, ciphertext: Uint8Array): Uint8Array {
+  assertLength(key, AEAD_KEY_LENGTH, 'XAEAD key');
+  assertLength(nonce, XCHACHA_NONCE_LENGTH, 'XAEAD nonce');
+  const cipher = xchacha20poly1305(key, nonce, associatedData);
+  return cipher.decrypt(ciphertext);
+}
+
+export function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a[i] ^ b[i];
+  }
+  return diff === 0;
+}
+
+export function concatBytes(...arrays: Uint8Array[]): Uint8Array {
+  const total = arrays.reduce((sum, arr) => sum + arr.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const arr of arrays) {
+    result.set(arr, offset);
+    offset += arr.length;
+  }
+  return result;
+}

--- a/packages/protocol/src/crypto/sas.ts
+++ b/packages/protocol/src/crypto/sas.ts
@@ -1,0 +1,61 @@
+/**
+ * Matrix-style short authentication string (SAS), derived from a completed
+ * pairing handshake's transcript hash (HandshakeState.getHandshakeHash()).
+ * Both peers compute this AFTER the handshake finishes, so it is a
+ * commitment over everything that happened - both static keys, both
+ * ephemeral keys, and the pairing token's contribution via MixKeyAndHash.
+ * A relay-in-the-middle that terminated two separate handshakes (one with
+ * each peer, forwarding neither honestly) would produce two DIFFERENT
+ * transcript hashes, so the SAS values shown on each screen would not
+ * match - this is what "defeats a photographed or relayed QR" means in
+ * practice: the human comparison step is what catches it.
+ *
+ * This is inspired by Matrix's SAS verification (commitment-before-reveal,
+ * a short decimal code plus an emoji sequence for the same underlying
+ * bytes), not a byte-compatible reimplementation of Matrix's own derivation.
+ */
+import { deriveLabeledKey } from './primitives';
+
+const SAS_LABEL = 'kangentic-pairing-sas';
+
+/** A representative, deliberately small, unambiguous set: no near-duplicate emoji, no PUA/flag glyphs that render inconsistently across platforms. */
+const SAS_EMOJI_TABLE = [
+  '🐶', '🐱', '🐭', '🐹', '🐰', '🦊', '🐻', '🐼', '🐨', '🐯', '🦁', '🐮', '🐷', '🐸', '🐵', '🐔',
+  '🐧', '🐦', '🦄', '🐴', '🐝', '🐢', '🐍', '🐙', '🦀', '🐳', '🐬', '🐠', '🦋', '🐌', '🐞', '🦂',
+  '🌵', '🌲', '🌸', '🍀', '🍎', '🍌', '🍉', '🍇', '🍓', '🍒', '🥑', '🌽', '🍕', '🍔', '🍩', '🎂',
+  '⚽', '🏀', '🎸', '🎲', '🎯', '🚗', '🚀', '⛵', '🚲', '⌛', '🔑', '💎', '🎈', '🎁', '🔔', '⭐',
+] as const;
+
+export interface ShortAuthenticationString {
+  /** A 6-digit code, e.g. "042917". */
+  digits: string;
+  /** 5 emoji from a fixed 64-entry table. */
+  emoji: string[];
+}
+
+/**
+ * Derives SAS bytes from the transcript hash via a domain-separated HKDF
+ * label, independent of any other derivation from the same hash. 4 bytes
+ * feed the decimal code, 5 bytes feed the emoji sequence - 9 bytes total,
+ * comfortably inside a single 32-byte HKDF output.
+ */
+function deriveSasBytes(handshakeHash: Uint8Array): Uint8Array {
+  return deriveLabeledKey(handshakeHash, SAS_LABEL, 9);
+}
+
+export function deriveShortAuthenticationString(handshakeHash: Uint8Array): ShortAuthenticationString {
+  const bytes = deriveSasBytes(handshakeHash);
+  // Manual big-endian uint32 read instead of a DataView over bytes.buffer:
+  // avoids any assumption about the returned Uint8Array's byteOffset within
+  // its backing ArrayBuffer.
+  const digitsRaw = (bytes[0] * 2 ** 24) + (bytes[1] << 16) + (bytes[2] << 8) + bytes[3];
+  const digitsValue = digitsRaw % 1_000_000;
+  const digits = digitsValue.toString(10).padStart(6, '0');
+
+  const emoji: string[] = [];
+  for (let i = 0; i < 5; i++) {
+    emoji.push(SAS_EMOJI_TABLE[bytes[4 + i] % SAS_EMOJI_TABLE.length]);
+  }
+
+  return { digits, emoji };
+}

--- a/packages/protocol/src/crypto/secretstream.ts
+++ b/packages/protocol/src/crypto/secretstream.ts
@@ -1,0 +1,111 @@
+/**
+ * Per-direction framed AEAD applied on top of an established Noise
+ * session, giving truncation/reorder/replay detection "out of the box":
+ * a noble-only equivalent of libsodium's crypto_secretstream_xchacha20poly1305
+ * (the research doc's stated design), not a byte-compatible reimplementation.
+ *
+ * Each direction gets its own 32-byte key and a 24-byte nonce header,
+ * both derived from the Noise session's final chaining key via a
+ * domain-separated label (deriveLabeledKey) - nothing extra needs to be
+ * transmitted to set this up, since both peers compute identical values
+ * from the same chaining key. Per message, the nonce is the header with
+ * its low 64 bits XORed against a monotonic counter; a one-byte TAG is
+ * authenticated (as associated data) but not encrypted, so a receiver can
+ * tell a MESSAGE frame from a REKEY or FINAL boundary before - and even
+ * if - decryption fails.
+ *
+ * Because both seal() and open() drive the AEAD nonce from the receiver's
+ * own expected counter (not one read off the wire), a replayed, reordered,
+ * or truncated frame fails to authenticate rather than silently decrypting:
+ * the detection IS the authentication failure, not a separate check.
+ */
+import { concatBytes, deriveLabeledKey, xaeadDecrypt, xaeadEncrypt, XCHACHA_NONCE_LENGTH } from './primitives';
+
+export const FrameTag = {
+  Message: 0,
+  Rekey: 1,
+  Final: 2,
+} as const;
+export type FrameTag = (typeof FrameTag)[keyof typeof FrameTag];
+
+const NONCE_COUNTER_OFFSET = XCHACHA_NONCE_LENGTH - 8;
+const MAX_COUNTER = 0xffffffffffffffffn;
+
+export class SecretstreamState {
+  private key: Uint8Array;
+  private readonly nonceHeader: Uint8Array;
+  private counter = 0n;
+
+  constructor(key: Uint8Array, nonceHeader: Uint8Array) {
+    if (nonceHeader.length !== XCHACHA_NONCE_LENGTH) {
+      throw new Error(`Secretstream nonce header must be ${XCHACHA_NONCE_LENGTH} bytes, got ${nonceHeader.length}`);
+    }
+    this.key = key;
+    this.nonceHeader = nonceHeader;
+  }
+
+  private nonceForCounter(counter: bigint): Uint8Array {
+    const nonce = this.nonceHeader.slice();
+    const view = new DataView(nonce.buffer, nonce.byteOffset, nonce.byteLength);
+    const suffix = view.getBigUint64(NONCE_COUNTER_OFFSET, true);
+    view.setBigUint64(NONCE_COUNTER_OFFSET, suffix ^ counter, true);
+    return nonce;
+  }
+
+  /** Encrypts one frame and advances this direction's counter. */
+  seal(plaintext: Uint8Array, tag: FrameTag = FrameTag.Message): Uint8Array {
+    if (this.counter >= MAX_COUNTER) throw new Error('Secretstream counter space exhausted; re-handshake required');
+    const associatedData = Uint8Array.of(tag);
+    const ciphertext = xaeadEncrypt(this.key, this.nonceForCounter(this.counter), associatedData, plaintext);
+    this.counter += 1n;
+    return concatBytes(associatedData, ciphertext);
+  }
+
+  /**
+   * Decrypts one frame and advances this direction's counter. Throws if
+   * the frame does not authenticate against the counter this instance
+   * currently expects - which is exactly what happens if a frame was
+   * replayed, reordered, or the stream was truncated and resumed wrong.
+   */
+  open(frame: Uint8Array): { tag: FrameTag; plaintext: Uint8Array } {
+    if (frame.length < 1) throw new Error('Secretstream frame is too short to contain a tag byte');
+    if (this.counter >= MAX_COUNTER) throw new Error('Secretstream counter space exhausted; re-handshake required');
+    const tag = frame[0] as FrameTag;
+    const associatedData = frame.subarray(0, 1);
+    const ciphertext = frame.subarray(1);
+    const plaintext = xaeadDecrypt(this.key, this.nonceForCounter(this.counter), associatedData, ciphertext);
+    this.counter += 1n;
+    return { tag, plaintext };
+  }
+
+  /** Rotates this direction's key without a full Noise re-handshake, matching libsodium's REKEY tag. */
+  rekey(): void {
+    this.key = deriveLabeledKey(this.key, 'kangentic-secretstream-rekey', this.key.length);
+  }
+}
+
+export interface SecretstreamDirectionPair {
+  send: SecretstreamState;
+  receive: SecretstreamState;
+}
+
+/**
+ * Derives both directions' secretstream state from a completed Noise
+ * session's chaining key (HandshakeState.getChainingKey(), valid once
+ * split() has run). Both peers call this with the SAME chaining key and
+ * opposite `isInitiator` values, so `initiator.send` pairs with
+ * `responder.receive` and vice versa.
+ */
+export function deriveSecretstreamPair(chainingKey: Uint8Array, isInitiator: boolean): SecretstreamDirectionPair {
+  const initiatorKey = deriveLabeledKey(chainingKey, 'kangentic-secretstream-key-initiator', 32);
+  const responderKey = deriveLabeledKey(chainingKey, 'kangentic-secretstream-key-responder', 32);
+  const initiatorNonceHeader = deriveLabeledKey(chainingKey, 'kangentic-secretstream-nonce-initiator', XCHACHA_NONCE_LENGTH);
+  const responderNonceHeader = deriveLabeledKey(chainingKey, 'kangentic-secretstream-nonce-responder', XCHACHA_NONCE_LENGTH);
+
+  const initiatorState = new SecretstreamState(initiatorKey, initiatorNonceHeader);
+  const responderState = new SecretstreamState(responderKey, responderNonceHeader);
+
+  return isInitiator
+    ? { send: initiatorState, receive: responderState }
+    : { send: responderState, receive: initiatorState };
+}

--- a/packages/protocol/src/events/event.ts
+++ b/packages/protocol/src/events/event.ts
@@ -1,0 +1,33 @@
+/**
+ * The event contract skeleton the phone consumes. Phase 1 establishes the
+ * three event FAMILIES (transcript, board, activity) and their envelope
+ * shape; Phase 2 (data feeds & interactive control) is what actually maps
+ * desktop internals - SessionManager's `data`/`activity` events,
+ * transcript-service output, repository/DiffService mutations - onto
+ * these envelopes. Keeping `payload` as JsonValue here rather than a
+ * fully-typed shape per event avoids guessing at Phase 2's real mapping
+ * before that integration exists.
+ */
+import type { JsonValue } from '../wire/messages';
+
+export interface TranscriptEvent {
+  kind: 'transcript';
+  sessionId: string;
+  taskId: string;
+  payload: JsonValue;
+}
+
+export interface BoardEvent {
+  kind: 'board';
+  taskId: string;
+  payload: JsonValue;
+}
+
+export interface ActivityEvent {
+  kind: 'activity';
+  sessionId: string;
+  taskId: string;
+  payload: JsonValue;
+}
+
+export type BridgeEvent = TranscriptEvent | BoardEvent | ActivityEvent;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,0 +1,70 @@
+export { PROTOCOL_VERSION, encodeProtocolVersion } from './version';
+
+export {
+  randomBytes,
+  generateX25519KeyPair,
+  x25519PublicKeyFrom,
+  generateEd25519KeyPair,
+  hexToBytes,
+  bytesToHex,
+  X25519_KEY_LENGTH,
+  ED25519_KEY_LENGTH,
+  type X25519KeyPair,
+  type Ed25519KeyPair,
+} from './crypto/primitives';
+
+export { HandshakeState, type HandshakeStateOptions, type HandshakeWriteResult, type HandshakeReadResult } from './crypto/noise/handshake-state';
+export { CipherState } from './crypto/noise/cipher-state';
+export { KK_PATTERN, IKPSK0_PATTERN, type NoisePattern, type NoiseToken } from './crypto/noise/patterns';
+export { createKKHandshake, type KKHandshakeOptions } from './crypto/noise/kk';
+export {
+  createPairingInitiatorHandshake,
+  createPairingResponderHandshake,
+  type PairingInitiatorOptions,
+  type PairingResponderOptions,
+} from './crypto/pairing-handshake';
+
+export {
+  SecretstreamState,
+  deriveSecretstreamPair,
+  FrameTag,
+  type SecretstreamDirectionPair,
+} from './crypto/secretstream';
+
+export { deriveShortAuthenticationString, type ShortAuthenticationString } from './crypto/sas';
+
+export type { JsonValue, BridgeMessage, HeartbeatMessage, CapabilityRequestMessage, CapabilityResponseMessage, EventMessage } from './wire/messages';
+export { encodeMessage, decodeMessage, MAX_FRAME_LENGTH } from './wire/framing';
+export { SessionFrameKind, wrapSessionFrame, unwrapSessionFrame } from './wire/session-frame';
+
+export {
+  PAIRING_URI_SCHEME,
+  encodePairingQrPayload,
+  decodePairingQrPayload,
+  type PairingQrPayload,
+} from './pairing/qr';
+
+export {
+  signRosterEntry,
+  verifyRosterEntry,
+  encodeRosterEntryForSigning,
+  isRosterEntryExpired,
+  findRosterDevice,
+  rosterDeviceCapabilitySet,
+  capabilitySetToRosterCapabilities,
+  type RosterDeviceEntry,
+  type DeviceRoster,
+} from './roster/roster';
+
+export {
+  CAPABILITY_VERBS,
+  isCapabilityVerb,
+  capabilitySetFromArray,
+  capabilitySetToArray,
+  type CapabilityVerb,
+  type CapabilitySet,
+} from './capabilities/verbs';
+
+export type { BridgeEvent, TranscriptEvent, BoardEvent, ActivityEvent } from './events/event';
+
+export type { Transport, TransportState, Unsubscribe } from './transport/transport';

--- a/packages/protocol/src/pairing/qr.ts
+++ b/packages/protocol/src/pairing/qr.ts
@@ -1,0 +1,125 @@
+/**
+ * The QR pairing payload: a bootstrap for the pairing ceremony, never a
+ * long-lived secret (Happy's `handy://<32-byte-master-secret>` is the
+ * mistake this avoids). It carries only the desktop's PUBLIC key, a
+ * single-use short-lived pairing token, the relay address, and the
+ * protocol version. Everything is size-bounded on decode, since this is
+ * the largest unauthenticated-input attack surface in the whole system
+ * (a malicious QR / malicious relay-address-carrying payload) - the KDE
+ * Connect CVE lesson from the research doc: minimize and size-bound
+ * everything pre-auth.
+ */
+import { X25519_KEY_LENGTH, concatBytes } from '../crypto/primitives';
+import { base64UrlDecode, base64UrlEncode } from '../wire/base64url';
+
+export const PAIRING_URI_SCHEME = 'kangentic-pair';
+const PAYLOAD_VERSION = 1;
+const PAIRING_TOKEN_LENGTH = 32;
+const MAX_RELAY_ADDRESS_LENGTH = 512;
+/** Generous cap on the whole decoded payload - defends against a QR/URI crafted to trigger unbounded allocation before any other validation runs. */
+const MAX_PAYLOAD_LENGTH = 4096;
+
+export interface PairingQrPayload {
+  desktopStaticPublicKey: Uint8Array;
+  pairingToken: Uint8Array;
+  relayAddress: string;
+  /** ISO 8601. The pairing service is the actual enforcement point; this is carried for the phone's own UX (e.g. "this code expired"). */
+  expiresAt: string;
+  /**
+   * The bridge protocol version (see version.ts's PROTOCOL_VERSION), so the
+   * phone can surface "this desktop is running an incompatible version,
+   * please update" BEFORE attempting a handshake doomed to fail, instead
+   * of only an opaque authentication error. The actual downgrade
+   * PROTECTION is the Noise prologue binding (crypto/pairing-handshake.ts),
+   * which is enforced independent of this field; this is diagnostic only.
+   */
+  protocolVersion: string;
+}
+
+function writeUint32(value: number): Uint8Array {
+  const bytes = new Uint8Array(4);
+  new DataView(bytes.buffer).setUint32(0, value, false);
+  return bytes;
+}
+
+function readUint32(bytes: Uint8Array, offset: number): number {
+  return new DataView(bytes.buffer, bytes.byteOffset + offset, 4).getUint32(0, false);
+}
+
+export function encodePairingQrPayload(payload: PairingQrPayload): string {
+  if (payload.desktopStaticPublicKey.length !== X25519_KEY_LENGTH) {
+    throw new Error(`desktopStaticPublicKey must be ${X25519_KEY_LENGTH} bytes`);
+  }
+  if (payload.pairingToken.length !== PAIRING_TOKEN_LENGTH) {
+    throw new Error(`pairingToken must be ${PAIRING_TOKEN_LENGTH} bytes`);
+  }
+  const relayAddressBytes = new TextEncoder().encode(payload.relayAddress);
+  if (relayAddressBytes.length > MAX_RELAY_ADDRESS_LENGTH) {
+    throw new Error(`relayAddress exceeds ${MAX_RELAY_ADDRESS_LENGTH} bytes`);
+  }
+  const expiresAtBytes = new TextEncoder().encode(payload.expiresAt);
+  const protocolVersionBytes = new TextEncoder().encode(payload.protocolVersion);
+
+  const body = concatBytes(
+    Uint8Array.of(PAYLOAD_VERSION),
+    payload.desktopStaticPublicKey,
+    payload.pairingToken,
+    writeUint32(relayAddressBytes.length),
+    relayAddressBytes,
+    writeUint32(expiresAtBytes.length),
+    expiresAtBytes,
+    writeUint32(protocolVersionBytes.length),
+    protocolVersionBytes,
+  );
+  if (body.length > MAX_PAYLOAD_LENGTH) {
+    throw new Error(`Pairing QR payload exceeds ${MAX_PAYLOAD_LENGTH} bytes`);
+  }
+  return `${PAIRING_URI_SCHEME}://${base64UrlEncode(body)}`;
+}
+
+export function decodePairingQrPayload(uri: string): PairingQrPayload {
+  const prefix = `${PAIRING_URI_SCHEME}://`;
+  if (!uri.startsWith(prefix)) throw new Error('Not a kangentic pairing URI');
+  const encoded = uri.slice(prefix.length);
+  if (encoded.length > MAX_PAYLOAD_LENGTH * 2) {
+    // base64 expands ~4/3; reject wildly-oversized input before even decoding.
+    throw new Error('Pairing QR payload is too large');
+  }
+  const body = base64UrlDecode(encoded);
+  if (body.length > MAX_PAYLOAD_LENGTH) throw new Error('Pairing QR payload is too large');
+  if (body.length < 1 + X25519_KEY_LENGTH + PAIRING_TOKEN_LENGTH + 4) throw new Error('Pairing QR payload is too short');
+
+  let offset = 0;
+  const version = body[offset];
+  offset += 1;
+  if (version !== PAYLOAD_VERSION) throw new Error(`Unsupported pairing QR payload version: ${version}`);
+
+  const desktopStaticPublicKey = body.subarray(offset, offset + X25519_KEY_LENGTH);
+  offset += X25519_KEY_LENGTH;
+
+  const pairingToken = body.subarray(offset, offset + PAIRING_TOKEN_LENGTH);
+  offset += PAIRING_TOKEN_LENGTH;
+
+  const relayAddressLength = readUint32(body, offset);
+  offset += 4;
+  if (relayAddressLength > MAX_RELAY_ADDRESS_LENGTH || offset + relayAddressLength > body.length) {
+    throw new Error('Pairing QR payload has an invalid relay address length');
+  }
+  const relayAddress = new TextDecoder().decode(body.subarray(offset, offset + relayAddressLength));
+  offset += relayAddressLength;
+
+  if (offset + 4 > body.length) throw new Error('Pairing QR payload is missing an expiresAt length');
+  const expiresAtLength = readUint32(body, offset);
+  offset += 4;
+  if (offset + expiresAtLength > body.length) throw new Error('Pairing QR payload has an invalid expiresAt length');
+  const expiresAt = new TextDecoder().decode(body.subarray(offset, offset + expiresAtLength));
+  offset += expiresAtLength;
+
+  if (offset + 4 > body.length) throw new Error('Pairing QR payload is missing a protocol version');
+  const protocolVersionLength = readUint32(body, offset);
+  offset += 4;
+  if (offset + protocolVersionLength > body.length) throw new Error('Pairing QR payload has an invalid protocolVersion length');
+  const protocolVersion = new TextDecoder().decode(body.subarray(offset, offset + protocolVersionLength));
+
+  return { desktopStaticPublicKey, pairingToken, relayAddress, expiresAt, protocolVersion };
+}

--- a/packages/protocol/src/roster/roster.ts
+++ b/packages/protocol/src/roster/roster.ts
@@ -1,0 +1,89 @@
+/**
+ * The signed device roster: the desktop's master Ed25519 signing key signs
+ * each paired phone's X25519 static public key into an entry carrying a
+ * per-device capability set. The roster - not the relay - is the source
+ * of truth for who is paired (anchoring trust in a desktop-held key is the
+ * fix for the Signal Sesame / DIMVA-2021 rogue-device-linking weakness of
+ * trusting a server for this).
+ *
+ * This module only provides the DATA SHAPE and the sign/verify primitives.
+ * The actual roster store (persistence, revoke-and-rekey policy) lives in
+ * the desktop bridge module (src/main/mobile-bridge/roster-store.ts) --
+ * "revocation = drop the device AND rotate channel keys" is an operational
+ * policy the desktop enforces, not something this package can express on
+ * its own.
+ */
+import { concatBytes, ed25519Sign, ed25519Verify } from '../crypto/primitives';
+import { capabilitySetFromArray, capabilitySetToArray, type CapabilitySet, type CapabilityVerb } from '../capabilities/verbs';
+
+export interface RosterDeviceEntry {
+  /** Stable identifier for this device, independent of display name - derived from its static public key by the caller. */
+  deviceId: string;
+  /** The device's X25519 static identity public key (32 bytes). */
+  staticPublicKey: Uint8Array;
+  displayName: string;
+  capabilities: CapabilityVerb[];
+  /** ISO 8601. */
+  pairedAt: string;
+  /** ISO 8601, or null for no expiry (Tailscale-style per-device key expiry is opt-in). */
+  expiresAt: string | null;
+  /** Ed25519 signature over encodeForSigning(this entry minus signature), by the roster's master signing key. */
+  signature: Uint8Array;
+}
+
+export interface DeviceRoster {
+  /** The desktop's Ed25519 master signing public key - the roster's root of trust. */
+  masterSigningPublicKey: Uint8Array;
+  devices: RosterDeviceEntry[];
+}
+
+function uint32LengthPrefixed(bytes: Uint8Array): Uint8Array {
+  const prefix = new Uint8Array(4);
+  new DataView(prefix.buffer).setUint32(0, bytes.length, false);
+  return concatBytes(prefix, bytes);
+}
+
+/**
+ * A deterministic, unambiguous byte encoding of a roster entry (minus its
+ * signature) for signing/verification. Every field is length-prefixed so
+ * concatenation cannot be reinterpreted across a field boundary (e.g.
+ * deviceId="ab"+displayName="c" cannot collide with deviceId="a"+displayName="bc").
+ */
+export function encodeRosterEntryForSigning(entry: Omit<RosterDeviceEntry, 'signature'>): Uint8Array {
+  const encoder = new TextEncoder();
+  const sortedCapabilities = entry.capabilities.slice().sort().join(',');
+  return concatBytes(
+    uint32LengthPrefixed(encoder.encode(entry.deviceId)),
+    uint32LengthPrefixed(entry.staticPublicKey),
+    uint32LengthPrefixed(encoder.encode(entry.displayName)),
+    uint32LengthPrefixed(encoder.encode(sortedCapabilities)),
+    uint32LengthPrefixed(encoder.encode(entry.pairedAt)),
+    uint32LengthPrefixed(encoder.encode(entry.expiresAt ?? '')),
+  );
+}
+
+export function signRosterEntry(masterSigningSecretKey: Uint8Array, entry: Omit<RosterDeviceEntry, 'signature'>): RosterDeviceEntry {
+  const signature = ed25519Sign(encodeRosterEntryForSigning(entry), masterSigningSecretKey);
+  return { ...entry, signature };
+}
+
+export function verifyRosterEntry(masterSigningPublicKey: Uint8Array, entry: RosterDeviceEntry): boolean {
+  return ed25519Verify(entry.signature, encodeRosterEntryForSigning(entry), masterSigningPublicKey);
+}
+
+export function isRosterEntryExpired(entry: RosterDeviceEntry, now: Date): boolean {
+  if (entry.expiresAt === null) return false;
+  return new Date(entry.expiresAt).getTime() <= now.getTime();
+}
+
+export function findRosterDevice(roster: DeviceRoster, deviceId: string): RosterDeviceEntry | undefined {
+  return roster.devices.find((device) => device.deviceId === deviceId);
+}
+
+export function rosterDeviceCapabilitySet(entry: RosterDeviceEntry): CapabilitySet {
+  return capabilitySetFromArray(entry.capabilities);
+}
+
+export function capabilitySetToRosterCapabilities(capabilities: CapabilitySet): CapabilityVerb[] {
+  return capabilitySetToArray(capabilities);
+}

--- a/packages/protocol/src/transport/transport.ts
+++ b/packages/protocol/src/transport/transport.ts
@@ -1,0 +1,24 @@
+/**
+ * The swappable transport boundary. A Transport moves opaque frames
+ * (already-encrypted secretstream frames, or raw Noise handshake bytes
+ * during pairing/session setup) between two peers; it knows nothing about
+ * Noise, capability verbs, or the message schema. The relay client
+ * (src/main/mobile-bridge/transport/relay-client.ts, desktop-side) is the
+ * v1 implementation; a WebRTC data channel implementation (Phase 4) slots
+ * in behind this exact interface, so nothing above the transport layer
+ * changes when direct P2P becomes available.
+ */
+export type TransportState = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'closed';
+
+export type Unsubscribe = () => void;
+
+export interface Transport {
+  readonly state: TransportState;
+  connect(): Promise<void>;
+  /** Sends one opaque frame. Throws if the transport is not connected. */
+  send(frame: Uint8Array): void;
+  /** Synchronous, idempotent teardown. */
+  close(): void;
+  onFrame(listener: (frame: Uint8Array) => void): Unsubscribe;
+  onStateChange(listener: (state: TransportState) => void): Unsubscribe;
+}

--- a/packages/protocol/src/version.ts
+++ b/packages/protocol/src/version.ts
@@ -1,0 +1,15 @@
+/**
+ * The protocol version string. Bumped on any wire-incompatible change to
+ * framing, message shapes, or the handshake patterns in this package.
+ *
+ * Bound into every Noise handshake's prologue (see crypto/noise/kk.ts and
+ * crypto/pairing-handshake.ts), so two peers running different protocol
+ * versions fail the handshake outright instead of silently downgrading: a
+ * differing prologue produces a differing transcript hash `h` from the
+ * first MixHash call, which cascades into every derived key.
+ */
+export const PROTOCOL_VERSION = '1';
+
+export function encodeProtocolVersion(version: string = PROTOCOL_VERSION): Uint8Array {
+  return new TextEncoder().encode(`kangentic-bridge-v${version}`);
+}

--- a/packages/protocol/src/wire/base64url.ts
+++ b/packages/protocol/src/wire/base64url.ts
@@ -1,0 +1,52 @@
+/**
+ * Dependency-free base64url (RFC 4648 section 5) encode/decode. Node has
+ * Buffer.from(...).toString('base64url'), but this package also runs on
+ * React Native, which does not provide Buffer without an app-level
+ * polyfill this package should not assume is present.
+ */
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+const DECODE_MAP: Record<string, number> = {};
+for (let i = 0; i < ALPHABET.length; i++) DECODE_MAP[ALPHABET[i]] = i;
+
+export function base64UrlEncode(bytes: Uint8Array): string {
+  let result = '';
+  let i = 0;
+  for (; i + 2 < bytes.length; i += 3) {
+    const chunk = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+    result += ALPHABET[(chunk >> 18) & 0x3f] + ALPHABET[(chunk >> 12) & 0x3f] + ALPHABET[(chunk >> 6) & 0x3f] + ALPHABET[chunk & 0x3f];
+  }
+  const remaining = bytes.length - i;
+  if (remaining === 1) {
+    const chunk = bytes[i] << 16;
+    result += ALPHABET[(chunk >> 18) & 0x3f] + ALPHABET[(chunk >> 12) & 0x3f];
+  } else if (remaining === 2) {
+    const chunk = (bytes[i] << 16) | (bytes[i + 1] << 8);
+    result += ALPHABET[(chunk >> 18) & 0x3f] + ALPHABET[(chunk >> 12) & 0x3f] + ALPHABET[(chunk >> 6) & 0x3f];
+  }
+  return result;
+}
+
+export function base64UrlDecode(encoded: string): Uint8Array {
+  // Every character is validated against DECODE_MAP below - unlike a
+  // "strip anything unrecognized first" approach, an invalid character
+  // (or accidental padding, whitespace, etc.) is rejected rather than
+  // silently dropped. Decoding untrusted wire input should fail loudly on
+  // garbage, not quietly reinterpret it.
+  const byteLength = Math.floor((encoded.length * 6) / 8);
+  const bytes = new Uint8Array(byteLength);
+  let bitBuffer = 0;
+  let bitCount = 0;
+  let outputIndex = 0;
+  for (const char of encoded) {
+    const value = DECODE_MAP[char];
+    if (value === undefined) throw new Error(`Invalid base64url character: "${char}"`);
+    bitBuffer = (bitBuffer << 6) | value;
+    bitCount += 6;
+    if (bitCount >= 8) {
+      bitCount -= 8;
+      bytes[outputIndex] = (bitBuffer >> bitCount) & 0xff;
+      outputIndex += 1;
+    }
+  }
+  return bytes;
+}

--- a/packages/protocol/src/wire/framing.ts
+++ b/packages/protocol/src/wire/framing.ts
@@ -1,0 +1,95 @@
+/**
+ * Encodes/decodes a BridgeMessage to/from the plaintext bytes that flow
+ * into and out of secretstream.seal()/open(). JSON for Phase 1 simplicity;
+ * nothing above this module cares about the wire encoding, so a future
+ * phase can switch to a binary format without touching callers.
+ *
+ * Size-bounded on both directions - even though this content is
+ * post-Noise-authentication (unlike the QR payload), a malformed or
+ * oversized message from a buggy or compromised peer should fail fast
+ * with a clear error rather than trigger unbounded JSON parsing.
+ */
+import { isCapabilityVerb } from '../capabilities/verbs';
+import type { BridgeEvent } from '../events/event';
+import type { BridgeMessage, JsonValue } from './messages';
+
+export const MAX_FRAME_LENGTH = 1024 * 1024;
+
+export function encodeMessage(message: BridgeMessage): Uint8Array {
+  const bytes = new TextEncoder().encode(JSON.stringify(message));
+  if (bytes.length > MAX_FRAME_LENGTH) {
+    throw new Error(`Encoded bridge message exceeds ${MAX_FRAME_LENGTH} bytes`);
+  }
+  return bytes;
+}
+
+export function decodeMessage(bytes: Uint8Array): BridgeMessage {
+  if (bytes.length > MAX_FRAME_LENGTH) {
+    throw new Error(`Bridge message frame exceeds ${MAX_FRAME_LENGTH} bytes`);
+  }
+  const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
+  return validateBridgeMessage(parsed);
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null) return true;
+  const t = typeof value;
+  if (t === 'boolean' || t === 'number' || t === 'string') return true;
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  if (t === 'object') return Object.values(value as Record<string, unknown>).every(isJsonValue);
+  return false;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function validateBridgeMessage(value: unknown): BridgeMessage {
+  if (!isRecord(value) || typeof value.type !== 'string') {
+    throw new Error('Invalid bridge message: missing "type"');
+  }
+
+  switch (value.type) {
+    case 'heartbeat':
+      return { type: 'heartbeat' };
+
+    case 'capability-request': {
+      if (typeof value.requestId !== 'string') throw new Error('capability-request missing "requestId"');
+      if (typeof value.verb !== 'string' || !isCapabilityVerb(value.verb)) throw new Error('capability-request has an invalid "verb"');
+      if (!isJsonValue(value.payload)) throw new Error('capability-request has a non-JSON "payload"');
+      return { type: 'capability-request', requestId: value.requestId, verb: value.verb, payload: value.payload };
+    }
+
+    case 'capability-response': {
+      if (typeof value.requestId !== 'string') throw new Error('capability-response missing "requestId"');
+      if (typeof value.ok !== 'boolean') throw new Error('capability-response missing "ok"');
+      if (value.payload !== undefined && !isJsonValue(value.payload)) throw new Error('capability-response has a non-JSON "payload"');
+      if (value.error !== undefined && typeof value.error !== 'string') throw new Error('capability-response has a non-string "error"');
+      return {
+        type: 'capability-response',
+        requestId: value.requestId,
+        ok: value.ok,
+        payload: value.payload as JsonValue | undefined,
+        error: value.error as string | undefined,
+      };
+    }
+
+    case 'event': {
+      const event = value.event;
+      if (!isRecord(event) || typeof event.kind !== 'string') {
+        throw new Error('event message missing a valid "event"');
+      }
+      if (typeof event.taskId !== 'string') throw new Error('event is missing "taskId"');
+      if (!isJsonValue(event.payload)) throw new Error('event payload is not JSON-serializable');
+      if (event.kind === 'transcript' || event.kind === 'activity') {
+        if (typeof event.sessionId !== 'string') throw new Error(`"${event.kind}" event is missing "sessionId"`);
+      } else if (event.kind !== 'board') {
+        throw new Error(`event message has an unknown event kind: ${event.kind}`);
+      }
+      return { type: 'event', event: event as unknown as BridgeEvent };
+    }
+
+    default:
+      throw new Error(`Unknown bridge message type: ${value.type}`);
+  }
+}

--- a/packages/protocol/src/wire/messages.ts
+++ b/packages/protocol/src/wire/messages.ts
@@ -1,0 +1,49 @@
+/**
+ * The application-level message shapes carried inside secretstream frames
+ * once a bridge session is established (crypto/secretstream.ts handles
+ * the encrypted framing; this is what gets encoded/decoded as the
+ * plaintext payload - see framing.ts).
+ *
+ * Phase 1 wires the transport and the message ENVELOPE, not real
+ * capability-verb handlers or event feeds - those are Phase 2 (data
+ * feeds, interactive control) and Phase 3 (notifications). `payload` on
+ * the request/response/event variants is intentionally a generic JSON
+ * value here rather than a fully-typed union per verb/event, since the
+ * real shapes depend on desktop internals (SessionManager, repositories,
+ * DiffService) that Phase 2 integrates with; over-specifying them now
+ * would just be guessing. The capability verb ENUM itself
+ * (capabilities/verbs.ts) and the event type skeleton (events/) are
+ * final for Phase 1; only their payload contents are deferred.
+ */
+import type { CapabilityVerb } from '../capabilities/verbs';
+import type { BridgeEvent } from '../events/event';
+
+/** JSON-serializable value - deliberately not `any`; every message payload must round-trip through JSON.stringify/parse. */
+export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
+export interface HeartbeatMessage {
+  type: 'heartbeat';
+}
+
+export interface CapabilityRequestMessage {
+  type: 'capability-request';
+  requestId: string;
+  verb: CapabilityVerb;
+  payload: JsonValue;
+}
+
+export interface CapabilityResponseMessage {
+  type: 'capability-response';
+  requestId: string;
+  ok: boolean;
+  payload?: JsonValue;
+  /** Present only when ok is false. */
+  error?: string;
+}
+
+export interface EventMessage {
+  type: 'event';
+  event: BridgeEvent;
+}
+
+export type BridgeMessage = HeartbeatMessage | CapabilityRequestMessage | CapabilityResponseMessage | EventMessage;

--- a/packages/protocol/src/wire/session-frame.ts
+++ b/packages/protocol/src/wire/session-frame.ts
@@ -1,0 +1,34 @@
+/**
+ * A one-byte frame-kind prefix for the ONGOING SESSION connection only
+ * (not pairing, which never mixes frame kinds on its dedicated
+ * connection). A bridge session periodically re-handshakes on the same
+ * transport connection it also carries application traffic on (Noise KK
+ * every ~2 minutes, per the research doc's bounded post-compromise
+ * security design), so an incoming frame is otherwise ambiguous: "the
+ * next message of an in-progress Noise handshake" and "a secretstream-sealed
+ * application frame" are both just opaque bytes at the transport level.
+ * This tiny, unauthenticated-but-harmless prefix removes that ambiguity
+ * for BOTH peers (desktop and mobile), so it lives here rather than as a
+ * desktop-only convention.
+ */
+export const SessionFrameKind = {
+  Handshake: 0,
+  Application: 1,
+} as const;
+export type SessionFrameKind = (typeof SessionFrameKind)[keyof typeof SessionFrameKind];
+
+export function wrapSessionFrame(kind: SessionFrameKind, payload: Uint8Array): Uint8Array {
+  const wrapped = new Uint8Array(payload.length + 1);
+  wrapped[0] = kind;
+  wrapped.set(payload, 1);
+  return wrapped;
+}
+
+export function unwrapSessionFrame(frame: Uint8Array): { kind: SessionFrameKind; payload: Uint8Array } {
+  if (frame.length < 1) throw new Error('Session frame is too short to contain a kind byte');
+  const kind = frame[0];
+  if (kind !== SessionFrameKind.Handshake && kind !== SessionFrameKind.Application) {
+    throw new Error(`Unknown session frame kind: ${kind}`);
+  }
+  return { kind, payload: frame.subarray(1) };
+}

--- a/packages/protocol/tsconfig.build.json
+++ b/packages/protocol/tsconfig.build.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    // Declaration-only emit (see package.json's `build` script: build.mjs
+    // handles the actual runtime JS via esbuild). "bundler" resolution lets
+    // relative imports stay extensionless, matching esbuild's resolver and
+    // the root app's classic "node" resolution used when this package's
+    // TS source is consumed in-repo via the @kangentic/protocol alias.
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -144,7 +144,7 @@ async function start() {
       cacheDir: viteCacheDir,
       plugins: [tailwindcss(), react()],
       resolve: {
-        alias: { '@shared': '/src/shared' },
+        alias: { '@shared': '/src/shared', '@kangentic/protocol': '/packages/protocol/src' },
         preserveSymlinks: true,
       },
       optimizeDeps: {

--- a/src/devtools/renderer/state-mirror.ts
+++ b/src/devtools/renderer/state-mirror.ts
@@ -2,6 +2,7 @@ import { useBacklogStore } from '../../renderer/stores/backlog-store';
 import { useBoardStore } from '../../renderer/stores/board-store';
 import { useConfigStore } from '../../renderer/stores/config-store';
 import { useDictationStore } from '../../renderer/stores/dictation-store';
+import { useMobileStore } from '../../renderer/stores/mobile-store';
 import { useProjectStore } from '../../renderer/stores/project-store';
 import { useSessionStore } from '../../renderer/stores/session-store';
 import { useToastStore } from '../../renderer/stores/toast-store';
@@ -66,6 +67,7 @@ const PREVIEW_STORES: Record<string, ReadableStore> = {
   board: useBoardStore,
   config: useConfigStore,
   dictation: useDictationStore,
+  mobile: useMobileStore,
   project: useProjectStore,
   session: useSessionStore,
   toast: useToastStore,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1004,6 +1004,12 @@ function getShutdownDependencies() {
         mcpServerHandle.close();
         mcpServerHandle = null;
       }
+      // Synchronously tear down the mobile bridge: cancels any in-progress
+      // pairing ceremony and disposes active sessions. All of its internal
+      // timers (the ~2-minute KK re-handshake, the relay client's reconnect
+      // backoff) are already .unref()'d, but dispose() clears them
+      // explicitly so nothing fires mid-shutdown.
+      getOptionalIpcContext()?.mobileBridgeService.dispose();
     },
     isEphemeral,
   };

--- a/src/main/ipc/handlers/mobile-bridge.ts
+++ b/src/main/ipc/handlers/mobile-bridge.ts
@@ -1,0 +1,66 @@
+import { ipcMain } from 'electron';
+import { IPC } from '../../../shared/ipc-channels';
+import type {
+  MobileBridgeStatus,
+  MobileCapabilityVerb,
+  MobilePairedDevice,
+  MobilePairingEndedPayload,
+  MobilePairingSasPayload,
+  MobileStartPairingResult,
+} from '../../../shared/types';
+import type { IpcContext } from '../ipc-context';
+
+/**
+ * Machine-global, not project-scoped - these channels take no trailing
+ * projectId and are unaffected by the project-scoped-ipc mutation set
+ * (see .claude/rules/project-scoped-ipc.md).
+ */
+export function registerMobileBridgeHandlers(context: IpcContext): void {
+  const service = context.mobileBridgeService;
+
+  ipcMain.handle(IPC.MOBILE_GET_STATUS, (): MobileBridgeStatus => service.getStatus());
+
+  ipcMain.handle(IPC.MOBILE_START_PAIRING, async (): Promise<MobileStartPairingResult> => {
+    const { qrUri, qrPayload } = await service.startPairing();
+    return { qrUri, expiresAt: qrPayload.expiresAt };
+  });
+
+  ipcMain.handle(IPC.MOBILE_CONFIRM_PAIRING, (_event, displayName: string, capabilities?: MobileCapabilityVerb[]) => {
+    service.confirmPairing(displayName, capabilities);
+  });
+
+  ipcMain.handle(IPC.MOBILE_CANCEL_PAIRING, () => {
+    service.cancelPairing();
+  });
+
+  ipcMain.handle(IPC.MOBILE_LIST_DEVICES, (): MobilePairedDevice[] => service.listDevices());
+
+  ipcMain.handle(IPC.MOBILE_REVOKE_DEVICE, (_event, deviceId: string) => {
+    service.revokeDevice(deviceId);
+  });
+
+  ipcMain.handle(IPC.MOBILE_SET_DEVICE_CAPABILITIES, (_event, deviceId: string, capabilities: MobileCapabilityVerb[]) => {
+    service.setDeviceCapabilities(deviceId, capabilities);
+  });
+
+  const sendIfWindowAlive = (channel: string, ...args: unknown[]): void => {
+    if (!context.mainWindow.isDestroyed()) context.mainWindow.webContents.send(channel, ...args);
+  };
+
+  service.on('pairingSas', (payload: { sas: { digits: string; emoji: string[] }; phoneStaticPublicKeyHex: string }) => {
+    const pushPayload: MobilePairingSasPayload = {
+      digits: payload.sas.digits,
+      emoji: payload.sas.emoji,
+      phoneStaticPublicKeyHex: payload.phoneStaticPublicKeyHex,
+    };
+    sendIfWindowAlive(IPC.MOBILE_PAIRING_SAS, pushPayload);
+  });
+
+  service.on('pairingEnded', (payload: MobilePairingEndedPayload) => {
+    sendIfWindowAlive(IPC.MOBILE_PAIRING_ENDED, payload);
+  });
+
+  service.on('stateChanged', () => {
+    sendIfWindowAlive(IPC.MOBILE_STATE_CHANGED);
+  });
+}

--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -70,6 +70,15 @@ export function registerSystemHandlers(context: IpcContext): void {
         retrievalService.reconcileEmbedWorker(context);
       });
     }
+    // Toggling the mobile bridge on/off, or changing the relay URL, takes
+    // effect immediately without reopening the app.
+    if (config.mobileBridge) {
+      const effectiveConfig = context.configManager.getEffectiveConfig(context.currentProjectPath || undefined);
+      context.mobileBridgeService.reconcile({
+        enabled: effectiveConfig.mobileBridge?.enabled ?? false,
+        relayUrl: effectiveConfig.mobileBridge?.relayUrl ?? '',
+      });
+    }
   });
 
   // Synchronous sibling of CONFIG_SET for the renderer's quit/unload flush: an async

--- a/src/main/ipc/ipc-context.ts
+++ b/src/main/ipc/ipc-context.ts
@@ -11,6 +11,7 @@ import type { TerminalSubmitScheduler } from '../transition-engine/terminal-subm
 import type { TerminalSubmit } from '../pty/terminal-submit';
 import type { McpHttpServerHandle } from '../agent/mcp-http-server';
 import type { TranscriptionService } from '../transcription/transcription-service';
+import type { MobileBridgeService } from '../mobile-bridge/mobile-bridge-service';
 
 export interface IpcContext {
   mainWindow: BrowserWindow;
@@ -72,4 +73,10 @@ export interface IpcContext {
    * the server has bound its port.
    */
   mcpServerHandle: McpHttpServerHandle | null;
+  /**
+   * Owns the desktop's mobile-bridge identity, signed device roster, and
+   * active pairing ceremony. Machine-global like config, not tied to the
+   * currently open project. See src/main/mobile-bridge/mobile-bridge-service.ts.
+   */
+  mobileBridgeService: MobileBridgeService;
 }

--- a/src/main/ipc/register-all.ts
+++ b/src/main/ipc/register-all.ts
@@ -38,7 +38,9 @@ import { registerGitDiffHandlers } from './handlers/git-diff';
 import { registerBrowserHandlers } from './handlers/browser';
 import { registerSearchHandlers } from './handlers/search';
 import { registerTranscriptHandlers } from './handlers/transcripts';
+import { registerMobileBridgeHandlers } from './handlers/mobile-bridge';
 import { retrievalService } from '../retrieval/retrieval-service';
+import { MobileBridgeService } from '../mobile-bridge/mobile-bridge-service';
 import type { IpcContext } from './ipc-context';
 import type { McpHttpServerHandle } from '../agent/mcp-http-server';
 
@@ -83,6 +85,11 @@ export function registerAllIpc(mainWindow: BrowserWindow, mcpServerHandle: McpHt
     ephemeral: process.argv.includes('--ephemeral'),
   });
   const diffWatcher = new DiffWatcher();
+  // Placeholder config -- reconciled to the real effective config right
+  // after `context` (and its configManager getter) is constructed below,
+  // since MobileBridgeService's constructor needs a config synchronously
+  // but configManager itself is only available once `context` exists.
+  const mobileBridgeService = new MobileBridgeService({ enabled: false, relayUrl: '' });
 
   // Lazy-initialize heavy objects on first access
   let projectRepo: ProjectRepository | null = null;
@@ -123,7 +130,14 @@ export function registerAllIpc(mainWindow: BrowserWindow, mcpServerHandle: McpHt
     currentProjectPath: null,
     recoveredProjects: new Set<string>(),
     mcpServerHandle,
+    mobileBridgeService,
   };
+
+  const effectiveConfig = context.configManager.getEffectiveConfig(context.currentProjectPath ?? undefined);
+  mobileBridgeService.reconcile({
+    enabled: effectiveConfig.mobileBridge?.enabled ?? false,
+    relayUrl: effectiveConfig.mobileBridge?.relayUrl ?? '',
+  });
 
   registerProjectHandlers(context);
   registerTaskCrudHandlers(context);
@@ -141,6 +155,7 @@ export function registerAllIpc(mainWindow: BrowserWindow, mcpServerHandle: McpHt
   registerSearchHandlers(context);
   registerTranscriptHandlers(context);
   registerSystemHandlers(context);
+  registerMobileBridgeHandlers(context);
 
   // Start the central embedding engine's background drain loop at boot, not
   // lazily on the first project:open. attach() is idempotent, so the later

--- a/src/main/mobile-bridge/capability-router.ts
+++ b/src/main/mobile-bridge/capability-router.ts
@@ -1,0 +1,55 @@
+import type { CapabilityRequestMessage, CapabilityResponseMessage, CapabilityVerb } from '@kangentic/protocol';
+import type { BridgeSession } from './session/bridge-session';
+
+export type CapabilityHandler = (
+  request: CapabilityRequestMessage,
+  session: BridgeSession,
+) => Promise<CapabilityResponseMessage> | CapabilityResponseMessage;
+
+/**
+ * Deny-by-default dispatch of inbound capability-request messages,
+ * checked against the SESSION's own capability set (bound at pairing time
+ * and adjustable per-device afterward via the roster), never a global
+ * allowlist. A verb absent from the session's set is refused before a
+ * handler is even looked up.
+ *
+ * Phase 1 ships this router and the authorization check only. No verb
+ * handler is registered here - the handlers that actually touch
+ * SessionManager, repositories, DiffService, or the activity engine are
+ * Phase 2 (data feeds & interactive control, per the research doc's
+ * phasing). An unregistered (but authorized) verb fails closed with a
+ * clear "no handler" error rather than doing nothing silently.
+ */
+export class CapabilityRouter {
+  private readonly handlers = new Map<CapabilityVerb, CapabilityHandler>();
+
+  register(verb: CapabilityVerb, handler: CapabilityHandler): void {
+    this.handlers.set(verb, handler);
+  }
+
+  unregister(verb: CapabilityVerb): void {
+    this.handlers.delete(verb);
+  }
+
+  async dispatch(request: CapabilityRequestMessage, session: BridgeSession): Promise<CapabilityResponseMessage> {
+    if (!session.capabilities.has(request.verb)) {
+      return { type: 'capability-response', requestId: request.requestId, ok: false, error: `Device is not authorized for verb: ${request.verb}` };
+    }
+
+    const handler = this.handlers.get(request.verb);
+    if (!handler) {
+      return { type: 'capability-response', requestId: request.requestId, ok: false, error: `No handler registered for verb: ${request.verb}` };
+    }
+
+    try {
+      return await handler(request, session);
+    } catch (error) {
+      return {
+        type: 'capability-response',
+        requestId: request.requestId,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+}

--- a/src/main/mobile-bridge/identity.ts
+++ b/src/main/mobile-bridge/identity.ts
@@ -1,0 +1,139 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { PATHS } from '../config/paths';
+import { decryptSecret, encryptSecret, isGenuineEncryptionAvailable } from '../boards/shared/auth';
+import {
+  bytesToHex,
+  generateEd25519KeyPair,
+  generateX25519KeyPair,
+  hexToBytes,
+  type Ed25519KeyPair,
+  type X25519KeyPair,
+} from '@kangentic/protocol';
+
+/**
+ * The desktop's mobile-bridge device identity: a static X25519 keypair
+ * (the Noise session/pairing identity) and an Ed25519 master signing
+ * keypair (roster signing root of trust). Generated once at first use and
+ * persisted globally (machine-wide, not per-project - the identity
+ * represents this desktop installation, like the Asana credential).
+ *
+ * Mirrors src/main/boards/adapters/asana/credential-store.ts's
+ * file-in-PATHS.configDir pattern: a JSON envelope whose single
+ * `encrypted` field is encryptSecret(JSON.stringify(secretMaterial)).
+ * Reuses encryptSecret/decryptSecret/isGenuineEncryptionAvailable from
+ * src/main/boards/shared/auth.ts verbatim - they are generic string-in/
+ * string-out helpers despite living under boards/.
+ *
+ * Unlike the Asana credential, the private key material here MUST be
+ * genuinely protected: refuses to persist when isGenuineEncryptionAvailable()
+ * is false (Linux basic_text backend), rather than falling back to
+ * encryptSecret's own plaintext degradation. A mobile bridge identity
+ * that can't be protected shouldn't silently exist on disk.
+ */
+export interface BridgeIdentity {
+  staticKeyPair: X25519KeyPair;
+  masterSigningKeyPair: Ed25519KeyPair;
+  createdAt: string;
+}
+
+interface StoredIdentity {
+  staticSecretKeyHex: string;
+  staticPublicKeyHex: string;
+  masterSigningSecretKeyHex: string;
+  masterSigningPublicKeyHex: string;
+  createdAt: string;
+}
+
+interface StoredShape {
+  encrypted: string;
+}
+
+const IDENTITY_FILENAME = 'mobile-bridge-identity.json';
+
+function identityPath(): string {
+  return path.join(PATHS.configDir, IDENTITY_FILENAME);
+}
+
+function toStored(identity: BridgeIdentity): StoredIdentity {
+  return {
+    staticSecretKeyHex: bytesToHex(identity.staticKeyPair.secretKey),
+    staticPublicKeyHex: bytesToHex(identity.staticKeyPair.publicKey),
+    masterSigningSecretKeyHex: bytesToHex(identity.masterSigningKeyPair.secretKey),
+    masterSigningPublicKeyHex: bytesToHex(identity.masterSigningKeyPair.publicKey),
+    createdAt: identity.createdAt,
+  };
+}
+
+function fromStored(stored: StoredIdentity): BridgeIdentity {
+  return {
+    staticKeyPair: { secretKey: hexToBytes(stored.staticSecretKeyHex), publicKey: hexToBytes(stored.staticPublicKeyHex) },
+    masterSigningKeyPair: { secretKey: hexToBytes(stored.masterSigningSecretKeyHex), publicKey: hexToBytes(stored.masterSigningPublicKeyHex) },
+    createdAt: stored.createdAt,
+  };
+}
+
+export function loadBridgeIdentity(): BridgeIdentity | null {
+  const filePath = identityPath();
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as StoredShape;
+    if (!parsed.encrypted) return null;
+    const decrypted = decryptSecret(parsed.encrypted);
+    const stored = JSON.parse(decrypted) as StoredIdentity;
+    if (typeof stored?.staticSecretKeyHex !== 'string' || stored.staticSecretKeyHex.length === 0) return null;
+    return fromStored(stored);
+  } catch (error) {
+    console.warn('[mobile-bridge/identity] failed to load identity:', error);
+    return null;
+  }
+}
+
+function saveBridgeIdentity(identity: BridgeIdentity): void {
+  fs.mkdirSync(PATHS.configDir, { recursive: true });
+  const encrypted = encryptSecret(JSON.stringify(toStored(identity)));
+  const payload: StoredShape = { encrypted };
+  // mode 0o600: best-effort defense-in-depth for the file holding the
+  // encrypted private-key material (no-op on Windows, honored on POSIX at
+  // create time). The payload is already safeStorage-encrypted; this just
+  // narrows who can read the ciphertext at rest.
+  fs.writeFileSync(identityPath(), JSON.stringify(payload, null, 2), { mode: 0o600 });
+}
+
+/**
+ * Loads the existing identity, or generates and persists a new one.
+ * Throws rather than persisting unprotected private key material when
+ * genuine encryption is unavailable (Linux basic_text backend) - callers
+ * should check isGenuineEncryptionAvailable() first and surface a clear
+ * "secure storage unavailable" status instead of calling this blindly.
+ */
+export function loadOrCreateBridgeIdentity(): BridgeIdentity {
+  const existing = loadBridgeIdentity();
+  if (existing) return existing;
+
+  if (!isGenuineEncryptionAvailable()) {
+    throw new Error(
+      'Cannot create a mobile bridge identity: secure storage is unavailable (Linux basic_text backend or safeStorage disabled). Refusing to persist an unprotected private key.',
+    );
+  }
+
+  const identity: BridgeIdentity = {
+    staticKeyPair: generateX25519KeyPair(),
+    masterSigningKeyPair: generateEd25519KeyPair(),
+    createdAt: new Date().toISOString(),
+  };
+  saveBridgeIdentity(identity);
+  return identity;
+}
+
+export function clearBridgeIdentity(): void {
+  // rmSync with force ignores a missing file (no existsSync TOCTOU); the
+  // try/catch swallows a transient Windows lock (AV/backup holding a handle)
+  // so a best-effort clear never throws into the caller.
+  try {
+    fs.rmSync(identityPath(), { force: true });
+  } catch (error) {
+    console.warn('[mobile-bridge/identity] failed to clear identity:', error);
+  }
+}

--- a/src/main/mobile-bridge/mobile-bridge-service.ts
+++ b/src/main/mobile-bridge/mobile-bridge-service.ts
@@ -1,0 +1,254 @@
+import { EventEmitter } from 'node:events';
+import {
+  bytesToHex,
+  capabilitySetFromArray,
+  encodePairingQrPayload,
+  PROTOCOL_VERSION,
+  type CapabilityVerb,
+  type PairingQrPayload,
+  type ShortAuthenticationString,
+} from '@kangentic/protocol';
+import { isGenuineEncryptionAvailable } from '../boards/shared/auth';
+import { loadBridgeIdentity, loadOrCreateBridgeIdentity, type BridgeIdentity } from './identity';
+import {
+  loadRoster,
+  revokeDevice as revokeDeviceInRoster,
+  setDeviceCapabilities as setDeviceCapabilitiesInRoster,
+} from './roster-store';
+import { DEFAULT_PAIRING_CAPABILITIES, PairingService } from './pairing/pairing-service';
+import { createTransport } from './transport/transport-factory';
+import type { BridgeSession } from './session/bridge-session';
+import { CapabilityRouter } from './capability-router';
+
+export interface MobileBridgeConfig {
+  enabled: boolean;
+  relayUrl: string;
+}
+
+export interface MobileBridgeStatus {
+  enabled: boolean;
+  secureStorageAvailable: boolean;
+  /** Hex-encoded static public key, for display/verification - never the private key. */
+  identityFingerprint: string | null;
+  relayUrl: string;
+  pairedDeviceCount: number;
+  pairingInProgress: boolean;
+}
+
+export interface PairedDeviceSummary {
+  deviceId: string;
+  displayName: string;
+  capabilities: CapabilityVerb[];
+  pairedAt: string;
+}
+
+/**
+ * The long-lived mobile bridge service: owned by IpcContext (constructed
+ * in register-all.ts, torn down synchronously in index.ts's
+ * clearPendingTimers), modeled on SessionManager/TranscriptionService's
+ * shape. Owns the desktop's identity, the signed device roster, the
+ * active pairing ceremony (if any), and (once Phase 2 gives sessions
+ * something to do) one BridgeSession per connected paired device.
+ *
+ * Identity creation is deferred to the FIRST deliberate pairing attempt
+ * (ensureIdentity(), called only from startPairing()), not the
+ * constructor and not any read path (getStatus/listDevices/etc use
+ * tryLoadIdentity(), which never creates one). Merely opening the
+ * settings tab or checking status must not have the side effect of
+ * generating and persisting a device keypair. Constructing this service
+ * never throws even when secure storage is unavailable - getStatus()
+ * surfaces that condition for the settings UI instead.
+ */
+export class MobileBridgeService extends EventEmitter {
+  readonly capabilityRouter = new CapabilityRouter();
+  private config: MobileBridgeConfig;
+  private identity: BridgeIdentity | null = null;
+  private activePairing: PairingService | null = null;
+  private pendingPairingDeviceId: string | null = null;
+  private readonly sessions = new Map<string, BridgeSession>();
+  private disposed = false;
+
+  constructor(config: MobileBridgeConfig) {
+    super();
+    this.config = config;
+  }
+
+  /** Applies effective config. Called from register-all.ts at startup and from applyRuntimeConfig on every config:set. */
+  reconcile(config: MobileBridgeConfig): void {
+    const wasEnabled = this.config.enabled;
+    this.config = config;
+    if (!config.enabled && wasEnabled) {
+      this.cancelPairing('Mobile bridge disabled');
+      this.disposeAllSessions();
+    }
+    // Reconnecting already-paired devices' sessions on enable/relayUrl
+    // change is a Phase 2 concern once capability verbs give a session
+    // something to do; Phase 1 establishes the identity/roster/pairing
+    // surface.
+  }
+
+  /** Creates a new identity if none exists. Only called from startPairing() - a deliberate user action - never from a read path. */
+  private ensureIdentity(): BridgeIdentity {
+    if (!this.identity) this.identity = loadOrCreateBridgeIdentity();
+    return this.identity;
+  }
+
+  /**
+   * Reads the identity WITHOUT creating one. Merely checking status,
+   * listing devices, or opening the settings tab must never have the side
+   * effect of generating and persisting a new device keypair - only
+   * startPairing() (a deliberate "Pair a device" click) does that.
+   */
+  private tryLoadIdentity(): BridgeIdentity | null {
+    if (this.identity) return this.identity;
+    const loaded = loadBridgeIdentity();
+    if (loaded) this.identity = loaded;
+    return loaded;
+  }
+
+  getStatus(): MobileBridgeStatus {
+    const secureStorageAvailable = isGenuineEncryptionAvailable();
+    let identityFingerprint: string | null = null;
+    let pairedDeviceCount = 0;
+    if (secureStorageAvailable) {
+      const identity = this.tryLoadIdentity();
+      if (identity) {
+        identityFingerprint = bytesToHex(identity.staticKeyPair.publicKey);
+        pairedDeviceCount = loadRoster(identity).devices.length;
+      }
+    }
+    return {
+      enabled: this.config.enabled,
+      secureStorageAvailable,
+      identityFingerprint,
+      relayUrl: this.config.relayUrl,
+      pairedDeviceCount,
+      pairingInProgress: this.activePairing !== null,
+    };
+  }
+
+  listDevices(): PairedDeviceSummary[] {
+    const identity = this.tryLoadIdentity();
+    if (!identity) return [];
+    return loadRoster(identity).devices.map((device) => ({
+      deviceId: device.deviceId,
+      displayName: device.displayName,
+      capabilities: device.capabilities,
+      pairedAt: device.pairedAt,
+    }));
+  }
+
+  revokeDevice(deviceId: string): void {
+    const identity = this.tryLoadIdentity();
+    if (!identity) return; // No identity means no roster, so nothing to revoke.
+    revokeDeviceInRoster(identity, deviceId);
+    const session = this.sessions.get(deviceId);
+    if (session) {
+      session.dispose();
+      this.sessions.delete(deviceId);
+    }
+    // Revocation = drop from the roster AND rotate channel keys (see
+    // roster-store.ts's revokeDevice doc comment). Rotating the desktop's
+    // own static key also invalidates every OTHER paired device's ability
+    // to complete a KK handshake, since KK requires both sides to already
+    // know the CURRENT static key - an actual rotation + re-provisioning
+    // flow for any remaining paired devices is Phase 2/3 scope once there
+    // is more than a single paired device to reason about in practice.
+    // Phase 1 ships the roster-side "drop" half.
+    this.emit('stateChanged');
+  }
+
+  setDeviceCapabilities(deviceId: string, capabilities: CapabilityVerb[]): void {
+    const identity = this.tryLoadIdentity();
+    if (!identity) throw new Error(`No such paired device: ${deviceId}`);
+    setDeviceCapabilitiesInRoster(identity, deviceId, capabilities);
+    const session = this.sessions.get(deviceId);
+    if (session) session.capabilities = capabilitySetFromArray(capabilities);
+    this.emit('stateChanged');
+  }
+
+  async startPairing(): Promise<{ qrPayload: PairingQrPayload; qrUri: string }> {
+    if (!this.config.enabled) throw new Error('Mobile bridge is not enabled');
+    if (this.activePairing) throw new Error('A pairing ceremony is already in progress');
+
+    const identity = this.ensureIdentity();
+    const pairingService = new PairingService(identity);
+    const token = pairingService.mintToken();
+    this.activePairing = pairingService;
+    this.pendingPairingDeviceId = null;
+
+    const slotId = bytesToHex(token.token);
+    const transport = createTransport({ relayUrl: this.config.relayUrl, slotId });
+
+    pairingService.on('sas', (payload: { sas: ShortAuthenticationString; phoneStaticPublicKeyHex: string }) => {
+      this.pendingPairingDeviceId = payload.phoneStaticPublicKeyHex;
+      this.emit('pairingSas', payload);
+    });
+    pairingService.once('confirmed', () => {
+      this.activePairing = null;
+      this.pendingPairingDeviceId = null;
+      this.emit('stateChanged');
+    });
+    pairingService.once('cancelled', (payload: { reason: string }) => {
+      this.activePairing = null;
+      this.pendingPairingDeviceId = null;
+      transport.close();
+      this.emit('pairingEnded', payload);
+    });
+    pairingService.once('failed', (payload: { reason: string }) => {
+      this.activePairing = null;
+      this.pendingPairingDeviceId = null;
+      transport.close();
+      this.emit('pairingEnded', payload);
+    });
+
+    try {
+      await transport.connect();
+    } catch (error) {
+      // Close the transport we just created before rethrowing: RelayClient
+      // arms an internal reconnect timer on a failed dial, so abandoning it
+      // here (it is not stored on `this`, so dispose() cannot reach it)
+      // would leak a permanent reconnect loop against a now-meaningless slot.
+      transport.close();
+      this.activePairing = null;
+      throw error;
+    }
+    pairingService.start(transport);
+
+    const qrPayload: PairingQrPayload = {
+      desktopStaticPublicKey: identity.staticKeyPair.publicKey,
+      pairingToken: token.token,
+      relayAddress: this.config.relayUrl,
+      expiresAt: new Date(token.expiresAt).toISOString(),
+      protocolVersion: PROTOCOL_VERSION,
+    };
+    return { qrPayload, qrUri: encodePairingQrPayload(qrPayload) };
+  }
+
+  /** deviceId is derived from the phone's static key at SAS time, not chosen by the caller - the settings UI only ever supplies a display name and the granted capabilities. */
+  confirmPairing(displayName: string, capabilities: CapabilityVerb[] = DEFAULT_PAIRING_CAPABILITIES): void {
+    if (!this.activePairing || !this.pendingPairingDeviceId) {
+      throw new Error('No pairing ceremony with a confirmed SAS is in progress');
+    }
+    this.activePairing.confirmSas(this.pendingPairingDeviceId, displayName, capabilities);
+  }
+
+  cancelPairing(reason = 'Cancelled by user'): void {
+    this.activePairing?.cancel(reason);
+    this.activePairing = null;
+    this.pendingPairingDeviceId = null;
+  }
+
+  private disposeAllSessions(): void {
+    for (const session of this.sessions.values()) session.dispose();
+    this.sessions.clear();
+  }
+
+  /** Synchronous, per synchronous-shutdown.md: no async work, no timers left un-cleared. */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.cancelPairing('Mobile bridge service shutting down');
+    this.disposeAllSessions();
+  }
+}

--- a/src/main/mobile-bridge/pairing/pairing-service.ts
+++ b/src/main/mobile-bridge/pairing/pairing-service.ts
@@ -1,0 +1,163 @@
+import { EventEmitter } from 'node:events';
+import {
+  bytesToHex,
+  createPairingResponderHandshake,
+  deriveShortAuthenticationString,
+  type CapabilityVerb,
+  type HandshakeState,
+  type ShortAuthenticationString,
+  type Transport,
+} from '@kangentic/protocol';
+import { addOrReplaceDevice } from '../roster-store';
+import type { BridgeIdentity } from '../identity';
+import { isPairingTokenValid, mintPairingToken, type PairingToken } from './pairing-token';
+
+/**
+ * Default grant for a newly paired device: read-only. The write/control
+ * verbs (send-user-message, move-task, answer-permission-prompt) require
+ * an explicit grant afterward via the paired-devices settings UI --
+ * matches "1:1 management UX is fine for v1" from the research doc: pair
+ * once, then adjust capabilities if wanted, rather than granting
+ * everything by default.
+ */
+export const DEFAULT_PAIRING_CAPABILITIES: CapabilityVerb[] = ['read-stream', 'read-board', 'read-diff'];
+
+type PairingPhase = 'idle' | 'waiting-for-phone' | 'sas-pending' | 'done';
+
+/**
+ * Orchestrates one pairing ceremony: mint a token -> (caller builds and
+ * displays the QR) -> run the responder side of the Noise IKpsk0
+ * handshake over an already-connected Transport -> derive the SAS and
+ * surface it for the user to confirm -> on confirmation, sign the
+ * phone's static key into the roster.
+ *
+ * Emits (see the corresponding IPC push channels in handlers/mobile-bridge.ts):
+ *   'sas'       ({ sas, phoneStaticPublicKeyHex }) - show the SAS to the user
+ *   'confirmed' ({ deviceId })                     - pairing succeeded
+ *   'cancelled' ({ reason })                       - user rejected the SAS or cancelled
+ *   'failed'    ({ reason })                       - handshake/transport error (e.g. wrong or expired token)
+ *
+ * One instance handles exactly one ceremony; the caller (mobile-bridge-service)
+ * creates a fresh instance per "Pair a device" attempt.
+ */
+export class PairingService extends EventEmitter {
+  private readonly identity: BridgeIdentity;
+  private phase: PairingPhase = 'idle';
+  private activeToken: PairingToken | null = null;
+  private activeTransport: Transport | null = null;
+  private unsubscribeFrame: (() => void) | null = null;
+  private handshake: HandshakeState | null = null;
+
+  constructor(identity: BridgeIdentity) {
+    super();
+    this.identity = identity;
+  }
+
+  mintToken(): PairingToken {
+    if (this.activeToken) throw new Error('mintToken() already called for this ceremony');
+    this.activeToken = mintPairingToken();
+    return this.activeToken;
+  }
+
+  /** `transport` must already be connected and scoped to this pairing token's relay slot. */
+  start(transport: Transport): void {
+    if (!this.activeToken) throw new Error('mintToken() must be called before start()');
+    if (this.phase !== 'idle') throw new Error(`Cannot start a pairing ceremony while phase is "${this.phase}"`);
+
+    this.phase = 'waiting-for-phone';
+    this.activeTransport = transport;
+    this.handshake = createPairingResponderHandshake({
+      localStatic: this.identity.staticKeyPair,
+      pairingToken: this.activeToken.token,
+    });
+    this.unsubscribeFrame = transport.onFrame((frame) => this.onFrame(frame));
+  }
+
+  private onFrame(frame: Uint8Array): void {
+    if (this.phase === 'waiting-for-phone') this.handleMessage1(frame);
+  }
+
+  private handleMessage1(frame: Uint8Array): void {
+    if (!this.handshake || !this.activeToken || !this.activeTransport) return;
+    if (!isPairingTokenValid(this.activeToken)) {
+      this.fail('Pairing token expired or already used');
+      return;
+    }
+    // Single-use regardless of outcome: one attempt is all an attacker (or a
+    // legitimate retry) gets against this token.
+    this.activeToken.consumed = true;
+
+    try {
+      // The payload (phone device name) is authenticated here but not yet
+      // surfaced - Phase 2 threads it through to the paired-device list.
+      this.handshake.readMessage(frame);
+    } catch {
+      this.fail('Pairing handshake failed to authenticate (wrong or expired code)');
+      return;
+    }
+
+    let writeResult: ReturnType<HandshakeState['writeMessage']>;
+    try {
+      writeResult = this.handshake.writeMessage(new Uint8Array(0));
+    } catch {
+      this.fail('Pairing handshake failed while responding');
+      return;
+    }
+    this.activeTransport.send(writeResult.message);
+
+    const phoneStaticPublicKey = this.handshake.getRemoteStaticKey();
+    if (!phoneStaticPublicKey) {
+      this.fail('Pairing handshake did not yield the phone identity key');
+      return;
+    }
+
+    this.phase = 'sas-pending';
+    const sas = deriveShortAuthenticationString(this.handshake.getHandshakeHash());
+    this.emit('sas', { sas, phoneStaticPublicKeyHex: bytesToHex(phoneStaticPublicKey) });
+  }
+
+  /** Called once the user confirms both screens show the same SAS. Signs the phone's static key into the roster. */
+  confirmSas(deviceId: string, displayName: string, capabilities: CapabilityVerb[] = DEFAULT_PAIRING_CAPABILITIES): void {
+    if (this.phase !== 'sas-pending' || !this.handshake) {
+      throw new Error(`Cannot confirm pairing while phase is "${this.phase}"`);
+    }
+    const phoneStaticPublicKey = this.handshake.getRemoteStaticKey();
+    if (!phoneStaticPublicKey) throw new Error('No phone identity key to confirm');
+
+    addOrReplaceDevice(this.identity, {
+      deviceId,
+      staticPublicKey: phoneStaticPublicKey,
+      displayName,
+      capabilities,
+      expiresAt: null,
+    });
+
+    this.phase = 'done';
+    this.emit('confirmed', { deviceId });
+    this.teardown();
+  }
+
+  /** Called if the user reports the SAS codes do NOT match, or cancels before that point. */
+  cancel(reason = 'Cancelled by user'): void {
+    if (this.phase === 'done') return;
+    this.phase = 'done';
+    this.emit('cancelled', { reason });
+    this.teardown();
+  }
+
+  private fail(reason: string): void {
+    if (this.phase === 'done') return;
+    this.phase = 'done';
+    this.emit('failed', { reason });
+    this.teardown();
+  }
+
+  private teardown(): void {
+    this.unsubscribeFrame?.();
+    this.unsubscribeFrame = null;
+    this.activeTransport = null;
+    this.handshake = null;
+  }
+}
+
+export type { ShortAuthenticationString };

--- a/src/main/mobile-bridge/pairing/pairing-token.ts
+++ b/src/main/mobile-bridge/pairing/pairing-token.ts
@@ -1,0 +1,21 @@
+import { randomBytes } from '@kangentic/protocol';
+
+/** ~10 minutes, per the research doc's pairing ceremony design. */
+export const PAIRING_TOKEN_TTL_MS = 10 * 60 * 1000;
+
+export interface PairingToken {
+  /** 32 bytes, used directly as the Noise PSK - see crypto/pairing-handshake.ts. */
+  token: Uint8Array;
+  createdAt: number;
+  expiresAt: number;
+  /** Single-use: set once a handshake attempt has been made against this token, success or failure. */
+  consumed: boolean;
+}
+
+export function mintPairingToken(now: number = Date.now()): PairingToken {
+  return { token: randomBytes(32), createdAt: now, expiresAt: now + PAIRING_TOKEN_TTL_MS, consumed: false };
+}
+
+export function isPairingTokenValid(pairingToken: PairingToken, now: number = Date.now()): boolean {
+  return !pairingToken.consumed && now < pairingToken.expiresAt;
+}

--- a/src/main/mobile-bridge/roster-store.ts
+++ b/src/main/mobile-bridge/roster-store.ts
@@ -1,0 +1,165 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { PATHS } from '../config/paths';
+import {
+  bytesToHex,
+  hexToBytes,
+  signRosterEntry,
+  verifyRosterEntry,
+  type CapabilityVerb,
+  type DeviceRoster,
+  type RosterDeviceEntry,
+} from '@kangentic/protocol';
+import type { BridgeIdentity } from './identity';
+
+/**
+ * Persists the signed device roster to a global JSON file (like the
+ * device identity, this represents the desktop installation, not any one
+ * project). The roster - not the relay - is the source of truth for
+ * who is paired; every entry read back off disk is re-verified against
+ * the roster's own master signing key before being trusted, so a
+ * corrupted or hand-edited roster file degrades to "that device drops
+ * out" rather than silently trusting tampered data.
+ */
+const ROSTER_FILENAME = 'mobile-bridge-roster.json';
+
+interface StoredRosterEntry {
+  deviceId: string;
+  staticPublicKeyHex: string;
+  displayName: string;
+  capabilities: CapabilityVerb[];
+  pairedAt: string;
+  expiresAt: string | null;
+  signatureHex: string;
+}
+
+interface StoredRoster {
+  masterSigningPublicKeyHex: string;
+  devices: StoredRosterEntry[];
+}
+
+function rosterPath(): string {
+  return path.join(PATHS.configDir, ROSTER_FILENAME);
+}
+
+function toStoredEntry(entry: RosterDeviceEntry): StoredRosterEntry {
+  return {
+    deviceId: entry.deviceId,
+    staticPublicKeyHex: bytesToHex(entry.staticPublicKey),
+    displayName: entry.displayName,
+    capabilities: entry.capabilities,
+    pairedAt: entry.pairedAt,
+    expiresAt: entry.expiresAt,
+    signatureHex: bytesToHex(entry.signature),
+  };
+}
+
+function fromStoredEntry(stored: StoredRosterEntry): RosterDeviceEntry {
+  return {
+    deviceId: stored.deviceId,
+    staticPublicKey: hexToBytes(stored.staticPublicKeyHex),
+    displayName: stored.displayName,
+    capabilities: stored.capabilities,
+    pairedAt: stored.pairedAt,
+    expiresAt: stored.expiresAt,
+    signature: hexToBytes(stored.signatureHex),
+  };
+}
+
+function emptyRoster(identity: BridgeIdentity): DeviceRoster {
+  return { masterSigningPublicKey: identity.masterSigningKeyPair.publicKey, devices: [] };
+}
+
+export function loadRoster(identity: BridgeIdentity): DeviceRoster {
+  const filePath = rosterPath();
+  if (!fs.existsSync(filePath)) return emptyRoster(identity);
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const stored = JSON.parse(raw) as StoredRoster;
+    const masterSigningPublicKey = hexToBytes(stored.masterSigningPublicKeyHex);
+    const devices = stored.devices
+      .map(fromStoredEntry)
+      .filter((entry) => verifyRosterEntry(masterSigningPublicKey, entry));
+    return { masterSigningPublicKey, devices };
+  } catch (error) {
+    console.warn('[mobile-bridge/roster-store] failed to load roster, starting empty:', error);
+    return emptyRoster(identity);
+  }
+}
+
+function saveRoster(roster: DeviceRoster): void {
+  fs.mkdirSync(PATHS.configDir, { recursive: true });
+  const stored: StoredRoster = {
+    masterSigningPublicKeyHex: bytesToHex(roster.masterSigningPublicKey),
+    devices: roster.devices.map(toStoredEntry),
+  };
+  fs.writeFileSync(rosterPath(), JSON.stringify(stored, null, 2));
+}
+
+export interface AddDeviceInput {
+  deviceId: string;
+  staticPublicKey: Uint8Array;
+  displayName: string;
+  capabilities: CapabilityVerb[];
+  expiresAt: string | null;
+}
+
+export function addOrReplaceDevice(identity: BridgeIdentity, input: AddDeviceInput): DeviceRoster {
+  const roster = loadRoster(identity);
+  const entry = signRosterEntry(identity.masterSigningKeyPair.secretKey, {
+    deviceId: input.deviceId,
+    staticPublicKey: input.staticPublicKey,
+    displayName: input.displayName,
+    capabilities: input.capabilities,
+    pairedAt: new Date().toISOString(),
+    expiresAt: input.expiresAt,
+  });
+  const nextRoster: DeviceRoster = {
+    ...roster,
+    devices: [...roster.devices.filter((device) => device.deviceId !== input.deviceId), entry],
+  };
+  saveRoster(nextRoster);
+  return nextRoster;
+}
+
+/** Capabilities are part of the signed payload, so changing them re-signs the entry. */
+export function setDeviceCapabilities(identity: BridgeIdentity, deviceId: string, capabilities: CapabilityVerb[]): DeviceRoster {
+  const roster = loadRoster(identity);
+  const existing = roster.devices.find((device) => device.deviceId === deviceId);
+  if (!existing) throw new Error(`No such paired device: ${deviceId}`);
+  return addOrReplaceDevice(identity, {
+    deviceId: existing.deviceId,
+    staticPublicKey: existing.staticPublicKey,
+    displayName: existing.displayName,
+    capabilities,
+    expiresAt: existing.expiresAt,
+  });
+}
+
+/**
+ * Revocation = drop the device from the roster AND rotate the desktop's
+ * own static identity key. Removal without rekey is not revocation: a
+ * revoked device that already completed a Noise KK handshake could
+ * otherwise still authenticate against future sessions as long as the
+ * desktop's static key is unchanged, since KK's mutual authentication
+ * only proves possession of the OLD key pair, which revocation from the
+ * roster alone does not invalidate. This function only owns the roster
+ * side; the caller (mobile-bridge-service) is responsible for rotating
+ * and re-persisting the identity and restarting the relay connection.
+ */
+export function revokeDevice(identity: BridgeIdentity, deviceId: string): DeviceRoster {
+  const roster = loadRoster(identity);
+  const nextRoster: DeviceRoster = { ...roster, devices: roster.devices.filter((device) => device.deviceId !== deviceId) };
+  saveRoster(nextRoster);
+  return nextRoster;
+}
+
+export function clearRoster(): void {
+  // rmSync with force ignores a missing file; the try/catch swallows a
+  // transient Windows file lock so a best-effort clear never throws.
+  try {
+    fs.rmSync(rosterPath(), { force: true });
+  } catch (error) {
+    console.warn('[mobile-bridge/roster-store] failed to clear roster:', error);
+  }
+}

--- a/src/main/mobile-bridge/session/bridge-session.ts
+++ b/src/main/mobile-bridge/session/bridge-session.ts
@@ -1,0 +1,174 @@
+import { EventEmitter } from 'node:events';
+import {
+  createKKHandshake,
+  decodeMessage,
+  deriveSecretstreamPair,
+  encodeMessage,
+  FrameTag,
+  SessionFrameKind,
+  unwrapSessionFrame,
+  wrapSessionFrame,
+  type BridgeMessage,
+  type CapabilitySet,
+  type HandshakeState,
+  type SecretstreamDirectionPair,
+  type Transport,
+} from '@kangentic/protocol';
+import type { BridgeIdentity } from '../identity';
+
+/** WireGuard's REKEY_AFTER_TIME: bounded post-compromise security via periodic re-handshake, not just initial forward secrecy. */
+const REHANDSHAKE_INTERVAL_MS = 2 * 60 * 1000;
+
+export interface BridgeSessionOptions {
+  identity: BridgeIdentity;
+  deviceId: string;
+  remoteStaticPublicKey: Uint8Array;
+  capabilities: CapabilitySet;
+  transport: Transport;
+}
+
+/**
+ * One connected device's secure session: the desktop always initiates the
+ * Noise KK handshake (both statics already pinned via the roster), so it
+ * owns the ~2-minute re-handshake timer - it is the always-on, source-of-truth
+ * side, so it is the natural side to drive that timing rather than
+ * waiting on the phone. Once established, application traffic
+ * (wire/messages.ts's BridgeMessage envelope) flows over secretstream
+ * framing keyed off the Noise session's chaining key.
+ *
+ * Phase 1 wires this session lifecycle and message transport; it does
+ * NOT dispatch capability-request messages to real handlers (that is
+ * Phase 2's capability router filling in). `capabilities` is carried here
+ * so Phase 2 has it ready to enforce.
+ */
+export class BridgeSession extends EventEmitter {
+  private readonly identity: BridgeIdentity;
+  readonly deviceId: string;
+  readonly remoteStaticPublicKey: Uint8Array;
+  capabilities: CapabilitySet;
+  private readonly transport: Transport;
+
+  private handshake: HandshakeState | null = null;
+  private streams: SecretstreamDirectionPair | null = null;
+  private rehandshakeTimer: ReturnType<typeof setInterval> | null = null;
+  private unsubscribeFrame: (() => void) | null = null;
+  private disposed = false;
+
+  constructor(options: BridgeSessionOptions) {
+    super();
+    this.identity = options.identity;
+    this.deviceId = options.deviceId;
+    this.remoteStaticPublicKey = options.remoteStaticPublicKey;
+    this.capabilities = options.capabilities;
+    this.transport = options.transport;
+  }
+
+  get isEstablished(): boolean {
+    return this.streams !== null;
+  }
+
+  start(): void {
+    if (this.unsubscribeFrame) throw new Error('BridgeSession.start() called twice');
+    this.unsubscribeFrame = this.transport.onFrame((frame) => this.onFrame(frame));
+    this.beginHandshake();
+    this.rehandshakeTimer = setInterval(() => this.beginHandshake(), REHANDSHAKE_INTERVAL_MS);
+    this.rehandshakeTimer.unref?.();
+  }
+
+  private beginHandshake(): void {
+    if (this.disposed) return;
+    this.handshake = createKKHandshake({
+      initiator: true,
+      localStatic: this.identity.staticKeyPair,
+      remoteStatic: this.remoteStaticPublicKey,
+    });
+    const { message } = this.handshake.writeMessage(new Uint8Array(0));
+    this.transport.send(wrapSessionFrame(SessionFrameKind.Handshake, message));
+  }
+
+  private onFrame(rawFrame: Uint8Array): void {
+    if (this.disposed) return;
+    let unwrapped: { kind: SessionFrameKind; payload: Uint8Array };
+    try {
+      unwrapped = unwrapSessionFrame(rawFrame);
+    } catch (error) {
+      this.emit('frameRejected', error);
+      return;
+    }
+    if (unwrapped.kind === SessionFrameKind.Handshake) {
+      this.handleHandshakeFrame(unwrapped.payload);
+    } else {
+      this.handleApplicationFrame(unwrapped.payload);
+    }
+  }
+
+  private handleHandshakeFrame(payload: Uint8Array): void {
+    if (!this.handshake) {
+      this.emit('handshakeFailed', new Error('Received a handshake frame with no handshake in progress'));
+      return;
+    }
+    let readResult: ReturnType<HandshakeState['readMessage']>;
+    try {
+      readResult = this.handshake.readMessage(payload);
+    } catch (error) {
+      this.emit('handshakeFailed', error);
+      return;
+    }
+    if (!readResult.split) {
+      // KK is exactly two messages; reading the responder's reply always completes it.
+      this.emit('handshakeFailed', new Error('KK handshake did not complete after the expected two messages'));
+      return;
+    }
+    const chainingKey = this.handshake.getChainingKey();
+    this.streams = deriveSecretstreamPair(chainingKey, true);
+    this.handshake = null;
+    this.emit('established');
+  }
+
+  private handleApplicationFrame(payload: Uint8Array): void {
+    if (!this.streams) {
+      // A stray application frame arriving before the first handshake
+      // completed, or after this session was disposed - ignore rather
+      // than throw, since a peer can legitimately race a reconnect.
+      return;
+    }
+    let opened: ReturnType<SecretstreamDirectionPair['receive']['open']>;
+    try {
+      opened = this.streams.receive.open(payload);
+    } catch (error) {
+      this.emit('frameRejected', error);
+      return;
+    }
+    if (opened.tag === FrameTag.Final) {
+      this.emit('remoteClosed');
+      return;
+    }
+    let message: BridgeMessage;
+    try {
+      message = decodeMessage(opened.plaintext);
+    } catch (error) {
+      this.emit('frameRejected', error);
+      return;
+    }
+    this.emit('message', message);
+  }
+
+  sendMessage(message: BridgeMessage): void {
+    if (!this.streams) throw new Error('BridgeSession is not established yet');
+    const frame = this.streams.send.seal(encodeMessage(message));
+    this.transport.send(wrapSessionFrame(SessionFrameKind.Application, frame));
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.rehandshakeTimer) {
+      clearInterval(this.rehandshakeTimer);
+      this.rehandshakeTimer = null;
+    }
+    this.unsubscribeFrame?.();
+    this.unsubscribeFrame = null;
+    this.handshake = null;
+    this.streams = null;
+  }
+}

--- a/src/main/mobile-bridge/transport/relay-client.ts
+++ b/src/main/mobile-bridge/transport/relay-client.ts
@@ -1,0 +1,214 @@
+import { EventEmitter } from 'node:events';
+import type { Transport, TransportState, Unsubscribe } from '@kangentic/protocol';
+
+/**
+ * The desktop's outbound relay connection: dials OUT to a blind WebSocket
+ * relay (self-hostable or Kangentic's hosted one) and reconnects with
+ * capped backoff. The relay forwards only opaque ciphertext frames - it
+ * authenticates nothing and reads nothing, since every frame sent through
+ * it is already Noise-encrypted (or, during pairing, is itself a Noise
+ * handshake message).
+ *
+ * Node 24 exposes a global `WebSocket` (browser-compatible API), so this
+ * has no runtime dependency beyond that - `ws` is a devDependency used
+ * only by the in-repo relay test double (tests/unit/mobile-bridge/).
+ *
+ * Wire contract with the relay (defined here because the relay SERVER is
+ * a separate task/repo; this is the assumed contract until that lands):
+ * connect to `${relayUrl}?slot=<hex-encoded-slot-id>`. The slot id is the
+ * pairing token during pairing (so the relay can rendezvous the phone and
+ * desktop connections that present the SAME token) or a value derived
+ * from the paired device's static key for an ongoing session. The relay
+ * never sees the slot id's cryptographic meaning, only its bytes.
+ *
+ * Accountless: no Kangentic account/entitlement coupling here. Any such
+ * gate lives only on the hosted relay's own connection-acceptance policy,
+ * per the open-core design - this client behaves identically against a
+ * self-hosted or hosted relay.
+ */
+
+const INITIAL_BACKOFF_MS = 500;
+const MAX_BACKOFF_MS = 30_000;
+const BACKOFF_MULTIPLIER = 2;
+
+export interface RelayClientOptions {
+  relayUrl: string;
+  slotId: string;
+  /** Per-session byte cap (defense-in-depth against a runaway loop on either end). */
+  maxBytesPerSession?: number;
+}
+
+export class RelayClient implements Transport {
+  private readonly relayUrl: string;
+  private readonly slotId: string;
+  private readonly maxBytesPerSession: number;
+  private readonly emitter = new EventEmitter();
+
+  private socket: WebSocket | null = null;
+  private currentState: TransportState = 'idle';
+  private reconnectBackoffMs = INITIAL_BACKOFF_MS;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private bytesSentThisSession = 0;
+  private explicitlyClosed = false;
+  /** Reject of the in-flight dial() promise, if a connect() is still pending. */
+  private pendingDialReject: ((error: Error) => void) | null = null;
+
+  constructor(options: RelayClientOptions) {
+    this.relayUrl = options.relayUrl;
+    this.slotId = options.slotId;
+    this.maxBytesPerSession = options.maxBytesPerSession ?? 256 * 1024 * 1024;
+  }
+
+  get state(): TransportState {
+    return this.currentState;
+  }
+
+  async connect(): Promise<void> {
+    this.explicitlyClosed = false;
+    return this.dial();
+  }
+
+  private dial(): Promise<void> {
+    this.setState(this.currentState === 'idle' ? 'connecting' : 'reconnecting');
+    const url = `${this.relayUrl}${this.relayUrl.includes('?') ? '&' : '?'}slot=${encodeURIComponent(this.slotId)}`;
+
+    return new Promise<void>((resolve, reject) => {
+      // Wrap resolve/reject so the pendingDialReject pointer is cleared once
+      // this dial settles by any path. close() consults that pointer to
+      // settle a dial still in flight (see close()).
+      const settle = () => {
+        this.pendingDialReject = null;
+      };
+      const resolveOnce = () => {
+        settle();
+        resolve();
+      };
+      const rejectOnce = (error: Error) => {
+        settle();
+        reject(error);
+      };
+      this.pendingDialReject = rejectOnce;
+
+      let socket: WebSocket;
+      try {
+        socket = new WebSocket(url);
+      } catch (error) {
+        this.scheduleReconnect();
+        rejectOnce(error instanceof Error ? error : new Error(String(error)));
+        return;
+      }
+      socket.binaryType = 'arraybuffer';
+      this.socket = socket;
+
+      socket.onopen = () => {
+        this.reconnectBackoffMs = INITIAL_BACKOFF_MS;
+        this.bytesSentThisSession = 0;
+        this.setState('connected');
+        resolveOnce();
+      };
+
+      socket.onmessage = (event: MessageEvent) => {
+        const frame = toUint8Array(event.data);
+        if (frame) this.emitter.emit('frame', frame);
+      };
+
+      socket.onerror = () => {
+        // The corresponding onclose fires right after in every browser-compatible
+        // WebSocket implementation; reconnect logic lives there, not here.
+      };
+
+      socket.onclose = () => {
+        this.socket = null;
+        if (this.explicitlyClosed) {
+          this.setState('closed');
+          // close() already settled any pending dial synchronously; this is a
+          // no-op if so. Guard against a socket closed via close() while still
+          // connecting so the awaiter is never left hanging.
+          rejectOnce(new Error('Relay connection closed before it opened'));
+          return;
+        }
+        this.scheduleReconnect();
+        // Only reject the in-flight connect() promise if we never reached 'open'.
+        if (this.currentState !== 'connected') rejectOnce(new Error('Relay connection closed before it opened'));
+      };
+    });
+  }
+
+  private scheduleReconnect(): void {
+    if (this.explicitlyClosed) return;
+    this.setState('reconnecting');
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.dial().catch(() => {
+        // dial() already scheduled the next attempt on failure.
+      });
+    }, this.reconnectBackoffMs);
+    this.reconnectTimer.unref?.();
+    this.reconnectBackoffMs = Math.min(this.reconnectBackoffMs * BACKOFF_MULTIPLIER, MAX_BACKOFF_MS);
+  }
+
+  send(frame: Uint8Array): void {
+    if (!this.socket || this.currentState !== 'connected') {
+      throw new Error('RelayClient.send() called while not connected');
+    }
+    if (this.bytesSentThisSession + frame.byteLength > this.maxBytesPerSession) {
+      throw new Error('RelayClient per-session byte cap exceeded');
+    }
+    this.bytesSentThisSession += frame.byteLength;
+    // Send the underlying bytes as a plain ArrayBuffer rather than the
+    // Uint8Array view directly: lib.dom's WebSocket.send() expects an
+    // ArrayBufferView<ArrayBuffer>, but a Uint8Array's generic buffer type
+    // is ArrayBufferLike (which also covers SharedArrayBuffer), so passing
+    // the view itself does not typecheck.
+    this.socket.send(frame.buffer.slice(frame.byteOffset, frame.byteOffset + frame.byteLength) as ArrayBuffer);
+  }
+
+  close(): void {
+    this.explicitlyClosed = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.socket) {
+      try {
+        this.socket.close();
+      } catch {
+        // best-effort
+      }
+      this.socket = null;
+    }
+    this.setState('closed');
+    // If close() raced an in-flight connect() before it opened, settle that
+    // pending dial() promise now so its awaiter (e.g. startPairing) does not
+    // hang forever. A socket closed while still CONNECTING may never deliver
+    // an onclose that settles the promise, so we settle it here directly.
+    if (this.pendingDialReject) {
+      const rejectPending = this.pendingDialReject;
+      this.pendingDialReject = null;
+      rejectPending(new Error('Relay connection closed before it opened'));
+    }
+  }
+
+  onFrame(listener: (frame: Uint8Array) => void): Unsubscribe {
+    this.emitter.on('frame', listener);
+    return () => this.emitter.off('frame', listener);
+  }
+
+  onStateChange(listener: (state: TransportState) => void): Unsubscribe {
+    this.emitter.on('state', listener);
+    return () => this.emitter.off('state', listener);
+  }
+
+  private setState(state: TransportState): void {
+    if (this.currentState === state) return;
+    this.currentState = state;
+    this.emitter.emit('state', state);
+  }
+}
+
+function toUint8Array(data: unknown): Uint8Array | null {
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  if (ArrayBuffer.isView(data)) return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  return null;
+}

--- a/src/main/mobile-bridge/transport/transport-factory.ts
+++ b/src/main/mobile-bridge/transport/transport-factory.ts
@@ -1,0 +1,18 @@
+import type { Transport } from '@kangentic/protocol';
+import { RelayClient } from './relay-client';
+
+/**
+ * The swap point named in the research doc's Phase 1 scope: relay is the
+ * only implementation today, but everything above this call (pairing
+ * service, bridge sessions, capability router) only ever sees the
+ * `Transport` interface. A WebRTC data channel implementation (Phase 4)
+ * slots in here with nothing above it changing.
+ */
+export interface TransportFactoryOptions {
+  relayUrl: string;
+  slotId: string;
+}
+
+export function createTransport(options: TransportFactoryOptions): Transport {
+  return new RelayClient({ relayUrl: options.relayUrl, slotId: options.slotId });
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import { IPC } from '../shared/ipc-channels';
-import type { ElectronAPI, NotificationInput, Project, Session, SessionUsage, ActivityState, ActivityReason, SessionEvent, UpdateDownloadedInfo, UsageTimePeriod, TaskBulkDeleteProgress, ProjectMoveProgress, DictationModelProgress } from '../shared/types';
+import type { ElectronAPI, NotificationInput, Project, Session, SessionUsage, ActivityState, ActivityReason, SessionEvent, UpdateDownloadedInfo, UsageTimePeriod, TaskBulkDeleteProgress, ProjectMoveProgress, DictationModelProgress, MobilePairingSasPayload, MobilePairingEndedPayload } from '../shared/types';
 import { installConsoleCapture } from './diagnostics/console-capture';
 import { installDevtoolsPreloadHooks } from '../devtools/preload/install-globals';
 
@@ -393,6 +393,31 @@ const api: ElectronAPI = {
       authStatus: () => ipcRenderer.invoke(IPC.BOARDS_ASANA_AUTH_STATUS),
       setPat: (input) => ipcRenderer.invoke(IPC.BOARDS_ASANA_SET_PAT, input),
       clearCredential: () => ipcRenderer.invoke(IPC.BOARDS_ASANA_CLEAR_CREDENTIAL),
+    },
+  },
+
+  mobile: {
+    getStatus: () => ipcRenderer.invoke(IPC.MOBILE_GET_STATUS),
+    startPairing: () => ipcRenderer.invoke(IPC.MOBILE_START_PAIRING),
+    confirmPairing: (displayName, capabilities) => ipcRenderer.invoke(IPC.MOBILE_CONFIRM_PAIRING, displayName, capabilities),
+    cancelPairing: () => ipcRenderer.invoke(IPC.MOBILE_CANCEL_PAIRING),
+    listDevices: () => ipcRenderer.invoke(IPC.MOBILE_LIST_DEVICES),
+    revokeDevice: (deviceId) => ipcRenderer.invoke(IPC.MOBILE_REVOKE_DEVICE, deviceId),
+    setDeviceCapabilities: (deviceId, capabilities) => ipcRenderer.invoke(IPC.MOBILE_SET_DEVICE_CAPABILITIES, deviceId, capabilities),
+    onPairingSas: (callback) => {
+      const handler = (_event: Electron.IpcRendererEvent, payload: MobilePairingSasPayload) => callback(payload);
+      ipcRenderer.on(IPC.MOBILE_PAIRING_SAS, handler);
+      return () => ipcRenderer.removeListener(IPC.MOBILE_PAIRING_SAS, handler);
+    },
+    onPairingEnded: (callback) => {
+      const handler = (_event: Electron.IpcRendererEvent, payload: MobilePairingEndedPayload) => callback(payload);
+      ipcRenderer.on(IPC.MOBILE_PAIRING_ENDED, handler);
+      return () => ipcRenderer.removeListener(IPC.MOBILE_PAIRING_ENDED, handler);
+    },
+    onStateChanged: (callback) => {
+      const handler = () => callback();
+      ipcRenderer.on(IPC.MOBILE_STATE_CHANGED, handler);
+      return () => ipcRenderer.removeListener(IPC.MOBILE_STATE_CHANGED, handler);
     },
   },
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,6 +6,7 @@ import { TestHarness } from '../devtools/renderer/TestHarness';
 import { useProjectStore } from './stores/project-store';
 import { useBoardStore } from './stores/board-store';
 import { useConfigStore } from './stores/config-store';
+import { useMobileStore } from './stores/mobile-store';
 import { useSessionStore } from './stores/session-store';
 import { useBacklogStore } from './stores/backlog-store';
 import { useToastStore } from './stores/toast-store';
@@ -682,6 +683,8 @@ if (import.meta.hot) {
     useConfigStore.getState().loadAgentList();
     useBoardStore.getState().loadBoard();
     useBacklogStore.getState().loadBacklog();
+    useMobileStore.getState().loadStatus();
+    useMobileStore.getState().loadDevices();
     useSessionStore.getState().syncSessions().then((applied) => {
       if (!applied) return;
 

--- a/src/renderer/components/settings/AppSettingsPanel.tsx
+++ b/src/renderer/components/settings/AppSettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { Bell, Bot, Brain, Bug, FolderCog, GitBranch, Globe, Keyboard, LayoutGrid, Mic, MousePointerClick, Palette, Plug, ShieldCheck, SlidersHorizontal, Terminal, Zap } from 'lucide-react';
+import { Bell, Bot, Brain, Bug, FolderCog, GitBranch, Globe, Keyboard, LayoutGrid, Mic, MousePointerClick, Palette, Plug, ShieldCheck, SlidersHorizontal, Smartphone, Terminal, Zap } from 'lucide-react';
 import { useConfigStore } from '../../stores/config-store';
 import { SettingsPanelProvider, SearchTabGroupHeader, NoSearchResults } from './shared';
 import type { SettingsTabDefinition, SettingScope, SettingsContentProps } from './shared';
@@ -17,6 +17,7 @@ import { DictationTab } from './tabs/DictationTab';
 import { McpServerTab } from './tabs/McpServerTab';
 import { BrowserAutomationTab } from './tabs/BrowserAutomationTab';
 import { NotificationsTab } from './tabs/NotificationsTab';
+import { MobileDevicesTab } from './tabs/MobileDevicesTab';
 import { MemoryTab } from './tabs/MemoryTab';
 import { PrivacyTab } from './tabs/PrivacyTab';
 import { DeveloperTab } from './tabs/DeveloperTab';
@@ -51,6 +52,7 @@ export const APP_TABS: SettingsTabDefinition[] = [
   { id: 'mcpServer', label: 'MCP Server', icon: Plug, tooltip: 'Applies to all projects' },
   { id: 'browserAutomation', label: 'Agent Browser', icon: MousePointerClick, tooltip: 'Applies to all projects' },
   { id: 'notifications', label: 'Notifications', icon: Bell, tooltip: 'Applies to all projects' },
+  { id: 'mobile', label: 'Mobile Devices', icon: Smartphone, tooltip: 'Applies to all projects' },
   { id: 'privacy', label: 'Privacy', icon: ShieldCheck, tooltip: 'Applies to all projects' },
   { id: 'developer', label: 'Developer', icon: Bug, tooltip: 'Applies to all projects' },
 ];
@@ -113,6 +115,7 @@ export function SettingsContent({ activeTab, isSearching, searchQuery, matchingT
       case 'mcpServer': return <McpServerTab globalConfig={globalConfig} />;
       case 'browserAutomation': return <BrowserAutomationTab globalConfig={globalConfig} />;
       case 'notifications': return <NotificationsTab globalConfig={globalConfig} />;
+      case 'mobile': return <MobileDevicesTab globalConfig={globalConfig} />;
       case 'memory': return <MemoryTab globalConfig={globalConfig} />;
       case 'privacy': return <PrivacyTab />;
       default: return null;

--- a/src/renderer/components/settings/settings-registry.ts
+++ b/src/renderer/components/settings/settings-registry.ts
@@ -137,6 +137,12 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
 
   // ── Developer ──
   { id: 'developer.activityDebugOverlay', tabId: 'developer', label: 'Activity Engine Debug Overlay', description: 'Show a floating panel with live activity-engine state for every running session. Useful for diagnosing spinner / idle bugs.', scope: 'global', keywords: ['debug', 'overlay', 'diagnostic', 'engine', 'activity', 'thinking', 'idle', 'subagent', 'background', 'shell', 'reason'] },
+
+  // ── Mobile Devices ──
+  { id: 'mobileBridge.enabled', tabId: 'mobile', label: 'Mobile Bridge', description: 'Let a paired phone connect to this desktop through an end-to-end encrypted relay.', scope: 'global', keywords: ['mobile', 'phone', 'companion', 'pair', 'pairing', 'qr', 'relay', 'bridge', 'remote'] },
+  { id: 'mobileBridge.relayUrl', tabId: 'mobile', label: 'Relay Address', description: 'The relay this desktop connects to (self-hosted or Kangentic-hosted). The relay only ever sees encrypted traffic.', scope: 'global', keywords: ['relay', 'server', 'url', 'address', 'self-host', 'websocket', 'mobile'] },
+  { id: 'mobileBridge.pairing', tabId: 'mobile', label: 'Pair a Device', description: 'Scan a QR code with the Kangentic mobile app to pair a new phone.', scope: 'global', keywords: ['pair', 'pairing', 'qr', 'scan', 'phone', 'mobile', 'sas', 'code'] },
+  { id: 'mobileBridge.devices', tabId: 'mobile', label: 'Paired Devices', description: 'Phones paired to this desktop, their granted capabilities, and revocation.', scope: 'global', keywords: ['paired', 'devices', 'phone', 'revoke', 'capabilities', 'mobile'] },
 ];
 
 /** Lookup by ID for O(1) access. */
@@ -160,6 +166,7 @@ export const TAB_LABELS: Record<string, string> = {
   notifications: 'Notifications',
   privacy: 'Privacy',
   dictation: 'Dictation',
+  mobile: 'Mobile Devices',
 };
 
 /** Helper to get props for a SettingRow from the registry. */

--- a/src/renderer/components/settings/tabs/MobileDevicesTab.tsx
+++ b/src/renderer/components/settings/tabs/MobileDevicesTab.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useState } from 'react';
+import { QrCode, Smartphone, Trash2 } from 'lucide-react';
+import QRCode from 'qrcode';
+import type { AppConfig } from '../../../../shared/types';
+import { INPUT_CLASS, SectionHeader, SettingRow, SettingToggleRow, useScopedUpdate } from '../shared';
+import { settingProps } from '../settings-registry';
+import { ConfirmDialog } from '../../dialogs/ConfirmDialog';
+import { useMobileStore } from '../../../stores/mobile-store';
+
+export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) {
+  const updateGlobal = useScopedUpdate('global');
+  const enabled = globalConfig.mobileBridge?.enabled ?? false;
+  const relayUrl = globalConfig.mobileBridge?.relayUrl ?? '';
+
+  const status = useMobileStore((state) => state.status);
+  const devices = useMobileStore((state) => state.devices);
+  const loading = useMobileStore((state) => state.loading);
+  const pairingSas = useMobileStore((state) => state.pairingSas);
+  const pairingEndedReason = useMobileStore((state) => state.pairingEndedReason);
+  const loadStatus = useMobileStore((state) => state.loadStatus);
+  const loadDevices = useMobileStore((state) => state.loadDevices);
+  const startPairing = useMobileStore((state) => state.startPairing);
+  const confirmPairing = useMobileStore((state) => state.confirmPairing);
+  const cancelPairing = useMobileStore((state) => state.cancelPairing);
+  const revokeDevice = useMobileStore((state) => state.revokeDevice);
+  const setPairingSas = useMobileStore((state) => state.setPairingSas);
+  const setPairingEnded = useMobileStore((state) => state.setPairingEnded);
+  const clearPairingEnded = useMobileStore((state) => state.clearPairingEnded);
+
+  const [qrUri, setQrUri] = useState<string | null>(null);
+  const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const [deviceNameDraft, setDeviceNameDraft] = useState('');
+  const [revokeTarget, setRevokeTarget] = useState<{ deviceId: string; displayName: string } | null>(null);
+
+  useEffect(() => {
+    void loadStatus();
+    void loadDevices();
+  }, [loadStatus, loadDevices]);
+
+  useEffect(() => {
+    const unsubscribeSas = window.electronAPI.mobile.onPairingSas((payload) => {
+      setPairingSas(payload);
+    });
+    const unsubscribeEnded = window.electronAPI.mobile.onPairingEnded((payload) => {
+      setPairingEnded(payload.reason);
+      setQrUri(null);
+      setQrDataUrl(null);
+    });
+    const unsubscribeState = window.electronAPI.mobile.onStateChanged(() => {
+      void loadStatus();
+      void loadDevices();
+    });
+    return () => {
+      unsubscribeSas();
+      unsubscribeEnded();
+      unsubscribeState();
+    };
+  }, [loadStatus, loadDevices, setPairingSas, setPairingEnded]);
+
+  useEffect(() => {
+    if (!qrUri) {
+      setQrDataUrl(null);
+      return;
+    }
+    let cancelled = false;
+    QRCode.toDataURL(qrUri, { margin: 1, width: 220 }).then((dataUrl) => {
+      if (!cancelled) setQrDataUrl(dataUrl);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [qrUri]);
+
+  const handleStartPairing = async () => {
+    clearPairingEnded();
+    const result = await startPairing();
+    setQrUri(result.qrUri);
+  };
+
+  const handleCancelPairing = async () => {
+    await cancelPairing();
+    setQrUri(null);
+    setQrDataUrl(null);
+  };
+
+  const handleConfirmMatch = async () => {
+    // Omit capabilities so the main-process default (DEFAULT_PAIRING_CAPABILITIES,
+    // read-only) applies. Passing [] here would defeat that default and leave the
+    // device with zero granted verbs (permanently inert until a capability UI ships).
+    await confirmPairing(deviceNameDraft.trim() || 'Paired Device');
+    setQrUri(null);
+    setQrDataUrl(null);
+    setDeviceNameDraft('');
+  };
+
+  return (
+    <div className="space-y-4">
+      <SettingToggleRow
+        {...settingProps('mobileBridge.enabled')}
+        icon={<Smartphone className="size-5" />}
+        checked={enabled}
+        onChange={(value) => updateGlobal({ mobileBridge: { enabled: value } })}
+      />
+
+      <div className={enabled ? 'space-y-4' : 'space-y-4 opacity-40 pointer-events-none'}>
+        <SettingRow {...settingProps('mobileBridge.relayUrl')}>
+          <input
+            type="text"
+            className={INPUT_CLASS}
+            value={relayUrl}
+            placeholder="wss://relay.example.com"
+            disabled={!enabled}
+            onChange={(event) => updateGlobal({ mobileBridge: { relayUrl: event.target.value } })}
+          />
+        </SettingRow>
+
+        {status && !status.secureStorageAvailable && (
+          <p className="text-xs text-danger">
+            Secure storage is unavailable on this system, so a device identity cannot be created.
+          </p>
+        )}
+
+        <SectionHeader label="Pair a Device" searchIds={['mobileBridge.pairing']} />
+        {!qrUri ? (
+          <div className="space-y-2">
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 rounded-md border border-edge bg-surface-hover px-3 py-1.5 text-sm text-fg hover:bg-surface-hover/70 transition-colors disabled:opacity-50"
+              onClick={() => void handleStartPairing()}
+              disabled={loading || !status?.secureStorageAvailable}
+            >
+              <QrCode size={16} />
+              Pair a device
+            </button>
+            {pairingEndedReason && <p className="text-xs text-danger">{pairingEndedReason}</p>}
+          </div>
+        ) : pairingSas ? (
+          <div className="space-y-3 rounded-md border border-edge bg-surface-hover/40 p-4">
+            <p className="text-sm text-fg-secondary">Confirm this code matches what your phone shows.</p>
+            <div className="flex items-center gap-3">
+              <span className="text-lg font-mono tracking-widest text-fg">{pairingSas.digits}</span>
+              <span className="text-lg">{pairingSas.emoji.join(' ')}</span>
+            </div>
+            <input
+              type="text"
+              className={INPUT_CLASS}
+              placeholder="Device name (e.g. My iPhone)"
+              value={deviceNameDraft}
+              onChange={(event) => setDeviceNameDraft(event.target.value)}
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded-md bg-accent-emphasis px-3 py-1.5 text-sm text-accent-on hover:bg-accent transition-colors"
+                onClick={() => void handleConfirmMatch()}
+              >
+                Codes match
+              </button>
+              <button
+                type="button"
+                className="rounded-md border border-edge px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-hover transition-colors"
+                onClick={() => void handleCancelPairing()}
+              >
+                Codes don&apos;t match
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3 rounded-md border border-edge bg-surface-hover/40 p-4">
+            <p className="text-sm text-fg-secondary">Scan this code with the Kangentic mobile app.</p>
+            {qrDataUrl && (
+              <img src={qrDataUrl} alt="Pairing QR code" className="rounded-md border border-edge" width={220} height={220} />
+            )}
+            <button
+              type="button"
+              className="rounded-md border border-edge px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-hover transition-colors"
+              onClick={() => void handleCancelPairing()}
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+
+        <SectionHeader label="Paired Devices" searchIds={['mobileBridge.devices']} />
+        {devices.length === 0 ? (
+          <p className="text-sm text-fg-faint">No devices paired yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {devices.map((device) => (
+              <li
+                key={device.deviceId}
+                className="flex items-center justify-between gap-3 rounded-md border border-edge bg-surface-hover/30 px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <div className="text-sm text-fg-secondary truncate">{device.displayName}</div>
+                  <div className="text-xs text-fg-faint truncate">{device.capabilities.join(', ') || 'No capabilities granted'}</div>
+                </div>
+                <button
+                  type="button"
+                  className="shrink-0 rounded p-1.5 text-fg-faint hover:text-danger hover:bg-danger/10 transition-colors"
+                  title="Revoke"
+                  onClick={() => setRevokeTarget({ deviceId: device.deviceId, displayName: device.displayName })}
+                >
+                  <Trash2 size={14} />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {revokeTarget && (
+        <ConfirmDialog
+          title="Revoke device"
+          message={`Revoke "${revokeTarget.displayName}"? It loses access immediately and must be paired again to reconnect.`}
+          confirmLabel="Revoke"
+          variant="danger"
+          onConfirm={() => {
+            const target = revokeTarget;
+            setRevokeTarget(null);
+            void revokeDevice(target.deviceId);
+          }}
+          onCancel={() => setRevokeTarget(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/renderer/stores/mobile-store.ts
+++ b/src/renderer/stores/mobile-store.ts
@@ -1,0 +1,93 @@
+import { create } from 'zustand';
+import type {
+  MobileBridgeStatus,
+  MobileCapabilityVerb,
+  MobilePairedDevice,
+  MobilePairingSasPayload,
+  MobileStartPairingResult,
+} from '../../shared/types';
+
+/**
+ * Backs the Mobile Devices settings tab. Machine-global (not project-scoped),
+ * matching the mobile bridge itself. Pairing push events (SAS, pairing
+ * ended) are NOT subscribed here - the tab component owns that
+ * subscription via a useEffect tied to its own mount lifecycle (it is the
+ * only consumer), and calls setPairingSas/clearPairingSas/setPairingEnded
+ * to reflect them into this store.
+ */
+interface MobileStore {
+  status: MobileBridgeStatus | null;
+  devices: MobilePairedDevice[];
+  loading: boolean;
+  pairingSas: MobilePairingSasPayload | null;
+  pairingEndedReason: string | null;
+
+  loadStatus: () => Promise<void>;
+  loadDevices: () => Promise<void>;
+  startPairing: () => Promise<MobileStartPairingResult>;
+  confirmPairing: (displayName: string, capabilities?: MobileCapabilityVerb[]) => Promise<void>;
+  cancelPairing: () => Promise<void>;
+  revokeDevice: (deviceId: string) => Promise<void>;
+  setDeviceCapabilities: (deviceId: string, capabilities: MobileCapabilityVerb[]) => Promise<void>;
+
+  setPairingSas: (payload: MobilePairingSasPayload) => void;
+  clearPairingSas: () => void;
+  setPairingEnded: (reason: string) => void;
+  clearPairingEnded: () => void;
+}
+
+export const useMobileStore = create<MobileStore>((set, get) => ({
+  status: null,
+  devices: [],
+  loading: false,
+  pairingSas: null,
+  pairingEndedReason: null,
+
+  loadStatus: async () => {
+    const status = await window.electronAPI.mobile.getStatus();
+    set({ status });
+  },
+
+  loadDevices: async () => {
+    const devices = await window.electronAPI.mobile.listDevices();
+    set({ devices });
+  },
+
+  startPairing: async () => {
+    set({ loading: true, pairingSas: null, pairingEndedReason: null });
+    try {
+      const result = await window.electronAPI.mobile.startPairing();
+      await get().loadStatus();
+      return result;
+    } finally {
+      set({ loading: false });
+    }
+  },
+
+  confirmPairing: async (displayName, capabilities) => {
+    await window.electronAPI.mobile.confirmPairing(displayName, capabilities);
+    set({ pairingSas: null });
+    await Promise.all([get().loadDevices(), get().loadStatus()]);
+  },
+
+  cancelPairing: async () => {
+    await window.electronAPI.mobile.cancelPairing();
+    set({ pairingSas: null });
+    await get().loadStatus();
+  },
+
+  revokeDevice: async (deviceId) => {
+    await window.electronAPI.mobile.revokeDevice(deviceId);
+    await Promise.all([get().loadDevices(), get().loadStatus()]);
+  },
+
+  setDeviceCapabilities: async (deviceId, capabilities) => {
+    await window.electronAPI.mobile.setDeviceCapabilities(deviceId, capabilities);
+    await get().loadDevices();
+  },
+
+  setPairingSas: (payload) => set({ pairingSas: payload }),
+  clearPairingSas: () => set({ pairingSas: null }),
+  setPairingEnded: (reason) => set({ pairingEndedReason: reason }),
+  clearPairingEnded: () => set({ pairingEndedReason: null }),
+}));

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -200,6 +200,18 @@ export const IPC = {
   BOARD_CONFIG_SHORTCUTS_CHANGED: 'boardConfig:shortcutsChanged',
   BOARD_CONFIG_SET_DEFAULT_BASE_BRANCH: 'boardConfig:setDefaultBaseBranch',
 
+  // Mobile Bridge -- machine-global (like config), not project-scoped.
+  MOBILE_GET_STATUS: 'mobile:getStatus',
+  MOBILE_START_PAIRING: 'mobile:startPairing',
+  MOBILE_CONFIRM_PAIRING: 'mobile:confirmPairing',
+  MOBILE_CANCEL_PAIRING: 'mobile:cancelPairing',
+  MOBILE_LIST_DEVICES: 'mobile:listDevices',
+  MOBILE_REVOKE_DEVICE: 'mobile:revokeDevice',
+  MOBILE_SET_DEVICE_CAPABILITIES: 'mobile:setDeviceCapabilities',
+  MOBILE_PAIRING_SAS: 'mobile:pairingSas',
+  MOBILE_PAIRING_ENDED: 'mobile:pairingEnded',
+  MOBILE_STATE_CHANGED: 'mobile:stateChanged',
+
   // Backlog
   BACKLOG_LIST: 'backlog:list',
   BACKLOG_CREATE: 'backlog:create',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1761,6 +1761,18 @@ export interface AppConfig {
     remote?: DictationRemoteEndpoint;
   };
 
+  /**
+   * Mobile companion app bridge. GLOBAL/shared scope (below the settings
+   * separator, in the Mobile Devices tab): the identity, roster, and relay
+   * connection represent this desktop installation, not any one project.
+   */
+  mobileBridge?: {
+    /** Master switch. When false, no relay connection is held and pairing is unavailable. Default false. */
+    enabled?: boolean;
+    /** The relay address to dial (self-hosted or Kangentic's hosted relay), e.g. "wss://relay.kangentic.com". */
+    relayUrl?: string;
+  };
+
   hasCompletedFirstRun: boolean;
   skipDeleteConfirm: boolean;
   skipBoardConfigConfirm: boolean;
@@ -1986,6 +1998,10 @@ export const DEFAULT_CONFIG: AppConfig = {
     releaseBufferMs: 250,
     experience: 'popup',
   },
+  mobileBridge: {
+    enabled: false,
+    relayUrl: '',
+  },
 };
 
 // === Agent Commands ===
@@ -2195,6 +2211,61 @@ export interface ImportCheckCliResult {
   available: boolean;
   authenticated: boolean;
   error?: string;
+}
+
+// === Mobile Bridge ===
+// This repo's types.ts is deliberately import-free (a dependency-free leaf
+// module), so these mirror @kangentic/protocol's CapabilityVerb/roster
+// shapes as plain, self-contained types rather than importing them -- keep
+// MOBILE_CAPABILITY_VERBS in sync with packages/protocol/src/capabilities/verbs.ts
+// (CAPABILITY_VERBS) by hand; there is no shell/file/arbitrary-command verb
+// in the protocol, by design.
+export const MOBILE_CAPABILITY_VERBS = [
+  'read-stream',
+  'read-board',
+  'read-diff',
+  'send-user-message',
+  'move-task',
+  'answer-permission-prompt',
+] as const;
+export type MobileCapabilityVerb = (typeof MOBILE_CAPABILITY_VERBS)[number];
+
+export interface MobileBridgeStatus {
+  enabled: boolean;
+  /** False when Electron safeStorage can't genuinely encrypt (e.g. the Linux basic_text backend) -- the bridge refuses to create/use an identity in that state. */
+  secureStorageAvailable: boolean;
+  /** Hex-encoded static public key, for display/verification. Never the private key. */
+  identityFingerprint: string | null;
+  relayUrl: string;
+  pairedDeviceCount: number;
+  pairingInProgress: boolean;
+}
+
+export interface MobileStartPairingResult {
+  /** The `kangentic-pair://...` URI to render as a QR code. */
+  qrUri: string;
+  /** ISO 8601. */
+  expiresAt: string;
+}
+
+export interface MobilePairedDevice {
+  deviceId: string;
+  displayName: string;
+  capabilities: MobileCapabilityVerb[];
+  /** ISO 8601. */
+  pairedAt: string;
+}
+
+export interface MobilePairingSasPayload {
+  /** 6-digit short authentication string, shown alongside `emoji` for the user to compare against the phone's screen. */
+  digits: string;
+  emoji: string[];
+  /** Hex-encoded, for display only -- the roster entry itself is signed and persisted main-side. */
+  phoneStaticPublicKeyHex: string;
+}
+
+export interface MobilePairingEndedPayload {
+  reason: string;
 }
 
 // === IPC API Types ===
@@ -3404,6 +3475,20 @@ export interface ElectronAPI {
       setPat: (input: AsanaSetPatInput) => Promise<AsanaSetPatResult>;
       clearCredential: () => Promise<void>;
     };
+  };
+
+  // Mobile Bridge -- machine-global (like config), not project-scoped.
+  mobile: {
+    getStatus: () => Promise<MobileBridgeStatus>;
+    startPairing: () => Promise<MobileStartPairingResult>;
+    confirmPairing: (displayName: string, capabilities?: MobileCapabilityVerb[]) => Promise<void>;
+    cancelPairing: () => Promise<void>;
+    listDevices: () => Promise<MobilePairedDevice[]>;
+    revokeDevice: (deviceId: string) => Promise<void>;
+    setDeviceCapabilities: (deviceId: string, capabilities: MobileCapabilityVerb[]) => Promise<void>;
+    onPairingSas: (callback: (payload: MobilePairingSasPayload) => void) => () => void;
+    onPairingEnded: (callback: (payload: MobilePairingEndedPayload) => void) => () => void;
+    onStateChanged: (callback: () => void) => () => void;
   };
 
   // Board Config

--- a/tests/ui/mobile-devices-settings.spec.ts
+++ b/tests/ui/mobile-devices-settings.spec.ts
@@ -1,0 +1,320 @@
+/**
+ * UI tests for the Mobile Devices settings tab.
+ *
+ * Covers the shared/global (below-separator) surface: the enable toggle and
+ * relay URL input persisting to global config, the pairing ceremony (start
+ * pairing -> QR render -> simulated SAS -> confirm), and the paired-device
+ * list with revoke-via-ConfirmDialog. Mirrors the structure of
+ * browser-settings.spec.ts and hotkeys-settings.spec.ts, the closest
+ * precedents for a global settings tab with a toggle + input + list +
+ * destructive action.
+ *
+ * Every test resets mobileBridge.enabled/relayUrl in beforeEach (never
+ * afterEach) so the first test to run in a worker does not depend on a
+ * prior test having already set a baseline - the mock's default config
+ * omits `mobileBridge` entirely, so the component's `?? false` / `?? ''`
+ * fallbacks are what a fresh page actually renders.
+ */
+import { test, expect } from '@playwright/test';
+import { launchPage, createProject } from './helpers';
+import type { Browser, Page } from '@playwright/test';
+import type { AppConfig, MobilePairedDevice } from '../../src/shared/types';
+
+// Each describe is isolated per worker (separate process; per-test page launch / goto reset),
+// so the file's tests can fan out across the UI workers safely.
+test.describe.configure({ mode: 'parallel' });
+
+let browser: Browser;
+let page: Page;
+
+test.beforeAll(async () => {
+  const result = await launchPage();
+  browser = result.browser;
+  page = result.page;
+  await createProject(page, `Mobile Devices Test ${Date.now()}`);
+});
+
+test.afterAll(async () => {
+  await browser?.close();
+});
+
+async function openMobileTab() {
+  await page.locator('[data-testid="settings-button"]').click();
+  await page.locator('h2:has-text("Settings")').waitFor({ state: 'visible', timeout: 3000 });
+  await page.getByRole('button', { name: 'Mobile Devices', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Pair a Device' })).toBeVisible();
+}
+
+async function closeSettings() {
+  await page.evaluate(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+  });
+  await page.locator('h2:has-text("Settings")').waitFor({ state: 'hidden', timeout: 2000 });
+}
+
+async function getGlobalConfig(): Promise<AppConfig> {
+  return page.evaluate(async () => window.electronAPI.config.getGlobal());
+}
+
+/**
+ * Sets mobileBridge config via the real config-store action (not the raw
+ * IPC mock directly) so the already-mounted MobileDevicesTab reactively
+ * re-renders. A raw `window.electronAPI.config.set(...)` call updates the
+ * mock's persisted state but bypasses the Zustand store the component
+ * subscribes to, leaving the rendered UI stale until some other event
+ * happens to trigger a refetch.
+ */
+async function setMobileBridgeConfig(partial: { enabled?: boolean; relayUrl?: string }): Promise<void> {
+  await page.evaluate(async (mobileBridgePartial) => {
+    const stores = (window as unknown as {
+      __zustandStores: { config: { getState: () => { updateConfig: (partial: { mobileBridge: typeof mobileBridgePartial }) => Promise<void> } } };
+    }).__zustandStores;
+    await stores.config.getState().updateConfig({ mobileBridge: mobileBridgePartial });
+  }, partial);
+}
+
+/** Drives the full pairing ceremony (start -> SAS -> confirm) so the named device lands in the mock's real (non-override) device list, exercising confirmPairing() for real. */
+async function pairDevice(displayName: string): Promise<void> {
+  await page.getByRole('button', { name: 'Pair a device' }).click();
+  await expect(page.getByAltText('Pairing QR code')).toBeVisible();
+
+  await page.evaluate(() => {
+    (window as unknown as {
+      __mockFireMobilePairingSas: (payload: { digits: string; emoji: string[]; phoneStaticPublicKeyHex: string }) => void;
+    }).__mockFireMobilePairingSas({ digits: '135790', emoji: ['star'], phoneStaticPublicKeyHex: 'deadbeef' });
+  });
+  await expect(page.getByText('135790')).toBeVisible();
+
+  const deviceNameInput = page.locator('input[placeholder="Device name (e.g. Tyler\'s iPhone)"]');
+  await deviceNameInput.fill(displayName);
+  await page.getByRole('button', { name: 'Codes match' }).click();
+
+  await expect(page.locator('li', { hasText: displayName })).toBeVisible();
+}
+
+/** Revokes a real, previously-paired device by name via the ConfirmDialog. */
+async function revokeDevice(displayName: string): Promise<void> {
+  await page.locator('li', { hasText: displayName }).getByTitle('Revoke').click();
+  const dialog = page.locator('h3:has-text("Revoke device")').locator('xpath=ancestor::*[contains(@class, "z-[60]")][1]');
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('button', { name: 'Revoke', exact: true }).click();
+  await expect(page.locator('li', { hasText: displayName })).toHaveCount(0);
+}
+
+test.describe('Mobile Devices settings tab', () => {
+  test.beforeEach(async () => {
+    // Known baseline before every test: bridge enabled, empty relay URL, no
+    // list/status overrides left over from a previous test.
+    await setMobileBridgeConfig({ enabled: true, relayUrl: '' });
+    await page.evaluate(() => {
+      delete (window as unknown as { __mockMobileDevices?: MobilePairedDevice[] }).__mockMobileDevices;
+      delete (window as unknown as { __mockMobileBridgeStatus?: object }).__mockMobileBridgeStatus;
+    });
+  });
+
+  test('tab appears below the separator and is visible with no project open', async () => {
+    // Independent, project-less page: confirms the tab is a GLOBAL_ONLY_TABS
+    // entry (rendered even before any project is opened), not a per-project tab.
+    const { browser: freshBrowser, page: freshPage } = await launchPage();
+    try {
+      await freshPage.locator('[data-testid="settings-button"]').click();
+      await freshPage.locator('h2:has-text("Settings")').waitFor({ state: 'visible', timeout: 3000 });
+      const tabButton = freshPage.getByRole('button', { name: 'Mobile Devices', exact: true });
+      await expect(tabButton).toBeVisible();
+      await tabButton.click();
+      await expect(freshPage.getByRole('heading', { name: 'Pair a Device' })).toBeVisible();
+    } finally {
+      await freshBrowser.close();
+    }
+  });
+
+  test('renders the enable toggle, relay URL input, and section headers', async () => {
+    await openMobileTab();
+    await expect(page.getByRole('switch')).toBeVisible();
+    await expect(page.locator('input[placeholder="wss://relay.example.com"]')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Pair a Device' })).toBeVisible();
+    await expect(page.getByText('Paired Devices')).toBeVisible();
+    await closeSettings();
+  });
+
+  test('toggling enable persists mobileBridge.enabled to global config', async () => {
+    await openMobileTab();
+
+    const toggle = page.getByRole('switch');
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+    await expect.poll(async () => (await getGlobalConfig()).mobileBridge?.enabled).toBe(false);
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+    await expect.poll(async () => (await getGlobalConfig()).mobileBridge?.enabled).toBe(true);
+
+    await closeSettings();
+  });
+
+  test('editing the relay URL persists mobileBridge.relayUrl to global config', async () => {
+    await openMobileTab();
+
+    const urlInput = page.locator('input[placeholder="wss://relay.example.com"]');
+    await urlInput.fill('wss://relay.mock.dev');
+    await urlInput.blur();
+
+    await expect.poll(async () => (await getGlobalConfig()).mobileBridge?.relayUrl).toBe('wss://relay.mock.dev');
+
+    await closeSettings();
+  });
+
+  test('the relay URL input is disabled when mobileBridge.enabled === false', async () => {
+    await setMobileBridgeConfig({ enabled: false });
+    await openMobileTab();
+
+    const urlInput = page.locator('input[placeholder="wss://relay.example.com"]');
+    await expect(urlInput).toBeDisabled();
+
+    await closeSettings();
+  });
+
+  test('clicking "Pair a device" starts pairing and renders a QR code', async () => {
+    await openMobileTab();
+
+    await page.getByRole('button', { name: 'Pair a device' }).click();
+
+    const qrImage = page.getByAltText('Pairing QR code');
+    await expect(qrImage).toBeVisible();
+    // The QR is rendered from a real qrcode.toDataURL() call in the component,
+    // so assert it produced actual image data rather than an empty/broken src.
+    await expect.poll(async () => (await qrImage.getAttribute('src'))?.startsWith('data:image')).toBe(true);
+
+    await closeSettings();
+  });
+
+  test('cancelling an in-progress pairing clears the QR and returns to the start button', async () => {
+    await openMobileTab();
+
+    await page.getByRole('button', { name: 'Pair a device' }).click();
+    await expect(page.getByAltText('Pairing QR code')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.getByAltText('Pairing QR code')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Pair a device' })).toBeVisible();
+
+    await closeSettings();
+  });
+
+  test('a simulated SAS renders digits/emoji, and confirming adds the device to the list', async () => {
+    await openMobileTab();
+
+    await page.getByRole('button', { name: 'Pair a device' }).click();
+    await expect(page.getByAltText('Pairing QR code')).toBeVisible();
+
+    await page.evaluate(() => {
+      (window as unknown as {
+        __mockFireMobilePairingSas: (payload: { digits: string; emoji: string[]; phoneStaticPublicKeyHex: string }) => void;
+      }).__mockFireMobilePairingSas({
+        digits: '123456',
+        emoji: ['rocket', 'lock', 'star'],
+        phoneStaticPublicKeyHex: 'deadbeef',
+      });
+    });
+
+    await expect(page.getByText('123456')).toBeVisible();
+    await expect(page.getByText('rocket lock star')).toBeVisible();
+
+    const deviceNameInput = page.locator('input[placeholder="Device name (e.g. Tyler\'s iPhone)"]');
+    await deviceNameInput.fill('SAS Confirm Device');
+    await page.getByRole('button', { name: 'Codes match' }).click();
+
+    // confirmPairing() resolves and the store re-fetches listDevices(), which
+    // the mock has already pushed the new device into.
+    await expect(page.locator('li', { hasText: 'SAS Confirm Device' })).toBeVisible();
+    // Pairing UI collapses back to the idle "Pair a device" button.
+    await expect(page.getByAltText('Pairing QR code')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Pair a device' })).toBeVisible();
+
+    // Clean up so later tests in this worker don't accumulate leftover devices.
+    await revokeDevice('SAS Confirm Device');
+
+    await closeSettings();
+  });
+
+  test('"Codes don\'t match" cancels pairing without adding a device', async () => {
+    await openMobileTab();
+
+    await page.getByRole('button', { name: 'Pair a device' }).click();
+    await page.evaluate(() => {
+      (window as unknown as {
+        __mockFireMobilePairingSas: (payload: { digits: string; emoji: string[]; phoneStaticPublicKeyHex: string }) => void;
+      }).__mockFireMobilePairingSas({ digits: '654321', emoji: ['ghost'], phoneStaticPublicKeyHex: 'facefeed' });
+    });
+    await expect(page.getByText('654321')).toBeVisible();
+
+    await page.getByRole('button', { name: "Codes don't match" }).click();
+
+    await expect(page.getByText('654321')).toHaveCount(0);
+    await expect(page.getByAltText('Pairing QR code')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Pair a device' })).toBeVisible();
+
+    await closeSettings();
+  });
+
+  test('paired-device list renders seeded devices with their capabilities', async () => {
+    await page.evaluate(() => {
+      (window as unknown as { __mockMobileDevices: MobilePairedDevice[] }).__mockMobileDevices = [
+        {
+          deviceId: 'seed-device-1',
+          displayName: 'Seeded iPhone',
+          capabilities: ['read-stream', 'read-board'],
+          pairedAt: new Date().toISOString(),
+        },
+      ];
+    });
+
+    await openMobileTab();
+
+    await expect(page.locator('li', { hasText: 'Seeded iPhone' })).toBeVisible();
+    await expect(page.getByText('read-stream, read-board')).toBeVisible();
+
+    await closeSettings();
+  });
+
+  test('devices with no capabilities show the "No capabilities granted" fallback', async () => {
+    await page.evaluate(() => {
+      (window as unknown as { __mockMobileDevices: MobilePairedDevice[] }).__mockMobileDevices = [
+        {
+          deviceId: 'seed-device-2',
+          displayName: 'Bare Device',
+          capabilities: [],
+          pairedAt: new Date().toISOString(),
+        },
+      ];
+    });
+
+    await openMobileTab();
+
+    await expect(page.locator('li', { hasText: 'Bare Device' })).toBeVisible();
+    await expect(page.getByText('No capabilities granted')).toBeVisible();
+
+    await closeSettings();
+  });
+
+  test('revoke: Cancel keeps the device, Revoke removes it via revokeDevice()', async () => {
+    await openMobileTab();
+    await pairDevice('Revoke Target Device');
+
+    // Cancel path: dialog closes, device stays in the list.
+    await page.locator('li', { hasText: 'Revoke Target Device' }).getByTitle('Revoke').click();
+    const dialog = page.locator('h3:has-text("Revoke device")').locator('xpath=ancestor::*[contains(@class, "z-[60]")][1]');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Revoke Target Device');
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dialog).toHaveCount(0);
+    await expect(page.locator('li', { hasText: 'Revoke Target Device' })).toBeVisible();
+
+    // Confirm path: the device is actually removed by the mock's revokeDevice().
+    await revokeDevice('Revoke Target Device');
+
+    await closeSettings();
+  });
+});

--- a/tests/ui/mobile-devices-settings.spec.ts
+++ b/tests/ui/mobile-devices-settings.spec.ts
@@ -85,7 +85,7 @@ async function pairDevice(displayName: string): Promise<void> {
   });
   await expect(page.getByText('135790')).toBeVisible();
 
-  const deviceNameInput = page.locator('input[placeholder="Device name (e.g. Tyler\'s iPhone)"]');
+  const deviceNameInput = page.locator('input[placeholder="Device name (e.g. My iPhone)"]');
   await deviceNameInput.fill(displayName);
   await page.getByRole('button', { name: 'Codes match' }).click();
 
@@ -222,7 +222,7 @@ test.describe('Mobile Devices settings tab', () => {
     await expect(page.getByText('123456')).toBeVisible();
     await expect(page.getByText('rocket lock star')).toBeVisible();
 
-    const deviceNameInput = page.locator('input[placeholder="Device name (e.g. Tyler\'s iPhone)"]');
+    const deviceNameInput = page.locator('input[placeholder="Device name (e.g. My iPhone)"]');
     await deviceNameInput.fill('SAS Confirm Device');
     await page.getByRole('button', { name: 'Codes match' }).click();
 

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -2479,6 +2479,103 @@
       })(),
     },
 
+    // Mobile bridge mock. Stateful (pairing a device persists into
+    // listDevices() for the rest of the test), with escape hatches for
+    // specs that need to drive the pairing flow's push events directly:
+    //   - window.__mockMobileBridgeStatus: shallow-merged onto getStatus()'s result
+    //   - window.__mockMobileDevices: overrides listDevices()'s return value
+    //   - window.__mockFireMobilePairingSas(payload) / __mockFireMobilePairingEnded(payload) / __mockFireMobileStateChanged()
+    mobile: (function () {
+      var state = {
+        enabled: false,
+        secureStorageAvailable: true,
+        identityFingerprint: null,
+        relayUrl: '',
+        devices: [],
+        pairingInProgress: false,
+      };
+      var sasListeners = [];
+      var pairingEndedListeners = [];
+      var stateChangedListeners = [];
+
+      if (typeof window !== 'undefined') {
+        window.__mockFireMobilePairingSas = function (payload) {
+          sasListeners.forEach(function (listener) { listener(payload); });
+        };
+        window.__mockFireMobilePairingEnded = function (payload) {
+          pairingEndedListeners.forEach(function (listener) { listener(payload); });
+        };
+        window.__mockFireMobileStateChanged = function () {
+          stateChangedListeners.forEach(function (listener) { listener(); });
+        };
+      }
+
+      return {
+        getStatus: async function () {
+          var overrides = (typeof window !== 'undefined' && window.__mockMobileBridgeStatus) || {};
+          return Object.assign({
+            enabled: state.enabled,
+            secureStorageAvailable: state.secureStorageAvailable,
+            identityFingerprint: state.identityFingerprint,
+            relayUrl: state.relayUrl,
+            pairedDeviceCount: state.devices.length,
+            pairingInProgress: state.pairingInProgress,
+          }, overrides);
+        },
+        startPairing: async function () {
+          state.pairingInProgress = true;
+          return {
+            qrUri: 'kangentic-pair://mock',
+            expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+          };
+        },
+        confirmPairing: async function (displayName, capabilities) {
+          state.pairingInProgress = false;
+          state.devices.push({
+            deviceId: 'mock-device-' + (state.devices.length + 1),
+            displayName: displayName,
+            capabilities: capabilities || [],
+            pairedAt: new Date().toISOString(),
+          });
+        },
+        cancelPairing: async function () {
+          state.pairingInProgress = false;
+        },
+        listDevices: async function () {
+          return (typeof window !== 'undefined' && window.__mockMobileDevices) || state.devices;
+        },
+        revokeDevice: async function (deviceId) {
+          state.devices = state.devices.filter(function (device) { return device.deviceId !== deviceId; });
+        },
+        setDeviceCapabilities: async function (deviceId, capabilities) {
+          state.devices.forEach(function (device) {
+            if (device.deviceId === deviceId) device.capabilities = capabilities;
+          });
+        },
+        onPairingSas: function (callback) {
+          sasListeners.push(callback);
+          return function () {
+            var index = sasListeners.indexOf(callback);
+            if (index >= 0) sasListeners.splice(index, 1);
+          };
+        },
+        onPairingEnded: function (callback) {
+          pairingEndedListeners.push(callback);
+          return function () {
+            var index = pairingEndedListeners.indexOf(callback);
+            if (index >= 0) pairingEndedListeners.splice(index, 1);
+          };
+        },
+        onStateChanged: function (callback) {
+          stateChangedListeners.push(callback);
+          return function () {
+            var index = stateChangedListeners.indexOf(callback);
+            if (index >= 0) stateChangedListeners.splice(index, 1);
+          };
+        },
+      };
+    })(),
+
     boardConfig: {
       exists: async function () { return false; },
       export: async function () {},

--- a/tests/unit/config-handler-wiring.test.ts
+++ b/tests/unit/config-handler-wiring.test.ts
@@ -175,6 +175,7 @@ function makeContext(overrides?: {
     currentProjectPath: overrides?.currentProjectPath ?? null,
     currentProjectId: overrides?.currentProjectId ?? null,
     mcpServerHandle: null,
+    mobileBridgeService: { reconcile: vi.fn() },
   };
 }
 
@@ -266,6 +267,63 @@ describe('CONFIG_SET IPC handler - retrieval-service reconcileEmbedWorker wiring
     await Promise.resolve();
 
     expect(reconcileEmbedWorkerSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('CONFIG_SET IPC handler - mobileBridgeService reconcile wiring', () => {
+  // Regression guard: toggling mobileBridge.enabled or editing relayUrl in
+  // Settings must take effect immediately (no app/project reopen), by
+  // calling mobileBridgeService.reconcile() with the freshly-saved
+  // EFFECTIVE config's mobileBridge fields - not the raw partial `config`
+  // argument, which may omit relayUrl entirely on an enabled-only toggle.
+  beforeEach(() => {
+    capturedHandlers.clear();
+    capturedOnHandlers.clear();
+    applyRuntimeConfigSpy.mockClear();
+  });
+
+  it('calls mobileBridgeService.reconcile() with the effective config when the saved config includes a mobileBridge key', () => {
+    const context = makeContext({ currentProjectPath: '/repo/main' });
+    context.configManager.getEffectiveConfig.mockReturnValue({
+      agent: { maxConcurrentSessions: 5, idleTimeoutMinutes: 30 },
+      terminal: { shell: null },
+      mobileBridge: { enabled: true, relayUrl: 'wss://relay.example.com' },
+    });
+    registerSystemHandlers(context as Parameters<typeof registerSystemHandlers>[0]);
+
+    invokeHandler('config:set', { mobileBridge: { enabled: true } });
+
+    expect(context.mobileBridgeService.reconcile).toHaveBeenCalledTimes(1);
+    expect(context.mobileBridgeService.reconcile).toHaveBeenCalledWith({
+      enabled: true,
+      relayUrl: 'wss://relay.example.com',
+    });
+  });
+
+  it('defaults enabled to false and relayUrl to empty string when the effective config omits mobileBridge fields', () => {
+    const context = makeContext({ currentProjectPath: '/repo/main' });
+    context.configManager.getEffectiveConfig.mockReturnValue({
+      agent: { maxConcurrentSessions: 5, idleTimeoutMinutes: 30 },
+      terminal: { shell: null },
+      mobileBridge: {},
+    });
+    registerSystemHandlers(context as Parameters<typeof registerSystemHandlers>[0]);
+
+    invokeHandler('config:set', { mobileBridge: { enabled: false } });
+
+    expect(context.mobileBridgeService.reconcile).toHaveBeenCalledWith({
+      enabled: false,
+      relayUrl: '',
+    });
+  });
+
+  it('does NOT call mobileBridgeService.reconcile() when the saved config has no mobileBridge key', () => {
+    const context = makeContext({ currentProjectPath: '/repo/main' });
+    registerSystemHandlers(context as Parameters<typeof registerSystemHandlers>[0]);
+
+    invokeHandler('config:set', { terminal: { shell: '/usr/bin/zsh' } });
+
+    expect(context.mobileBridgeService.reconcile).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/mobile-bridge/bridge-session.test.ts
+++ b/tests/unit/mobile-bridge/bridge-session.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Unit tests for src/main/mobile-bridge/session/bridge-session.ts, the
+ * ongoing (post-pairing) Noise KK session. BridgeSession is hardcoded to
+ * the Noise INITIATOR role (the desktop always drives the ~2-minute
+ * re-handshake timer), so these tests drive the RESPONDER side by hand
+ * directly against @kangentic/protocol - exactly what the (not-yet-built)
+ * mobile app's own session client will do - using the same
+ * SessionFrameKind wrap/unwrap the production code uses to disambiguate
+ * handshake frames from application frames on the shared connection.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createKKHandshake,
+  decodeMessage,
+  deriveSecretstreamPair,
+  encodeMessage,
+  generateEd25519KeyPair,
+  generateX25519KeyPair,
+  SessionFrameKind,
+  unwrapSessionFrame,
+  wrapSessionFrame,
+  type BridgeMessage,
+  type CapabilitySet,
+  type HandshakeState,
+  type SecretstreamDirectionPair,
+  type Transport,
+} from '@kangentic/protocol';
+import { BridgeSession } from '../../../src/main/mobile-bridge/session/bridge-session';
+import type { BridgeIdentity } from '../../../src/main/mobile-bridge/identity';
+
+function testIdentity(): BridgeIdentity {
+  return {
+    staticKeyPair: generateX25519KeyPair(),
+    masterSigningKeyPair: generateEd25519KeyPair(),
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function createLoopbackTransportPair(): [Transport, Transport] {
+  const listenersOfFirst = new Set<(frame: Uint8Array) => void>();
+  const listenersOfSecond = new Set<(frame: Uint8Array) => void>();
+
+  const first: Transport = {
+    state: 'connected',
+    connect: () => Promise.resolve(),
+    send: (frame) => {
+      for (const listener of listenersOfSecond) listener(frame);
+    },
+    close: () => undefined,
+    onFrame: (listener) => {
+      listenersOfFirst.add(listener);
+      return () => listenersOfFirst.delete(listener);
+    },
+    onStateChange: () => () => undefined,
+  };
+
+  const second: Transport = {
+    state: 'connected',
+    connect: () => Promise.resolve(),
+    send: (frame) => {
+      for (const listener of listenersOfFirst) listener(frame);
+    },
+    close: () => undefined,
+    onFrame: (listener) => {
+      listenersOfSecond.add(listener);
+      return () => listenersOfSecond.delete(listener);
+    },
+    onStateChange: () => () => undefined,
+  };
+
+  return [first, second];
+}
+
+/** Drives the responder side of the Noise KK handshake and the resulting secretstream pair, by hand, against a raw loopback Transport. */
+class SimulatedDeviceResponder {
+  private handshake: HandshakeState;
+  streams: SecretstreamDirectionPair | null = null;
+  readonly receivedMessages: BridgeMessage[] = [];
+
+  constructor(
+    private readonly deviceStatic: ReturnType<typeof generateX25519KeyPair>,
+    desktopStaticPublicKey: Uint8Array,
+    private readonly transport: Transport,
+  ) {
+    this.handshake = createKKHandshake({ initiator: false, localStatic: deviceStatic, remoteStatic: desktopStaticPublicKey });
+    transport.onFrame((frame) => this.onFrame(frame));
+  }
+
+  private onFrame(rawFrame: Uint8Array): void {
+    const { kind, payload } = unwrapSessionFrame(rawFrame);
+    if (kind === SessionFrameKind.Handshake) {
+      // KK is two messages: reading message 1 (desktop's) never splits;
+      // writing message 2 (this side's reply) is the one that completes
+      // the handshake, so `split` comes from THIS call, not the read above.
+      this.handshake.readMessage(payload);
+      const { message, split } = this.handshake.writeMessage(new Uint8Array(0));
+      this.transport.send(wrapSessionFrame(SessionFrameKind.Handshake, message));
+      if (split) {
+        this.streams = deriveSecretstreamPair(this.handshake.getChainingKey(), false);
+      }
+    } else {
+      if (!this.streams) throw new Error('Received an application frame before the handshake completed');
+      const { plaintext } = this.streams.receive.open(payload);
+      this.receivedMessages.push(decodeMessage(plaintext));
+    }
+  }
+
+  send(message: BridgeMessage): void {
+    if (!this.streams) throw new Error('Cannot send before the session is established');
+    const frame = this.streams.send.seal(encodeMessage(message));
+    this.transport.send(wrapSessionFrame(SessionFrameKind.Application, frame));
+  }
+}
+
+describe('BridgeSession', () => {
+  it('establishes a KK session with a responder and exchanges an application message', async () => {
+    const desktopIdentity = testIdentity();
+    const deviceStatic = generateX25519KeyPair();
+    const [desktopTransport, deviceTransport] = createLoopbackTransportPair();
+    const capabilities: CapabilitySet = new Set(['read-board']);
+
+    const responder = new SimulatedDeviceResponder(deviceStatic, desktopIdentity.staticKeyPair.publicKey, deviceTransport);
+    const session = new BridgeSession({
+      identity: desktopIdentity,
+      deviceId: 'device-1',
+      remoteStaticPublicKey: deviceStatic.publicKey,
+      capabilities,
+      transport: desktopTransport,
+    });
+
+    const established = new Promise<void>((resolve) => session.once('established', resolve));
+    session.start();
+    await established;
+
+    expect(session.isEstablished).toBe(true);
+
+    session.sendMessage({ type: 'heartbeat' });
+    expect(responder.receivedMessages).toEqual([{ type: 'heartbeat' }]);
+
+    responder.send({ type: 'heartbeat' });
+    // Give the synchronous loopback delivery a microtask tick to land the emit.
+    await Promise.resolve();
+    session.dispose();
+  });
+
+  it('emits frameRejected for a garbled application frame instead of throwing', async () => {
+    const desktopIdentity = testIdentity();
+    const deviceStatic = generateX25519KeyPair();
+    const [desktopTransport, deviceTransport] = createLoopbackTransportPair();
+
+    new SimulatedDeviceResponder(deviceStatic, desktopIdentity.staticKeyPair.publicKey, deviceTransport);
+    const session = new BridgeSession({
+      identity: desktopIdentity,
+      deviceId: 'device-1',
+      remoteStaticPublicKey: deviceStatic.publicKey,
+      capabilities: new Set(),
+      transport: desktopTransport,
+    });
+
+    const established = new Promise<void>((resolve) => session.once('established', resolve));
+    session.start();
+    await established;
+
+    const rejectedPromise = new Promise<unknown>((resolve) => session.once('frameRejected', resolve));
+    const garbled = wrapSessionFrame(SessionFrameKind.Application, new Uint8Array([1, 2, 3, 4, 5]));
+    deviceTransport.send(garbled);
+
+    const rejection = await rejectedPromise;
+    expect(rejection).toBeInstanceOf(Error);
+    session.dispose();
+  });
+
+  it('sendMessage() throws before the session is established', () => {
+    const desktopIdentity = testIdentity();
+    const deviceStatic = generateX25519KeyPair();
+    const [desktopTransport] = createLoopbackTransportPair();
+
+    const session = new BridgeSession({
+      identity: desktopIdentity,
+      deviceId: 'device-1',
+      remoteStaticPublicKey: deviceStatic.publicKey,
+      capabilities: new Set(),
+      transport: desktopTransport,
+    });
+
+    expect(() => session.sendMessage({ type: 'heartbeat' })).toThrow(/not established/);
+  });
+
+  it('dispose() unsubscribes from the transport so no further frames are processed', async () => {
+    const desktopIdentity = testIdentity();
+    const deviceStatic = generateX25519KeyPair();
+    const [desktopTransport, deviceTransport] = createLoopbackTransportPair();
+
+    const responder = new SimulatedDeviceResponder(deviceStatic, desktopIdentity.staticKeyPair.publicKey, deviceTransport);
+    const session = new BridgeSession({
+      identity: desktopIdentity,
+      deviceId: 'device-1',
+      remoteStaticPublicKey: deviceStatic.publicKey,
+      capabilities: new Set(),
+      transport: desktopTransport,
+    });
+
+    const established = new Promise<void>((resolve) => session.once('established', resolve));
+    session.start();
+    await established;
+
+    const messageListener = vi.fn();
+    session.on('message', messageListener);
+    session.dispose();
+
+    responder.send({ type: 'heartbeat' });
+    await Promise.resolve();
+    expect(messageListener).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/mobile-bridge/capability-router.test.ts
+++ b/tests/unit/mobile-bridge/capability-router.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for src/main/mobile-bridge/capability-router.ts. The
+ * load-bearing property: authorization is checked against the SESSION's
+ * capability set BEFORE a handler is even looked up, so a device without
+ * a granted verb never reaches a registered handler, and a granted-but-
+ * unregistered verb fails closed with a clear error rather than doing
+ * nothing silently.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { CapabilityRequestMessage } from '@kangentic/protocol';
+import { CapabilityRouter } from '../../../src/main/mobile-bridge/capability-router';
+import type { BridgeSession } from '../../../src/main/mobile-bridge/session/bridge-session';
+
+function fakeSession(capabilities: string[]): BridgeSession {
+  return { capabilities: new Set(capabilities) } as unknown as BridgeSession;
+}
+
+function fakeRequest(verb: CapabilityRequestMessage['verb'], overrides: Partial<CapabilityRequestMessage> = {}): CapabilityRequestMessage {
+  return { type: 'capability-request', requestId: 'req-1', verb, payload: {}, ...overrides };
+}
+
+describe('CapabilityRouter', () => {
+  it('refuses an unauthorized verb without ever calling a registered handler', async () => {
+    const router = new CapabilityRouter();
+    const handler = vi.fn();
+    router.register('move-task', handler);
+
+    const session = fakeSession(['read-board']); // no move-task
+    const response = await router.dispatch(fakeRequest('move-task'), session);
+
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/not authorized/i);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('fails closed with a clear error for an authorized but unregistered verb', async () => {
+    const router = new CapabilityRouter();
+    const session = fakeSession(['move-task']);
+
+    const response = await router.dispatch(fakeRequest('move-task'), session);
+
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/no handler registered/i);
+  });
+
+  it('dispatches to the registered handler when the verb is authorized', async () => {
+    const router = new CapabilityRouter();
+    const session = fakeSession(['read-board']);
+    router.register('read-board', (request) => ({ type: 'capability-response', requestId: request.requestId, ok: true, payload: { columns: [] } }));
+
+    const response = await router.dispatch(fakeRequest('read-board'), session);
+
+    expect(response.ok).toBe(true);
+    expect(response.payload).toEqual({ columns: [] });
+  });
+
+  it('supports an async handler', async () => {
+    const router = new CapabilityRouter();
+    const session = fakeSession(['read-diff']);
+    router.register('read-diff', async (request) => {
+      await Promise.resolve();
+      return { type: 'capability-response', requestId: request.requestId, ok: true };
+    });
+
+    const response = await router.dispatch(fakeRequest('read-diff'), session);
+    expect(response.ok).toBe(true);
+  });
+
+  it('catches a handler that throws and returns a failed response instead of rejecting', async () => {
+    const router = new CapabilityRouter();
+    const session = fakeSession(['answer-permission-prompt']);
+    router.register('answer-permission-prompt', () => {
+      throw new Error('handler exploded');
+    });
+
+    const response = await router.dispatch(fakeRequest('answer-permission-prompt'), session);
+    expect(response.ok).toBe(false);
+    expect(response.error).toBe('handler exploded');
+  });
+
+  it('unregister() removes a handler so the verb falls back to fail-closed', async () => {
+    const router = new CapabilityRouter();
+    const session = fakeSession(['read-stream']);
+    router.register('read-stream', () => ({ type: 'capability-response', requestId: 'x', ok: true }));
+    router.unregister('read-stream');
+
+    const response = await router.dispatch(fakeRequest('read-stream'), session);
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/no handler registered/i);
+  });
+
+  it('every response carries the original requestId', async () => {
+    const router = new CapabilityRouter();
+    const session = fakeSession([]);
+    const response = await router.dispatch(fakeRequest('send-user-message', { requestId: 'abc-123' }), session);
+    expect(response.requestId).toBe('abc-123');
+  });
+});

--- a/tests/unit/mobile-bridge/identity.test.ts
+++ b/tests/unit/mobile-bridge/identity.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for src/main/mobile-bridge/identity.ts
+ *
+ * Verifies that loadBridgeIdentity/loadOrCreateBridgeIdentity/clearBridgeIdentity
+ * persist the desktop's mobile-bridge identity (an X25519 static keypair plus
+ * an Ed25519 master signing keypair) correctly, and - the load-bearing safety
+ * property of this module - that loadOrCreateBridgeIdentity() REFUSES to
+ * generate and persist a brand-new private key when genuine encryption is
+ * unavailable (Linux basic_text safeStorage backend, or safeStorage disabled
+ * entirely), rather than silently writing an unprotected key to disk.
+ *
+ * Mirrors the mocking pattern from tests/unit/asana-credential-store.test.ts
+ * and tests/unit/boards-auth.test.ts: the electron module is mocked so
+ * safeStorage never touches a real OS keychain, node:fs is mocked (both
+ * named exports and a bundled `default`, since fs is imported CJS-style) so
+ * no real file I/O occurs, and PATHS is mocked to a stable fake configDir.
+ * Unlike the asana test, encryptSecret/decryptSecret from
+ * src/main/boards/shared/auth.ts are NOT mocked - they run for real against
+ * the mocked safeStorage, so an encrypt-then-decrypt round trip through this
+ * test exercises the real sentinel + JSON envelope logic end to end.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Electron mock: a reversible "encrypted:<plaintext>" scheme so encryptSecret/
+// decryptSecret (which run for real) can genuinely round-trip through it. ---
+const mockElectronState = {
+  isEncryptionAvailable: true,
+  storageBackend: 'keychain' as string,
+};
+
+vi.mock('electron', () => ({
+  app: {
+    isReady: () => true,
+    whenReady: () => Promise.resolve(),
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => mockElectronState.isEncryptionAvailable,
+    encryptString: (plaintext: string) => Buffer.from(`encrypted:${plaintext}`, 'utf8'),
+    decryptString: (buffer: Buffer) => {
+      const raw = buffer.toString('utf8');
+      if (raw.startsWith('encrypted:')) return raw.slice('encrypted:'.length);
+      throw new Error('safeStorage.decryptString: invalid ciphertext');
+    },
+    getSelectedStorageBackend: () => mockElectronState.storageBackend,
+  },
+}));
+
+// --- Mock node:fs so no real file I/O occurs. Bundle both named exports and a
+// `default` object, since identity.ts imports fs as a CJS-style default. ---
+const existsSyncSpy = vi.hoisted(() => vi.fn<(filePath: string) => boolean>());
+const readFileSyncSpy = vi.hoisted(() => vi.fn<(filePath: string, encoding: BufferEncoding) => string>());
+const writeFileSyncSpy = vi.hoisted(() => vi.fn<(filePath: string, data: string) => void>());
+const mkdirSyncSpy = vi.hoisted(() => vi.fn());
+const unlinkSyncSpy = vi.hoisted(() => vi.fn());
+const rmSyncSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: existsSyncSpy,
+      readFileSync: readFileSyncSpy,
+      writeFileSync: writeFileSyncSpy,
+      mkdirSync: mkdirSyncSpy,
+      unlinkSync: unlinkSyncSpy,
+      rmSync: rmSyncSpy,
+    },
+    existsSync: existsSyncSpy,
+    readFileSync: readFileSyncSpy,
+    writeFileSync: writeFileSyncSpy,
+    mkdirSync: mkdirSyncSpy,
+    unlinkSync: unlinkSyncSpy,
+    rmSync: rmSyncSpy,
+  };
+});
+
+// --- Mock PATHS so identityPath() produces a stable, fake path. ---
+vi.mock('../../../src/main/config/paths', () => ({
+  PATHS: { configDir: '/mock/config' },
+}));
+
+// Import AFTER all vi.mock declarations.
+const { loadBridgeIdentity, loadOrCreateBridgeIdentity, clearBridgeIdentity } = await import(
+  '../../../src/main/mobile-bridge/identity'
+);
+
+beforeEach(() => {
+  existsSyncSpy.mockReset();
+  readFileSyncSpy.mockReset();
+  writeFileSyncSpy.mockReset();
+  mkdirSyncSpy.mockReset();
+  unlinkSyncSpy.mockReset();
+  rmSyncSpy.mockReset();
+  mockElectronState.isEncryptionAvailable = true;
+  mockElectronState.storageBackend = 'keychain';
+});
+
+describe('loadBridgeIdentity', () => {
+  it('returns null when the identity file does not exist', () => {
+    existsSyncSpy.mockReturnValue(false);
+    expect(loadBridgeIdentity()).toBeNull();
+  });
+
+  it('returns null and logs a warning when the file contains invalid JSON', () => {
+    existsSyncSpy.mockReturnValue(true);
+    readFileSyncSpy.mockReturnValue('not-valid-json');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const result = loadBridgeIdentity();
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('mobile-bridge/identity'),
+      expect.any(Error),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('returns null when the JSON file has no encrypted field', () => {
+    existsSyncSpy.mockReturnValue(true);
+    readFileSyncSpy.mockReturnValue(JSON.stringify({ someOtherKey: 'value' }));
+
+    expect(loadBridgeIdentity()).toBeNull();
+  });
+
+  it('returns null when the decrypted JSON is missing staticSecretKeyHex', () => {
+    existsSyncSpy.mockReturnValue(true);
+    const malformed = { masterSigningSecretKeyHex: 'ab', createdAt: new Date().toISOString() };
+    // Build the stored envelope the way saveBridgeIdentity would: 'e' + base64(safeStorage output).
+    const cipherBuffer = Buffer.from(`encrypted:${JSON.stringify(malformed)}`, 'utf8');
+    readFileSyncSpy.mockReturnValue(
+      JSON.stringify({ encrypted: 'e' + cipherBuffer.toString('base64') }),
+    );
+
+    expect(loadBridgeIdentity()).toBeNull();
+  });
+
+  it('returns null when the decrypted JSON has an empty staticSecretKeyHex', () => {
+    existsSyncSpy.mockReturnValue(true);
+    const malformed = {
+      staticSecretKeyHex: '',
+      staticPublicKeyHex: 'ab',
+      masterSigningSecretKeyHex: 'ab',
+      masterSigningPublicKeyHex: 'ab',
+      createdAt: new Date().toISOString(),
+    };
+    const cipherBuffer = Buffer.from(`encrypted:${JSON.stringify(malformed)}`, 'utf8');
+    readFileSyncSpy.mockReturnValue(
+      JSON.stringify({ encrypted: 'e' + cipherBuffer.toString('base64') }),
+    );
+
+    expect(loadBridgeIdentity()).toBeNull();
+  });
+});
+
+describe('loadOrCreateBridgeIdentity', () => {
+  it('generates and persists a new identity when none exists', () => {
+    existsSyncSpy.mockReturnValue(false);
+
+    const identity = loadOrCreateBridgeIdentity();
+
+    expect(writeFileSyncSpy).toHaveBeenCalledTimes(1);
+    expect(identity.staticKeyPair.secretKey).toHaveLength(32);
+    expect(identity.staticKeyPair.publicKey).toHaveLength(32);
+    expect(identity.masterSigningKeyPair.secretKey).toHaveLength(32);
+    expect(identity.masterSigningKeyPair.publicKey).toHaveLength(32);
+    expect(identity.createdAt).toEqual(expect.any(String));
+    expect(() => new Date(identity.createdAt).toISOString()).not.toThrow();
+  });
+
+  it('returns the existing identity without calling writeFileSync when one is already persisted', () => {
+    existsSyncSpy.mockReturnValue(false);
+    const created = loadOrCreateBridgeIdentity();
+    const writtenPayload = writeFileSyncSpy.mock.calls[0][1] as string;
+
+    // Simulate a fresh process: the file now "exists" and readFileSync returns
+    // exactly what saveBridgeIdentity wrote.
+    writeFileSyncSpy.mockClear();
+    existsSyncSpy.mockReturnValue(true);
+    readFileSyncSpy.mockReturnValue(writtenPayload);
+
+    const loaded = loadOrCreateBridgeIdentity();
+
+    expect(writeFileSyncSpy).not.toHaveBeenCalled();
+    expect(Buffer.from(loaded.staticKeyPair.secretKey).toString('hex')).toBe(
+      Buffer.from(created.staticKeyPair.secretKey).toString('hex'),
+    );
+    expect(Buffer.from(loaded.staticKeyPair.publicKey).toString('hex')).toBe(
+      Buffer.from(created.staticKeyPair.publicKey).toString('hex'),
+    );
+    expect(Buffer.from(loaded.masterSigningKeyPair.secretKey).toString('hex')).toBe(
+      Buffer.from(created.masterSigningKeyPair.secretKey).toString('hex'),
+    );
+    expect(Buffer.from(loaded.masterSigningKeyPair.publicKey).toString('hex')).toBe(
+      Buffer.from(created.masterSigningKeyPair.publicKey).toString('hex'),
+    );
+    expect(loaded.createdAt).toBe(created.createdAt);
+  });
+
+  it('throws and does not call writeFileSync when safeStorage.isEncryptionAvailable() is false', () => {
+    existsSyncSpy.mockReturnValue(false);
+    mockElectronState.isEncryptionAvailable = false;
+
+    expect(() => loadOrCreateBridgeIdentity()).toThrow(/secure storage is unavailable/);
+    expect(writeFileSyncSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws and does not call writeFileSync on Linux with the basic_text storage backend', () => {
+    existsSyncSpy.mockReturnValue(false);
+    mockElectronState.storageBackend = 'basic_text';
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+    try {
+      expect(() => loadOrCreateBridgeIdentity()).toThrow(/secure storage is unavailable/);
+      expect(writeFileSyncSpy).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    }
+  });
+});
+
+describe('clearBridgeIdentity', () => {
+  it('removes the identity file via rmSync with force (no existsSync gate, Windows-lock safe)', () => {
+    clearBridgeIdentity();
+    expect(rmSyncSpy).toHaveBeenCalledTimes(1);
+    expect(rmSyncSpy).toHaveBeenCalledWith(expect.stringContaining('mobile-bridge-identity.json'), { force: true });
+  });
+
+  it('swallows a transient filesystem error (e.g. a Windows file lock) rather than throwing', () => {
+    rmSyncSpy.mockImplementation(() => {
+      throw new Error('EBUSY: resource busy or locked');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    expect(() => clearBridgeIdentity()).not.toThrow();
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/unit/mobile-bridge/mobile-bridge-ipc-handler.test.ts
+++ b/tests/unit/mobile-bridge/mobile-bridge-ipc-handler.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for src/main/ipc/handlers/mobile-bridge.ts.
+ *
+ * Every other mobile-bridge test file (mobile-bridge-service.test.ts,
+ * pairing-service.test.ts, etc.) exercises MobileBridgeService directly.
+ * Nothing exercised the IPC handler layer itself: whether each channel
+ * forwards to the right service method with the right arguments and shapes
+ * its return value correctly, and whether the three push-event listeners
+ * (pairingSas, pairingEnded, stateChanged) forward the service's emitted
+ * payloads to the renderer and honor the mainWindow.isDestroyed() guard
+ * documented on every other push-event handler in the codebase.
+ *
+ * Strategy mirrors config-handler-wiring.test.ts: mock electron's ipcMain to
+ * capture registered handlers, build a fake MobileBridgeService (a real
+ * EventEmitter so service.on(...) wiring is exercised for real, with spied
+ * methods), then invoke the captured handlers directly.
+ */
+import { EventEmitter } from 'node:events';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { IPC } from '../../../src/shared/ipc-channels';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const capturedHandlers = new Map<string, (...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      capturedHandlers.set(channel, handler);
+    }),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after the electron mock)
+// ---------------------------------------------------------------------------
+
+import { registerMobileBridgeHandlers } from '../../../src/main/ipc/handlers/mobile-bridge';
+import type { IpcContext } from '../../../src/main/ipc/ipc-context';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+class FakeMobileBridgeService extends EventEmitter {
+  getStatus = vi.fn(() => ({
+    enabled: true,
+    secureStorageAvailable: true,
+    identityFingerprint: 'deadbeef',
+    relayUrl: 'wss://relay.example.com',
+    pairedDeviceCount: 0,
+    pairingInProgress: false,
+  }));
+  startPairing = vi.fn(async () => ({
+    qrPayload: { expiresAt: '2026-01-01T00:10:00.000Z' } as { expiresAt: string },
+    qrUri: 'kangentic-pair://mock',
+  }));
+  confirmPairing = vi.fn();
+  cancelPairing = vi.fn();
+  listDevices = vi.fn(() => []);
+  revokeDevice = vi.fn();
+  setDeviceCapabilities = vi.fn();
+}
+
+function makeContext(overrides?: { isDestroyed?: boolean }): IpcContext & { mobileBridgeService: FakeMobileBridgeService } {
+  const mobileBridgeService = new FakeMobileBridgeService();
+  const mainWindow = {
+    isDestroyed: vi.fn(() => overrides?.isDestroyed ?? false),
+    webContents: { send: vi.fn() },
+  };
+  return {
+    mainWindow,
+    mobileBridgeService,
+  } as unknown as IpcContext & { mobileBridgeService: FakeMobileBridgeService };
+}
+
+function invokeHandler(channel: string, ...args: unknown[]): unknown {
+  const handler = capturedHandlers.get(channel);
+  if (!handler) throw new Error(`Handler not registered for channel: ${channel}`);
+  return handler(undefined, ...args);
+}
+
+describe('registerMobileBridgeHandlers - request/response channels', () => {
+  beforeEach(() => {
+    capturedHandlers.clear();
+  });
+
+  it('MOBILE_GET_STATUS forwards to service.getStatus() and returns its result verbatim', () => {
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    const result = invokeHandler(IPC.MOBILE_GET_STATUS);
+
+    expect(context.mobileBridgeService.getStatus).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(context.mobileBridgeService.getStatus.mock.results[0]!.value);
+  });
+
+  it('MOBILE_START_PAIRING forwards to service.startPairing() and reshapes the result to { qrUri, expiresAt }', async () => {
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    const result = await invokeHandler(IPC.MOBILE_START_PAIRING);
+
+    expect(context.mobileBridgeService.startPairing).toHaveBeenCalledTimes(1);
+    // The handler must NOT leak the full qrPayload (desktopStaticPublicKey,
+    // pairingToken) to the renderer - only qrUri and expiresAt.
+    expect(result).toEqual({ qrUri: 'kangentic-pair://mock', expiresAt: '2026-01-01T00:10:00.000Z' });
+  });
+
+  it('MOBILE_CONFIRM_PAIRING forwards displayName and capabilities to service.confirmPairing()', () => {
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    invokeHandler(IPC.MOBILE_CONFIRM_PAIRING, "Tyler's Phone", ['read-board', 'move-task']);
+
+    expect(context.mobileBridgeService.confirmPairing).toHaveBeenCalledWith("Tyler's Phone", ['read-board', 'move-task']);
+  });
+
+  it('MOBILE_CONFIRM_PAIRING forwards an omitted capabilities arg as undefined (service applies its own default)', () => {
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    invokeHandler(IPC.MOBILE_CONFIRM_PAIRING, 'Paired Device');
+
+    expect(context.mobileBridgeService.confirmPairing).toHaveBeenCalledWith('Paired Device', undefined);
+  });
+
+  it('MOBILE_CANCEL_PAIRING forwards to service.cancelPairing() with no arguments', () => {
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    invokeHandler(IPC.MOBILE_CANCEL_PAIRING);
+
+    expect(context.mobileBridgeService.cancelPairing).toHaveBeenCalledWith();
+  });
+
+  it('MOBILE_LIST_DEVICES forwards to service.listDevices() and returns its result verbatim', () => {
+    const context = makeContext();
+    const seeded = [{ deviceId: 'd1', displayName: 'Phone', capabilities: [], pairedAt: '2026-01-01T00:00:00.000Z' }];
+    context.mobileBridgeService.listDevices.mockReturnValue(seeded);
+    registerMobileBridgeHandlers(context);
+
+    const result = invokeHandler(IPC.MOBILE_LIST_DEVICES);
+
+    expect(result).toBe(seeded);
+  });
+
+  it('MOBILE_REVOKE_DEVICE forwards the deviceId to service.revokeDevice()', () => {
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    invokeHandler(IPC.MOBILE_REVOKE_DEVICE, 'device-123');
+
+    expect(context.mobileBridgeService.revokeDevice).toHaveBeenCalledWith('device-123');
+  });
+
+  it('MOBILE_SET_DEVICE_CAPABILITIES forwards deviceId and capabilities to service.setDeviceCapabilities()', () => {
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    invokeHandler(IPC.MOBILE_SET_DEVICE_CAPABILITIES, 'device-123', ['read-stream']);
+
+    expect(context.mobileBridgeService.setDeviceCapabilities).toHaveBeenCalledWith('device-123', ['read-stream']);
+  });
+});
+
+describe('registerMobileBridgeHandlers - push events', () => {
+  beforeEach(() => {
+    capturedHandlers.clear();
+  });
+
+  it('forwards a pairingSas event to the renderer with the reshaped payload (drops any extra service fields)', () => {
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    context.mobileBridgeService.emit('pairingSas', {
+      sas: { digits: '123456', emoji: ['star', 'rocket'] },
+      phoneStaticPublicKeyHex: 'deadbeef',
+    });
+
+    expect(context.mainWindow.webContents.send).toHaveBeenCalledWith(IPC.MOBILE_PAIRING_SAS, {
+      digits: '123456',
+      emoji: ['star', 'rocket'],
+      phoneStaticPublicKeyHex: 'deadbeef',
+    });
+  });
+
+  it('does NOT forward a pairingSas event when the main window is destroyed', () => {
+    const context = makeContext({ isDestroyed: true });
+    registerMobileBridgeHandlers(context);
+
+    context.mobileBridgeService.emit('pairingSas', {
+      sas: { digits: '123456', emoji: [] },
+      phoneStaticPublicKeyHex: 'deadbeef',
+    });
+
+    expect(context.mainWindow.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('forwards a pairingEnded event to the renderer verbatim', () => {
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    context.mobileBridgeService.emit('pairingEnded', { reason: 'Cancelled by user' });
+
+    expect(context.mainWindow.webContents.send).toHaveBeenCalledWith(IPC.MOBILE_PAIRING_ENDED, { reason: 'Cancelled by user' });
+  });
+
+  it('does NOT forward a pairingEnded event when the main window is destroyed', () => {
+    const context = makeContext({ isDestroyed: true });
+    registerMobileBridgeHandlers(context);
+
+    context.mobileBridgeService.emit('pairingEnded', { reason: 'timeout' });
+
+    expect(context.mainWindow.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('forwards a stateChanged event to the renderer with no payload', () => {
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    context.mobileBridgeService.emit('stateChanged');
+
+    expect(context.mainWindow.webContents.send).toHaveBeenCalledWith(IPC.MOBILE_STATE_CHANGED);
+  });
+
+  it('does NOT forward a stateChanged event when the main window is destroyed', () => {
+    const context = makeContext({ isDestroyed: true });
+    registerMobileBridgeHandlers(context);
+
+    context.mobileBridgeService.emit('stateChanged');
+
+    expect(context.mainWindow.webContents.send).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/mobile-bridge/mobile-bridge-service.test.ts
+++ b/tests/unit/mobile-bridge/mobile-bridge-service.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for src/main/mobile-bridge/mobile-bridge-service.ts
+ *
+ * The load-bearing property covered here: merely checking status, listing
+ * devices, or opening the settings tab must NEVER have the side effect of
+ * generating and persisting a new device identity keypair. Only a
+ * deliberate "Pair a device" (startPairing()) does that. This was caught
+ * as a real bug during review - getStatus() originally called the
+ * create-if-missing path, so opening Settings with the bridge globally
+ * disabled would still silently write an identity file to disk.
+ *
+ * Mocking mirrors the other mobile-bridge tests: electron and node:fs are
+ * mocked so no real file I/O occurs, PATHS is mocked to a stable fake
+ * configDir, and transport-factory is mocked so startPairing() never opens
+ * a real socket (the relay client itself is covered by
+ * relay-pairing-integration.test.ts).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    isReady: () => true,
+    whenReady: () => Promise.resolve(),
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`encrypted:${plaintext}`, 'utf8'),
+    decryptString: (buffer: Buffer) => {
+      const raw = buffer.toString('utf8');
+      if (raw.startsWith('encrypted:')) return raw.slice('encrypted:'.length);
+      throw new Error('safeStorage.decryptString: invalid ciphertext');
+    },
+    getSelectedStorageBackend: () => 'keychain',
+  },
+}));
+
+const existsSyncSpy = vi.hoisted(() => vi.fn<(filePath: string) => boolean>());
+const readFileSyncSpy = vi.hoisted(() => vi.fn<(filePath: string, encoding: BufferEncoding) => string>());
+const writeFileSyncSpy = vi.hoisted(() => vi.fn<(filePath: string, data: string) => void>());
+const mkdirSyncSpy = vi.hoisted(() => vi.fn());
+const unlinkSyncSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: existsSyncSpy,
+      readFileSync: readFileSyncSpy,
+      writeFileSync: writeFileSyncSpy,
+      mkdirSync: mkdirSyncSpy,
+      unlinkSync: unlinkSyncSpy,
+    },
+    existsSync: existsSyncSpy,
+    readFileSync: readFileSyncSpy,
+    writeFileSync: writeFileSyncSpy,
+    mkdirSync: mkdirSyncSpy,
+    unlinkSync: unlinkSyncSpy,
+  };
+});
+
+vi.mock('../../../src/main/config/paths', () => ({
+  PATHS: { configDir: '/mock/config' },
+}));
+
+const fakeTransport = {
+  state: 'connected' as const,
+  connect: vi.fn(async () => undefined),
+  send: vi.fn(),
+  close: vi.fn(),
+  onFrame: vi.fn(() => () => undefined),
+  onStateChange: vi.fn(() => () => undefined),
+};
+
+vi.mock('../../../src/main/mobile-bridge/transport/transport-factory', () => ({
+  createTransport: vi.fn(() => fakeTransport),
+}));
+
+const { MobileBridgeService } = await import('../../../src/main/mobile-bridge/mobile-bridge-service');
+
+beforeEach(() => {
+  existsSyncSpy.mockReset();
+  readFileSyncSpy.mockReset();
+  writeFileSyncSpy.mockReset();
+  mkdirSyncSpy.mockReset();
+  unlinkSyncSpy.mockReset();
+  existsSyncSpy.mockReturnValue(false); // no identity/roster file exists yet, by default
+  fakeTransport.connect.mockClear();
+  fakeTransport.close.mockClear();
+});
+
+describe('MobileBridgeService read paths never create an identity', () => {
+  it('getStatus() does not persist an identity when none exists yet', () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const status = service.getStatus();
+
+    expect(writeFileSyncSpy).not.toHaveBeenCalled();
+    expect(status.identityFingerprint).toBeNull();
+    expect(status.pairedDeviceCount).toBe(0);
+    expect(status.enabled).toBe(true);
+  });
+
+  it('getStatus() reports the bridge as disabled without touching identity state', () => {
+    const service = new MobileBridgeService({ enabled: false, relayUrl: '' });
+    const status = service.getStatus();
+
+    expect(writeFileSyncSpy).not.toHaveBeenCalled();
+    expect(status.enabled).toBe(false);
+  });
+
+  it('listDevices() returns an empty array without persisting an identity when none exists', () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const devices = service.listDevices();
+
+    expect(devices).toEqual([]);
+    expect(writeFileSyncSpy).not.toHaveBeenCalled();
+  });
+
+  it('revokeDevice() is a no-op without persisting an identity when none exists', () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    expect(() => service.revokeDevice('some-device')).not.toThrow();
+    expect(writeFileSyncSpy).not.toHaveBeenCalled();
+  });
+
+  it('setDeviceCapabilities() throws rather than creating an identity when none exists', () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    expect(() => service.setDeviceCapabilities('some-device', ['read-board'])).toThrow(/No such paired device/);
+    expect(writeFileSyncSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('MobileBridgeService.startPairing() is the deliberate identity-creation trigger', () => {
+  it('creates and persists an identity on the first pairing attempt', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const { qrUri } = await service.startPairing();
+
+    expect(writeFileSyncSpy).toHaveBeenCalledTimes(1);
+    expect(qrUri.startsWith('kangentic-pair://')).toBe(true);
+    expect(fakeTransport.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws without creating an identity when the bridge is disabled', async () => {
+    const service = new MobileBridgeService({ enabled: false, relayUrl: '' });
+    await expect(service.startPairing()).rejects.toThrow(/not enabled/);
+    expect(writeFileSyncSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('MobileBridgeService.reconcile()', () => {
+  it('cancels an in-progress pairing when the bridge is disabled', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    await service.startPairing();
+    expect(service.getStatus().pairingInProgress).toBe(true);
+
+    service.reconcile({ enabled: false, relayUrl: '' });
+
+    expect(service.getStatus().pairingInProgress).toBe(false);
+    expect(fakeTransport.close).toHaveBeenCalled();
+  });
+});
+
+describe('MobileBridgeService.startPairing() closes the transport on a failed connect', () => {
+  it('closes the transport, clears activePairing, and rethrows when transport.connect() rejects', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    fakeTransport.connect.mockRejectedValueOnce(new Error('relay unreachable'));
+
+    await expect(service.startPairing()).rejects.toThrow(/relay unreachable/);
+
+    expect(fakeTransport.close).toHaveBeenCalledTimes(1);
+    expect(service.getStatus().pairingInProgress).toBe(false);
+  });
+});

--- a/tests/unit/mobile-bridge/pairing-service.test.ts
+++ b/tests/unit/mobile-bridge/pairing-service.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Unit tests for src/main/mobile-bridge/pairing/pairing-service.ts
+ *
+ * Drives a full pairing ceremony end to end over an in-memory loopback
+ * Transport pair, with the "phone" side built directly from
+ * @kangentic/protocol's createPairingInitiatorHandshake (the phone app
+ * itself is out of scope for this repo, so it is simulated by hand here,
+ * exactly the way a real phone would drive the initiator side of the Noise
+ * IKpsk0 handshake). This proves the desktop's responder wiring - token
+ * validation, message 2 construction, remote static key capture, and SAS
+ * derivation - against a real peer rather than against mocked crypto.
+ *
+ * PairingService itself needs no fs/electron mocking, but confirmSas()
+ * calls roster-store's addOrReplaceDevice(), which touches disk unless
+ * mocked. So this file carries the same electron+fs+PATHS mocking
+ * scaffolding as tests/unit/mobile-bridge/identity.test.ts and
+ * roster-store.test.ts (mirroring tests/unit/asana-credential-store.test.ts),
+ * even though PairingService's own logic never calls into electron.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createPairingInitiatorHandshake,
+  deriveShortAuthenticationString,
+  generateX25519KeyPair,
+  randomBytes,
+  bytesToHex,
+  type Transport,
+} from '@kangentic/protocol';
+import { PAIRING_TOKEN_TTL_MS } from '../../../src/main/mobile-bridge/pairing/pairing-token';
+
+vi.mock('electron', () => ({
+  app: {
+    isReady: () => true,
+    whenReady: () => Promise.resolve(),
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`encrypted:${plaintext}`, 'utf8'),
+    decryptString: (buffer: Buffer) => {
+      const raw = buffer.toString('utf8');
+      if (raw.startsWith('encrypted:')) return raw.slice('encrypted:'.length);
+      throw new Error('safeStorage.decryptString: invalid ciphertext');
+    },
+    getSelectedStorageBackend: () => 'keychain',
+  },
+}));
+
+const existsSyncSpy = vi.hoisted(() => vi.fn<(filePath: string) => boolean>());
+const readFileSyncSpy = vi.hoisted(() => vi.fn<(filePath: string, encoding: BufferEncoding) => string>());
+const writeFileSyncSpy = vi.hoisted(() => vi.fn<(filePath: string, data: string) => void>());
+const mkdirSyncSpy = vi.hoisted(() => vi.fn());
+const unlinkSyncSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: existsSyncSpy,
+      readFileSync: readFileSyncSpy,
+      writeFileSync: writeFileSyncSpy,
+      mkdirSync: mkdirSyncSpy,
+      unlinkSync: unlinkSyncSpy,
+    },
+    existsSync: existsSyncSpy,
+    readFileSync: readFileSyncSpy,
+    writeFileSync: writeFileSyncSpy,
+    mkdirSync: mkdirSyncSpy,
+    unlinkSync: unlinkSyncSpy,
+  };
+});
+
+vi.mock('../../../src/main/config/paths', () => ({
+  PATHS: { configDir: '/mock/config' },
+}));
+
+// Import AFTER all vi.mock declarations.
+const { PairingService, DEFAULT_PAIRING_CAPABILITIES } = await import(
+  '../../../src/main/mobile-bridge/pairing/pairing-service'
+);
+const { generateEd25519KeyPair } = await import('@kangentic/protocol');
+type BridgeIdentityModule = typeof import('../../../src/main/mobile-bridge/identity');
+type BridgeIdentity = ReturnType<BridgeIdentityModule['loadOrCreateBridgeIdentity']>;
+
+function testIdentity(): BridgeIdentity {
+  return {
+    staticKeyPair: generateX25519KeyPair(),
+    masterSigningKeyPair: generateEd25519KeyPair(),
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * A loopback pair simulating what a relay would do: sending on one half
+ * synchronously invokes the other half's registered onFrame listeners.
+ * Both PairingService's Noise responder and this test's simulated Noise
+ * initiator are fully synchronous per-message, so the entire ceremony
+ * (message 1 -> message 2 -> SAS emission) completes inside the single
+ * synchronous call to the first .send(), with no timers involved.
+ */
+function createLoopbackTransportPair(): [Transport, Transport] {
+  const listenersOfFirst = new Set<(frame: Uint8Array) => void>();
+  const listenersOfSecond = new Set<(frame: Uint8Array) => void>();
+
+  const first: Transport = {
+    state: 'connected',
+    connect: () => Promise.resolve(),
+    send: (frame) => {
+      for (const listener of listenersOfSecond) listener(frame);
+    },
+    close: () => undefined,
+    onFrame: (listener) => {
+      listenersOfFirst.add(listener);
+      return () => listenersOfFirst.delete(listener);
+    },
+    onStateChange: () => () => undefined,
+  };
+
+  const second: Transport = {
+    state: 'connected',
+    connect: () => Promise.resolve(),
+    send: (frame) => {
+      for (const listener of listenersOfFirst) listener(frame);
+    },
+    close: () => undefined,
+    onFrame: (listener) => {
+      listenersOfSecond.add(listener);
+      return () => listenersOfSecond.delete(listener);
+    },
+    onStateChange: () => () => undefined,
+  };
+
+  return [first, second];
+}
+
+beforeEach(() => {
+  existsSyncSpy.mockReset();
+  readFileSyncSpy.mockReset();
+  writeFileSyncSpy.mockReset();
+  mkdirSyncSpy.mockReset();
+  unlinkSyncSpy.mockReset();
+});
+
+describe('PairingService ceremony', () => {
+  it('completes the happy path: matching SAS on both sides, then confirmSas signs the device into the roster', async () => {
+    const identity = testIdentity();
+    const service = new PairingService(identity);
+    const token = service.mintToken();
+    const [desktopTransport, phoneTransport] = createLoopbackTransportPair();
+    service.start(desktopTransport);
+
+    const phoneStaticKeyPair = generateX25519KeyPair();
+    const phoneHandshake = createPairingInitiatorHandshake({
+      localStatic: phoneStaticKeyPair,
+      remoteStatic: identity.staticKeyPair.publicKey,
+      pairingToken: token.token,
+    });
+
+    let phoneComputedSas: ReturnType<typeof deriveShortAuthenticationString> | undefined;
+    phoneTransport.onFrame((frame) => {
+      phoneHandshake.readMessage(frame);
+      phoneComputedSas = deriveShortAuthenticationString(phoneHandshake.getHandshakeHash());
+    });
+
+    const sasEventPromise = new Promise<{
+      sas: ReturnType<typeof deriveShortAuthenticationString>;
+      phoneStaticPublicKeyHex: string;
+    }>((resolve) => {
+      service.once('sas', resolve);
+    });
+
+    const message1 = phoneHandshake.writeMessage(new TextEncoder().encode('Test Phone')).message;
+    phoneTransport.send(message1);
+
+    const sasEvent = await sasEventPromise;
+
+    expect(sasEvent.phoneStaticPublicKeyHex).toBe(bytesToHex(phoneStaticKeyPair.publicKey));
+    expect(phoneComputedSas).toBeDefined();
+    expect(sasEvent.sas).toEqual(phoneComputedSas);
+
+    const confirmedEventPromise = new Promise<{ deviceId: string }>((resolve) => {
+      service.once('confirmed', resolve);
+    });
+    service.confirmSas('device-abc', 'Test Phone');
+    const confirmedEvent = await confirmedEventPromise;
+
+    expect(confirmedEvent.deviceId).toBe('device-abc');
+  });
+
+  it('emits failed (not sas) when the phone uses the wrong pairing token', async () => {
+    const identity = testIdentity();
+    const service = new PairingService(identity);
+    const token = service.mintToken();
+    void token;
+    const [desktopTransport, phoneTransport] = createLoopbackTransportPair();
+    service.start(desktopTransport);
+
+    const phoneStaticKeyPair = generateX25519KeyPair();
+    const wrongToken = randomBytes(32);
+    const phoneHandshake = createPairingInitiatorHandshake({
+      localStatic: phoneStaticKeyPair,
+      remoteStatic: identity.staticKeyPair.publicKey,
+      pairingToken: wrongToken,
+    });
+
+    const sasListener = vi.fn();
+    service.on('sas', sasListener);
+    const failedEventPromise = new Promise<{ reason: string }>((resolve) => {
+      service.once('failed', resolve);
+    });
+
+    const message1 = phoneHandshake.writeMessage(new TextEncoder().encode('Test Phone')).message;
+    phoneTransport.send(message1);
+
+    const failedEvent = await failedEventPromise;
+
+    expect(failedEvent.reason).toEqual(expect.any(String));
+    expect(sasListener).not.toHaveBeenCalled();
+  });
+
+  it('start() before mintToken() throws synchronously', () => {
+    const identity = testIdentity();
+    const service = new PairingService(identity);
+    const [desktopTransport] = createLoopbackTransportPair();
+
+    expect(() => service.start(desktopTransport)).toThrow(/mintToken\(\) must be called before start\(\)/);
+  });
+
+  it('confirmSas() before the sas event has fired throws synchronously', () => {
+    const identity = testIdentity();
+    const service = new PairingService(identity);
+    service.mintToken();
+
+    expect(() => service.confirmSas('device-x', 'Some Device')).toThrow(/Cannot confirm pairing while phase is/);
+  });
+
+  it('cancel() before any frame arrives emits cancelled and does not throw', () => {
+    const identity = testIdentity();
+    const service = new PairingService(identity);
+    service.mintToken();
+    const [desktopTransport] = createLoopbackTransportPair();
+    service.start(desktopTransport);
+
+    const cancelledListener = vi.fn();
+    service.on('cancelled', cancelledListener);
+
+    expect(() => service.cancel('User backed out')).not.toThrow();
+    expect(cancelledListener).toHaveBeenCalledWith({ reason: 'User backed out' });
+  });
+});
+
+interface ParsedRosterFile {
+  devices: Array<{ deviceId: string; capabilities: string[] }>;
+}
+
+describe('PairingService.confirmSas default capabilities', () => {
+  it('persists the read-only default capability set when confirmSas is called without an explicit capabilities argument', async () => {
+    const identity = testIdentity();
+    const service = new PairingService(identity);
+    const token = service.mintToken();
+    const [desktopTransport, phoneTransport] = createLoopbackTransportPair();
+    service.start(desktopTransport);
+
+    const phoneStaticKeyPair = generateX25519KeyPair();
+    const phoneHandshake = createPairingInitiatorHandshake({
+      localStatic: phoneStaticKeyPair,
+      remoteStatic: identity.staticKeyPair.publicKey,
+      pairingToken: token.token,
+    });
+
+    const sasEventPromise = new Promise<void>((resolve) => {
+      service.once('sas', () => resolve());
+    });
+    const message1 = phoneHandshake.writeMessage(new TextEncoder().encode('Test Phone')).message;
+    phoneTransport.send(message1);
+    await sasEventPromise;
+
+    // Deliberately omit the capabilities argument - this is the exact call
+    // shape the settings UI makes for a brand-new pairing.
+    service.confirmSas('device-default-caps', 'Test Phone');
+
+    expect(writeFileSyncSpy).toHaveBeenCalledTimes(1);
+    const [, writtenJson] = writeFileSyncSpy.mock.calls[0] as [string, string];
+    const writtenRoster = JSON.parse(writtenJson) as ParsedRosterFile;
+    const persistedDevice = writtenRoster.devices.find((device) => device.deviceId === 'device-default-caps');
+
+    expect(persistedDevice).toBeDefined();
+    expect(persistedDevice?.capabilities).toEqual(DEFAULT_PAIRING_CAPABILITIES);
+    expect(persistedDevice?.capabilities).toEqual(['read-stream', 'read-board', 'read-diff']);
+  });
+});
+
+describe('PairingService pairing-token expiry and single-use enforcement', () => {
+  it('rejects a message-1 handshake attempt against an expired pairing token', async () => {
+    vi.useFakeTimers();
+    try {
+      const identity = testIdentity();
+      const service = new PairingService(identity);
+      const token = service.mintToken();
+      const [desktopTransport, phoneTransport] = createLoopbackTransportPair();
+      service.start(desktopTransport);
+
+      vi.advanceTimersByTime(PAIRING_TOKEN_TTL_MS + 1);
+
+      const phoneStaticKeyPair = generateX25519KeyPair();
+      const phoneHandshake = createPairingInitiatorHandshake({
+        localStatic: phoneStaticKeyPair,
+        remoteStatic: identity.staticKeyPair.publicKey,
+        pairingToken: token.token,
+      });
+
+      const sasListener = vi.fn();
+      service.on('sas', sasListener);
+      const failedEventPromise = new Promise<{ reason: string }>((resolve) => {
+        service.once('failed', resolve);
+      });
+
+      const message1 = phoneHandshake.writeMessage(new TextEncoder().encode('Test Phone')).message;
+      phoneTransport.send(message1);
+
+      const failedEvent = await failedEventPromise;
+      expect(failedEvent.reason).toMatch(/expired or already used/);
+      expect(sasListener).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects a handshake attempt once the pairing token has already been marked consumed', async () => {
+    const identity = testIdentity();
+    const service = new PairingService(identity);
+    const token = service.mintToken();
+    const [desktopTransport, phoneTransport] = createLoopbackTransportPair();
+    service.start(desktopTransport);
+
+    // Force the single-use flag directly rather than driving two full
+    // handshake attempts: a genuine second frame is unreachable through the
+    // public API here, because the first attempt's processing is entirely
+    // synchronous and always leaves "waiting-for-phone" (moving to either
+    // "sas-pending" or "done", tearing down the frame subscription) before a
+    // second frame could ever arrive. This isolates the "already consumed"
+    // branch of handleMessage1's validity check on its own.
+    (service as unknown as { activeToken: { consumed: boolean } }).activeToken.consumed = true;
+
+    const phoneStaticKeyPair = generateX25519KeyPair();
+    const phoneHandshake = createPairingInitiatorHandshake({
+      localStatic: phoneStaticKeyPair,
+      remoteStatic: identity.staticKeyPair.publicKey,
+      pairingToken: token.token,
+    });
+
+    const failedEventPromise = new Promise<{ reason: string }>((resolve) => {
+      service.once('failed', resolve);
+    });
+
+    const message1 = phoneHandshake.writeMessage(new TextEncoder().encode('Test Phone')).message;
+    phoneTransport.send(message1);
+
+    const failedEvent = await failedEventPromise;
+    expect(failedEvent.reason).toMatch(/expired or already used/);
+  });
+});

--- a/tests/unit/mobile-bridge/pairing-token.test.ts
+++ b/tests/unit/mobile-bridge/pairing-token.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for src/main/mobile-bridge/pairing/pairing-token.ts
+ *
+ * Pure logic, no fs/electron mocking needed: mintPairingToken() and
+ * isPairingTokenValid() only touch @kangentic/protocol's randomBytes() and
+ * an injectable `now` clock, so a real clock is never involved here.
+ *
+ * The service-level rejection behavior that consumes these checks (a
+ * message-1 handshake attempt against an expired or already-consumed
+ * token emitting 'failed') is covered in pairing-service.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { isPairingTokenValid, mintPairingToken, PAIRING_TOKEN_TTL_MS } from '../../../src/main/mobile-bridge/pairing/pairing-token';
+
+describe('pairing token validity', () => {
+  it('is valid immediately after minting', () => {
+    const now = 1_000_000;
+    const token = mintPairingToken(now);
+    expect(isPairingTokenValid(token, now)).toBe(true);
+  });
+
+  it('is valid the instant before expiresAt and invalid at or after it', () => {
+    const now = 1_000_000;
+    const token = mintPairingToken(now);
+
+    expect(isPairingTokenValid(token, token.expiresAt - 1)).toBe(true);
+    expect(isPairingTokenValid(token, token.expiresAt)).toBe(false);
+    expect(isPairingTokenValid(token, token.expiresAt + 1)).toBe(false);
+  });
+
+  it('is invalid once consumed, even when not yet expired', () => {
+    const now = 1_000_000;
+    const token = mintPairingToken(now);
+    token.consumed = true;
+
+    expect(isPairingTokenValid(token, now)).toBe(false);
+  });
+
+  it('mints a token with the documented 10 minute TTL', () => {
+    const now = 1_000_000;
+    const token = mintPairingToken(now);
+
+    expect(token.expiresAt - token.createdAt).toBe(PAIRING_TOKEN_TTL_MS);
+    expect(PAIRING_TOKEN_TTL_MS).toBe(10 * 60 * 1000);
+  });
+
+  it('defaults `now` to the current wall clock when omitted', () => {
+    const before = Date.now();
+    const token = mintPairingToken();
+    const after = Date.now();
+
+    expect(token.createdAt).toBeGreaterThanOrEqual(before);
+    expect(token.createdAt).toBeLessThanOrEqual(after);
+  });
+});

--- a/tests/unit/mobile-bridge/relay-client.test.ts
+++ b/tests/unit/mobile-bridge/relay-client.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for src/main/mobile-bridge/transport/relay-client.ts, focused
+ * on the reconnect behavior (the one Phase-1 deliverable this module owns
+ * that relay-pairing-integration.test.ts doesn't exercise - that file
+ * only covers a single successful connection through to pairing
+ * completion). Runs against a real local `ws` server (not the shared
+ * relay-double.ts, since these tests need to unilaterally drop a
+ * connection from the server side, which the double's pairing-rendezvous
+ * shape doesn't model).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { WebSocketServer } from 'ws';
+import { RelayClient } from '../../../src/main/mobile-bridge/transport/relay-client';
+
+/**
+ * A minimal controllable stand-in for the global `WebSocket` used only by
+ * the close-during-pending-connect test below. Deliberately never fires
+ * `onopen`/`onclose` on its own - the point of that test is to prove
+ * RelayClient.close() settles a still-pending connect() promise ITSELF,
+ * without depending on any later socket event (a real local `ws` server
+ * opens far too fast on localhost to reliably observe a still-CONNECTING
+ * socket, so this is not testable against a real socket).
+ */
+class FakeWebSocket {
+  binaryType = 'blob';
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  closeCallCount = 0;
+
+  constructor(readonly url: string) {}
+
+  send(): void {
+    // no-op: never reached by the pending-connect test.
+  }
+
+  close(): void {
+    this.closeCallCount += 1;
+    // Intentionally does NOT fire onclose - see class doc comment.
+  }
+}
+
+async function startEchoServer(): Promise<{ url: string; wss: WebSocketServer; connectionCount: () => number }> {
+  const wss = new WebSocketServer({ port: 0 });
+  let connectionCount = 0;
+  wss.on('connection', (socket) => {
+    connectionCount += 1;
+    socket.on('message', (data, isBinary) => socket.send(data, { binary: isBinary }));
+  });
+  await new Promise<void>((resolve) => wss.once('listening', resolve));
+  const address = wss.address();
+  if (!address || typeof address === 'string') throw new Error('Echo server failed to bind a port');
+  return { url: `ws://127.0.0.1:${address.port}`, wss, connectionCount: () => connectionCount };
+}
+
+describe('RelayClient', () => {
+  let activeClients: RelayClient[] = [];
+  let activeServers: WebSocketServer[] = [];
+
+  afterEach(async () => {
+    for (const client of activeClients) client.close();
+    activeClients = [];
+    await Promise.all(
+      activeServers.map(
+        (server) =>
+          new Promise<void>((resolve) => {
+            for (const socket of server.clients) socket.terminate();
+            server.close(() => resolve());
+          }),
+      ),
+    );
+    activeServers = [];
+  });
+
+  it('connects, sends, and receives a frame round trip', async () => {
+    const { url, wss } = await startEchoServer();
+    activeServers.push(wss);
+    const client = new RelayClient({ relayUrl: url, slotId: 'test-slot' });
+    activeClients.push(client);
+
+    await client.connect();
+    expect(client.state).toBe('connected');
+
+    const framePromise = new Promise<Uint8Array>((resolve) => {
+      client.onFrame(resolve);
+    });
+    client.send(new TextEncoder().encode('hello relay'));
+    const received = await framePromise;
+    expect(new TextDecoder().decode(received)).toBe('hello relay');
+  });
+
+  it('automatically reconnects after the server drops the connection', async () => {
+    const { url, wss, connectionCount } = await startEchoServer();
+    activeServers.push(wss);
+    const client = new RelayClient({ relayUrl: url, slotId: 'test-slot' });
+    activeClients.push(client);
+
+    await client.connect();
+    expect(connectionCount()).toBe(1);
+
+    const states: string[] = [];
+    client.onStateChange((state) => states.push(state));
+
+    const reconnected = new Promise<void>((resolve) => {
+      const unsubscribe = client.onStateChange((state) => {
+        if (state === 'connected') {
+          unsubscribe();
+          resolve();
+        }
+      });
+    });
+
+    // Drop the connection from the server side.
+    for (const socket of wss.clients) socket.terminate();
+
+    await reconnected;
+    expect(states).toContain('reconnecting');
+    expect(client.state).toBe('connected');
+    expect(connectionCount()).toBe(2);
+
+    // The reconnected socket still works.
+    const framePromise = new Promise<Uint8Array>((resolve) => client.onFrame(resolve));
+    client.send(new TextEncoder().encode('still alive'));
+    const received = await framePromise;
+    expect(new TextDecoder().decode(received)).toBe('still alive');
+  }, 15_000);
+
+  it('does not reconnect after an explicit close()', async () => {
+    const { url, wss } = await startEchoServer();
+    activeServers.push(wss);
+    const client = new RelayClient({ relayUrl: url, slotId: 'test-slot' });
+    activeClients.push(client);
+
+    await client.connect();
+    client.close();
+
+    expect(client.state).toBe('closed');
+    // Give any stray reconnect timer a chance to fire, if the bug existed.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(client.state).toBe('closed');
+  });
+
+  it('send() throws when called before connecting', () => {
+    const client = new RelayClient({ relayUrl: 'ws://127.0.0.1:1', slotId: 'test-slot' });
+    activeClients.push(client);
+    expect(() => client.send(new Uint8Array([1, 2, 3]))).toThrow(/not connected/);
+  });
+
+  it('send() throws once the per-session byte cap is exceeded', async () => {
+    const { url, wss } = await startEchoServer();
+    activeServers.push(wss);
+    const client = new RelayClient({ relayUrl: url, slotId: 'test-slot', maxBytesPerSession: 4 });
+    activeClients.push(client);
+
+    await client.connect();
+    expect(() => client.send(new Uint8Array(5))).toThrow(/byte cap/);
+  });
+
+  it('settles a still-pending connect() promise (rejects) when close() is called before the socket opens', async () => {
+    const fakeSockets: FakeWebSocket[] = [];
+    class TrackedFakeWebSocket extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        fakeSockets.push(this);
+      }
+    }
+    vi.stubGlobal('WebSocket', TrackedFakeWebSocket as unknown as typeof WebSocket);
+
+    try {
+      const client = new RelayClient({ relayUrl: 'ws://127.0.0.1:1', slotId: 'test-slot' });
+      activeClients.push(client);
+
+      // dial()'s Promise executor runs synchronously up through
+      // `new WebSocket(url)`, so by the time connect() returns, the fake
+      // socket already exists and onopen has NOT fired.
+      const connectPromise = client.connect();
+      expect(fakeSockets).toHaveLength(1);
+
+      client.close();
+
+      await expect(connectPromise).rejects.toThrow(/closed before it opened/);
+      expect(fakeSockets[0].closeCallCount).toBe(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/tests/unit/mobile-bridge/relay-double.ts
+++ b/tests/unit/mobile-bridge/relay-double.ts
@@ -1,0 +1,63 @@
+/**
+ * A minimal in-repo stand-in for the (separate, not-yet-built) relay
+ * server task: a "blind" WebSocket rendezvous that pairs up exactly two
+ * connections presenting the same `?slot=` query param and forwards raw
+ * frames between them byte-for-byte, reading nothing from the payload.
+ * This is the simplest possible interpretation of relay-client.ts's own
+ * documented wire contract, and is the closest to end-to-end this repo can
+ * exercise until the real relay repo exists - RelayClient's production
+ * code (real Node global WebSocket) connects to this exactly as it would
+ * to the eventual real relay.
+ */
+import { WebSocketServer, WebSocket as NodeWebSocket } from 'ws';
+
+export interface RelayDouble {
+  url: string;
+  close: () => Promise<void>;
+}
+
+export async function startRelayDouble(): Promise<RelayDouble> {
+  const waitingBySlot = new Map<string, InstanceType<typeof NodeWebSocket>>();
+  const wss = new WebSocketServer({ port: 0 });
+
+  wss.on('connection', (socket, request) => {
+    const slot = new URL(request.url ?? '', 'http://localhost').searchParams.get('slot');
+    if (!slot) {
+      socket.close();
+      return;
+    }
+    const waiting = waitingBySlot.get(slot);
+    if (!waiting || waiting.readyState !== NodeWebSocket.OPEN) {
+      waitingBySlot.set(slot, socket);
+      socket.on('close', () => {
+        if (waitingBySlot.get(slot) === socket) waitingBySlot.delete(slot);
+      });
+      return;
+    }
+    waitingBySlot.delete(slot);
+    socket.on('message', (data, isBinary) => {
+      if (waiting.readyState === NodeWebSocket.OPEN) waiting.send(data, { binary: isBinary });
+    });
+    waiting.on('message', (data, isBinary) => {
+      if (socket.readyState === NodeWebSocket.OPEN) socket.send(data, { binary: isBinary });
+    });
+  });
+
+  await new Promise<void>((resolve) => wss.once('listening', resolve));
+  const address = wss.address();
+  if (!address || typeof address === 'string') throw new Error('Relay double failed to bind a port');
+  const url = `ws://127.0.0.1:${address.port}`;
+
+  return {
+    url,
+    // wss.close() stops accepting new connections and shuts down the
+    // internally-created HTTP server, but does NOT terminate existing
+    // client sockets - do that explicitly so a test's sockets never
+    // linger past the test.
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        for (const client of wss.clients) client.terminate();
+        wss.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}

--- a/tests/unit/mobile-bridge/relay-pairing-integration.test.ts
+++ b/tests/unit/mobile-bridge/relay-pairing-integration.test.ts
@@ -1,0 +1,207 @@
+/**
+ * End-to-end pairing over a REAL WebSocket connection (not the in-memory
+ * loopback Transport double used in pairing-service.test.ts): the desktop
+ * side runs the actual production RelayClient (Node's global WebSocket)
+ * against a local relay-double.ts server, and a simulated phone connects
+ * with the `ws` package's WebSocket client to the same slot. This is the
+ * closest to a real end-to-end run achievable without the separate relay
+ * server task/repo - see relay-double.ts's doc comment.
+ *
+ * Same electron/fs/PATHS mocking as pairing-service.test.ts: PairingService's
+ * own logic never touches electron, but confirmSas() calls roster-store's
+ * addOrReplaceDevice(), which does.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WebSocket as NodeWebSocket } from 'ws';
+import {
+  bytesToHex,
+  createPairingInitiatorHandshake,
+  deriveShortAuthenticationString,
+  generateX25519KeyPair,
+  type ShortAuthenticationString,
+} from '@kangentic/protocol';
+import { startRelayDouble, type RelayDouble } from './relay-double';
+
+vi.mock('electron', () => ({
+  app: {
+    isReady: () => true,
+    whenReady: () => Promise.resolve(),
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`encrypted:${plaintext}`, 'utf8'),
+    decryptString: (buffer: Buffer) => {
+      const raw = buffer.toString('utf8');
+      if (raw.startsWith('encrypted:')) return raw.slice('encrypted:'.length);
+      throw new Error('safeStorage.decryptString: invalid ciphertext');
+    },
+    getSelectedStorageBackend: () => 'keychain',
+  },
+}));
+
+const existsSyncSpy = vi.hoisted(() => vi.fn<(filePath: string) => boolean>());
+const readFileSyncSpy = vi.hoisted(() => vi.fn<(filePath: string, encoding: BufferEncoding) => string>());
+const writeFileSyncSpy = vi.hoisted(() => vi.fn<(filePath: string, data: string) => void>());
+const mkdirSyncSpy = vi.hoisted(() => vi.fn());
+const unlinkSyncSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: existsSyncSpy,
+      readFileSync: readFileSyncSpy,
+      writeFileSync: writeFileSyncSpy,
+      mkdirSync: mkdirSyncSpy,
+      unlinkSync: unlinkSyncSpy,
+    },
+    existsSync: existsSyncSpy,
+    readFileSync: readFileSyncSpy,
+    writeFileSync: writeFileSyncSpy,
+    mkdirSync: mkdirSyncSpy,
+    unlinkSync: unlinkSyncSpy,
+  };
+});
+
+vi.mock('../../../src/main/config/paths', () => ({
+  PATHS: { configDir: '/mock/config' },
+}));
+
+const { PairingService } = await import('../../../src/main/mobile-bridge/pairing/pairing-service');
+const { RelayClient } = await import('../../../src/main/mobile-bridge/transport/relay-client');
+const { generateEd25519KeyPair } = await import('@kangentic/protocol');
+type BridgeIdentityModule = typeof import('../../../src/main/mobile-bridge/identity');
+type BridgeIdentity = ReturnType<BridgeIdentityModule['loadOrCreateBridgeIdentity']>;
+
+function testIdentity(): BridgeIdentity {
+  return {
+    staticKeyPair: generateX25519KeyPair(),
+    masterSigningKeyPair: generateEd25519KeyPair(),
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function toBytes(data: unknown): Uint8Array {
+  if (Buffer.isBuffer(data)) return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  throw new Error('Unexpected ws message data type in test');
+}
+
+beforeEach(() => {
+  existsSyncSpy.mockReset();
+  readFileSyncSpy.mockReset();
+  writeFileSyncSpy.mockReset();
+  mkdirSyncSpy.mockReset();
+  unlinkSyncSpy.mockReset();
+});
+
+describe('mobile bridge pairing over a real relay double', () => {
+  let relay: RelayDouble;
+
+  beforeEach(async () => {
+    relay = await startRelayDouble();
+  });
+
+  afterEach(async () => {
+    await relay.close();
+  });
+
+  it('completes pairing end to end: RelayClient <-> relay double <-> simulated phone', async () => {
+    const identity = testIdentity();
+    const service = new PairingService(identity);
+    const token = service.mintToken();
+    const slotId = bytesToHex(token.token);
+
+    const desktopTransport = new RelayClient({ relayUrl: relay.url, slotId });
+    await desktopTransport.connect();
+    service.start(desktopTransport);
+
+    const phoneSocket = new NodeWebSocket(`${relay.url}?slot=${encodeURIComponent(slotId)}`);
+    await new Promise<void>((resolve, reject) => {
+      phoneSocket.once('open', () => resolve());
+      phoneSocket.once('error', reject);
+    });
+
+    const phoneStaticKeyPair = generateX25519KeyPair();
+    const phoneHandshake = createPairingInitiatorHandshake({
+      localStatic: phoneStaticKeyPair,
+      remoteStatic: identity.staticKeyPair.publicKey,
+      pairingToken: token.token,
+    });
+
+    let phoneComputedSas: ShortAuthenticationString | undefined;
+    const phoneSasReady = new Promise<void>((resolve) => {
+      phoneSocket.on('message', (data) => {
+        phoneHandshake.readMessage(toBytes(data));
+        phoneComputedSas = deriveShortAuthenticationString(phoneHandshake.getHandshakeHash());
+        resolve();
+      });
+    });
+
+    const sasEventPromise = new Promise<{ sas: ShortAuthenticationString; phoneStaticPublicKeyHex: string }>((resolve) => {
+      service.once('sas', resolve);
+    });
+
+    const message1 = phoneHandshake.writeMessage(new TextEncoder().encode('Real Relay Phone')).message;
+    phoneSocket.send(message1);
+
+    const [sasEvent] = await Promise.all([sasEventPromise, phoneSasReady]);
+
+    expect(sasEvent.phoneStaticPublicKeyHex).toBe(bytesToHex(phoneStaticKeyPair.publicKey));
+    expect(phoneComputedSas).toBeDefined();
+    expect(sasEvent.sas).toEqual(phoneComputedSas);
+
+    const confirmedPromise = new Promise<{ deviceId: string }>((resolve) => {
+      service.once('confirmed', resolve);
+    });
+    service.confirmSas('relay-device-1', 'Real Relay Phone');
+    const confirmed = await confirmedPromise;
+    expect(confirmed.deviceId).toBe('relay-device-1');
+
+    phoneSocket.close();
+    desktopTransport.close();
+  });
+
+  it('rejects pairing when the simulated phone presents the wrong token, even over a real relay connection', async () => {
+    const identity = testIdentity();
+    const service = new PairingService(identity);
+    const token = service.mintToken();
+    const slotId = bytesToHex(token.token);
+
+    const desktopTransport = new RelayClient({ relayUrl: relay.url, slotId });
+    await desktopTransport.connect();
+    service.start(desktopTransport);
+
+    const phoneSocket = new NodeWebSocket(`${relay.url}?slot=${encodeURIComponent(slotId)}`);
+    await new Promise<void>((resolve, reject) => {
+      phoneSocket.once('open', () => resolve());
+      phoneSocket.once('error', reject);
+    });
+
+    const phoneStaticKeyPair = generateX25519KeyPair();
+    const wrongToken = new Uint8Array(32).fill(0x42);
+    const phoneHandshake = createPairingInitiatorHandshake({
+      localStatic: phoneStaticKeyPair,
+      remoteStatic: identity.staticKeyPair.publicKey,
+      pairingToken: wrongToken,
+    });
+
+    const sasListener = vi.fn();
+    service.on('sas', sasListener);
+    const failedEventPromise = new Promise<{ reason: string }>((resolve) => {
+      service.once('failed', resolve);
+    });
+
+    const message1 = phoneHandshake.writeMessage(new TextEncoder().encode('Wrong Token Phone')).message;
+    phoneSocket.send(message1);
+
+    const failedEvent = await failedEventPromise;
+    expect(failedEvent.reason).toEqual(expect.any(String));
+    expect(sasListener).not.toHaveBeenCalled();
+
+    phoneSocket.close();
+    desktopTransport.close();
+  });
+});

--- a/tests/unit/mobile-bridge/roster-store.test.ts
+++ b/tests/unit/mobile-bridge/roster-store.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Unit tests for src/main/mobile-bridge/roster-store.ts
+ *
+ * Verifies the signed-device-roster persistence: signing/upserting a device,
+ * capability changes re-signing an entry, revocation, and - the load-bearing
+ * safety property of this module - that loadRoster() re-verifies EVERY
+ * stored entry's signature against the roster's own master signing key and
+ * silently drops any entry that fails verification, so a corrupted or
+ * hand-edited roster file degrades to "that device drops out" instead of
+ * trusting tampered data.
+ *
+ * Mocking mirrors tests/unit/asana-credential-store.test.ts: electron and
+ * node:fs are mocked so no real file I/O occurs (fs is bundled as both named
+ * exports and a `default`, since roster-store.ts imports it CJS-style), and
+ * PATHS is mocked to a stable fake configDir. Ed25519 signing/verification
+ * comes from the real @kangentic/protocol package (fast, already proven
+ * correct) rather than being mocked, so these tests exercise the real
+ * signature round trip.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  bytesToHex,
+  generateEd25519KeyPair,
+  generateX25519KeyPair,
+  hexToBytes,
+  verifyRosterEntry,
+  type CapabilityVerb,
+} from '@kangentic/protocol';
+import type { BridgeIdentity } from '../../../src/main/mobile-bridge/identity';
+
+vi.mock('electron', () => ({
+  app: {
+    isReady: () => true,
+    whenReady: () => Promise.resolve(),
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`encrypted:${plaintext}`, 'utf8'),
+    decryptString: (buffer: Buffer) => {
+      const raw = buffer.toString('utf8');
+      if (raw.startsWith('encrypted:')) return raw.slice('encrypted:'.length);
+      throw new Error('safeStorage.decryptString: invalid ciphertext');
+    },
+    getSelectedStorageBackend: () => 'keychain',
+  },
+}));
+
+const existsSyncSpy = vi.hoisted(() => vi.fn<(filePath: string) => boolean>());
+const readFileSyncSpy = vi.hoisted(() => vi.fn<(filePath: string, encoding: BufferEncoding) => string>());
+const writeFileSyncSpy = vi.hoisted(() => vi.fn<(filePath: string, data: string) => void>());
+const mkdirSyncSpy = vi.hoisted(() => vi.fn());
+const unlinkSyncSpy = vi.hoisted(() => vi.fn());
+const rmSyncSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: existsSyncSpy,
+      readFileSync: readFileSyncSpy,
+      writeFileSync: writeFileSyncSpy,
+      mkdirSync: mkdirSyncSpy,
+      unlinkSync: unlinkSyncSpy,
+      rmSync: rmSyncSpy,
+    },
+    existsSync: existsSyncSpy,
+    readFileSync: readFileSyncSpy,
+    writeFileSync: writeFileSyncSpy,
+    mkdirSync: mkdirSyncSpy,
+    unlinkSync: unlinkSyncSpy,
+    rmSync: rmSyncSpy,
+  };
+});
+
+vi.mock('../../../src/main/config/paths', () => ({
+  PATHS: { configDir: '/mock/config' },
+}));
+
+// Import AFTER all vi.mock declarations.
+const { loadRoster, addOrReplaceDevice, setDeviceCapabilities, revokeDevice, clearRoster } = await import(
+  '../../../src/main/mobile-bridge/roster-store'
+);
+
+function testIdentity(): BridgeIdentity {
+  return {
+    staticKeyPair: generateX25519KeyPair(),
+    masterSigningKeyPair: generateEd25519KeyPair(),
+    createdAt: new Date().toISOString(),
+  };
+}
+
+interface FakeDeviceInput {
+  deviceId: string;
+  displayName: string;
+  capabilities: CapabilityVerb[];
+}
+
+function fakeDeviceInput(overrides: Partial<FakeDeviceInput> = {}) {
+  return {
+    deviceId: overrides.deviceId ?? 'device-1',
+    staticPublicKey: generateX25519KeyPair().publicKey,
+    displayName: overrides.displayName ?? 'My iPhone',
+    capabilities: overrides.capabilities ?? (['read-stream'] as CapabilityVerb[]),
+    expiresAt: null,
+  };
+}
+
+beforeEach(() => {
+  existsSyncSpy.mockReset();
+  readFileSyncSpy.mockReset();
+  writeFileSyncSpy.mockReset();
+  mkdirSyncSpy.mockReset();
+  unlinkSyncSpy.mockReset();
+  rmSyncSpy.mockReset();
+});
+
+describe('loadRoster', () => {
+  it('returns an empty roster carrying the identity master signing key when the file does not exist', () => {
+    existsSyncSpy.mockReturnValue(false);
+    const identity = testIdentity();
+
+    const roster = loadRoster(identity);
+
+    expect(roster.devices).toEqual([]);
+    expect(bytesToHex(roster.masterSigningPublicKey)).toBe(bytesToHex(identity.masterSigningKeyPair.publicKey));
+  });
+
+  it('drops an entry whose signature fails verification against the roster master key', () => {
+    const identity = testIdentity();
+    existsSyncSpy.mockReturnValue(false);
+    const input = fakeDeviceInput();
+    const roster = addOrReplaceDevice(identity, input);
+    const persistedJson = writeFileSyncSpy.mock.calls[0][1] as string;
+    const persisted = JSON.parse(persistedJson) as {
+      masterSigningPublicKeyHex: string;
+      devices: Array<{ signatureHex: string }>;
+    };
+
+    // Tamper: flip one hex nibble in the signature.
+    const originalSignatureHex = persisted.devices[0].signatureHex;
+    const tamperedNibble = originalSignatureHex[0] === '0' ? '1' : '0';
+    persisted.devices[0].signatureHex = tamperedNibble + originalSignatureHex.slice(1);
+
+    existsSyncSpy.mockReturnValue(true);
+    readFileSyncSpy.mockReturnValue(JSON.stringify(persisted));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const reloaded = loadRoster(identity);
+
+    warnSpy.mockRestore();
+    expect(reloaded.devices).toEqual([]);
+    expect(roster.devices).toHaveLength(1);
+  });
+
+  it('logs a warning and returns an empty roster when the file contains invalid JSON', () => {
+    existsSyncSpy.mockReturnValue(true);
+    readFileSyncSpy.mockReturnValue('not-valid-json');
+    const identity = testIdentity();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const roster = loadRoster(identity);
+
+    expect(roster.devices).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('mobile-bridge/roster-store'),
+      expect.any(Error),
+    );
+    warnSpy.mockRestore();
+  });
+});
+
+describe('addOrReplaceDevice', () => {
+  it('signs an entry and persists it via writeFileSync', () => {
+    existsSyncSpy.mockReturnValue(false);
+    const identity = testIdentity();
+    const input = fakeDeviceInput();
+
+    addOrReplaceDevice(identity, input);
+
+    expect(writeFileSyncSpy).toHaveBeenCalledTimes(1);
+    const persistedJson = writeFileSyncSpy.mock.calls[0][1] as string;
+    expect(persistedJson).toContain(input.deviceId);
+    expect(persistedJson).toContain(input.displayName);
+  });
+
+  it('round-trips through loadRoster with matching capabilities/displayName and a valid signature', () => {
+    existsSyncSpy.mockReturnValue(false);
+    const identity = testIdentity();
+    const input = fakeDeviceInput({ capabilities: ['read-stream', 'read-board'] });
+    addOrReplaceDevice(identity, input);
+    const persistedJson = writeFileSyncSpy.mock.calls[0][1] as string;
+
+    existsSyncSpy.mockReturnValue(true);
+    readFileSyncSpy.mockReturnValue(persistedJson);
+
+    const reloaded = loadRoster(identity);
+
+    expect(reloaded.devices).toHaveLength(1);
+    const entry = reloaded.devices[0];
+    expect(entry.deviceId).toBe(input.deviceId);
+    expect(entry.displayName).toBe(input.displayName);
+    expect(entry.capabilities).toEqual(input.capabilities);
+    expect(bytesToHex(entry.staticPublicKey)).toBe(bytesToHex(input.staticPublicKey));
+    expect(verifyRosterEntry(identity.masterSigningKeyPair.publicKey, entry)).toBe(true);
+  });
+
+  it('replaces (not duplicates) an entry when called twice with the same deviceId', () => {
+    existsSyncSpy.mockReturnValue(false);
+    const identity = testIdentity();
+    addOrReplaceDevice(identity, fakeDeviceInput({ deviceId: 'device-1', displayName: 'First Name' }));
+    const firstPersistedJson = writeFileSyncSpy.mock.calls[0][1] as string;
+
+    existsSyncSpy.mockReturnValue(true);
+    readFileSyncSpy.mockReturnValue(firstPersistedJson);
+    writeFileSyncSpy.mockClear();
+
+    addOrReplaceDevice(identity, fakeDeviceInput({ deviceId: 'device-1', displayName: 'Second Name' }));
+
+    const secondPersistedJson = writeFileSyncSpy.mock.calls[0][1] as string;
+    const secondPersisted = JSON.parse(secondPersistedJson) as { devices: Array<{ deviceId: string; displayName: string }> };
+    expect(secondPersisted.devices).toHaveLength(1);
+    expect(secondPersisted.devices[0].displayName).toBe('Second Name');
+  });
+});
+
+describe('setDeviceCapabilities', () => {
+  it('throws for an unknown deviceId', () => {
+    existsSyncSpy.mockReturnValue(false);
+    const identity = testIdentity();
+
+    expect(() => setDeviceCapabilities(identity, 'unknown-device', ['read-board'])).toThrow(/No such paired device/);
+  });
+
+  it('re-signs and changes capabilities for a known device, invalidating the old signature', () => {
+    existsSyncSpy.mockReturnValue(false);
+    const identity = testIdentity();
+    addOrReplaceDevice(identity, fakeDeviceInput({ deviceId: 'device-1', capabilities: ['read-stream'] }));
+    const firstPersistedJson = writeFileSyncSpy.mock.calls[0][1] as string;
+    const firstPersisted = JSON.parse(firstPersistedJson) as { devices: Array<{ signatureHex: string }> };
+    const oldSignatureHex = firstPersisted.devices[0].signatureHex;
+
+    existsSyncSpy.mockReturnValue(true);
+    readFileSyncSpy.mockReturnValue(firstPersistedJson);
+    writeFileSyncSpy.mockClear();
+
+    setDeviceCapabilities(identity, 'device-1', ['read-stream', 'read-board', 'read-diff']);
+
+    const secondPersistedJson = writeFileSyncSpy.mock.calls[0][1] as string;
+    const secondPersisted = JSON.parse(secondPersistedJson) as {
+      devices: Array<{ deviceId: string; capabilities: string[]; signatureHex: string }>;
+    };
+    expect(secondPersisted.devices).toHaveLength(1);
+    const updatedEntry = secondPersisted.devices[0];
+    expect(updatedEntry.capabilities).toEqual(['read-stream', 'read-board', 'read-diff']);
+    expect(updatedEntry.signatureHex).not.toBe(oldSignatureHex);
+
+    existsSyncSpy.mockReturnValue(true);
+    readFileSyncSpy.mockReturnValue(secondPersistedJson);
+    const reloaded = loadRoster(identity);
+    expect(reloaded.devices).toHaveLength(1);
+    expect(verifyRosterEntry(identity.masterSigningKeyPair.publicKey, reloaded.devices[0])).toBe(true);
+
+    // The OLD signature no longer verifies against the NEW capability set.
+    const tamperedBackToOldSignature = {
+      ...reloaded.devices[0],
+      signature: hexToBytes(oldSignatureHex),
+    };
+    expect(verifyRosterEntry(identity.masterSigningKeyPair.publicKey, tamperedBackToOldSignature)).toBe(false);
+  });
+});
+
+describe('revokeDevice', () => {
+  it('removes the device from the persisted roster', () => {
+    existsSyncSpy.mockReturnValue(false);
+    const identity = testIdentity();
+    addOrReplaceDevice(identity, fakeDeviceInput({ deviceId: 'device-1' }));
+    const firstPersistedJson = writeFileSyncSpy.mock.calls[0][1] as string;
+
+    existsSyncSpy.mockReturnValue(true);
+    readFileSyncSpy.mockReturnValue(firstPersistedJson);
+    writeFileSyncSpy.mockClear();
+
+    revokeDevice(identity, 'device-1');
+
+    const secondPersistedJson = writeFileSyncSpy.mock.calls[0][1] as string;
+    const secondPersisted = JSON.parse(secondPersistedJson) as { devices: unknown[] };
+    expect(secondPersisted.devices).toEqual([]);
+  });
+});
+
+describe('clearRoster', () => {
+  it('removes the roster file via rmSync with force (no existsSync gate, Windows-lock safe)', () => {
+    clearRoster();
+    expect(rmSyncSpy).toHaveBeenCalledTimes(1);
+    expect(rmSyncSpy).toHaveBeenCalledWith(expect.stringContaining('mobile-bridge-roster.json'), { force: true });
+  });
+
+  it('swallows a transient filesystem error (e.g. a Windows file lock) rather than throwing', () => {
+    rmSyncSpy.mockImplementation(() => {
+      throw new Error('EBUSY: resource busy or locked');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    expect(() => clearRoster()).not.toThrow();
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/unit/mobile-bridge/transport-factory.test.ts
+++ b/tests/unit/mobile-bridge/transport-factory.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for src/main/mobile-bridge/transport/transport-factory.ts.
+ *
+ * The module's own doc comment names it as the deliberate swap point for a
+ * future non-relay Transport implementation (WebRTC, Phase 4): everything
+ * above createTransport() only ever sees the Transport interface, never
+ * RelayClient directly. Every existing test mocks this factory out entirely
+ * (mobile-bridge-service.test.ts, relay-pairing-integration.test.ts), so
+ * nothing pinned that it actually forwards its options to RelayClient
+ * correctly. RelayClient itself is fully covered by relay-client.test.ts;
+ * this file only needs to confirm the thin forwarding contract.
+ */
+import { describe, it, expect } from 'vitest';
+import { createTransport } from '../../../src/main/mobile-bridge/transport/transport-factory';
+import { RelayClient } from '../../../src/main/mobile-bridge/transport/relay-client';
+
+describe('createTransport()', () => {
+  it('returns a RelayClient instance', () => {
+    const transport = createTransport({ relayUrl: 'ws://127.0.0.1:1', slotId: 'slot-a' });
+    expect(transport).toBeInstanceOf(RelayClient);
+  });
+
+  it('forwards relayUrl and slotId through to the underlying RelayClient', () => {
+    // RelayClient keeps relayUrl/slotId private, so the forwarding contract
+    // is observed indirectly: the dial URL RelayClient builds embeds both
+    // (see relay-client.ts's `dial()`), which surfaces as the actual
+    // WebSocket connection target. We assert this via the connect-time URL
+    // rather than reaching into RelayClient internals.
+    const capturedUrls: string[] = [];
+    class RecordingWebSocket {
+      binaryType = 'blob';
+      onopen: (() => void) | null = null;
+      onmessage: ((event: { data: unknown }) => void) | null = null;
+      onerror: (() => void) | null = null;
+      onclose: (() => void) | null = null;
+      constructor(url: string) {
+        capturedUrls.push(url);
+      }
+      close(): void {
+        // no-op: this test only inspects the constructed URL.
+      }
+    }
+    const originalWebSocket = globalThis.WebSocket;
+    (globalThis as unknown as { WebSocket: unknown }).WebSocket = RecordingWebSocket;
+
+    try {
+      const transport = createTransport({ relayUrl: 'ws://relay.example.com', slotId: 'my-slot-id' });
+      // connect() never resolves here (RecordingWebSocket never fires onopen)
+      // and that is fine - we only need dial()'s synchronous URL construction
+      // to have run, which happens before any await point.
+      void transport.connect().catch(() => undefined);
+
+      expect(capturedUrls).toEqual(['ws://relay.example.com?slot=my-slot-id']);
+      transport.close();
+    } finally {
+      (globalThis as unknown as { WebSocket: unknown }).WebSocket = originalWebSocket;
+    }
+  });
+
+  it('each call constructs a fresh transport instance (no shared/singleton state across pairing attempts)', () => {
+    const first = createTransport({ relayUrl: 'ws://127.0.0.1:1', slotId: 'slot-a' });
+    const second = createTransport({ relayUrl: 'ws://127.0.0.1:1', slotId: 'slot-b' });
+    expect(first).not.toBe(second);
+  });
+});

--- a/tests/unit/mobile-capability-verbs-parity.test.ts
+++ b/tests/unit/mobile-capability-verbs-parity.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Pins the hand-maintained parity between src/shared/types.ts's
+ * MOBILE_CAPABILITY_VERBS and @kangentic/protocol's CAPABILITY_VERBS.
+ *
+ * src/shared/types.ts is deliberately import-free (a dependency-free leaf
+ * module - see its own comment above MOBILE_CAPABILITY_VERBS), so it cannot
+ * import CapabilityVerb from the protocol package and mirrors the union by
+ * hand instead. That comment says "keep MOBILE_CAPABILITY_VERBS in sync ...
+ * by hand" with zero mechanical enforcement before this test: a future verb
+ * added to the protocol package (or renamed) would silently desync the
+ * renderer's type from the wire protocol, and the mismatch would only
+ * surface as a confusing runtime cast failure, not a build error.
+ */
+import { describe, it, expect } from 'vitest';
+import { MOBILE_CAPABILITY_VERBS } from '../../src/shared/types';
+import { CAPABILITY_VERBS } from '../../packages/protocol/src/capabilities/verbs';
+
+describe('MOBILE_CAPABILITY_VERBS <-> protocol CAPABILITY_VERBS parity', () => {
+  it('has the exact same members, in the same order, as the protocol package', () => {
+    expect(MOBILE_CAPABILITY_VERBS).toEqual(CAPABILITY_VERBS);
+  });
+
+  it('has no shell, file, or arbitrary-command verb (mirrors the protocol-side guarantee)', () => {
+    const suspicious = MOBILE_CAPABILITY_VERBS.filter((verb) => /shell|file|exec|command|run/i.test(verb));
+    expect(suspicious).toEqual([]);
+  });
+});

--- a/tests/unit/mobile-store.test.ts
+++ b/tests/unit/mobile-store.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Unit tests for src/renderer/stores/mobile-store.ts.
+ *
+ * tests/ui/mobile-devices-settings.spec.ts already exercises this store
+ * end-to-end through MobileDevicesTab and a real headless mock-electron-api,
+ * but only reaches the branches the component happens to touch through DOM
+ * interactions. This file drives the store directly to pin the contract
+ * pieces the UI spec does not assert on:
+ *  - startPairing() resets pairingSas/pairingEndedReason to null on entry
+ *    (so a stale error from a PREVIOUS failed ceremony doesn't linger under
+ *    the new QR) and toggles `loading` around the call, including on a
+ *    rejected startPairing (the `finally` branch).
+ *  - confirmPairing() clears pairingSas and reloads devices+status in
+ *    parallel (both IPC calls happen, not just one).
+ *  - cancelPairing() clears pairingSas and reloads status only (not
+ *    devices - cancelling never changes the device list).
+ *  - revokeDevice() reloads BOTH devices and status (status.pairedDeviceCount
+ *    must drop).
+ *  - setDeviceCapabilities() reloads devices only, NOT status - the one
+ *    asymmetric case in this store, easy to get wrong by copy-pasting
+ *    revokeDevice's Promise.all.
+ *  - the four pure push-event reducers (setPairingSas/clearPairingSas/
+ *    setPairingEnded/clearPairingEnded) mutate exactly the field they name.
+ *
+ * window.electronAPI.mobile is stubbed globally before importing the store,
+ * mirroring session-store-rate-limits.test.ts's pattern for a Node
+ * (non-jsdom) test environment.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { MobileBridgeStatus, MobilePairedDevice, MobileStartPairingResult } from '../../src/shared/types';
+
+// ---------------------------------------------------------------------------
+// Stub window.electronAPI.mobile before importing the store.
+// ---------------------------------------------------------------------------
+
+const getStatusMock = vi.fn<() => Promise<MobileBridgeStatus>>();
+const listDevicesMock = vi.fn<() => Promise<MobilePairedDevice[]>>();
+const startPairingMock = vi.fn<() => Promise<MobileStartPairingResult>>();
+const confirmPairingMock = vi.fn<() => Promise<void>>();
+const cancelPairingMock = vi.fn<() => Promise<void>>();
+const revokeDeviceMock = vi.fn<() => Promise<void>>();
+const setDeviceCapabilitiesMock = vi.fn<() => Promise<void>>();
+
+(globalThis as Record<string, unknown>).window = {
+  electronAPI: {
+    mobile: {
+      getStatus: getStatusMock,
+      listDevices: listDevicesMock,
+      startPairing: startPairingMock,
+      confirmPairing: confirmPairingMock,
+      cancelPairing: cancelPairingMock,
+      revokeDevice: revokeDeviceMock,
+      setDeviceCapabilities: setDeviceCapabilitiesMock,
+    },
+  },
+};
+
+// Import after the global stub so the store module sees the mocked window.
+import { useMobileStore } from '../../src/renderer/stores/mobile-store';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeStatus(overrides: Partial<MobileBridgeStatus> = {}): MobileBridgeStatus {
+  return {
+    enabled: true,
+    secureStorageAvailable: true,
+    identityFingerprint: 'deadbeef',
+    relayUrl: 'wss://relay.example.com',
+    pairedDeviceCount: 0,
+    pairingInProgress: false,
+    ...overrides,
+  };
+}
+
+function makeDevice(overrides: Partial<MobilePairedDevice> = {}): MobilePairedDevice {
+  return {
+    deviceId: 'device-1',
+    displayName: 'Test Phone',
+    capabilities: ['read-board'],
+    pairedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function resetStore(): void {
+  useMobileStore.setState({
+    status: null,
+    devices: [],
+    loading: false,
+    pairingSas: null,
+    pairingEndedReason: null,
+  });
+}
+
+beforeEach(() => {
+  resetStore();
+  getStatusMock.mockReset().mockResolvedValue(makeStatus());
+  listDevicesMock.mockReset().mockResolvedValue([]);
+  startPairingMock.mockReset().mockResolvedValue({ qrUri: 'kangentic-pair://mock', expiresAt: '2026-01-01T00:10:00.000Z' });
+  confirmPairingMock.mockReset().mockResolvedValue(undefined);
+  cancelPairingMock.mockReset().mockResolvedValue(undefined);
+  revokeDeviceMock.mockReset().mockResolvedValue(undefined);
+  setDeviceCapabilitiesMock.mockReset().mockResolvedValue(undefined);
+});
+
+// ---------------------------------------------------------------------------
+// loadStatus / loadDevices
+// ---------------------------------------------------------------------------
+
+describe('loadStatus / loadDevices', () => {
+  it('loadStatus() writes the resolved status into state', async () => {
+    const status = makeStatus({ pairedDeviceCount: 3 });
+    getStatusMock.mockResolvedValue(status);
+
+    await useMobileStore.getState().loadStatus();
+
+    expect(useMobileStore.getState().status).toEqual(status);
+  });
+
+  it('loadDevices() writes the resolved device list into state', async () => {
+    const devices = [makeDevice(), makeDevice({ deviceId: 'device-2' })];
+    listDevicesMock.mockResolvedValue(devices);
+
+    await useMobileStore.getState().loadDevices();
+
+    expect(useMobileStore.getState().devices).toEqual(devices);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// startPairing
+// ---------------------------------------------------------------------------
+
+describe('startPairing()', () => {
+  it('clears a stale pairingSas/pairingEndedReason from a previous ceremony before starting', async () => {
+    useMobileStore.setState({
+      pairingSas: { digits: '000000', emoji: [], phoneStaticPublicKeyHex: 'stale' },
+      pairingEndedReason: 'Previous ceremony timed out',
+    });
+
+    await useMobileStore.getState().startPairing();
+
+    expect(useMobileStore.getState().pairingSas).toBeNull();
+    expect(useMobileStore.getState().pairingEndedReason).toBeNull();
+  });
+
+  it('sets loading true for the duration of the call and false once it resolves', async () => {
+    let loadingDuringCall: boolean | undefined;
+    startPairingMock.mockImplementation(async () => {
+      loadingDuringCall = useMobileStore.getState().loading;
+      return { qrUri: 'kangentic-pair://mock', expiresAt: '2026-01-01T00:10:00.000Z' };
+    });
+
+    expect(useMobileStore.getState().loading).toBe(false);
+    await useMobileStore.getState().startPairing();
+
+    expect(loadingDuringCall).toBe(true);
+    expect(useMobileStore.getState().loading).toBe(false);
+  });
+
+  it('clears loading via the finally branch even when startPairing() rejects', async () => {
+    startPairingMock.mockRejectedValue(new Error('relay unreachable'));
+
+    await expect(useMobileStore.getState().startPairing()).rejects.toThrow('relay unreachable');
+
+    expect(useMobileStore.getState().loading).toBe(false);
+  });
+
+  it('reloads status after a successful startPairing() (pairingInProgress flips to true)', async () => {
+    getStatusMock.mockResolvedValue(makeStatus({ pairingInProgress: true }));
+
+    await useMobileStore.getState().startPairing();
+
+    expect(useMobileStore.getState().status?.pairingInProgress).toBe(true);
+  });
+
+  it('returns the IPC result to the caller', async () => {
+    const result = await useMobileStore.getState().startPairing();
+    expect(result).toEqual({ qrUri: 'kangentic-pair://mock', expiresAt: '2026-01-01T00:10:00.000Z' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// confirmPairing
+// ---------------------------------------------------------------------------
+
+describe('confirmPairing()', () => {
+  it('forwards displayName and capabilities to the IPC call', async () => {
+    await useMobileStore.getState().confirmPairing('My Phone', ['read-board', 'move-task']);
+    expect(confirmPairingMock).toHaveBeenCalledWith('My Phone', ['read-board', 'move-task']);
+  });
+
+  it('clears pairingSas', async () => {
+    useMobileStore.setState({ pairingSas: { digits: '123456', emoji: [], phoneStaticPublicKeyHex: 'abc' } });
+
+    await useMobileStore.getState().confirmPairing('My Phone');
+
+    expect(useMobileStore.getState().pairingSas).toBeNull();
+  });
+
+  it('reloads BOTH devices and status', async () => {
+    const devices = [makeDevice({ displayName: 'My Phone' })];
+    const status = makeStatus({ pairedDeviceCount: 1 });
+    listDevicesMock.mockResolvedValue(devices);
+    getStatusMock.mockResolvedValue(status);
+
+    await useMobileStore.getState().confirmPairing('My Phone');
+
+    expect(listDevicesMock).toHaveBeenCalledTimes(1);
+    expect(getStatusMock).toHaveBeenCalledTimes(1);
+    expect(useMobileStore.getState().devices).toEqual(devices);
+    expect(useMobileStore.getState().status).toEqual(status);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cancelPairing
+// ---------------------------------------------------------------------------
+
+describe('cancelPairing()', () => {
+  it('clears pairingSas and reloads status, but does NOT reload devices', async () => {
+    useMobileStore.setState({ pairingSas: { digits: '654321', emoji: [], phoneStaticPublicKeyHex: 'def' } });
+
+    await useMobileStore.getState().cancelPairing();
+
+    expect(useMobileStore.getState().pairingSas).toBeNull();
+    expect(getStatusMock).toHaveBeenCalledTimes(1);
+    expect(listDevicesMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// revokeDevice
+// ---------------------------------------------------------------------------
+
+describe('revokeDevice()', () => {
+  it('forwards the deviceId to the IPC call and reloads BOTH devices and status', async () => {
+    getStatusMock.mockResolvedValue(makeStatus({ pairedDeviceCount: 0 }));
+    listDevicesMock.mockResolvedValue([]);
+
+    await useMobileStore.getState().revokeDevice('device-1');
+
+    expect(revokeDeviceMock).toHaveBeenCalledWith('device-1');
+    expect(listDevicesMock).toHaveBeenCalledTimes(1);
+    expect(getStatusMock).toHaveBeenCalledTimes(1);
+    expect(useMobileStore.getState().status?.pairedDeviceCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setDeviceCapabilities - the asymmetric case
+// ---------------------------------------------------------------------------
+
+describe('setDeviceCapabilities()', () => {
+  it('forwards deviceId and capabilities to the IPC call', async () => {
+    await useMobileStore.getState().setDeviceCapabilities('device-1', ['read-stream']);
+    expect(setDeviceCapabilitiesMock).toHaveBeenCalledWith('device-1', ['read-stream']);
+  });
+
+  it('reloads devices but does NOT reload status (unlike revokeDevice/confirmPairing)', async () => {
+    await useMobileStore.getState().setDeviceCapabilities('device-1', ['read-stream']);
+
+    expect(listDevicesMock).toHaveBeenCalledTimes(1);
+    expect(getStatusMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure push-event reducers
+// ---------------------------------------------------------------------------
+
+describe('push-event reducers', () => {
+  it('setPairingSas() writes the payload without touching other fields', () => {
+    useMobileStore.setState({ pairingEndedReason: 'unrelated' });
+    const payload = { digits: '111222', emoji: ['star'], phoneStaticPublicKeyHex: 'abc' };
+
+    useMobileStore.getState().setPairingSas(payload);
+
+    expect(useMobileStore.getState().pairingSas).toEqual(payload);
+    expect(useMobileStore.getState().pairingEndedReason).toBe('unrelated');
+  });
+
+  it('clearPairingSas() resets pairingSas to null', () => {
+    useMobileStore.setState({ pairingSas: { digits: '111222', emoji: [], phoneStaticPublicKeyHex: 'abc' } });
+
+    useMobileStore.getState().clearPairingSas();
+
+    expect(useMobileStore.getState().pairingSas).toBeNull();
+  });
+
+  it('setPairingEnded() writes the reason without touching pairingSas', () => {
+    useMobileStore.setState({ pairingSas: { digits: '111222', emoji: [], phoneStaticPublicKeyHex: 'abc' } });
+
+    useMobileStore.getState().setPairingEnded('Device declined pairing');
+
+    expect(useMobileStore.getState().pairingEndedReason).toBe('Device declined pairing');
+    expect(useMobileStore.getState().pairingSas).not.toBeNull();
+  });
+
+  it('clearPairingEnded() resets pairingEndedReason to null', () => {
+    useMobileStore.setState({ pairingEndedReason: 'some reason' });
+
+    useMobileStore.getState().clearPairingEnded();
+
+    expect(useMobileStore.getState().pairingEndedReason).toBeNull();
+  });
+});

--- a/tests/unit/protocol/base64url.test.ts
+++ b/tests/unit/protocol/base64url.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { randomBytes } from '../../../packages/protocol/src/crypto/primitives';
+import { base64UrlDecode, base64UrlEncode } from '../../../packages/protocol/src/wire/base64url';
+
+describe('base64url', () => {
+  it('round-trips arbitrary byte lengths (covers all padding cases)', () => {
+    for (const length of [0, 1, 2, 3, 4, 5, 31, 32, 33, 64, 100]) {
+      const bytes = randomBytes(length);
+      const encoded = base64UrlEncode(bytes);
+      expect(encoded).not.toMatch(/[+/=]/);
+      const decoded = base64UrlDecode(encoded);
+      expect(Buffer.from(decoded).toString('hex')).toBe(Buffer.from(bytes).toString('hex'));
+    }
+  });
+
+  it('rejects an invalid character', () => {
+    expect(() => base64UrlDecode('!!!not-valid???')).toThrow();
+  });
+});

--- a/tests/unit/protocol/capabilities.test.ts
+++ b/tests/unit/protocol/capabilities.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { CAPABILITY_VERBS, capabilitySetFromArray, capabilitySetToArray, isCapabilityVerb } from '../../../packages/protocol/src/capabilities/verbs';
+
+describe('capability verbs', () => {
+  it('has no shell, file, or arbitrary-command verb', () => {
+    const suspicious = CAPABILITY_VERBS.filter((verb) => /shell|file|exec|command|run/i.test(verb));
+    expect(suspicious).toEqual([]);
+  });
+
+  it('isCapabilityVerb accepts only the known set', () => {
+    expect(isCapabilityVerb('move-task')).toBe(true);
+    expect(isCapabilityVerb('run-shell-command')).toBe(false);
+    expect(isCapabilityVerb('')).toBe(false);
+  });
+
+  it('capabilitySetFromArray drops unrecognized entries (deny-by-default for unknown verbs)', () => {
+    const set = capabilitySetFromArray(['read-board', 'delete-everything', 'move-task']);
+    expect(capabilitySetToArray(set).sort()).toEqual(['move-task', 'read-board']);
+  });
+
+  it('capability set membership is deny-by-default for anything not explicitly granted', () => {
+    const set = capabilitySetFromArray(['read-board']);
+    expect(set.has('read-board')).toBe(true);
+    expect(set.has('answer-permission-prompt')).toBe(false);
+  });
+});

--- a/tests/unit/protocol/framing.test.ts
+++ b/tests/unit/protocol/framing.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { decodeMessage, encodeMessage } from '../../../packages/protocol/src/wire/framing';
+import type { BridgeMessage } from '../../../packages/protocol/src/wire/messages';
+
+describe('wire message framing', () => {
+  it('round-trips a heartbeat message', () => {
+    const message: BridgeMessage = { type: 'heartbeat' };
+    expect(decodeMessage(encodeMessage(message))).toEqual(message);
+  });
+
+  it('round-trips a capability-request message', () => {
+    const message: BridgeMessage = {
+      type: 'capability-request',
+      requestId: 'req-1',
+      verb: 'move-task',
+      payload: { taskId: 'abc', toColumnId: 'def' },
+    };
+    expect(decodeMessage(encodeMessage(message))).toEqual(message);
+  });
+
+  it('round-trips a capability-response message', () => {
+    const message: BridgeMessage = {
+      type: 'capability-response',
+      requestId: 'req-1',
+      ok: false,
+      error: 'not authorized',
+    };
+    expect(decodeMessage(encodeMessage(message))).toEqual(message);
+  });
+
+  it('round-trips a board event message', () => {
+    const message: BridgeMessage = {
+      type: 'event',
+      event: { kind: 'board', taskId: 'abc', payload: { column: 'Done' } },
+    };
+    expect(decodeMessage(encodeMessage(message))).toEqual(message);
+  });
+
+  it('rejects an unknown message type', () => {
+    const bytes = new TextEncoder().encode(JSON.stringify({ type: 'not-a-real-type' }));
+    expect(() => decodeMessage(bytes)).toThrow();
+  });
+
+  it('rejects a capability-request with an unknown verb', () => {
+    const bytes = new TextEncoder().encode(
+      JSON.stringify({ type: 'capability-request', requestId: 'r', verb: 'run-shell-command', payload: {} }),
+    );
+    expect(() => decodeMessage(bytes)).toThrow();
+  });
+
+  it('rejects a transcript event missing sessionId', () => {
+    const bytes = new TextEncoder().encode(
+      JSON.stringify({ type: 'event', event: { kind: 'transcript', taskId: 'abc', payload: {} } }),
+    );
+    expect(() => decodeMessage(bytes)).toThrow();
+  });
+
+  it('rejects malformed JSON', () => {
+    expect(() => decodeMessage(new TextEncoder().encode('{not json'))).toThrow();
+  });
+
+  it('rejects an oversized frame', () => {
+    const huge: BridgeMessage = {
+      type: 'capability-request',
+      requestId: 'r',
+      verb: 'send-user-message',
+      payload: { text: 'x'.repeat(2 * 1024 * 1024) },
+    };
+    expect(() => encodeMessage(huge)).toThrow();
+  });
+});

--- a/tests/unit/protocol/noise-kk-session.test.ts
+++ b/tests/unit/protocol/noise-kk-session.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Behavioral tests for the production ongoing-session driver
+ * (crypto/noise/kk.ts, Noise_KK_25519_ChaChaPoly_BLAKE2s). Byte-correctness
+ * of the underlying interpreter is proven against an official test vector
+ * in noise-vectors.test.ts; these tests prove the driver's own contract:
+ * both statics must already be known (no pairing step embedded here),
+ * peers mutually authenticate, and a fresh handshake (the ~2-minute
+ * re-handshake) derives independent keys each time.
+ */
+import { describe, expect, it } from 'vitest';
+import { generateX25519KeyPair } from '../../../packages/protocol/src/crypto/primitives';
+import { createKKHandshake } from '../../../packages/protocol/src/crypto/noise/kk';
+
+function runSession(deviceStatic: ReturnType<typeof generateX25519KeyPair>, peerStatic: ReturnType<typeof generateX25519KeyPair>) {
+  const initiator = createKKHandshake({ initiator: true, localStatic: deviceStatic, remoteStatic: peerStatic.publicKey });
+  const responder = createKKHandshake({ initiator: false, localStatic: peerStatic, remoteStatic: deviceStatic.publicKey });
+
+  const message1 = initiator.writeMessage(new Uint8Array(0));
+  responder.readMessage(message1.message);
+  const message2 = responder.writeMessage(new Uint8Array(0));
+  initiator.readMessage(message2.message);
+
+  return { initiator, responder };
+}
+
+describe('KK session handshake (Noise_KK_25519_ChaChaPoly_BLAKE2s)', () => {
+  it('two devices with pre-pinned roster keys mutually authenticate and agree on the transcript hash', () => {
+    const device = generateX25519KeyPair();
+    const peer = generateX25519KeyPair();
+    const { initiator, responder } = runSession(device, peer);
+    expect(Buffer.from(initiator.getHandshakeHash()).toString('hex')).toBe(Buffer.from(responder.getHandshakeHash()).toString('hex'));
+  });
+
+  it('rejects a peer whose static key does not match the pinned roster entry', () => {
+    const device = generateX25519KeyPair();
+    const peer = generateX25519KeyPair();
+    const impostor = generateX25519KeyPair();
+
+    // Device pins `peer`'s static, but the responder on the wire is actually
+    // `impostor`. The "es"/"ss" DH combiners only agree when both sides hold
+    // the SAME static keypair the other side pinned, so this diverges the
+    // derived key immediately - message 1's payload fails to authenticate
+    // on the very first readMessage() call, before any session key exists.
+    const initiator = createKKHandshake({ initiator: true, localStatic: device, remoteStatic: peer.publicKey });
+    const responder = createKKHandshake({ initiator: false, localStatic: impostor, remoteStatic: device.publicKey });
+
+    const message1 = initiator.writeMessage(new Uint8Array(0));
+    expect(() => responder.readMessage(message1.message)).toThrow();
+  });
+
+  it('a fresh re-handshake between the same pair derives independent transcript hashes each time (bounded post-compromise security)', () => {
+    const device = generateX25519KeyPair();
+    const peer = generateX25519KeyPair();
+
+    const first = runSession(device, peer);
+    const second = runSession(device, peer);
+
+    expect(Buffer.from(first.initiator.getHandshakeHash()).toString('hex')).not.toBe(
+      Buffer.from(second.initiator.getHandshakeHash()).toString('hex'),
+    );
+  });
+});

--- a/tests/unit/protocol/noise-pairing.test.ts
+++ b/tests/unit/protocol/noise-pairing.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Behavioral tests for the production pairing driver (crypto/pairing-handshake.ts,
+ * Noise_IKpsk0_25519_ChaChaPoly_BLAKE2s). The underlying interpreter's
+ * byte-correctness is proven against official test vectors in
+ * noise-vectors.test.ts (KK, IK, and NKpsk0 combined cover every token
+ * type IKpsk0 uses); these tests instead prove the SECURITY PROPERTIES the
+ * pairing ceremony depends on: two honest peers agree, a wrong token is
+ * rejected, a downgraded/mismatched prologue is rejected, and a tampered
+ * message is rejected.
+ */
+import { describe, expect, it } from 'vitest';
+import { generateX25519KeyPair, randomBytes } from '../../../packages/protocol/src/crypto/primitives';
+import { createPairingInitiatorHandshake, createPairingResponderHandshake } from '../../../packages/protocol/src/crypto/pairing-handshake';
+
+function completedHandshake() {
+  const phoneStatic = generateX25519KeyPair();
+  const desktopStatic = generateX25519KeyPair();
+  const pairingToken = randomBytes(32);
+
+  const phone = createPairingInitiatorHandshake({
+    localStatic: phoneStatic,
+    remoteStatic: desktopStatic.publicKey,
+    pairingToken,
+  });
+  const desktop = createPairingResponderHandshake({
+    localStatic: desktopStatic,
+    pairingToken,
+  });
+
+  const message1 = phone.writeMessage(new TextEncoder().encode('phone-device-name'));
+  const read1 = desktop.readMessage(message1.message);
+  const message2 = desktop.writeMessage(new Uint8Array(0));
+  const read2 = phone.readMessage(message2.message);
+
+  return { phoneStatic, desktopStatic, pairingToken, phone, desktop, read1, message2, read2 };
+}
+
+describe('pairing handshake (Noise_IKpsk0_25519_ChaChaPoly_BLAKE2s)', () => {
+  it('two honest peers complete the handshake and agree on the transcript hash', () => {
+    const { phone, desktop, read1, read2 } = completedHandshake();
+
+    expect(new TextDecoder().decode(read1.payload)).toBe('phone-device-name');
+    expect(read2.payload.length).toBe(0);
+    expect(Buffer.from(phone.getHandshakeHash()).toString('hex')).toBe(Buffer.from(desktop.getHandshakeHash()).toString('hex'));
+  });
+
+  it('lets the desktop learn the phone identity static key from message 1', () => {
+    const { phoneStatic, desktop } = completedHandshake();
+    expect(Buffer.from(desktop.getRemoteStaticKey() ?? new Uint8Array()).toString('hex')).toBe(
+      Buffer.from(phoneStatic.publicKey).toString('hex'),
+    );
+  });
+
+  it('rejects a wrong pairing token with an authentication failure, not a usable oracle', () => {
+    const phoneStatic = generateX25519KeyPair();
+    const desktopStatic = generateX25519KeyPair();
+    const realToken = randomBytes(32);
+    const guessedToken = randomBytes(32);
+
+    const phone = createPairingInitiatorHandshake({
+      localStatic: phoneStatic,
+      remoteStatic: desktopStatic.publicKey,
+      pairingToken: guessedToken,
+    });
+    const desktop = createPairingResponderHandshake({
+      localStatic: desktopStatic,
+      pairingToken: realToken,
+    });
+
+    const message1 = phone.writeMessage(new TextEncoder().encode('phone-device-name'));
+    expect(() => desktop.readMessage(message1.message)).toThrow();
+  });
+
+  it('rejects a mismatched protocol version bound into the prologue (downgrade protection)', () => {
+    const phoneStatic = generateX25519KeyPair();
+    const desktopStatic = generateX25519KeyPair();
+    const pairingToken = randomBytes(32);
+
+    const phone = createPairingInitiatorHandshake({
+      localStatic: phoneStatic,
+      remoteStatic: desktopStatic.publicKey,
+      pairingToken,
+      protocolVersion: '2',
+    });
+    const desktop = createPairingResponderHandshake({
+      localStatic: desktopStatic,
+      pairingToken,
+      protocolVersion: '1',
+    });
+
+    const message1 = phone.writeMessage(new TextEncoder().encode('phone-device-name'));
+    expect(() => desktop.readMessage(message1.message)).toThrow();
+  });
+
+  it('rejects a tampered message 1 (bit flip anywhere in the ciphertext)', () => {
+    const phoneStatic = generateX25519KeyPair();
+    const desktopStatic = generateX25519KeyPair();
+    const pairingToken = randomBytes(32);
+
+    const phone = createPairingInitiatorHandshake({
+      localStatic: phoneStatic,
+      remoteStatic: desktopStatic.publicKey,
+      pairingToken,
+    });
+    const desktop = createPairingResponderHandshake({
+      localStatic: desktopStatic,
+      pairingToken,
+    });
+
+    const message1 = phone.writeMessage(new TextEncoder().encode('phone-device-name'));
+    const tampered = new Uint8Array(message1.message);
+    tampered[tampered.length - 1] ^= 0x01;
+
+    expect(() => desktop.readMessage(tampered)).toThrow();
+  });
+
+  it('produces distinct pairing sessions for two different tokens (no cross-session key reuse)', () => {
+    const a = completedHandshake();
+    const b = completedHandshake();
+    expect(Buffer.from(a.phone.getHandshakeHash()).toString('hex')).not.toBe(Buffer.from(b.phone.getHandshakeHash()).toString('hex'));
+  });
+});

--- a/tests/unit/protocol/noise-vectors.test.ts
+++ b/tests/unit/protocol/noise-vectors.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Validates the shared Noise interpreter (HandshakeState + SymmetricState +
+ * CipherState) against three independent official test vectors, sourced
+ * from the cacophony vector suite (mirrored at
+ * https://github.com/mcginty/snow/blob/main/tests/vectors/cacophony.txt):
+ *
+ *   - Noise_KK_25519_ChaChaPoly_BLAKE2s: the production ongoing-session
+ *     pattern. Covers pre-message static mixing on both sides, the
+ *     es/se/ss/ee DH combiners, Split(), and post-handshake transport
+ *     encryption with the split CipherStates.
+ *   - Noise_IK_25519_ChaChaPoly_BLAKE2s: covers the in-message "s" token
+ *     (encrypted-with-current-key on write, HasKey()-gated length on
+ *     read) that KK never exercises, since KK's statics are pre-messages.
+ *   - Noise_NKpsk0_25519_ChaChaPoly_BLAKE2s: covers the "psk" token /
+ *     MixKeyAndHash path.
+ *
+ * Together these three vectors exercise every token type the interpreter
+ * supports. The production KK driver (crypto/noise/kk.ts) and pairing
+ * driver (crypto/pairing-handshake.ts, pattern IKpsk0) are thin wrappers
+ * around the exact same interpreter, combining what these three vectors
+ * validate independently (KK's pre-message statics, IK's in-message "s"
+ * token, and psk0's MixKeyAndHash) - see noise-pairing.test.ts for
+ * dedicated behavioral tests of the pairing driver itself.
+ */
+import { describe, expect, it } from 'vitest';
+import { hexToBytes, x25519PublicKeyFrom, type X25519KeyPair } from '../../../packages/protocol/src/crypto/primitives';
+import { HandshakeState } from '../../../packages/protocol/src/crypto/noise/handshake-state';
+import { KK_PATTERN, type NoisePattern } from '../../../packages/protocol/src/crypto/noise/patterns';
+
+const IK_PATTERN: NoisePattern = {
+  name: 'IK',
+  initiatorPreMessage: [],
+  responderPreMessage: ['s'],
+  messages: [
+    ['e', 'es', 's', 'ss'],
+    ['e', 'ee', 'se'],
+  ],
+  usesPsk: false,
+};
+
+const NKPSK0_PATTERN: NoisePattern = {
+  name: 'NKpsk0',
+  initiatorPreMessage: [],
+  responderPreMessage: ['s'],
+  messages: [
+    ['psk', 'e', 'es'],
+    ['e', 'ee'],
+  ],
+  usesPsk: true,
+};
+
+function keyPairFromSecretHex(secretHex: string): X25519KeyPair {
+  const secretKey = hexToBytes(secretHex);
+  return { secretKey, publicKey: x25519PublicKeyFrom(secretKey) };
+}
+
+function fixedEphemeral(secretHex: string): () => X25519KeyPair {
+  const keyPair = keyPairFromSecretHex(secretHex);
+  return () => keyPair;
+}
+
+interface VectorSpec {
+  pattern: NoisePattern;
+  prologueHex: string;
+  initStaticHex?: string;
+  initEphemeralHex: string;
+  initRemoteStaticHex?: string;
+  initPskHex?: string;
+  respStaticHex?: string;
+  respEphemeralHex: string;
+  respRemoteStaticHex?: string;
+  respPskHex?: string;
+  handshakeHashHex: string;
+  messages: { payloadHex: string; ciphertextHex: string }[];
+}
+
+function runVector(spec: VectorSpec): void {
+  const initiator = new HandshakeState({
+    pattern: spec.pattern,
+    initiator: true,
+    prologue: hexToBytes(spec.prologueHex),
+    s: spec.initStaticHex ? keyPairFromSecretHex(spec.initStaticHex) : undefined,
+    rs: spec.initRemoteStaticHex ? hexToBytes(spec.initRemoteStaticHex) : undefined,
+    psk: spec.initPskHex ? hexToBytes(spec.initPskHex) : undefined,
+    generateEphemeral: fixedEphemeral(spec.initEphemeralHex),
+  });
+  const responder = new HandshakeState({
+    pattern: spec.pattern,
+    initiator: false,
+    prologue: hexToBytes(spec.prologueHex),
+    s: spec.respStaticHex ? keyPairFromSecretHex(spec.respStaticHex) : undefined,
+    rs: spec.respRemoteStaticHex ? hexToBytes(spec.respRemoteStaticHex) : undefined,
+    psk: spec.respPskHex ? hexToBytes(spec.respPskHex) : undefined,
+    generateEphemeral: fixedEphemeral(spec.respEphemeralHex),
+  });
+
+  const handshakeMessageCount = spec.pattern.messages.length;
+  // Each side calls split() independently on its own HandshakeState, so
+  // these are two distinct pairs of CipherState objects with independent
+  // nonce counters - exactly modeling two real, separate peers. Track
+  // which pair belongs to which role explicitly rather than assuming an
+  // order, since the writer of the LAST handshake message alternates
+  // with the pattern's message count.
+  let initiatorSplit: NonNullable<ReturnType<HandshakeState['writeMessage']>['split']> | undefined;
+  let responderSplit: NonNullable<ReturnType<HandshakeState['writeMessage']>['split']> | undefined;
+
+  for (let i = 0; i < handshakeMessageCount; i++) {
+    const { payloadHex, ciphertextHex } = spec.messages[i];
+    const initiatorWrites = i % 2 === 0;
+    const writer = initiatorWrites ? initiator : responder;
+    const reader = initiatorWrites ? responder : initiator;
+
+    const writeResult = writer.writeMessage(hexToBytes(payloadHex));
+    expect(Buffer.from(writeResult.message).toString('hex')).toBe(ciphertextHex);
+
+    const readResult = reader.readMessage(hexToBytes(ciphertextHex));
+    expect(Buffer.from(readResult.payload).toString('hex')).toBe(payloadHex);
+
+    if (i === handshakeMessageCount - 1) {
+      expect(writeResult.split).toBeDefined();
+      expect(readResult.split).toBeDefined();
+      if (initiatorWrites) {
+        initiatorSplit = writeResult.split;
+        responderSplit = readResult.split;
+      } else {
+        responderSplit = writeResult.split;
+        initiatorSplit = readResult.split;
+      }
+    }
+  }
+
+  expect(Buffer.from(initiator.getHandshakeHash()).toString('hex')).toBe(spec.handshakeHashHex);
+  expect(Buffer.from(responder.getHandshakeHash()).toString('hex')).toBe(spec.handshakeHashHex);
+
+  if (!initiatorSplit || !responderSplit) throw new Error('Split ciphers were not produced');
+  // Split() convention (Noise section 5.2): c1 is the initiator's send
+  // cipher (and the responder's receive cipher for the same messages);
+  // c2 is the reverse. Each side uses its OWN split() result here, as a
+  // real peer would.
+  const [initiatorSend, initiatorReceive] = initiatorSplit;
+  const [responderReceive, responderSend] = responderSplit;
+
+  for (let i = handshakeMessageCount; i < spec.messages.length; i++) {
+    const { payloadHex, ciphertextHex } = spec.messages[i];
+    const initiatorTurn = i % 2 === 0;
+    const sendCipher = initiatorTurn ? initiatorSend : responderSend;
+    const receiveCipher = initiatorTurn ? responderReceive : initiatorReceive;
+
+    const ciphertext = sendCipher.encryptWithAd(new Uint8Array(0), hexToBytes(payloadHex));
+    expect(Buffer.from(ciphertext).toString('hex')).toBe(ciphertextHex);
+
+    const plaintext = receiveCipher.decryptWithAd(new Uint8Array(0), hexToBytes(ciphertextHex));
+    expect(Buffer.from(plaintext).toString('hex')).toBe(payloadHex);
+  }
+}
+
+describe('Noise interpreter vs official test vectors', () => {
+  it('Noise_KK_25519_ChaChaPoly_BLAKE2s', () => {
+    runVector({
+      pattern: KK_PATTERN,
+      prologueHex: '4a6f686e2047616c74',
+      initStaticHex: 'e61ef9919cde45dd5f82166404bd08e38bceb5dfdfded0a34c8df7ed542214d1',
+      initEphemeralHex: '893e28b9dc6ca8d611ab664754b8ceb7bac5117349a4439a6b0569da977c464a',
+      initRemoteStaticHex: '31e0303fd6418d2f8c0e78b91f22e8caed0fbe48656dcf4767e4834f701b8f62',
+      respStaticHex: '4a3acbfdb163dec651dfa3194dece676d437029c62a408b4c5ea9114246e4893',
+      respEphemeralHex: 'bbdb4cdbd309f1a1f2e1456967fe288cadd6f712d65dc7b7793d5e63da6b375b',
+      respRemoteStaticHex: '6bc3822a2aa7f4e6981d6538692b3cdf3e6df9eea6ed269eb41d93c22757b75a',
+      handshakeHashHex: '1362b8627a00907ce11e558aba8ce7cbca88e83f0e84ce7db5159b1c3e25ab59',
+      messages: [
+        { payloadHex: '4c756477696720766f6e204d69736573', ciphertextHex: 'ca35def5ae56cec33dc2036731ab14896bc4c75dbb07a61f879f8e3afa4c7944266a5f53784aa3becb0f7485c2759c328937867a4cbaafef07422b0725e098be' },
+        { payloadHex: '4d757272617920526f746862617264', ciphertextHex: '95ebc60d2b1fa672c1f46a8aa265ef51bfe38e7ccb39ec5be34069f144808843008aeea5d76d6abcbab87a18502c8a8352d9933ac11e2a7d228038d721e31e' },
+        { payloadHex: '462e20412e20486179656b', ciphertextHex: '5f92113edf78c3e56e6d67201f5f9e0c8f2930c3e1ffb64ede0358' },
+        { payloadHex: '4361726c204d656e676572', ciphertextHex: '30ebbd9cdcef7f40d99c8cd11e880dac28f5c9e5032c1059b3b56a' },
+        { payloadHex: '4a65616e2d426170746973746520536179', ciphertextHex: 'b011620dc31f88abd1788db50912952fe45da56e9d0907ab2cbce5f609b58b1cf2' },
+        { payloadHex: '457567656e2042f6686d20766f6e2042617765726b', ciphertextHex: 'a0661971e9047b28a815c7b1f62fefb471e4d34bc2a5b48149e7f80c3772b8e4aae8b44baa' },
+      ],
+    });
+  });
+
+  it('Noise_IK_25519_ChaChaPoly_BLAKE2s', () => {
+    runVector({
+      pattern: IK_PATTERN,
+      prologueHex: '4a6f686e2047616c74',
+      initStaticHex: 'e61ef9919cde45dd5f82166404bd08e38bceb5dfdfded0a34c8df7ed542214d1',
+      initEphemeralHex: '893e28b9dc6ca8d611ab664754b8ceb7bac5117349a4439a6b0569da977c464a',
+      initRemoteStaticHex: '31e0303fd6418d2f8c0e78b91f22e8caed0fbe48656dcf4767e4834f701b8f62',
+      respStaticHex: '4a3acbfdb163dec651dfa3194dece676d437029c62a408b4c5ea9114246e4893',
+      respEphemeralHex: 'bbdb4cdbd309f1a1f2e1456967fe288cadd6f712d65dc7b7793d5e63da6b375b',
+      handshakeHashHex: '48f3cb8bc9319da4ba1e9933991b1c4ed4034f1f126a76d3a1fbcfd7f94248d4',
+      messages: [
+        { payloadHex: '4c756477696720766f6e204d69736573', ciphertextHex: 'ca35def5ae56cec33dc2036731ab14896bc4c75dbb07a61f879f8e3afa4c79440b03ddc7aac5123d06a1b23b71670e32e76c28239a7ca4ac8f784de7e44c1adbfc6e83fef7352a58d9d56157400c0a737b1d171ce368229c7b752ac25b8faf4eca690f6d896f543be02c996ab2b86b76' },
+        { payloadHex: '4d757272617920526f746862617264', ciphertextHex: '95ebc60d2b1fa672c1f46a8aa265ef51bfe38e7ccb39ec5be34069f144808843d9b5a8927f0ac9655ef76833bc7e5561f42e691ac8404efd6fbd6308b6a27c' },
+        { payloadHex: '462e20412e20486179656b', ciphertextHex: '2c256ed08fcd08c2980f954ee4beaccb61c9581340f5dd2fd1cf3b' },
+        { payloadHex: '4361726c204d656e676572', ciphertextHex: 'd6033f70eee20945c7c9dba304e397ee3b284ff5e00fd9efb095d3' },
+        { payloadHex: '4a65616e2d426170746973746520536179', ciphertextHex: 'a9c068ca5d8babf72560652d8e851adbfac35c8a66e810d560863173e96adf4cfe' },
+        { payloadHex: '457567656e2042f6686d20766f6e2042617765726b', ciphertextHex: '2a09d8f459e5927e40fdd2eddc99bdafb04e13a26f145cb5cfe9e6ba34c94331ebc17d5156' },
+      ],
+    });
+  });
+
+  it('Noise_NKpsk0_25519_ChaChaPoly_BLAKE2s', () => {
+    const psk = '54686973206973206d7920417573747269616e20706572737065637469766521';
+    runVector({
+      pattern: NKPSK0_PATTERN,
+      prologueHex: '4a6f686e2047616c74',
+      initPskHex: psk,
+      initEphemeralHex: '893e28b9dc6ca8d611ab664754b8ceb7bac5117349a4439a6b0569da977c464a',
+      initRemoteStaticHex: '31e0303fd6418d2f8c0e78b91f22e8caed0fbe48656dcf4767e4834f701b8f62',
+      respPskHex: psk,
+      respStaticHex: '4a3acbfdb163dec651dfa3194dece676d437029c62a408b4c5ea9114246e4893',
+      respEphemeralHex: 'bbdb4cdbd309f1a1f2e1456967fe288cadd6f712d65dc7b7793d5e63da6b375b',
+      handshakeHashHex: '6bd69bd4066f41f32e47134976f5bf01606f7a4a0e04369fe61158b06f3a144e',
+      messages: [
+        { payloadHex: '4c756477696720766f6e204d69736573', ciphertextHex: 'ca35def5ae56cec33dc2036731ab14896bc4c75dbb07a61f879f8e3afa4c794427635ede06947b2d3acd77a36788aaaf17e9f5a8ac252e560fb421ba161a2cf8' },
+        { payloadHex: '4d757272617920526f746862617264', ciphertextHex: '95ebc60d2b1fa672c1f46a8aa265ef51bfe38e7ccb39ec5be34069f144808843d682eb9cf4fee6816c8c8cfd34c15774321e234e3a426d7cfd3f13e5e84d04' },
+        { payloadHex: '462e20412e20486179656b', ciphertextHex: 'b6645684db57679aa08f0b3352d58f32ec7f1e1a02083d5bd54277' },
+        { payloadHex: '4361726c204d656e676572', ciphertextHex: '473a9a4109eba0939e934640d318984df8d0900aa922f0195a09ad' },
+        { payloadHex: '4a65616e2d426170746973746520536179', ciphertextHex: 'c8c44a16fff728f83e61272382149feadd3eb0ee1bab6313f84c72fe1581225236' },
+        { payloadHex: '457567656e2042f6686d20766f6e2042617765726b', ciphertextHex: '21354f87158ac5e357529e87e8c84cfcdb49c8a080550c8f908d05ef7ea82ca525e3d1398e' },
+      ],
+    });
+  });
+});

--- a/tests/unit/protocol/qr.test.ts
+++ b/tests/unit/protocol/qr.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { generateX25519KeyPair, randomBytes } from '../../../packages/protocol/src/crypto/primitives';
+import { decodePairingQrPayload, encodePairingQrPayload, PAIRING_URI_SCHEME, type PairingQrPayload } from '../../../packages/protocol/src/pairing/qr';
+
+function samplePayload(overrides: Partial<PairingQrPayload> = {}): PairingQrPayload {
+  return {
+    desktopStaticPublicKey: generateX25519KeyPair().publicKey,
+    pairingToken: randomBytes(32),
+    relayAddress: 'wss://relay.kangentic.com',
+    expiresAt: '2026-07-10T00:10:00.000Z',
+    protocolVersion: '1',
+    ...overrides,
+  };
+}
+
+describe('pairing QR payload', () => {
+  it('round-trips through encode/decode', () => {
+    const payload = samplePayload();
+    const uri = encodePairingQrPayload(payload);
+    expect(uri.startsWith(`${PAIRING_URI_SCHEME}://`)).toBe(true);
+
+    const decoded = decodePairingQrPayload(uri);
+    expect(Buffer.from(decoded.desktopStaticPublicKey).toString('hex')).toBe(Buffer.from(payload.desktopStaticPublicKey).toString('hex'));
+    expect(Buffer.from(decoded.pairingToken).toString('hex')).toBe(Buffer.from(payload.pairingToken).toString('hex'));
+    expect(decoded.relayAddress).toBe(payload.relayAddress);
+    expect(decoded.expiresAt).toBe(payload.expiresAt);
+    expect(decoded.protocolVersion).toBe(payload.protocolVersion);
+  });
+
+  it('never carries a long-lived secret - only a 32-byte single-use token', () => {
+    const payload = samplePayload();
+    const uri = encodePairingQrPayload(payload);
+    // The encoded body is bounded: 1 version + 32 static key + 32 token +
+    // 4 length + relay bytes + 4 length + expiresAt bytes. Assert it stays
+    // in that small ballpark rather than growing to accommodate a bigger secret.
+    expect(uri.length).toBeLessThan(300);
+  });
+
+  it('rejects a non-kangentic-pair URI', () => {
+    expect(() => decodePairingQrPayload('https://example.com')).toThrow();
+  });
+
+  it('rejects an oversized relay address at encode time', () => {
+    const payload = samplePayload({ relayAddress: 'wss://' + 'a'.repeat(600) });
+    expect(() => encodePairingQrPayload(payload)).toThrow();
+  });
+
+  it('rejects a corrupted/truncated payload at decode time', () => {
+    const uri = encodePairingQrPayload(samplePayload());
+    const truncated = uri.slice(0, uri.length - 40);
+    expect(() => decodePairingQrPayload(truncated)).toThrow();
+  });
+});

--- a/tests/unit/protocol/roster.test.ts
+++ b/tests/unit/protocol/roster.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { generateEd25519KeyPair, generateX25519KeyPair } from '../../../packages/protocol/src/crypto/primitives';
+import {
+  findRosterDevice,
+  isRosterEntryExpired,
+  rosterDeviceCapabilitySet,
+  signRosterEntry,
+  verifyRosterEntry,
+  type DeviceRoster,
+} from '../../../packages/protocol/src/roster/roster';
+
+function buildSignedEntry(masterSigningSecretKey: Uint8Array, overrides: Partial<Parameters<typeof signRosterEntry>[1]> = {}) {
+  const device = generateX25519KeyPair();
+  return signRosterEntry(masterSigningSecretKey, {
+    deviceId: 'device-1',
+    staticPublicKey: device.publicKey,
+    displayName: "My iPhone",
+    capabilities: ['read-board', 'read-stream'],
+    pairedAt: '2026-07-10T00:00:00.000Z',
+    expiresAt: null,
+    ...overrides,
+  });
+}
+
+describe('device roster signing', () => {
+  it('signs and verifies a roster entry against the master signing key', () => {
+    const master = generateEd25519KeyPair();
+    const entry = buildSignedEntry(master.secretKey);
+    expect(verifyRosterEntry(master.publicKey, entry)).toBe(true);
+  });
+
+  it('rejects an entry signed by a different key', () => {
+    const master = generateEd25519KeyPair();
+    const otherMaster = generateEd25519KeyPair();
+    const entry = buildSignedEntry(master.secretKey);
+    expect(verifyRosterEntry(otherMaster.publicKey, entry)).toBe(false);
+  });
+
+  it('rejects a tampered entry (capability escalation after signing)', () => {
+    const master = generateEd25519KeyPair();
+    const entry = buildSignedEntry(master.secretKey, { capabilities: ['read-board'] });
+    const escalated = { ...entry, capabilities: [...entry.capabilities, 'answer-permission-prompt' as const] };
+    expect(verifyRosterEntry(master.publicKey, escalated)).toBe(false);
+  });
+
+  it('rejects a tampered displayName (field-boundary confusion is not exploitable)', () => {
+    const master = generateEd25519KeyPair();
+    const entry = buildSignedEntry(master.secretKey, { deviceId: 'ab', displayName: 'c' });
+    const shifted = { ...entry, deviceId: 'a', displayName: 'bc' };
+    expect(verifyRosterEntry(master.publicKey, shifted)).toBe(false);
+  });
+
+  it('capability set round-trips through the roster entry', () => {
+    const master = generateEd25519KeyPair();
+    const entry = buildSignedEntry(master.secretKey, { capabilities: ['move-task', 'send-user-message'] });
+    const set = rosterDeviceCapabilitySet(entry);
+    expect(set.has('move-task')).toBe(true);
+    expect(set.has('read-diff')).toBe(false);
+  });
+
+  it('findRosterDevice locates an entry by deviceId', () => {
+    const master = generateEd25519KeyPair();
+    const entry = buildSignedEntry(master.secretKey, { deviceId: 'phone-a' });
+    const roster: DeviceRoster = { masterSigningPublicKey: master.publicKey, devices: [entry] };
+    expect(findRosterDevice(roster, 'phone-a')).toBe(entry);
+    expect(findRosterDevice(roster, 'phone-b')).toBeUndefined();
+  });
+
+  it('isRosterEntryExpired reflects expiresAt', () => {
+    const master = generateEd25519KeyPair();
+    const noExpiry = buildSignedEntry(master.secretKey, { expiresAt: null });
+    const expired = buildSignedEntry(master.secretKey, { expiresAt: '2020-01-01T00:00:00.000Z' });
+    const future = buildSignedEntry(master.secretKey, { expiresAt: '2099-01-01T00:00:00.000Z' });
+
+    const now = new Date('2026-07-10T00:00:00.000Z');
+    expect(isRosterEntryExpired(noExpiry, now)).toBe(false);
+    expect(isRosterEntryExpired(expired, now)).toBe(true);
+    expect(isRosterEntryExpired(future, now)).toBe(false);
+  });
+});

--- a/tests/unit/protocol/sas.test.ts
+++ b/tests/unit/protocol/sas.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { generateX25519KeyPair, randomBytes } from '../../../packages/protocol/src/crypto/primitives';
+import { createPairingInitiatorHandshake, createPairingResponderHandshake } from '../../../packages/protocol/src/crypto/pairing-handshake';
+import { deriveShortAuthenticationString } from '../../../packages/protocol/src/crypto/sas';
+
+describe('short authentication string', () => {
+  it('is deterministic for the same transcript hash', () => {
+    const hash = randomBytes(32);
+    const first = deriveShortAuthenticationString(hash);
+    const second = deriveShortAuthenticationString(hash);
+    expect(first).toEqual(second);
+  });
+
+  it('produces a 6-digit code and 5 emoji', () => {
+    const { digits, emoji } = deriveShortAuthenticationString(randomBytes(32));
+    expect(digits).toMatch(/^\d{6}$/);
+    expect(emoji).toHaveLength(5);
+  });
+
+  it('two honest pairing peers derive the identical SAS from their completed handshake', () => {
+    const phoneStatic = generateX25519KeyPair();
+    const desktopStatic = generateX25519KeyPair();
+    const pairingToken = randomBytes(32);
+
+    const phone = createPairingInitiatorHandshake({ localStatic: phoneStatic, remoteStatic: desktopStatic.publicKey, pairingToken });
+    const desktop = createPairingResponderHandshake({ localStatic: desktopStatic, pairingToken });
+
+    const message1 = phone.writeMessage(new Uint8Array(0));
+    desktop.readMessage(message1.message);
+    const message2 = desktop.writeMessage(new Uint8Array(0));
+    phone.readMessage(message2.message);
+
+    const phoneSas = deriveShortAuthenticationString(phone.getHandshakeHash());
+    const desktopSas = deriveShortAuthenticationString(desktop.getHandshakeHash());
+    expect(phoneSas).toEqual(desktopSas);
+  });
+
+  it('a different transcript (different pairing token) produces a different SAS with overwhelming probability', () => {
+    const first = deriveShortAuthenticationString(randomBytes(32));
+    const second = deriveShortAuthenticationString(randomBytes(32));
+    expect(first).not.toEqual(second);
+  });
+
+  it('an active relay-in-the-middle terminating two separate handshakes shows different SAS on each screen', () => {
+    // Simulates the attack SAS exists to defeat: an attacker sits between the
+    // phone and the desktop and terminates TWO independent Noise handshakes
+    // instead of transparently forwarding one - one leg impersonating the
+    // desktop toward the real phone, the other impersonating the phone
+    // toward the real desktop - using a DISTINCT attacker-controlled static
+    // keypair on each leg. Even though both legs share the same pairing
+    // token (as relayed/photographed from the real QR), the transcript hash
+    // still commits to the static keys actually used on that leg, so the SAS
+    // the phone displays and the SAS the desktop displays must differ.
+    const pairingToken = randomBytes(32);
+    const phoneStatic = generateX25519KeyPair();
+    const desktopStatic = generateX25519KeyPair();
+    const attackerStaticTowardPhone = generateX25519KeyPair();
+    const attackerStaticTowardDesktop = generateX25519KeyPair();
+
+    // Leg 1: real phone <-> attacker impersonating the desktop.
+    const phone = createPairingInitiatorHandshake({
+      localStatic: phoneStatic,
+      remoteStatic: attackerStaticTowardPhone.publicKey,
+      pairingToken,
+    });
+    const attackerAsDesktop = createPairingResponderHandshake({
+      localStatic: attackerStaticTowardPhone,
+      pairingToken,
+    });
+    const phoneMessage1 = phone.writeMessage(new Uint8Array(0));
+    attackerAsDesktop.readMessage(phoneMessage1.message);
+    const attackerMessage2ToPhone = attackerAsDesktop.writeMessage(new Uint8Array(0));
+    phone.readMessage(attackerMessage2ToPhone.message);
+
+    // Leg 2: attacker impersonating the phone <-> real desktop.
+    const attackerAsPhone = createPairingInitiatorHandshake({
+      localStatic: attackerStaticTowardDesktop,
+      remoteStatic: desktopStatic.publicKey,
+      pairingToken,
+    });
+    const desktop = createPairingResponderHandshake({
+      localStatic: desktopStatic,
+      pairingToken,
+    });
+    const attackerMessage1ToDesktop = attackerAsPhone.writeMessage(new Uint8Array(0));
+    desktop.readMessage(attackerMessage1ToDesktop.message);
+    const desktopMessage2 = desktop.writeMessage(new Uint8Array(0));
+    attackerAsPhone.readMessage(desktopMessage2.message);
+
+    const sasShownOnPhone = deriveShortAuthenticationString(phone.getHandshakeHash());
+    const sasShownOnDesktop = deriveShortAuthenticationString(desktop.getHandshakeHash());
+
+    expect(sasShownOnPhone).not.toEqual(sasShownOnDesktop);
+    expect(sasShownOnPhone.digits).not.toEqual(sasShownOnDesktop.digits);
+  });
+});

--- a/tests/unit/protocol/secretstream.test.ts
+++ b/tests/unit/protocol/secretstream.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { randomBytes } from '../../../packages/protocol/src/crypto/primitives';
+import { deriveSecretstreamPair, FrameTag, SecretstreamState } from '../../../packages/protocol/src/crypto/secretstream';
+
+describe('secretstream framing', () => {
+  it('round-trips a sequence of frames in order', () => {
+    const chainingKey = randomBytes(32);
+    const initiator = deriveSecretstreamPair(chainingKey, true);
+    const responder = deriveSecretstreamPair(chainingKey, false);
+
+    for (const text of ['first', 'second', 'third']) {
+      const frame = initiator.send.seal(new TextEncoder().encode(text));
+      const { tag, plaintext } = responder.receive.open(frame);
+      expect(tag).toBe(FrameTag.Message);
+      expect(new TextDecoder().decode(plaintext)).toBe(text);
+    }
+  });
+
+  it('derives matching key material for both peers from the same chaining key', () => {
+    const chainingKey = randomBytes(32);
+    const initiator = deriveSecretstreamPair(chainingKey, true);
+    const responder = deriveSecretstreamPair(chainingKey, false);
+
+    const fromInitiator = initiator.send.seal(new TextEncoder().encode('hello'));
+    expect(() => responder.receive.open(fromInitiator)).not.toThrow();
+
+    const fromResponder = responder.send.seal(new TextEncoder().encode('hi back'));
+    expect(() => initiator.receive.open(fromResponder)).not.toThrow();
+  });
+
+  it('rejects a tampered frame', () => {
+    const chainingKey = randomBytes(32);
+    const initiator = deriveSecretstreamPair(chainingKey, true);
+    const responder = deriveSecretstreamPair(chainingKey, false);
+
+    const frame = initiator.send.seal(new TextEncoder().encode('payload'));
+    const tampered = new Uint8Array(frame);
+    tampered[tampered.length - 1] ^= 0x01;
+    expect(() => responder.receive.open(tampered)).toThrow();
+  });
+
+  it('rejects a replayed frame (same frame processed twice)', () => {
+    const chainingKey = randomBytes(32);
+    const initiator = deriveSecretstreamPair(chainingKey, true);
+    const responder = deriveSecretstreamPair(chainingKey, false);
+
+    const frame = initiator.send.seal(new TextEncoder().encode('payload'));
+    responder.receive.open(frame);
+    // The receiver's counter has already advanced past this frame's nonce;
+    // replaying it fails to authenticate against the now-current counter.
+    expect(() => responder.receive.open(frame)).toThrow();
+  });
+
+  it('rejects an out-of-order frame (a gap causes the wrong nonce to be derived)', () => {
+    const chainingKey = randomBytes(32);
+    const initiator = deriveSecretstreamPair(chainingKey, true);
+    const responder = deriveSecretstreamPair(chainingKey, false);
+
+    const frame1 = initiator.send.seal(new TextEncoder().encode('one'));
+    const frame2 = initiator.send.seal(new TextEncoder().encode('two'));
+    // Skip frame1 entirely; hand the receiver frame2 first.
+    expect(() => responder.receive.open(frame2)).toThrow();
+    void frame1;
+  });
+
+  it('rekey() rotates the key so a frame sealed under the old key no longer opens', () => {
+    const key = randomBytes(32);
+    const nonceHeader = randomBytes(24);
+    const sender = new SecretstreamState(key, nonceHeader);
+    const receiverBeforeRekey = new SecretstreamState(key, nonceHeader);
+    const receiverAfterRekey = new SecretstreamState(key, nonceHeader);
+    receiverAfterRekey.rekey();
+
+    sender.rekey();
+    const frame = sender.seal(new TextEncoder().encode('post-rekey'));
+
+    expect(() => receiverBeforeRekey.open(frame)).toThrow();
+    const { plaintext } = receiverAfterRekey.open(frame);
+    expect(new TextDecoder().decode(plaintext)).toBe('post-rekey');
+  });
+
+  it('carries the FINAL tag so a receiver can distinguish a clean close from a truncation', () => {
+    const chainingKey = randomBytes(32);
+    const initiator = deriveSecretstreamPair(chainingKey, true);
+    const responder = deriveSecretstreamPair(chainingKey, false);
+
+    const frame = initiator.send.seal(new Uint8Array(0), FrameTag.Final);
+    const { tag } = responder.receive.open(frame);
+    expect(tag).toBe(FrameTag.Final);
+  });
+});

--- a/tests/unit/protocol/session-frame.test.ts
+++ b/tests/unit/protocol/session-frame.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { SessionFrameKind, unwrapSessionFrame, wrapSessionFrame } from '../../../packages/protocol/src/wire/session-frame';
+
+describe('session frame prefix', () => {
+  it('round-trips a handshake frame', () => {
+    const payload = new Uint8Array([1, 2, 3, 4]);
+    const wrapped = wrapSessionFrame(SessionFrameKind.Handshake, payload);
+    const { kind, payload: unwrapped } = unwrapSessionFrame(wrapped);
+    expect(kind).toBe(SessionFrameKind.Handshake);
+    expect(Array.from(unwrapped)).toEqual(Array.from(payload));
+  });
+
+  it('round-trips an application frame', () => {
+    const payload = new Uint8Array([9, 8, 7]);
+    const wrapped = wrapSessionFrame(SessionFrameKind.Application, payload);
+    const { kind, payload: unwrapped } = unwrapSessionFrame(wrapped);
+    expect(kind).toBe(SessionFrameKind.Application);
+    expect(Array.from(unwrapped)).toEqual(Array.from(payload));
+  });
+
+  it('handles an empty payload', () => {
+    const wrapped = wrapSessionFrame(SessionFrameKind.Application, new Uint8Array(0));
+    const { payload } = unwrapSessionFrame(wrapped);
+    expect(payload.length).toBe(0);
+  });
+
+  it('rejects an empty frame (no kind byte)', () => {
+    expect(() => unwrapSessionFrame(new Uint8Array(0))).toThrow();
+  });
+
+  it('rejects an unknown kind byte', () => {
+    expect(() => unwrapSessionFrame(new Uint8Array([99, 1, 2]))).toThrow();
+  });
+});

--- a/tests/unit/register-all-idempotency.test.ts
+++ b/tests/unit/register-all-idempotency.test.ts
@@ -180,6 +180,28 @@ vi.mock('../../src/main/ipc/handlers/git-diff', () => ({
 vi.mock('../../src/main/ipc/handlers/system', () => ({
   registerSystemHandlers: vi.fn(),
 }));
+vi.mock('../../src/main/ipc/handlers/mobile-bridge', () => ({
+  registerMobileBridgeHandlers: vi.fn(),
+}));
+
+// MobileBridgeService is constructed directly by register-all.ts (unlike the
+// other services above, which are all injected via a registerXHandlers mock),
+// so it needs its own lightweight class mock: a real .reconcile() spy to
+// assert the effective-config wiring below, and no real fs/electron/identity
+// work (the real class already covers that in mobile-bridge-service.test.ts).
+const mobileBridgeReconcileSpy = vi.fn();
+const mobileBridgeDisposeSpy = vi.fn();
+vi.mock('../../src/main/mobile-bridge/mobile-bridge-service', () => ({
+  MobileBridgeService: class {
+    config: unknown;
+    constructor(config: unknown) {
+      this.config = config;
+    }
+    reconcile = mobileBridgeReconcileSpy;
+    dispose = mobileBridgeDisposeSpy;
+    on = vi.fn();
+  },
+}));
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -192,6 +214,8 @@ function makeMockWindow(id: number) {
 describe('registerAllIpc idempotency', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    mobileBridgeReconcileSpy.mockClear();
+    mobileBridgeDisposeSpy.mockClear();
     // Reset the module-level `context` singleton between tests
     vi.resetModules();
   });
@@ -210,6 +234,7 @@ describe('registerAllIpc idempotency', () => {
     const { registerTaskMoveHandlers } = await import('../../src/main/ipc/handlers/task-move');
     const { registerTaskBranchHandlers } = await import('../../src/main/ipc/handlers/task-branch');
     const { registerTaskRuntimeOverrideHandlers } = await import('../../src/main/ipc/handlers/task-runtime-override');
+    const { registerMobileBridgeHandlers } = await import('../../src/main/ipc/handlers/mobile-bridge');
     const { retrievalService } = await import('../../src/main/retrieval/retrieval-service');
 
     const window = makeMockWindow(1);
@@ -222,11 +247,20 @@ describe('registerAllIpc idempotency', () => {
     expect(registerTaskMoveHandlers).toHaveBeenCalledTimes(1);
     expect(registerTaskBranchHandlers).toHaveBeenCalledTimes(1);
     expect(registerTaskRuntimeOverrideHandlers).toHaveBeenCalledTimes(1);
+    expect(registerMobileBridgeHandlers).toHaveBeenCalledTimes(1);
 
     // The central embedding engine's drain loop is started at boot (not just
     // lazily on the first project:open), so the drain loop is already alive
     // before any project is opened.
     expect(retrievalService.attach).toHaveBeenCalledTimes(1);
+
+    // MobileBridgeService.reconcile() is called once at startup with the
+    // real effective config's mobileBridge fields (defaulted, since the
+    // mocked ConfigManager.getEffectiveConfig() here returns no mobileBridge
+    // key) - not left at the { enabled: false, relayUrl: '' } placeholder
+    // the constructor takes before configManager is available.
+    expect(mobileBridgeReconcileSpy).toHaveBeenCalledTimes(1);
+    expect(mobileBridgeReconcileSpy).toHaveBeenCalledWith({ enabled: false, relayUrl: '' });
 
     // Context is initialized (wrappers don't throw)
     expect(() => getSessionManager()).not.toThrow();
@@ -246,6 +280,7 @@ describe('registerAllIpc idempotency', () => {
     const { registerBacklogHandlers } = await import('../../src/main/ipc/handlers/backlog');
     const { registerGitDiffHandlers } = await import('../../src/main/ipc/handlers/git-diff');
     const { registerSystemHandlers } = await import('../../src/main/ipc/handlers/system');
+    const { registerMobileBridgeHandlers } = await import('../../src/main/ipc/handlers/mobile-bridge');
     const { retrievalService } = await import('../../src/main/retrieval/retrieval-service');
 
     const window1 = makeMockWindow(1);
@@ -277,10 +312,16 @@ describe('registerAllIpc idempotency', () => {
     expect(registerBacklogHandlers).toHaveBeenCalledTimes(1);
     expect(registerGitDiffHandlers).toHaveBeenCalledTimes(1);
     expect(registerSystemHandlers).toHaveBeenCalledTimes(1);
+    expect(registerMobileBridgeHandlers).toHaveBeenCalledTimes(1);
 
     // The second call short-circuits before reaching retrievalService.attach,
     // so it stays called exactly once total across both registerAllIpc calls.
     expect(retrievalService.attach).toHaveBeenCalledTimes(1);
+
+    // Same idempotency guarantee for the mobile bridge: a re-activate on
+    // macOS must not construct a second MobileBridgeService (which would
+    // hold a second relay connection) nor re-run reconcile() a second time.
+    expect(mobileBridgeReconcileSpy).toHaveBeenCalledTimes(1);
   }, 30000);
 
   it('second call preserves existing services', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,9 +16,11 @@
     "resolveJsonModule": true,
     "jsx": "react-jsx",
     "paths": {
-      "@shared/*": ["src/shared/*"]
+      "@shared/*": ["src/shared/*"],
+      "@kangentic/protocol": ["packages/protocol/src/index.ts"],
+      "@kangentic/protocol/*": ["packages/protocol/src/*"]
     }
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "packages/protocol/src/**/*"],
   "exclude": ["node_modules"]
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -39,6 +39,7 @@ export default defineConfig(({ mode }) => ({
   resolve: {
     alias: {
       '@shared': '/src/shared',
+      '@kangentic/protocol': '/packages/protocol/src',
     },
   },
   server: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,20 @@
 import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const configDir = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  resolve: {
+    // No existing alias precedent for @shared in this config (unit tests import
+    // it via relative paths instead); this one is added specifically so
+    // tests/unit/protocol/*.test.ts can exercise the real public export
+    // surface of the package (`import ... from '@kangentic/protocol'`) rather
+    // than reaching into its internals via deep relative paths.
+    alias: {
+      '@kangentic/protocol': path.join(configDir, 'packages/protocol/src'),
+    },
+  },
   // Match the build-time constant used by esbuild (scripts/{dev,build}.js)
   // and Vite (vite.config.mts). Vitest evaluates source TS with on-the-fly
   // transforms - the constant is unset by default, so any `if (__KANGENTIC_DEV__)`


### PR DESCRIPTION
## What

Mobile Bridge Phase 1: the desktop/bridge half of the Kangentic mobile companion app foundation.

- **New `@kangentic/protocol` npm workspace** (`packages/protocol/`): a from-scratch Noise Protocol
  Framework implementation (`KK` pattern for ongoing sessions, `IKpsk0` for pairing) built on
  `@noble/curves` + `@noble/hashes` + `@noble/ciphers`, verified against the official Noise test
  vectors. Also: secretstream-style AEAD framing (truncation/reorder/replay detection), Matrix-style
  SAS derivation, a signed device roster, a capability-verb allowlist, QR pairing payload
  encode/decode, and the shared wire message schema. Dual CJS/ESM build via esbuild + `tsc`
  declaration emit.
- **New `src/main/mobile-bridge/` desktop module**: encrypted-at-rest device identity (reusing the
  existing `safeStorage` wrapper pattern, refusing to persist an unprotected key), a signed roster
  store with revoke-drop-plus-rekey semantics, a pairing service (token mint, QR, SAS confirm,
  roster sign), an outbound WebSocket relay transport client with reconnect/backoff, an ongoing
  bridge session (Noise KK + ~2 minute re-handshake on the same connection), and a deny-by-default
  capability router skeleton (no verb handlers yet - that is Phase 2).
- **Full IPC 7-layer wiring** for the mobile bridge (10 `mobile:*` channels), a new global
  `mobileBridge` config key, and a new **Mobile Devices** settings tab: enable toggle + relay URL,
  QR pairing with SAS confirmation, a paired-device list with per-device capabilities and revoke.
- **An independent, decoupled publish pipeline for `@kangentic/protocol`**: its own version
  (`0.1.0`, not locked to the root `package.json`), a separate `protocol-v*` tag namespace, a
  separate `publish-protocol.yml` workflow, and a companion `/release-protocol` skill - so the
  package can ship on its own cadence without forcing a Kangentic desktop release while the feature
  is still being built out.
- `docs/mobile-bridge.md` plus the doc-anchor updates (`architecture.md`, `configuration.md`,
  `user-guide.md`, `README.md`) this change requires.

## Why

Foundation for the planned Kangentic mobile companion app (project memory: mobile companion app,
board task #377): a phone should be able to pair with a running desktop instance over a relay and
hold an authenticated, end-to-end-encrypted session, with the desktop remaining the sole source of
truth for identity and granted capabilities. Nothing works when the desktop is off, by design.

Closes #377.

## How

Pairing uses a token-bound Noise PSK (not SPAKE2): the QR carries a machine-generated, high-entropy,
single-use pairing token mixed in as the Noise PSK, since SPAKE2's offline-grind resistance is a
property that matters for low-entropy human-typed codes, not machine-generated ones. A Matrix-style
SAS derived from the handshake transcript still defeats a photographed/relayed QR. Ongoing sessions
use Noise `KK` (both parties' static keys are already known post-pairing, giving mutual
authentication with no trust-on-first-use gap), with a periodic re-handshake disambiguated on the
wire via a new `SessionFrameKind` prefix byte.

The protocol package is published independently from Kangentic itself (separate version, tag
namespace, and workflow) specifically so the package can iterate and ship while the desktop app
does not need a matching release - a deliberate decoupling requested mid-build once the publishing
implications became clear. First publish requires a one-time manual npm bootstrap (OIDC Trusted
Publishing cannot be linked to a package that has never been published); this is documented in the
workflow, the `/release-protocol` skill, and tracked by follow-up board task #385, which is
explicitly gated on this PR merging first.

Trade-off: the crypto is hand-rolled (no `libsodium`/off-the-shelf Noise library) because the
noble suite is the only audited, pure-JS crypto stack with identical behavior on Node and React
Native - the mobile app will consume the exact same `@kangentic/protocol` module. This is mitigated
by testing against the official Noise spec test vectors rather than by inspection alone.

## Breaking changes

None. `mobileBridge` defaults to disabled; no existing surface changes behavior.

## Tests

- 108 unit tests across `tests/unit/protocol/` (11 files: Noise vectors for `KK`/`IK`/`NKpsk0`,
  framing, SAS, roster sign/verify, secretstream reorder/replay/truncation, QR encode/decode) and
  `tests/unit/mobile-bridge/` (9 files: identity + Linux secure-storage refusal, roster
  revoke-rekey, pairing token TTL/single-use, pairing service happy-path/MITM/downgrade negatives,
  relay client against a real local WebSocket double, bridge session against a simulated Noise
  peer, capability router deny-by-default).
- An additional coverage pass (this PR) added 61 more unit tests closing gaps in the IPC handler
  layer, the `mobile-store` Zustand store, the `config:set` -> `MobileBridgeService.reconcile()`
  wiring, `register-all.ts` lifecycle construction, `transport-factory.ts`, and a
  `MOBILE_CAPABILITY_VERBS` parity guard against the protocol package's verb enum.
- 12 UI tests (`tests/ui/mobile-devices-settings.spec.ts`) covering the settings tab, pairing/QR/SAS
  flow, and device list/revoke against the mocked Electron API.
- CI (typecheck, lint, unit, build, UI shards, Linux Electron E2E shards) is the authoritative gate
  for this PR per the Tests-column workflow.

Generated with [Claude Code](https://claude.com/claude-code)
