### PR TITLE
feat(branding): theme-adaptive title-bar mark + dev favicon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@electron/fuses": "^2.1.1",
         "@electron/notarize": "^3.1.1",
         "@eslint/js": "^9.39.4",
-        "@kangentic/branding": "^2.0.0",
+        "@kangentic/branding": "^2.1.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.3.0",
@@ -2497,9 +2497,9 @@
       }
     },
     "node_modules/@kangentic/branding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@kangentic/branding/-/branding-2.0.0.tgz",
-      "integrity": "sha512-ZdFaSPosqy95w94lRlrb820yY23Mf10xzmhnPT9dM6B9Zj/Z1lHQSmXJOIyKfYx45vYsXCdvHZupaB4NiazUaQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@kangentic/branding/-/branding-2.1.0.tgz",
+      "integrity": "sha512-/5aQ2W/0CpE9RyG0kzP5bIJDwYQHB5O7f9Ozf8ggxOjD6dl4XTQV9EFl6tOuAKcc6bFtEnrDAoGpfVRnwPTcAg==",
       "dev": true,
       "license": "AGPL-3.0-only"
     },
@@ -13993,7 +13993,7 @@
     },
     "packages/protocol": {
       "name": "@kangentic/protocol",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@electron/fuses": "^2.1.1",
     "@electron/notarize": "^3.1.1",
     "@eslint/js": "^9.39.4",
-    "@kangentic/branding": "^2.0.0",
+    "@kangentic/branding": "^2.1.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.0",

--- a/src/renderer/components/BrandMark.tsx
+++ b/src/renderer/components/BrandMark.tsx
@@ -1,0 +1,18 @@
+import brandMarkSvg from '@kangentic/branding/assets/brandmark-mono-amber.svg?raw';
+
+/**
+ * Inline (not `<img>`) so the disc inherits `currentColor` from the surrounding text token
+ * while the amber slit stays fixed - a themed lockup that reads as one unit with the wordmark
+ * on every theme. Deliberate exception to the "use lucide, no inline SVGs" rule: this consumes
+ * a shipped brand asset that must theme-tint and cannot be a lucide glyph (precedent:
+ * CommandTerminalIcon in TitleBar.tsx). The `?raw` source is a trusted build-time package asset.
+ */
+export function BrandMark({ className = '' }: { className?: string }) {
+  return (
+    <span
+      className={`inline-block [&>svg]:block [&>svg]:h-full [&>svg]:w-full ${className}`}
+      aria-hidden="true"
+      dangerouslySetInnerHTML={{ __html: brandMarkSvg }}
+    />
+  );
+}

--- a/src/renderer/components/board/WelcomeOverlay.tsx
+++ b/src/renderer/components/board/WelcomeOverlay.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { ListPlus, ArrowRightLeft, Eye, Lightbulb } from 'lucide-react';
 import { useConfigStore } from '../../stores/config-store';
 import { useProjectStore } from '../../stores/project-store';
-import logoSrc from '@kangentic/branding/assets/brandmark-small.svg?url';
+import { BrandMark } from '../BrandMark';
 
 const DISPLAY_DURATION_MS = 15000;
 const FADE_DURATION_MS = 500;
@@ -118,7 +118,7 @@ export function WelcomeOverlay() {
         <div className="px-12 pt-10 pb-8 text-center">
           {/* Logo */}
           <div className="flex justify-center mb-4">
-            <img src={logoSrc} alt="" className="w-10 h-10" />
+            <BrandMark className="w-10 h-10 text-fg" />
           </div>
 
           <h2 className="text-2xl font-bold text-fg mb-1.5">

--- a/src/renderer/components/layout/TitleBar.tsx
+++ b/src/renderer/components/layout/TitleBar.tsx
@@ -10,7 +10,7 @@ import { selectCurrentProjectTransientSessionIds } from '../../stores/session-st
 import { isWorktreePath } from '../../../shared/git-utils';
 import { requiresUserInteraction, isActive } from '../../../shared/activity-state';
 import { useFormattedCombo } from '../../hooks/useKeybinding';
-import logoSrc from '@kangentic/branding/assets/brandmark-small.svg?url';
+import { BrandMark } from '../BrandMark';
 
 const isMac = window.electronAPI.platform === 'darwin';
 
@@ -177,7 +177,7 @@ export function TitleBar({
          style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}>
       {/* Branding -- logo + app name */}
       <div className="flex items-center gap-1.5 flex-shrink-0">
-        <img src={logoSrc} alt="Kangentic" className="w-5 h-5" />
+        <BrandMark className="w-5 h-5 text-fg-secondary" />
         <span className="text-sm font-semibold text-fg-secondary">Kangentic</span>
         {/*
           Dev-only (preview): the original task's title after the wordmark, in a muted

--- a/src/renderer/components/layout/WelcomeScreen.tsx
+++ b/src/renderer/components/layout/WelcomeScreen.tsx
@@ -3,7 +3,7 @@ import { FolderOpen, FileText, GitBranch, Terminal, CheckCircle, CircleAlert, Co
 import { useProjectStore } from '../../stores/project-store';
 import { useConfigStore } from '../../stores/config-store';
 import { agentInstallUrl, agentLoginCommand } from '../../utils/agent-display-name';
-import logoSrc from '@kangentic/branding/assets/brandmark-small.svg?url';
+import { BrandMark } from '../BrandMark';
 
 /** Reusable detection card used for both Git and agent entries */
 function DetectionCard({ name, testId, found, version, installUrl, loading, authenticated, loginCommand }: {
@@ -153,7 +153,7 @@ export function WelcomeScreen() {
     <div className="flex-1 flex justify-center items-start pt-[12vh] text-fg-faint overflow-y-auto">
       <div className="text-center max-w-md">
         <div className="flex items-center justify-center gap-2.5 mb-1">
-          <img src={logoSrc} alt="" className="w-9 h-9" />
+          <BrandMark className="w-9 h-9 text-fg" />
           <span className="text-3xl font-bold text-fg leading-none">Kangentic</span>
           {appVersion && <span className="text-xs text-fg-faint/50 self-end mb-0.5">v{appVersion}</span>}
         </div>

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -4,12 +4,23 @@ import { App } from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { readPopOutDescriptor } from './pop-out/read-descriptor';
 import { PopOutSurfaceRoot } from './pop-out/PopOutSurfaceRoot';
+import faviconHref from '@kangentic/branding/assets/brandmark-small.svg?url';
 import './index.css';
 
 window.addEventListener('unhandledrejection', (event) => {
   const message = event.reason instanceof Error ? event.reason.message : String(event.reason);
   window.electronAPI?.analytics?.trackRendererError(message);
 });
+
+// Dev-server tab / devtools favicon (the packaged app icon is the native BrowserWindow icon,
+// unaffected). `?url` so Vite hashes it into the build graph and it resolves in both dev and prod.
+if (!document.querySelector('link[rel="icon"]')) {
+  const iconLink = document.createElement('link');
+  iconLink.rel = 'icon';
+  iconLink.type = 'image/svg+xml';
+  iconLink.href = faviconHref;
+  document.head.appendChild(iconLink);
+}
 
 // A pop-out window (usage stats, git changes, the Browser pane) carries a surface
 // descriptor via additionalArguments / URL hash; mount its minimal root instead of

--- a/tests/unit/branding-assets.test.ts
+++ b/tests/unit/branding-assets.test.ts
@@ -12,8 +12,13 @@ const REPO_ROOT = path.resolve(__dirname, '../..');
 const BRANDING_ROOT = path.join(REPO_ROOT, 'node_modules', '@kangentic', 'branding');
 const DESKTOP_ASSETS_DIR = path.join(BRANDING_ROOT, 'resources', 'desktop');
 const REQUIRED_DESKTOP_ICONS = ['icon.ico', 'icon.icns', 'icon.png'];
-const IN_APP_LOGO_ASSET = path.join(BRANDING_ROOT, 'assets', 'brandmark-small.svg');
-const IN_APP_LOGO_IMPORTERS = [
+const FAVICON_ASSET = path.join(BRANDING_ROOT, 'assets', 'brandmark-small.svg');
+const THEMED_MARK_ASSETS = [
+  path.join(BRANDING_ROOT, 'assets', 'brandmark-mono.svg'),
+  path.join(BRANDING_ROOT, 'assets', 'brandmark-mono-amber.svg'),
+];
+const BRAND_MARK_COMPONENT = 'src/renderer/components/BrandMark.tsx';
+const BRAND_MARK_IMPORTERS = [
   'src/renderer/components/layout/TitleBar.tsx',
   'src/renderer/components/layout/WelcomeScreen.tsx',
   'src/renderer/components/board/WelcomeOverlay.tsx',
@@ -121,18 +126,38 @@ describe('@kangentic/branding desktop assets', () => {
     expect(windowUtilsSource.includes("'@kangentic'") && windowUtilsSource.includes("'branding'")).toBe(true);
   });
 
-  it('ships the in-app nav/header mark and every renderer importer references it', () => {
+  it('ships the dev-server favicon asset and index.tsx references it', () => {
     expect(
-      fs.existsSync(IN_APP_LOGO_ASSET),
-      '@kangentic/branding is missing assets/brandmark-small.svg (the documented in-app nav/header mark)',
+      fs.existsSync(FAVICON_ASSET),
+      '@kangentic/branding is missing assets/brandmark-small.svg (the documented dev-server favicon source)',
     ).toBe(true);
-    const notReferencing = IN_APP_LOGO_IMPORTERS.filter((relativePath) => {
+    const indexSource = fs.readFileSync(path.join(REPO_ROOT, 'src/renderer/index.tsx'), 'utf-8');
+    expect(
+      indexSource.includes('@kangentic/branding/assets/brandmark-small.svg'),
+      'src/renderer/index.tsx should import the favicon from @kangentic/branding, not a local asset',
+    ).toBe(true);
+  });
+
+  it('ships the themed in-app mark and BrandMark and its importers reference it', () => {
+    const missing = THEMED_MARK_ASSETS.filter((assetPath) => !fs.existsSync(assetPath));
+    expect(
+      missing,
+      `@kangentic/branding is missing themed brandmark assets:\n${missing.join('\n')}`,
+    ).toEqual([]);
+
+    const brandMarkSource = fs.readFileSync(path.join(REPO_ROOT, BRAND_MARK_COMPONENT), 'utf-8');
+    expect(
+      brandMarkSource.includes('@kangentic/branding/assets/brandmark-mono-amber.svg'),
+      `${BRAND_MARK_COMPONENT} should import the theme-tinting brandmark from @kangentic/branding`,
+    ).toBe(true);
+
+    const notReferencing = BRAND_MARK_IMPORTERS.filter((relativePath) => {
       const source = fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf-8');
-      return !source.includes('@kangentic/branding/assets/brandmark-small.svg');
+      return !source.includes('BrandMark');
     });
     expect(
       notReferencing,
-      `These renderer files should import the brandmark from @kangentic/branding, not a local asset:\n${notReferencing.join('\n')}`,
+      `These renderer files should render the shared BrandMark component:\n${notReferencing.join('\n')}`,
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

Makes the app's brand mark theme-adaptive, and adds a dev-server favicon.

- Bumps `@kangentic/branding` to `^2.1.0`, which ships two new `currentColor` mark variants for
  in-app chrome.
- Adds a shared `BrandMark` component (`src/renderer/components/BrandMark.tsx`) that inlines
  `brandmark-mono-amber.svg` via a Vite `?raw` import, so the disc tints to `currentColor` while
  the amber accent stays fixed.
- Swaps the fixed-color `brandmark-small.svg` `<img>` for `<BrandMark>` in `TitleBar.tsx`,
  `WelcomeScreen.tsx`, and `WelcomeOverlay.tsx`, each tinted to the token its adjacent wordmark
  already uses, so the lockup reads as one unit on every theme.
- Injects a `<link rel="icon">` in `index.tsx` (`brandmark-small.svg` via `?url`) so the Vite
  dev-server tab and devtools carry the mark. Dev-only cosmetic change; the packaged app icon
  (native `BrowserWindow` icon) is untouched.

## Why

The mark was previously rendered as a fixed-color `<img src=... ?url>`, so its baked-in rust/amber
fills could not follow the theme. On light and warm-tinted themes it read as a slightly foreign
chip next to the theme-colored wordmark beside it. Separately, `index.html` had no favicon, so the
dev-server tab and devtools views showed a blank icon.

## How

`currentColor` does not tint through `<img>`, and the mark's fixed amber accent rules out a CSS
`mask-image` approach (a mask is monochrome and would flatten the amber). `BrandMark` inlines the
raw SVG markup instead, letting the disc inherit `currentColor` from a `className`-driven text
token while the amber slit stays put. This is a deliberate, documented exception to the "use
lucide, no inline SVGs" convention, following the existing `CommandTerminalIcon` precedent in
`TitleBar.tsx`.

The mono-amber variant (over the pure-mono alternative) was picked as the one that keeps the amber
brand note while still adapting, after comparing all three candidates rendered against the app's
real theme tokens.

The favicon uses a runtime `?url` import + `<link>` injection rather than a static
`/node_modules/...` reference in `index.html`, per Vite's asset-handling docs: an asset that lives
in a dependency should be imported so Vite includes it in the build graph and resolves it in both
dev and the packaged build; a hardcoded `node_modules` path in `index.html` would be a dead
reference in production.

## Breaking changes

None.

## Tests

- `npm run typecheck` and `npm run lint` pass locally.
- `tests/unit/branding-assets.test.ts` updated: asserts both mono SVG assets ship in
  `@kangentic/branding`, `BrandMark.tsx` imports the mono-amber asset, all three call sites render
  `BrandMark`, and `index.tsx` references the favicon asset. Ran scoped
  (`npx vitest run tests/unit/branding-assets.test.ts`), 10/10 passing.
- Coverage audited via `test-builder`: no additional gaps found. `BrandMark` has no branching
  logic to unit-test in isolation and is exercised implicitly by every UI/E2E spec that mounts
  `TitleBar`; the favicon injection follows this file's existing convention of leaving small,
  cosmetic bootstrap effects (e.g. the `unhandledrejection` listener) untested.
- CI's unit, UI, and E2E tiers will run as PR checks.

Generated with [Claude Code](https://claude.com/claude-code)
