### PR TITLE
feat(mobile-bridge): wire Phase 2 capability handlers, data feeds, and board-tool surface

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -746,7 +746,7 @@ Asana ships an additional `boards:asana:*` group (3 channels: `authStatus`, `set
 
 Desktop half of the mobile companion app's secure pairing/transport link, consuming the shared `@kangentic/protocol` package (`packages/protocol/`). Owns the device identity, signed device roster, QR pairing ceremony, capability-verb router, and the outbound relay transport client. Constructed in `src/main/ipc/register-all.ts`, torn down synchronously in `src/main/index.ts`'s `clearPendingTimers`. Machine-global (not project-scoped), backing the Mobile Devices settings tab via the `mobile:*` IPC group above.
 
-Phase 1 (shipped) covers identity/roster/pairing/transport and the deny-by-default capability router with no verb handlers registered yet; capability data feeds, notifications, and a direct P2P transport upgrade are later phases. See [Mobile Bridge](mobile-bridge.md) for the full pairing ceremony, SAS confirmation, roster revocation model, capability verb list, ongoing-session crypto, relay transport contract, and phase scope.
+Phase 1 (shipped) covers identity/roster/pairing/transport and the deny-by-default capability router. Phase 2 (shipped) wires all 9 capability-verb handlers to their live main-process data feeds (SessionManager's unfiltered output tap, the transcript service, repositories, `DiffService`, the activity engine's permission-prompt state) and the board/task MCP surface; notifications and a direct P2P transport upgrade are later phases. See [Mobile Bridge](mobile-bridge.md) for the full pairing ceremony, SAS confirmation, roster revocation model, capability verb list, data feeds, ongoing-session crypto, relay transport contract, and phase scope.
 
 ## See Also
 

--- a/docs/mobile-bridge.md
+++ b/docs/mobile-bridge.md
@@ -2,7 +2,7 @@
 
 Kangentic's mobile companion app (`kangentic-mobile`, a separate repo) pairs with the desktop over an end-to-end encrypted connection so a user can walk away from their PC while agents run, then get notified, read the live conversation, see code changes, send messages back, and move tasks from their phone. The full product rationale and architecture research live in [docs/research/mobile-companion-app.md](research/mobile-companion-app.md); this doc covers what actually shipped in the desktop bridge and the shared protocol package.
 
-This doc covers **Phase 1: Protocol, pairing & secure relay transport** - the identity, pairing ceremony, signed device roster, capability-verb envelope, ongoing session crypto, and outbound relay transport client. See [Scope](#scope) at the bottom for what is explicitly deferred to later phases.
+This doc covers **Phase 1 (protocol, pairing & secure relay transport)** and **Phase 2 (data feeds, interactive control & capabilities)**: identity, pairing ceremony, signed device roster, capability-verb envelope, ongoing session crypto, outbound relay transport client, the live capability-verb handlers, and the data feeds they subscribe to (SessionManager output, the transcript service, board state, `DiffService`). See [Scope](#scope) at the bottom for what is still deferred to later phases.
 
 ## Layout
 
@@ -34,9 +34,22 @@ src/main/mobile-bridge/       # desktop implementation, consumes @kangentic/prot
   transport/
     relay-client.ts           # outbound WebSocket relay client with reconnect/backoff
     transport-factory.ts      # Transport swap point (relay today, P2P later)
-  session/bridge-session.ts   # one connected device's Noise KK session + re-handshake timer
-  capability-router.ts        # deny-by-default verb dispatch (no handlers yet - Phase 2)
-  mobile-bridge-service.ts    # top-level service: identity, roster, pairing, sessions
+  session/
+    bridge-session.ts         # one connected device's Noise KK session + re-handshake timer
+    subscription-registry.ts  # per-device live event subscriptions (read-stream/board/diff), keyed and torn down together
+  capability-router.ts        # deny-by-default verb dispatch
+  handlers/                   # one module per capability verb, registered once at attachContext()
+    read-stream.ts            # SessionManager scrollback/data-tap/activity/usage + transcript deltas
+    read-board.ts              # repository snapshot + the consolidated board-changed bus
+    read-diff.ts               # DiffService (bridge-owned DiffWatcher, never IpcContext.diffWatcher)
+    send-user-message.ts       # delivery via TerminalSubmit.submitContent (bracketed paste), not a raw write
+    move-task.ts               # routes through handleTaskMove (task-lifecycle-lock + transition engine)
+    interactive-terminal.ts    # raw PTY write-path parity (explicit grant only)
+    answer-permission-prompt.ts # binds the response to a specific outstanding prompt id
+    board-tool.ts                # board-tool-read/board-tool-write - NOT MCP; routes directly into commandHandlers, gated by board-tool-allowlist.ts
+    board-tool-allowlist.ts      # per-tool read/mutate classification (excludes query_db + move_task/list_tasks/list_columns/list_backlog, which duplicate dedicated verbs; browser/devtools/diagnostics/cross-project tools are absent from commandHandlers, so they are excluded for free)
+  board-event-bus.ts          # consolidated main-process board-mutation event stream (IpcContext.boardEvents)
+  mobile-bridge-service.ts    # top-level service: identity, roster, pairing, sessions, attachContext()
 ```
 
 The desktop service is constructed in `src/main/ipc/register-all.ts` and torn down synchronously in `src/main/index.ts`'s `clearPendingTimers` (see [Synchronous Shutdown](../.claude/rules/synchronous-shutdown.md)). It is wired to the renderer through the full 7-layer IPC bridge - channels in `src/shared/ipc-channels.ts` (`MOBILE_*`, see [Architecture > Mobile Bridge](architecture.md#mobile-bridge-10-channels)), types in `src/shared/types.ts` ("Mobile Bridge" section), the `mobile:` namespace in `src/preload/preload.ts`, the handler in `src/main/ipc/handlers/mobile-bridge.ts`, the `useMobileStore` renderer store, and the Mobile Devices settings tab.
@@ -63,7 +76,7 @@ The original research doc considered a PAKE (SPAKE2) for the pairing exchange so
 
 After the handshake completes, both sides derive a **Short Authentication String** (`packages/protocol/src/crypto/sas.ts`, `deriveShortAuthenticationString`) from the handshake transcript hash - a 6-digit code plus a short emoji sequence, Matrix-style commitment-before-reveal. The desktop's settings UI shows this alongside a device-name field and two buttons: "Codes match" and "Codes don't match." The user visually compares the code against what the phone displays. This step defeats a photographed or relayed QR: an attacker who intercepts the QR cannot also make both sides' SAS values agree, because the SAS is derived from a live handshake transcript involving both parties' ephemeral keys, not from anything printed on the QR.
 
-Confirming ("Codes match") signs the phone's static public key into the device roster with a display name and an initial capability grant (`DEFAULT_PAIRING_CAPABILITIES` - `read-stream`, `read-board`, `read-diff`; write/control verbs are granted explicitly afterward, not by default). Rejecting ("Codes don't match") or cancelling tears down the pairing ceremony without touching the roster.
+Confirming ("Codes match") signs the phone's static public key into the device roster with a display name and an initial capability grant (`DEFAULT_PAIRING_CAPABILITIES` - `read-stream`, `read-board`, `read-diff`, `board-tool-read`; write/control verbs are granted explicitly afterward, not by default). Rejecting ("Codes don't match") or cancelling tears down the pairing ceremony without touching the roster.
 
 ## Signed Device Roster
 
@@ -71,22 +84,53 @@ Confirming ("Codes match") signs the phone's static public key into the device r
 
 ### Revocation is drop-plus-rekey
 
-Revoking a device (`revokeDevice()`) removes its entry from the roster **and** is intended to rotate the desktop's own static identity key. Dropping the roster entry alone is not sufficient: Noise KK's mutual authentication only proves possession of a static keypair, so a revoked device that already completed a handshake could still authenticate against a future session as long as the desktop's static key is unchanged. Phase 1 ships the roster-side "drop" half (`roster-store.ts`'s `revokeDevice`) plus session teardown for that device; a full key-rotation-and-re-provisioning flow for any *other* still-paired devices is Phase 2/3 scope, since Phase 1 typically has at most one paired device to reason about in practice.
+Revoking a device (`revokeDevice()`) removes its entry from the roster **and** is intended to rotate the desktop's own static identity key. Dropping the roster entry alone is not sufficient: Noise KK's mutual authentication only proves possession of a static keypair, so a revoked device that already completed a handshake could still authenticate against a future session as long as the desktop's static key is unchanged. Phases 1 and 2 ship the roster-side "drop" half (`roster-store.ts`'s `revokeDevice`) plus live `BridgeSession`/subscription teardown for that device (`MobileBridgeService.disposeSession`); a full key-rotation-and-re-provisioning flow for any *other* still-paired devices is Phase 3 scope, since a small paired-device count is the common case in practice.
 
 ## Capability Verbs
 
 `packages/protocol/src/capabilities/verbs.ts` defines the complete allowlist a paired device can be granted:
 
