### PR TITLE
fix(stats): fill the two empty cost cards in the Usage Live view

### DIFF
--- a/scripts/seed-usage-data.js
+++ b/scripts/seed-usage-data.js
@@ -22,9 +22,11 @@
  * Options: --days N (default 14), --config-dir <path> (default per-OS kangentic dir),
  *          --seed N (PRNG seed, default 42 - reruns are deterministic).
  *
- * The last seeded "session" of today ends within the trailing 2 hours so the
- * Live range has data too. Safe to run while the app is open (WAL); the
- * dashboard's poll picks the rows up within ~30s, or switch ranges to refetch.
+ * A dense trailing-2h block tiles several short sessions across the full live
+ * window so the Live range's per-bucket and cumulative charts have data across
+ * most buckets, not just one thin tail session. Safe to run while the app is
+ * open (WAL); the dashboard's poll picks the rows up within ~30s, or switch
+ * ranges to refetch.
  *
  * NOTE: open the project in the app at least once after updating Kangentic so
  * migrations have added the usage_history.agent column; the script refuses to
@@ -64,6 +66,9 @@ function parseArgs(argv) {
   }
   return args;
 }
+
+/** Trailing live window, mirrors LIVE_WINDOW_MS in src/main/usage-stats/bucketing.ts. */
+const LIVE_WINDOW_MS = 120 * 60_000;
 
 /** Deterministic PRNG (mulberry32) so reruns produce identical data. */
 function makeRandom(seed) {
@@ -150,6 +155,60 @@ function seedProject(configDir, project, days, random) {
     let turnCounter = 0;
     const nowMs = Date.now();
 
+    // Writes one session's turns + its usage_history row. Shared by the daily
+    // history loop and the dense live-window block below so both feed the
+    // same two ledgers the dashboard reads.
+    function insertSeededSession(sessionId, profile, startMs, turnCount) {
+      const durationMs = turnCount * (30_000 + Math.floor(random() * 90_000));
+
+      let sessionInput = 0;
+      let sessionOutput = 0;
+      for (let turnIndex = 0; turnIndex < turnCount; turnIndex++) {
+        const ts = Math.min(startMs + Math.floor((durationMs * turnIndex) / turnCount), nowMs);
+        const inputTokens = 500 + Math.floor(random() * 6_000);
+        const outputTokens = 200 + Math.floor(random() * 2_500);
+        sessionInput += inputTokens;
+        sessionOutput += outputTokens;
+        insertTurn.run(
+          `seed-turn-${sessionId}-${turnCounter++}`,
+          null,
+          sessionId,
+          null,
+          profile.modelId,
+          ts,
+          inputTokens,
+          outputTokens,
+          Math.floor(inputTokens * 0.4),
+          Math.floor(inputTokens * (8 + random() * 10)),
+          new Date(ts).toISOString(),
+        );
+      }
+
+      const totalTokens = sessionInput + sessionOutput;
+      const costUsd = (totalTokens / 1_000_000) * profile.costPerMTokens * (0.8 + random() * 0.4);
+      insertSession.run(
+        `seed-usage-row-${sessionId}`,
+        sessionId,
+        new Date(Math.min(startMs + durationMs, nowMs)).toISOString(),
+        new Date(startMs).toISOString(),
+        'main',
+        Math.round(costUsd * 10_000) / 10_000,
+        // Snapshot-style tokens: the last context window, not the cumulative sum.
+        Math.floor(sessionInput / Math.max(1, turnCount / 3)),
+        Math.floor(sessionOutput / Math.max(1, turnCount / 3)),
+        durationMs,
+        Math.floor(turnCount * (1 + random() * 2)),
+        profile.modelId,
+        profile.modelDisplayName,
+        Math.floor(random() * 400),
+        Math.floor(random() * 120),
+        Math.floor(random() * 20),
+        random() < 0.15 ? 1 : 0,
+        profile.agent,
+        pickEffort(random, profile),
+      );
+    }
+
     db.exec('BEGIN');
     try {
       for (let dayOffset = days - 1; dayOffset >= 0; dayOffset--) {
@@ -162,67 +221,31 @@ function seedProject(configDir, project, days, random) {
         for (let sessionIndex = 0; sessionIndex < sessionsToday; sessionIndex++) {
           const profile = pickProfile(random);
 
-          // Session start spread over local working hours (9:00 - 19:00);
-          // today's LAST session starts inside the trailing live window.
-          const isLiveWindowSession = dayOffset === 0 && sessionIndex === sessionsToday - 1;
+          // Session start spread over local working hours (9:00 - 19:00).
           const startHour = 9 + Math.floor(random() * 10);
-          const startMs = isLiveWindowSession
-            ? nowMs - Math.floor(random() * 60) * 60_000 - 10 * 60_000
-            : new Date(day.getFullYear(), day.getMonth(), day.getDate(), startHour, Math.floor(random() * 60)).getTime();
+          const startMs = new Date(day.getFullYear(), day.getMonth(), day.getDate(), startHour, Math.floor(random() * 60)).getTime();
           if (startMs > nowMs) continue;
           const sessionId = `seed-usage-${project.id.slice(0, 8)}-${dayOffset}-${sessionCounter++}`;
-
           const turnCount = 4 + Math.floor(random() * 20);
-          const durationMs = turnCount * (30_000 + Math.floor(random() * 90_000));
-
-          let sessionInput = 0;
-          let sessionOutput = 0;
-          for (let turnIndex = 0; turnIndex < turnCount; turnIndex++) {
-            const ts = Math.min(startMs + Math.floor((durationMs * turnIndex) / turnCount), nowMs);
-            const inputTokens = 500 + Math.floor(random() * 6_000);
-            const outputTokens = 200 + Math.floor(random() * 2_500);
-            sessionInput += inputTokens;
-            sessionOutput += outputTokens;
-            insertTurn.run(
-              `seed-turn-${sessionId}-${turnCounter++}`,
-              null,
-              sessionId,
-              null,
-              profile.modelId,
-              ts,
-              inputTokens,
-              outputTokens,
-              Math.floor(inputTokens * 0.4),
-              Math.floor(inputTokens * (8 + random() * 10)),
-              new Date(ts).toISOString(),
-            );
-          }
-
-          const totalTokens = sessionInput + sessionOutput;
-          const costUsd = (totalTokens / 1_000_000) * profile.costPerMTokens * (0.8 + random() * 0.4);
-          insertSession.run(
-            `seed-usage-row-${sessionId}`,
-            sessionId,
-            new Date(Math.min(startMs + durationMs, nowMs)).toISOString(),
-            new Date(startMs).toISOString(),
-            'main',
-            Math.round(costUsd * 10_000) / 10_000,
-            // Snapshot-style tokens: the last context window, not the cumulative sum.
-            Math.floor(sessionInput / Math.max(1, turnCount / 3)),
-            Math.floor(sessionOutput / Math.max(1, turnCount / 3)),
-            durationMs,
-            Math.floor(turnCount * (1 + random() * 2)),
-            profile.modelId,
-            profile.modelDisplayName,
-            Math.floor(random() * 400),
-            Math.floor(random() * 120),
-            Math.floor(random() * 20),
-            random() < 0.15 ? 1 : 0,
-            profile.agent,
-            pickEffort(random, profile),
-          );
+          insertSeededSession(sessionId, profile, startMs, turnCount);
         }
       }
+
+      // Dense trailing-2h live window: tile several short sessions across the
+      // full LIVE_WINDOW_MS so the Live period's per-bucket (token-type) and
+      // cumulative chart cards have data across most of the ~24 five-minute
+      // buckets, not just one thin tail session.
+      const liveSessionCount = 3;
+      const liveSliceMs = LIVE_WINDOW_MS / liveSessionCount;
+      for (let liveIndex = 0; liveIndex < liveSessionCount; liveIndex++) {
+        const profile = pickProfile(random);
+        const sliceStartMs = nowMs - LIVE_WINDOW_MS + liveIndex * liveSliceMs;
+        const startMs = Math.min(sliceStartMs + Math.floor(random() * liveSliceMs * 0.3), nowMs);
+        const sessionId = `seed-usage-${project.id.slice(0, 8)}-live-${sessionCounter++}`;
+        const turnCount = 6 + Math.floor(random() * 4);
+        insertSeededSession(sessionId, profile, startMs, turnCount);
+      }
+
       db.exec('COMMIT');
     } catch (error) {
       db.exec('ROLLBACK');

--- a/src/renderer/components/stats/StatsDashboardBody.tsx
+++ b/src/renderer/components/stats/StatsDashboardBody.tsx
@@ -100,7 +100,7 @@ export function StatsDashboardBody() {
 
   const coldLoading = loading && !payload;
   // A drill or custom window bounds its own range, so live-specific
-  // presentation (empty cost cards, the trailing-2h subtitle) does not apply.
+  // presentation (empty cost cards, token-series-derived chart data) does not apply.
   const isLivePeriod = period === 'live' && !drill && !customWindow;
   const xFormatter = useCallback(
     (ms: number) => formatBucketLabel(ms, payload?.bucketSizeMs ?? 3_600_000),
@@ -136,6 +136,21 @@ export function StatsDashboardBody() {
   const drillLabel = drill
     ? new Date(drill.dayStartMs).toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })
     : null;
+
+  // Live has no finalized costSeries, so the by-model stack and cumulative
+  // cards fall back to tokenSeries-derived data (populated in Live).
+  const perBucketStack = isLivePeriod ? data.tokenTypeStack : data.modelStack;
+  const perBucketEmpty = isLivePeriod
+    ? perBucketStack.rows.every((row) =>
+        perBucketStack.series.every((entry) => (row[entry.key] as number) === 0))
+    : perBucketStack.rows.length === 0;
+  const cumulativePoints = isLivePeriod ? data.cumulativeFromTokens : data.cumulative;
+  const cumulativeEmpty = isLivePeriod
+    ? cumulativePoints.every((point) => point.y === 0)
+    : cumulativePoints.length === 0;
+  // Live buckets are 5 minutes wide: a click would mint a bogus day drill on
+  // a 5-minute boundary, so neither Live card is drillable.
+  const canDrillTimeCards = !isLivePeriod && canDrillCostBuckets;
 
   return (
     <>
@@ -199,16 +214,16 @@ export function StatsDashboardBody() {
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
           <ChartCard
-            title={`${effectiveMetric === 'cost' ? 'Cost' : 'Tokens'} per ${costBucketNoun} by model`}
+            title={isLivePeriod ? 'Tokens by type' : `${effectiveMetric === 'cost' ? 'Cost' : 'Tokens'} per ${costBucketNoun} by model`}
             loading={coldLoading}
-            empty={!coldLoading && data.modelStack.rows.length === 0}
-            emptyMessage={isLivePeriod ? 'Totals per hour/day appear in Today / Week / Month / All Time' : 'No usage recorded yet'}
+            empty={!coldLoading && perBucketEmpty}
+            emptyMessage={isLivePeriod ? 'No agent turns recorded in the last 2 hours' : 'No usage recorded yet'}
             testId="chart-daily"
           >
             <div className="h-full flex flex-col">
-              {data.modelStack.series.length > 1 && (
+              {perBucketStack.series.length > 1 && (
                 <div className="flex flex-wrap gap-x-3 gap-y-0.5 mb-1 flex-shrink-0" data-testid="chart-daily-legend">
-                  {data.modelStack.series.map((entry) => (
+                  {perBucketStack.series.map((entry) => (
                     <span key={entry.key} className="flex items-center gap-1 text-[11px] text-fg-muted">
                       <span
                         aria-hidden
@@ -222,11 +237,11 @@ export function StatsDashboardBody() {
               )}
               <div className="flex-1 min-h-0">
                 <KngBarChart
-                  series={data.modelStack.series}
-                  rows={data.modelStack.rows}
-                  yFormatter={yFormatter}
-                  ariaLabel={`${metricNoun} per ${costBucketNoun}, stacked by model`}
-                  onBucketClick={canDrillCostBuckets ? handleDrillDay : undefined}
+                  series={perBucketStack.series}
+                  rows={perBucketStack.rows}
+                  yFormatter={isLivePeriod ? formatTokenCount : yFormatter}
+                  ariaLabel={isLivePeriod ? 'tokens per 5 minutes, stacked by token type' : `${metricNoun} per ${costBucketNoun}, stacked by model`}
+                  onBucketClick={canDrillTimeCards ? handleDrillDay : undefined}
                   animate={animateCharts}
                 />
               </div>
@@ -236,18 +251,24 @@ export function StatsDashboardBody() {
           <ChartCard
             title={effectiveMetric === 'cost' ? 'Cumulative spend' : 'Cumulative tokens'}
             loading={coldLoading}
-            empty={!coldLoading && data.cumulative.length === 0}
-            emptyMessage={isLivePeriod ? 'Cumulative totals appear in Today / Week / Month / All Time' : 'No usage recorded yet'}
+            empty={!coldLoading && cumulativeEmpty}
+            emptyMessage={
+              isLivePeriod
+                ? effectiveMetric === 'cost'
+                  ? 'No spend recorded in the last 2 hours'
+                  : 'No tokens recorded in the last 2 hours'
+                : 'No usage recorded yet'
+            }
             testId="chart-cumulative"
           >
             <KngLineAreaChart
-              points={data.cumulative}
+              points={cumulativePoints}
               colorVar="--kng-accent"
               yFormatter={yFormatter}
-              xFormatter={costXFormatter}
+              xFormatter={isLivePeriod ? xFormatter : costXFormatter}
               seriesLabel={`cumulative ${metricNoun}`}
               ariaLabel={`Cumulative ${metricNoun} over the selected range`}
-              onBucketClick={canDrillCostBuckets ? handleDrillDay : undefined}
+              onBucketClick={canDrillTimeCards ? handleDrillDay : undefined}
               animate={animateCharts}
             />
           </ChartCard>
@@ -285,7 +306,6 @@ export function StatsDashboardBody() {
 
         <ChartCard
           title={`Burn rate (${metricNoun}/hr)`}
-          subtitle={isLivePeriod ? 'Trailing 2 hours, 5-minute buckets' : undefined}
           loading={coldLoading}
           empty={!coldLoading && data.burnRate.every((point) => point.y === 0)}
           emptyMessage="No agent turns recorded in this range"

--- a/src/renderer/components/stats/StatsDashboardBody.tsx
+++ b/src/renderer/components/stats/StatsDashboardBody.tsx
@@ -14,7 +14,7 @@ import { StatsScopePicker } from './StatsScopePicker';
 import { useWindowResizing } from '../../hooks/useWindowResizing';
 import { KngLineAreaChart } from './charts/KngLineAreaChart';
 import { KngBarChart } from './charts/KngBarChart';
-import { formatBucketLabel, useStatsData } from './useStatsData';
+import { formatBucketLabel, isModelStackEmpty, useStatsData } from './useStatsData';
 
 /** Poll cadence while the page is visible (live watches the trailing window). */
 const LIVE_POLL_MS = 15_000;
@@ -141,8 +141,7 @@ export function StatsDashboardBody() {
   // cards fall back to tokenSeries-derived data (populated in Live).
   const perBucketStack = isLivePeriod ? data.tokenTypeStack : data.modelStack;
   const perBucketEmpty = isLivePeriod
-    ? perBucketStack.rows.every((row) =>
-        perBucketStack.series.every((entry) => (row[entry.key] as number) === 0))
+    ? isModelStackEmpty(perBucketStack)
     : perBucketStack.rows.length === 0;
   const cumulativePoints = isLivePeriod ? data.cumulativeFromTokens : data.cumulative;
   const cumulativeEmpty = isLivePeriod

--- a/src/renderer/components/stats/useStatsData.ts
+++ b/src/renderer/components/stats/useStatsData.ts
@@ -169,6 +169,50 @@ export function deriveCumulative(
   });
 }
 
+/** Running sum over the turn-derived token series, so the Cumulative card
+ *  populates in Live where costSeries (and thus `deriveCumulative`) is empty. */
+export function deriveCumulativeFromTokenSeries(
+  tokenSeries: TokenSeriesPoint[],
+  metric: UsageMetricMode,
+): TimePoint[] {
+  let runningTotal = 0;
+  return tokenSeries.map((point) => {
+    runningTotal += metric === 'cost' ? point.allocatedCostUsd : point.inputTokens + point.outputTokens;
+    return { x: point.bucketStartMs, y: runningTotal };
+  });
+}
+
+/**
+ * Per-bucket TOKEN-TYPE stack (input / output / cache read / cache write) in
+ * the ModelStack shape, so KngBarChart renders it unchanged. Used for the
+ * Live per-bucket card, where per-model cost splits are unavailable; this is
+ * always a tokens view regardless of the cost/tokens toggle.
+ */
+export function deriveTokenTypeStack(
+  tokenSeries: TokenSeriesPoint[],
+  formatLabel: (bucketStartMs: number) => string,
+): ModelStack {
+  // Slot 6 (not the sequential slot 4) for Cache write: slot 4 is also a
+  // green and sits alongside slot 2 (Output) with only a floor-band CVD
+  // separation (validated via the dataviz palette validator); slot 6 (red)
+  // clears CVD separation cleanly on every theme with no other slot reused.
+  const series: ModelStackSeries[] = [
+    { key: 'stack0', label: 'Input', colorVar: CHART_SLOT_VARS[0] },
+    { key: 'stack1', label: 'Output', colorVar: CHART_SLOT_VARS[1] },
+    { key: 'stack2', label: 'Cache read', colorVar: CHART_SLOT_VARS[2] },
+    { key: 'stack3', label: 'Cache write', colorVar: CHART_SLOT_VARS[5] },
+  ];
+  const rows: ModelStackRow[] = tokenSeries.map((point) => ({
+    x: point.bucketStartMs,
+    label: formatLabel(point.bucketStartMs),
+    stack0: point.inputTokens,
+    stack1: point.outputTokens,
+    stack2: point.cacheReadTokens,
+    stack3: point.cacheCreationTokens,
+  }));
+  return { series, rows };
+}
+
 /** Sparkline input: total tokens per bucket. */
 export function deriveTokenSparkline(tokenSeries: TokenSeriesPoint[]): TimePoint[] {
   return tokenSeries.map((point) => ({
@@ -208,6 +252,10 @@ export interface StatsDerivedData {
   /** Stacked-by-model daily bars (colors/ranking shared with the donut). */
   modelStack: ModelStack;
   cumulative: TimePoint[];
+  /** Cumulative running sum from tokenSeries, for the Live card (costSeries empty). */
+  cumulativeFromTokens: TimePoint[];
+  /** Per-bucket token-type stack for the Live per-bucket card (ModelStack shape). */
+  tokenTypeStack: ModelStack;
   tokenSparkline: TimePoint[];
   costSparkline: TimePoint[];
   byModelSlices: DonutSlice[];
@@ -228,6 +276,8 @@ export function useStatsData(effectiveMetric: UsageMetricMode): StatsDerivedData
         burnRate: [],
         modelStack: { series: [], rows: [] },
         cumulative: [],
+        cumulativeFromTokens: [],
+        tokenTypeStack: { series: [], rows: [] },
         tokenSparkline: [],
         costSparkline: [],
         byModelSlices: [],
@@ -254,6 +304,11 @@ export function useStatsData(effectiveMetric: UsageMetricMode): StatsDerivedData
         (bucketStartMs) => formatBucketLabel(bucketStartMs, payload.costBucketSizeMs),
       ),
       cumulative: deriveCumulative(payload.costSeries, effectiveMetric),
+      cumulativeFromTokens: deriveCumulativeFromTokenSeries(payload.tokenSeries, effectiveMetric),
+      tokenTypeStack: deriveTokenTypeStack(
+        payload.tokenSeries,
+        (bucketStartMs) => formatBucketLabel(bucketStartMs, payload.bucketSizeMs),
+      ),
       tokenSparkline: deriveTokenSparkline(payload.tokenSeries),
       costSparkline: deriveCostSparkline(payload.tokenSeries),
       byModelSlices,

--- a/src/renderer/components/stats/useStatsData.ts
+++ b/src/renderer/components/stats/useStatsData.ts
@@ -213,6 +213,17 @@ export function deriveTokenTypeStack(
   return { series, rows };
 }
 
+/**
+ * True when a ModelStack's rows are all dense-zero (every series entry is 0
+ * in every row), used for the Live per-bucket card's empty-state gate. Rows
+ * are dense there (a row for every 5-minute slot even with no activity), so a
+ * length check alone would call a quiet-but-present window non-empty; this
+ * checks values, not row count. An empty `rows` array is vacuously empty too.
+ */
+export function isModelStackEmpty(stack: ModelStack): boolean {
+  return stack.rows.every((row) => stack.series.every((entry) => (row[entry.key] as number) === 0));
+}
+
 /** Sparkline input: total tokens per bucket. */
 export function deriveTokenSparkline(tokenSeries: TokenSeriesPoint[]): TimePoint[] {
   return tokenSeries.map((point) => ({

--- a/tests/ui/usage-dashboard.spec.ts
+++ b/tests/ui/usage-dashboard.spec.ts
@@ -324,8 +324,18 @@ test.describe('usage dashboard', () => {
       await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
       await openDashboard(page);
 
-      // The default fixture's cost buckets are daily, so the stacked bars are
-      // drillable. Click a bar segment.
+      // Live's per-bucket cards are never drillable (5-minute buckets), so
+      // switch to a non-Live period first. The default fixture's cost buckets
+      // are daily regardless of period, so the stacked bars stay drillable.
+      await page.locator('[data-testid="stats-period-group"] button:has-text("This Week")').click();
+      await expect
+        .poll(async () => {
+          const calls = await getCalls(page);
+          return calls[calls.length - 1]?.period ?? '';
+        }, { timeout: 5000 })
+        .toBe('week');
+
+      // Click a bar segment.
       await page.locator('[data-testid="chart-daily"] .recharts-rectangle').first().click();
 
       // Drill chip appears and the refetch carries the drill day.
@@ -577,6 +587,85 @@ test.describe('usage dashboard', () => {
       await expect(page.locator('[data-testid="kpi-cost"] .recharts-area-area')).toBeVisible({ timeout: 10000 });
     } finally {
       await browser.close();
+    }
+  });
+
+  test('Live default period disables per-bucket drilling, retitles by token type, and uses token-count empty messages', async () => {
+    // Phase 1: default (non-empty) fixture at the default Live period. The
+    // left card retitles to a token-type stack, and its bars are NOT
+    // drillable (Live buckets are 5 minutes wide, so a day drill is nonsense).
+    {
+      const { browser, page } = await launchWithState(twoProjectPreConfig());
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+        // Default period on open is Live: do not switch periods here.
+        await openDashboard(page);
+
+        await expect(page.locator('[data-testid="chart-daily"]')).toContainText('Tokens by type', { timeout: 10000 });
+
+        await page.locator('[data-testid="chart-daily"] .recharts-rectangle').first().click();
+        // Bounded negative check (no bare waitForTimeout): onBucketClick is
+        // undefined in Live, so nothing async could produce a drill chip
+        // later; the timeout budget still covers a mistaken async wiring.
+        await expect(page.locator('[data-testid="stats-drill-chip"]')).not.toBeVisible({ timeout: 2000 });
+      } finally {
+        await browser.close();
+      }
+    }
+
+    // Phase 2: an empty tokenSeries fixture (no agent turns recorded yet).
+    // Both per-bucket Live cards fall back to their tokens-aware empty
+    // message; costKnown: false forces the tokens metric so the cumulative
+    // card's empty message is the tokens variant, not the cost variant.
+    {
+      const emptyLiveFixture = `
+        (function () {
+          window.electronAPI.usage.__dashboardStatsFixture = function (scope, period) {
+            var now = Date.now();
+            var hour = 3600000;
+            return {
+              scope: scope,
+              period: period,
+              rangeStartMs: now - 2 * hour,
+              rangeEndMs: now,
+              bucketSizeMs: hour,
+              costBucketSizeMs: 86400000,
+              generatedAtMs: now,
+              kpis: {
+                totalCostUsd: 0, costKnown: false,
+                totalInputTokens: 0, totalOutputTokens: 0, totalTokens: 0,
+                sessionCount: 0, toolCallCount: 0,
+                linesAdded: 0, linesRemoved: 0, filesChanged: 0,
+                compactionCount: 0, totalDurationMs: 0,
+                turnInputTokens: 0, turnOutputTokens: 0,
+                cacheCreationTokens: 0, cacheReadTokens: 0,
+                burnRateTokensPerHour: null, burnRateUsdPerHour: null,
+              },
+              previousKpis: null,
+              tokenSeries: [],
+              costSeries: [],
+              byModel: [],
+              byAgent: [],
+              byEffort: [],
+            };
+          };
+        })();
+      `;
+      const { browser, page } = await launchWithState(twoProjectPreConfig() + emptyLiveFixture);
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+        await openDashboard(page);
+
+        await expect(page.locator('[data-testid="chart-daily"]')).toContainText(
+          'No agent turns recorded in the last 2 hours',
+          { timeout: 10000 },
+        );
+        await expect(page.locator('[data-testid="chart-cumulative"]')).toContainText(
+          'No tokens recorded in the last 2 hours',
+        );
+      } finally {
+        await browser.close();
+      }
     }
   });
 

--- a/tests/ui/usage-dashboard.spec.ts
+++ b/tests/ui/usage-dashboard.spec.ts
@@ -590,10 +590,13 @@ test.describe('usage dashboard', () => {
     }
   });
 
-  test('Live default period disables per-bucket drilling, retitles by token type, and uses token-count empty messages', async () => {
-    // Phase 1: default (non-empty) fixture at the default Live period. The
-    // left card retitles to a token-type stack, and its bars are NOT
-    // drillable (Live buckets are 5 minutes wide, so a day drill is nonsense).
+  test('Live default period fills the token-type and cumulative cards from tokenSeries, disables per-bucket drilling, and uses token-count empty messages', async () => {
+    // Phase 1: default (non-empty) fixture at the default Live period. Both
+    // cards read from tokenSeries (the bug this diff fixes: costSeries is
+    // empty in Live, so both previously rendered empty placeholders). The
+    // left card retitles to a token-type stack with its own legend, and
+    // NEITHER card is drillable (Live buckets are 5 minutes wide, so a day
+    // drill is nonsense).
     {
       const { browser, page } = await launchWithState(twoProjectPreConfig());
       try {
@@ -602,12 +605,39 @@ test.describe('usage dashboard', () => {
         await openDashboard(page);
 
         await expect(page.locator('[data-testid="chart-daily"]')).toContainText('Tokens by type', { timeout: 10000 });
+        // The legend switches from model names to the fixed token-type labels
+        // (deriveTokenTypeStack's series), the actual wiring this diff added.
+        const legend = page.locator('[data-testid="chart-daily-legend"]');
+        await expect(legend).toContainText('Input');
+        await expect(legend).toContainText('Output');
+        await expect(legend).toContainText('Cache read');
+        await expect(legend).toContainText('Cache write');
+        await expect(legend).not.toContainText('Mock Large');
 
         await page.locator('[data-testid="chart-daily"] .recharts-rectangle').first().click();
         // Bounded negative check (no bare waitForTimeout): onBucketClick is
         // undefined in Live, so nothing async could produce a drill chip
         // later; the timeout budget still covers a mistaken async wiring.
         await expect(page.locator('[data-testid="stats-drill-chip"]')).not.toBeVisible({ timeout: 2000 });
+
+        // The Cumulative card must render the tokenSeries-derived running sum
+        // (a rising area), not the empty placeholder: this is the exact card
+        // that previously stayed blank in Live.
+        const cumulativeCard = page.locator('[data-testid="chart-cumulative"]');
+        await expect(cumulativeCard).not.toContainText('recorded');
+        await expect(cumulativeCard.locator('.recharts-area-area')).toBeVisible({ timeout: 10000 });
+        // Neither Live card accepts a day drill: their chart containers never
+        // pick up the onBucketClick cursor-pointer affordance.
+        await expect(cumulativeCard.locator('[role="img"]')).not.toHaveClass(/cursor-pointer/);
+        await expect(page.locator('[data-testid="chart-daily"] [role="img"]')).not.toHaveClass(/cursor-pointer/);
+
+        // Toggling the Cost/Tokens metric while still in Live re-keys the
+        // Cumulative card's title and value source, but it must STAY
+        // populated from tokenSeries either way (not silently go empty).
+        await page.locator('[data-testid="stats-metric-group"] button:has-text("Tokens")').click();
+        await expect(cumulativeCard).toContainText('Cumulative tokens');
+        await expect(cumulativeCard).not.toContainText('recorded');
+        await expect(cumulativeCard.locator('.recharts-area-area')).toBeVisible({ timeout: 10000 });
       } finally {
         await browser.close();
       }

--- a/tests/unit/usage-dashboard-helpers.test.ts
+++ b/tests/unit/usage-dashboard-helpers.test.ts
@@ -37,7 +37,9 @@ import {
   deriveModelStack,
   deriveTokenTypeStack,
   foldBreakdownForDonut,
+  isModelStackEmpty,
   type BreakdownEntry,
+  type ModelStack,
 } from '../../src/renderer/components/stats/useStatsData';
 import type { CostSeriesPoint, TokenSeriesPoint, UsageDashboardStats } from '../../src/shared/types';
 
@@ -190,6 +192,44 @@ describe('deriveTokenTypeStack', () => {
     const stack = deriveTokenTypeStack([], (bucketStartMs) => `t${bucketStartMs}`);
     expect(stack.rows).toHaveLength(0);
     expect(stack.series).toHaveLength(4);
+  });
+});
+
+describe('isModelStackEmpty', () => {
+  // Live's per-bucket rows are DENSE (a row per 5-minute slot even with no
+  // activity), so this must check VALUES, not row count - the real-world
+  // regression this guards is a quiet-but-present window (rows exist, every
+  // value is 0) being mistaken for non-empty by a length-only check.
+  it('is true when every row is all-zero across every series entry, even with multiple present rows', () => {
+    const stack: ModelStack = {
+      series: [
+        { key: 'stack0', label: 'Input', colorVar: '--kng-chart-1' },
+        { key: 'stack1', label: 'Output', colorVar: '--kng-chart-2' },
+      ],
+      rows: [
+        { x: 0, label: 't0', stack0: 0, stack1: 0 },
+        { x: 1, label: 't1', stack0: 0, stack1: 0 },
+      ],
+    };
+    expect(isModelStackEmpty(stack)).toBe(true);
+  });
+
+  it('is false when any row has a nonzero value in any series entry', () => {
+    const stack: ModelStack = {
+      series: [
+        { key: 'stack0', label: 'Input', colorVar: '--kng-chart-1' },
+        { key: 'stack1', label: 'Output', colorVar: '--kng-chart-2' },
+      ],
+      rows: [
+        { x: 0, label: 't0', stack0: 0, stack1: 0 },
+        { x: 1, label: 't1', stack0: 0, stack1: 5 },
+      ],
+    };
+    expect(isModelStackEmpty(stack)).toBe(false);
+  });
+
+  it('is vacuously true for an empty rows array', () => {
+    expect(isModelStackEmpty({ series: [], rows: [] })).toBe(true);
   });
 });
 

--- a/tests/unit/usage-dashboard-helpers.test.ts
+++ b/tests/unit/usage-dashboard-helpers.test.ts
@@ -33,7 +33,9 @@ import {
   deriveBurnRateSeries,
   deriveCostSparkline,
   deriveCumulative,
+  deriveCumulativeFromTokenSeries,
   deriveModelStack,
+  deriveTokenTypeStack,
   foldBreakdownForDonut,
   type BreakdownEntry,
 } from '../../src/renderer/components/stats/useStatsData';
@@ -152,6 +154,42 @@ describe('chart series derivations', () => {
     ];
     expect(deriveCumulative(costSeries, 'cost').map((point) => point.y)).toEqual([1, 3, 3]);
     expect(deriveCumulative(costSeries, 'tokens').map((point) => point.y)).toEqual([15, 45, 45]);
+  });
+
+  it('deriveCumulativeFromTokenSeries sums the token series, so Cumulative populates in Live', () => {
+    const tokenSeries: TokenSeriesPoint[] = [
+      { bucketStartMs: 0, inputTokens: 10, outputTokens: 5, cacheCreationTokens: 0, cacheReadTokens: 0, allocatedCostUsd: 1, turnCount: 1 },
+      { bucketStartMs: 1, inputTokens: 20, outputTokens: 10, cacheCreationTokens: 0, cacheReadTokens: 0, allocatedCostUsd: 2, turnCount: 1 },
+      { bucketStartMs: 2, inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, allocatedCostUsd: 0, turnCount: 0 },
+    ];
+    expect(deriveCumulativeFromTokenSeries(tokenSeries, 'cost').map((point) => point.y)).toEqual([1, 3, 3]);
+    expect(deriveCumulativeFromTokenSeries(tokenSeries, 'tokens').map((point) => point.y)).toEqual([15, 45, 45]);
+    expect(deriveCumulativeFromTokenSeries(tokenSeries, 'tokens').map((point) => point.x)).toEqual([0, 1, 2]);
+  });
+});
+
+describe('deriveTokenTypeStack', () => {
+  it('stacks input / output / cache-read / cache-write per bucket in slot colors', () => {
+    const tokenSeries: TokenSeriesPoint[] = [
+      { bucketStartMs: 1000, inputTokens: 100, outputTokens: 50, cacheCreationTokens: 20, cacheReadTokens: 200, allocatedCostUsd: 0.5, turnCount: 2 },
+      { bucketStartMs: 2000, inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, allocatedCostUsd: 0, turnCount: 0 },
+    ];
+    const stack = deriveTokenTypeStack(tokenSeries, (bucketStartMs) => `t${bucketStartMs}`);
+    expect(stack.series.map((entry) => entry.label)).toEqual(['Input', 'Output', 'Cache read', 'Cache write']);
+    expect(stack.series.map((entry) => entry.colorVar)).toEqual([
+      '--kng-chart-1',
+      '--kng-chart-2',
+      '--kng-chart-3',
+      '--kng-chart-6',
+    ]);
+    expect(stack.rows[0]).toMatchObject({ x: 1000, label: 't1000', stack0: 100, stack1: 50, stack2: 200, stack3: 20 });
+    expect(stack.rows[1]).toMatchObject({ label: 't2000', stack0: 0, stack1: 0, stack2: 0, stack3: 0 });
+  });
+
+  it('stays dense and never gap-fills an empty series', () => {
+    const stack = deriveTokenTypeStack([], (bucketStartMs) => `t${bucketStartMs}`);
+    expect(stack.rows).toHaveLength(0);
+    expect(stack.series).toHaveLength(4);
   });
 });
 


### PR DESCRIPTION
## What

Fills the two chart cards in the Usage dashboard's **Live** period (trailing 2h, 5-minute buckets) that previously rendered empty placeholders:

- **"Cost/Tokens per day by model"** -> now **"Tokens by type"** in Live: a stacked bar of input / output / cache read / cache write tokens per 5-minute bucket.
- **"Cumulative spend/tokens"** -> a running sum (cost or tokens, per the metric toggle) over the trailing 2h.

Non-Live periods (Today/Week/Month/All Time/drills) are unchanged.

Also:
- Extends `scripts/seed-usage-data.js` to tile several sessions densely across the trailing 2h window (previously only one thin tail session), so `/preview` has enough Live data to exercise both cards.
- Simplifies the two Live cards' titles/subtitles (and the pre-existing Burn rate card's subtitle) to drop text the chart axes already show.
- Picks `--kng-chart-6` (not the sequential `--kng-chart-4`) for the token-type stack's "Cache write" series, validated across all 10 themes with the dataviz palette validator.

## Why

Both cards read from `payload.costSeries`, which the main process intentionally sends empty for Live (`usage-stats-service.ts`: `costStarts = live ? [] : ...`) since `costSeries` is bucketed from finalized-session snapshots at day/week granularity, meaningless inside a 2h rolling window. `payload.tokenSeries`, however, is fully populated in Live (5-minute buckets with `allocatedCostUsd`, per-type token counts). Everything else in Live already sources from `tokenSeries` (the three hero sparklines, the burn-rate chart), so this applies the same pattern to the two remaining dead cards.

## How

- `src/renderer/components/stats/useStatsData.ts`: two new pure helpers, `deriveCumulativeFromTokenSeries` (running sum over `tokenSeries`) and `deriveTokenTypeStack` (token-type stack in the existing `ModelStack` shape, so `KngBarChart` needs no changes). Also extracts `isModelStackEmpty` for the per-bucket card's dense-empty-state check.
- `src/renderer/components/stats/StatsDashboardBody.tsx`: both cards switch data source, empty-state message, and axis formatters on `isLivePeriod`, and disable day-drill (5-minute buckets can't drill into a day).
- Trade-off: the token-type stack is always a tokens view, even when the Cost/Tokens toggle is on Cost, since per-token-type cost splits don't exist. The cumulative card does respect the toggle.

## Breaking changes

None.

## Tests

- `tests/unit/usage-dashboard-helpers.test.ts`: new coverage for `deriveCumulativeFromTokenSeries`, `deriveTokenTypeStack` (including the fixed color-slot assignment), and `isModelStackEmpty` (dense-all-zero vs. dense-with-nonzero vs. vacuously-empty).
- `tests/ui/usage-dashboard.spec.ts`: extends the Live-period test to cover both cards populating from `tokenSeries`, the token-type legend rendering, drill being disabled on both cards, and the Cost/Tokens toggle keeping the cumulative card populated while in Live.
- CI: lint, typecheck, unit, UI, and E2E checks.

Generated with [Claude Code](https://claude.com/claude-code)
