### PR TITLE
fix(command-terminal): scope Changes panel state to each window

### DIFF
--- a/src/renderer/components/backlog/NewBacklogTaskDialog.tsx
+++ b/src/renderer/components/backlog/NewBacklogTaskDialog.tsx
@@ -49,7 +49,6 @@ interface NewBacklogTaskDialogProps {
 
 // Non-task sentinel key for the maximize toggle (the backlog dialog has no task
 // row). One key covers both create and edit-backlog modes; it is one surface.
-// Mirrors CommandBarOverlay's COMMAND_TERMINAL_ENTITY_ID precedent.
 const NEW_BACKLOG_TASK_ENTITY_ID = 'new-backlog-task-dialog';
 
 export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: NewBacklogTaskDialogProps) {

--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -34,6 +34,7 @@ import { FileDropOverlay } from '../terminal/FileDropOverlay';
 import { ContextBar } from '../terminal/ContextBar';
 import { useSessionStore } from '../../stores/session-store';
 import { transientKey } from '../../stores/session-store/transient-session-slice';
+import { commandTerminalChangesEntityId } from '../../stores/session-store/task-changes-panel-slice';
 import { useBoardStore } from '../../stores/board-store';
 import { useConfigStore } from '../../stores/config-store';
 import { useProjectStore } from '../../stores/project-store';
@@ -50,10 +51,6 @@ import { useCommandTerminalLayer } from './command-terminal-context';
 import { PanelErrorBoundary } from '../PanelErrorBoundary';
 
 const ChangesPanel = lazy(() => import('../dialogs/task-detail/changes/ChangesPanel').then((module) => ({ default: module.ChangesPanel })));
-
-/** The entity id the transient Command Terminal uses for its changes panel +
- *  per-entity UI flags (matches the old `CommandBarOverlay`). */
-const COMMAND_TERMINAL_ENTITY_ID = 'command-terminal';
 
 /**
  * The centered stop glyph: one small rounded square, sized + colored to sit dead
@@ -111,6 +108,10 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
   // `slot-2`, ...). It pairs the persistent window to its ephemeral PTY across
   // hide/reopen and project switches; the transient session is keyed by it.
   const slot = managedWindow.anchor;
+  // This window's own Changes-panel entity id (namespaced by slot), so the
+  // open flag and per-entity panel state (selected file, scroll, scope, ...)
+  // never leak across Command Terminal windows.
+  const commandTerminalEntityId = commandTerminalChangesEntityId(slot);
   const useStore = useLayerStore();
   const toggleMaximizeWindow = useStore((state) => state.toggleMaximizeWindow);
   const closeWindow = useStore((state) => state.closeWindow);
@@ -139,9 +140,9 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
   // Resolve to the main repo root if the current project is a worktree.
   const projectPath = useMemo(() => (rawProjectPath ? resolveProjectRoot(rawProjectPath) : null), [rawProjectPath]);
   const shortcuts = useBoardStore((s) => s.shortcuts);
-  const changesOpen = useSessionStore((s) => s.changesOpenTasks.has(COMMAND_TERMINAL_ENTITY_ID));
+  const changesOpen = useSessionStore((s) => s.changesOpenTasks.has(commandTerminalEntityId));
   const toggleChangesOpen = useSessionStore((s) => s.toggleChangesOpen);
-  const handleToggleChanges = useCallback(() => toggleChangesOpen(COMMAND_TERMINAL_ENTITY_ID), [toggleChangesOpen]);
+  const handleToggleChanges = useCallback(() => toggleChangesOpen(commandTerminalEntityId), [toggleChangesOpen, commandTerminalEntityId]);
 
   const maximizeCombo = useFormattedCombo('panel.maximize');
   const spawnedRef = useRef(false);
@@ -709,7 +710,7 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
                 }
               >
                 <ChangesPanel
-                  entityId={COMMAND_TERMINAL_ENTITY_ID}
+                  entityId={commandTerminalEntityId}
                   projectPath={projectPath}
                   baseBranch="HEAD"
                 />

--- a/src/renderer/components/dialogs/NewTaskDialog.tsx
+++ b/src/renderer/components/dialogs/NewTaskDialog.tsx
@@ -39,8 +39,7 @@ interface NewTaskDialogProps {
 }
 
 // Non-task sentinel key for the maximize toggle (the create dialog has no task
-// yet). Mirrors CommandBarOverlay's COMMAND_TERMINAL_ENTITY_ID precedent so the
-// flag lives in the same `maximizedTasks` store set and survives HMR.
+// yet), so the flag lives in the same `maximizedTasks` store set and survives HMR.
 const NEW_TASK_ENTITY_ID = 'new-task-dialog';
 
 export function NewTaskDialog({ swimlaneId, onClose }: NewTaskDialogProps) {

--- a/src/renderer/components/dialogs/dialog-maximize.tsx
+++ b/src/renderer/components/dialogs/dialog-maximize.tsx
@@ -2,12 +2,13 @@ import { Maximize2, Minimize2 } from 'lucide-react';
 import { useFormattedCombo } from '../../hooks/useKeybinding';
 
 /**
- * Shared layout + control for the dialog maximize toggle (#184). Used by the
- * Task Detail dialog (view and edit modes) and the create dialogs (New Task,
- * New Backlog Task). Maximize state is tracked in the session store's
- * `maximizedTasks` set, keyed by task id for the detail dialog and by a
- * non-task sentinel id for the create dialogs (mirroring the command
- * terminal's `COMMAND_TERMINAL_ENTITY_ID`).
+ * Shared layout + toggle button for maximizable surfaces (#184).
+ * `MaximizeToggleButton` is the generic control (used by the task-detail and
+ * conversation windows, the window title bar, and the sentinel dialogs below).
+ * `maximizedDialogLayout` pairs with the session store's `maximizedTasks` set,
+ * which is keyed by a non-task sentinel id and holds only the create dialogs
+ * (New Task, New Backlog Task) and the Edit Columns dialog. (The task-detail and
+ * Command Terminal windows maximize through the window manager, not this set.)
  */
 
 export interface MaximizedDialogLayout {

--- a/src/renderer/stores/session-store/task-changes-panel-slice.ts
+++ b/src/renderer/stores/session-store/task-changes-panel-slice.ts
@@ -55,11 +55,12 @@ export interface TaskChangesPanelSlice {
    */
   changesHistoryHeight: Record<string, number>;
   /**
-   * Entity IDs whose dialog is maximized (persists across dialog open/close).
-   * Keyed by task ID for the task detail dialog, and by a non-task sentinel id
-   * for the command terminal ('command-terminal'), the create dialogs
-   * ('new-task-dialog', 'new-backlog-task-dialog'), and the Edit Columns dialog
-   * ('board-manager-dialog').
+   * Non-task sentinel ids whose dialog is maximized (persists across dialog
+   * open/close). Holds only the create dialogs ('new-task-dialog',
+   * 'new-backlog-task-dialog') and the Edit Columns dialog
+   * ('board-manager-dialog'). The task-detail window and the Command Terminal
+   * maximize through the window manager (`toggleMaximizeWindow`), not this set,
+   * so it never holds a real task id.
    */
   maximizedTasks: Set<string>;
   /**
@@ -142,13 +143,32 @@ function buildDetailViewBlob(state: SessionStore, taskId: string): TaskDetailVie
 }
 
 /**
- * Non-task entity ids that share the Changes-panel setters (the create dialogs,
- * the Command Terminal, and the Edit Columns dialog) but have no `tasks` row to
- * persist into. They must not schedule a `detail_view_state` save: the DB UPDATE
- * would be a no-op, and the Command Terminal would otherwise emit a spurious IPC
- * write on every Changes interaction.
+ * Prefix for the Command Terminal's per-window Changes-panel entity ids. Each
+ * window/slot gets its own id (`command-terminal::slot-1`, `command-terminal::slot-2`,
+ * ...) so `changesOpenTasks` and the per-entity Changes-panel state (selected
+ * file, scroll, scope, viewed marks, tree width, history height) never leak
+ * across windows the way a single shared id used to.
  */
-const NON_TASK_DETAIL_VIEW_IDS = new Set(['new-task-dialog', 'new-backlog-task-dialog', 'command-terminal', 'board-manager-dialog']);
+const COMMAND_TERMINAL_ENTITY_PREFIX = 'command-terminal';
+
+/** Build a Command Terminal window's own Changes-panel entity id from its durable slot id. */
+export function commandTerminalChangesEntityId(slot: string): string {
+  return `${COMMAND_TERMINAL_ENTITY_PREFIX}::${slot}`;
+}
+
+/**
+ * Non-task entity ids that share the Changes-panel setters (the create dialogs
+ * and the Edit Columns dialog) but have no `tasks` row to persist into, plus
+ * every Command Terminal window id (`command-terminal::<slot>`). They must not
+ * schedule a `detail_view_state` save: the DB UPDATE would be a no-op, and the
+ * Command Terminal would otherwise emit a spurious IPC write on every Changes
+ * interaction.
+ */
+const NON_TASK_DETAIL_VIEW_IDS = new Set(['new-task-dialog', 'new-backlog-task-dialog', 'board-manager-dialog']);
+
+function isNonTaskDetailViewId(entityId: string): boolean {
+  return NON_TASK_DETAIL_VIEW_IDS.has(entityId) || entityId.startsWith(`${COMMAND_TERMINAL_ENTITY_PREFIX}::`);
+}
 
 /**
  * Schedule a debounced persist of a task's detail-view layout. Captures the
@@ -156,7 +176,7 @@ const NON_TASK_DETAIL_VIEW_IDS = new Set(['new-task-dialog', 'new-backlog-task-d
  * Sentinel (non-task) ids are ignored - they have no `tasks` row to write.
  */
 function scheduleDetailViewSave(taskId: string, get: () => SessionStore): void {
-  if (NON_TASK_DETAIL_VIEW_IDS.has(taskId)) return;
+  if (isNonTaskDetailViewId(taskId)) return;
   const projectId = useProjectStore.getState().currentProject?.id ?? null;
   detailViewPendingSaves.set(taskId, { state: buildDetailViewBlob(get(), taskId), projectId });
   const existing = detailViewSaveTimers.get(taskId);

--- a/tests/ui/command-terminal.spec.ts
+++ b/tests/ui/command-terminal.spec.ts
@@ -492,6 +492,35 @@ async function activeProjectId(page: Page): Promise<string | null> {
   });
 }
 
+/** Command-terminal window ids in the singleton store, keyed by slot anchor. Lets
+ *  a test scope a Playwright locator to one specific window's WindowFrame
+ *  (`data-testid="window-frame-<id>"`) when two windows are open side by side. */
+async function commandWindowIdBySlot(page: Page): Promise<Record<string, string>> {
+  return page.evaluate(() => {
+    const stores = (window as unknown as {
+      __zustandStores?: { commandWindow?: { getState: () => { windows: Record<string, { anchor: string }> } } };
+    }).__zustandStores;
+    const windows = stores?.commandWindow?.getState().windows ?? {};
+    const bySlot: Record<string, string> = {};
+    for (const [id, managedWindow] of Object.entries(windows)) {
+      bySlot[managedWindow.anchor] = id;
+    }
+    return bySlot;
+  });
+}
+
+/** The Changes-panel entity ids currently marked open in the session store
+ *  (`changesOpenTasks`), as a plain array for assertion. */
+async function changesOpenEntityIds(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const stores = (window as unknown as {
+      __zustandStores?: { session?: { getState: () => { changesOpenTasks: Set<string> } } };
+    }).__zustandStores;
+    const set = stores?.session?.getState().changesOpenTasks ?? new Set<string>();
+    return Array.from(set);
+  });
+}
+
 test.describe('Command Terminal', () => {
   // ---------------------------------------------------------------------------
   // TitleBar Button - these two tests use different base preconfigs so each
@@ -1278,6 +1307,58 @@ test.describe('Command Terminal', () => {
         // Pop one out: both terminals remain, the popped one is just floating now.
         await page.getByTestId('command-bar-popout').first().click();
         await expect(page.getByTestId('command-terminal-window')).toHaveCount(2);
+      } finally {
+        await browser.close();
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Per-window Changes panel isolation - each Command Terminal window derives its
+  // own Changes-panel entity id from its durable slot
+  // (`commandTerminalChangesEntityId(slot)` => 'command-terminal::slot-N'), so
+  // toggling Changes on one window must not affect another window's panel. Uses
+  // the kebab "Show changes" / "Hide changes" menu item rather than the header
+  // pill: the pill can fold into the kebab once two windows are docked
+  // side-by-side and narrower than the priority-plus floor, but the kebab trigger
+  // is a protected trailing control (see useHeaderPillOverflow) and is always
+  // rendered, so it is the stable way to drive this regardless of window width.
+  // ---------------------------------------------------------------------------
+  test.describe('Per-window Changes panel isolation', () => {
+    test('toggling Changes on one window does not open it on another window', async () => {
+      const { browser, page } = await launchWithState(multiTerminalPreConfig());
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+        await page.keyboard.press('Control+Shift+P');
+        await expect(page.getByTestId('command-terminal-window')).toHaveCount(1, { timeout: 5000 });
+        await page.getByTestId('quick-session-button').click();
+        await expect(page.getByTestId('command-terminal-window')).toHaveCount(2, { timeout: 5000 });
+
+        const idsBySlot = await commandWindowIdBySlot(page);
+        expect(Object.keys(idsBySlot).sort()).toEqual(['slot-1', 'slot-2']);
+        const windowOneFrame = page.getByTestId(`window-frame-${idsBySlot['slot-1']}`);
+        const windowTwoFrame = page.getByTestId(`window-frame-${idsBySlot['slot-2']}`);
+
+        // Open window 1's Changes panel via its own kebab menu.
+        await windowOneFrame.getByTitle('Actions').click();
+        await page.getByText('Show changes', { exact: true }).click();
+
+        // Store-level assertion: only window 1's per-slot entity id is open -
+        // proves the toggle scheduled against 'command-terminal::slot-1', not a
+        // shared 'command-terminal' id that would also cover window 2.
+        await expect.poll(() => changesOpenEntityIds(page), { timeout: 3000 }).toEqual(['command-terminal::slot-1']);
+
+        // UI-level assertion: window 2's own kebab still reads "Show changes"
+        // (unaffected). This exercises the real render path (the changesOpen
+        // selector read inside CommandTerminalWindow), not just the store.
+        await windowTwoFrame.getByTitle('Actions').click();
+        await expect(page.getByText('Show changes', { exact: true })).toBeVisible();
+
+        // And window 1's own kebab now reads "Hide changes", confirming its
+        // toggle round-tripped through the real component, not just the store.
+        await windowTwoFrame.getByTitle('Actions').click(); // close window 2's menu first
+        await windowOneFrame.getByTitle('Actions').click();
+        await expect(page.getByText('Hide changes', { exact: true })).toBeVisible();
       } finally {
         await browser.close();
       }

--- a/tests/unit/session-store-detail-view-hydration.test.ts
+++ b/tests/unit/session-store-detail-view-hydration.test.ts
@@ -88,6 +88,7 @@ const setDetailViewStateMock = vi.fn(async (_taskId: string, _state: TaskDetailV
 
 // Import after the global stub so the store module sees the mocked window.
 import { useSessionStore } from '../../src/renderer/stores/session-store';
+import { commandTerminalChangesEntityId } from '../../src/renderer/stores/session-store/task-changes-panel-slice';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -326,5 +327,58 @@ describe('changesSelectedCommit - persists to and hydrates from detail_view_stat
     useSessionStore.getState().hydrateDetailViewStateForTasks([task]);
 
     expect(useSessionStore.getState().changesSelectedCommit['task-hydrate-default']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Behavior 4: a Command Terminal window's per-slot entity id is excluded from
+// detail_view_state persistence, the same as the old shared 'command-terminal'
+// sentinel was. Each window now gets its own id via commandTerminalChangesEntityId
+// (e.g. 'command-terminal::slot-1'), so the exclusion check must recognize the
+// whole family, not just the single old literal.
+// Red condition: revert isNonTaskDetailViewId to a bare
+// `NON_TASK_DETAIL_VIEW_IDS.has(taskId)` (no prefix check) and this test fails -
+// the per-slot id no longer matches, so scheduleDetailViewSave stops skipping it
+// and setDetailViewStateMock is called twice instead of once.
+//
+// The second test below pins the OTHER branch of isNonTaskDetailViewId's OR: the
+// fixed-literal NON_TASK_DETAIL_VIEW_IDS.has(entityId) set (the create dialogs and
+// the Edit Columns dialog), which the first test does not exercise.
+// Red condition: drop 'board-manager-dialog' from NON_TASK_DETAIL_VIEW_IDS (or
+// break the `||` into only the startsWith check) and this test fails -
+// scheduleDetailViewSave stops skipping the sentinel id and setDetailViewStateMock
+// is called twice instead of once.
+// ---------------------------------------------------------------------------
+
+describe('commandTerminalChangesEntityId - excluded from detail_view_state persistence', () => {
+  beforeEach(() => {
+    vi.advanceTimersByTime(1000);
+    resetSliceState();
+  });
+
+  it('does not schedule a setDetailViewState save for a per-slot command-terminal id, but does for a real task id', () => {
+    const slotOneEntityId = commandTerminalChangesEntityId('slot-1');
+    const slotTwoEntityId = commandTerminalChangesEntityId('slot-2');
+
+    useSessionStore.getState().toggleChangesOpen(slotOneEntityId);
+    useSessionStore.getState().toggleChangesOpen(slotTwoEntityId);
+    useSessionStore.getState().toggleChangesOpen('task-1');
+
+    vi.advanceTimersByTime(1000);
+
+    expect(setDetailViewStateMock).toHaveBeenCalledTimes(1);
+    const [taskId] = setDetailViewStateMock.mock.calls[0];
+    expect(taskId).toBe('task-1');
+  });
+
+  it('does not schedule a setDetailViewState save for a fixed sentinel id (board-manager-dialog), but does for a real task id', () => {
+    useSessionStore.getState().toggleChangesOpen('board-manager-dialog');
+    useSessionStore.getState().toggleChangesOpen('task-1');
+
+    vi.advanceTimersByTime(1000);
+
+    expect(setDetailViewStateMock).toHaveBeenCalledTimes(1);
+    const [taskId] = setDetailViewStateMock.mock.calls[0];
+    expect(taskId).toBe('task-1');
   });
 });

--- a/tests/unit/task-changes-panel-slice.test.ts
+++ b/tests/unit/task-changes-panel-slice.test.ts
@@ -18,7 +18,7 @@ import { describe, it, expect, vi } from 'vitest';
 vi.mock('../../src/renderer/stores/project-store', () => ({
   useProjectStore: { getState: () => ({ currentProject: null }) },
 }));
-import { createTaskChangesPanelSlice } from '../../src/renderer/stores/session-store/task-changes-panel-slice';
+import { createTaskChangesPanelSlice, commandTerminalChangesEntityId } from '../../src/renderer/stores/session-store/task-changes-panel-slice';
 import type { TaskChangesPanelSlice } from '../../src/renderer/stores/session-store/task-changes-panel-slice';
 
 // ---------------------------------------------------------------------------
@@ -103,6 +103,29 @@ describe('toggleBrowserOpen', () => {
   it('starts with an empty browserOpenTasks set', () => {
     const { getState } = createTestStore();
     expect(getState().browserOpenTasks.size).toBe(0);
+  });
+
+  it('toggles changesOpenTasks independently per Command Terminal window slot id', () => {
+    // Guards against the bug where every Command Terminal window shared one
+    // 'command-terminal' entity id: toggling one window's Changes pill opened
+    // every window's panel. Each window now derives its own id via
+    // commandTerminalChangesEntityId(slot), so they must toggle independently,
+    // like any other pair of entity ids.
+    const { actions, getState } = createTestStore();
+    const slotOneEntityId = commandTerminalChangesEntityId('slot-1');
+    const slotTwoEntityId = commandTerminalChangesEntityId('slot-2');
+
+    actions.toggleChangesOpen(slotOneEntityId);
+    expect(getState().changesOpenTasks.has(slotOneEntityId)).toBe(true);
+    expect(getState().changesOpenTasks.has(slotTwoEntityId)).toBe(false);
+
+    actions.toggleChangesOpen(slotTwoEntityId);
+    expect(getState().changesOpenTasks.has(slotOneEntityId)).toBe(true);
+    expect(getState().changesOpenTasks.has(slotTwoEntityId)).toBe(true);
+
+    actions.toggleChangesOpen(slotOneEntityId);
+    expect(getState().changesOpenTasks.has(slotOneEntityId)).toBe(false);
+    expect(getState().changesOpenTasks.has(slotTwoEntityId)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What

Every open Command Terminal window shared a single hardcoded Changes-panel entity id (`'command-terminal'`). Opening the git-diff Changes panel on one window opened it on every window, and their per-entity panel state (selected file, scroll position, diff scope, viewed-file marks, file-tree width, history-region height) was shared too, since it was all keyed off the same id.

Fixes `CommandTerminalWindow.tsx` and the session store's `task-changes-panel-slice.ts`.

## Why

With more than one Command Terminal window open, toggling Changes on one window incorrectly toggled it on all windows (see the task's attached screenshot: two terminals both showing the same README diff because the panel was opened on only one).

## How

Each Command Terminal window now derives its own Changes-panel entity id from its durable window slot via a new `commandTerminalChangesEntityId(slot)` helper (`command-terminal::slot-1`, `command-terminal::slot-2`, ...), mirroring the existing `transientKey(projectId, slot)` precedent and the `dialog-`/`popout-` prefixed ids the other `ChangesPanel` mounts already use.

The entity id is purely an opaque namespace key everywhere it's used (`changesOpenTasks: Set<string>`, and every per-entity map in `ChangesPanel`) - it's never used to look up a task or fetch diff data (diffs are fetched from `projectPath`/`worktreePath`/`baseBranch`/`scope`), so this is a safe, additive change with no persistence migration: the session store has no `persist` middleware, and the command terminal was already excluded from the durable `tasks.detail_view_state` DB blob.

One related fix: `task-changes-panel-slice.ts`'s `NON_TASK_DETAIL_VIEW_IDS` set used an exact-string match (`'command-terminal'`) to skip persisting the command terminal's view state (it has no `tasks` row). Since the id is now per-slot, that exact match would miss and start firing a spurious `tasks.setDetailViewState` IPC write on every Changes toggle. Replaced with a prefix-aware `isNonTaskDetailViewId()` check.

## Breaking changes

None.

## Tests

- `tests/unit/task-changes-panel-slice.test.ts`: toggling `changesOpenTasks` for two different window-slot ids is independent (locks the exact bug's fix).
- `tests/unit/session-store-detail-view-hydration.test.ts`: two persistence-guard tests, one per branch of `isNonTaskDetailViewId`'s OR - a per-slot command-terminal id never schedules a `setDetailViewState` save, and neither does a fixed sentinel id (`board-manager-dialog`), while a real task id does. Verified genuinely red before the prefix-check fix (3 calls instead of 1).
- `tests/ui/command-terminal.spec.ts`: a new end-to-end UI test opening two real Command Terminal windows and toggling Changes on one via its kebab menu, asserting isolation both at the store level (`changesOpenTasks`) and the render level (each window's own "Show changes"/"Hide changes" label).
- A `test-builder` coverage audit of the full diff found no further gaps.
- `npm run typecheck` and `npm run lint` (`--max-warnings 0`) both pass locally.

Generated with [Claude Code](https://claude.com/claude-code)