-- `read-stream`
-- `read-board`
-- `read-diff`
-- `send-user-message`
-- `move-task`
-- `answer-permission-prompt`
+- `read-stream` - live scrollback, terminal output, activity/usage telemetry, and transcript deltas for one session.
+- `read-board` - a project's columns/tasks/backlog, or (with no `projectId`) the machine's project list; live updates via the board-changed bus.
+- `read-diff` - a task's diff file list or a single file's content, via `DiffService`; live "something changed, re-fetch" pushes via a bridge-owned `DiffWatcher`.
+- `send-user-message` - deliver text to a running session via the same bracketed-paste path (`TerminalSubmit.submitContent`) the renderer's Browser-pane Send affordance uses.
+- `move-task` - move a task between columns via `handleTaskMove` (respects `withTaskLock` and the transition engine).
+- `answer-permission-prompt` - the most sensitive verb; binds a phone's raw keystrokes to a specific outstanding permission-prompt id before writing them to the PTY.
+- `interactive-terminal` - raw PTY write-path parity (full desktop-terminal keystroke control), an explicit-grant-only verb, not in the read-only default.
+- `board-tool-read` / `board-tool-write` - the long-tail task/backlog CRUD surface (create, edit, delete, link PR, ...) that has no dedicated verb, split by read vs mutate access so the grant granularity matches the rest of the model. **Not MCP** - no agent, LLM, or JSON-RPC round-trip is involved; see [Board Tool Surface](#board-tool-surface) below.
 
 There is **deliberately no shell, file-read, or arbitrary-command verb** - absent from the protocol entirely, not filtered at runtime. This mirrors the lesson from SSH forced-command escapes and is the counter-example to Chrome Remote Desktop / VS Code tunnels, which are identity-gated but capability-unscoped. Adding a verb to this list is a protocol change; it does not by itself grant anything to a device - a device's roster entry still has to include the verb in its `CapabilitySet`, and the desktop's `CapabilityRouter` still has to have a handler registered for it.
 
-`src/main/mobile-bridge/capability-router.ts` is the desktop-side dispatch point: it checks the requesting session's `CapabilitySet` (bound at pairing time, adjustable per-device afterward) before even looking up a handler, so an unauthorized verb is rejected before any handler code runs. **Phase 1 ships the router and the deny-by-default authorization check only - no verb has a registered handler yet.** An authorized-but-unregistered verb fails closed with an explicit "no handler registered" error rather than doing nothing silently. Wiring real handlers (SessionManager output tap, transcript service, repositories, DiffService, activity engine, the PTY write path) is Phase 2.
+`src/main/mobile-bridge/capability-router.ts` is the desktop-side dispatch point: it checks the requesting session's `CapabilitySet` (bound at pairing time, adjustable per-device afterward via the Mobile Devices settings tab's per-verb toggles) before even looking up a handler, so an unauthorized verb is rejected before any handler code runs. Every verb has a registered handler (`src/main/mobile-bridge/handlers/`, wired once by `MobileBridgeService.attachContext()`); an authorized-but-unregistered verb would still fail closed with an explicit "no handler registered" error rather than doing nothing silently - that guarantee stays load-bearing even though nothing exercises it in production today.
+
+`DEFAULT_PAIRING_CAPABILITIES` (granted automatically on a successful pairing) is read-only: `read-stream`, `read-board`, `read-diff`, `board-tool-read`. Every write/control verb (`send-user-message`, `move-task`, `answer-permission-prompt`, `interactive-terminal`, `board-tool-write`) requires an explicit grant afterward via the settings UI.
+
+## Data Feeds
+
+Each `read-*` handler subscribes to a live main-process source and pushes `BridgeEvent`s (`packages/protocol/src/events/event.ts`: `transcript` / `activity` / `terminal` / `board` / `diff`) over the established `BridgeSession`, tracked per-device in a `SubscriptionRegistry` so a device's live subscriptions tear down together on disconnect or revocation:
+
+- **`read-stream`** taps `SessionManager`'s **unfiltered `data-tap` event** (`src/main/pty/session-manager.ts`), added specifically for this feed: SessionManager's pre-existing `data` event is gated to `focusedSessionIds` (the renderer's active tab), so a background session's output never reached a listener that isn't the focused renderer tab. `data-tap` fires for every session's output unconditionally and does not feed the renderer's backpressure accounting (that protocol exists only for the focused-tab drain handshake). Raw output is coalesced on a short timer before pushing (`TerminalEvent`). `activity`/`usage`/`event` telemetry pushes as `ActivityEvent`, and a transcript delta pushes (`TranscriptEvent`) only when `resolveTaskTranscript`'s memoized `revision` increases, so an idle poll costs nothing.
+- **`read-board`** subscribes to `IpcContext.boardEvents` (below), filtered by `projectId`.
+- **`read-diff`** subscribes a **bridge-owned `DiffWatcher`** instance (`MobileBridgeService`'s own `diffWatcher` field), never `IpcContext.diffWatcher` - that instance is shared with the renderer's Changes panel and is single-watch-per-path, so a bridge teardown would kill the renderer's live watch on the same worktree (and vice versa).
+
+### Consolidated board-changed bus
+
+`src/main/mobile-bridge/board-event-bus.ts`'s `BoardEventBus` (exposed as `IpcContext.boardEvents`, a plain Node `EventEmitter`, not an IPC channel) is a single main-process-internal stream for every agent-driven board mutation, so `read-board` subscribes once instead of listening to each ad-hoc `IPC.*_BY_AGENT` renderer-push channel individually. It is fed **additively**, right next to the existing `sendToRenderer(...)` calls in `buildCommandContextForProject`'s six callbacks (`src/main/agent/mcp-project-context.ts`) and the PR-linking push (`src/main/pr/pr-linking.ts`) - the renderer's existing `*_BY_AGENT` pushes and `useAgentDrivenInvalidation` are untouched.
+
+### Permission-prompt id binding
+
+There is no dedicated permission-prompt object in the desktop app - a prompt is just the agent's own TUI prompt, and the activity engine tracks only that one is pending (`ActivityStatsSnapshot.permissionPending`) plus which tool it is for (`permissionAwaitedToolId`, the `tool_use_id` - added in Phase 2, kept in sync between the engine-internal and IPC copies of `ActivityStatsSnapshot` per `activity-stats-snapshot-parity.test.ts`). `answer-permission-prompt`'s handler synthesizes a prompt id (`${sessionId}:${permissionAwaitedToolId}`), reports it in `read-stream`'s snapshot as `awaitedPromptId`, and rejects an answer whose `promptId` does not match the CURRENT live value - the safety property that makes this verb meaningfully different from a plain `interactive-terminal` write. The phone sends raw keystrokes; no agent-specific interpretation happens in the bridge (per `agent-adapters-boundary.md`).
+
+## Board Tool Surface
+
+`board-tool-read` / `board-tool-write` are **not the MCP protocol** - despite the `{tool, params}` shape, no agent, LLM, or JSON-RPC round-trip happens anywhere in this path. `handleBoardTool` (`src/main/mobile-bridge/handlers/board-tool.ts`) is a plain function call straight into `commandHandlers` (`src/main/agent/commands/index.ts` - the same registry the in-process MCP HTTP server also happens to dispatch into), reusing the exact handlers and board-mutation side-effect fan-out without re-deriving the `register*Tools` layer's zod schemas, defaulting, rate limiting, or LLM-facing prose formatting. This is the same kind of direct reuse `read-board`/`move-task` do against their own repositories/`handleTaskMove` - a thin authorization + routing wrapper over the existing engine, not a second protocol surface. It exists for the long tail of task/backlog CRUD (create, edit, delete, link PR, backlog promote/update/delete, stats, transcript, handoff) that would be tedious to give each its own bespoke verb. The `tool` field a request names is the **internal `commandHandlers` key** (e.g. `'create_task'`), not a public MCP tool name.
+
+`src/main/mobile-bridge/handlers/board-tool-allowlist.ts` hand-classifies every `commandHandlers` key as `'read'` or `'mutate'` (`board-tool-allowlist.test.ts` fails if a new registry entry ships unclassified). Excluded from both verbs:
+- `query_db` (raw SQL escape hatch).
+- `move_task`, `list_tasks`, `list_columns`, `list_backlog` - real, safe `commandHandlers` entries, but **duplicates** of the dedicated `move-task` and `read-board` verbs, which give a cleaner contract (swimlaneId not column-name resolution; full `Task`/`Swimlane` objects; `read-board` also has a live subscription these one-shot tools lack). Excluding them here keeps exactly one path per capability instead of two competing ones.
+- Everything not in `commandHandlers` at all: the `kangentic_browser_*` family, the dev-only `kangentic_devtools_*` family, the diagnostics tools (`tail_logs`, `get_recent_crashes`, ...), and the remaining cross-project tools (`list_projects`, unified `search`, `move_task_to_project`) are registered through entirely separate registries, so building the allowlist from `commandHandlers`'s keys excludes them for free, with no separate name-matching needed.
+
+A phone bootstraps its project list through `read-board` with no `projectId`, since `commandHandlers` has no `list_projects` entry.
 
 ## Ongoing Session: Noise KK + Re-handshake + Secretstream
 
@@ -115,20 +159,28 @@ Even a correctly-implemented blind relay is not metadata-invisible. A relay oper
 
 ## Scope
 
-**Shipped in this phase (Bridge Phase 1):**
+**Shipped (Bridge Phase 1 - protocol, pairing & secure relay transport):**
 
 - `@kangentic/protocol` package: wire schema, Noise KK + IKpsk0 implementations, secretstream framing, capability verb list, roster signing, QR payload encode/decode, transport interface.
 - Device identity (encrypted at rest via Electron `safeStorage`, refuses to persist unprotected).
 - Signed device roster with revoke-drop (rekey-on-revoke is scaffolded but the full multi-device re-provisioning flow is deferred).
 - QR pairing ceremony (token-bound Noise PSK + SAS confirmation) with desktop settings UI.
 - The desktop's outbound relay CLIENT connection with reconnect/backoff.
-- `CapabilityRouter` with the deny-by-default authorization check (no verb handlers registered).
 - Mobile Devices settings tab: enable toggle, relay URL, pairing flow, paired-device list, revoke.
 
-**Explicitly out of scope for this phase:**
+**Shipped (Bridge Phase 2 - data feeds, interactive control & capabilities):**
 
-- **Bridge Phase 2 (data feeds, interactive control & capabilities):** actual capability-verb handlers wired to `SessionManager`'s output tap, the transcript service, repositories, `DiffService`, and the activity engine; the PTY write path for phone-originated input, including `answer-permission-prompt` bound to a specific outstanding prompt id; a consolidated main-side board event stream; the MCP tool surface exposed to paired devices.
-- **Bridge Phase 3 (notifications & push sender):** moving the notification should-fire policy into main; an Expo push sender; presence suppression; the paired-devices capability-editing UI beyond revoke.
+- `interactive-terminal`, `board-tool-read`, `board-tool-write` added to `CAPABILITY_VERBS`; per-verb request/response payload types (`packages/protocol/src/wire/payloads.ts`); `terminal`/`diff` event kinds and a reshaped project-keyed `BoardEvent` (`packages/protocol/src/events/event.ts`); a per-kind `framing.ts` event validator; `deriveSessionSlotId` for the ongoing-session relay slot.
+- `MobileBridgeService.attachContext()` + `syncSessions()`: opens one live `BridgeSession` per roster device, routes decoded `capability-request` messages through `CapabilityRouter.dispatch()`.
+- All 9 capability-verb handlers (`src/main/mobile-bridge/handlers/`), each described under [Data Feeds](#data-feeds) and [Board Tool Surface](#board-tool-surface) above.
+- `SessionManager`'s unfiltered `data-tap` event and `ActivityStatsSnapshot.permissionAwaitedToolId`.
+- The consolidated `BoardEventBus` (`IpcContext.boardEvents`).
+- Per-device capability-granting UI in the Mobile Devices settings tab (one toggle per verb, driven by `MOBILE_CAPABILITY_VERBS`).
+- Still deferred within Phase 2's own scope: re-handshaking `BridgeSession` on a transport reconnect (mid-interval connect latency is a UX rough edge, not a correctness gap - the existing ~2-minute timer still re-handshakes).
+
+**Explicitly out of scope, later phases:**
+
+- **Bridge Phase 3 (notifications & push sender):** moving the notification should-fire policy into main; an Expo push sender; presence suppression; full desktop static-key rotation and re-provisioning of remaining paired devices on revoke; fuller device-management UX beyond the per-verb toggles.
 - **Bridge Phase 4 (direct P2P + IPv6 speed upgrade):** WebRTC data channels (`node-datachannel` desktop / `react-native-webrtc` mobile), signaling over the already-secure channel, DTLS fingerprint pinning, IPv6-first candidate ordering, Tailscale detection.
 - **The relay SERVER.** This doc describes the desktop's client-side contract against a relay; the relay itself (a tiny stateless blind byte-forwarder) lives in the separate, open-source [`kangentic-relay`](https://github.com/Kangentic/kangentic-relay) repo and is not part of this codebase.
 - The mobile app itself (`kangentic-mobile`, a separate repo).

--- a/packages/protocol/src/capabilities/verbs.ts
+++ b/packages/protocol/src/capabilities/verbs.ts
@@ -16,6 +16,9 @@ export const CAPABILITY_VERBS = [
   'send-user-message',
   'move-task',
   'answer-permission-prompt',
+  'interactive-terminal',
+  'board-tool-read',
+  'board-tool-write',
 ] as const;
 
 export type CapabilityVerb = (typeof CAPABILITY_VERBS)[number];

--- a/packages/protocol/src/crypto/slot.ts
+++ b/packages/protocol/src/crypto/slot.ts
@@ -1,0 +1,27 @@
+/**
+ * Derives the relay rendezvous slot id for an ONGOING (post-pairing) bridge
+ * session, as a deterministic function of both peers' static public keys
+ * (see relay-client.ts's wire-contract doc: "a value derived from the
+ * paired device's static key for an ongoing session"). Desktop-first
+ * ordering in the concatenation keeps it symmetric: both peers already know
+ * both static keys from the pairing roster, so either side computes the
+ * same slot id independently, with no extra negotiation round-trip.
+ *
+ * This is a BLIND rendezvous label only - the relay never learns its
+ * cryptographic meaning, only its bytes, and every frame sent through it is
+ * already Noise-encrypted. It is intentionally stable (a pure function of
+ * the two static keys) rather than a rotating epoch, so a relay operator
+ * can correlate a device's reconnects over time by watching the same slot
+ * id recur; the channel CONTENTS stay end-to-end encrypted regardless. A
+ * rotating-epoch variant is a candidate future hardening, not required for
+ * Phase 2.
+ */
+import { deriveLabeledKey, concatBytes, bytesToHex } from './primitives';
+
+const SESSION_SLOT_LABEL = 'kangentic-session-slot-v1';
+const SESSION_SLOT_LENGTH = 16;
+
+export function deriveSessionSlotId(desktopStaticPublicKey: Uint8Array, phoneStaticPublicKey: Uint8Array): string {
+  const material = concatBytes(desktopStaticPublicKey, phoneStaticPublicKey);
+  return bytesToHex(deriveLabeledKey(material, SESSION_SLOT_LABEL, SESSION_SLOT_LENGTH));
+}

--- a/packages/protocol/src/events/event.ts
+++ b/packages/protocol/src/events/event.ts
@@ -1,12 +1,22 @@
 /**
- * The event contract skeleton the phone consumes. Phase 1 establishes the
- * three event FAMILIES (transcript, board, activity) and their envelope
- * shape; Phase 2 (data feeds & interactive control) is what actually maps
- * desktop internals - SessionManager's `data`/`activity` events,
- * transcript-service output, repository/DiffService mutations - onto
- * these envelopes. Keeping `payload` as JsonValue here rather than a
- * fully-typed shape per event avoids guessing at Phase 2's real mapping
- * before that integration exists.
+ * The event contract the phone consumes, pushed as EventMessage.event over
+ * an established BridgeSession once Phase 2's capability handlers (desktop
+ * bridge module) subscribe SessionManager/transcript-service/DiffService to
+ * a session's live state. Five kinds:
+ *
+ * - transcript: a revision-gated delta from resolveTaskTranscript, for the
+ *   phone's transcript-styled conversation view.
+ * - activity: a discriminated union consolidating SessionManager's
+ *   separate `activity`/`usage`/`event` emissions plus permission state
+ *   (carrying the synthesized prompt id `answer-permission-prompt` binds
+ *   to), so one event kind covers session telemetry instead of three.
+ * - terminal: raw PTY output from the unfiltered data-tap, for the phone's
+ *   raw-terminal-mirror view (a distinct consumer from the parsed
+ *   transcript).
+ * - board: a board-mutation notification, filterable by project and
+ *   (optionally) task.
+ * - diff: a payload-less "something under this task's worktree changed,
+ *   re-fetch via read-diff" signal, mirroring the desktop's GIT_DIFF_CHANGED.
  */
 import type { JsonValue } from '../wire/messages';
 
@@ -17,17 +27,42 @@ export interface TranscriptEvent {
   payload: JsonValue;
 }
 
-export interface BoardEvent {
-  kind: 'board';
-  taskId: string;
-  payload: JsonValue;
-}
+export type ActivityEventPayload =
+  | { type: 'activity'; state: JsonValue; reason: JsonValue }
+  | { type: 'usage'; usage: JsonValue }
+  | { type: 'event'; event: JsonValue }
+  | { type: 'permission'; promptId: string; pending: boolean };
 
 export interface ActivityEvent {
   kind: 'activity';
   sessionId: string;
   taskId: string;
-  payload: JsonValue;
+  payload: ActivityEventPayload;
 }
 
-export type BridgeEvent = TranscriptEvent | BoardEvent | ActivityEvent;
+export interface TerminalEvent {
+  kind: 'terminal';
+  sessionId: string;
+  taskId: string;
+  payload: { data: string };
+}
+
+export interface BoardEventPayload {
+  change: 'task-created' | 'task-updated' | 'task-deleted' | 'swimlane-updated' | 'backlog-changed';
+  ids: string[];
+}
+
+export interface BoardEvent {
+  kind: 'board';
+  projectId: string;
+  taskId?: string;
+  payload: BoardEventPayload;
+}
+
+export interface DiffEvent {
+  kind: 'diff';
+  taskId: string;
+  payload: null;
+}
+
+export type BridgeEvent = TranscriptEvent | ActivityEvent | TerminalEvent | BoardEvent | DiffEvent;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -32,10 +32,38 @@ export {
 } from './crypto/secretstream';
 
 export { deriveShortAuthenticationString, type ShortAuthenticationString } from './crypto/sas';
+export { deriveSessionSlotId } from './crypto/slot';
 
 export type { JsonValue, BridgeMessage, HeartbeatMessage, CapabilityRequestMessage, CapabilityResponseMessage, EventMessage } from './wire/messages';
 export { encodeMessage, decodeMessage, MAX_FRAME_LENGTH } from './wire/framing';
+export { isJsonValue, isRecord } from './wire/json-value';
 export { SessionFrameKind, wrapSessionFrame, unwrapSessionFrame } from './wire/session-frame';
+
+export {
+  parseCapabilityRequestPayload,
+  type CapabilityRequestPayloadMap,
+  type CapabilityResponsePayloadMap,
+  type ReadStreamRequestPayload,
+  type ReadStreamResponsePayload,
+  type ReadBoardRequestPayload,
+  type ReadBoardProjectSummary,
+  type ReadBoardProjectListResponsePayload,
+  type ReadBoardSnapshotResponsePayload,
+  type ReadBoardResponsePayload,
+  type ReadDiffScope,
+  type ReadDiffRequestPayload,
+  type ReadDiffResponsePayload,
+  type SendUserMessageRequestPayload,
+  type SendUserMessageResponsePayload,
+  type MoveTaskRequestPayload,
+  type MoveTaskResponsePayload,
+  type AnswerPermissionPromptRequestPayload,
+  type AnswerPermissionPromptResponsePayload,
+  type InteractiveTerminalRequestPayload,
+  type InteractiveTerminalResponsePayload,
+  type BoardToolRequestPayload,
+  type BoardToolResponsePayload,
+} from './wire/payloads';
 
 export {
   PAIRING_URI_SCHEME,
@@ -65,6 +93,15 @@ export {
   type CapabilitySet,
 } from './capabilities/verbs';
 
-export type { BridgeEvent, TranscriptEvent, BoardEvent, ActivityEvent } from './events/event';
+export type {
+  BridgeEvent,
+  TranscriptEvent,
+  ActivityEvent,
+  ActivityEventPayload,
+  TerminalEvent,
+  BoardEvent,
+  BoardEventPayload,
+  DiffEvent,
+} from './events/event';
 
 export type { Transport, TransportState, Unsubscribe } from './transport/transport';

--- a/packages/protocol/src/wire/framing.ts
+++ b/packages/protocol/src/wire/framing.ts
@@ -12,6 +12,7 @@
 import { isCapabilityVerb } from '../capabilities/verbs';
 import type { BridgeEvent } from '../events/event';
 import type { BridgeMessage, JsonValue } from './messages';
+import { isJsonValue, isRecord } from './json-value';
 
 export const MAX_FRAME_LENGTH = 1024 * 1024;
 
@@ -31,17 +32,37 @@ export function decodeMessage(bytes: Uint8Array): BridgeMessage {
   return validateBridgeMessage(parsed);
 }
 
-function isJsonValue(value: unknown): value is JsonValue {
-  if (value === null) return true;
-  const t = typeof value;
-  if (t === 'boolean' || t === 'number' || t === 'string') return true;
-  if (Array.isArray(value)) return value.every(isJsonValue);
-  if (t === 'object') return Object.values(value as Record<string, unknown>).every(isJsonValue);
-  return false;
-}
+/**
+ * Per-kind event validation. Each kind has a different required key set
+ * (transcript/activity/terminal are session-scoped, board is project-scoped
+ * with an optional task, diff is task-scoped) - there is no single field
+ * (e.g. a universal "taskId") every event kind carries, so this cannot be a
+ * single shared check.
+ */
+function validateEvent(event: Record<string, unknown>): BridgeEvent {
+  if (typeof event.kind !== 'string') throw new Error('event message missing a valid "kind"');
+  if (!isJsonValue(event.payload)) throw new Error('event payload is not JSON-serializable');
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  switch (event.kind) {
+    case 'transcript':
+    case 'activity':
+    case 'terminal': {
+      if (typeof event.sessionId !== 'string') throw new Error(`"${event.kind}" event is missing "sessionId"`);
+      if (typeof event.taskId !== 'string') throw new Error(`"${event.kind}" event is missing "taskId"`);
+      return event as unknown as BridgeEvent;
+    }
+    case 'board': {
+      if (typeof event.projectId !== 'string') throw new Error('"board" event is missing "projectId"');
+      if (event.taskId !== undefined && typeof event.taskId !== 'string') throw new Error('"board" event has a non-string "taskId"');
+      return event as unknown as BridgeEvent;
+    }
+    case 'diff': {
+      if (typeof event.taskId !== 'string') throw new Error('"diff" event is missing "taskId"');
+      return event as unknown as BridgeEvent;
+    }
+    default:
+      throw new Error(`event message has an unknown event kind: ${event.kind}`);
+  }
 }
 
 function validateBridgeMessage(value: unknown): BridgeMessage {
@@ -75,18 +96,8 @@ function validateBridgeMessage(value: unknown): BridgeMessage {
     }
 
     case 'event': {
-      const event = value.event;
-      if (!isRecord(event) || typeof event.kind !== 'string') {
-        throw new Error('event message missing a valid "event"');
-      }
-      if (typeof event.taskId !== 'string') throw new Error('event is missing "taskId"');
-      if (!isJsonValue(event.payload)) throw new Error('event payload is not JSON-serializable');
-      if (event.kind === 'transcript' || event.kind === 'activity') {
-        if (typeof event.sessionId !== 'string') throw new Error(`"${event.kind}" event is missing "sessionId"`);
-      } else if (event.kind !== 'board') {
-        throw new Error(`event message has an unknown event kind: ${event.kind}`);
-      }
-      return { type: 'event', event: event as unknown as BridgeEvent };
+      if (!isRecord(value.event)) throw new Error('event message missing a valid "event"');
+      return { type: 'event', event: validateEvent(value.event) };
     }
 
     default:

--- a/packages/protocol/src/wire/json-value.ts
+++ b/packages/protocol/src/wire/json-value.ts
@@ -1,0 +1,20 @@
+/**
+ * The single `isJsonValue` runtime check, shared by framing.ts (validating a
+ * whole decoded BridgeMessage) and payloads.ts (validating one verb's
+ * request payload before a handler trusts it). Split out so neither module
+ * has to re-derive the other's copy.
+ */
+import type { JsonValue } from './messages';
+
+export function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null) return true;
+  const valueType = typeof value;
+  if (valueType === 'boolean' || valueType === 'number' || valueType === 'string') return true;
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  if (valueType === 'object') return Object.values(value as Record<string, unknown>).every(isJsonValue);
+  return false;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/protocol/src/wire/payloads.ts
+++ b/packages/protocol/src/wire/payloads.ts
@@ -1,0 +1,291 @@
+/**
+ * Concrete per-verb request/response payload shapes. `CapabilityRequestMessage.payload`
+ * and `CapabilityResponseMessage.payload` stay `JsonValue` on the envelope
+ * (messages.ts) - these interfaces narrow that generic value at the handler
+ * boundary, and the `parse*RequestPayload` guards below are the runtime
+ * checks a handler runs against an untrusted phone-originated request before
+ * trusting any field.
+ *
+ * Fields that mirror an app-internal shape the protocol package cannot
+ * import (git diff results, board rows, an MCP tool's result) stay
+ * `JsonValue`, same rationale as messages.ts/events/event.ts: this package
+ * is a dependency-light leaf shared by desktop and phone, so it does not
+ * know the desktop app's internal types. Only the fixed envelope fields
+ * (ids, actions, booleans) are concretely typed and runtime-validated here.
+ */
+import type { CapabilityVerb } from '../capabilities/verbs';
+import type { JsonValue } from './messages';
+import { isJsonValue, isRecord } from './json-value';
+
+// === read-stream ===
+
+export interface ReadStreamRequestPayload {
+  sessionId: string;
+  action: 'subscribe' | 'unsubscribe';
+}
+
+/** Initial snapshot returned on subscribe; live updates arrive as TerminalEvent/ActivityEvent/TranscriptEvent. */
+export interface ReadStreamResponsePayload {
+  scrollback: string;
+  activity: JsonValue;
+  usage: JsonValue | null;
+  /** The live outstanding permission-prompt id (see answer-permission-prompt), or null when none is pending. */
+  awaitedPromptId: string | null;
+}
+
+function parseReadStreamRequestPayload(payload: JsonValue): ReadStreamRequestPayload {
+  if (!isRecord(payload)) throw new Error('read-stream payload must be an object');
+  if (typeof payload.sessionId !== 'string') throw new Error('read-stream payload missing "sessionId"');
+  if (payload.action !== 'subscribe' && payload.action !== 'unsubscribe') {
+    throw new Error('read-stream payload has an invalid "action"');
+  }
+  return { sessionId: payload.sessionId, action: payload.action };
+}
+
+// === read-board ===
+
+export interface ReadBoardRequestPayload {
+  projectId?: string;
+  /** Defaults to 'subscribe' when omitted. 'unsubscribe' only has an effect when projectId is set - the no-projectId project list is a one-shot read with no live feed to tear down. */
+  action?: 'subscribe' | 'unsubscribe';
+}
+
+export interface ReadBoardProjectSummary {
+  id: string;
+  name: string;
+}
+
+/** Returned when the request omits projectId - the phone's project-bootstrap listing. */
+export interface ReadBoardProjectListResponsePayload {
+  projects: ReadBoardProjectSummary[];
+}
+
+/** Returned when the request carries a projectId - a snapshot of that project's board. */
+export interface ReadBoardSnapshotResponsePayload {
+  projectId: string;
+  columns: JsonValue;
+  tasks: JsonValue;
+  backlog: JsonValue;
+}
+
+export type ReadBoardResponsePayload = ReadBoardProjectListResponsePayload | ReadBoardSnapshotResponsePayload;
+
+function parseReadBoardRequestPayload(payload: JsonValue): ReadBoardRequestPayload {
+  if (!isRecord(payload)) throw new Error('read-board payload must be an object');
+  if (payload.projectId !== undefined && typeof payload.projectId !== 'string') {
+    throw new Error('read-board payload has a non-string "projectId"');
+  }
+  if (payload.action !== undefined && payload.action !== 'subscribe' && payload.action !== 'unsubscribe') {
+    throw new Error('read-board payload has an invalid "action"');
+  }
+  return { projectId: payload.projectId, action: payload.action };
+}
+
+// === read-diff ===
+
+/** Mirrors DiffService's GitDiffScope in the desktop app; kept as a literal union here rather than an import, since the protocol package does not depend on the app. */
+export type ReadDiffScope = 'working' | 'staged' | 'branch';
+
+export interface ReadDiffRequestPayload {
+  taskId: string;
+  projectId: string;
+  filePath?: string;
+  scope?: ReadDiffScope;
+  /** Defaults to 'subscribe' when omitted. Only the file-list watch (no filePath) has a live feed to tear down; a single-file content fetch is always one-shot. */
+  action?: 'subscribe' | 'unsubscribe';
+}
+
+/** Structurally mirrors the desktop app's GitDiffFilesResult (no filePath) or GitFileContentResult (filePath set). */
+export type ReadDiffResponsePayload = JsonValue;
+
+function parseReadDiffRequestPayload(payload: JsonValue): ReadDiffRequestPayload {
+  if (!isRecord(payload)) throw new Error('read-diff payload must be an object');
+  if (typeof payload.taskId !== 'string') throw new Error('read-diff payload missing "taskId"');
+  if (typeof payload.projectId !== 'string') throw new Error('read-diff payload missing "projectId"');
+  if (payload.filePath !== undefined && typeof payload.filePath !== 'string') {
+    throw new Error('read-diff payload has a non-string "filePath"');
+  }
+  if (payload.scope !== undefined && payload.scope !== 'working' && payload.scope !== 'staged' && payload.scope !== 'branch') {
+    throw new Error('read-diff payload has an invalid "scope"');
+  }
+  if (payload.action !== undefined && payload.action !== 'subscribe' && payload.action !== 'unsubscribe') {
+    throw new Error('read-diff payload has an invalid "action"');
+  }
+  return {
+    taskId: payload.taskId,
+    projectId: payload.projectId,
+    filePath: payload.filePath,
+    scope: payload.scope,
+    action: payload.action,
+  };
+}
+
+// === send-user-message ===
+
+export interface SendUserMessageRequestPayload {
+  sessionId: string;
+  text: string;
+}
+
+export interface SendUserMessageResponsePayload {
+  delivered: boolean;
+}
+
+function parseSendUserMessageRequestPayload(payload: JsonValue): SendUserMessageRequestPayload {
+  if (!isRecord(payload)) throw new Error('send-user-message payload must be an object');
+  if (typeof payload.sessionId !== 'string') throw new Error('send-user-message payload missing "sessionId"');
+  if (typeof payload.text !== 'string') throw new Error('send-user-message payload missing "text"');
+  return { sessionId: payload.sessionId, text: payload.text };
+}
+
+// === move-task ===
+
+export interface MoveTaskRequestPayload {
+  taskId: string;
+  targetSwimlaneId: string;
+  targetPosition: number;
+  projectId: string;
+}
+
+export interface MoveTaskResponsePayload {
+  ok: boolean;
+}
+
+function parseMoveTaskRequestPayload(payload: JsonValue): MoveTaskRequestPayload {
+  if (!isRecord(payload)) throw new Error('move-task payload must be an object');
+  if (typeof payload.taskId !== 'string') throw new Error('move-task payload missing "taskId"');
+  if (typeof payload.targetSwimlaneId !== 'string') throw new Error('move-task payload missing "targetSwimlaneId"');
+  if (typeof payload.targetPosition !== 'number') throw new Error('move-task payload missing "targetPosition"');
+  if (typeof payload.projectId !== 'string') throw new Error('move-task payload missing "projectId"');
+  return {
+    taskId: payload.taskId,
+    targetSwimlaneId: payload.targetSwimlaneId,
+    targetPosition: payload.targetPosition,
+    projectId: payload.projectId,
+  };
+}
+
+// === answer-permission-prompt ===
+
+export interface AnswerPermissionPromptRequestPayload {
+  sessionId: string;
+  /** The prompt id the phone believes is outstanding - the handler rejects a stale/replayed answer whose id no longer matches the live awaited prompt. */
+  promptId: string;
+  keystrokes: string;
+}
+
+export interface AnswerPermissionPromptResponsePayload {
+  answered: boolean;
+}
+
+function parseAnswerPermissionPromptRequestPayload(payload: JsonValue): AnswerPermissionPromptRequestPayload {
+  if (!isRecord(payload)) throw new Error('answer-permission-prompt payload must be an object');
+  if (typeof payload.sessionId !== 'string') throw new Error('answer-permission-prompt payload missing "sessionId"');
+  if (typeof payload.promptId !== 'string') throw new Error('answer-permission-prompt payload missing "promptId"');
+  if (typeof payload.keystrokes !== 'string') throw new Error('answer-permission-prompt payload missing "keystrokes"');
+  return { sessionId: payload.sessionId, promptId: payload.promptId, keystrokes: payload.keystrokes };
+}
+
+// === interactive-terminal ===
+
+export interface InteractiveTerminalRequestPayload {
+  sessionId: string;
+  data: string;
+}
+
+export interface InteractiveTerminalResponsePayload {
+  written: boolean;
+}
+
+function parseInteractiveTerminalRequestPayload(payload: JsonValue): InteractiveTerminalRequestPayload {
+  if (!isRecord(payload)) throw new Error('interactive-terminal payload must be an object');
+  if (typeof payload.sessionId !== 'string') throw new Error('interactive-terminal payload missing "sessionId"');
+  if (typeof payload.data !== 'string') throw new Error('interactive-terminal payload missing "data"');
+  return { sessionId: payload.sessionId, data: payload.data };
+}
+
+// === board-tool-read / board-tool-write ===
+// Despite the shape ("tool" + "params"), this is NOT the MCP protocol - no
+// agent, LLM, or JSON-RPC round-trip is involved. `tool` names an entry in
+// the desktop's internal task/board/backlog CRUD registry
+// (src/main/agent/commands/index.ts's commandHandlers), the same registry
+// the actual MCP server also happens to dispatch into. The bridge calls it
+// directly, the same way read-board/move-task call their own repositories/
+// handleTaskMove directly - this is reuse of that registry, not a second
+// MCP surface.
+
+export interface BoardToolRequestPayload {
+  tool: string;
+  params: JsonValue;
+}
+
+export interface BoardToolResponsePayload {
+  result: JsonValue;
+}
+
+function parseBoardToolRequestPayload(payload: JsonValue): BoardToolRequestPayload {
+  if (!isRecord(payload)) throw new Error('board-tool payload must be an object');
+  if (typeof payload.tool !== 'string') throw new Error('board-tool payload missing "tool"');
+  if (payload.params === undefined || !isJsonValue(payload.params)) throw new Error('board-tool payload missing a JSON "params"');
+  return { tool: payload.tool, params: payload.params };
+}
+
+// === dispatch map + entry point ===
+
+export interface CapabilityRequestPayloadMap {
+  'read-stream': ReadStreamRequestPayload;
+  'read-board': ReadBoardRequestPayload;
+  'read-diff': ReadDiffRequestPayload;
+  'send-user-message': SendUserMessageRequestPayload;
+  'move-task': MoveTaskRequestPayload;
+  'answer-permission-prompt': AnswerPermissionPromptRequestPayload;
+  'interactive-terminal': InteractiveTerminalRequestPayload;
+  'board-tool-read': BoardToolRequestPayload;
+  'board-tool-write': BoardToolRequestPayload;
+}
+
+export interface CapabilityResponsePayloadMap {
+  'read-stream': ReadStreamResponsePayload;
+  'read-board': ReadBoardResponsePayload;
+  'read-diff': ReadDiffResponsePayload;
+  'send-user-message': SendUserMessageResponsePayload;
+  'move-task': MoveTaskResponsePayload;
+  'answer-permission-prompt': AnswerPermissionPromptResponsePayload;
+  'interactive-terminal': InteractiveTerminalResponsePayload;
+  'board-tool-read': BoardToolResponsePayload;
+  'board-tool-write': BoardToolResponsePayload;
+}
+
+/**
+ * Validates and narrows a decoded capability-request's generic JsonValue
+ * payload into its verb-specific shape. This is the runtime trust boundary:
+ * every field the phone supplies is checked before a handler reads it.
+ */
+export function parseCapabilityRequestPayload<Verb extends CapabilityVerb>(
+  verb: Verb,
+  payload: JsonValue,
+): CapabilityRequestPayloadMap[Verb] {
+  switch (verb) {
+    case 'read-stream':
+      return parseReadStreamRequestPayload(payload) as CapabilityRequestPayloadMap[Verb];
+    case 'read-board':
+      return parseReadBoardRequestPayload(payload) as CapabilityRequestPayloadMap[Verb];
+    case 'read-diff':
+      return parseReadDiffRequestPayload(payload) as CapabilityRequestPayloadMap[Verb];
+    case 'send-user-message':
+      return parseSendUserMessageRequestPayload(payload) as CapabilityRequestPayloadMap[Verb];
+    case 'move-task':
+      return parseMoveTaskRequestPayload(payload) as CapabilityRequestPayloadMap[Verb];
+    case 'answer-permission-prompt':
+      return parseAnswerPermissionPromptRequestPayload(payload) as CapabilityRequestPayloadMap[Verb];
+    case 'interactive-terminal':
+      return parseInteractiveTerminalRequestPayload(payload) as CapabilityRequestPayloadMap[Verb];
+    case 'board-tool-read':
+    case 'board-tool-write':
+      return parseBoardToolRequestPayload(payload) as CapabilityRequestPayloadMap[Verb];
+    default: {
+      const exhaustiveCheck: never = verb;
+      throw new Error(`Unknown capability verb: ${String(exhaustiveCheck)}`);
+    }
+  }
+}

--- a/src/main/activity-engine/engine/activity-engine.ts
+++ b/src/main/activity-engine/engine/activity-engine.ts
@@ -195,6 +195,7 @@ export class ActivityEngine {
       anonymousBackgroundShellCount: state.anonymousBackgroundShellCount,
       turnActive: state.turnActive,
       permissionPending: state.permissionPending,
+      permissionAwaitedToolId: state.permissionAwaitedToolId,
       msSinceLastSignal: lastSignalAt === null ? null : this.now() - lastSignalAt,
       lastSignalAt,
       lastPtyOutputAt,

--- a/src/main/activity-engine/engine/shapes.ts
+++ b/src/main/activity-engine/engine/shapes.ts
@@ -500,6 +500,8 @@ export interface ActivityStatsSnapshot {
   anonymousBackgroundShellCount: number;
   turnActive: boolean;
   permissionPending: boolean;
+  /** The tool_use_id awaiting a permission decision when `permissionPending` is true, else null. See `SessionEngineState.permissionAwaitedToolId`. */
+  permissionAwaitedToolId: string | null;
   msSinceLastSignal: number | null;
   /** Wall-clock ms of the most recent thinking-signal. Lets the
    *  debug-overlay timeline render the active watchdog deadline as

--- a/src/main/agent/mcp-project-context.ts
+++ b/src/main/agent/mcp-project-context.ts
@@ -56,6 +56,7 @@ export function buildCommandContextForProject(
       sendToRenderer(
         ipcContext.mainWindow, IPC.TASK_CREATED_BY_AGENT, task.id, task.title, columnName, projectId,
       );
+      ipcContext.boardEvents.emitBoardChanged({ projectId, change: 'task-created', ids: [task.id] });
       // Auto-spawn fire-and-forget so the tool call returns immediately
       // and Claude doesn't block on a multi-second PTY spawn.
       autoSpawnForTask(ipcContext, projectId, task, swimlaneId).catch((err) => {
@@ -65,6 +66,7 @@ export function buildCommandContextForProject(
 
     onTaskUpdated: (task) => {
       sendToRenderer(ipcContext.mainWindow, IPC.TASK_UPDATED_BY_AGENT, task.id, task.title, projectId);
+      ipcContext.boardEvents.emitBoardChanged({ projectId, change: 'task-updated', ids: [task.id] });
     },
 
     onTaskDeleted: (task) => {
@@ -95,6 +97,7 @@ export function buildCommandContextForProject(
       }
 
       sendToRenderer(ipcContext.mainWindow, IPC.TASK_DELETED_BY_AGENT, task.id, task.title, projectId);
+      ipcContext.boardEvents.emitBoardChanged({ projectId, change: 'task-deleted', ids: [task.id] });
     },
 
     onTaskMove: async (input) => {
@@ -105,11 +108,13 @@ export function buildCommandContextForProject(
         .get(input.taskId) as { id: string; title: string } | undefined;
       if (movedTask) {
         sendToRenderer(ipcContext.mainWindow, IPC.TASK_UPDATED_BY_AGENT, movedTask.id, movedTask.title, projectId);
+        ipcContext.boardEvents.emitBoardChanged({ projectId, change: 'task-updated', ids: [movedTask.id] });
       }
     },
 
     onSwimlaneUpdated: (swimlane) => {
       sendToRenderer(ipcContext.mainWindow, IPC.SWIMLANE_UPDATED_BY_AGENT, swimlane.id, swimlane.name, projectId);
+      ipcContext.boardEvents.emitBoardChanged({ projectId, change: 'swimlane-updated', ids: [swimlane.id] });
       // Persist team-shared column fields (color, model/effort/permission
       // overrides, auto-command, ...) to kangentic.json so an agent's column
       // edit survives a restart and reaches teammates via git. Project-scoped
@@ -121,6 +126,7 @@ export function buildCommandContextForProject(
 
     onBacklogChanged: () => {
       sendToRenderer(ipcContext.mainWindow, IPC.BACKLOG_CHANGED_BY_AGENT, projectId);
+      ipcContext.boardEvents.emitBoardChanged({ projectId, change: 'backlog-changed', ids: [] });
     },
 
     onLabelColorsChanged: (colors) => {

--- a/src/main/git/diff-watcher.ts
+++ b/src/main/git/diff-watcher.ts
@@ -17,6 +17,16 @@ const GIT_META_FILES = new Set(['index', 'HEAD', 'ORIG_HEAD', 'MERGE_HEAD', 'pac
 interface WatcherEntry {
   watchers: fs.FSWatcher[];
   debounceTimer: ReturnType<typeof setTimeout> | null;
+  /**
+   * Every subscriber's callback for this path. The renderer's git-diff panel
+   * is single-subscriber-per-path, but the mobile bridge fans out one live
+   * `read-diff` subscription per paired device/task onto the SAME path (two
+   * worktree-less tasks in one repo, or two phones on one task, both resolve
+   * to the same git directory), so a path must multiplex - one debounced
+   * `fs.watch` set feeding every registered callback, torn down only when the
+   * last subscriber leaves.
+   */
+  callbacks: Set<() => void>;
 }
 
 /**
@@ -33,21 +43,31 @@ interface WatcherEntry {
 export class DiffWatcher {
   private readonly watchers = new Map<string, WatcherEntry>();
 
-  subscribe(worktreePath: string, callback: () => void): void {
-    // Already watching this path
-    if (this.watchers.has(worktreePath)) return;
+  /**
+   * Register a change callback for a path, returning a teardown that removes
+   * ONLY this callback (closing the underlying `fs.watch` handles when it was
+   * the last one). A repeat subscribe for an already-watched path attaches to
+   * the existing watch instead of no-oping, so every subscriber is wired.
+   */
+  subscribe(worktreePath: string, callback: () => void): () => void {
+    const existing = this.watchers.get(worktreePath);
+    if (existing) {
+      existing.callbacks.add(callback);
+      return () => this.removeCallback(worktreePath, callback);
+    }
 
-    const entry: WatcherEntry = { watchers: [], debounceTimer: null };
+    const entry: WatcherEntry = { watchers: [], debounceTimer: null, callbacks: new Set([callback]) };
     this.watchers.set(worktreePath, entry);
 
-    // Debounce: reset the shared timer on each change from any watcher.
+    // Debounce: reset the shared timer on each change from any watcher, then
+    // fan the single fire out to every registered callback.
     const fire = () => {
       const current = this.watchers.get(worktreePath);
       if (current !== entry) return; // unsubscribed/replaced while debouncing
       if (entry.debounceTimer !== null) clearTimeout(entry.debounceTimer);
       entry.debounceTimer = setTimeout(() => {
         entry.debounceTimer = null;
-        callback();
+        for (const registeredCallback of entry.callbacks) registeredCallback();
       }, DEBOUNCE_MS);
     };
 
@@ -68,6 +88,21 @@ export class DiffWatcher {
     //    needs the absolute git dir (a worktree's lives under the main repo's
     //    .git/worktrees/<name>, not <worktree>/.git).
     this.watchGitMetadata(worktreePath, entry, fire);
+
+    return () => this.removeCallback(worktreePath, callback);
+  }
+
+  /**
+   * Remove one subscriber's callback from a path, closing the underlying
+   * watchers only when it was the last subscriber. `unsubscribe()` still
+   * force-closes every callback for a path (used by the renderer's single
+   * subscriber and by relocation's `releaseUnder`/`closeAll`).
+   */
+  private removeCallback(worktreePath: string, callback: () => void): void {
+    const entry = this.watchers.get(worktreePath);
+    if (!entry) return;
+    entry.callbacks.delete(callback);
+    if (entry.callbacks.size === 0) this.unsubscribe(worktreePath);
   }
 
   /**

--- a/src/main/ipc/ipc-context.ts
+++ b/src/main/ipc/ipc-context.ts
@@ -12,6 +12,7 @@ import type { TerminalSubmit } from '../pty/terminal-submit';
 import type { McpHttpServerHandle } from '../agent/mcp-http-server';
 import type { TranscriptionService } from '../transcription/transcription-service';
 import type { MobileBridgeService } from '../mobile-bridge/mobile-bridge-service';
+import type { BoardEventBus } from '../mobile-bridge/board-event-bus';
 
 export interface IpcContext {
   mainWindow: BrowserWindow;
@@ -79,4 +80,12 @@ export interface IpcContext {
    * currently open project. See src/main/mobile-bridge/mobile-bridge-service.ts.
    */
   mobileBridgeService: MobileBridgeService;
+  /**
+   * Consolidated main-process-internal board-mutation event stream, fed
+   * alongside (never instead of) the existing `IPC.*_BY_AGENT` renderer
+   * pushes. Lets the mobile bridge's read-board handler subscribe once,
+   * filtered by projectId, rather than to each ad-hoc `*_BY_AGENT` channel.
+   * See src/main/mobile-bridge/board-event-bus.ts.
+   */
+  boardEvents: BoardEventBus;
 }

--- a/src/main/ipc/register-all.ts
+++ b/src/main/ipc/register-all.ts
@@ -43,6 +43,7 @@ import { registerUsageStatsHandlers } from './handlers/usage-stats';
 import { registerPopOutHandlers } from './handlers/pop-out';
 import { retrievalService } from '../retrieval/retrieval-service';
 import { MobileBridgeService } from '../mobile-bridge/mobile-bridge-service';
+import { BoardEventBus } from '../mobile-bridge/board-event-bus';
 import type { IpcContext } from './ipc-context';
 import type { McpHttpServerHandle } from '../agent/mcp-http-server';
 
@@ -92,6 +93,7 @@ export function registerAllIpc(mainWindow: BrowserWindow, mcpServerHandle: McpHt
   // since MobileBridgeService's constructor needs a config synchronously
   // but configManager itself is only available once `context` exists.
   const mobileBridgeService = new MobileBridgeService({ enabled: false, relayUrl: '' });
+  const boardEvents = new BoardEventBus();
 
   // Lazy-initialize heavy objects on first access
   let projectRepo: ProjectRepository | null = null;
@@ -133,7 +135,15 @@ export function registerAllIpc(mainWindow: BrowserWindow, mcpServerHandle: McpHt
     recoveredProjects: new Set<string>(),
     mcpServerHandle,
     mobileBridgeService,
+    boardEvents,
   };
+
+  // The bridge needs IpcContext (SessionManager, repos, DiffService,
+  // commandHandlers) to register its capability-verb handlers - it cannot
+  // receive it at construction time above since IpcContext does not exist
+  // yet at that point. attachContext() must run before reconcile() so the
+  // first reconcile's syncSessions() has handlers to route into.
+  mobileBridgeService.attachContext(context);
 
   const effectiveConfig = context.configManager.getEffectiveConfig(context.currentProjectPath ?? undefined);
   mobileBridgeService.reconcile({

--- a/src/main/mobile-bridge/board-event-bus.ts
+++ b/src/main/mobile-bridge/board-event-bus.ts
@@ -1,0 +1,35 @@
+import { EventEmitter } from 'node:events';
+
+export type BoardChange = 'task-created' | 'task-updated' | 'task-deleted' | 'swimlane-updated' | 'backlog-changed';
+
+export interface BoardChangedEvent {
+  projectId: string;
+  change: BoardChange;
+  ids: string[];
+}
+
+/**
+ * A single main-process-internal event stream for every agent-driven board
+ * mutation, consolidating the ad-hoc `IPC.*_BY_AGENT` renderer pushes
+ * (fired from `buildCommandContextForProject`'s six callbacks in
+ * mcp-project-context.ts, plus the PR-linking push in pr-linking.ts) into
+ * one place a bridge session can subscribe to and filter by projectId,
+ * instead of listening to each ad-hoc channel individually.
+ *
+ * This is purely additive: it is fed alongside the existing renderer
+ * `sendToRenderer(...)` calls, never replacing them, so the renderer's
+ * `useAgentDrivenInvalidation` path is entirely unaffected. Not an IPC
+ * channel - `IpcContext.boardEvents` is a plain Node EventEmitter consumed
+ * only by other main-process code (the mobile bridge's read-board handler),
+ * so the ipc-7-layer-parity rule does not apply here.
+ */
+export class BoardEventBus extends EventEmitter {
+  emitBoardChanged(event: BoardChangedEvent): void {
+    this.emit('board-changed', event);
+  }
+
+  onBoardChanged(listener: (event: BoardChangedEvent) => void): () => void {
+    this.on('board-changed', listener);
+    return () => this.off('board-changed', listener);
+  }
+}

--- a/src/main/mobile-bridge/handlers/answer-permission-prompt.ts
+++ b/src/main/mobile-bridge/handlers/answer-permission-prompt.ts
@@ -1,0 +1,44 @@
+import { parseCapabilityRequestPayload, type AnswerPermissionPromptResponsePayload, type CapabilityRequestMessage, type CapabilityResponseMessage, type JsonValue } from '@kangentic/protocol';
+import type { IpcContext } from '../../ipc/ipc-context';
+import { buildPermissionPromptId } from './permission-prompt-id';
+
+/**
+ * The most sensitive verb: it can authorize the agent to run a command. The
+ * phone sends raw keystrokes (no agent-specific semantics here - keeps
+ * agent knowledge out of the bridge per agent-adapters-boundary.md) plus
+ * the prompt id it believes is outstanding; this handler is the desktop
+ * enforcement point that the response binds to a SPECIFIC live prompt,
+ * rejecting a stale or already-resolved one rather than blindly forwarding
+ * keystrokes (which interactive-terminal already allows for a granted
+ * device - the value here is exclusively the binding check).
+ */
+export function handleAnswerPermissionPrompt(
+  request: CapabilityRequestMessage,
+  context: IpcContext,
+): CapabilityResponseMessage {
+  const payload = parseCapabilityRequestPayload('answer-permission-prompt', request.payload);
+
+  if (!context.sessionManager.getSession(payload.sessionId)) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: `No such session: ${payload.sessionId}` };
+  }
+
+  const snapshot = context.sessionManager.getActivityStatsSnapshot(payload.sessionId);
+  if (!snapshot?.permissionPending || !snapshot.permissionAwaitedToolId) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: 'No permission prompt is currently outstanding for this session' };
+  }
+
+  const livePromptId = buildPermissionPromptId(payload.sessionId, snapshot.permissionAwaitedToolId);
+  if (livePromptId !== payload.promptId) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: 'promptId does not match the currently outstanding prompt (stale or already answered)' };
+  }
+  // A pending prompt on a live session implies a writable PTY; guard anyway so
+  // a race that nulled the pty reports the drop instead of a false answered:true.
+  if (!context.sessionManager.isWritable(payload.sessionId)) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: `Session is not accepting input (not running): ${payload.sessionId}` };
+  }
+
+  context.sessionManager.write(payload.sessionId, payload.keystrokes);
+
+  const responsePayload: AnswerPermissionPromptResponsePayload = { answered: true };
+  return { type: 'capability-response', requestId: request.requestId, ok: true, payload: responsePayload as unknown as JsonValue };
+}

