### PR TITLE
fix(stats): add toolbar top padding and fix Cost sparkline in Live

### DIFF
--- a/src/renderer/components/stats/StatsDashboardBody.tsx
+++ b/src/renderer/components/stats/StatsDashboardBody.tsx
@@ -139,7 +139,7 @@ export function StatsDashboardBody() {
 
   return (
     <>
-      <div className="flex items-center gap-3 flex-wrap px-4 pb-2 flex-shrink-0">
+      <div className="flex items-center gap-3 flex-wrap px-4 pt-3 pb-2 flex-shrink-0">
         {/* Selecting a project here views its stats without switching the
             app; the metric toggle is hidden when no agent reported cost
             (tokens is forced). */}

--- a/src/renderer/components/stats/useStatsData.ts
+++ b/src/renderer/components/stats/useStatsData.ts
@@ -177,9 +177,10 @@ export function deriveTokenSparkline(tokenSeries: TokenSeriesPoint[]): TimePoint
   }));
 }
 
-/** Sparkline input: session-derived cost per bucket (the Cost hero tile). */
-export function deriveCostSparkline(costSeries: CostSeriesPoint[]): TimePoint[] {
-  return costSeries.map((point) => ({ x: point.bucketStartMs, y: point.costUsd }));
+/** Sparkline input: turn-allocated cost per bucket (the Cost hero tile). Sourced from
+ *  tokenSeries so it populates in Live, matching the Tokens and Burn hero sparklines. */
+export function deriveCostSparkline(tokenSeries: TokenSeriesPoint[]): TimePoint[] {
+  return tokenSeries.map((point) => ({ x: point.bucketStartMs, y: point.allocatedCostUsd }));
 }
 
 /**
@@ -254,7 +255,7 @@ export function useStatsData(effectiveMetric: UsageMetricMode): StatsDerivedData
       ),
       cumulative: deriveCumulative(payload.costSeries, effectiveMetric),
       tokenSparkline: deriveTokenSparkline(payload.tokenSeries),
-      costSparkline: deriveCostSparkline(payload.costSeries),
+      costSparkline: deriveCostSparkline(payload.tokenSeries),
       byModelSlices,
       byAgentSlices: foldBreakdownForDonut(
         payload.byAgent.map((agent) => ({

--- a/tests/ui/usage-dashboard.spec.ts
+++ b/tests/ui/usage-dashboard.spec.ts
@@ -522,6 +522,64 @@ test.describe('usage dashboard', () => {
     }
   });
 
+  test('Cost hero sparkline populates in Live from turn-derived cost, not the empty session ledger', async () => {
+    // Live has no finalized costSeries yet (the session ledger only writes on
+    // completion), but tokenSeries carries turn-allocated cost as it happens.
+    // KngSparkline renders nothing for fewer than 2 points, so an empty
+    // costSeries with a populated tokenSeries is the exact real-world shape
+    // that previously left the Cost hero tile's sparkline blank in Live.
+    const liveFixture = `
+      (function () {
+        window.electronAPI.usage.__dashboardStatsFixture = function (scope, period) {
+          var now = Date.now();
+          var hour = 3600000;
+          return {
+            scope: scope,
+            period: period,
+            rangeStartMs: now - 2 * hour,
+            rangeEndMs: now,
+            bucketSizeMs: hour,
+            costBucketSizeMs: 24 * hour,
+            generatedAtMs: now,
+            kpis: {
+              totalCostUsd: 1.75, costKnown: true,
+              totalInputTokens: 4000, totalOutputTokens: 1500, totalTokens: 5500,
+              sessionCount: 1, toolCallCount: 9,
+              linesAdded: 4, linesRemoved: 1, filesChanged: 2,
+              compactionCount: 0, totalDurationMs: hour,
+              turnInputTokens: 4000, turnOutputTokens: 1500,
+              cacheCreationTokens: 0, cacheReadTokens: 0,
+              burnRateTokensPerHour: 5500, burnRateUsdPerHour: 1.75,
+            },
+            previousKpis: null,
+            tokenSeries: [
+              { bucketStartMs: now - 2 * hour, inputTokens: 2000, outputTokens: 800, cacheCreationTokens: 0, cacheReadTokens: 0, allocatedCostUsd: 1.0, turnCount: 4 },
+              { bucketStartMs: now - hour, inputTokens: 2000, outputTokens: 700, cacheCreationTokens: 0, cacheReadTokens: 0, allocatedCostUsd: 0.75, turnCount: 5 },
+            ],
+            costSeries: [],
+            byModel: [],
+            byAgent: [],
+            byEffort: [],
+          };
+        };
+      })();
+    `;
+    const { browser, page } = await launchWithState(twoProjectPreConfig() + liveFixture);
+    try {
+      await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+      // Default period on open is Live (see the first test's comment above).
+      // The Cost hero VALUE in Live is sourced from the in-memory running
+      // session aggregate, not this payload (there is no running session
+      // here, so it reads $0.00) - only the sparkline is payload-derived, so
+      // that is the one assertion this test needs.
+      await openDashboard(page);
+
+      await expect(page.locator('[data-testid="kpi-cost"] .recharts-area-area')).toBeVisible({ timeout: 10000 });
+    } finally {
+      await browser.close();
+    }
+  });
+
   test('with no project open, the dashboard opens app-wide (picker reads All Projects)', async () => {
     const noProjectPreConfig = `
       window.__mockPreConfigure(function () {

--- a/tests/unit/usage-dashboard-helpers.test.ts
+++ b/tests/unit/usage-dashboard-helpers.test.ts
@@ -31,6 +31,7 @@ import {
   OTHER_SLICE_VAR,
   UNKNOWN_SLICE_VAR,
   deriveBurnRateSeries,
+  deriveCostSparkline,
   deriveCumulative,
   deriveModelStack,
   foldBreakdownForDonut,
@@ -129,6 +130,18 @@ describe('chart series derivations', () => {
     expect(tokens[0].y).toBeCloseTo(1800);
     const cost = deriveBurnRateSeries(tokenSeries, HOUR / 12, 'cost');
     expect(cost[0].y).toBeCloseTo(6);
+  });
+
+  it('deriveCostSparkline reads allocated cost from the turn-derived series, so it populates in Live', () => {
+    const tokenSeries: TokenSeriesPoint[] = [
+      { bucketStartMs: 0, inputTokens: 100, outputTokens: 50, cacheCreationTokens: 0, cacheReadTokens: 0, allocatedCostUsd: 0.5, turnCount: 1 },
+      { bucketStartMs: 1, inputTokens: 20, outputTokens: 10, cacheCreationTokens: 0, cacheReadTokens: 0, allocatedCostUsd: 0.1, turnCount: 1 },
+    ];
+    // Live has no finalized costSeries yet, only tokenSeries; the sparkline must still populate.
+    expect(deriveCostSparkline(tokenSeries)).toEqual([
+      { x: 0, y: 0.5 },
+      { x: 1, y: 0.1 },
+    ]);
   });
 
   it('deriveCumulative produces a running sum over the cost series', () => {


### PR DESCRIPTION
## What

Two small fixes to the usage-stats dashboard (`StatsDashboardBody`, shared by both the in-app overlay and the popped-out OS window):

- The toolbar row (scope picker, Cost/Tokens toggle, period buttons) had bottom padding but no top padding, so it butted directly against the surface header's bottom border in both hosts.
- The COST hero KPI tile rendered no sparkline in the Live period, while TOTAL TOKENS and BURN RATE both did.

## Why

1. The toolbar sits flush against the header with no breathing room, in both the in-app overlay and the pop-out window.
2. TOTAL TOKENS and BURN RATE derive from `payload.tokenSeries` (turn-derived, populated in Live). COST derived from `payload.costSeries` (the finalized-session ledger, empty in Live), leaving its sparkline blank - the same reason the "Cost per day by model" and "Cumulative spend" charts show their empty state in Live.

## How

- `StatsDashboardBody.tsx`: toolbar row padding changed from `pb-2` to `pt-3 pb-2`. Single change fixes both hosts since the toolbar is shared.
- `useStatsData.ts`: `deriveCostSparkline` now takes `TokenSeriesPoint[]` and maps `point.allocatedCostUsd` instead of `CostSeriesPoint[]` / `point.costUsd` - the same field `deriveBurnRateSeries` already uses for the cost metric. The call site now passes `payload.tokenSeries` instead of `payload.costSeries`.
- This also changes what the Cost sparkline glyph shows in Today/Week/Month/All Time (turn-allocated approximate cost instead of the exact per-day ledger), now consistent with Burn Rate. The KPI total value and the detailed cost charts still read the exact `costSeries` ledger - only the small trend glyph changed.

## Breaking changes

None.

## Tests

- `tests/unit/usage-dashboard-helpers.test.ts`: new unit test pinning that `deriveCostSparkline` maps `allocatedCostUsd` from the turn-derived series.
- `tests/ui/usage-dashboard.spec.ts`: new UI-tier test exercising the real-world Live shape (empty `costSeries`, populated `tokenSeries`) and asserting the Cost hero tile's sparkline renders. Red-green verified against the pre-fix wiring.
- Full `usage-dashboard.spec.ts` suite (15 tests) passes locally with no regressions.

Generated with [Claude Code](https://claude.com/claude-code)
