### PR TITLE
fix(mcp): let move_task resolve the archived Done column by name

### DIFF
--- a/src/main/agent/commands/column-resolver.ts
+++ b/src/main/agent/commands/column-resolver.ts
@@ -11,20 +11,36 @@ interface ColumnResolution {
  * List all non-archived swimlanes from the database.
  */
 export function listActiveSwimlanes(db: Database.Database): Swimlane[] {
+  return listResolvableSwimlanes(db, false);
+}
+
+/**
+ * List swimlanes eligible for name/role resolution. The Done lane is always
+ * persisted archived (it is collapsed in the board UI by design), so it is
+ * excluded unless includeArchivedDone is set - letting an agent resolve
+ * "Done" as a genuine move target without exposing other archived lanes,
+ * which a user archived deliberately to hide them.
+ */
+function listResolvableSwimlanes(db: Database.Database, includeArchivedDone: boolean): Swimlane[] {
   const swimlaneRepo = new SwimlaneRepository(db);
-  return swimlaneRepo.list().filter((swimlane) => !swimlane.is_archived);
+  return swimlaneRepo
+    .list()
+    .filter((swimlane) => !swimlane.is_archived || (includeArchivedDone && swimlane.role === 'done'));
 }
 
 /**
  * Resolve a column name to a swimlane. If columnName is null, returns the
  * default 'todo' column. Returns an error response if the column is not found.
+ * Pass options.includeArchivedDone to also match the archived Done lane by
+ * name (see listResolvableSwimlanes); it stays excluded by default.
  */
 export function resolveColumn(
   db: Database.Database,
   columnName: string | null,
   defaultRole: 'todo' | 'done' = 'todo',
+  options: { includeArchivedDone?: boolean } = {},
 ): ColumnResolution | { error: string } {
-  const allSwimlanes = listActiveSwimlanes(db);
+  const allSwimlanes = listResolvableSwimlanes(db, options.includeArchivedDone ?? false);
   let swimlane = allSwimlanes.find((lane) => lane.role === defaultRole);
 
   if (columnName) {

--- a/src/main/agent/commands/task-commands.ts
+++ b/src/main/agent/commands/task-commands.ts
@@ -450,7 +450,7 @@ export const handleMoveTask: CommandHandler = (
     return { success: false, error: `Task "${taskIdParam}" not found` };
   }
 
-  const resolution = resolveColumn(db, columnName);
+  const resolution = resolveColumn(db, columnName, 'todo', { includeArchivedDone: true });
   if ('error' in resolution) {
     return { success: false, error: resolution.error };
   }

--- a/tests/unit/mcp-move-task-to-done.test.ts
+++ b/tests/unit/mcp-move-task-to-done.test.ts
@@ -20,6 +20,8 @@
  *   - handleMoveTask moves a task to Done, dispatching to onTaskMove with the
  *     archived Done lane's id
  *   - handleCreateTask still rejects column: "Done" (regression)
+ *   - includeArchivedDone does NOT expose a non-Done archived lane by name -
+ *     the fix's carve-out is scoped to role 'done', not "any archived lane"
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -152,5 +154,31 @@ describe.runIf(CAN_RUN)('resolving and moving a task to the Done column', () => 
     if (!response.success) {
       expect(response.error).toContain('Column "Done" not found');
     }
+  });
+
+  it('does not expose a non-Done archived lane by name, even with includeArchivedDone set', () => {
+    // A user can archive a custom column deliberately to hide it (distinct
+    // from the Done lane, which is archived by design). The fix's carve-out
+    // is `swimlane.role === 'done'`, not "any archived lane" - assert the
+    // narrower condition directly so a future refactor that widens the OR to
+    // just `includeArchivedDone` (leaking every hidden archived lane through
+    // move_task) fails this test.
+    const swimlaneRepo = new SwimlaneRepository(db);
+    const hiddenLane = swimlaneRepo.create({ name: 'Retired Column', auto_spawn: false, is_archived: true });
+
+    const withFlag = resolveColumn(db, 'Retired Column', 'todo', { includeArchivedDone: true });
+    expect('error' in withFlag).toBe(true);
+    if ('error' in withFlag) {
+      expect(withFlag.error).toContain('Column "Retired Column" not found');
+    }
+
+    const taskRepo = new TaskRepository(db);
+    const task = taskRepo.create({ title: 'Task', description: '', swimlane_id: todoLane.id });
+    const response = handleMoveTask({ taskId: task.id, column: 'Retired Column' }, context);
+    expect(response.success).toBe(false);
+    if (!response.success) {
+      expect(response.error).not.toContain(hiddenLane.id);
+    }
+    expect(context.onTaskMove).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/mcp-move-task-to-done.test.ts
+++ b/tests/unit/mcp-move-task-to-done.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for resolving and moving a task to the Done column via MCP
+ * (kangentic_move_task with column: "Done").
+ *
+ * The Done swimlane is always seeded/persisted `is_archived: 1`, and
+ * resolveColumn's default lookup filters archived lanes out - so before this
+ * fix, `handleMoveTask` could not resolve "Done" by name even though the
+ * downstream id-based handleTaskMove already handles the archive correctly.
+ *
+ * Uses a real in-memory better-sqlite3 DB run through the actual project
+ * migrations (which seed the default swimlane set, including the archived
+ * Done lane), mirroring the ABI-probe pattern from
+ * mcp-move-task-to-project.test.ts so the suite skips cleanly if
+ * better-sqlite3 cannot load under the test runner's Node ABI.
+ *
+ * Covers:
+ *   - resolveColumn resolves "Done" by name only when includeArchivedDone is set
+ *   - resolveColumn still rejects "Done" by name without the flag (regression
+ *     for create_task / move_task_to_project, which keep the active-only filter)
+ *   - handleMoveTask moves a task to Done, dispatching to onTaskMove with the
+ *     archived Done lane's id
+ *   - handleCreateTask still rejects column: "Done" (regression)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type DatabaseType from 'better-sqlite3';
+
+// ---------------------------------------------------------------------------
+// ABI probe - mirrors mcp-move-task-to-project.test.ts / swimlane-repository.test.ts.
+// ---------------------------------------------------------------------------
+
+function probeBetterSqlite3(): typeof DatabaseType | null {
+  try {
+    const moduleName = 'better-sqlite3';
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const nativeModule = require(moduleName) as unknown;
+    const databaseConstructor = (
+      (nativeModule as { default?: typeof DatabaseType }).default ?? nativeModule
+    ) as typeof DatabaseType;
+    const probeHandle = new databaseConstructor(':memory:');
+    probeHandle.close();
+    return databaseConstructor;
+  } catch {
+    return null;
+  }
+}
+
+const Database = probeBetterSqlite3();
+const CAN_RUN = Database !== null;
+
+import { runProjectMigrations } from '../../src/main/db/migrations/project-schema';
+import { SwimlaneRepository } from '../../src/main/db/repositories/swimlane-repository';
+import { TaskRepository } from '../../src/main/db/repositories/task-repository';
+import { resolveColumn } from '../../src/main/agent/commands/column-resolver';
+import { handleMoveTask, handleCreateTask } from '../../src/main/agent/commands/task-commands';
+import type { CommandContext } from '../../src/main/agent/commands/types';
+
+function makeContext(db: InstanceType<typeof DatabaseType>, projectPath: string): CommandContext & {
+  onTaskCreated: ReturnType<typeof vi.fn>;
+  onTaskMove: ReturnType<typeof vi.fn>;
+} {
+  return {
+    getProjectDb: () => db as unknown as ReturnType<CommandContext['getProjectDb']>,
+    getProjectPath: () => projectPath,
+    onTaskCreated: vi.fn(),
+    onTaskUpdated: vi.fn(),
+    onTaskDeleted: vi.fn(),
+    onTaskMove: vi.fn(async () => {}),
+    onSwimlaneUpdated: vi.fn(),
+    onBacklogChanged: vi.fn(),
+    onLabelColorsChanged: vi.fn(),
+  };
+}
+
+describe.runIf(CAN_RUN)('resolving and moving a task to the Done column', () => {
+  let db: InstanceType<typeof DatabaseType>;
+  let context: ReturnType<typeof makeContext>;
+  let todoLane: { id: string; name: string };
+  let doneLane: { id: string; name: string; is_archived: boolean };
+
+  beforeEach(() => {
+    if (!Database) return;
+    db = new Database(':memory:');
+    runProjectMigrations(db);
+
+    const swimlanes = new SwimlaneRepository(db).list();
+    const foundTodo = swimlanes.find((lane) => lane.role === 'todo');
+    const foundDone = swimlanes.find((lane) => lane.role === 'done');
+    if (!foundTodo) throw new Error('Seeded To Do swimlane not found');
+    if (!foundDone) throw new Error('Seeded Done swimlane not found');
+    todoLane = foundTodo;
+    doneLane = foundDone;
+    expect(doneLane.is_archived).toBe(true);
+
+    context = makeContext(db, '/mock/project');
+  });
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  it('resolves "Done" by name when includeArchivedDone is set', () => {
+    const resolution = resolveColumn(db, 'Done', 'todo', { includeArchivedDone: true });
+
+    expect('error' in resolution).toBe(false);
+    if (!('error' in resolution)) {
+      expect(resolution.swimlane.id).toBe(doneLane.id);
+    }
+  });
+
+  it('still rejects "Done" by name without the flag', () => {
+    const resolution = resolveColumn(db, 'Done');
+
+    expect('error' in resolution).toBe(true);
+    if ('error' in resolution) {
+      expect(resolution.error).toContain('Column "Done" not found');
+      const availableColumns = resolution.error.split('Available columns: ')[1]?.split('.')[0] ?? '';
+      expect(availableColumns.split(', ')).not.toContain('Done');
+    }
+  });
+
+  it('moves a task to Done, dispatching onTaskMove with the archived Done lane id', () => {
+    const taskRepo = new TaskRepository(db);
+    const task = taskRepo.create({ title: 'Finish the thing', description: '', swimlane_id: todoLane.id });
+
+    const response = handleMoveTask({ taskId: task.id, column: 'Done' }, context);
+
+    expect(response.success).toBe(true);
+    expect(context.onTaskMove).toHaveBeenCalledWith({
+      taskId: task.id,
+      targetSwimlaneId: doneLane.id,
+      targetPosition: 0,
+    });
+  });
+
+  it('surfaces Done in the "Available columns" list on a bad column name', () => {
+    const taskRepo = new TaskRepository(db);
+    const task = taskRepo.create({ title: 'Task', description: '', swimlane_id: todoLane.id });
+
+    const response = handleMoveTask({ taskId: task.id, column: 'Nonexistent' }, context);
+
+    expect(response.success).toBe(false);
+    if (!response.success) {
+      expect(response.error).toContain('Done');
+    }
+  });
+
+  it('handleCreateTask still rejects column: "Done" by name', () => {
+    const response = handleCreateTask({ title: 'New task', column: 'Done' }, context);
+
+    expect(response.success).toBe(false);
+    if (!response.success) {
+      expect(response.error).toContain('Column "Done" not found');
+    }
+  });
+});


### PR DESCRIPTION
## What

`kangentic_move_task` can now resolve `column: "Done"` by name. `resolveColumn` gains an opt-in `{ includeArchivedDone: boolean }` option, and `handleMoveTask` (the `kangentic_move_task` handler) is the only caller that sets it.

## Why

An agent working inside a task could self-advance it across every column except Done: the move failed with `Column "Done" not found`. The Done swimlane is always persisted `is_archived: 1` by design (seeded that way, and force-archived by `board-config/apply-config.ts`), and `resolveColumn` only searched non-archived lanes, so Done was invisible to name resolution. A human dragging the card to Done worked fine, because the UI drag path passes the swimlane ID directly.

## How

- `column-resolver.ts`: added a private `listResolvableSwimlanes(db, includeArchivedDone)` helper. `listActiveSwimlanes` is unchanged in behavior (delegates with `false`). `resolveColumn` takes a new 4th `options` param.
- `task-commands.ts`: `handleMoveTask` passes `{ includeArchivedDone: true }`. `handleCreateTask`, `handleMoveTaskToProject`, `update_column`, and backlog-promote are untouched, so none of them can create-or-target Done by name (the desired restriction, per the id-based UI drag path being the only thing that already handles Done's archive/suspend/worktree-cleanup correctly - `handleTaskMove` in `task-move.ts` needed no changes).
- Scoped to the `role: 'done'` lane specifically, not any archived lane, so a custom column a user archived to hide it stays unreachable by name.

## Breaking changes

None.

## Tests

New `tests/unit/mcp-move-task-to-done.test.ts` (real in-memory better-sqlite3 DB via `runProjectMigrations`), covering:
- `resolveColumn` resolves "Done" with the flag, still rejects it without
- `handleMoveTask` moves a task to Done and dispatches `onTaskMove` with the correct lane id
- The "Available columns" error on a bad name now includes Done
- `handleCreateTask` still rejects `column: "Done"` (regression)
- A non-Done archived lane stays unreachable by name even with the flag set (regression for the scoping decision)

Plus the standard CI checks: lint, typecheck, unit, build, UI, and E2E shards.

Generated with [Claude Code](https://claude.com/claude-code)