--- a/src/main/mobile-bridge/handlers/board-tool-allowlist.ts
+++ b/src/main/mobile-bridge/handlers/board-tool-allowlist.ts
@@ -1,0 +1,95 @@
+/**
+ * The `tool` field a phone's `board-tool-read`/`board-tool-write` request
+ * names is the INTERNAL command-registry key from
+ * src/main/agent/commands/index.ts (`commandHandlers`, e.g. 'create_task',
+ * 'update_task'), not a public MCP tool name. Despite the "tool"/"params"
+ * shape, this is NOT the MCP protocol - no agent, LLM, or JSON-RPC
+ * round-trip is involved anywhere in this path. It routes straight into
+ * `commandHandlers`, reusing the exact same handlers + board-mutation
+ * side-effect fan-out the actual MCP server also happens to dispatch into,
+ * without re-deriving the `register*Tools` layer's zod schemas, defaulting,
+ * rate limiting, or LLM-facing prose formatting - the same kind of direct
+ * reuse read-board/move-task/etc. do against their own repositories/
+ * handleTaskMove. This exists for the long tail of task/backlog CRUD
+ * (create, edit, delete, link PR, ...) that does not warrant a bespoke
+ * verb each.
+ *
+ * Deliberately excluded rather than reachable-by-omission:
+ * - `move_task`, `list_tasks`, `list_columns`, `list_backlog` - NOT unsafe,
+ *   but duplicates: the dedicated `move-task` and `read-board` verbs
+ *   already cover moving a task and listing tasks/columns/backlog, with a
+ *   cleaner contract (swimlaneId not column-name resolution; full Task/
+ *   Swimlane objects, not LLM-prose-oriented summaries) and, for
+ *   read-board, a live subscription these one-shot tools do not have.
+ *   Keeping them reachable through BOTH paths would mean two different
+ *   contracts for the same action with no reason to prefer one - excluding
+ *   them here keeps exactly one path per capability.
+ * - `query_db` (raw SQL escape hatch - the research doc's explicit
+ *   "minus code-execution verbs (no devtools/browser/raw-query_db)").
+ * - Everything NOT in `commandHandlers` at all: the `kangentic_browser_*`
+ *   family and the dev-only `kangentic_devtools_*` family are registered
+ *   through entirely separate registries, never through `commandHandlers` -
+ *   so building this allowlist FROM `commandHandlers`'s keys excludes them
+ *   for free, with no separate name-matching needed. The same is true of
+ *   the diagnostics tools (`tail_logs`, `get_recent_crashes`,
+ *   `get_process_metrics`, `get_ipc_log`, `list_worktrees`) and the
+ *   remaining cross-project tools (`list_projects`, unified `search`,
+ *   `move_task_to_project`) - none of them are `commandHandlers` entries,
+ *   so none of them are reachable here.
+ */
+import { commandHandlers } from '../../agent/commands';
+
+export type BoardToolAccess = 'read' | 'mutate';
+
+/**
+ * Every `commandHandlers` key EXCEPT the excluded set below, classified
+ * read vs mutate. `board-tool-allowlist.test.ts` fails if a new
+ * `commandHandlers` entry is added without a classification (or exclusion)
+ * here, or if this table drifts from `commandHandlers`'s actual key set.
+ */
+export const MOBILE_BOARD_TOOL_ACCESS: Readonly<Record<string, BoardToolAccess>> = {
+  create_task: 'mutate',
+  update_task: 'mutate',
+  delete_task: 'mutate',
+  link_pr: 'mutate',
+  remove_attachment: 'mutate',
+  update_column: 'mutate',
+  search_tasks: 'read',
+  find_task: 'read',
+  get_current_task: 'read',
+  get_task_stats: 'read',
+  get_usage_stats: 'read',
+  board_summary: 'read',
+  list_sessions: 'read',
+  get_session_history: 'read',
+  get_column_detail: 'read',
+  create_backlog_task: 'mutate',
+  promote_backlog: 'mutate',
+  update_backlog_item: 'mutate',
+  delete_backlog_item: 'mutate',
+  get_handoff_context: 'read',
+  get_transcript: 'read',
+  get_session_files: 'read',
+  get_session_events: 'read',
+};
+
+/** query_db is unsafe; move_task/list_tasks/list_columns/list_backlog are safe but duplicate the dedicated move-task/read-board verbs - see the module doc comment. */
+export const MOBILE_EXCLUDED_BOARD_TOOLS: ReadonlySet<string> = new Set([
+  'query_db',
+  'move_task',
+  'list_tasks',
+  'list_columns',
+  'list_backlog',
+]);
+
+/** True only for a `commandHandlers` key that is both classified here and not on the exclusion list. */
+export function isKnownMobileBoardTool(tool: string): boolean {
+  return tool in commandHandlers && !MOBILE_EXCLUDED_BOARD_TOOLS.has(tool) && tool in MOBILE_BOARD_TOOL_ACCESS;
+}
+
+/** Deny-by-default: an unknown tool, or a known tool whose access class does not match the requested verb, is refused. */
+export function isBoardToolAllowedForVerb(tool: string, verb: 'board-tool-read' | 'board-tool-write'): boolean {
+  if (!isKnownMobileBoardTool(tool)) return false;
+  const access = MOBILE_BOARD_TOOL_ACCESS[tool];
+  return verb === 'board-tool-read' ? access === 'read' : access === 'mutate';
+}

--- a/src/main/mobile-bridge/handlers/board-tool.ts
+++ b/src/main/mobile-bridge/handlers/board-tool.ts
@@ -1,0 +1,58 @@
+import { isRecord, parseCapabilityRequestPayload, type CapabilityRequestMessage, type CapabilityResponseMessage, type JsonValue, type BoardToolResponsePayload } from '@kangentic/protocol';
+import { commandHandlers } from '../../agent/commands';
+import { buildCommandContextForProject } from '../../agent/mcp-project-context';
+import type { IpcContext } from '../../ipc/ipc-context';
+import { isBoardToolAllowedForVerb } from './board-tool-allowlist';
+
+/**
+ * Routes a phone's board-tool-read/board-tool-write request straight into
+ * the same `commandHandlers` registry (src/main/agent/commands/index.ts)
+ * the MCP HTTP server also dispatches into - the exact same handlers and
+ * board-mutation side-effect fan-out (buildCommandContextForProject's
+ * callbacks, which also feed the consolidated board-changed bus). This is
+ * NOT the MCP protocol: no agent, LLM, or JSON-RPC round-trip happens
+ * anywhere in this call - it is a direct function call, the same as every
+ * other capability handler, reusing `commandHandlers` instead of
+ * re-deriving the `register*Tools` layer's zod schemas / defaulting / rate
+ * limiting / LLM-facing prose formatting. `tool` is the internal
+ * commandHandlers key (e.g. 'create_task'), not the public
+ * 'kangentic_create_task' MCP name - see board-tool-allowlist.ts's doc
+ * comment for why, and for why move_task/list_tasks/list_columns/
+ * list_backlog are excluded here (covered by the dedicated move-task/
+ * read-board verbs instead, so there is exactly one path per capability).
+ */
+export async function handleBoardTool(
+  request: CapabilityRequestMessage,
+  context: IpcContext,
+): Promise<CapabilityResponseMessage> {
+  const verb = request.verb as 'board-tool-read' | 'board-tool-write';
+  const payload = parseCapabilityRequestPayload(verb, request.payload);
+
+  if (!isBoardToolAllowedForVerb(payload.tool, verb)) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: `Tool not allowed for ${verb}: ${payload.tool}` };
+  }
+  if (!isRecord(payload.params)) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: '"params" must be an object' };
+  }
+
+  const projectId = (typeof payload.params.project === 'string' ? payload.params.project : undefined)
+    ?? context.currentProjectId
+    ?? undefined;
+  if (!projectId) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: 'No project is currently open and no project was specified' };
+  }
+  const commandContext = buildCommandContextForProject(context, projectId);
+  if (!commandContext) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: `No such project: ${projectId}` };
+  }
+
+  const handler = commandHandlers[payload.tool];
+  const response = await handler(payload.params, commandContext);
+
+  if (!response.success) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: response.error ?? response.message ?? 'Tool call failed' };
+  }
+
+  const responsePayload: BoardToolResponsePayload = { result: response.data as unknown as JsonValue };
+  return { type: 'capability-response', requestId: request.requestId, ok: true, payload: responsePayload as unknown as JsonValue };
+}

--- a/src/main/mobile-bridge/handlers/index.ts
+++ b/src/main/mobile-bridge/handlers/index.ts
@@ -1,0 +1,40 @@
+import type { DiffWatcher } from '../../git/diff-watcher';
+import type { IpcContext } from '../../ipc/ipc-context';
+import type { CapabilityRouter } from '../capability-router';
+import type { SubscriptionRegistry } from '../session/subscription-registry';
+import { handleReadStream } from './read-stream';
+import { handleReadBoard } from './read-board';
+import { handleReadDiff } from './read-diff';
+import { handleSendUserMessage } from './send-user-message';
+import { handleMoveTask } from './move-task';
+import { handleInteractiveTerminal } from './interactive-terminal';
+import { handleAnswerPermissionPrompt } from './answer-permission-prompt';
+import { handleBoardTool } from './board-tool';
+
+export interface CapabilityHandlerDeps {
+  context: IpcContext;
+  /** Bridge-owned, never `context.diffWatcher` - that instance is shared with the renderer's git-diff panel and is single-watch-per-path, so a bridge teardown would kill the renderer's live watch (and vice versa). */
+  diffWatcher: DiffWatcher;
+  getSubscriptions: (deviceId: string) => SubscriptionRegistry;
+}
+
+/**
+ * Registers every Phase 2 capability verb's handler on the router, once,
+ * at MobileBridgeService.attachContext() - never per-session. Deny-by-default
+ * authorization already happened in CapabilityRouter.dispatch() before a
+ * handler here ever runs; these only implement behavior.
+ */
+export function registerCapabilityHandlers(router: CapabilityRouter, deps: CapabilityHandlerDeps): void {
+  router.register('read-stream', (request, session) =>
+    handleReadStream(request, session, deps.context, deps.getSubscriptions(session.deviceId)));
+  router.register('read-board', (request, session) =>
+    handleReadBoard(request, session, deps.context, deps.getSubscriptions(session.deviceId)));
+  router.register('read-diff', (request, session) =>
+    handleReadDiff(request, session, deps.context, deps.getSubscriptions(session.deviceId), deps.diffWatcher));
+  router.register('send-user-message', (request) => handleSendUserMessage(request, deps.context));
+  router.register('move-task', (request) => handleMoveTask(request, deps.context));
+  router.register('interactive-terminal', (request) => handleInteractiveTerminal(request, deps.context));
+  router.register('answer-permission-prompt', (request) => handleAnswerPermissionPrompt(request, deps.context));
+  router.register('board-tool-read', (request) => handleBoardTool(request, deps.context));
+  router.register('board-tool-write', (request) => handleBoardTool(request, deps.context));
+}

--- a/src/main/mobile-bridge/handlers/interactive-terminal.ts
+++ b/src/main/mobile-bridge/handlers/interactive-terminal.ts
@@ -1,0 +1,30 @@
+import { parseCapabilityRequestPayload, type CapabilityRequestMessage, type CapabilityResponseMessage, type InteractiveTerminalResponsePayload, type JsonValue } from '@kangentic/protocol';
+import type { IpcContext } from '../../ipc/ipc-context';
+
+/**
+ * Raw PTY write-path parity ("the '! npm login while away' scenario"): the
+ * phone types directly into the running session, no different from the
+ * desktop terminal. This is the power write verb - explicit grant only,
+ * never in the default read-only capability set.
+ */
+export function handleInteractiveTerminal(
+  request: CapabilityRequestMessage,
+  context: IpcContext,
+): CapabilityResponseMessage {
+  const payload = parseCapabilityRequestPayload('interactive-terminal', request.payload);
+
+  if (!context.sessionManager.getSession(payload.sessionId)) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: `No such session: ${payload.sessionId}` };
+  }
+  // A suspended/queued/exited session stays in the registry but has no live
+  // PTY, so write() silently drops the bytes - report that rather than a
+  // false written:true.
+  if (!context.sessionManager.isWritable(payload.sessionId)) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: `Session is not accepting input (not running): ${payload.sessionId}` };
+  }
+
+  context.sessionManager.write(payload.sessionId, payload.data);
+
+  const responsePayload: InteractiveTerminalResponsePayload = { written: true };
+  return { type: 'capability-response', requestId: request.requestId, ok: true, payload: responsePayload as unknown as JsonValue };
+}

--- a/src/main/mobile-bridge/handlers/move-task.ts
+++ b/src/main/mobile-bridge/handlers/move-task.ts
@@ -1,0 +1,31 @@
+import { parseCapabilityRequestPayload, type CapabilityRequestMessage, type CapabilityResponseMessage, type JsonValue, type MoveTaskResponsePayload } from '@kangentic/protocol';
+import { handleTaskMove } from '../../ipc/handlers/task-move';
+import { resolveProjectContext } from '../../ipc/helpers/project-repos';
+import type { IpcContext } from '../../ipc/ipc-context';
+
+export async function handleMoveTask(
+  request: CapabilityRequestMessage,
+  context: IpcContext,
+): Promise<CapabilityResponseMessage> {
+  const payload = parseCapabilityRequestPayload('move-task', request.payload);
+  const { projectId, projectPath } = resolveProjectContext(context, payload.projectId);
+  if (!projectId) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: `No such project: ${payload.projectId}` };
+  }
+
+  // handleTaskMove already wraps withTaskLock + the transition engine +
+  // rollback (see task-lifecycle-lock.md). Never call
+  // TaskRepository.move() directly, and never forward a continuationPrompt
+  // from the wire payload - it is deliberately excluded from the raw
+  // renderer-facing input shape, and a phone is no more trusted than the
+  // renderer here.
+  await handleTaskMove(
+    context,
+    { taskId: payload.taskId, targetSwimlaneId: payload.targetSwimlaneId, targetPosition: payload.targetPosition },
+    projectId,
+    projectPath,
+  );
+
+  const responsePayload: MoveTaskResponsePayload = { ok: true };
+  return { type: 'capability-response', requestId: request.requestId, ok: true, payload: responsePayload as unknown as JsonValue };
+}

--- a/src/main/mobile-bridge/handlers/permission-prompt-id.ts
+++ b/src/main/mobile-bridge/handlers/permission-prompt-id.ts
@@ -1,0 +1,14 @@
+/**
+ * There is no dedicated permission-prompt object or id scheme in the
+ * desktop app today - a permission prompt is just the agent's own TUI
+ * prompt, and the activity engine tracks only that one is outstanding
+ * (`permissionPending`) plus which tool it is for
+ * (`permissionAwaitedToolId`, the `tool_use_id`). This synthesizes a
+ * stable prompt id from those two pieces of session state, used both to
+ * report "what is outstanding" (read-stream's snapshot) and to bind
+ * answer-permission-prompt's response to the SPECIFIC prompt it answers,
+ * rejecting a stale or replayed answer whose id no longer matches.
+ */
+export function buildPermissionPromptId(sessionId: string, awaitedToolId: string): string {
+  return `${sessionId}:${awaitedToolId}`;
+}

--- a/src/main/mobile-bridge/handlers/read-board.ts
+++ b/src/main/mobile-bridge/handlers/read-board.ts
@@ -1,0 +1,71 @@
+import {
+  parseCapabilityRequestPayload,
+  type CapabilityRequestMessage,
+  type CapabilityResponseMessage,
+  type JsonValue,
+  type ReadBoardResponsePayload,
+} from '@kangentic/protocol';
+import { getProjectRepos } from '../../ipc/helpers/project-repos';
+import { getProjectDb } from '../../db/database';
+import { BacklogRepository } from '../../db/repositories/backlog-repository';
+import type { IpcContext } from '../../ipc/ipc-context';
+import type { BridgeSession } from '../session/bridge-session';
+import type { SubscriptionRegistry } from '../session/subscription-registry';
+import type { BoardChangedEvent } from '../board-event-bus';
+import { sendEvent } from './send-event';
+
+function subscriptionKeyFor(projectId: string): string {
+  return `board:${projectId}`;
+}
+
+export async function handleReadBoard(
+  request: CapabilityRequestMessage,
+  session: BridgeSession,
+  context: IpcContext,
+  subscriptions: SubscriptionRegistry,
+): Promise<CapabilityResponseMessage> {
+  const payload = parseCapabilityRequestPayload('read-board', request.payload);
+
+  if (!payload.projectId) {
+    const projects = context.projectRepo.list().map((project) => ({ id: project.id, name: project.name }));
+    const responsePayload: ReadBoardResponsePayload = { projects };
+    return { type: 'capability-response', requestId: request.requestId, ok: true, payload: responsePayload as unknown as JsonValue };
+  }
+
+  const projectId = payload.projectId;
+  const subscriptionKey = subscriptionKeyFor(projectId);
+
+  if (payload.action === 'unsubscribe') {
+    subscriptions.remove(subscriptionKey);
+    return { type: 'capability-response', requestId: request.requestId, ok: true };
+  }
+
+  const project = context.projectRepo.getById(projectId);
+  if (!project) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: `No such project: ${projectId}` };
+  }
+
+  const repos = getProjectRepos(context, projectId);
+  const backlogRepo = new BacklogRepository(getProjectDb(projectId));
+
+  const responsePayload: ReadBoardResponsePayload = {
+    projectId,
+    columns: repos.swimlanes.list() as unknown as JsonValue,
+    tasks: repos.tasks.list() as unknown as JsonValue,
+    backlog: backlogRepo.list() as unknown as JsonValue,
+  };
+
+  const listener = (event: BoardChangedEvent): void => {
+    if (event.projectId !== projectId) return;
+    sendEvent(session, {
+      kind: 'board',
+      projectId,
+      taskId: event.ids[0],
+      payload: { change: event.change, ids: event.ids },
+    });
+  };
+  const unsubscribe = context.boardEvents.onBoardChanged(listener);
+  subscriptions.set(subscriptionKey, unsubscribe);
+
+  return { type: 'capability-response', requestId: request.requestId, ok: true, payload: responsePayload as unknown as JsonValue };
+}

--- a/src/main/mobile-bridge/handlers/read-diff.ts
+++ b/src/main/mobile-bridge/handlers/read-diff.ts
@@ -1,0 +1,95 @@
+import {
+  parseCapabilityRequestPayload,
+  type CapabilityRequestMessage,
+  type CapabilityResponseMessage,
+  type JsonValue,
+} from '@kangentic/protocol';
+import type { DiffWatcher } from '../../git/diff-watcher';
+import { DiffService } from '../../git/diff-service';
+import { getProjectRepos } from '../../ipc/helpers/project-repos';
+import type { IpcContext } from '../../ipc/ipc-context';
+import type { BridgeSession } from '../session/bridge-session';
+import type { SubscriptionRegistry } from '../session/subscription-registry';
+import { sendEvent } from './send-event';
+
+// Cache DiffService instances per directory so the merge-base cache persists
+// across calls, mirroring src/main/ipc/handlers/git-diff.ts's own cache.
+// Stale post-relocation entries are harmless (same rationale as that file).
+const serviceCache = new Map<string, DiffService>();
+
+function getOrCreateService(gitDirectory: string): DiffService {
+  const existing = serviceCache.get(gitDirectory);
+  if (existing) return existing;
+  const service = new DiffService(gitDirectory);
+  serviceCache.set(gitDirectory, service);
+  return service;
+}
+
+function subscriptionKeyFor(taskId: string): string {
+  return `diff:${taskId}`;
+}
+
+export async function handleReadDiff(
+  request: CapabilityRequestMessage,
+  session: BridgeSession,
+  context: IpcContext,
+  subscriptions: SubscriptionRegistry,
+  diffWatcher: DiffWatcher,
+): Promise<CapabilityResponseMessage> {
+  const payload = parseCapabilityRequestPayload('read-diff', request.payload);
+  const subscriptionKey = subscriptionKeyFor(payload.taskId);
+
+  if (payload.action === 'unsubscribe') {
+    subscriptions.remove(subscriptionKey);
+    return { type: 'capability-response', requestId: request.requestId, ok: true };
+  }
+
+  const project = context.projectRepo.getById(payload.projectId);
+  if (!project) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: `No such project: ${payload.projectId}` };
+  }
+  const repos = getProjectRepos(context, payload.projectId);
+  const task = repos.tasks.getById(payload.taskId);
+  if (!task) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: `No such task: ${payload.taskId}` };
+  }
+
+  const worktreePath = task.worktree_path ?? undefined;
+  const baseBranch = task.base_branch ?? 'main';
+  const gitDirectory = worktreePath ?? project.path;
+  const service = getOrCreateService(gitDirectory);
+
+  if (payload.filePath) {
+    // The wire contract does not carry the file's diff status (added/modified/deleted/...),
+    // which getFileContent requires - resolve it from the current file list first.
+    const fileList = await service.getDiffFiles({ worktreePath, projectPath: project.path, baseBranch, scope: payload.scope });
+    const entry = fileList.files.find((file) => file.path === payload.filePath);
+    if (!entry) {
+      return { type: 'capability-response', requestId: request.requestId, ok: false, error: `No such file in the diff: ${payload.filePath}` };
+    }
+    const content = await service.getFileContent({
+      worktreePath,
+      projectPath: project.path,
+      baseBranch,
+      filePath: payload.filePath,
+      status: entry.status,
+      oldPath: entry.oldPath,
+      scope: payload.scope,
+    });
+    return { type: 'capability-response', requestId: request.requestId, ok: true, payload: content as unknown as JsonValue };
+  }
+
+  const fileList = await service.getDiffFiles({ worktreePath, projectPath: project.path, baseBranch, scope: payload.scope });
+
+  const watchPath = gitDirectory;
+  // Use the per-subscriber teardown DiffWatcher.subscribe returns, NOT
+  // unsubscribe(watchPath): the watcher multiplexes callbacks per path, so a
+  // blanket unsubscribe(watchPath) would kill a co-located subscription (a
+  // second device, or another worktree-less task in the same repo) too.
+  const unsubscribeDiff = diffWatcher.subscribe(watchPath, () => {
+    sendEvent(session, { kind: 'diff', taskId: payload.taskId, payload: null });
+  });
+  subscriptions.set(subscriptionKey, unsubscribeDiff);
+
+  return { type: 'capability-response', requestId: request.requestId, ok: true, payload: fileList as unknown as JsonValue };
+}

--- a/src/main/mobile-bridge/handlers/read-stream.ts
+++ b/src/main/mobile-bridge/handlers/read-stream.ts
@@ -1,0 +1,143 @@
+import {
+  parseCapabilityRequestPayload,
+  type CapabilityRequestMessage,
+  type CapabilityResponseMessage,
+  type JsonValue,
+  type ReadStreamResponsePayload,
+} from '@kangentic/protocol';
+import type { ActivityReason, ActivityState, SessionEvent, SessionUsage } from '../../../shared/types';
+import { getProjectDb } from '../../db/database';
+import { resolveTaskTranscript } from '../../agent/transcript-service';
+import type { IpcContext } from '../../ipc/ipc-context';
+import type { BridgeSession } from '../session/bridge-session';
+import type { SubscriptionRegistry } from '../session/subscription-registry';
+import { sendEvent } from './send-event';
+import { buildPermissionPromptId } from './permission-prompt-id';
+
+/** Coalesce raw PTY output before pushing, so a burst of small onData chunks does not become a flood of tiny frames. */
+const TERMINAL_COALESCE_MS = 50;
+
+function subscriptionKeyFor(sessionId: string): string {
+  return `stream:${sessionId}`;
+}
+
+function subscribeReadStream(
+  sessionId: string,
+  taskId: string,
+  session: BridgeSession,
+  context: IpcContext,
+  subscriptions: SubscriptionRegistry,
+): void {
+  const db = getProjectDb(context.sessionManager.getSessionProjectId(sessionId) ?? '');
+  let lastKnownRevision = -1;
+  let pendingTerminalChunks: string[] = [];
+  let terminalFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const flushTerminal = (): void => {
+    terminalFlushTimer = null;
+    if (pendingTerminalChunks.length === 0) return;
+    const data = pendingTerminalChunks.join('');
+    pendingTerminalChunks = [];
+    sendEvent(session, { kind: 'terminal', sessionId, taskId, payload: { data } });
+  };
+
+  const pushTranscriptIfChanged = async (): Promise<void> => {
+    try {
+      const resolved = await resolveTaskTranscript(db, sessionId);
+      if (!resolved || resolved.revision === lastKnownRevision) return;
+      lastKnownRevision = resolved.revision;
+      sendEvent(session, { kind: 'transcript', sessionId, taskId, payload: resolved.entries as unknown as JsonValue });
+    } catch {
+      // Best-effort; a transcript-read failure should not tear down the subscription.
+    }
+  };
+
+  const onDataTap = (tappedSessionId: string, data: string): void => {
+    if (tappedSessionId !== sessionId) return;
+    pendingTerminalChunks.push(data);
+    if (!terminalFlushTimer) terminalFlushTimer = setTimeout(flushTerminal, TERMINAL_COALESCE_MS);
+  };
+  const onActivity = (activitySessionId: string, state: ActivityState, reason: ActivityReason): void => {
+    if (activitySessionId !== sessionId) return;
+    sendEvent(session, {
+      kind: 'activity',
+      sessionId,
+      taskId,
+      payload: { type: 'activity', state: state as unknown as JsonValue, reason: reason as unknown as JsonValue },
+    });
+  };
+  const onUsage = (usageSessionId: string, usage: SessionUsage): void => {
+    if (usageSessionId !== sessionId) return;
+    sendEvent(session, { kind: 'activity', sessionId, taskId, payload: { type: 'usage', usage: usage as unknown as JsonValue } });
+  };
+  const onSessionEvent = (eventSessionId: string, event: SessionEvent): void => {
+    if (eventSessionId !== sessionId) return;
+    sendEvent(session, { kind: 'activity', sessionId, taskId, payload: { type: 'event', event: event as unknown as JsonValue } });
+    void pushTranscriptIfChanged();
+  };
+
+  // When the session exits, tear our own subscription down: nothing else
+  // removes these listeners until the device disconnects, so without this a
+  // long-lived phone connection would leak four listeners per session it ever
+  // streamed onto the singleton SessionManager.
+  const onExit = (exitedSessionId: string): void => {
+    if (exitedSessionId !== sessionId) return;
+    flushTerminal(); // push any last coalesced output before we stop listening
+    subscriptions.remove(subscriptionKeyFor(sessionId));
+  };
+
+  context.sessionManager.on('data-tap', onDataTap);
+  context.sessionManager.on('activity', onActivity);
+  context.sessionManager.on('usage', onUsage);
+  context.sessionManager.on('event', onSessionEvent);
+  context.sessionManager.on('exit', onExit);
+
+  subscriptions.set(subscriptionKeyFor(sessionId), () => {
+    context.sessionManager.off('data-tap', onDataTap);
+    context.sessionManager.off('activity', onActivity);
+    context.sessionManager.off('usage', onUsage);
+    context.sessionManager.off('event', onSessionEvent);
+    context.sessionManager.off('exit', onExit);
+    if (terminalFlushTimer) clearTimeout(terminalFlushTimer);
+  });
+}
+
+export async function handleReadStream(
+  request: CapabilityRequestMessage,
+  session: BridgeSession,
+  context: IpcContext,
+  subscriptions: SubscriptionRegistry,
+): Promise<CapabilityResponseMessage> {
+  const payload = parseCapabilityRequestPayload('read-stream', request.payload);
+  const subscriptionKey = subscriptionKeyFor(payload.sessionId);
+
+  if (payload.action === 'unsubscribe') {
+    subscriptions.remove(subscriptionKey);
+    return { type: 'capability-response', requestId: request.requestId, ok: true };
+  }
+
+  const liveSession = context.sessionManager.getSession(payload.sessionId);
+  if (!liveSession) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: `No such session: ${payload.sessionId}` };
+  }
+
+  const scrollback = await context.sessionManager.getScrollback(payload.sessionId);
+  const activityState = context.sessionManager.getActivityCache()[payload.sessionId] ?? null;
+  const activityReason = context.sessionManager.getActivityReason(payload.sessionId);
+  const usage = context.sessionManager.getUsageCache()[payload.sessionId] ?? null;
+  const statsSnapshot = context.sessionManager.getActivityStatsSnapshot(payload.sessionId);
+  const awaitedPromptId = statsSnapshot?.permissionPending && statsSnapshot.permissionAwaitedToolId
+    ? buildPermissionPromptId(payload.sessionId, statsSnapshot.permissionAwaitedToolId)
+    : null;
+
+  const responsePayload: ReadStreamResponsePayload = {
+    scrollback,
+    activity: { state: activityState, reason: activityReason } as unknown as JsonValue,
+    usage: usage as unknown as JsonValue,
+    awaitedPromptId,
+  };
+
+  subscribeReadStream(payload.sessionId, liveSession.taskId, session, context, subscriptions);
+
+  return { type: 'capability-response', requestId: request.requestId, ok: true, payload: responsePayload as unknown as JsonValue };
+}

--- a/src/main/mobile-bridge/handlers/send-event.ts
+++ b/src/main/mobile-bridge/handlers/send-event.ts
@@ -1,0 +1,24 @@
+import type { BridgeEvent } from '@kangentic/protocol';
+import type { BridgeSession } from '../session/bridge-session';
+
+/**
+ * Pushes one BridgeEvent to a device, silently dropping it if the session
+ * is not established. `isEstablished` is only false before the first Noise
+ * handshake completes or after the session is torn down; a routine ~2-minute
+ * re-handshake (bridge-session.ts) keeps the existing secretstream until the
+ * new one is derived, so it does NOT drop events. A dropped event is not
+ * recovered - there is no 'established' re-push, so the phone catches up by
+ * re-issuing its read-* requests (each of which returns a fresh snapshot),
+ * not by this side replaying missed deltas. `BridgeSession.sendMessage` also
+ * throws once torn down; the try/catch keeps a transient send failure from
+ * escaping an event-listener callback.
+ */
+export function sendEvent(session: BridgeSession, event: BridgeEvent): void {
+  if (!session.isEstablished) return;
+  try {
+    session.sendMessage({ type: 'event', event });
+  } catch {
+    // Best-effort push; a transient send failure should not throw out of
+    // an event listener callback.
+  }
+}

--- a/src/main/mobile-bridge/handlers/send-user-message.ts
+++ b/src/main/mobile-bridge/handlers/send-user-message.ts
@@ -1,0 +1,22 @@
+import { parseCapabilityRequestPayload, type CapabilityRequestMessage, type CapabilityResponseMessage, type JsonValue, type SendUserMessageResponsePayload } from '@kangentic/protocol';
+import type { IpcContext } from '../../ipc/ipc-context';
+
+export async function handleSendUserMessage(
+  request: CapabilityRequestMessage,
+  context: IpcContext,
+): Promise<CapabilityResponseMessage> {
+  const payload = parseCapabilityRequestPayload('send-user-message', request.payload);
+
+  if (!context.sessionManager.getSession(payload.sessionId)) {
+    return { type: 'capability-response', requestId: request.requestId, ok: false, error: `No such session: ${payload.sessionId}` };
+  }
+
+  // The same bracketed-paste delivery path the renderer's Browser-pane
+  // "Send" affordance uses, not a raw sessionManager.write - this handles
+  // drain, chunked write, and submission evidence rather than a bare
+  // keystroke injection.
+  await context.terminalSubmit.submitContent(payload.sessionId, payload.text, { source: 'mobile-bridge' });
+
+  const responsePayload: SendUserMessageResponsePayload = { delivered: true };
+  return { type: 'capability-response', requestId: request.requestId, ok: true, payload: responsePayload as unknown as JsonValue };
+}

--- a/src/main/mobile-bridge/mobile-bridge-service.ts
+++ b/src/main/mobile-bridge/mobile-bridge-service.ts
@@ -2,13 +2,17 @@ import { EventEmitter } from 'node:events';
 import {
   bytesToHex,
   capabilitySetFromArray,
+  deriveSessionSlotId,
   encodePairingQrPayload,
   PROTOCOL_VERSION,
+  rosterDeviceCapabilitySet,
   type CapabilityVerb,
   type PairingQrPayload,
+  type RosterDeviceEntry,
   type ShortAuthenticationString,
 } from '@kangentic/protocol';
 import { isGenuineEncryptionAvailable } from '../boards/shared/auth';
+import { DiffWatcher } from '../git/diff-watcher';
 import { loadBridgeIdentity, loadOrCreateBridgeIdentity, type BridgeIdentity } from './identity';
 import {
   loadRoster,
@@ -17,8 +21,11 @@ import {
 } from './roster-store';
 import { DEFAULT_PAIRING_CAPABILITIES, PairingService } from './pairing/pairing-service';
 import { createTransport } from './transport/transport-factory';
-import type { BridgeSession } from './session/bridge-session';
+import { BridgeSession } from './session/bridge-session';
+import { SubscriptionRegistry } from './session/subscription-registry';
 import { CapabilityRouter } from './capability-router';
+import { registerCapabilityHandlers } from './handlers';
+import type { IpcContext } from '../ipc/ipc-context';
 
 export interface MobileBridgeConfig {
   enabled: boolean;
@@ -47,8 +54,10 @@ export interface PairedDeviceSummary {
  * in register-all.ts, torn down synchronously in index.ts's
  * clearPendingTimers), modeled on SessionManager/TranscriptionService's
  * shape. Owns the desktop's identity, the signed device roster, the
- * active pairing ceremony (if any), and (once Phase 2 gives sessions
- * something to do) one BridgeSession per connected paired device.
+ * active pairing ceremony (if any), and one live BridgeSession per roster
+ * device once `attachContext()` has wired the capability handlers -
+ * `syncSessions()` (driven by `reconcile()` and by a successful pairing
+ * confirmation) keeps the `sessions` map in step with the roster.
  *
  * Identity creation is deferred to the FIRST deliberate pairing attempt
  * (ensureIdentity(), called only from startPairing()), not the
@@ -66,6 +75,15 @@ export class MobileBridgeService extends EventEmitter {
   private activePairing: PairingService | null = null;
   private pendingPairingDeviceId: string | null = null;
   private readonly sessions = new Map<string, BridgeSession>();
+  private readonly subscriptionsByDevice = new Map<string, SubscriptionRegistry>();
+  /**
+   * Bridge-owned diff watcher, NEVER `IpcContext.diffWatcher` - that
+   * instance is shared with the renderer's git-diff panel and is
+   * single-watch-per-path, so a bridge subscription teardown would kill
+   * the renderer's live watch on the same worktree (and vice versa).
+   */
+  private readonly diffWatcher = new DiffWatcher();
+  private ipcContext: IpcContext | null = null;
   private disposed = false;
 
   constructor(config: MobileBridgeConfig) {
@@ -73,18 +91,172 @@ export class MobileBridgeService extends EventEmitter {
     this.config = config;
   }
 
+  /**
+   * Wires the capability-verb handlers to the main-process seams they need
+   * (SessionManager, repositories, DiffService, commandHandlers) and stores
+   * the context for syncSessions() to use. Called once from register-all.ts
+   * after IpcContext is assembled - IpcContext does not exist yet at this
+   * service's construction time, so it cannot be a constructor argument.
+   * Registers handlers exactly once; never call this more than once.
+   */
+  attachContext(context: IpcContext): void {
+    this.ipcContext = context;
+    registerCapabilityHandlers(this.capabilityRouter, {
+      context,
+      diffWatcher: this.diffWatcher,
+      getSubscriptions: (deviceId) => this.getOrCreateSubscriptions(deviceId),
+    });
+  }
+
+  private getOrCreateSubscriptions(deviceId: string): SubscriptionRegistry {
+    let subscriptions = this.subscriptionsByDevice.get(deviceId);
+    if (!subscriptions) {
+      subscriptions = new SubscriptionRegistry();
+      this.subscriptionsByDevice.set(deviceId, subscriptions);
+    }
+    return subscriptions;
+  }
+
   /** Applies effective config. Called from register-all.ts at startup and from applyRuntimeConfig on every config:set. */
   reconcile(config: MobileBridgeConfig): void {
+    const previousRelayUrl = this.config.relayUrl;
     const wasEnabled = this.config.enabled;
     this.config = config;
     if (!config.enabled && wasEnabled) {
       this.cancelPairing('Mobile bridge disabled');
       this.disposeAllSessions();
+      return;
     }
-    // Reconnecting already-paired devices' sessions on enable/relayUrl
-    // change is a Phase 2 concern once capability verbs give a session
-    // something to do; Phase 1 establishes the identity/roster/pairing
-    // surface.
+    // A relay URL change while already enabled invalidates every open
+    // session's transport (it dials a now-stale address) - dispose and let
+    // syncSessions() below reopen each roster device against the new relay.
+    if (config.enabled && config.relayUrl !== previousRelayUrl) {
+      this.disposeAllSessions();
+    }
+    void this.syncSessions();
+  }
+
+  /**
+   * Coalesces concurrent sync requests. `runSyncSessions()` awaits a real
+   * network dial per device and only inserts into `sessions` after it
+   * resolves, so two overlapping callers (reconcile() fires on every
+   * config:set, and pairing-confirmation calls in independently) could both
+   * see "no session for this device" and each open a full BridgeSession +
+   * transport + re-handshake timer, orphaning one that can never be disposed.
+   * A single in-flight run serializes them; a request that arrives mid-run
+   * queues exactly one follow-up so the roster is re-diffed after the current
+   * pass finishes.
+   */
+  private syncInFlight: Promise<void> | null = null;
+  private syncRequestedDuringRun = false;
+
+  private syncSessions(): Promise<void> {
+    if (this.syncInFlight) {
+      this.syncRequestedDuringRun = true;
+      return this.syncInFlight;
+    }
+    this.syncInFlight = this.runSyncSessions().finally(() => {
+      this.syncInFlight = null;
+      if (this.syncRequestedDuringRun) {
+        this.syncRequestedDuringRun = false;
+        void this.syncSessions();
+      }
+    });
+    return this.syncInFlight;
+  }
+
+  /**
+   * Diffs the live `sessions` map against the signed roster: opens a
+   * BridgeSession for every roster device that does not already have one,
+   * and disposes any session whose device fell out of the roster
+   * (revocation). Never call directly - go through syncSessions() so
+   * overlapping runs are coalesced. Fire-and-forget from reconcile() -
+   * callers do not await session establishment, matching startPairing()'s own
+   * connect-then-close-on-throw guard so a failed dial does not leak the
+   * relay's internal reconnect loop against a now-abandoned attempt.
+   */
+  private async runSyncSessions(): Promise<void> {
+    if (!this.ipcContext) return;
+    if (!this.config.enabled || !isGenuineEncryptionAvailable()) {
+      this.disposeAllSessions();
+      return;
+    }
+    const identity = this.tryLoadIdentity();
+    if (!identity) {
+      this.disposeAllSessions();
+      return;
+    }
+
+    const roster = loadRoster(identity);
+    const rosterDeviceIds = new Set(roster.devices.map((device) => device.deviceId));
+    for (const deviceId of this.sessions.keys()) {
+      if (!rosterDeviceIds.has(deviceId)) this.disposeSession(deviceId);
+    }
+
+    for (const device of roster.devices) {
+      if (this.sessions.has(device.deviceId)) continue;
+      await this.openSessionForDevice(identity, device);
+    }
+  }
+
+  private async openSessionForDevice(identity: BridgeIdentity, device: RosterDeviceEntry): Promise<void> {
+    const slotId = deriveSessionSlotId(identity.staticKeyPair.publicKey, device.staticPublicKey);
+    const transport = createTransport({ relayUrl: this.config.relayUrl, slotId });
+    const session = new BridgeSession({
+      identity,
+      deviceId: device.deviceId,
+      remoteStaticPublicKey: device.staticPublicKey,
+      capabilities: rosterDeviceCapabilitySet(device),
+      transport,
+    });
+    this.wireSessionListeners(session);
+    try {
+      await transport.connect();
+    } catch {
+      // Close the transport we just created before bailing: RelayClient
+      // arms an internal reconnect timer on a failed dial, so abandoning it
+      // here would leak a permanent reconnect loop against a now-meaningless
+      // attempt (same reasoning as startPairing()'s connect-failure guard).
+      transport.close();
+      return;
+    }
+    session.start();
+    this.sessions.set(device.deviceId, session);
+  }
+
+  /**
+   * Routes every decoded capability-request through the router and sends
+   * the response back. Non-request message types (heartbeat,
+   * capability-response, event) are inbound-to-phone-only and ignored here.
+   */
+  private wireSessionListeners(session: BridgeSession): void {
+    const deviceId = session.deviceId;
+    session.on('message', (message) => {
+      if (message.type !== 'capability-request') return;
+      void this.capabilityRouter.dispatch(message, session).then((response) => {
+        try {
+          session.sendMessage(response);
+        } catch {
+          // The session may have dropped mid-dispatch; nothing to recover here.
+        }
+      });
+    });
+    session.on('remoteClosed', () => {
+      // Stop pushing events into a dead channel. The BridgeSession/transport
+      // stay alive so the relay's reconnect + next re-handshake re-establish
+      // the connection; the phone re-arms live subscriptions with fresh
+      // read-* requests once reconnected, rather than this side guessing
+      // what to re-push.
+      this.subscriptionsByDevice.get(deviceId)?.dispose();
+      this.subscriptionsByDevice.delete(deviceId);
+    });
+  }
+
+  private disposeSession(deviceId: string): void {
+    this.sessions.get(deviceId)?.dispose();
+    this.sessions.delete(deviceId);
+    this.subscriptionsByDevice.get(deviceId)?.dispose();
+    this.subscriptionsByDevice.delete(deviceId);
   }
 
   /** Creates a new identity if none exists. Only called from startPairing() - a deliberate user action - never from a read path. */
@@ -142,11 +314,7 @@ export class MobileBridgeService extends EventEmitter {
     const identity = this.tryLoadIdentity();
     if (!identity) return; // No identity means no roster, so nothing to revoke.
     revokeDeviceInRoster(identity, deviceId);
-    const session = this.sessions.get(deviceId);
-    if (session) {
-      session.dispose();
-      this.sessions.delete(deviceId);
-    }
+    this.disposeSession(deviceId);
     // Revocation = drop from the roster AND rotate channel keys (see
     // roster-store.ts's revokeDevice doc comment). Rotating the desktop's
     // own static key also invalidates every OTHER paired device's ability
@@ -188,6 +356,10 @@ export class MobileBridgeService extends EventEmitter {
       this.activePairing = null;
       this.pendingPairingDeviceId = null;
       this.emit('stateChanged');
+      // The freshly-paired device is now in the roster; open its
+      // BridgeSession immediately rather than waiting for the next
+      // config-driven reconcile() (which may not happen again this run).
+      void this.syncSessions();
     });
     pairingService.once('cancelled', (payload: { reason: string }) => {
       this.activePairing = null;
@@ -242,6 +414,8 @@ export class MobileBridgeService extends EventEmitter {
   private disposeAllSessions(): void {
     for (const session of this.sessions.values()) session.dispose();
     this.sessions.clear();
+    for (const subscriptions of this.subscriptionsByDevice.values()) subscriptions.dispose();
+    this.subscriptionsByDevice.clear();
   }
 
   /** Synchronous, per synchronous-shutdown.md: no async work, no timers left un-cleared. */
@@ -250,5 +424,6 @@ export class MobileBridgeService extends EventEmitter {
     this.disposed = true;
     this.cancelPairing('Mobile bridge service shutting down');
     this.disposeAllSessions();
+    this.diffWatcher.closeAll();
   }
 }

--- a/src/main/mobile-bridge/pairing/pairing-service.ts
+++ b/src/main/mobile-bridge/pairing/pairing-service.ts
@@ -14,13 +14,13 @@ import { isPairingTokenValid, mintPairingToken, type PairingToken } from './pair
 
 /**
  * Default grant for a newly paired device: read-only. The write/control
- * verbs (send-user-message, move-task, answer-permission-prompt) require
- * an explicit grant afterward via the paired-devices settings UI --
- * matches "1:1 management UX is fine for v1" from the research doc: pair
- * once, then adjust capabilities if wanted, rather than granting
- * everything by default.
+ * verbs (send-user-message, move-task, answer-permission-prompt,
+ * interactive-terminal, board-tool-write) require an explicit grant
+ * afterward via the paired-devices settings UI - matches "1:1 management
+ * UX is fine for v1" from the research doc: pair once, then adjust
+ * capabilities if wanted, rather than granting everything by default.
  */
-export const DEFAULT_PAIRING_CAPABILITIES: CapabilityVerb[] = ['read-stream', 'read-board', 'read-diff'];
+export const DEFAULT_PAIRING_CAPABILITIES: CapabilityVerb[] = ['read-stream', 'read-board', 'read-diff', 'board-tool-read'];
 
 type PairingPhase = 'idle' | 'waiting-for-phone' | 'sas-pending' | 'done';
 

--- a/src/main/mobile-bridge/session/subscription-registry.ts
+++ b/src/main/mobile-bridge/session/subscription-registry.ts
@@ -1,0 +1,40 @@
+/**
+ * Tracks a single BridgeSession's live event subscriptions (a read-stream
+ * tail on a PTY session, a read-board watch on a project, a read-diff watch
+ * on a task's worktree), keyed by a caller-chosen subscription id (e.g.
+ * `stream:<sessionId>`, `board:<projectId>`, `diff:<taskId>`) so a repeat
+ * subscribe to the same key replaces the prior teardown instead of leaking
+ * it, and every subscription can be torn down together when the device's
+ * transport drops or the bridge shuts the session down.
+ */
+export class SubscriptionRegistry {
+  private readonly teardowns = new Map<string, () => void>();
+
+  /** Registers a subscription's teardown, replacing (and running) any prior teardown under the same key. */
+  set(key: string, teardown: () => void): void {
+    this.remove(key);
+    this.teardowns.set(key, teardown);
+  }
+
+  /** Tears down and forgets one subscription. No-op if the key is not present. */
+  remove(key: string): void {
+    const teardown = this.teardowns.get(key);
+    if (!teardown) return;
+    this.teardowns.delete(key);
+    teardown();
+  }
+
+  has(key: string): boolean {
+    return this.teardowns.has(key);
+  }
+
+  keys(): string[] {
+    return Array.from(this.teardowns.keys());
+  }
+
+  /** Tears down every subscription. Safe to call repeatedly. */
+  dispose(): void {
+    for (const teardown of this.teardowns.values()) teardown();
+    this.teardowns.clear();
+  }
+}

--- a/src/main/pr/pr-linking.ts
+++ b/src/main/pr/pr-linking.ts
@@ -312,6 +312,7 @@ export async function linkPR(context: IpcContext, options: LinkPROptions): Promi
       if (!context.mainWindow.isDestroyed()) {
         context.mainWindow.webContents.send(IPC.TASK_UPDATED_BY_AGENT, linked.id, linked.title, projectId);
       }
+      context.boardEvents.emitBoardChanged({ projectId, change: 'task-updated', ids: [linked.id] });
     },
   });
 }

--- a/src/main/pty/session-manager.ts
+++ b/src/main/pty/session-manager.ts
@@ -107,6 +107,13 @@ export class SessionManager extends EventEmitter {
 
   constructor(options: SessionManagerOptions = {}) {
     super();
+    // The mobile bridge's read-stream feed attaches per-subscription listeners
+    // (data-tap/activity/usage/event) for every session a paired phone streams,
+    // on top of the app's own baseline listeners. That legitimately crosses
+    // Node's default max of 10 per event, so raise the cap to keep a normal
+    // multi-session fan-out from tripping a spurious MaxListenersExceededWarning
+    // (a genuine leak still shows as an unbounded climb well past this).
+    this.setMaxListeners(100);
     this.activityEngineOptions = options.activityEngineOptions;
 
     this.sessionQueue = new SessionQueue({
@@ -131,6 +138,16 @@ export class SessionManager extends EventEmitter {
             this.emit('session-changed', sessionId, toSession(session));
           }
         }
+        // Unfiltered output tap: fires for EVERY session regardless of
+        // renderer focus, unlike 'data' below. This is the mobile bridge's
+        // seam onto live PTY output (see src/main/mobile-bridge/handlers)
+        // - it deliberately does NOT feed backpressure.recordEmitted,
+        // since that accounting exists only for the renderer's focused-tab
+        // drain protocol, which a bridge subscriber does not participate
+        // in. With no listener attached this emit is a no-op call, so it
+        // costs nothing when no device is paired.
+        this.emit('data-tap', sessionId, data);
+
         // Only emit IPC data for focused sessions. Background sessions
         // accumulate in scrollback and reload via getScrollback() on tab switch.
         if (this.focusedSessionIds.size === 0 || this.focusedSessionIds.has(sessionId)) {
@@ -471,6 +488,17 @@ export class SessionManager extends EventEmitter {
       },
       emit: (event, ...args) => this.emit(event, ...args),
     });
+  }
+
+  /**
+   * True when the session has a live PTY that `write()` will actually deliver
+   * to (as opposed to a suspended/queued/exited session still in the registry
+   * with a null pty, whose writes `write()` silently drops). Lets a caller
+   * distinguish "delivered" from "dropped" instead of assuming existence means
+   * writability.
+   */
+  isWritable(sessionId: string): boolean {
+    return !!this.registry.get(sessionId)?.pty;
   }
 
   write(sessionId: string, data: string): void {

--- a/src/renderer/components/settings/tabs/MobileDevicesTab.tsx
+++ b/src/renderer/components/settings/tabs/MobileDevicesTab.tsx
@@ -1,11 +1,24 @@
 import { useEffect, useState } from 'react';
 import { QrCode, Smartphone, Trash2 } from 'lucide-react';
 import QRCode from 'qrcode';
-import type { AppConfig } from '../../../../shared/types';
-import { INPUT_CLASS, SectionHeader, SettingRow, SettingToggleRow, useScopedUpdate } from '../shared';
+import { MOBILE_CAPABILITY_VERBS, type AppConfig, type MobileCapabilityVerb, type MobilePairedDevice } from '../../../../shared/types';
+import { CompactToggleList, INPUT_CLASS, SectionHeader, SettingRow, SettingToggleRow, useScopedUpdate } from '../shared';
 import { settingProps } from '../settings-registry';
 import { ConfirmDialog } from '../../dialogs/ConfirmDialog';
 import { useMobileStore } from '../../../stores/mobile-store';
+
+/** Short label + blurb per verb, for the per-device capability toggle list. Keyed off MOBILE_CAPABILITY_VERBS so a new verb is a compile error here until classified. */
+const CAPABILITY_LABELS: Record<MobileCapabilityVerb, { label: string; description: string }> = {
+  'read-stream': { label: 'Live output', description: 'Terminal output and activity for running sessions' },
+  'read-board': { label: 'Board', description: 'View tasks, columns, and backlog' },
+  'read-diff': { label: 'Diffs', description: 'View code changes' },
+  'send-user-message': { label: 'Send messages', description: 'Send a message to a running agent' },
+  'move-task': { label: 'Move tasks', description: 'Move tasks between columns' },
+  'answer-permission-prompt': { label: 'Answer prompts', description: 'Approve or deny an agent permission request' },
+  'interactive-terminal': { label: 'Interactive terminal', description: 'Full keystroke control of the running terminal' },
+  'board-tool-read': { label: 'Task details', description: 'Search tasks and read stats, transcripts, and handoff notes' },
+  'board-tool-write': { label: 'Task actions', description: 'Create, edit, and delete tasks or backlog items, link PRs' },
+};
 
 export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) {
   const updateGlobal = useScopedUpdate('global');
@@ -23,6 +36,7 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
   const confirmPairing = useMobileStore((state) => state.confirmPairing);
   const cancelPairing = useMobileStore((state) => state.cancelPairing);
   const revokeDevice = useMobileStore((state) => state.revokeDevice);
+  const setDeviceCapabilities = useMobileStore((state) => state.setDeviceCapabilities);
   const setPairingSas = useMobileStore((state) => state.setPairingSas);
   const setPairingEnded = useMobileStore((state) => state.setPairingEnded);
   const clearPairingEnded = useMobileStore((state) => state.clearPairingEnded);
@@ -189,20 +203,20 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
             {devices.map((device) => (
               <li
                 key={device.deviceId}
-                className="flex items-center justify-between gap-3 rounded-md border border-edge bg-surface-hover/30 px-3 py-2"
+                className="rounded-md border border-edge bg-surface-hover/30 px-3 py-2 space-y-2"
               >
-                <div className="min-w-0">
-                  <div className="text-sm text-fg-secondary truncate">{device.displayName}</div>
-                  <div className="text-xs text-fg-faint truncate">{device.capabilities.join(', ') || 'No capabilities granted'}</div>
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0 text-sm text-fg-secondary truncate">{device.displayName}</div>
+                  <button
+                    type="button"
+                    className="shrink-0 rounded p-1.5 text-fg-faint hover:text-danger hover:bg-danger/10 transition-colors"
+                    title="Revoke"
+                    onClick={() => setRevokeTarget({ deviceId: device.deviceId, displayName: device.displayName })}
+                  >
+                    <Trash2 size={14} />
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  className="shrink-0 rounded p-1.5 text-fg-faint hover:text-danger hover:bg-danger/10 transition-colors"
-                  title="Revoke"
-                  onClick={() => setRevokeTarget({ deviceId: device.deviceId, displayName: device.displayName })}
-                >
-                  <Trash2 size={14} />
-                </button>
+                <DeviceCapabilityToggles device={device} onChange={setDeviceCapabilities} />
               </li>
             ))}
           </ul>
@@ -224,5 +238,39 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
         />
       )}
     </div>
+  );
+}
+
+/**
+ * Minimal per-device capability grant UI: one toggle per verb in
+ * MOBILE_CAPABILITY_VERBS, so a new verb auto-surfaces here without a
+ * component change. Fuller device-management UX (grouping, presets) is
+ * Bridge Phase 3 scope - this exists so the Phase 2 write/control verbs
+ * (interactive-terminal, move-task, answer-permission-prompt,
+ * send-user-message, board-tool-write) are actually grantable, since
+ * pairing itself only grants the read-only default set.
+ */
+function DeviceCapabilityToggles({
+  device,
+  onChange,
+}: {
+  device: MobilePairedDevice;
+  onChange: (deviceId: string, capabilities: MobileCapabilityVerb[]) => void;
+}) {
+  const granted = new Set(device.capabilities);
+  return (
+    <CompactToggleList
+      items={MOBILE_CAPABILITY_VERBS.map((verb) => ({
+        label: CAPABILITY_LABELS[verb].label,
+        description: CAPABILITY_LABELS[verb].description,
+        checked: granted.has(verb),
+        onChange: (value) => {
+          const next = value
+            ? [...device.capabilities, verb]
+            : device.capabilities.filter((existing) => existing !== verb);
+          onChange(device.deviceId, next);
+        },
+      }))}
+    />
   );
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -607,6 +607,8 @@ export interface ActivityStatsSnapshot {
   anonymousBackgroundShellCount: number;
   turnActive: boolean;
   permissionPending: boolean;
+  /** The tool_use_id awaiting a permission decision when `permissionPending` is true, else null. */
+  permissionAwaitedToolId: string | null;
   msSinceLastSignal: number | null;
   /** Wall-clock ms of the most recent thinking-signal. Lets the
    *  debug-overlay timeline render the active watchdog deadline as
@@ -2442,6 +2444,9 @@ export const MOBILE_CAPABILITY_VERBS = [
   'send-user-message',
   'move-task',
   'answer-permission-prompt',
+  'interactive-terminal',
+  'board-tool-read',
+  'board-tool-write',
 ] as const;
 export type MobileCapabilityVerb = (typeof MOBILE_CAPABILITY_VERBS)[number];
 

--- a/tests/e2e/cursor-activity-detection.spec.ts
+++ b/tests/e2e/cursor-activity-detection.spec.ts
@@ -134,7 +134,13 @@ test.describe('Cursor Agent - Activity Detection', () => {
 
     await moveTaskIpc(page, taskId, swimlaneIds.planning);
 
-    const scrollback = await waitForScrollback(page, 'MOCK_CURSOR_MODE:', 15000);
+    // mock-cursor.js writes MOCK_CURSOR_MODE: and the stream-json init event
+    // as two separate console.log calls, so they can land in two separate
+    // PTY chunks - waiting on the first marker alone raced the second's
+    // arrival. Wait on the later-arriving marker instead: scrollback is
+    // append-only, so its presence guarantees the earlier line already
+    // landed too.
+    const scrollback = await waitForScrollback(page, '"subtype":"init"', 15000);
     expect(scrollback).toContain('MOCK_CURSOR_MODE:noninteractive');
     // And the stream-json init event is present so ContextBar can light up.
     expect(scrollback).toContain('"subtype":"init"');

--- a/tests/ui/mobile-devices-settings.spec.ts
+++ b/tests/ui/mobile-devices-settings.spec.ts
@@ -259,7 +259,7 @@ test.describe('Mobile Devices settings tab', () => {
     await closeSettings();
   });
 
-  test('paired-device list renders seeded devices with their capabilities', async () => {
+  test('paired-device list renders seeded devices with a toggle per capability, checked for granted verbs', async () => {
     await page.evaluate(() => {
       (window as unknown as { __mockMobileDevices: MobilePairedDevice[] }).__mockMobileDevices = [
         {
@@ -273,13 +273,16 @@ test.describe('Mobile Devices settings tab', () => {
 
     await openMobileTab();
 
-    await expect(page.locator('li', { hasText: 'Seeded iPhone' })).toBeVisible();
-    await expect(page.getByText('read-stream, read-board')).toBeVisible();
+    const deviceRow = page.locator('li', { hasText: 'Seeded iPhone' });
+    await expect(deviceRow).toBeVisible();
+    await expect(deviceRow.getByRole('switch', { name: 'Live output', exact: true })).toHaveAttribute('aria-checked', 'true');
+    await expect(deviceRow.getByRole('switch', { name: 'Board', exact: true })).toHaveAttribute('aria-checked', 'true');
+    await expect(deviceRow.getByRole('switch', { name: 'Interactive terminal', exact: true })).toHaveAttribute('aria-checked', 'false');
 
     await closeSettings();
   });
 
-  test('devices with no capabilities show the "No capabilities granted" fallback', async () => {
+  test('devices with no capabilities show every toggle unchecked', async () => {
     await page.evaluate(() => {
       (window as unknown as { __mockMobileDevices: MobilePairedDevice[] }).__mockMobileDevices = [
         {
@@ -293,9 +296,49 @@ test.describe('Mobile Devices settings tab', () => {
 
     await openMobileTab();
 
-    await expect(page.locator('li', { hasText: 'Bare Device' })).toBeVisible();
-    await expect(page.getByText('No capabilities granted')).toBeVisible();
+    const deviceRow = page.locator('li', { hasText: 'Bare Device' });
+    await expect(deviceRow).toBeVisible();
+    const switches = deviceRow.getByRole('switch');
+    await expect(switches).toHaveCount(9);
+    for (const toggle of await switches.all()) {
+      await expect(toggle).toHaveAttribute('aria-checked', 'false');
+    }
 
+    await closeSettings();
+  });
+
+  test('toggling a capability grants it and persists via setDeviceCapabilities', async () => {
+    await openMobileTab();
+    await pairDevice('Capability Toggle Device');
+
+    const deviceRow = page.locator('li', { hasText: 'Capability Toggle Device' });
+    // Pairing grants only the read-only default set - interactive-terminal
+    // (a write/control verb) starts ungranted.
+    const terminalToggle = deviceRow.getByRole('switch', { name: 'Interactive terminal', exact: true });
+    await expect(terminalToggle).toHaveAttribute('aria-checked', 'false');
+
+    await terminalToggle.click();
+    await expect(terminalToggle).toHaveAttribute('aria-checked', 'true');
+
+    // Persisted through setDeviceCapabilities + a devices re-fetch, not just local UI state.
+    await expect.poll(async () =>
+      page.evaluate(async () => {
+        const devices = await window.electronAPI.mobile.listDevices();
+        return devices.find((device) => device.displayName === 'Capability Toggle Device')?.capabilities.includes('interactive-terminal');
+      }),
+    ).toBe(true);
+
+    // Toggling off removes it again.
+    await terminalToggle.click();
+    await expect(terminalToggle).toHaveAttribute('aria-checked', 'false');
+    await expect.poll(async () =>
+      page.evaluate(async () => {
+        const devices = await window.electronAPI.mobile.listDevices();
+        return devices.find((device) => device.displayName === 'Capability Toggle Device')?.capabilities.includes('interactive-terminal');
+      }),
+    ).toBe(false);
+
+    await revokeDevice('Capability Toggle Device');
     await closeSettings();
   });
 

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -2678,8 +2678,14 @@
           state.devices = state.devices.filter(function (device) { return device.deviceId !== deviceId; });
         },
         setDeviceCapabilities: async function (deviceId, capabilities) {
-          state.devices.forEach(function (device) {
-            if (device.deviceId === deviceId) device.capabilities = capabilities;
+          // Reassign to a NEW array (like revokeDevice's .filter above), not an
+          // in-place mutation of the existing array/device objects: the
+          // renderer's useMobileStore((state) => state.devices) selector is
+          // reference-equality gated, so mutating devices in place while
+          // keeping the same array reference would silently skip the
+          // re-render even though loadDevices() re-fetched "fresh" data.
+          state.devices = state.devices.map(function (device) {
+            return device.deviceId === deviceId ? Object.assign({}, device, { capabilities: capabilities }) : device;
           });
         },
         onPairingSas: function (callback) {

--- a/tests/unit/diff-watcher.test.ts
+++ b/tests/unit/diff-watcher.test.ts
@@ -18,11 +18,15 @@ const watchCallbacksByPath = new Map<string, (eventType: string, filename: strin
 /** Controls whether fs.existsSync reports the logs/ directory as present. */
 let mockExistsSyncResult = true;
 
+/** Count of fs.watch() handles created, per watched path, to assert a repeat subscribe reuses one handle. */
+const watchHandleCountByPath = new Map<string, number>();
+
 vi.mock('node:fs', () => ({
   default: {
     watch: vi.fn((watchPath: string, _options: unknown, callback: (eventType: string, filename: string | null) => void) => {
       watchCallback = callback;
       watchCallbacksByPath.set(watchPath, callback);
+      watchHandleCountByPath.set(watchPath, (watchHandleCountByPath.get(watchPath) ?? 0) + 1);
       const closeFn = vi.fn();
       mockCloseFns.set(watchPath, closeFn);
       return { close: closeFn };
@@ -68,6 +72,7 @@ describe('DiffWatcher', () => {
     vi.clearAllMocks();
     mockCloseFns.clear();
     watchCallbacksByPath.clear();
+    watchHandleCountByPath.clear();
     watchCallback = null;
     mockExistsSyncResult = true;
     // Default: git is not a real repo, so rev-parse rejects and watchGitMetadata no-ops.
@@ -88,20 +93,43 @@ describe('DiffWatcher', () => {
     expect(watchCallback).not.toBeNull();
   });
 
-  it('does not create duplicate watchers for the same path', () => {
+  it('multiplexes multiple callbacks onto a single fs.watch for the same path', () => {
     const callback = vi.fn();
+    const secondCallback = vi.fn();
 
     watcher.subscribe('/project', callback);
-
-    const secondCallback = vi.fn();
     watcher.subscribe('/project', secondCallback);
 
-    // Trigger a change - only the first callback should be wired
+    // The second subscribe reuses the existing watch (no new fs.watch handle)...
+    expect(watchHandleCountByPath.get('/project')).toBe(1);
+
+    // ...but BOTH callbacks fire on a change (the pre-fix bug dropped the second).
     watchCallback!('change', 'src/file.ts');
     vi.advanceTimersByTime(500);
 
     expect(callback).toHaveBeenCalledTimes(1);
-    expect(secondCallback).not.toHaveBeenCalled();
+    expect(secondCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribe returns a teardown that removes only its own callback; the watch closes when the last leaves', () => {
+    const callbackA = vi.fn();
+    const callbackB = vi.fn();
+
+    const unsubscribeA = watcher.subscribe('/project', callbackA);
+    watcher.subscribe('/project', callbackB);
+
+    // Tearing down A leaves B's watch alive.
+    unsubscribeA();
+    expect(mockCloseFns.get('/project')).not.toHaveBeenCalled();
+
+    watchCallback!('change', 'src/file.ts');
+    vi.advanceTimersByTime(500);
+    expect(callbackA).not.toHaveBeenCalled();
+    expect(callbackB).toHaveBeenCalledTimes(1);
+
+    // Tearing down the last subscriber closes the underlying fs.watch.
+    watcher.unsubscribe('/project');
+    expect(mockCloseFns.get('/project')).toHaveBeenCalledTimes(1);
   });
 
   it('fires callback after debounce period', () => {

--- a/tests/unit/mcp-project-context.test.ts
+++ b/tests/unit/mcp-project-context.test.ts
@@ -81,6 +81,7 @@ function makeIpcContext(projectResult: Project | null): IpcContext {
       getById: vi.fn(() => projectResult),
       list: vi.fn(() => (projectResult ? [projectResult] : [])),
     },
+    boardEvents: { emitBoardChanged: vi.fn() },
   } as unknown as IpcContext;
 }
 
@@ -211,12 +212,14 @@ describe('buildCommandContextForProject - onSwimlaneUpdated write-back', () => {
     const project = makeProject({ id: DEFAULT_ID, path: PROJECT_PATH });
     const send = vi.fn();
     const writeBackForProject = vi.fn();
+    const emitBoardChanged = vi.fn();
     const ipcContext = {
       projectRepo: { getById: vi.fn(() => project), list: vi.fn(() => [project]) },
       mainWindow: { isDestroyed: () => false, webContents: { send } },
       boardConfigManager: { writeBackForProject },
+      boardEvents: { emitBoardChanged },
     } as unknown as IpcContext;
-    return { ipcContext, send, writeBackForProject };
+    return { ipcContext, send, writeBackForProject, emitBoardChanged };
   }
 
   // onSwimlaneUpdated only reads id + name off the swimlane.
@@ -253,5 +256,80 @@ describe('buildCommandContextForProject - onSwimlaneUpdated write-back', () => {
     context!.onBacklogChanged();
 
     expect(writeBackForProject).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Consolidated board-changed bus fan-out
+//
+// The mobile bridge's read-board subscription consumes context.boardEvents
+// instead of each ad-hoc *_BY_AGENT channel. Every board-mutation callback
+// must feed BOTH the existing renderer IPC push (unchanged, zero risk to the
+// renderer) AND the boardEvents bus (additive).
+// ---------------------------------------------------------------------------
+
+describe('buildCommandContextForProject - consolidated board-changed bus fan-out', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeFanOutContext() {
+    const project = makeProject({ id: DEFAULT_ID });
+    const send = vi.fn();
+    const emitBoardChanged = vi.fn();
+    const ipcContext = {
+      projectRepo: { getById: vi.fn(() => project), list: vi.fn(() => [project]) },
+      mainWindow: { isDestroyed: () => false, webContents: { send } },
+      boardConfigManager: { writeBackForProject: vi.fn() },
+      boardEvents: { emitBoardChanged },
+      sessionManager: { removeByTaskId: vi.fn() },
+    } as unknown as IpcContext;
+    return { ipcContext, send, emitBoardChanged };
+  }
+
+  it('onTaskCreated fires a task-created board event', () => {
+    const { ipcContext, emitBoardChanged } = makeFanOutContext();
+    const context = buildCommandContextForProject(ipcContext, DEFAULT_ID)!;
+
+    context.onTaskCreated({ id: 'task-0', title: 'Task Zero' } as never, 'To Do', 'lane-0');
+
+    expect(emitBoardChanged).toHaveBeenCalledWith({ projectId: DEFAULT_ID, change: 'task-created', ids: ['task-0'] });
+  });
+
+  it('onTaskUpdated fires both the IPC push and a task-updated board event', () => {
+    const { ipcContext, send, emitBoardChanged } = makeFanOutContext();
+    const context = buildCommandContextForProject(ipcContext, DEFAULT_ID)!;
+
+    context.onTaskUpdated({ id: 'task-1', title: 'Task One' } as never);
+
+    expect(send).toHaveBeenCalledWith('TASK_UPDATED_BY_AGENT', 'task-1', 'Task One', DEFAULT_ID);
+    expect(emitBoardChanged).toHaveBeenCalledWith({ projectId: DEFAULT_ID, change: 'task-updated', ids: ['task-1'] });
+  });
+
+  it('onTaskDeleted fires a task-deleted board event', () => {
+    const { ipcContext, emitBoardChanged } = makeFanOutContext();
+    const context = buildCommandContextForProject(ipcContext, DEFAULT_ID)!;
+
+    context.onTaskDeleted({ id: 'task-2', title: 'Task Two', session_id: null, worktree_path: null } as never);
+
+    expect(emitBoardChanged).toHaveBeenCalledWith({ projectId: DEFAULT_ID, change: 'task-deleted', ids: ['task-2'] });
+  });
+
+  it('onSwimlaneUpdated fires a swimlane-updated board event', () => {
+    const { ipcContext, emitBoardChanged } = makeFanOutContext();
+    const context = buildCommandContextForProject(ipcContext, DEFAULT_ID)!;
+
+    context.onSwimlaneUpdated({ id: 'lane-1', name: 'Review' } as never);
+
+    expect(emitBoardChanged).toHaveBeenCalledWith({ projectId: DEFAULT_ID, change: 'swimlane-updated', ids: ['lane-1'] });
+  });
+
+  it('onBacklogChanged fires a backlog-changed board event with no ids', () => {
+    const { ipcContext, emitBoardChanged } = makeFanOutContext();
+    const context = buildCommandContextForProject(ipcContext, DEFAULT_ID)!;
+
+    context.onBacklogChanged();
+
+    expect(emitBoardChanged).toHaveBeenCalledWith({ projectId: DEFAULT_ID, change: 'backlog-changed', ids: [] });
   });
 });

--- a/tests/unit/mobile-bridge/answer-permission-prompt.test.ts
+++ b/tests/unit/mobile-bridge/answer-permission-prompt.test.ts
@@ -1,0 +1,115 @@
+/**
+ * answer-permission-prompt is the most sensitive verb - it can authorize an
+ * agent to run a command. These tests lock the binding check that makes it
+ * safer than a plain interactive-terminal write: the response must match
+ * the LIVE outstanding prompt id, rejecting a stale or already-resolved one.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { CapabilityRequestMessage } from '@kangentic/protocol';
+import { handleAnswerPermissionPrompt } from '../../../src/main/mobile-bridge/handlers/answer-permission-prompt';
+import type { IpcContext } from '../../../src/main/ipc/ipc-context';
+
+function fakeRequest(payload: Record<string, unknown>): CapabilityRequestMessage {
+  return { type: 'capability-request', requestId: 'req-1', verb: 'answer-permission-prompt', payload };
+}
+
+function fakeContext(overrides: {
+  session?: unknown;
+  snapshot?: { permissionPending: boolean; permissionAwaitedToolId: string | null } | null;
+  write?: ReturnType<typeof vi.fn>;
+  writable?: boolean;
+} = {}): IpcContext {
+  const write = overrides.write ?? vi.fn();
+  return {
+    sessionManager: {
+      getSession: vi.fn(() => (overrides.session === undefined ? { id: 'sess-1' } : overrides.session)),
+      getActivityStatsSnapshot: vi.fn(() => (overrides.snapshot === undefined ? null : overrides.snapshot)),
+      isWritable: vi.fn(() => overrides.writable ?? true),
+      write,
+    },
+  } as unknown as IpcContext;
+}
+
+describe('handleAnswerPermissionPrompt', () => {
+  it('rejects when the session does not exist', () => {
+    const context = fakeContext({ session: null });
+    const response = handleAnswerPermissionPrompt(
+      fakeRequest({ sessionId: 'sess-1', promptId: 'sess-1:tool-1', keystrokes: '1\r' }),
+      context,
+    );
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/no such session/i);
+  });
+
+  it('rejects when no permission prompt is currently outstanding', () => {
+    const context = fakeContext({ snapshot: { permissionPending: false, permissionAwaitedToolId: null } });
+    const response = handleAnswerPermissionPrompt(
+      fakeRequest({ sessionId: 'sess-1', promptId: 'sess-1:tool-1', keystrokes: '1\r' }),
+      context,
+    );
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/no permission prompt/i);
+  });
+
+  it('rejects a stale/mismatched promptId without writing to the PTY', () => {
+    const write = vi.fn();
+    const context = fakeContext({
+      snapshot: { permissionPending: true, permissionAwaitedToolId: 'tool-CURRENT' },
+      write,
+    });
+    const response = handleAnswerPermissionPrompt(
+      fakeRequest({ sessionId: 'sess-1', promptId: 'sess-1:tool-STALE', keystrokes: '1\r' }),
+      context,
+    );
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/does not match/i);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('writes the keystrokes only when promptId matches the live awaited prompt exactly', () => {
+    const write = vi.fn();
+    const context = fakeContext({
+      snapshot: { permissionPending: true, permissionAwaitedToolId: 'tool-9' },
+      write,
+    });
+    const response = handleAnswerPermissionPrompt(
+      fakeRequest({ sessionId: 'sess-1', promptId: 'sess-1:tool-9', keystrokes: '1\r' }),
+      context,
+    );
+    expect(response.ok).toBe(true);
+    expect(response.payload).toEqual({ answered: true });
+    expect(write).toHaveBeenCalledWith('sess-1', '1\r');
+  });
+
+  it('rejects (without writing) when the prompt matches but the PTY is no longer writable', () => {
+    const write = vi.fn();
+    const context = fakeContext({
+      snapshot: { permissionPending: true, permissionAwaitedToolId: 'tool-9' },
+      writable: false,
+      write,
+    });
+    const response = handleAnswerPermissionPrompt(
+      fakeRequest({ sessionId: 'sess-1', promptId: 'sess-1:tool-9', keystrokes: '1\r' }),
+      context,
+    );
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/not accepting input/i);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the request carries a different sessionId than the awaited prompt was bound to', () => {
+    // A prompt id is built as `${sessionId}:${toolId}` - reusing another
+    // session's tool id under a different sessionId must not match.
+    const write = vi.fn();
+    const context = fakeContext({
+      snapshot: { permissionPending: true, permissionAwaitedToolId: 'tool-9' },
+      write,
+    });
+    const response = handleAnswerPermissionPrompt(
+      fakeRequest({ sessionId: 'sess-1', promptId: 'sess-OTHER:tool-9', keystrokes: '1\r' }),
+      context,
+    );
+    expect(response.ok).toBe(false);
+    expect(write).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/mobile-bridge/board-event-bus.test.ts
+++ b/tests/unit/mobile-bridge/board-event-bus.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for src/main/mobile-bridge/board-event-bus.ts.
+ *
+ * The consolidated board-changed event stream fed by
+ * mcp-project-context.ts's six callbacks and pr-linking.ts, and consumed by
+ * the mobile bridge's read-board handler. mcp-project-context.test.ts and
+ * read-board.test.ts each mock context.boardEvents at their own seam
+ * (emitBoardChanged as a bare vi.fn() on the emitter side, onBoardChanged
+ * returning a captured listener on the consumer side), so the REAL
+ * BoardEventBus class - the thing that actually connects those two mocks in
+ * production - is never exercised end to end by either suite. This file
+ * closes that gap directly, mirroring subscription-registry.test.ts's
+ * pattern for the sibling thin wrapper class.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { BoardEventBus, type BoardChangedEvent } from '../../../src/main/mobile-bridge/board-event-bus';
+
+describe('BoardEventBus', () => {
+  it('emitBoardChanged() delivers the event to a subscribed listener', () => {
+    const bus = new BoardEventBus();
+    const listener = vi.fn();
+    bus.onBoardChanged(listener);
+
+    const event: BoardChangedEvent = { projectId: 'proj-1', change: 'task-created', ids: ['task-1'] };
+    bus.emitBoardChanged(event);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(event);
+  });
+
+  it('fans a single emit out to every subscribed listener', () => {
+    const bus = new BoardEventBus();
+    const first = vi.fn();
+    const second = vi.fn();
+    bus.onBoardChanged(first);
+    bus.onBoardChanged(second);
+
+    bus.emitBoardChanged({ projectId: 'proj-1', change: 'backlog-changed', ids: [] });
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('the teardown returned by onBoardChanged() removes only that listener', () => {
+    const bus = new BoardEventBus();
+    const staying = vi.fn();
+    const leaving = vi.fn();
+    bus.onBoardChanged(staying);
+    const unsubscribeLeaving = bus.onBoardChanged(leaving);
+
+    unsubscribeLeaving();
+    bus.emitBoardChanged({ projectId: 'proj-1', change: 'task-deleted', ids: ['task-2'] });
+
+    expect(staying).toHaveBeenCalledTimes(1);
+    expect(leaving).not.toHaveBeenCalled();
+  });
+
+  it('emitting with no subscribers does not throw', () => {
+    const bus = new BoardEventBus();
+    expect(() => bus.emitBoardChanged({ projectId: 'proj-1', change: 'swimlane-updated', ids: ['lane-1'] })).not.toThrow();
+  });
+
+  it('an unsubscribed listener stays silent on later events, even after a fresh subscription is added', () => {
+    const bus = new BoardEventBus();
+    const listener = vi.fn();
+    const unsubscribe = bus.onBoardChanged(listener);
+    unsubscribe();
+
+    bus.onBoardChanged(vi.fn());
+    bus.emitBoardChanged({ projectId: 'proj-1', change: 'task-updated', ids: ['task-3'] });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/mobile-bridge/board-tool-allowlist.test.ts
+++ b/tests/unit/mobile-bridge/board-tool-allowlist.test.ts
@@ -1,0 +1,63 @@
+/**
+ * The mobile bridge's board-tool-read/board-tool-write allowlist
+ * hand-classifies every `commandHandlers` key (see board-tool-allowlist.ts's
+ * doc comment for why it cannot be derived automatically: annotations live
+ * on the public kangentic_* MCP tool registrations, not on the internal
+ * command-registry keys this module routes into directly - and this path
+ * is not MCP at all). This is the mechanical guard against that
+ * classification drifting from the registry - a new commandHandlers entry
+ * added without a classification (or exclusion) here would otherwise
+ * silently fall out of the mobile surface (deny-by-default fails safe, but
+ * silently) instead of forcing a deliberate decision.
+ */
+import { describe, it, expect } from 'vitest';
+import { commandHandlers } from '../../../src/main/agent/commands';
+import {
+  MOBILE_BOARD_TOOL_ACCESS,
+  MOBILE_EXCLUDED_BOARD_TOOLS,
+  isKnownMobileBoardTool,
+  isBoardToolAllowedForVerb,
+} from '../../../src/main/mobile-bridge/handlers/board-tool-allowlist';
+
+describe('mobile board tool allowlist parity', () => {
+  it('classifies every commandHandlers key except the deliberately excluded ones', () => {
+    const registryKeys = Object.keys(commandHandlers).filter((key) => !MOBILE_EXCLUDED_BOARD_TOOLS.has(key));
+    const classifiedKeys = Object.keys(MOBILE_BOARD_TOOL_ACCESS);
+    expect(new Set(classifiedKeys)).toEqual(new Set(registryKeys));
+  });
+
+  it('excludes query_db from both read and write access', () => {
+    expect(isBoardToolAllowedForVerb('query_db', 'board-tool-read')).toBe(false);
+    expect(isBoardToolAllowedForVerb('query_db', 'board-tool-write')).toBe(false);
+  });
+
+  it('excludes move_task, list_tasks, list_columns, and list_backlog even though they are real commandHandlers entries - duplicates of the dedicated move-task/read-board verbs', () => {
+    for (const tool of ['move_task', 'list_tasks', 'list_columns', 'list_backlog']) {
+      expect(isKnownMobileBoardTool(tool)).toBe(false);
+      expect(isBoardToolAllowedForVerb(tool, 'board-tool-read')).toBe(false);
+      expect(isBoardToolAllowedForVerb(tool, 'board-tool-write')).toBe(false);
+    }
+  });
+
+  it('a read-only tool is reachable only via board-tool-read', () => {
+    expect(isBoardToolAllowedForVerb('search_tasks', 'board-tool-read')).toBe(true);
+    expect(isBoardToolAllowedForVerb('search_tasks', 'board-tool-write')).toBe(false);
+  });
+
+  it('a mutating tool is reachable only via board-tool-write', () => {
+    expect(isBoardToolAllowedForVerb('update_task', 'board-tool-write')).toBe(true);
+    expect(isBoardToolAllowedForVerb('update_task', 'board-tool-read')).toBe(false);
+  });
+
+  it('an unrecognized tool name is denied for both verbs (fail closed)', () => {
+    expect(isKnownMobileBoardTool('delete_everything')).toBe(false);
+    expect(isBoardToolAllowedForVerb('delete_everything', 'board-tool-read')).toBe(false);
+    expect(isBoardToolAllowedForVerb('delete_everything', 'board-tool-write')).toBe(false);
+  });
+
+  it('excludes tools reachable only through registries other than commandHandlers (browser, devtools, diagnostics, cross-project)', () => {
+    for (const tool of ['browser_eval', 'devtools_run_command', 'tail_logs', 'list_projects', 'search', 'move_task_to_project']) {
+      expect(isKnownMobileBoardTool(tool)).toBe(false);
+    }
+  });
+});

--- a/tests/unit/mobile-bridge/board-tool.test.ts
+++ b/tests/unit/mobile-bridge/board-tool.test.ts
@@ -1,0 +1,139 @@
+/**
+ * board-tool-read/board-tool-write route straight into the real
+ * commandHandlers registry (see board-tool-allowlist.ts's doc comment for
+ * why - this is NOT the MCP protocol, no agent/LLM/JSON-RPC round-trip is
+ * involved), gated by the allowlist and read/mutate classification tested
+ * separately in board-tool-allowlist.test.ts. These tests cover the
+ * handler's own responsibilities: refusing an excluded/unknown tool before
+ * ever calling a handler, refusing a verb/access mismatch (board-tool-read
+ * reaching a mutating tool or vice versa), resolving the project, and
+ * mapping a CommandResponse into a capability response.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const searchTasksHandler = vi.fn();
+const updateTaskHandler = vi.fn();
+const queryDbHandler = vi.fn();
+const moveTaskHandler = vi.fn();
+
+vi.mock('../../../src/main/agent/commands', () => ({
+  commandHandlers: {
+    search_tasks: (...args: unknown[]) => searchTasksHandler(...args),
+    update_task: (...args: unknown[]) => updateTaskHandler(...args),
+    query_db: (...args: unknown[]) => queryDbHandler(...args),
+    // Present in commandHandlers but deliberately excluded from the mobile
+    // surface - covered by the dedicated move-task verb instead.
+    move_task: (...args: unknown[]) => moveTaskHandler(...args),
+  },
+}));
+
+const buildCommandContextForProjectMock = vi.fn();
+vi.mock('../../../src/main/agent/mcp-project-context', () => ({
+  buildCommandContextForProject: (...args: unknown[]) => buildCommandContextForProjectMock(...args),
+}));
+
+import type { CapabilityRequestMessage } from '@kangentic/protocol';
+import { handleBoardTool } from '../../../src/main/mobile-bridge/handlers/board-tool';
+import type { IpcContext } from '../../../src/main/ipc/ipc-context';
+
+function fakeRequest(verb: 'board-tool-read' | 'board-tool-write', payload: Record<string, unknown>): CapabilityRequestMessage {
+  return { type: 'capability-request', requestId: 'req-1', verb, payload };
+}
+
+function fakeContext(currentProjectId: string | null = 'proj-1'): IpcContext {
+  return { currentProjectId } as unknown as IpcContext;
+}
+
+describe('handleBoardTool', () => {
+  beforeEach(() => {
+    searchTasksHandler.mockReset();
+    updateTaskHandler.mockReset();
+    queryDbHandler.mockReset();
+    moveTaskHandler.mockReset();
+    buildCommandContextForProjectMock.mockReset();
+    buildCommandContextForProjectMock.mockReturnValue({ getProjectPath: () => '/projects/proj-1' });
+  });
+
+  it('rejects query_db outright, before ever building a project context', async () => {
+    const response = await handleBoardTool(fakeRequest('board-tool-read', { tool: 'query_db', params: {} }), fakeContext());
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/not allowed/i);
+    expect(queryDbHandler).not.toHaveBeenCalled();
+    expect(buildCommandContextForProjectMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects move_task even though it is a real commandHandlers entry - covered by the dedicated move-task verb instead', async () => {
+    const readResponse = await handleBoardTool(fakeRequest('board-tool-read', { tool: 'move_task', params: {} }), fakeContext());
+    const writeResponse = await handleBoardTool(fakeRequest('board-tool-write', { tool: 'move_task', params: {} }), fakeContext());
+    expect(readResponse.ok).toBe(false);
+    expect(writeResponse.ok).toBe(false);
+    expect(moveTaskHandler).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unrecognized tool name (not in commandHandlers)', async () => {
+    const response = await handleBoardTool(fakeRequest('board-tool-read', { tool: 'browser_eval', params: {} }), fakeContext());
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/not allowed/i);
+  });
+
+  it('rejects a mutating tool reached via board-tool-read', async () => {
+    const response = await handleBoardTool(fakeRequest('board-tool-read', { tool: 'update_task', params: {} }), fakeContext());
+    expect(response.ok).toBe(false);
+    expect(updateTaskHandler).not.toHaveBeenCalled();
+  });
+
+  it('rejects a read-only tool reached via board-tool-write', async () => {
+    const response = await handleBoardTool(fakeRequest('board-tool-write', { tool: 'search_tasks', params: {} }), fakeContext());
+    expect(response.ok).toBe(false);
+    expect(searchTasksHandler).not.toHaveBeenCalled();
+  });
+
+  it('resolves the ambient current project when params.project is omitted', async () => {
+    searchTasksHandler.mockReturnValue({ success: true, data: { tasks: [] } });
+    const response = await handleBoardTool(fakeRequest('board-tool-read', { tool: 'search_tasks', params: {} }), fakeContext('proj-1'));
+
+    expect(response.ok).toBe(true);
+    expect(buildCommandContextForProjectMock).toHaveBeenCalledWith(expect.anything(), 'proj-1');
+  });
+
+  it('prefers an explicit params.project over the ambient current project', async () => {
+    searchTasksHandler.mockReturnValue({ success: true, data: { tasks: [] } });
+    await handleBoardTool(fakeRequest('board-tool-read', { tool: 'search_tasks', params: { project: 'proj-other' } }), fakeContext('proj-1'));
+
+    expect(buildCommandContextForProjectMock).toHaveBeenCalledWith(expect.anything(), 'proj-other');
+  });
+
+  it('rejects when no project can be resolved at all', async () => {
+    const response = await handleBoardTool(fakeRequest('board-tool-read', { tool: 'search_tasks', params: {} }), fakeContext(null));
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/no project/i);
+  });
+
+  it('rejects when the resolved project is unknown', async () => {
+    buildCommandContextForProjectMock.mockReturnValue(null);
+    const response = await handleBoardTool(fakeRequest('board-tool-read', { tool: 'search_tasks', params: {} }), fakeContext('ghost'));
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/no such project/i);
+  });
+
+  it('maps a successful CommandResponse.data into the board-tool result payload', async () => {
+    searchTasksHandler.mockReturnValue({ success: true, data: { tasks: [{ id: 't-1' }] } });
+    const response = await handleBoardTool(fakeRequest('board-tool-read', { tool: 'search_tasks', params: {} }), fakeContext('proj-1'));
+
+    expect(response.ok).toBe(true);
+    expect(response.payload).toEqual({ result: { tasks: [{ id: 't-1' }] } });
+  });
+
+  it('maps a failed CommandResponse into a capability-response error', async () => {
+    updateTaskHandler.mockReturnValue({ success: false, error: 'task not found' });
+    const response = await handleBoardTool(fakeRequest('board-tool-write', { tool: 'update_task', params: {} }), fakeContext('proj-1'));
+
+    expect(response.ok).toBe(false);
+    expect(response.error).toBe('task not found');
+  });
+
+  it('rejects a non-object params field', async () => {
+    const response = await handleBoardTool(fakeRequest('board-tool-read', { tool: 'search_tasks', params: 'nope' }), fakeContext('proj-1'));
+    expect(response.ok).toBe(false);
+  });
+});

--- a/tests/unit/mobile-bridge/capability-router.test.ts
+++ b/tests/unit/mobile-bridge/capability-router.test.ts
@@ -95,4 +95,20 @@ describe('CapabilityRouter', () => {
     const response = await router.dispatch(fakeRequest('send-user-message', { requestId: 'abc-123' }), session);
     expect(response.requestId).toBe('abc-123');
   });
+
+  // Phase 2 added interactive-terminal, board-tool-read, board-tool-write to
+  // CAPABILITY_VERBS. The router's dispatch logic is verb-agnostic (no
+  // per-verb branching), so this is not re-proving the tests above per
+  // verb - it confirms the new verbs are valid router inputs at all.
+  it.each(['interactive-terminal', 'board-tool-read', 'board-tool-write'] as const)(
+    'dispatches the new verb "%s" like any other once registered and authorized',
+    async (verb) => {
+      const router = new CapabilityRouter();
+      const session = fakeSession([verb]);
+      router.register(verb, (request) => ({ type: 'capability-response', requestId: request.requestId, ok: true }));
+
+      const response = await router.dispatch(fakeRequest(verb), session);
+      expect(response.ok).toBe(true);
+    },
+  );
 });

--- a/tests/unit/mobile-bridge/handlers-registration.test.ts
+++ b/tests/unit/mobile-bridge/handlers-registration.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Locks that attachContext() (via registerCapabilityHandlers) registers a
+ * handler for every one of the 9 Phase 2 capability verbs, exactly once
+ * each. Each real handler module is mocked out here so this test exercises
+ * only the registration wiring, not the handlers' own logic (each has its
+ * own dedicated test file).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../src/main/mobile-bridge/handlers/read-stream', () => ({ handleReadStream: vi.fn() }));
+vi.mock('../../../src/main/mobile-bridge/handlers/read-board', () => ({ handleReadBoard: vi.fn() }));
+vi.mock('../../../src/main/mobile-bridge/handlers/read-diff', () => ({ handleReadDiff: vi.fn() }));
+vi.mock('../../../src/main/mobile-bridge/handlers/send-user-message', () => ({ handleSendUserMessage: vi.fn() }));
+vi.mock('../../../src/main/mobile-bridge/handlers/move-task', () => ({ handleMoveTask: vi.fn() }));
+vi.mock('../../../src/main/mobile-bridge/handlers/interactive-terminal', () => ({ handleInteractiveTerminal: vi.fn() }));
+vi.mock('../../../src/main/mobile-bridge/handlers/answer-permission-prompt', () => ({ handleAnswerPermissionPrompt: vi.fn() }));
+vi.mock('../../../src/main/mobile-bridge/handlers/board-tool', () => ({ handleBoardTool: vi.fn() }));
+
+import { CAPABILITY_VERBS } from '@kangentic/protocol';
+import { registerCapabilityHandlers } from '../../../src/main/mobile-bridge/handlers';
+import { CapabilityRouter } from '../../../src/main/mobile-bridge/capability-router';
+import type { IpcContext } from '../../../src/main/ipc/ipc-context';
+import type { DiffWatcher } from '../../../src/main/git/diff-watcher';
+import type { SubscriptionRegistry } from '../../../src/main/mobile-bridge/session/subscription-registry';
+
+describe('registerCapabilityHandlers', () => {
+  it('registers a handler for every verb in CAPABILITY_VERBS, exactly once', () => {
+    const router = new CapabilityRouter();
+    const registerSpy = vi.spyOn(router, 'register');
+
+    registerCapabilityHandlers(router, {
+      context: {} as IpcContext,
+      diffWatcher: {} as DiffWatcher,
+      getSubscriptions: () => ({}) as SubscriptionRegistry,
+    });
+
+    const registeredVerbs = registerSpy.mock.calls.map(([verb]) => verb);
+    expect(new Set(registeredVerbs)).toEqual(new Set(CAPABILITY_VERBS));
+    expect(registeredVerbs.length).toBe(CAPABILITY_VERBS.length);
+  });
+});

--- a/tests/unit/mobile-bridge/interactive-terminal.test.ts
+++ b/tests/unit/mobile-bridge/interactive-terminal.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { CapabilityRequestMessage } from '@kangentic/protocol';
+import { handleInteractiveTerminal } from '../../../src/main/mobile-bridge/handlers/interactive-terminal';
+import type { IpcContext } from '../../../src/main/ipc/ipc-context';
+
+function fakeRequest(payload: Record<string, unknown>): CapabilityRequestMessage {
+  return { type: 'capability-request', requestId: 'req-1', verb: 'interactive-terminal', payload };
+}
+
+describe('handleInteractiveTerminal', () => {
+  it('rejects when the session does not exist', () => {
+    const context = { sessionManager: { getSession: vi.fn(() => undefined), write: vi.fn() } } as unknown as IpcContext;
+    const response = handleInteractiveTerminal(fakeRequest({ sessionId: 'sess-1', data: 'ls\r' }), context);
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/no such session/i);
+  });
+
+  it('writes raw keystrokes straight through to the live session (full terminal parity)', () => {
+    const write = vi.fn();
+    const context = {
+      sessionManager: { getSession: vi.fn(() => ({ id: 'sess-1' })), isWritable: vi.fn(() => true), write },
+    } as unknown as IpcContext;
+
+    const response = handleInteractiveTerminal(fakeRequest({ sessionId: 'sess-1', data: 'npm login\r' }), context);
+
+    expect(response.ok).toBe(true);
+    expect(response.payload).toEqual({ written: true });
+    expect(write).toHaveBeenCalledWith('sess-1', 'npm login\r');
+  });
+
+  it('rejects (never reports written:true) when the session exists but has no live PTY', () => {
+    // A suspended/queued/exited session is still in the registry, so getSession
+    // is truthy, but write() would silently drop the bytes - the handler must
+    // surface that instead of a false written:true.
+    const write = vi.fn();
+    const context = {
+      sessionManager: { getSession: vi.fn(() => ({ id: 'sess-1' })), isWritable: vi.fn(() => false), write },
+    } as unknown as IpcContext;
+
+    const response = handleInteractiveTerminal(fakeRequest({ sessionId: 'sess-1', data: 'ls\r' }), context);
+
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/not accepting input/i);
+    expect(write).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/mobile-bridge/mobile-bridge-service.test.ts
+++ b/tests/unit/mobile-bridge/mobile-bridge-service.test.ts
@@ -32,6 +32,25 @@ vi.mock('electron', () => ({
     },
     getSelectedStorageBackend: () => 'keychain',
   },
+  // Phase 2's capability handlers reach real src/main/ipc/handlers and
+  // src/main/agent modules at import time (attachContext() wires them into
+  // the router), so their module-scope `import { ipcMain } from 'electron'`
+  // statements need this to exist even though nothing in this test suite
+  // ever calls ipcMain.handle/.on.
+  ipcMain: {
+    handle: vi.fn(),
+    on: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+}));
+
+// Reached transitively via handlers/mcp-tool.ts -> mcp-project-context.ts ->
+// task-move.ts, which imports the real analytics module (pulls in the
+// aptabase-electron package and electron's `app`). Mocked the same way
+// session-manager.test.ts does, since nothing here exercises analytics.
+vi.mock('../../../src/main/analytics/analytics', () => ({
+  trackEvent: vi.fn(),
+  sanitizeErrorMessage: (message: string) => message,
 }));
 
 const existsSyncSpy = vi.hoisted(() => vi.fn<(filePath: string) => boolean>());

--- a/tests/unit/mobile-bridge/mobile-bridge-session-lifecycle.test.ts
+++ b/tests/unit/mobile-bridge/mobile-bridge-session-lifecycle.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Session-lifecycle wiring added to MobileBridgeService in Phase 2:
+ * wireSessionListeners(), openSessionForDevice(), disposeSession(), and the
+ * roster-diff eviction loop in runSyncSessions(). None of these are new
+ * *files* (they live in mobile-bridge-service.ts), so they are not caught by
+ * "does this module have its own test file" - but they are new *code paths*
+ * that neither existing suite drives end to end:
+ *
+ *  - mobile-bridge-service.test.ts covers the identity-creation invariant
+ *    (getStatus/listDevices/etc never persist an identity; only
+ *    startPairing() does) and reconcile()'s pairing-cancel-on-disable branch,
+ *    but never opens a session, so it never reaches wireSessionListeners(),
+ *    disposeSession(), or the roster-diff eviction loop.
+ *  - mobile-bridge-sync-race.test.ts opens a session, but only to prove the
+ *    syncInFlight reentrancy guard coalesces two overlapping opens into one
+ *    BridgeSession; it never emits a message or a remoteClosed on the
+ *    resulting session, and never revokes or disables afterward.
+ *
+ * This file closes that gap: message routing through capabilityRouter back
+ * out via sendMessage(), remoteClosed's subscriptions-only teardown (session
+ * stays alive for the relay's reconnect), revokeDevice()/reconcile(disable)
+ * actually disposing a LIVE session (not just the "no identity yet" no-op
+ * already covered), and the roster-diff eviction path that disposes a
+ * session whose device fell out of the roster without going through
+ * revokeDevice() at all.
+ *
+ * Mocking mirrors mobile-bridge-sync-race.test.ts's pattern (mock
+ * electron/analytics/paths/identity/roster-store/bridge-session/transport),
+ * with a mutable roster device list so the eviction test can drop a device
+ * between two reconcile() calls, and a FakeBridgeSession that is a real
+ * EventEmitter so tests can emit 'message' / 'remoteClosed' the same way the
+ * real BridgeSession would.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { CapabilityRequestMessage, CapabilityResponseMessage, RosterDeviceEntry } from '@kangentic/protocol';
+
+vi.mock('electron', () => ({
+  app: { isReady: () => true, whenReady: () => Promise.resolve() },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`encrypted:${plaintext}`, 'utf8'),
+    decryptString: (buffer: Buffer) => buffer.toString('utf8').replace(/^encrypted:/, ''),
+    getSelectedStorageBackend: () => 'keychain',
+  },
+  ipcMain: { handle: vi.fn(), on: vi.fn(), removeHandler: vi.fn() },
+}));
+
+vi.mock('../../../src/main/analytics/analytics', () => ({
+  trackEvent: vi.fn(),
+  sanitizeErrorMessage: (message: string) => message,
+}));
+
+vi.mock('../../../src/main/config/paths', () => ({
+  PATHS: { configDir: '/mock/config' },
+}));
+
+const fakeIdentity = {
+  staticKeyPair: { publicKey: new Uint8Array(32).fill(1), secretKey: new Uint8Array(32).fill(2) },
+};
+const fakeDevice: RosterDeviceEntry = {
+  deviceId: 'device-A',
+  displayName: 'Phone A',
+  staticPublicKey: new Uint8Array(32).fill(3),
+  capabilities: ['read-board'],
+  pairedAt: new Date(0).toISOString(),
+  expiresAt: null,
+};
+
+// Mutable so the roster-diff eviction test can drop a device between two
+// reconcile() calls without touching the module-level roster file at all.
+let rosterDevices: RosterDeviceEntry[] = [fakeDevice];
+
+const revokeDeviceSpy = vi.fn();
+const setDeviceCapabilitiesSpy = vi.fn();
+
+vi.mock('../../../src/main/mobile-bridge/identity', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/main/mobile-bridge/identity')>()),
+  loadBridgeIdentity: () => fakeIdentity,
+  loadOrCreateBridgeIdentity: () => fakeIdentity,
+}));
+
+vi.mock('../../../src/main/mobile-bridge/roster-store', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/main/mobile-bridge/roster-store')>()),
+  loadRoster: () => ({ devices: rosterDevices }),
+  revokeDevice: (...args: unknown[]) => revokeDeviceSpy(...args),
+  setDeviceCapabilities: (...args: unknown[]) => setDeviceCapabilitiesSpy(...args),
+}));
+
+/** A real EventEmitter so tests can drive 'message' / 'remoteClosed' exactly like the real BridgeSession does. */
+const createdSessions: FakeBridgeSession[] = [];
+class FakeBridgeSession extends EventEmitter {
+  readonly deviceId: string;
+  capabilities: Set<string>;
+  start = vi.fn();
+  dispose = vi.fn();
+  sendMessage = vi.fn();
+  constructor(options: { deviceId: string; capabilities: Set<string> }) {
+    super();
+    this.deviceId = options.deviceId;
+    this.capabilities = options.capabilities;
+    createdSessions.push(this);
+  }
+}
+vi.mock('../../../src/main/mobile-bridge/session/bridge-session', () => ({
+  BridgeSession: FakeBridgeSession,
+}));
+
+const fakeTransport = {
+  state: 'connected' as const,
+  connect: vi.fn(async () => undefined),
+  send: vi.fn(),
+  close: vi.fn(),
+  onFrame: vi.fn(() => () => undefined),
+  onStateChange: vi.fn(() => () => undefined),
+};
+vi.mock('../../../src/main/mobile-bridge/transport/transport-factory', () => ({
+  createTransport: vi.fn(() => fakeTransport),
+}));
+
+const { MobileBridgeService } = await import('../../../src/main/mobile-bridge/mobile-bridge-service');
+type MobileBridgeServiceInstance = InstanceType<typeof MobileBridgeService>;
+
+/** Settle every microtask queued by the fire-and-forget async chain reconcile() -> syncSessions() -> runSyncSessions() -> openSessionForDevice() kicks off. */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+/** Opens a session for the single-device roster and returns the FakeBridgeSession instance the service created for it. */
+async function openSession(service: MobileBridgeServiceInstance): Promise<FakeBridgeSession> {
+  const countBefore = createdSessions.length;
+  service.attachContext({} as never);
+  service.reconcile({ enabled: true, relayUrl: 'wss://relay.example.com' });
+  await flushMicrotasks();
+  expect(createdSessions.length).toBe(countBefore + 1);
+  const session = createdSessions.at(-1);
+  if (!session) throw new Error('openSession(): no FakeBridgeSession was created');
+  return session;
+}
+
+beforeEach(() => {
+  createdSessions.length = 0;
+  rosterDevices = [fakeDevice];
+  revokeDeviceSpy.mockClear();
+  setDeviceCapabilitiesSpy.mockClear();
+  fakeTransport.connect.mockClear();
+  fakeTransport.close.mockClear();
+});
+
+describe('MobileBridgeService session-lifecycle wiring', () => {
+  it('wireSessionListeners routes a capability-request message through the router and sends the response back', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const session = await openSession(service);
+
+    const fakeResponse: CapabilityResponseMessage = { type: 'capability-response', requestId: 'req-1', ok: true, payload: { mocked: true } };
+    // fakeDevice only grants read-board; override its real handler so this
+    // test controls the response without wiring a real IpcContext.
+    service.capabilityRouter.register('read-board', () => fakeResponse);
+
+    const request: CapabilityRequestMessage = { type: 'capability-request', requestId: 'req-1', verb: 'read-board', payload: {} };
+    session.emit('message', request);
+    await flushMicrotasks();
+
+    expect(session.sendMessage).toHaveBeenCalledTimes(1);
+    expect(session.sendMessage).toHaveBeenCalledWith(fakeResponse);
+
+    service.dispose();
+  });
+
+  it('ignores a non-capability-request message type (e.g. an inbound heartbeat) without dispatching or responding', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const session = await openSession(service);
+    const dispatchSpy = vi.spyOn(service.capabilityRouter, 'dispatch');
+
+    session.emit('message', { type: 'heartbeat' });
+    await flushMicrotasks();
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(session.sendMessage).not.toHaveBeenCalled();
+
+    service.dispose();
+  });
+
+  it('remoteClosed tears down the device live subscriptions but leaves the session itself alive for the relay reconnect', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const session = await openSession(service);
+
+    // Register a live subscription the same way a real handler would (via
+    // the getSubscriptions closure attachContext() wires into the router),
+    // by reaching the same private accessor wireSessionListeners' teardown
+    // path reads from.
+    const subscriptionTeardown = vi.fn();
+    (service as unknown as { getOrCreateSubscriptions(deviceId: string): { set(key: string, teardown: () => void): void } })
+      .getOrCreateSubscriptions(session.deviceId)
+      .set('board:proj-1', subscriptionTeardown);
+
+    session.emit('remoteClosed');
+
+    expect(subscriptionTeardown).toHaveBeenCalledTimes(1);
+    expect(session.dispose).not.toHaveBeenCalled();
+    // Session-count bookkeeping is untouched by a remote close (unlike an
+    // actual revoke/eviction) - the device is still "paired".
+    expect(service.getStatus().pairedDeviceCount).toBe(1);
+
+    service.dispose();
+  });
+
+  it('revokeDevice() disposes a LIVE session, not just the no-identity no-op', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const session = await openSession(service);
+
+    service.revokeDevice(session.deviceId);
+
+    expect(revokeDeviceSpy).toHaveBeenCalledWith(fakeIdentity, session.deviceId);
+    expect(session.dispose).toHaveBeenCalledTimes(1);
+
+    service.dispose();
+  });
+
+  it('reconcile() disabling the bridge disposes a LIVE session, not just an in-progress pairing', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const session = await openSession(service);
+
+    service.reconcile({ enabled: false, relayUrl: '' });
+
+    expect(session.dispose).toHaveBeenCalledTimes(1);
+
+    service.dispose();
+  });
+
+  it('a relay URL change while enabled disposes the old session before syncSessions reopens against the new relay', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const firstSession = await openSession(service);
+
+    service.reconcile({ enabled: true, relayUrl: 'wss://relay2.example.com' });
+    await flushMicrotasks();
+
+    expect(firstSession.dispose).toHaveBeenCalledTimes(1);
+    // A fresh session was opened against the new relay for the same device.
+    expect(createdSessions.length).toBe(2);
+    expect(createdSessions[1]).not.toBe(firstSession);
+    expect(service.getStatus().pairedDeviceCount).toBe(1);
+
+    service.dispose();
+  });
+
+  it('runSyncSessions evicts a session whose device fell out of the roster, without going through revokeDevice()', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const session = await openSession(service);
+
+    // Device revoked out-of-band (e.g. from another process) - the roster
+    // file itself now omits it, but nobody called service.revokeDevice().
+    rosterDevices = [];
+    service.reconcile({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    await flushMicrotasks();
+
+    expect(session.dispose).toHaveBeenCalledTimes(1);
+    expect(revokeDeviceSpy).not.toHaveBeenCalled();
+    expect(service.getStatus().pairedDeviceCount).toBe(0);
+
+    service.dispose();
+  });
+});

--- a/tests/unit/mobile-bridge/mobile-bridge-sync-race.test.ts
+++ b/tests/unit/mobile-bridge/mobile-bridge-sync-race.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Reentrancy guard for MobileBridgeService.syncSessions(): reconcile() fires on
+ * every config:set and pairing-confirmation calls in independently, both
+ * fire-and-forget. syncSessions() awaits a real network dial per device and
+ * only inserts into its `sessions` map AFTER the dial resolves, so two
+ * overlapping runs could each see "no session for this device" and both open a
+ * full BridgeSession + transport + re-handshake timer - orphaning one that can
+ * never be disposed or revoked. The guard coalesces overlapping runs so exactly
+ * one session is opened per device.
+ *
+ * Isolated in its own file (not mobile-bridge-service.test.ts) because it mocks
+ * identity/roster/BridgeSession, which the identity-creation tests there need
+ * to be real.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+vi.mock('electron', () => ({
+  app: { isReady: () => true, whenReady: () => Promise.resolve() },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`encrypted:${plaintext}`, 'utf8'),
+    decryptString: (buffer: Buffer) => buffer.toString('utf8').replace(/^encrypted:/, ''),
+    getSelectedStorageBackend: () => 'keychain',
+  },
+  ipcMain: { handle: vi.fn(), on: vi.fn(), removeHandler: vi.fn() },
+}));
+
+vi.mock('../../../src/main/analytics/analytics', () => ({
+  trackEvent: vi.fn(),
+  sanitizeErrorMessage: (message: string) => message,
+}));
+
+vi.mock('../../../src/main/config/paths', () => ({
+  PATHS: { configDir: '/mock/config' },
+}));
+
+// A single fake identity + one-device roster: enough for syncSessions to want
+// to open exactly one BridgeSession.
+const fakeIdentity = {
+  staticKeyPair: { publicKey: new Uint8Array(32).fill(1), secretKey: new Uint8Array(32).fill(2) },
+};
+const fakeDevice = {
+  deviceId: 'device-A',
+  displayName: 'Phone A',
+  staticPublicKey: new Uint8Array(32).fill(3),
+  capabilities: ['read-board'],
+};
+
+vi.mock('../../../src/main/mobile-bridge/identity', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/main/mobile-bridge/identity')>()),
+  loadBridgeIdentity: () => fakeIdentity,
+  loadOrCreateBridgeIdentity: () => fakeIdentity,
+}));
+
+vi.mock('../../../src/main/mobile-bridge/roster-store', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/main/mobile-bridge/roster-store')>()),
+  loadRoster: () => ({ devices: [fakeDevice] }),
+}));
+
+// Count BridgeSession instantiations - the whole point of the test.
+let bridgeSessionInstances = 0;
+class FakeBridgeSession extends EventEmitter {
+  readonly deviceId: string;
+  start = vi.fn();
+  dispose = vi.fn();
+  sendMessage = vi.fn();
+  constructor(options: { deviceId: string }) {
+    super();
+    this.deviceId = options.deviceId;
+    bridgeSessionInstances += 1;
+  }
+}
+vi.mock('../../../src/main/mobile-bridge/session/bridge-session', () => ({
+  BridgeSession: FakeBridgeSession,
+}));
+
+// A transport whose connect() stays pending until we release it, opening the
+// race window between reconcile() #1 (suspended on the dial) and #2.
+let releaseConnect: (() => void) | null = null;
+const fakeTransport = {
+  state: 'connecting' as const,
+  connect: vi.fn(() => new Promise<void>((resolve) => { releaseConnect = resolve; })),
+  send: vi.fn(),
+  close: vi.fn(),
+  onFrame: vi.fn(() => () => undefined),
+  onStateChange: vi.fn(() => () => undefined),
+};
+vi.mock('../../../src/main/mobile-bridge/transport/transport-factory', () => ({
+  createTransport: vi.fn(() => fakeTransport),
+}));
+
+const { MobileBridgeService } = await import('../../../src/main/mobile-bridge/mobile-bridge-service');
+const { createTransport } = await import('../../../src/main/mobile-bridge/transport/transport-factory');
+
+beforeEach(() => {
+  bridgeSessionInstances = 0;
+  releaseConnect = null;
+  fakeTransport.connect.mockClear();
+  fakeTransport.close.mockClear();
+  vi.mocked(createTransport).mockClear();
+});
+
+describe('MobileBridgeService.syncSessions() reentrancy', () => {
+  it('two overlapping reconciles open exactly one BridgeSession per device', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    service.attachContext({} as never);
+
+    // Fire two reconciles with the SAME config while the first is still
+    // suspended on transport.connect(). Without the guard, both would each
+    // create a BridgeSession for the same device.
+    service.reconcile({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    service.reconcile({ enabled: true, relayUrl: 'wss://relay.example.com' });
+
+    // The dial is still pending: exactly one open attempt is in flight.
+    expect(bridgeSessionInstances).toBe(1);
+
+    // Release the dial and let the coalesced follow-up run settle.
+    releaseConnect?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Still exactly one session; the second reconcile coalesced instead of
+    // opening a duplicate, orphaned session.
+    expect(bridgeSessionInstances).toBe(1);
+    expect(service.getStatus().pairedDeviceCount).toBe(1);
+
+    service.dispose();
+  });
+});

--- a/tests/unit/mobile-bridge/move-task.test.ts
+++ b/tests/unit/mobile-bridge/move-task.test.ts
@@ -1,0 +1,76 @@
+/**
+ * move-task must route through handleTaskMove (withTaskLock + transition
+ * engine + rollback), never TaskRepository.move() directly, and must never
+ * forward a continuationPrompt from the wire payload - see task-move.ts's
+ * own doc comment on why that field is deliberately excluded from `input`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const handleTaskMoveMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+vi.mock('../../../src/main/ipc/handlers/task-move', () => ({
+  handleTaskMove: handleTaskMoveMock,
+}));
+
+import type { CapabilityRequestMessage } from '@kangentic/protocol';
+import { handleMoveTask } from '../../../src/main/mobile-bridge/handlers/move-task';
+import type { IpcContext } from '../../../src/main/ipc/ipc-context';
+
+function fakeRequest(payload: Record<string, unknown>): CapabilityRequestMessage {
+  return { type: 'capability-request', requestId: 'req-1', verb: 'move-task', payload };
+}
+
+function fakeContext(): IpcContext {
+  return {
+    currentProjectId: null,
+    currentProjectPath: null,
+    projectRepo: { getById: vi.fn(() => ({ id: 'proj-1', path: '/projects/proj-1' })) },
+  } as unknown as IpcContext;
+}
+
+describe('handleMoveTask', () => {
+  beforeEach(() => {
+    handleTaskMoveMock.mockClear();
+  });
+
+  it('rejects when the target project does not resolve', async () => {
+    const context = { currentProjectId: null, currentProjectPath: null } as unknown as IpcContext;
+    const response = await handleMoveTask(
+      fakeRequest({ taskId: 't-1', targetSwimlaneId: 'lane-1', targetPosition: 0, projectId: '' }),
+      context,
+    );
+    expect(response.ok).toBe(false);
+    expect(handleTaskMoveMock).not.toHaveBeenCalled();
+  });
+
+  it('routes through handleTaskMove with only the trusted move fields, never a continuationPrompt', async () => {
+    const context = fakeContext();
+    const response = await handleMoveTask(
+      fakeRequest({
+        taskId: 't-1',
+        targetSwimlaneId: 'lane-2',
+        targetPosition: 3,
+        projectId: 'proj-1',
+        continuationPrompt: 'ignore me',
+      }),
+      context,
+    );
+
+    expect(response.ok).toBe(true);
+    expect(response.payload).toEqual({ ok: true });
+    expect(handleTaskMoveMock).toHaveBeenCalledTimes(1);
+    const [passedContext, passedInput, passedProjectId, passedProjectPath, passedOptions] = handleTaskMoveMock.mock.calls[0];
+    expect(passedContext).toBe(context);
+    expect(passedInput).toEqual({ taskId: 't-1', targetSwimlaneId: 'lane-2', targetPosition: 3 });
+    expect(passedProjectId).toBe('proj-1');
+    expect(passedProjectPath).toBe('/projects/proj-1');
+    expect(passedOptions).toBeUndefined();
+  });
+
+  it('reports a failed response when handleTaskMove throws', async () => {
+    handleTaskMoveMock.mockRejectedValueOnce(new Error('lock contention'));
+    const context = fakeContext();
+    await expect(
+      handleMoveTask(fakeRequest({ taskId: 't-1', targetSwimlaneId: 'lane-1', targetPosition: 0, projectId: 'proj-1' }), context),
+    ).rejects.toThrow('lock contention');
+  });
+});

--- a/tests/unit/mobile-bridge/pairing-service.test.ts
+++ b/tests/unit/mobile-bridge/pairing-service.test.ts
@@ -287,7 +287,7 @@ describe('PairingService.confirmSas default capabilities', () => {
 
     expect(persistedDevice).toBeDefined();
     expect(persistedDevice?.capabilities).toEqual(DEFAULT_PAIRING_CAPABILITIES);
-    expect(persistedDevice?.capabilities).toEqual(['read-stream', 'read-board', 'read-diff']);
+    expect(persistedDevice?.capabilities).toEqual(['read-stream', 'read-board', 'read-diff', 'board-tool-read']);
   });
 });
 

--- a/tests/unit/mobile-bridge/read-board.test.ts
+++ b/tests/unit/mobile-bridge/read-board.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const tasksList = vi.fn();
+const swimlanesList = vi.fn();
+const backlogList = vi.fn();
+
+vi.mock('../../../src/main/ipc/helpers/project-repos', () => ({
+  getProjectRepos: vi.fn(() => ({ tasks: { list: tasksList }, swimlanes: { list: swimlanesList } })),
+}));
+vi.mock('../../../src/main/db/database', () => ({
+  getProjectDb: vi.fn(() => ({})),
+}));
+vi.mock('../../../src/main/db/repositories/backlog-repository', () => ({
+  BacklogRepository: class {
+    list(): unknown {
+      return backlogList();
+    }
+  },
+}));
+
+import type { CapabilityRequestMessage } from '@kangentic/protocol';
+import { handleReadBoard } from '../../../src/main/mobile-bridge/handlers/read-board';
+import type { IpcContext } from '../../../src/main/ipc/ipc-context';
+import type { BridgeSession } from '../../../src/main/mobile-bridge/session/bridge-session';
+import { SubscriptionRegistry } from '../../../src/main/mobile-bridge/session/subscription-registry';
+
+function fakeRequest(payload: Record<string, unknown>): CapabilityRequestMessage {
+  return { type: 'capability-request', requestId: 'req-1', verb: 'read-board', payload };
+}
+
+function fakeSession(): BridgeSession {
+  return { deviceId: 'device-1', isEstablished: true, sendMessage: vi.fn() } as unknown as BridgeSession;
+}
+
+describe('handleReadBoard', () => {
+  beforeEach(() => {
+    tasksList.mockReset().mockReturnValue([{ id: 't-1' }]);
+    swimlanesList.mockReset().mockReturnValue([{ id: 'lane-1' }]);
+    backlogList.mockReset().mockReturnValue([{ id: 'b-1' }]);
+  });
+
+  it('with no projectId, returns the project bootstrap list and never touches repos', async () => {
+    const projectRepoList = vi.fn(() => [{ id: 'proj-1', name: 'Alpha' }]);
+    const context = { projectRepo: { list: projectRepoList, getById: vi.fn() } } as unknown as IpcContext;
+    const subscriptions = new SubscriptionRegistry();
+
+    const response = await handleReadBoard(fakeRequest({}), fakeSession(), context, subscriptions);
+
+    expect(response.ok).toBe(true);
+    expect(response.payload).toEqual({ projects: [{ id: 'proj-1', name: 'Alpha' }] });
+    expect(tasksList).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsubscribe with no projectId as a no-op success (nothing to tear down)', async () => {
+    // action alone with no projectId falls through to the project-list branch
+    // since there is no per-project subscription to identify.
+    const context = { projectRepo: { list: vi.fn(() => []), getById: vi.fn() } } as unknown as IpcContext;
+    const response = await handleReadBoard(fakeRequest({ action: 'unsubscribe' }), fakeSession(), context, new SubscriptionRegistry());
+    expect(response.ok).toBe(true);
+  });
+
+  it('rejects an unknown project id', async () => {
+    const context = { projectRepo: { getById: vi.fn(() => undefined) } } as unknown as IpcContext;
+    const response = await handleReadBoard(fakeRequest({ projectId: 'ghost' }), fakeSession(), context, new SubscriptionRegistry());
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/no such project/i);
+  });
+
+  it('returns a full board snapshot and subscribes to board-changed events filtered by projectId', async () => {
+    let capturedListener: ((event: unknown) => void) | undefined;
+    const onBoardChanged = vi.fn((listener: (event: unknown) => void) => {
+      capturedListener = listener;
+      return vi.fn();
+    });
+    const context = {
+      projectRepo: { getById: vi.fn(() => ({ id: 'proj-1', name: 'Alpha' })) },
+      boardEvents: { onBoardChanged },
+    } as unknown as IpcContext;
+    const subscriptions = new SubscriptionRegistry();
+    const session = fakeSession();
+
+    const response = await handleReadBoard(fakeRequest({ projectId: 'proj-1' }), session, context, subscriptions);
+
+    expect(response.ok).toBe(true);
+    expect(response.payload).toEqual({
+      projectId: 'proj-1',
+      columns: [{ id: 'lane-1' }],
+      tasks: [{ id: 't-1' }],
+      backlog: [{ id: 'b-1' }],
+    });
+    expect(subscriptions.has('board:proj-1')).toBe(true);
+
+    // A board-changed event for a DIFFERENT project must not push.
+    capturedListener?.({ projectId: 'proj-OTHER', change: 'task-updated', ids: ['x'] });
+    expect(session.sendMessage).not.toHaveBeenCalled();
+
+    // The same project's event pushes a BoardEvent.
+    capturedListener?.({ projectId: 'proj-1', change: 'task-updated', ids: ['t-9'] });
+    expect(session.sendMessage).toHaveBeenCalledWith({
+      type: 'event',
+      event: { kind: 'board', projectId: 'proj-1', taskId: 't-9', payload: { change: 'task-updated', ids: ['t-9'] } },
+    });
+  });
+
+  it('unsubscribe tears down the board subscription', async () => {
+    const unsubscribe = vi.fn();
+    const context = {
+      projectRepo: { getById: vi.fn(() => ({ id: 'proj-1', name: 'Alpha' })) },
+      boardEvents: { onBoardChanged: vi.fn(() => unsubscribe) },
+    } as unknown as IpcContext;
+    const subscriptions = new SubscriptionRegistry();
+    const session = fakeSession();
+
+    await handleReadBoard(fakeRequest({ projectId: 'proj-1' }), session, context, subscriptions);
+    expect(subscriptions.has('board:proj-1')).toBe(true);
+
+    const response = await handleReadBoard(fakeRequest({ projectId: 'proj-1', action: 'unsubscribe' }), session, context, subscriptions);
+    expect(response.ok).toBe(true);
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(subscriptions.has('board:proj-1')).toBe(false);
+  });
+});

--- a/tests/unit/mobile-bridge/read-diff.test.ts
+++ b/tests/unit/mobile-bridge/read-diff.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getDiffFiles = vi.fn();
+const getFileContent = vi.fn();
+
+vi.mock('../../../src/main/git/diff-service', () => ({
+  DiffService: class {
+    getDiffFiles(...args: unknown[]): unknown {
+      return getDiffFiles(...args);
+    }
+    getFileContent(...args: unknown[]): unknown {
+      return getFileContent(...args);
+    }
+  },
+}));
+
+const tasksGetById = vi.fn();
+vi.mock('../../../src/main/ipc/helpers/project-repos', () => ({
+  getProjectRepos: vi.fn(() => ({ tasks: { getById: tasksGetById } })),
+}));
+
+import type { CapabilityRequestMessage } from '@kangentic/protocol';
+import { handleReadDiff } from '../../../src/main/mobile-bridge/handlers/read-diff';
+import type { IpcContext } from '../../../src/main/ipc/ipc-context';
+import type { DiffWatcher } from '../../../src/main/git/diff-watcher';
+import type { BridgeSession } from '../../../src/main/mobile-bridge/session/bridge-session';
+import { SubscriptionRegistry } from '../../../src/main/mobile-bridge/session/subscription-registry';
+
+function fakeRequest(payload: Record<string, unknown>): CapabilityRequestMessage {
+  return { type: 'capability-request', requestId: 'req-1', verb: 'read-diff', payload };
+}
+
+function fakeSession(): BridgeSession {
+  return { deviceId: 'device-1', isEstablished: true, sendMessage: vi.fn() } as unknown as BridgeSession;
+}
+
+function fakeDiffWatcher(): DiffWatcher {
+  // subscribe returns a per-subscriber teardown (the real DiffWatcher does),
+  // which the handler must store as the subscription teardown.
+  return { subscribe: vi.fn(() => vi.fn()), unsubscribe: vi.fn() } as unknown as DiffWatcher;
+}
+
+describe('handleReadDiff', () => {
+  beforeEach(() => {
+    getDiffFiles.mockReset();
+    getFileContent.mockReset();
+    tasksGetById.mockReset();
+  });
+
+  it('rejects an unknown project', async () => {
+    const context = { projectRepo: { getById: vi.fn(() => undefined) } } as unknown as IpcContext;
+    const response = await handleReadDiff(
+      fakeRequest({ taskId: 't-1', projectId: 'ghost' }),
+      fakeSession(),
+      context,
+      new SubscriptionRegistry(),
+      fakeDiffWatcher(),
+    );
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/no such project/i);
+  });
+
+  it('rejects an unknown task', async () => {
+    tasksGetById.mockReturnValue(undefined);
+    const context = { projectRepo: { getById: vi.fn(() => ({ id: 'proj-1', path: '/projects/proj-1' })) } } as unknown as IpcContext;
+    const response = await handleReadDiff(
+      fakeRequest({ taskId: 'ghost', projectId: 'proj-1' }),
+      fakeSession(),
+      context,
+      new SubscriptionRegistry(),
+      fakeDiffWatcher(),
+    );
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/no such task/i);
+  });
+
+  it('returns the file list and subscribes the bridge-owned DiffWatcher to the worktree, never context.diffWatcher', async () => {
+    tasksGetById.mockReturnValue({ id: 't-1', worktree_path: '/worktrees/t-1', base_branch: 'main' });
+    getDiffFiles.mockResolvedValue({ files: [{ path: 'a.ts', status: 'M' }], totalInsertions: 1, totalDeletions: 0 });
+    const rendererDiffWatcher = { subscribe: vi.fn(), unsubscribe: vi.fn() };
+    const bridgeDiffWatcher = fakeDiffWatcher();
+    const context = {
+      projectRepo: { getById: vi.fn(() => ({ id: 'proj-1', path: '/projects/proj-1' })) },
+      diffWatcher: rendererDiffWatcher,
+    } as unknown as IpcContext;
+    const subscriptions = new SubscriptionRegistry();
+
+    const response = await handleReadDiff(
+      fakeRequest({ taskId: 't-1', projectId: 'proj-1' }),
+      fakeSession(),
+      context,
+      subscriptions,
+      bridgeDiffWatcher,
+    );
+
+    expect(response.ok).toBe(true);
+    expect(response.payload).toEqual({ files: [{ path: 'a.ts', status: 'M' }], totalInsertions: 1, totalDeletions: 0 });
+    expect(getDiffFiles).toHaveBeenCalledWith({
+      worktreePath: '/worktrees/t-1',
+      projectPath: '/projects/proj-1',
+      baseBranch: 'main',
+      scope: undefined,
+    });
+    expect(bridgeDiffWatcher.subscribe).toHaveBeenCalledWith('/worktrees/t-1', expect.any(Function));
+    expect(rendererDiffWatcher.subscribe).not.toHaveBeenCalled();
+    expect(subscriptions.has('diff:t-1')).toBe(true);
+  });
+
+  it('stores the per-subscriber teardown returned by subscribe, not a blanket unsubscribe(path)', async () => {
+    // The shared DiffWatcher multiplexes callbacks per path, so tearing a
+    // subscription down must remove only this device's callback (the returned
+    // teardown) rather than unsubscribe(watchPath), which would kill a
+    // co-located subscription (another device / worktree-less task in the same repo).
+    tasksGetById.mockReturnValue({ id: 't-1', worktree_path: '/worktrees/t-1', base_branch: 'main' });
+    getDiffFiles.mockResolvedValue({ files: [], totalInsertions: 0, totalDeletions: 0 });
+    const perSubscriberTeardown = vi.fn();
+    const unsubscribe = vi.fn();
+    const bridgeDiffWatcher = {
+      subscribe: vi.fn(() => perSubscriberTeardown),
+      unsubscribe,
+    } as unknown as DiffWatcher;
+    const context = {
+      projectRepo: { getById: vi.fn(() => ({ id: 'proj-1', path: '/projects/proj-1' })) },
+    } as unknown as IpcContext;
+    const subscriptions = new SubscriptionRegistry();
+
+    await handleReadDiff(
+      fakeRequest({ taskId: 't-1', projectId: 'proj-1' }),
+      fakeSession(),
+      context,
+      subscriptions,
+      bridgeDiffWatcher,
+    );
+
+    subscriptions.remove('diff:t-1');
+    expect(perSubscriberTeardown).toHaveBeenCalledTimes(1);
+    expect(unsubscribe).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribe tears down via the bridge-owned watcher, never context.diffWatcher', async () => {
+    const rendererDiffWatcher = { subscribe: vi.fn(), unsubscribe: vi.fn() };
+    const bridgeDiffWatcher = fakeDiffWatcher();
+    const context = { diffWatcher: rendererDiffWatcher } as unknown as IpcContext;
+    const subscriptions = new SubscriptionRegistry();
+    subscriptions.set('diff:t-1', () => bridgeDiffWatcher.unsubscribe('/worktrees/t-1'));
+
+    const response = await handleReadDiff(
+      fakeRequest({ taskId: 't-1', projectId: 'proj-1', action: 'unsubscribe' }),
+      fakeSession(),
+      context,
+      subscriptions,
+      bridgeDiffWatcher,
+    );
+
+    expect(response.ok).toBe(true);
+    expect(bridgeDiffWatcher.unsubscribe).toHaveBeenCalledWith('/worktrees/t-1');
+    expect(rendererDiffWatcher.unsubscribe).not.toHaveBeenCalled();
+    expect(subscriptions.has('diff:t-1')).toBe(false);
+  });
+
+  it('resolves the file status from the current diff list before fetching content (the wire payload carries no status)', async () => {
+    tasksGetById.mockReturnValue({ id: 't-1', worktree_path: '/worktrees/t-1', base_branch: 'main' });
+    getDiffFiles.mockResolvedValue({
+      files: [{ path: 'a.ts', status: 'A', oldPath: undefined }],
+      totalInsertions: 5,
+      totalDeletions: 0,
+    });
+    getFileContent.mockResolvedValue({ original: '', modified: 'content', language: 'typescript' });
+    const context = {
+      projectRepo: { getById: vi.fn(() => ({ id: 'proj-1', path: '/projects/proj-1' })) },
+    } as unknown as IpcContext;
+
+    const response = await handleReadDiff(
+      fakeRequest({ taskId: 't-1', projectId: 'proj-1', filePath: 'a.ts' }),
+      fakeSession(),
+      context,
+      new SubscriptionRegistry(),
+      fakeDiffWatcher(),
+    );
+
+    expect(response.ok).toBe(true);
+    expect(response.payload).toEqual({ original: '', modified: 'content', language: 'typescript' });
+    expect(getFileContent).toHaveBeenCalledWith({
+      worktreePath: '/worktrees/t-1',
+      projectPath: '/projects/proj-1',
+      baseBranch: 'main',
+      filePath: 'a.ts',
+      status: 'A',
+      oldPath: undefined,
+      scope: undefined,
+    });
+  });
+
+  it('rejects a filePath not present in the current diff', async () => {
+    tasksGetById.mockReturnValue({ id: 't-1', worktree_path: '/worktrees/t-1', base_branch: 'main' });
+    getDiffFiles.mockResolvedValue({ files: [], totalInsertions: 0, totalDeletions: 0 });
+    const context = {
+      projectRepo: { getById: vi.fn(() => ({ id: 'proj-1', path: '/projects/proj-1' })) },
+    } as unknown as IpcContext;
+
+    const response = await handleReadDiff(
+      fakeRequest({ taskId: 't-1', projectId: 'proj-1', filePath: 'missing.ts' }),
+      fakeSession(),
+      context,
+      new SubscriptionRegistry(),
+      fakeDiffWatcher(),
+    );
+
+    expect(response.ok).toBe(false);
+    expect(getFileContent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/mobile-bridge/read-stream.test.ts
+++ b/tests/unit/mobile-bridge/read-stream.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+vi.mock('../../../src/main/db/database', () => ({
+  getProjectDb: vi.fn(() => ({})),
+}));
+
+const resolveTaskTranscriptMock = vi.fn();
+vi.mock('../../../src/main/agent/transcript-service', () => ({
+  resolveTaskTranscript: (...args: unknown[]) => resolveTaskTranscriptMock(...args),
+}));
+
+import type { CapabilityRequestMessage } from '@kangentic/protocol';
+import { handleReadStream } from '../../../src/main/mobile-bridge/handlers/read-stream';
+import type { IpcContext } from '../../../src/main/ipc/ipc-context';
+import type { BridgeSession } from '../../../src/main/mobile-bridge/session/bridge-session';
+import { SubscriptionRegistry } from '../../../src/main/mobile-bridge/session/subscription-registry';
+
+function fakeRequest(payload: Record<string, unknown>): CapabilityRequestMessage {
+  return { type: 'capability-request', requestId: 'req-1', verb: 'read-stream', payload };
+}
+
+function fakeSession(): BridgeSession {
+  return { deviceId: 'device-1', isEstablished: true, sendMessage: vi.fn() } as unknown as BridgeSession;
+}
+
+class FakeSessionManager extends EventEmitter {
+  getSession = vi.fn((id: string) => ({ id, taskId: 'task-1' }));
+  getScrollback = vi.fn(() => Promise.resolve('scrollback-content'));
+  getActivityCache = vi.fn(() => ({ 'sess-1': 'thinking' }));
+  getActivityReason = vi.fn(() => ({ kind: 'turn-active' }));
+  getUsageCache = vi.fn(() => ({ 'sess-1': { contextWindow: { used: 1 } } }));
+  getActivityStatsSnapshot = vi.fn(() => ({ permissionPending: false, permissionAwaitedToolId: null }));
+  getSessionProjectId = vi.fn(() => 'proj-1');
+}
+
+describe('handleReadStream', () => {
+  let sessionManager: FakeSessionManager;
+
+  beforeEach(() => {
+    sessionManager = new FakeSessionManager();
+    resolveTaskTranscriptMock.mockReset();
+  });
+
+  it('rejects when the session does not exist', async () => {
+    sessionManager.getSession.mockReturnValueOnce(undefined as never);
+    const context = { sessionManager } as unknown as IpcContext;
+    const response = await handleReadStream(fakeRequest({ sessionId: 'sess-1', action: 'subscribe' }), fakeSession(), context, new SubscriptionRegistry());
+    expect(response.ok).toBe(false);
+  });
+
+  it('returns the initial snapshot including the awaited prompt id when a permission prompt is pending', async () => {
+    sessionManager.getActivityStatsSnapshot.mockReturnValue({ permissionPending: true, permissionAwaitedToolId: 'tool-9' });
+    const context = { sessionManager } as unknown as IpcContext;
+    const response = await handleReadStream(fakeRequest({ sessionId: 'sess-1', action: 'subscribe' }), fakeSession(), context, new SubscriptionRegistry());
+
+    expect(response.ok).toBe(true);
+    const payload = response.payload as { scrollback: string; awaitedPromptId: string | null };
+    expect(payload.scrollback).toBe('scrollback-content');
+    expect(payload.awaitedPromptId).toBe('sess-1:tool-9');
+  });
+
+  it('awaitedPromptId is null when no permission is pending', async () => {
+    const context = { sessionManager } as unknown as IpcContext;
+    const response = await handleReadStream(fakeRequest({ sessionId: 'sess-1', action: 'subscribe' }), fakeSession(), context, new SubscriptionRegistry());
+    const payload = response.payload as { awaitedPromptId: string | null };
+    expect(payload.awaitedPromptId).toBeNull();
+  });
+
+  it('subscribe registers session-manager listeners; unsubscribe removes them', async () => {
+    const context = { sessionManager } as unknown as IpcContext;
+    const subscriptions = new SubscriptionRegistry();
+
+    await handleReadStream(fakeRequest({ sessionId: 'sess-1', action: 'subscribe' }), fakeSession(), context, subscriptions);
+    expect(sessionManager.listenerCount('data-tap')).toBe(1);
+    expect(sessionManager.listenerCount('activity')).toBe(1);
+    expect(sessionManager.listenerCount('usage')).toBe(1);
+    expect(sessionManager.listenerCount('event')).toBe(1);
+
+    const response = await handleReadStream(fakeRequest({ sessionId: 'sess-1', action: 'unsubscribe' }), fakeSession(), context, subscriptions);
+    expect(response.ok).toBe(true);
+    expect(sessionManager.listenerCount('data-tap')).toBe(0);
+    expect(sessionManager.listenerCount('activity')).toBe(0);
+    expect(sessionManager.listenerCount('usage')).toBe(0);
+    expect(sessionManager.listenerCount('event')).toBe(0);
+  });
+
+  it('tears its own subscription down when the streamed session exits (no listener leak)', async () => {
+    const context = { sessionManager } as unknown as IpcContext;
+    const subscriptions = new SubscriptionRegistry();
+
+    await handleReadStream(fakeRequest({ sessionId: 'sess-1', action: 'subscribe' }), fakeSession(), context, subscriptions);
+    expect(sessionManager.listenerCount('data-tap')).toBe(1);
+    expect(sessionManager.listenerCount('exit')).toBe(1);
+
+    // Exiting a DIFFERENT session leaves this subscription intact.
+    sessionManager.emit('exit', 'sess-OTHER', 0, false);
+    expect(sessionManager.listenerCount('data-tap')).toBe(1);
+
+    // Exiting the streamed session removes EVERY listener it registered, so a
+    // long-lived phone connection does not leak listeners per streamed session.
+    sessionManager.emit('exit', 'sess-1', 0, false);
+    expect(sessionManager.listenerCount('data-tap')).toBe(0);
+    expect(sessionManager.listenerCount('activity')).toBe(0);
+    expect(sessionManager.listenerCount('usage')).toBe(0);
+    expect(sessionManager.listenerCount('event')).toBe(0);
+    expect(sessionManager.listenerCount('exit')).toBe(0);
+    expect(subscriptions.has('stream:sess-1')).toBe(false);
+  });
+
+  it('data-tap for a DIFFERENT session does not push, and coalesces same-session chunks into one terminal event', async () => {
+    vi.useFakeTimers();
+    try {
+      const session = fakeSession();
+      const context = { sessionManager } as unknown as IpcContext;
+      await handleReadStream(fakeRequest({ sessionId: 'sess-1', action: 'subscribe' }), session, context, new SubscriptionRegistry());
+
+      sessionManager.emit('data-tap', 'sess-OTHER', 'ignored');
+      sessionManager.emit('data-tap', 'sess-1', 'hello ');
+      sessionManager.emit('data-tap', 'sess-1', 'world');
+      expect(session.sendMessage).not.toHaveBeenCalled();
+
+      await vi.runAllTimersAsync();
+
+      expect(session.sendMessage).toHaveBeenCalledTimes(1);
+      expect(session.sendMessage).toHaveBeenCalledWith({
+        type: 'event',
+        event: { kind: 'terminal', sessionId: 'sess-1', taskId: 'task-1', payload: { data: 'hello world' } },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a session event push also checks the transcript and pushes a delta only when the revision increased', async () => {
+    resolveTaskTranscriptMock
+      .mockResolvedValueOnce({ revision: 1, entries: ['a'] })
+      .mockResolvedValueOnce({ revision: 1, entries: ['a'] }) // unchanged revision - no second push
+      .mockResolvedValueOnce({ revision: 2, entries: ['a', 'b'] });
+    const session = fakeSession();
+    const context = { sessionManager } as unknown as IpcContext;
+    await handleReadStream(fakeRequest({ sessionId: 'sess-1', action: 'subscribe' }), session, context, new SubscriptionRegistry());
+
+    sessionManager.emit('event', 'sess-1', { type: 'tool_start' });
+    await Promise.resolve();
+    await Promise.resolve();
+    sessionManager.emit('event', 'sess-1', { type: 'tool_end' });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const transcriptPushes = (session.sendMessage as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([message]) => message.event?.kind === 'transcript',
+    );
+    expect(transcriptPushes).toHaveLength(1);
+    expect(transcriptPushes[0][0]).toEqual({
+      type: 'event',
+      event: { kind: 'transcript', sessionId: 'sess-1', taskId: 'task-1', payload: ['a'] },
+    });
+
+    sessionManager.emit('event', 'sess-1', { type: 'tool_start' });
+    await Promise.resolve();
+    await Promise.resolve();
+    const secondTranscriptPushes = (session.sendMessage as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([message]) => message.event?.kind === 'transcript',
+    );
+    expect(secondTranscriptPushes).toHaveLength(2);
+    expect(secondTranscriptPushes[1][0].event.payload).toEqual(['a', 'b']);
+  });
+});

--- a/tests/unit/mobile-bridge/send-user-message.test.ts
+++ b/tests/unit/mobile-bridge/send-user-message.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { CapabilityRequestMessage } from '@kangentic/protocol';
+import { handleSendUserMessage } from '../../../src/main/mobile-bridge/handlers/send-user-message';
+import type { IpcContext } from '../../../src/main/ipc/ipc-context';
+
+function fakeRequest(payload: Record<string, unknown>): CapabilityRequestMessage {
+  return { type: 'capability-request', requestId: 'req-1', verb: 'send-user-message', payload };
+}
+
+describe('handleSendUserMessage', () => {
+  it('rejects when the session does not exist', async () => {
+    const context = {
+      sessionManager: { getSession: vi.fn(() => undefined) },
+      terminalSubmit: { submitContent: vi.fn() },
+    } as unknown as IpcContext;
+
+    const response = await handleSendUserMessage(fakeRequest({ sessionId: 'sess-1', text: 'hello' }), context);
+    expect(response.ok).toBe(false);
+    expect(context.terminalSubmit.submitContent).not.toHaveBeenCalled();
+  });
+
+  it('delivers via the bracketed-paste submit path, not a raw PTY write', async () => {
+    const submitContent = vi.fn(() => Promise.resolve());
+    const context = {
+      sessionManager: { getSession: vi.fn(() => ({ id: 'sess-1' })) },
+      terminalSubmit: { submitContent },
+    } as unknown as IpcContext;
+
+    const response = await handleSendUserMessage(fakeRequest({ sessionId: 'sess-1', text: 'please continue' }), context);
+
+    expect(response.ok).toBe(true);
+    expect(response.payload).toEqual({ delivered: true });
+    expect(submitContent).toHaveBeenCalledWith('sess-1', 'please continue', { source: 'mobile-bridge' });
+  });
+});

--- a/tests/unit/mobile-bridge/subscription-registry.test.ts
+++ b/tests/unit/mobile-bridge/subscription-registry.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SubscriptionRegistry } from '../../../src/main/mobile-bridge/session/subscription-registry';
+
+describe('SubscriptionRegistry', () => {
+  it('set() then remove() runs the teardown exactly once', () => {
+    const registry = new SubscriptionRegistry();
+    const teardown = vi.fn();
+    registry.set('stream:sess-1', teardown);
+    expect(registry.has('stream:sess-1')).toBe(true);
+
+    registry.remove('stream:sess-1');
+    expect(teardown).toHaveBeenCalledTimes(1);
+    expect(registry.has('stream:sess-1')).toBe(false);
+  });
+
+  it('remove() on an unknown key is a no-op', () => {
+    const registry = new SubscriptionRegistry();
+    expect(() => registry.remove('nope')).not.toThrow();
+  });
+
+  it('re-subscribing under the same key tears down the prior subscription instead of leaking it', () => {
+    const registry = new SubscriptionRegistry();
+    const firstTeardown = vi.fn();
+    const secondTeardown = vi.fn();
+
+    registry.set('board:proj-1', firstTeardown);
+    registry.set('board:proj-1', secondTeardown);
+
+    expect(firstTeardown).toHaveBeenCalledTimes(1);
+    expect(secondTeardown).not.toHaveBeenCalled();
+    expect(registry.keys()).toEqual(['board:proj-1']);
+  });
+
+  it('dispose() tears down every subscription and is idempotent', () => {
+    const registry = new SubscriptionRegistry();
+    const teardownA = vi.fn();
+    const teardownB = vi.fn();
+    registry.set('stream:a', teardownA);
+    registry.set('diff:b', teardownB);
+
+    registry.dispose();
+    expect(teardownA).toHaveBeenCalledTimes(1);
+    expect(teardownB).toHaveBeenCalledTimes(1);
+    expect(registry.keys()).toEqual([]);
+
+    // Calling dispose again must not re-run already-torn-down teardowns.
+    registry.dispose();
+    expect(teardownA).toHaveBeenCalledTimes(1);
+    expect(teardownB).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/mobile-bridge/verbs-parity.test.ts
+++ b/tests/unit/mobile-bridge/verbs-parity.test.ts
@@ -1,0 +1,19 @@
+/**
+ * src/shared/types.ts is deliberately import-free, so MOBILE_CAPABILITY_VERBS
+ * hand-mirrors @kangentic/protocol's CAPABILITY_VERBS rather than importing
+ * it (see the comment on MOBILE_CAPABILITY_VERBS). This test is the
+ * mechanical guard against that mirror drifting: a verb added to one tuple
+ * without the other fails here instead of surfacing as a silent runtime gap
+ * between what the desktop bridge can grant and what the renderer/IPC layer
+ * can express.
+ */
+import { describe, it, expect } from 'vitest';
+import { CAPABILITY_VERBS } from '@kangentic/protocol';
+import { MOBILE_CAPABILITY_VERBS } from '../../../src/shared/types';
+
+describe('mobile capability verb parity', () => {
+  it('MOBILE_CAPABILITY_VERBS matches @kangentic/protocol CAPABILITY_VERBS exactly', () => {
+    expect(new Set(MOBILE_CAPABILITY_VERBS)).toEqual(new Set(CAPABILITY_VERBS));
+    expect(MOBILE_CAPABILITY_VERBS.length).toBe(CAPABILITY_VERBS.length);
+  });
+});

--- a/tests/unit/protocol/framing.test.ts
+++ b/tests/unit/protocol/framing.test.ts
@@ -28,12 +28,75 @@ describe('wire message framing', () => {
     expect(decodeMessage(encodeMessage(message))).toEqual(message);
   });
 
-  it('round-trips a board event message', () => {
+  it('round-trips a board event message with a taskId', () => {
     const message: BridgeMessage = {
       type: 'event',
-      event: { kind: 'board', taskId: 'abc', payload: { column: 'Done' } },
+      event: { kind: 'board', projectId: 'proj-1', taskId: 'abc', payload: { change: 'task-updated', ids: ['abc'] } },
     };
     expect(decodeMessage(encodeMessage(message))).toEqual(message);
+  });
+
+  it('round-trips a board event message with no taskId (e.g. a swimlane or backlog change)', () => {
+    const message: BridgeMessage = {
+      type: 'event',
+      event: { kind: 'board', projectId: 'proj-1', payload: { change: 'backlog-changed', ids: [] } },
+    };
+    expect(decodeMessage(encodeMessage(message))).toEqual(message);
+  });
+
+  it('rejects a board event missing projectId', () => {
+    const bytes = new TextEncoder().encode(
+      JSON.stringify({ type: 'event', event: { kind: 'board', taskId: 'abc', payload: { change: 'task-updated', ids: ['abc'] } } }),
+    );
+    expect(() => decodeMessage(bytes)).toThrow();
+  });
+
+  it('round-trips a terminal event message', () => {
+    const message: BridgeMessage = {
+      type: 'event',
+      event: { kind: 'terminal', sessionId: 'sess-1', taskId: 'task-1', payload: { data: 'hello\r\n' } },
+    };
+    expect(decodeMessage(encodeMessage(message))).toEqual(message);
+  });
+
+  it('rejects a terminal event missing taskId', () => {
+    const bytes = new TextEncoder().encode(
+      JSON.stringify({ type: 'event', event: { kind: 'terminal', sessionId: 'sess-1', payload: { data: 'x' } } }),
+    );
+    expect(() => decodeMessage(bytes)).toThrow();
+  });
+
+  it('round-trips a diff event message', () => {
+    const message: BridgeMessage = {
+      type: 'event',
+      event: { kind: 'diff', taskId: 'task-1', payload: null },
+    };
+    expect(decodeMessage(encodeMessage(message))).toEqual(message);
+  });
+
+  it('rejects a diff event missing taskId', () => {
+    const bytes = new TextEncoder().encode(JSON.stringify({ type: 'event', event: { kind: 'diff', payload: null } }));
+    expect(() => decodeMessage(bytes)).toThrow();
+  });
+
+  it('round-trips an activity event with a discriminated permission payload', () => {
+    const message: BridgeMessage = {
+      type: 'event',
+      event: {
+        kind: 'activity',
+        sessionId: 'sess-1',
+        taskId: 'task-1',
+        payload: { type: 'permission', promptId: 'sess-1:tool-9', pending: true },
+      },
+    };
+    expect(decodeMessage(encodeMessage(message))).toEqual(message);
+  });
+
+  it('rejects an unknown event kind', () => {
+    const bytes = new TextEncoder().encode(
+      JSON.stringify({ type: 'event', event: { kind: 'shell-output', taskId: 'abc', payload: {} } }),
+    );
+    expect(() => decodeMessage(bytes)).toThrow();
   });
 
   it('rejects an unknown message type', () => {

--- a/tests/unit/protocol/payloads.test.ts
+++ b/tests/unit/protocol/payloads.test.ts
@@ -1,0 +1,153 @@
+/**
+ * parseCapabilityRequestPayload() is the runtime trust boundary for every
+ * field a phone-originated capability-request supplies: framing.ts only
+ * confirms the envelope's payload is SOME JSON value, so a handler must
+ * still narrow it to its verb's concrete shape before trusting a field.
+ * These tests cover the missing-field / wrong-type / unknown-verb cases for
+ * every verb.
+ */
+import { describe, expect, it } from 'vitest';
+import { parseCapabilityRequestPayload } from '../../../packages/protocol/src/wire/payloads';
+import type { JsonValue } from '../../../packages/protocol/src/wire/messages';
+import type { CapabilityVerb } from '../../../packages/protocol/src/capabilities/verbs';
+
+describe('parseCapabilityRequestPayload', () => {
+  it('read-stream: parses a valid subscribe payload', () => {
+    const parsed = parseCapabilityRequestPayload('read-stream', { sessionId: 'sess-1', action: 'subscribe' });
+    expect(parsed).toEqual({ sessionId: 'sess-1', action: 'subscribe' });
+  });
+
+  it('read-stream: rejects a missing sessionId', () => {
+    expect(() => parseCapabilityRequestPayload('read-stream', { action: 'subscribe' })).toThrow(/sessionId/);
+  });
+
+  it('read-stream: rejects an invalid action', () => {
+    expect(() => parseCapabilityRequestPayload('read-stream', { sessionId: 'sess-1', action: 'watch' })).toThrow(/action/);
+  });
+
+  it('read-board: allows an omitted projectId', () => {
+    const parsed = parseCapabilityRequestPayload('read-board', {});
+    expect(parsed).toEqual({ projectId: undefined, action: undefined });
+  });
+
+  it('read-board: rejects a non-string projectId', () => {
+    expect(() => parseCapabilityRequestPayload('read-board', { projectId: 42 })).toThrow(/projectId/);
+  });
+
+  it('read-board: parses an unsubscribe action', () => {
+    const parsed = parseCapabilityRequestPayload('read-board', { projectId: 'p-1', action: 'unsubscribe' });
+    expect(parsed).toEqual({ projectId: 'p-1', action: 'unsubscribe' });
+  });
+
+  it('read-board: rejects an invalid action', () => {
+    expect(() => parseCapabilityRequestPayload('read-board', { action: 'watch' })).toThrow(/action/);
+  });
+
+  it('read-diff: parses a minimal valid payload', () => {
+    const parsed = parseCapabilityRequestPayload('read-diff', { taskId: 't-1', projectId: 'p-1' });
+    expect(parsed).toEqual({ taskId: 't-1', projectId: 'p-1', filePath: undefined, scope: undefined, action: undefined });
+  });
+
+  it('read-diff: parses an unsubscribe action', () => {
+    const parsed = parseCapabilityRequestPayload('read-diff', { taskId: 't-1', projectId: 'p-1', action: 'unsubscribe' });
+    expect(parsed).toEqual({ taskId: 't-1', projectId: 'p-1', filePath: undefined, scope: undefined, action: 'unsubscribe' });
+  });
+
+  it('read-diff: rejects an invalid action', () => {
+    expect(() => parseCapabilityRequestPayload('read-diff', { taskId: 't-1', projectId: 'p-1', action: 'watch' })).toThrow(/action/);
+  });
+
+  it('read-diff: rejects an invalid scope', () => {
+    expect(() =>
+      parseCapabilityRequestPayload('read-diff', { taskId: 't-1', projectId: 'p-1', scope: 'everything' }),
+    ).toThrow(/scope/);
+  });
+
+  it('read-diff: rejects a missing taskId', () => {
+    expect(() => parseCapabilityRequestPayload('read-diff', { projectId: 'p-1' })).toThrow(/taskId/);
+  });
+
+  it('send-user-message: rejects a missing text', () => {
+    expect(() => parseCapabilityRequestPayload('send-user-message', { sessionId: 'sess-1' })).toThrow(/text/);
+  });
+
+  it('move-task: rejects a non-number targetPosition', () => {
+    expect(() =>
+      parseCapabilityRequestPayload('move-task', {
+        taskId: 't-1',
+        targetSwimlaneId: 'lane-1',
+        targetPosition: '0',
+        projectId: 'p-1',
+      }),
+    ).toThrow(/targetPosition/);
+  });
+
+  it('move-task: parses a valid payload', () => {
+    const parsed = parseCapabilityRequestPayload('move-task', {
+      taskId: 't-1',
+      targetSwimlaneId: 'lane-1',
+      targetPosition: 2,
+      projectId: 'p-1',
+    });
+    expect(parsed).toEqual({ taskId: 't-1', targetSwimlaneId: 'lane-1', targetPosition: 2, projectId: 'p-1' });
+  });
+
+  it('answer-permission-prompt: rejects a missing promptId', () => {
+    expect(() =>
+      parseCapabilityRequestPayload('answer-permission-prompt', { sessionId: 'sess-1', keystrokes: '1\r' }),
+    ).toThrow(/promptId/);
+  });
+
+  it('answer-permission-prompt: parses a valid payload', () => {
+    const parsed = parseCapabilityRequestPayload('answer-permission-prompt', {
+      sessionId: 'sess-1',
+      promptId: 'sess-1:tool-9',
+      keystrokes: '1\r',
+    });
+    expect(parsed).toEqual({ sessionId: 'sess-1', promptId: 'sess-1:tool-9', keystrokes: '1\r' });
+  });
+
+  it('interactive-terminal: rejects a missing data field', () => {
+    expect(() => parseCapabilityRequestPayload('interactive-terminal', { sessionId: 'sess-1' })).toThrow(/data/);
+  });
+
+  it('interactive-terminal: parses a valid payload', () => {
+    const parsed = parseCapabilityRequestPayload('interactive-terminal', { sessionId: 'sess-1', data: 'ls\r' });
+    expect(parsed).toEqual({ sessionId: 'sess-1', data: 'ls\r' });
+  });
+
+  it('board-tool-read: rejects a missing tool', () => {
+    expect(() => parseCapabilityRequestPayload('board-tool-read', { params: {} })).toThrow(/tool/);
+  });
+
+  it('board-tool-read: parses a valid payload (tool is an internal commandHandlers key, not an MCP tool name)', () => {
+    const parsed = parseCapabilityRequestPayload('board-tool-read', { tool: 'search_tasks', params: { query: 'flaky test' } });
+    expect(parsed).toEqual({ tool: 'search_tasks', params: { query: 'flaky test' } });
+  });
+
+  it('board-tool-write: shares the same shape as board-tool-read', () => {
+    const parsed = parseCapabilityRequestPayload('board-tool-write', { tool: 'update_task', params: {} });
+    expect(parsed).toEqual({ tool: 'update_task', params: {} });
+  });
+
+  it('rejects a non-object payload for every verb', () => {
+    expect(() => parseCapabilityRequestPayload('read-board', 'not-an-object' as unknown as JsonValue)).toThrow();
+    expect(() => parseCapabilityRequestPayload('move-task', null as unknown as JsonValue)).toThrow();
+  });
+
+  it('rejects an array payload (an array is not a record, even for the all-optional read-board shape)', () => {
+    // read-board's fields are all optional, so an array payload would slip
+    // through the "list projects" branch unless isRecord excludes arrays.
+    expect(() => parseCapabilityRequestPayload('read-board', [] as unknown as JsonValue)).toThrow();
+    expect(() => parseCapabilityRequestPayload('board-tool-read', [] as unknown as JsonValue)).toThrow();
+  });
+
+  it('throws for an unrecognized verb rather than silently passing through', () => {
+    // In production framing.ts's decodeMessage already rejects an unknown
+    // verb before a request reaches this parser (see framing.test.ts);
+    // this exercises the exhaustiveness default branch directly as
+    // defense in depth.
+    const unrecognizedVerb = 'delete-everything' as unknown as CapabilityVerb;
+    expect(() => parseCapabilityRequestPayload(unrecognizedVerb, {})).toThrow(/Unknown capability verb/);
+  });
+});

--- a/tests/unit/protocol/slot.test.ts
+++ b/tests/unit/protocol/slot.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { deriveSessionSlotId } from '../../../packages/protocol/src/crypto/slot';
+import { generateX25519KeyPair } from '../../../packages/protocol/src/crypto/primitives';
+
+describe('deriveSessionSlotId', () => {
+  it('is deterministic across calls for the same key pair', () => {
+    const desktop = generateX25519KeyPair();
+    const phone = generateX25519KeyPair();
+    const first = deriveSessionSlotId(desktop.publicKey, phone.publicKey);
+    const second = deriveSessionSlotId(desktop.publicKey, phone.publicKey);
+    expect(first).toBe(second);
+  });
+
+  it('argument order matters, which is why both peers must agree on desktop-first', () => {
+    // Both peers know both static keys from the pairing roster, so each side
+    // always calls deriveSessionSlotId(desktopKey, phoneKey) - desktop
+    // first, regardless of which side is calling. If the function were
+    // order-independent this convention would not matter; it is not, so
+    // both sides genuinely have to agree on the ordering.
+    const desktop = generateX25519KeyPair();
+    const phone = generateX25519KeyPair();
+    const desktopFirst = deriveSessionSlotId(desktop.publicKey, phone.publicKey);
+    const phoneFirst = deriveSessionSlotId(phone.publicKey, desktop.publicKey);
+    expect(desktopFirst).not.toBe(phoneFirst);
+  });
+
+  it('produces a distinct slot id for a distinct phone key', () => {
+    const desktop = generateX25519KeyPair();
+    const phoneA = generateX25519KeyPair();
+    const phoneB = generateX25519KeyPair();
+    expect(deriveSessionSlotId(desktop.publicKey, phoneA.publicKey)).not.toBe(
+      deriveSessionSlotId(desktop.publicKey, phoneB.publicKey),
+    );
+  });
+
+  it('produces a distinct slot id for a distinct desktop key', () => {
+    const desktopA = generateX25519KeyPair();
+    const desktopB = generateX25519KeyPair();
+    const phone = generateX25519KeyPair();
+    expect(deriveSessionSlotId(desktopA.publicKey, phone.publicKey)).not.toBe(
+      deriveSessionSlotId(desktopB.publicKey, phone.publicKey),
+    );
+  });
+
+  it('returns a 32-character lowercase hex string (16 bytes)', () => {
+    const desktop = generateX25519KeyPair();
+    const phone = generateX25519KeyPair();
+    const slotId = deriveSessionSlotId(desktop.publicKey, phone.publicKey);
+    expect(slotId).toMatch(/^[0-9a-f]{32}$/);
+  });
+});

--- a/tests/unit/register-all-idempotency.test.ts
+++ b/tests/unit/register-all-idempotency.test.ts
@@ -191,12 +191,14 @@ vi.mock('../../src/main/ipc/handlers/mobile-bridge', () => ({
 // work (the real class already covers that in mobile-bridge-service.test.ts).
 const mobileBridgeReconcileSpy = vi.fn();
 const mobileBridgeDisposeSpy = vi.fn();
+const mobileBridgeAttachContextSpy = vi.fn();
 vi.mock('../../src/main/mobile-bridge/mobile-bridge-service', () => ({
   MobileBridgeService: class {
     config: unknown;
     constructor(config: unknown) {
       this.config = config;
     }
+    attachContext = mobileBridgeAttachContextSpy;
     reconcile = mobileBridgeReconcileSpy;
     dispose = mobileBridgeDisposeSpy;
     on = vi.fn();
@@ -262,6 +264,11 @@ describe('registerAllIpc idempotency', () => {
     expect(mobileBridgeReconcileSpy).toHaveBeenCalledTimes(1);
     expect(mobileBridgeReconcileSpy).toHaveBeenCalledWith({ enabled: false, relayUrl: '' });
 
+    // attachContext() wires the capability-verb handlers and must run once,
+    // before reconcile() (which drives syncSessions()) so the first sync has
+    // handlers to route into.
+    expect(mobileBridgeAttachContextSpy).toHaveBeenCalledTimes(1);
+
     // Context is initialized (wrappers don't throw)
     expect(() => getSessionManager()).not.toThrow();
   }, 30000);
@@ -322,6 +329,10 @@ describe('registerAllIpc idempotency', () => {
     // macOS must not construct a second MobileBridgeService (which would
     // hold a second relay connection) nor re-run reconcile() a second time.
     expect(mobileBridgeReconcileSpy).toHaveBeenCalledTimes(1);
+    // Nor re-run attachContext() - re-registering the same verb on the
+    // router a second time would be a correctness bug even if the mock
+    // doesn't throw the way a real double-registration might.
+    expect(mobileBridgeAttachContextSpy).toHaveBeenCalledTimes(1);
   }, 30000);
 
   it('second call preserves existing services', async () => {

--- a/tests/unit/session-manager-data-tap.test.ts
+++ b/tests/unit/session-manager-data-tap.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for the 'data-tap' unfiltered PTY output event added to
+ * SessionManager for the mobile bridge (see session-manager.ts's onFlush
+ * callback). The load-bearing property: 'data-tap' fires for EVERY
+ * session's output regardless of renderer focus, unlike 'data' - which is
+ * gated to focusedSessionIds - and it must not feed the renderer's
+ * backpressure accounting, since that protocol exists only for the
+ * focused-tab drain handshake a bridge subscriber never participates in.
+ *
+ * Follows the same mock-pty harness as session-manager.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock('../../src/main/pty/spawn/shell-resolver', () => {
+  class MockShellResolver {
+    async getDefaultShell() { return '/bin/bash'; }
+  }
+  return { ShellResolver: MockShellResolver };
+});
+
+vi.mock('../../src/shared/paths', () => ({
+  adaptCommandForShell: (cmd: string) => cmd,
+  isUncPath: (p: string) => /^[\\/]{2}[^\\/]/.test(p),
+}));
+
+vi.mock('../../src/main/analytics/analytics', () => ({
+  trackEvent: vi.fn(),
+  sanitizeErrorMessage: (message: string) => message,
+}));
+
+import * as pty from 'node-pty';
+import { SessionManager } from '../../src/main/pty/session-manager';
+
+let tmpDir: string;
+
+function createMockPty() {
+  let dataHandler: ((data: string) => void) | null = null;
+  let exitHandler: ((e: { exitCode: number }) => void) | null = null;
+
+  const mockPty = {
+    pid: 12345,
+    cols: 120,
+    rows: 30,
+    onData: vi.fn((cb: (data: string) => void) => {
+      dataHandler = cb;
+    }),
+    onExit: vi.fn((cb: (e: { exitCode: number }) => void) => {
+      exitHandler = cb;
+    }),
+    write: vi.fn(),
+    resize: vi.fn((cols: number, rows: number) => {
+      mockPty.cols = cols;
+      mockPty.rows = rows;
+    }),
+    kill: vi.fn(() => {
+      if (exitHandler) setTimeout(() => exitHandler!({ exitCode: 0 }), 0);
+    }),
+  };
+
+  return {
+    mockPty,
+    feedData: (data: string) => dataHandler?.(data),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kangentic-session-data-tap-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('SessionManager data-tap', () => {
+  let manager: SessionManager;
+  let spawnedSessionId: string | null = null;
+
+  beforeEach(() => {
+    manager = new SessionManager();
+  });
+
+  afterEach(async () => {
+    if (spawnedSessionId) {
+      await manager.suspend(spawnedSessionId);
+      spawnedSessionId = null;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  });
+
+  async function spawnSession(taskId: string) {
+    const mock = createMockPty();
+    vi.mocked(pty.spawn).mockReturnValue(mock.mockPty as unknown as pty.IPty);
+    const session = await manager.spawn({ taskId, command: '', cwd: tmpDir });
+    spawnedSessionId = session.id;
+    return { session, ...mock };
+  }
+
+  it('fires for an unfocused session, where "data" does not', async () => {
+    const { session, feedData } = await spawnSession('task-data-tap-unfocused');
+    // Focus a DIFFERENT session, so this one is explicitly excluded.
+    manager.setFocusedSessions(['some-other-session-id']);
+
+    const dataTapListener = vi.fn();
+    const dataListener = vi.fn();
+    manager.on('data-tap', dataTapListener);
+    manager.on('data', dataListener);
+
+    feedData('hello from a background session');
+    // PtyBufferManager flushes on a 16ms timer, not synchronously on onData.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(dataTapListener).toHaveBeenCalledWith(session.id, 'hello from a background session');
+    expect(dataListener).not.toHaveBeenCalled();
+  });
+
+  it('does not feed the focused-session backpressure accounting for an unfocused session', async () => {
+    const { session, feedData } = await spawnSession('task-data-tap-backpressure');
+    manager.setFocusedSessions(['some-other-session-id']);
+
+    feedData('x'.repeat(1024));
+    // PtyBufferManager flushes on a 16ms timer; wait for it to actually run
+    // so this assertion covers the flushed state, not just the pre-flush
+    // window where inFlightBytes would trivially still read 0.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const stats = manager.getPipelineStats().find((entry) => entry.sessionId === session.id);
+    expect(stats?.inFlightBytes).toBe(0);
+  });
+
+  it('still fires alongside "data" for a focused session (unfiltered means "in addition to", not "instead of")', async () => {
+    const { session, feedData } = await spawnSession('task-data-tap-focused');
+    // Empty set means "all focused" (session-manager.ts's documented default),
+    // so no explicit setFocusedSessions call is needed here.
+
+    const dataTapListener = vi.fn();
+    const dataListener = vi.fn();
+    manager.on('data-tap', dataTapListener);
+    manager.on('data', dataListener);
+
+    feedData('hello from a focused session');
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(dataTapListener).toHaveBeenCalledWith(session.id, 'hello from a focused session');
+    expect(dataListener).toHaveBeenCalledWith(session.id, 'hello from a focused session');
+  });
+});


### PR DESCRIPTION
## What

Implements Bridge Phase 2 (data feeds, interactive control & capabilities) for the Kangentic mobile companion app, on top of Bridge Phase 1's protocol/pairing/transport foundation. Every capability verb now has a live handler wired to a real desktop data source instead of the deny-by-default router having nothing registered.

- **Protocol package** (`packages/protocol/`): `interactive-terminal`, `board-tool-read`, `board-tool-write` verbs; per-verb request/response payload types with runtime parse guards; new `terminal`/`diff` event kinds; a project-keyed `BoardEvent` reshape; a per-kind rewrite of the event validator; `deriveSessionSlotId` for the ongoing-session relay slot.
- **Desktop bridge** (`src/main/mobile-bridge/`): `MobileBridgeService.attachContext()` + `syncSessions()` open one live `BridgeSession` per roster device and route capability requests through `CapabilityRouter.dispatch()`. All 9 capability-verb handlers (`handlers/`): `read-stream`, `read-board`, `read-diff`, `send-user-message`, `move-task`, `answer-permission-prompt`, `interactive-terminal`, `board-tool-read`, `board-tool-write`.
- **`answer-permission-prompt`** binds a response to a synthesized, live outstanding prompt id, rejecting stale/replayed answers.
- **`board-tool-read`/`board-tool-write`** route directly into the same `commandHandlers` registry the MCP server uses - not the MCP protocol itself (no agent/LLM/JSON-RPC round-trip anywhere in the path). `move_task`/`list_tasks`/`list_columns`/`list_backlog` are excluded from that surface in favor of the dedicated `move-task`/`read-board` verbs, so there's exactly one path per capability.
- A consolidated `BoardEventBus` (`IpcContext.boardEvents`), fed additively alongside the existing renderer `*_BY_AGENT` pushes.
- `SessionManager` gains an unfiltered `data-tap` event (fires for every session's output regardless of renderer focus) for `read-stream`'s live terminal feed.
- Per-device capability-granting toggles in the Mobile Devices settings tab.
- `docs/mobile-bridge.md` and `docs/architecture.md` updated to describe the shipped surface.

## Why

Bridge Phase 1 shipped identity, pairing, roster, and secure transport, but the capability router had zero registered handlers - a paired phone could authenticate but not actually do anything. This phase makes the bridge functional: read live terminal output and conversation, drive an interactive terminal, steer agents, answer permission prompts, view diffs, and use the board/task surface, all from a paired phone.

## How

Every handler reuses the same desktop engine the renderer/IPC layer already uses (`handleTaskMove`, `SessionManager.write`/`getScrollback`, the same repositories, the same `commandHandlers` registry) rather than reimplementing business logic - only the wire format and the authorization layer (deny-by-default per-verb capability grants) are new, since IPC's `ipcMain`/`ipcRenderer` is a same-process API that cannot reach a phone at all and was never designed for an untrusted-until-paired remote caller.

Mid-review, the original `mcp-read`/`mcp-write` verb names were renamed to `board-tool-read`/`board-tool-write` and clarified as NOT the MCP protocol (they were confusingly named after MCP despite involving no agent/LLM/JSON-RPC), and `move_task`/`list_tasks`/`list_columns`/`list_backlog` were excluded from that surface since the dedicated `move-task`/`read-board` verbs already cover them with a cleaner, purpose-built contract - keeping exactly one path per capability instead of two competing ones.

## Breaking changes

None (mobile bridge has no external consumers yet; `@kangentic/protocol` versions independently via `/release-protocol`).

## Tests

- 39 unit test files / ~250 tests across `packages/protocol` and `src/main/mobile-bridge` covering: per-verb payload validation, event framing per-kind, slot derivation, capability-router dispatch, all 9 handlers (happy path + auth/not-found/malformed-payload edge cases), the board-tool allowlist parity guard, `SessionManager`'s `data-tap` unfiltered emit, `BoardEventBus` direct coverage, and `MobileBridgeService`'s session-lifecycle wiring (open/close/revoke/relay-change).
- Extended UI test (`tests/ui/mobile-devices-settings.spec.ts`) for the new per-device capability toggles.
- `npm run typecheck` and `npm run lint` (`--max-warnings 0`) clean.
- CI runs the full unit/UI/E2E tiers on this PR.

Generated with [Claude Code](https://claude.com/claude-code)
