### PR TITLE
perf(changes-panel): keep git + Monaco diff work off the UI thread

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -52,6 +52,7 @@ asarUnpack:
   - "node_modules/onnxruntime-node/**"
   - "node_modules/onnxruntime-web/**"
   - ".vite/build/embed-worker.js"
+  - ".vite/build/line-count-worker.js"
   - ".vite/build/event-bridge.js"
   - ".vite/build/status-bridge.js"
   - ".vite/build/plugins/**"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -86,8 +86,16 @@ async function build() {
       entryPoints: [path.join(projectDir, 'src/main/retrieval/embedder/embed-worker.ts')],
       outfile: path.join(projectDir, '.vite/build/embed-worker.js'),
     }),
+    // The untracked-file line-count worker also runs in an Electron
+    // utilityProcess (see src/main/git/line-count/line-count-client.ts), so
+    // it is bundled as its own entry next to the main bundle.
+    esbuild.build({
+      ...esbuildCommon,
+      entryPoints: [path.join(projectDir, 'src/main/git/line-count/line-count-worker.ts')],
+      outfile: path.join(projectDir, '.vite/build/line-count-worker.js'),
+    }),
   ]);
-  console.log('[build] Main + preload + embed worker built');
+  console.log('[build] Main + preload + embed worker + line-count worker built');
 
   // Copy external scripts (bridges + adapter plugins) that run outside the
   // esbuild bundle as raw .js/.mjs and must sit next to the bundle. The copy

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -214,9 +214,16 @@ async function start() {
       entryPoints: [path.join(projectDir, 'src/main/retrieval/embedder/embed-worker.ts')],
       outfile: path.join(projectDir, '.vite/build/embed-worker.js'),
     }),
+    // Untracked-file line-count worker (Electron utilityProcess entry), same
+    // dev-parity reasoning as the embed worker above.
+    esbuild.build({
+      ...esbuildCommon,
+      entryPoints: [path.join(projectDir, 'src/main/git/line-count/line-count-worker.ts')],
+      outfile: path.join(projectDir, '.vite/build/line-count-worker.js'),
+    }),
   ]);
   console.timeEnd('[dev] esbuild');
-  console.log('[dev] Main + preload + embed worker built');
+  console.log('[dev] Main + preload + embed worker + line-count worker built');
 
   // Copy external scripts (bridges + adapter plugins) next to the bundle, the
   // same step scripts/build.js runs. Without this, dev runs whatever stale copy

--- a/src/main/git/diff-service.ts
+++ b/src/main/git/diff-service.ts
@@ -2,6 +2,16 @@ import simpleGit from 'simple-git';
 import fs from 'node:fs';
 import path from 'node:path';
 import type { GitDiffFilesInput, GitDiffFilesResult, GitDiffFileEntry, GitDiffScope, GitDiffStatus, GitFileContentInput, GitFileContentResult } from '../../shared/types';
+import { countFileLines } from './line-count/count-lines';
+import { lineCountClient } from './line-count/line-count-client';
+
+/** Above this combined untracked-file byte size, counting is delegated to the
+ *  line-count utilityProcess worker instead of running inline, so a large or
+ *  numerous untracked tree (an untracked `resources/`, a generated bundle)
+ *  never runs its byte-scan on the main event loop (which owns
+ *  better-sqlite3, the PTYs, and IPC). Below it, counting inline is cheap
+ *  enough that the worker's IPC round-trip would only add latency. */
+const UNTRACKED_OFFLOAD_THRESHOLD_BYTES = 2 * 1024 * 1024;
 
 const EXTENSION_LANGUAGE_MAP: Record<string, string> = {
   '.ts': 'typescript', '.tsx': 'typescript', '.mts': 'typescript', '.cts': 'typescript',
@@ -243,33 +253,7 @@ export class DiffService {
       ? gitStatus.not_added.filter((filePath) => !trackedPaths.has(filePath))
       : [];
 
-    const untrackedEntries = await Promise.all(
-      untrackedPaths.map(async (filePath): Promise<GitDiffFileEntry> => {
-        const absolutePath = path.join(this.gitDirectory, filePath);
-        try {
-          const buffer = await fs.promises.readFile(absolutePath);
-          // Binary detection: check first 8KB for null bytes (same heuristic as git)
-          const checkLength = Math.min(buffer.length, 8192);
-          let isBinary = false;
-          for (let index = 0; index < checkLength; index++) {
-            if (buffer[index] === 0) { isBinary = true; break; }
-          }
-          // Count newline bytes directly on the buffer to avoid a full string allocation.
-          // Add 1 for the last line if the file doesn't end with a newline.
-          let insertions = 0;
-          if (!isBinary) {
-            for (let index = 0; index < buffer.length; index++) {
-              if (buffer[index] === 0x0A) insertions++;
-            }
-            if (buffer.length > 0 && buffer[buffer.length - 1] !== 0x0A) insertions++;
-          }
-          return { path: filePath, status: 'U', insertions, deletions: 0, binary: isBinary };
-        } catch {
-          // File may have been deleted between status and read
-          return { path: filePath, status: 'U', insertions: 0, deletions: 0, binary: false };
-        }
-      }),
-    );
+    const untrackedEntries = await this.countUntrackedEntries(untrackedPaths);
 
     files.push(...untrackedEntries);
     const untrackedInsertions = untrackedEntries.reduce((sum, entry) => sum + entry.insertions, 0);
@@ -279,6 +263,58 @@ export class DiffService {
       totalInsertions: summary.insertions + untrackedInsertions,
       totalDeletions: summary.deletions,
     };
+  }
+
+  /**
+   * Counts inserted lines (and detects binary content) for every untracked
+   * path relative to `gitDirectory`. Small untracked sets are counted inline
+   * (cheap enough that a worker round-trip would only add latency); once the
+   * aggregate size crosses UNTRACKED_OFFLOAD_THRESHOLD_BYTES, the batch is
+   * delegated to the line-count worker so the scan never runs on the main
+   * event loop. Falls back to inline counting if the worker is unavailable.
+   */
+  private async countUntrackedEntries(untrackedPaths: string[]): Promise<GitDiffFileEntry[]> {
+    if (untrackedPaths.length === 0) return [];
+
+    const absolutePaths = untrackedPaths.map((filePath) => path.join(this.gitDirectory, filePath));
+    const sizes = await Promise.all(
+      absolutePaths.map(async (absolutePath) => {
+        try {
+          const stats = await fs.promises.stat(absolutePath);
+          return stats.size;
+        } catch {
+          return 0;
+        }
+      }),
+    );
+    const aggregateBytes = sizes.reduce((sum, size) => sum + size, 0);
+
+    if (aggregateBytes > UNTRACKED_OFFLOAD_THRESHOLD_BYTES) {
+      const workerEntries = await lineCountClient.countFiles(absolutePaths);
+      if (workerEntries) {
+        return workerEntries.map((entry, index) => ({
+          path: untrackedPaths[index],
+          status: 'U' as const,
+          insertions: entry.insertions,
+          deletions: 0,
+          binary: entry.binary,
+        }));
+      }
+      // Worker unavailable (not spawned, crashed, timed out) - fall through
+      // to inline counting so the diff still resolves.
+    }
+
+    return Promise.all(
+      untrackedPaths.map(async (filePath, index): Promise<GitDiffFileEntry> => {
+        try {
+          const result = await countFileLines(absolutePaths[index]);
+          return { path: filePath, status: 'U', insertions: result.insertions, deletions: 0, binary: result.binary };
+        } catch {
+          // File may have been deleted between status and read
+          return { path: filePath, status: 'U', insertions: 0, deletions: 0, binary: false };
+        }
+      }),
+    );
   }
 
   /**

--- a/src/main/git/line-count/count-lines.ts
+++ b/src/main/git/line-count/count-lines.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+
+/** First-N bytes checked for a null byte to detect binary content (same
+ *  heuristic git itself uses). */
+const BINARY_CHECK_BYTES = 8192;
+
+/** Above this size, only the first LARGE_FILE_CAP_BYTES are read and scanned,
+ *  and the resulting count is a floor rather than an exact total - protects
+ *  the scan from allocating/walking an unbounded buffer for a pathologically
+ *  large untracked file (a generated bundle, a log, a checked-in binary blob
+ *  that slipped past the binary check). */
+const LARGE_FILE_CAP_BYTES = 20 * 1024 * 1024;
+
+export interface LineCountResult {
+  insertions: number;
+  binary: boolean;
+  /** True when the file exceeded LARGE_FILE_CAP_BYTES: insertions only counts
+   *  the first LARGE_FILE_CAP_BYTES, not the whole file. */
+  truncated: boolean;
+}
+
+function isBinaryBuffer(buffer: Buffer): boolean {
+  const checkLength = Math.min(buffer.length, BINARY_CHECK_BYTES);
+  for (let index = 0; index < checkLength; index++) {
+    if (buffer[index] === 0) return true;
+  }
+  return false;
+}
+
+/** Counts newline (0x0A) bytes via Buffer.indexOf - a native memchr scan,
+ *  tens of times faster than a per-byte JS loop over the same buffer - plus
+ *  one more for a final line with no trailing newline. */
+function countNewlines(buffer: Buffer): number {
+  let count = 0;
+  let index = buffer.indexOf(0x0A);
+  while (index !== -1) {
+    count += 1;
+    index = buffer.indexOf(0x0A, index + 1);
+  }
+  if (buffer.length > 0 && buffer[buffer.length - 1] !== 0x0A) count += 1;
+  return count;
+}
+
+/**
+ * Counts inserted lines for a single untracked file (and detects binary
+ * content), reading at most LARGE_FILE_CAP_BYTES so neither the read nor the
+ * scan is unbounded. Used both inline (small untracked sets) and inside the
+ * line-count worker (large ones) - see diff-service.ts.
+ */
+export async function countFileLines(absolutePath: string): Promise<LineCountResult> {
+  const stats = await fs.promises.stat(absolutePath);
+  const truncated = stats.size > LARGE_FILE_CAP_BYTES;
+  const readLength = truncated ? LARGE_FILE_CAP_BYTES : stats.size;
+
+  const handle = await fs.promises.open(absolutePath, 'r');
+  try {
+    // A single FileHandle.read is not guaranteed to fill the buffer (there is no
+    // internal retry loop, unlike fs.readFile), so scan only the bytes actually
+    // returned. The zero-padded tail of an over-allocated buffer would otherwise
+    // flip a short read to a false binary result and corrupt the newline count.
+    // allocUnsafe skips zero-filling up to LARGE_FILE_CAP_BYTES since the read
+    // overwrites what we scan.
+    const buffer = Buffer.allocUnsafe(readLength);
+    const { bytesRead } = await handle.read(buffer, 0, readLength, 0);
+    const scanned = buffer.subarray(0, bytesRead);
+    if (isBinaryBuffer(scanned)) {
+      return { insertions: 0, binary: true, truncated: false };
+    }
+    return { insertions: countNewlines(scanned), binary: false, truncated };
+  } finally {
+    await handle.close();
+  }
+}

--- a/src/main/git/line-count/line-count-client.ts
+++ b/src/main/git/line-count/line-count-client.ts
@@ -1,0 +1,174 @@
+import path from 'node:path';
+import { app, utilityProcess, type UtilityProcess } from 'electron';
+import type { LineCountEntry } from './line-count-worker';
+
+/** Per-request timeout; generous since the worker itself bounds each file's
+ *  read to LARGE_FILE_CAP_BYTES (count-lines.ts), so a batch's total work is
+ *  capped regardless of how many files it contains. */
+const DEFAULT_TIMEOUT_MS = 15_000;
+/** Kill the worker after this long idle. Unlike the embedding worker, this
+ *  process holds no expensive warm state (no loaded model) - a short idle
+ *  window still avoids paying fork overhead repeatedly during a burst of
+ *  closely-spaced diff refreshes, without holding a process open for no
+ *  reason once the Changes panel is no longer in view. */
+const IDLE_SHUTDOWN_MS = 60_000;
+/** After this many crashes in one app run, stop trying to offload - callers
+ *  fall back to inline counting (see diff-service.ts). */
+const MAX_CRASHES = 3;
+
+/** Rewrite an in-asar path to its asar.unpacked twin when packaged. */
+function unpacked(absolutePath: string): string {
+  return app.isPackaged ? absolutePath.replace('app.asar', 'app.asar.unpacked') : absolutePath;
+}
+
+interface PendingRequest {
+  resolve: (entries: LineCountEntry[] | null) => void;
+  timer: NodeJS.Timeout;
+}
+
+/**
+ * Client for the line-count utilityProcess worker. Spawns lazily on first
+ * demand, shuts the worker down when idle, and restarts it (with a crash cap)
+ * after an unexpected exit. Every failure path - not spawned, crashed, timed
+ * out - resolves `null` so callers degrade to inline (main-thread, bounded)
+ * counting rather than throwing. `dispose()` is synchronous for the shutdown
+ * path (mirrors EmbedClient).
+ */
+export class LineCountClient {
+  private child: UtilityProcess | null = null;
+  private nextRequestId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+  private crashCount = 0;
+  private disposed = false;
+  private idleTimer: NodeJS.Timeout | null = null;
+  /** True while an intentional teardown (idle recycle or dispose) is in
+   *  flight, so the resulting 'exit' is not miscounted as a crash. */
+  private intentionalShutdown = false;
+
+  get crashed(): boolean {
+    return this.crashCount >= MAX_CRASHES;
+  }
+
+  /** Count newline-derived insertions (and detect binary content) for a batch
+   *  of absolute file paths. Returns `null` on any failure (not spawned,
+   *  crashed, timed out) so the caller falls back to inline counting. */
+  async countFiles(absolutePaths: string[], timeoutMs = DEFAULT_TIMEOUT_MS): Promise<LineCountEntry[] | null> {
+    if (absolutePaths.length === 0) return [];
+    if (this.disposed || this.crashed) return null;
+
+    const child = this.ensureSpawned();
+    if (!child) return null;
+
+    this.clearIdleTimer();
+    try {
+      return await this.sendCount(child, absolutePaths, timeoutMs);
+    } finally {
+      this.armIdleShutdown();
+    }
+  }
+
+  private ensureSpawned(): UtilityProcess | null {
+    if (this.child) return this.child;
+    if (this.disposed || this.crashed) return null;
+
+    const workerPath = unpacked(path.join(__dirname, 'line-count-worker.js'));
+    let child: UtilityProcess;
+    try {
+      child = utilityProcess.fork(workerPath, [], { serviceName: 'kangentic-line-count' });
+    } catch (error) {
+      console.warn('[git] line-count worker fork failed:', error);
+      this.crashCount = MAX_CRASHES;
+      return null;
+    }
+    this.child = child;
+    child.on('message', (message: unknown) => this.onWorkerMessage(message));
+    child.on('exit', () => this.onWorkerExit(child));
+    return child;
+  }
+
+  private sendCount(child: UtilityProcess, paths: string[], timeoutMs: number): Promise<LineCountEntry[] | null> {
+    const requestId = this.nextRequestId++;
+    return new Promise<LineCountEntry[] | null>((resolve) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        resolve(null);
+      }, timeoutMs);
+      timer.unref();
+      this.pending.set(requestId, { resolve, timer });
+      child.postMessage({ type: 'count', id: requestId, paths });
+    });
+  }
+
+  private onWorkerMessage(message: unknown): void {
+    if (typeof message !== 'object' || message === null) return;
+    const record = message as { type?: string; id?: number; entries?: LineCountEntry[] };
+    if ((record.type === 'result' || record.type === 'error') && typeof record.id === 'number') {
+      const entry = this.pending.get(record.id);
+      if (!entry) return;
+      clearTimeout(entry.timer);
+      this.pending.delete(record.id);
+      entry.resolve(record.type === 'result' ? record.entries ?? null : null);
+    }
+  }
+
+  private onWorkerExit(child: UtilityProcess): void {
+    const intentional = this.intentionalShutdown;
+    this.intentionalShutdown = false;
+    // A killed worker's 'exit' arrives asynchronously, after a replacement may
+    // already have been spawned and tracked. Ignore the stale exit so it never
+    // nulls the live child or resolves the replacement's in-flight requests.
+    if (child !== this.child) return;
+    this.child = null;
+    for (const entry of this.pending.values()) {
+      clearTimeout(entry.timer);
+      entry.resolve(null);
+    }
+    this.pending.clear();
+    // An idle recycle or dispose is not a crash; only an unexpected exit counts.
+    if (!this.disposed && !intentional) this.crashCount += 1;
+  }
+
+  private armIdleShutdown(): void {
+    if (this.disposed || this.idleTimer || this.pending.size > 0) return;
+    this.idleTimer = setTimeout(() => {
+      this.idleTimer = null;
+      if (this.pending.size === 0) this.killChild();
+    }, IDLE_SHUTDOWN_MS);
+    this.idleTimer.unref();
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+  }
+
+  private killChild(): void {
+    this.intentionalShutdown = true;
+    const child = this.child;
+    this.child = null;
+    if (child) {
+      try {
+        child.postMessage({ type: 'shutdown' });
+      } catch {
+        // ignore; kill below is the real teardown
+      }
+      child.kill();
+    }
+  }
+
+  /** Synchronous shutdown for the before-quit path. */
+  dispose(): void {
+    this.disposed = true;
+    this.clearIdleTimer();
+    for (const entry of this.pending.values()) {
+      clearTimeout(entry.timer);
+      entry.resolve(null);
+    }
+    this.pending.clear();
+    this.killChild();
+  }
+}
+
+export const lineCountClient = new LineCountClient();

--- a/src/main/git/line-count/line-count-worker.ts
+++ b/src/main/git/line-count/line-count-worker.ts
@@ -1,0 +1,68 @@
+/**
+ * Line-count worker - runs in an Electron utilityProcess child so counting
+ * newlines across a large set of untracked files never blocks the main event
+ * loop (which owns better-sqlite3, the PTYs, and IPC).
+ *
+ * A deliberately dumb translation layer: for each requested path, run the
+ * same bounded count-lines helper the main process uses inline for small
+ * batches, and post the results back.
+ *
+ * Bundled by esbuild as its own entry (`.vite/build/line-count-worker.js`).
+ */
+
+import { countFileLines } from './count-lines';
+
+interface CountMessage {
+  type: 'count';
+  id: number;
+  paths: string[];
+}
+interface ShutdownMessage {
+  type: 'shutdown';
+}
+type IncomingMessage = CountMessage | ShutdownMessage;
+
+export interface LineCountEntry {
+  path: string;
+  insertions: number;
+  binary: boolean;
+}
+
+const parentPort = process.parentPort;
+
+function post(message: unknown): void {
+  parentPort.postMessage(message);
+}
+
+async function countPaths(paths: string[]): Promise<LineCountEntry[]> {
+  return Promise.all(
+    paths.map(async (absolutePath): Promise<LineCountEntry> => {
+      try {
+        const result = await countFileLines(absolutePath);
+        return { path: absolutePath, insertions: result.insertions, binary: result.binary };
+      } catch {
+        // File may have been deleted/moved between the caller's stat and this read.
+        return { path: absolutePath, insertions: 0, binary: false };
+      }
+    }),
+  );
+}
+
+parentPort.on('message', (event: Electron.MessageEvent) => {
+  const message = event.data as IncomingMessage;
+  // Defensive parse boundary (mirrors LineCountClient.onWorkerMessage): a
+  // malformed payload must be ignored, not throw inside the handler.
+  if (typeof message !== 'object' || message === null) return;
+
+  if (message.type === 'shutdown') {
+    process.exit(0);
+    return;
+  }
+
+  if (message.type === 'count') {
+    const requestId = message.id;
+    countPaths(message.paths)
+      .then((entries) => post({ type: 'result', id: requestId, entries }))
+      .catch((error: unknown) => post({ type: 'error', id: requestId, message: String(error) }));
+  }
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,6 +32,7 @@ import { loadReactDevTools } from './devtools';
 import { syncShutdownCleanup, startHardShutdownFailsafe } from './shutdown';
 import { prRefreshScheduler } from './pr/pr-refresh-scheduler';
 import { retrievalService } from './retrieval/retrieval-service';
+import { lineCountClient } from './git/line-count/line-count-client';
 import { setProjectDbInitializer } from './db/database';
 import { loadVecExtension } from './retrieval/vec-extension';
 import { restoreShellEnv } from './shell-env';
@@ -1027,6 +1028,9 @@ function getShutdownDependencies() {
       // Stop conversation-memory indexing synchronously: drop pending finalize
       // timers and abandon any in-flight sweep (recovered on next open).
       retrievalService.dispose();
+      // Synchronously kill the line-count worker (if spawned); in-flight
+      // counts abandon and their callers fall back to inline counting.
+      lineCountClient.dispose();
       // Stop accepting new MCP requests synchronously. The server's close()
       // is non-blocking; in-flight requests are abandoned, which is fine
       // because they're idempotent (the agent will retry on reconnect or

--- a/src/renderer/components/dialogs/task-detail/TaskDetailBody.tsx
+++ b/src/renderer/components/dialogs/task-detail/TaskDetailBody.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useRef } from 'react';
+import { Suspense, lazy, useEffect, useRef } from 'react';
 import { Loader2, Play, RotateCcw } from 'lucide-react';
 import { TerminalTab } from '../../terminal/TerminalTab';
 import { ContextBar } from '../../terminal/ContextBar';
@@ -20,8 +20,45 @@ import { useSessionStore } from '../../../stores/session-store';
 import { useTaskSplitResize } from '../../../hooks/useTaskSplitResize';
 import { PanelErrorBoundary } from '../../PanelErrorBoundary';
 import { usePopOut } from '../../../pop-out/usePopOut';
+import { onIdle } from '../../../utils/on-idle';
 
 const ChangesPanel = lazy(() => import('./changes/ChangesPanel').then((module) => ({ default: module.ChangesPanel })));
+
+// hmr-safe: reset-on-HMR just re-fires the already-resolved dynamic import below - resolves instantly from the module cache (a no-op unless ChangesPanel's own module graph also changed in the same HMR batch).
+let hasWarmedChangesPanel = false;
+
+/** Warm the Changes panel's lazy chunk (and its Monaco module graph) once per
+ *  session, off the interaction path, so the first real Changes open never
+ *  pays for the synchronous monaco-editor parse/eval on the click. Idle-time
+ *  only: never competes with an in-flight task-detail interaction. */
+function warmChangesPanelOnIdle(): void {
+  if (hasWarmedChangesPanel) return;
+  hasWarmedChangesPanel = true;
+  onIdle(() => {
+    void import('./changes/ChangesPanel');
+  });
+}
+
+/** Suspense fallback for the lazy ChangesPanel chunk: a two-pane shell
+ *  (file rail + diff area) that mirrors the panel's real layout, so a cold
+ *  open (chunk not yet warmed) paints instantly instead of a bare spinner
+ *  that gives no sense of what's loading. */
+function ChangesPanelSkeleton() {
+  return (
+    <div className="flex h-full" data-testid="changes-panel-skeleton">
+      <div className="w-[220px] flex-shrink-0 border-r border-edge p-2 space-y-1.5">
+        {Array.from({ length: 6 }, (_, index) => (
+          <div key={index} className="h-4 rounded bg-surface-hover animate-pulse" style={{ opacity: 1 - index * 0.1 }} />
+        ))}
+      </div>
+      <div className="flex-1 min-w-0 p-3 space-y-2">
+        {Array.from({ length: 10 }, (_, index) => (
+          <div key={index} className="h-3.5 rounded bg-surface-hover animate-pulse" style={{ width: `${60 + (index * 13) % 35}%` }} />
+        ))}
+      </div>
+    </div>
+  );
+}
 
 interface TaskDetailBodyProps {
   task: Task;
@@ -95,6 +132,11 @@ export function TaskDetailBody({
   const splitContainerRef = useRef<HTMLDivElement>(null);
   const { ratio: splitRatio, isResizing: isSplitResizing, onResizeStart: onSplitResizeStart } =
     useTaskSplitResize(task.id, splitContainerRef);
+  // Warm the Changes panel's chunk as soon as a task detail is open, so a later
+  // click into Changes resolves the lazy import instantly.
+  useEffect(() => {
+    warmChangesPanelOnIdle();
+  }, []);
   // The right panel (Changes diff / Browser) opens and closes instantly, like a
   // split pane in VS Code / JetBrains. Opening it reflows the split - the
   // terminal resizes and re-fits its canvas - and an entrance animation only
@@ -191,13 +233,7 @@ export function TaskDetailBody({
 
   const changesContent = (
     <PanelErrorBoundary label="Changes panel">
-      <Suspense
-        fallback={
-          <div className="flex items-center justify-center h-full">
-            <Loader2 size={20} className="animate-spin text-fg-muted" />
-          </div>
-        }
-      >
+      <Suspense fallback={<ChangesPanelSkeleton />}>
         <ChangesPanel
           entityId={task.id}
           isFocused={isFocused}

--- a/src/renderer/components/dialogs/task-detail/changes/ChangesPanel.tsx
+++ b/src/renderer/components/dialogs/task-detail/changes/ChangesPanel.tsx
@@ -185,7 +185,22 @@ export function ChangesPanel({ entityId, isFocused = false, scrollKey, projectPa
   // the restore effect and suppress error display during live updates.
   const initialFetchDoneRef = useRef(false);
 
+  // Guards against overlapping diffFiles fetches. A rapid string of fs.watch
+  // fires (e.g. an agent writing many files in a burst) would otherwise queue
+  // multiple concurrent git subprocess calls whose responses can resolve out
+  // of order. While a fetch is in flight, a new call just marks a pending
+  // re-fetch and returns; the pending fetch runs once the in-flight one
+  // completes, through fetchFilesRef so it always picks up the latest
+  // scope/selection rather than the params captured when it was queued.
+  const filesFetchInFlightRef = useRef(false);
+  const filesFetchPendingRef = useRef(false);
+
   const fetchFiles = useCallback(async () => {
+    if (filesFetchInFlightRef.current) {
+      filesFetchPendingRef.current = true;
+      return;
+    }
+    filesFetchInFlightRef.current = true;
     try {
       if (!initialFetchDoneRef.current) {
         setError(null);
@@ -200,6 +215,12 @@ export function ChangesPanel({ entityId, isFocused = false, scrollKey, projectPa
       setFiles(result.files);
       setTotalInsertions(result.totalInsertions);
       setTotalDeletions(result.totalDeletions);
+      // A working-scope, no-commit-selected fetch is exactly the query
+      // fetchUncommittedCount would make - derive the badge count here so the
+      // watcher cascade doesn't fire a second diffFiles call for it.
+      if (!changesSelectedCommit && scope === 'working') {
+        setUncommittedFileCount(result.files.length);
+      }
       initialFetchDoneRef.current = true;
       setLoaded(true);
     } catch (fetchError) {
@@ -207,6 +228,12 @@ export function ChangesPanel({ entityId, isFocused = false, scrollKey, projectPa
       // updates (e.g. git lock contention) are silently ignored.
       if (!initialFetchDoneRef.current) {
         setError(fetchError instanceof Error ? fetchError.message : 'Failed to load diff');
+      }
+    } finally {
+      filesFetchInFlightRef.current = false;
+      if (filesFetchPendingRef.current) {
+        filesFetchPendingRef.current = false;
+        void fetchFilesRef.current();
       }
     }
   }, [worktreePath, projectPath, baseBranch, scope, changesSelectedCommit]);
@@ -314,13 +341,23 @@ export function ChangesPanel({ entityId, isFocused = false, scrollKey, projectPa
   // re-subscribe on every commit-selection change (see that effect's comment).
   const selectedCommitRef = useRef(changesSelectedCommit);
   selectedCommitRef.current = changesSelectedCommit;
+  // Scope ref for the same subscription effect, to decide whether fetchFiles's
+  // result already covers the Uncommitted-row count (see onDiffChanged below).
+  const scopeRef = useRef(scope);
+  scopeRef.current = scope;
 
   // Fetch file list + branch context + the Uncommitted-row count on mount, and
   // re-fetch whenever the scope, base branch, or commit selection changes.
   useEffect(() => {
     fetchFilesRef.current();
     fetchBranchSummaryRef.current();
-    fetchUncommittedCountRef.current();
+    // fetchFiles already derives uncommittedFileCount for a working-scope,
+    // no-commit fetch (see its body), so firing the separate query too would be
+    // a second, redundant diffFiles call. Only fire it for the cases fetchFiles
+    // doesn't cover, mirroring the onDiffChanged watcher guard below.
+    if (changesSelectedCommit || scope !== 'working') {
+      fetchUncommittedCountRef.current();
+    }
   }, [worktreePath, projectPath, baseBranch, scope, changesSelectedCommit]);
 
   // Restore content for the persisted selected file after files load.
@@ -378,15 +415,23 @@ export function ChangesPanel({ entityId, isFocused = false, scrollKey, projectPa
       // Entries are not deleted - they're served immediately as stale-while-revalidate.
       cacheGenerationRef.current += 1;
       fetchBranchSummaryRef.current();
-      fetchUncommittedCountRef.current();
       // A selected commit's diff is immutable - skip the file/content refetch
       // while browsing one; only the Uncommitted (working-diff) detail needs it.
       if (!selectedCommitRef.current) {
         fetchFilesRef.current();
+        // When scope is 'working', the fetchFiles call above already derives
+        // uncommittedFileCount from its own result - firing this too would be
+        // a second, redundant diffFiles call on every watcher fire. Any other
+        // scope needs the separate working-scope query.
+        if (scopeRef.current !== 'working') {
+          fetchUncommittedCountRef.current();
+        }
         const currentFile = selectedFileRef.current;
         if (currentFile) {
           fetchFileContentRef.current(currentFile);
         }
+      } else {
+        fetchUncommittedCountRef.current();
       }
     });
 

--- a/src/renderer/components/dialogs/task-detail/changes/DiffViewer.tsx
+++ b/src/renderer/components/dialogs/task-detail/changes/DiffViewer.tsx
@@ -16,6 +16,7 @@ import {
   saveDiffScroll,
 } from '../../../../utils/diff-scroll-memory';
 import { copyDiffSelection } from '../../../../utils/diff-clipboard';
+import { selectDiffAlgorithmOptions } from './diff-render-options';
 
 interface DiffViewerProps {
   original: string;
@@ -182,15 +183,17 @@ export function DiffViewer({
 
   // Live diff-rendering options derived from the global config. ignoreTrimWhitespace
   // is a diff-COMPUTATION option, so it applies when the diff loads. The diff
-  // algorithm is fixed to 'advanced' (Monaco's modern word-level diff, always on -
-  // there is no meaningful on/off toggle for it). hideUnchangedRegions is a
-  // VIEW-fold option handled separately (see applyCollapseFold): Monaco only folds
-  // on a false->true transition, so passing it as a construction option that
+  // algorithm defaults to 'advanced' (Monaco's modern word-level diff) but drops to
+  // the cheaper 'legacy' line diff with a bounded computation time for a large diff
+  // (see selectDiffAlgorithmOptions) so a huge file resolves faster instead of
+  // paying for the full word-level diff. hideUnchangedRegions is a VIEW-fold option
+  // handled separately (see applyCollapseFold): Monaco only folds on a
+  // false->true transition, so passing it as a construction option that
   // @monaco-editor/react re-applies on every render never folds a diff that loads
   // while collapse is already on.
   const diffRenderOptions = {
     ignoreTrimWhitespace: ignoreWhitespace,
-    diffAlgorithm: 'advanced' as const,
+    ...selectDiffAlgorithmOptions(original.length, modified.length),
   };
 
   const collapseUnchangedRef = useRef(collapseUnchanged);

--- a/src/renderer/components/dialogs/task-detail/changes/diff-render-options.ts
+++ b/src/renderer/components/dialogs/task-detail/changes/diff-render-options.ts
@@ -1,0 +1,25 @@
+/** Above this combined original+modified character count, a diff is large
+ *  enough that Monaco's 'advanced' (word-level) algorithm can take noticeably
+ *  longer to resolve in its worker than the simpler 'legacy' line diff -
+ *  visible as a delayed diff paint, not a frozen UI (Monaco's diff computation
+ *  always runs off the main thread; see editorWebWorker's $computeDiff). */
+const LARGE_DIFF_CHAR_THRESHOLD = 200_000;
+
+/** Bounded computation time (ms) for a large diff, below Monaco's 5000ms
+ *  default, so a pathological file fails fast to the "diff took too long"
+ *  fallback instead of leaving the pane blank for several seconds. */
+const LARGE_DIFF_MAX_COMPUTATION_MS = 2_000;
+
+export interface DiffAlgorithmOptions {
+  diffAlgorithm: 'legacy' | 'advanced';
+  maxComputationTime?: number;
+}
+
+/** Picks the diff algorithm and computation-time bound by content size, so a
+ *  large diff resolves faster instead of paying for the full word-level diff. */
+export function selectDiffAlgorithmOptions(originalLength: number, modifiedLength: number): DiffAlgorithmOptions {
+  if (originalLength + modifiedLength > LARGE_DIFF_CHAR_THRESHOLD) {
+    return { diffAlgorithm: 'legacy', maxComputationTime: LARGE_DIFF_MAX_COMPUTATION_MS };
+  }
+  return { diffAlgorithm: 'advanced' };
+}

--- a/src/renderer/utils/on-idle.ts
+++ b/src/renderer/utils/on-idle.ts
@@ -1,0 +1,14 @@
+/** Schedule `callback` for a moment the browser considers idle, so heavy but
+ *  non-urgent work (warming a lazy chunk) never competes with an in-flight
+ *  interaction. Falls back to a short `setTimeout` where `requestIdleCallback`
+ *  is unavailable (older WebViews); the callback still runs off the current
+ *  task, just without the "only when actually idle" guarantee. */
+export function onIdle(callback: () => void): void {
+  // requestIdleCallback is typed on Window but genuinely absent at runtime in
+  // some browsers (e.g. older WebViews), so guard before calling.
+  if (typeof window.requestIdleCallback === 'function') {
+    window.requestIdleCallback(callback);
+  } else {
+    setTimeout(callback, 1);
+  }
+}

--- a/tests/ui/changes-panel-fetch-guard.spec.ts
+++ b/tests/ui/changes-panel-fetch-guard.spec.ts
@@ -1,0 +1,293 @@
+/**
+ * UI test for ChangesPanel's fetchFiles in-flight/pending-rerun guard.
+ *
+ * Background: a rapid string of fs.watch fires (e.g. an agent writing many
+ * files in a burst) would otherwise queue multiple concurrent `diffFiles` IPC
+ * calls whose responses can resolve out of order. `fetchFiles` guards against
+ * this: while a call is in flight, a new trigger just marks a pending
+ * re-fetch and returns; once the in-flight call resolves, the pending
+ * re-fetch runs exactly once, through `fetchFilesRef` so it picks up the
+ * LATEST scope/selection rather than the params captured when it was queued.
+ * See src/renderer/components/dialogs/task-detail/changes/ChangesPanel.tsx.
+ *
+ * `fetchUncommittedCount` also calls `diffFiles` (a separate, unguarded call
+ * fired whenever scope isn't 'working' or a commit is selected), so a scope
+ * switch legitimately adds its OWN diffFiles traffic alongside fetchFiles's.
+ * That call never includes a `commitOid` key, while fetchFiles always does
+ * (even when its value is undefined) - the mock's `hasCommitOidKey` flag
+ * (tests/ui/mock-electron-api.js) lets this spec isolate fetchFiles's own
+ * call sequence from that unrelated, expected traffic.
+ *
+ * This spec locks two properties, using only fetchFiles-origin calls
+ * (`hasCommitOidKey === true`):
+ *   1. Coalescing - two `onDiffChanged` triggers that land while a diffFiles
+ *      call is in flight produce zero extra calls (not one call per trigger).
+ *   2. Latest params - when scope changes while the initial call is still in
+ *      flight, the queued rerun fires with the NEW scope, not the one
+ *      captured when fetchFiles was first invoked; the panel settles on the
+ *      new scope's files.
+ *
+ * Tier: UI (headless Chromium). window.__mockGitDiffFilesDeferred holds each
+ * diffFiles call open until its resolver is invoked, and
+ * window.__mockGitDiffFilesCalls records every call's params - both test
+ * hooks added to tests/ui/mock-electron-api.js for this spec. No PTY or real
+ * git needed.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const RUN_ID = Date.now();
+const PROJECT_ID = `proj-fetch-guard-${RUN_ID}`;
+const TASK_ID = `task-fetch-guard-${RUN_ID}`;
+const SESSION_ID = `sess-fetch-guard-${RUN_ID}`;
+
+// Distinct fixtures per scope so the test can tell, from the rendered file
+// tree, which scope's result actually won the race.
+const WORKING_FIXTURE = {
+  files: [
+    { path: 'src/working-only.ts', status: 'M', insertions: 1, deletions: 0, original: 'a', modified: 'b', language: 'typescript' },
+  ],
+};
+const STAGED_FIXTURE = {
+  files: [
+    { path: 'src/staged-only.ts', status: 'M', insertions: 2, deletions: 0, original: 'c', modified: 'd', language: 'typescript' },
+    { path: 'src/staged-second.ts', status: 'A', insertions: 3, deletions: 0, original: '', modified: 'e', language: 'typescript' },
+  ],
+};
+
+interface MockDiffFilesCall {
+  scope: string;
+  commitOid: string | null;
+  hasCommitOidKey: boolean;
+}
+
+async function getAllCalls(page: Page): Promise<MockDiffFilesCall[]> {
+  return page.evaluate(() => (window as unknown as { __mockGitDiffFilesCalls?: MockDiffFilesCall[] }).__mockGitDiffFilesCalls ?? []);
+}
+
+/** Only the calls that came from fetchFiles's own guarded call site (see
+ *  file header: fetchUncommittedCount never sends a `commitOid` key). */
+async function getFetchFilesCalls(page: Page): Promise<MockDiffFilesCall[]> {
+  return (await getAllCalls(page)).filter((call) => call.hasCommitOidKey);
+}
+
+/** Resolve the Nth (0-indexed, across ALL diffFiles calls - fetchFiles and
+ *  fetchUncommittedCount share the same resolver queue in call order). */
+async function resolveDiffFilesCall(page: Page, index: number): Promise<void> {
+  await page.evaluate((callIndex) => {
+    const resolvers = (window as unknown as { __mockGitDiffFilesResolvers?: Array<() => void> }).__mockGitDiffFilesResolvers ?? [];
+    const resolve = resolvers[callIndex];
+    if (!resolve) throw new Error(`No diffFiles resolver queued at index ${callIndex}`);
+    resolve();
+  }, index);
+}
+
+/**
+ * Launch a headless page with a project, an Executing lane, a task with a
+ * suspended session (so the dialog opens in view mode and the suspended body
+ * branch renders Changes without a live TerminalTab / PTY), and the
+ * working/staged diff fixtures seeded. Mirrors
+ * tests/ui/changes-panel-diff-disposal.spec.ts's launch helper.
+ */
+async function launchWithFetchGuardTask(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+
+  await page.addInitScript(`
+    window.__mockGitDiffByScope = {
+      working: ${JSON.stringify(WORKING_FIXTURE)},
+      staged: ${JSON.stringify(STAGED_FIXTURE)},
+    };
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+
+      state.projects.push({
+        id: '${PROJECT_ID}',
+        name: 'Fetch Guard Test ${RUN_ID}',
+        path: '/mock/fetch-guard-${RUN_ID}',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+
+      var executingLaneId = null;
+      state.DEFAULT_SWIMLANES.forEach(function (template, index) {
+        var laneId = 'lane-fetch-guard-' + template.name.toLowerCase().replace(/\\s+/g, '-') + '-${RUN_ID}';
+        if (template.name === 'Executing') executingLaneId = laneId;
+        state.swimlanes.push(Object.assign({}, template, {
+          id: laneId,
+          position: index,
+          created_at: ts,
+        }));
+      });
+
+      state.sessions.push({
+        id: '${SESSION_ID}',
+        taskId: '${TASK_ID}',
+        projectId: '${PROJECT_ID}',
+        pid: null,
+        status: 'suspended',
+        shell: 'bash',
+        cwd: '/mock/fetch-guard-${RUN_ID}',
+        startedAt: ts,
+        exitCode: null,
+        resuming: false,
+      });
+
+      state.tasks.push({
+        id: '${TASK_ID}',
+        title: 'Fetch Guard Task ${RUN_ID}',
+        description: 'Verifies the fetchFiles overlapping-fetch guard',
+        swimlane_id: executingLaneId,
+        position: 0,
+        agent: 'claude',
+        session_id: null,
+        worktree_path: null,
+        branch_name: null,
+        pr_number: null,
+        pr_url: null,
+        base_branch: null,
+        labels: [],
+        priority: 0,
+        archived_at: null,
+        created_at: ts,
+        updated_at: ts,
+      });
+
+      return { currentProjectId: '${PROJECT_ID}' };
+    });
+  `);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  await page.locator('[data-swimlane-name="Executing"]').waitFor({ state: 'visible', timeout: 10000 });
+
+  // Keep the session suspended: the dialog's reconcile-on-mount probe must not
+  // heal it into a live (terminal) session, which would change the body branch.
+  await page.evaluate(() => {
+    window.electronAPI.sessions.reconcile = async function () {
+      return null;
+    };
+  });
+
+  return { browser, page };
+}
+
+test.describe('ChangesPanel - fetchFiles overlapping-fetch guard', () => {
+  let browser: Browser;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    ({ browser, page } = await launchWithFetchGuardTask());
+  });
+
+  test.afterAll(async () => {
+    await browser?.close();
+  });
+
+  test('coalesces bursts of triggers in flight and reruns with the latest scope', async () => {
+    // Hold every diffFiles call open until its resolver is explicitly invoked.
+    await page.evaluate(() => {
+      (window as unknown as { __mockGitDiffFilesDeferred: boolean }).__mockGitDiffFilesDeferred = true;
+    });
+
+    const card = page.locator(`[data-task-id="${TASK_ID}"]`);
+    await card.waitFor({ state: 'visible', timeout: 8000 });
+    await card.click();
+    const dialog = page.locator('[data-testid="task-detail-dialog"]');
+    await dialog.waitFor({ state: 'visible', timeout: 8000 });
+
+    const changesToggle = page.locator('[data-testid="changes-toggle"]');
+    await changesToggle.waitFor({ state: 'visible', timeout: 8000 });
+    await changesToggle.click();
+
+    // Opening Changes mounts ChangesPanel, whose mount effect fires the
+    // initial fetchFiles() - the first diffFiles call, held open by the
+    // deferred hook above. Scope defaults to 'working' with no commit
+    // selected, so fetchUncommittedCount's separate call is NOT triggered
+    // yet (see ChangesPanel's mount-effect guard) - only fetchFiles's own
+    // call site is exercised so far.
+    await expect.poll(async () => (await getFetchFilesCalls(page)).length, { timeout: 8000 }).toBe(1);
+    expect((await getFetchFilesCalls(page))[0].scope).toBe('working'); // diffDefaultScope
+
+    // Fire two rapid fs.watch triggers while that call is still in flight.
+    // Both must just mark a pending re-fetch (fetchFilesRef.current() hits
+    // the in-flight guard) - neither should start a second diffFiles call.
+    await page.evaluate(() => {
+      const fire = (window as unknown as { __mockFireDiffChanged?: () => void }).__mockFireDiffChanged;
+      fire?.();
+      fire?.();
+    });
+
+    // Give any (incorrect) extra call a fixed budget to appear - this is a
+    // negative assertion (no additional call fires), which cannot be proven
+    // by polling for absence. 500ms is ample: a real overlapping call would
+    // be recorded synchronously within the same task-queue turn the trigger
+    // ran in, well under this window.
+    await page.waitForTimeout(500);
+    expect((await getFetchFilesCalls(page)).length).toBe(1);
+    // Also zero unrelated traffic at this point: scope is still 'working'
+    // throughout the burst, so fetchUncommittedCount never fires either.
+    expect((await getAllCalls(page)).length).toBe(1);
+
+    // Now change scope while the ORIGINAL fetchFiles call is still in
+    // flight - a third trigger of fetchFiles's call site (again just
+    // coalesced into the same pending flag), plus fetchUncommittedCount's
+    // own (separate, unguarded, by-design) call for the new non-working
+    // scope.
+    const scopeSelect = page.locator('[data-testid="changes-scope-select"]');
+    await scopeSelect.waitFor({ state: 'visible', timeout: 8000 });
+    await page.locator('[data-testid="changes-scope-staged"]').click();
+    await expect.poll(async () => (await getAllCalls(page)).length, { timeout: 8000 }).toBe(2);
+    // Still exactly one fetchFiles-origin call outstanding - the scope
+    // change did not spawn a second one despite being the third trigger
+    // received while the first call was in flight.
+    expect((await getFetchFilesCalls(page)).length).toBe(1);
+
+    // Resolve the in-flight (first, 'working') fetchFiles call. Its `finally`
+    // block sees the pending flag and fires exactly ONE rerun - through
+    // fetchFilesRef, so it picks up the CURRENT (staged) scope, not the
+    // 'working' scope captured when the original call was queued - despite
+    // THREE triggers (two watch fires + the scope change) having landed
+    // while it was in flight.
+    const allCallsBeforeResolve = await getAllCalls(page);
+    const originalFetchFilesIndex = allCallsBeforeResolve.findIndex((call) => call.hasCommitOidKey);
+    await resolveDiffFilesCall(page, originalFetchFilesIndex);
+    await expect.poll(async () => (await getFetchFilesCalls(page)).length, { timeout: 8000 }).toBe(2);
+    const fetchFilesCalls = await getFetchFilesCalls(page);
+    expect(fetchFilesCalls[1].scope).toBe('staged');
+
+    // Resolve every remaining outstanding call (fetchUncommittedCount's
+    // 'staged' call, and the coalesced fetchFiles rerun) so the panel
+    // settles fully.
+    const resolverCount = await page.evaluate(() => ((window as unknown as { __mockGitDiffFilesResolvers?: unknown[] }).__mockGitDiffFilesResolvers ?? []).length);
+    for (let index = 0; index < resolverCount; index++) {
+      if (index === originalFetchFilesIndex) continue; // already resolved above
+      await resolveDiffFilesCall(page, index);
+    }
+
+    // Final state reflects the staged fixture (the scope actually selected),
+    // not a stale working-scope result from the coalesced race. The tree
+    // groups files under a shared "src/" directory node and shows each leaf
+    // name once (no repeated "src/" prefix per file), so match on leaf names.
+    await expect(page.locator('[data-testid="changes-file-tree"]')).toContainText('staged-only.ts', { timeout: 8000 });
+    await expect(page.locator('[data-testid="changes-file-tree"]')).toContainText('staged-second.ts');
+    expect(await page.locator('[data-testid="changes-file-tree"]').textContent()).not.toContain('working-only.ts');
+
+    // Across the whole sequence (initial call + 2 watch fires + 1 scope
+    // change = 4 total triggers of fetchFiles's call site), the guard
+    // coalesced them into exactly 2 real diffFiles calls - never 3 or 4.
+    expect((await getFetchFilesCalls(page)).length).toBe(2);
+  });
+});

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -2115,6 +2115,38 @@
         // original, modified, language? }, or per-scope via
         // window.__mockGitDiffByScope = { working: {...}, staged: {...}, branch: {...} }.
         // Default stays empty.
+
+        // Test hook: record every diffFiles call (scope + commitOid + whether
+        // the request carries a 'commitOid' key at all) so a test can assert
+        // how many calls actually fired, with what params, and from which
+        // call site - used to verify ChangesPanel's fetchFiles
+        // in-flight/pending-rerun guard (a burst of fs.watch fires while a
+        // call is in flight must coalesce into a single queued rerun, not one
+        // call per fire). fetchFiles always passes a literal `commitOid:
+        // changesSelectedCommit ?? undefined` key (present even when
+        // undefined); the separate, unguarded fetchUncommittedCount never
+        // includes that key - hasCommitOidKey lets a test isolate fetchFiles's
+        // own call sequence from fetchUncommittedCount's independent calls.
+        if (typeof window !== 'undefined') {
+          window.__mockGitDiffFilesCalls = window.__mockGitDiffFilesCalls || [];
+          window.__mockGitDiffFilesCalls.push({
+            scope: request && request.scope,
+            commitOid: (request && request.commitOid) || null,
+            hasCommitOidKey: Object.prototype.hasOwnProperty.call(request || {}, 'commitOid'),
+          });
+        }
+        // Test hook: make diffFiles return a controlled promise so a test can
+        // hold a call in flight and observe the overlapping-fetch guard. Set
+        // window.__mockGitDiffFilesDeferred = true before triggering the
+        // call; each call then hangs until its own resolver (appended to
+        // window.__mockGitDiffFilesResolvers, in call order) is invoked.
+        if (typeof window !== 'undefined' && window.__mockGitDiffFilesDeferred) {
+          var diffFilesResolveRef;
+          var diffFilesPending = new Promise(function (res) { diffFilesResolveRef = res; });
+          window.__mockGitDiffFilesResolvers = window.__mockGitDiffFilesResolvers || [];
+          window.__mockGitDiffFilesResolvers.push(diffFilesResolveRef);
+          await diffFilesPending;
+        }
         var fixture = resolveGitDiffFixture(request);
         if (fixture && Array.isArray(fixture.files)) {
           var totalInsertions = 0;

--- a/tests/unit/count-lines.test.ts
+++ b/tests/unit/count-lines.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { countFileLines } from '../../src/main/git/line-count/count-lines';
+
+/** countFileLines' bounded read/scan contract: exact counts for normal files,
+ *  binary detection, and a floor (not a throw) for a file over the size cap. */
+describe('countFileLines', () => {
+  const tempDirs: string[] = [];
+
+  function makeTempFile(content: Buffer | string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kangentic-count-lines-'));
+    tempDirs.push(dir);
+    const filePath = path.join(dir, 'file.txt');
+    fs.writeFileSync(filePath, content);
+    return filePath;
+  }
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('counts newlines for a file ending with a trailing newline', async () => {
+    const filePath = makeTempFile('a\nb\nc\n');
+    await expect(countFileLines(filePath)).resolves.toEqual({ insertions: 3, binary: false, truncated: false });
+  });
+
+  it('adds one for a final line with no trailing newline', async () => {
+    const filePath = makeTempFile('a\nb\nc');
+    await expect(countFileLines(filePath)).resolves.toEqual({ insertions: 3, binary: false, truncated: false });
+  });
+
+  it('reports zero insertions for an empty file', async () => {
+    const filePath = makeTempFile('');
+    await expect(countFileLines(filePath)).resolves.toEqual({ insertions: 0, binary: false, truncated: false });
+  });
+
+  it('detects binary content from a null byte in the first 8KB and reports zero insertions', async () => {
+    const filePath = makeTempFile(Buffer.from([0x61, 0x00, 0x62, 0x0a, 0x63]));
+    await expect(countFileLines(filePath)).resolves.toEqual({ insertions: 0, binary: true, truncated: false });
+  });
+
+  it('bounds the read to the size cap for a pathologically large file, reporting a floor with truncated=true', async () => {
+    // One line per byte-pair well past the cap boundary, so the exact total
+    // line count is knowable while only a prefix is ever read/scanned.
+    const capBytes = 20 * 1024 * 1024;
+    const lineCount = Math.floor(capBytes / 2) + 1000;
+    const content = Buffer.from('a\n'.repeat(lineCount));
+    const filePath = makeTempFile(content);
+
+    const result = await countFileLines(filePath);
+    expect(result.binary).toBe(false);
+    expect(result.truncated).toBe(true);
+    // Only the capped prefix was scanned, so insertions is a floor strictly
+    // less than the file's true line count.
+    expect(result.insertions).toBeLessThan(lineCount);
+    expect(result.insertions).toBeGreaterThan(0);
+  }, 20_000);
+
+  // A single FileHandle.read is not guaranteed to fill the requested length
+  // (unlike fs.readFile, there is no internal retry loop). Real temp files
+  // via fs.mkdtempSync/writeFileSync always read back in one shot, so a
+  // short read cannot be forced through the real filesystem - this case
+  // spies on node:fs's promises.open/stat (restored immediately after) to
+  // simulate handle.read() returning fewer bytes than requested, mirroring
+  // the mock shape used by tests/unit/diff-service.test.ts's
+  // mockUntrackedFileContent.
+  it('scans only the bytes actually returned by a short FileHandle.read, not the zero-padded tail of an over-allocated buffer', async () => {
+    // Real file size is 5 bytes ("a\nb\nc"), but the read only returns the
+    // first 3 ("a\nb"). If the implementation scans the full requested
+    // length instead of just bytesRead, the unread tail is either zero
+    // bytes (old Buffer.alloc behavior -> a false binary detection, since a
+    // 0x00 byte is in the scanned range) or uninitialized garbage
+    // (allocUnsafe scanned past bytesRead -> a non-deterministic count).
+    // Only "a\nb" (3 bytes) must be scanned: one newline plus a final
+    // unterminated 'b' => 2 insertions, not binary.
+    const fullContent = Buffer.from('a\nb\nc');
+    const shortReadBytes = 3;
+
+    const statSpy = vi.spyOn(fs.promises, 'stat').mockResolvedValue({ size: fullContent.length } as never);
+    const readMock = vi.fn(async (buffer: Buffer, offset: number, length: number, position: number) => {
+      // Simulate a short read: copy only `shortReadBytes`, regardless of the
+      // full `length` requested, and report that truncated bytesRead. The
+      // rest of the caller's buffer (whatever its allocation strategy) must
+      // never be scanned.
+      fullContent.copy(buffer, offset, position, position + shortReadBytes);
+      return { bytesRead: shortReadBytes, buffer };
+    });
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+    const openSpy = vi.spyOn(fs.promises, 'open').mockResolvedValue({
+      read: readMock,
+      close: closeMock,
+    } as never);
+
+    try {
+      const result = await countFileLines('/mock/short-read-fixture.txt');
+      expect(result).toEqual({ insertions: 2, binary: false, truncated: false });
+    } finally {
+      statSpy.mockRestore();
+      openSpy.mockRestore();
+    }
+  });
+});

--- a/tests/unit/diff-render-options.test.ts
+++ b/tests/unit/diff-render-options.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { selectDiffAlgorithmOptions } from '../../src/renderer/components/dialogs/task-detail/changes/diff-render-options';
+
+describe('selectDiffAlgorithmOptions', () => {
+  it('uses the advanced algorithm with no computation-time bound for a small diff', () => {
+    expect(selectDiffAlgorithmOptions(100, 200)).toEqual({ diffAlgorithm: 'advanced' });
+  });
+
+  it('drops to the legacy algorithm with a bounded computation time for a large diff', () => {
+    expect(selectDiffAlgorithmOptions(150_000, 150_000)).toEqual({
+      diffAlgorithm: 'legacy',
+      maxComputationTime: 2_000,
+    });
+  });
+
+  it('is exactly at the boundary when combined length equals the threshold (still advanced)', () => {
+    expect(selectDiffAlgorithmOptions(100_000, 100_000)).toEqual({ diffAlgorithm: 'advanced' });
+  });
+});

--- a/tests/unit/diff-service.test.ts
+++ b/tests/unit/diff-service.test.ts
@@ -76,7 +76,12 @@ describe('DiffService', () => {
   let service: DiffService;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    // resetAllMocks (not clearAllMocks) also drops each mock's configured
+    // implementation/resolved-value - clearAllMocks only clears call history,
+    // so a mockResolvedValue set by one test (e.g. mockUntrackedFileContent's
+    // fs.promises.stat/open) would otherwise silently leak into the next test
+    // that never configures those mocks itself.
+    vi.resetAllMocks();
     service = new DiffService('/project');
     // Default merge-base mock - tests can override as needed
     mockGit.raw.mockResolvedValue('abc123\n');
@@ -506,7 +511,7 @@ describe('DiffService', () => {
       mockGit.diffSummary.mockResolvedValue(makeDiffSummary([]));
       mockGit.diff.mockResolvedValue('');
       mockGit.status.mockResolvedValue({ not_added: ['src/brand-new.ts'] });
-      vi.mocked(fs.promises.readFile).mockResolvedValue(Buffer.from('line1\nline2\n') as never);
+      mockUntrackedFileContent(Buffer.from('line1\nline2\n'));
 
       const result = await service.getChurnSummary('main');
 

--- a/tests/unit/diff-service.test.ts
+++ b/tests/unit/diff-service.test.ts
@@ -22,12 +22,37 @@ vi.mock('node:fs', () => ({
   default: {
     promises: {
       readFile: vi.fn(),
+      stat: vi.fn(),
+      open: vi.fn(),
     },
   },
 }));
 
+// Isolates the offload-threshold decision (diff-service.ts) from the
+// worker's own behavior (covered separately in line-count-client.test.ts).
+const { mockCountFiles } = vi.hoisted(() => ({ mockCountFiles: vi.fn() }));
+
+vi.mock('../../src/main/git/line-count/line-count-client', () => ({
+  lineCountClient: { countFiles: mockCountFiles },
+}));
+
 import fs from 'node:fs';
+import path from 'node:path';
 import { DiffService } from '../../src/main/git/diff-service';
+
+/** Backs the countFileLines bounded stat+open read path (see
+ *  src/main/git/line-count/count-lines.ts) with a single in-memory buffer, so
+ *  an untracked-file test can simulate its content without touching disk. */
+function mockUntrackedFileContent(content: Buffer): void {
+  vi.mocked(fs.promises.stat).mockResolvedValue({ size: content.length } as never);
+  vi.mocked(fs.promises.open).mockResolvedValue({
+    read: vi.fn(async (buffer: Buffer, offset: number, length: number, position: number) => {
+      content.copy(buffer, offset, position, position + length);
+      return { bytesRead: length, buffer };
+    }),
+    close: vi.fn().mockResolvedValue(undefined),
+  } as never);
+}
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -263,8 +288,8 @@ describe('DiffService', () => {
       ]));
       mockGit.diff.mockResolvedValue('M\tsrc/existing.ts\n');
       mockGit.status.mockResolvedValue({ not_added: ['src/brand-new.ts'] });
-      // Mock readFile to return a buffer with 3 lines (2 newlines + content after last)
-      vi.mocked(fs.promises.readFile).mockResolvedValue(Buffer.from('line1\nline2\nline3') as never);
+      // 3 lines (2 newlines + content after the last, unterminated line)
+      mockUntrackedFileContent(Buffer.from('line1\nline2\nline3'));
 
       const result = await service.getDiffFiles({
         projectPath: '/project',
@@ -289,7 +314,7 @@ describe('DiffService', () => {
       mockGit.status.mockResolvedValue({ not_added: ['image.png'] });
       // Buffer with a null byte in the first 8KB
       const binaryBuffer = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x00, 0x0A]);
-      vi.mocked(fs.promises.readFile).mockResolvedValue(binaryBuffer as never);
+      mockUntrackedFileContent(binaryBuffer);
 
       const result = await service.getDiffFiles({
         projectPath: '/project',
@@ -327,7 +352,7 @@ describe('DiffService', () => {
       mockGit.diffSummary.mockResolvedValue(makeDiffSummary([]));
       mockGit.diff.mockResolvedValue('');
       mockGit.status.mockResolvedValue({ not_added: ['deleted-before-read.ts'] });
-      vi.mocked(fs.promises.readFile).mockRejectedValue(new Error('ENOENT'));
+      vi.mocked(fs.promises.stat).mockRejectedValue(new Error('ENOENT'));
 
       const result = await service.getDiffFiles({
         projectPath: '/project',
@@ -349,7 +374,7 @@ describe('DiffService', () => {
       mockGit.diff.mockResolvedValue('');
       mockGit.status.mockResolvedValue({ not_added: ['src/file.ts'] });
       // File with trailing newline: 2 lines
-      vi.mocked(fs.promises.readFile).mockResolvedValue(Buffer.from('line1\nline2\n') as never);
+      mockUntrackedFileContent(Buffer.from('line1\nline2\n'));
 
       const result = await service.getDiffFiles({
         projectPath: '/project',
@@ -357,6 +382,91 @@ describe('DiffService', () => {
       });
 
       expect(result.files[0].insertions).toBe(2);
+    });
+
+    describe('untracked line-count offload (UNTRACKED_OFFLOAD_THRESHOLD_BYTES)', () => {
+      it('delegates to the line-count worker, with joined absolute paths, when aggregate untracked bytes exceed the offload threshold', async () => {
+        mockGit.diffSummary.mockResolvedValue(makeDiffSummary([]));
+        mockGit.diff.mockResolvedValue('');
+        mockGit.status.mockResolvedValue({ not_added: ['big-file.bin'] });
+        // A single 3MB untracked file - aggregate (3MB) > the 2MB threshold.
+        vi.mocked(fs.promises.stat).mockResolvedValue({ size: 3 * 1024 * 1024 } as never);
+        const absolutePath = path.join('/project', 'big-file.bin');
+        mockCountFiles.mockResolvedValue([{ path: absolutePath, insertions: 42, binary: false }]);
+
+        await service.getDiffFiles({ projectPath: '/project', baseBranch: 'main' });
+
+        expect(mockCountFiles).toHaveBeenCalledWith([absolutePath]);
+      });
+
+      it('does NOT delegate to the line-count worker when aggregate untracked bytes are under the offload threshold', async () => {
+        mockGit.diffSummary.mockResolvedValue(makeDiffSummary([]));
+        mockGit.diff.mockResolvedValue('');
+        mockGit.status.mockResolvedValue({ not_added: ['small-file.txt'] });
+        // A handful of bytes, well under the 2MB threshold.
+        mockUntrackedFileContent(Buffer.from('a\nb\n'));
+
+        await service.getDiffFiles({ projectPath: '/project', baseBranch: 'main' });
+
+        expect(mockCountFiles).not.toHaveBeenCalled();
+      });
+
+      it('falls back to inline counting when the worker is unavailable (countFiles resolves null)', async () => {
+        mockGit.diffSummary.mockResolvedValue(makeDiffSummary([]));
+        mockGit.diff.mockResolvedValue('');
+        mockGit.status.mockResolvedValue({ not_added: ['big-file.bin'] });
+        // Force the offload branch (large reported size)...
+        vi.mocked(fs.promises.stat).mockResolvedValue({ size: 3 * 1024 * 1024 } as never);
+        // ...but the worker is unavailable (not spawned / crashed / timed out).
+        mockCountFiles.mockResolvedValue(null);
+        // The inline countFileLines fallback reads via fs.promises.open/read;
+        // only the actually-returned bytes are scanned regardless of the
+        // inflated stat() size above (see count-lines.test.ts's short-read
+        // coverage), so this content resolves deterministically to 3 lines.
+        const content = Buffer.from('line1\nline2\nline3\n');
+        vi.mocked(fs.promises.open).mockResolvedValue({
+          read: vi.fn(async (buffer: Buffer, offset: number, _length: number, position: number) => {
+            content.copy(buffer, offset, position, position + content.length);
+            return { bytesRead: content.length, buffer };
+          }),
+          close: vi.fn().mockResolvedValue(undefined),
+        } as never);
+
+        const result = await service.getDiffFiles({ projectPath: '/project', baseBranch: 'main' });
+
+        // The offload was attempted (and declined the worker's result), then
+        // fell through to inline counting instead of losing the file.
+        expect(mockCountFiles).toHaveBeenCalled();
+        expect(result.files[0]).toEqual({
+          path: 'big-file.bin',
+          status: 'U',
+          insertions: 3,
+          deletions: 0,
+          binary: false,
+        });
+      });
+
+      it('maps worker results back to the original relative untracked paths by index, not by the entry.path field', async () => {
+        mockGit.diffSummary.mockResolvedValue(makeDiffSummary([]));
+        mockGit.diff.mockResolvedValue('');
+        mockGit.status.mockResolvedValue({ not_added: ['src/big-one.bin', 'assets/big-two.bin'] });
+        // 2 files * 1.5MB = 3MB aggregate, over the 2MB threshold.
+        vi.mocked(fs.promises.stat).mockResolvedValue({ size: 1.5 * 1024 * 1024 } as never);
+        // Deliberately mismatched `path` fields on the worker's entries, so a
+        // regression that zips by entry.path (instead of untrackedPaths[index])
+        // would surface as a wrong path in the result.
+        mockCountFiles.mockResolvedValue([
+          { path: 'garbage-value-should-be-ignored-0', insertions: 10, binary: false },
+          { path: 'garbage-value-should-be-ignored-1', insertions: 0, binary: true },
+        ]);
+
+        const result = await service.getDiffFiles({ projectPath: '/project', baseBranch: 'main' });
+
+        expect(result.files).toEqual([
+          { path: 'src/big-one.bin', status: 'U', insertions: 10, deletions: 0, binary: false },
+          { path: 'assets/big-two.bin', status: 'U', insertions: 0, deletions: 0, binary: true },
+        ]);
+      });
     });
 
     it('skips malformed name-status lines', async () => {

--- a/tests/unit/line-count-client.test.ts
+++ b/tests/unit/line-count-client.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+/**
+ * LineCountClient lifecycle + degradation contract, mirroring embed-client's
+ * test shape. The real client talks to an Electron utilityProcess worker;
+ * vitest has no Electron, so 'electron' is mocked with a fork that returns a
+ * controllable EventEmitter "child". Every failure path must resolve `null`
+ * (never throw) so diff-service.ts falls back to inline counting.
+ */
+
+const { mockFork } = vi.hoisted(() => ({ mockFork: vi.fn() }));
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false },
+  utilityProcess: { fork: mockFork },
+}));
+
+import { LineCountClient } from '../../src/main/git/line-count/line-count-client';
+
+// Mirrors the private IDLE_SHUTDOWN_MS in line-count-client.ts.
+const IDLE_SHUTDOWN_MS = 60_000;
+
+interface FakeChild extends EventEmitter {
+  postMessage: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+const forkedChildren: FakeChild[] = [];
+
+function makeFakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.postMessage = vi.fn();
+  child.kill = vi.fn();
+  return child;
+}
+
+function lastChild(): FakeChild {
+  return forkedChildren[forkedChildren.length - 1];
+}
+
+describe('LineCountClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    forkedChildren.length = 0;
+    mockFork.mockImplementation(() => {
+      const child = makeFakeChild();
+      forkedChildren.push(child);
+      return child;
+    });
+  });
+
+  it('short-circuits an empty batch to [] without forking', async () => {
+    const client = new LineCountClient();
+    await expect(client.countFiles([])).resolves.toEqual([]);
+    expect(mockFork).not.toHaveBeenCalled();
+  });
+
+  it('forks the worker, posts a count request, and resolves the returned entries', async () => {
+    const client = new LineCountClient();
+    const promise = client.countFiles(['/mock/a.txt', '/mock/b.txt']);
+    const child = lastChild();
+
+    expect(mockFork).toHaveBeenCalledTimes(1);
+    expect(child.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'count', id: 1, paths: ['/mock/a.txt', '/mock/b.txt'] }),
+    );
+
+    const entries = [
+      { path: '/mock/a.txt', insertions: 3, binary: false },
+      { path: '/mock/b.txt', insertions: 0, binary: true },
+    ];
+    child.emit('message', { type: 'result', id: 1, entries });
+
+    await expect(promise).resolves.toBe(entries);
+    client.dispose();
+  });
+
+  it('reuses the same worker across sequential requests', async () => {
+    const client = new LineCountClient();
+    const first = client.countFiles(['/mock/a.txt']);
+    lastChild().emit('message', { type: 'result', id: 1, entries: [] });
+    await first;
+
+    const second = client.countFiles(['/mock/b.txt']);
+    expect(mockFork).toHaveBeenCalledTimes(1);
+    lastChild().emit('message', { type: 'result', id: 2, entries: [] });
+    await second;
+
+    client.dispose();
+  });
+
+  it('resolves null when the worker replies with an error for the request', async () => {
+    const client = new LineCountClient();
+    const promise = client.countFiles(['/mock/a.txt']);
+    lastChild().emit('message', { type: 'error', id: 1, message: 'boom' });
+
+    await expect(promise).resolves.toBeNull();
+    client.dispose();
+  });
+
+  it('resolves null when the request times out with no reply', async () => {
+    const client = new LineCountClient();
+    const promise = client.countFiles(['/mock/a.txt'], 10);
+
+    await expect(promise).resolves.toBeNull();
+    client.dispose();
+  });
+
+  it('resolves in-flight requests null on an unexpected worker exit and disables offload after MAX_CRASHES', async () => {
+    const client = new LineCountClient();
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      const promise = client.countFiles(['/mock/a.txt']);
+      lastChild().emit('exit');
+      await expect(promise).resolves.toBeNull();
+    }
+
+    expect(client.crashed).toBe(true);
+    expect(mockFork).toHaveBeenCalledTimes(3);
+
+    // Further calls degrade to null without forking again, so diff-service.ts
+    // always has a working inline fallback.
+    await expect(client.countFiles(['/mock/again.txt'])).resolves.toBeNull();
+    expect(mockFork).toHaveBeenCalledTimes(3);
+  });
+
+  it('dispose() kills the worker, resolves pending null, and refuses further work', async () => {
+    const client = new LineCountClient();
+    const promise = client.countFiles(['/mock/a.txt']);
+    const child = lastChild();
+
+    client.dispose();
+
+    await expect(promise).resolves.toBeNull();
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    await expect(client.countFiles(['/mock/later.txt'])).resolves.toBeNull();
+    expect(mockFork).toHaveBeenCalledTimes(1);
+  });
+
+  it('recycles the worker after an idle timeout without counting it as a crash', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new LineCountClient();
+
+      const promise = client.countFiles(['/mock/a.txt']);
+      const child = lastChild();
+      child.emit('message', { type: 'result', id: 1, entries: [] });
+      await promise;
+
+      await vi.advanceTimersByTimeAsync(IDLE_SHUTDOWN_MS);
+      // The real utilityProcess emits 'exit' asynchronously after kill(); the
+      // mock's kill() is a no-op, so simulate that exit explicitly.
+      child.emit('exit');
+
+      expect(client.crashed).toBe(false);
+
+      const nextPromise = client.countFiles(['/mock/b.txt']);
+      expect(mockFork).toHaveBeenCalledTimes(2);
+      lastChild().emit('message', { type: 'result', id: 2, entries: [] });
+      await nextPromise;
+
+      client.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores a stale exit from a killed predecessor so it cannot null a freshly spawned replacement or resolve its in-flight request', async () => {
+    // Mirrors the real utilityProcess timing gap: killChild() synchronously
+    // nulls this.child and requests a kill, but the OS reaps the process (and
+    // fires 'exit') asynchronously later - potentially after a replacement
+    // has already been spawned and given work of its own.
+    vi.useFakeTimers();
+    try {
+      const client = new LineCountClient();
+
+      // C1 serves one request, then goes idle so the recycle timer fires.
+      const firstPromise = client.countFiles(['/mock/a.txt']);
+      const firstChild = lastChild();
+      firstChild.emit('message', { type: 'result', id: 1, entries: [] });
+      await firstPromise;
+
+      // Idle recycle: killChild() nulls this.child synchronously. C1's real
+      // 'exit' has NOT fired yet (we deliberately don't emit it here).
+      await vi.advanceTimersByTimeAsync(IDLE_SHUTDOWN_MS);
+
+      // Before C1's late exit arrives, a fresh request spawns its
+      // replacement, C2, and leaves it with an in-flight request.
+      const secondPromise = client.countFiles(['/mock/b.txt']);
+      expect(mockFork).toHaveBeenCalledTimes(2);
+      const secondChild = lastChild();
+      expect(secondChild).not.toBe(firstChild);
+
+      // C1's 'exit' now arrives late, after C2 is already tracked and has
+      // work in flight.
+      firstChild.emit('exit');
+
+      // The stale exit must not have nulled the live child (C2) or resolved
+      // C2's pending request - C2's own 'result' message must still resolve
+      // it normally.
+      const entries = [{ path: '/mock/b.txt', insertions: 5, binary: false }];
+      secondChild.emit('message', { type: 'result', id: 2, entries });
+      await expect(secondPromise).resolves.toBe(entries);
+      expect(client.crashed).toBe(false);
+
+      // If the stale exit had nulled this.child, this next call would fork a
+      // THIRD child instead of reusing C2.
+      const thirdPromise = client.countFiles(['/mock/c.txt']);
+      expect(mockFork).toHaveBeenCalledTimes(2);
+      secondChild.emit('message', { type: 'result', id: 3, entries: [] });
+      await thirdPromise;
+
+      client.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/unit/on-idle.test.ts
+++ b/tests/unit/on-idle.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Unit tests for src/renderer/utils/on-idle.ts.
+ *
+ * vitest runs this suite in the default 'node' environment (no jsdom in this
+ * project's vitest.config.ts), so `window` is not a real global here. We stub
+ * `globalThis.window` per test, mirroring the pattern used by
+ * tests/unit/terminal-clipboard-osc52.test.ts.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { onIdle } from '../../src/renderer/utils/on-idle';
+
+describe('onIdle', () => {
+  const originalWindow = globalThis.window;
+
+  afterEach(() => {
+    globalThis.window = originalWindow;
+    vi.useRealTimers();
+  });
+
+  it('calls window.requestIdleCallback when it is available, without falling back to a timer', () => {
+    const requestIdleCallback = vi.fn();
+    // @ts-expect-error -- minimal window stub carrying only what onIdle reads
+    globalThis.window = { requestIdleCallback };
+    const callback = vi.fn();
+
+    onIdle(callback);
+
+    expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+    expect(requestIdleCallback).toHaveBeenCalledWith(callback);
+    // The callback itself is only invoked by requestIdleCallback, never by onIdle directly.
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('falls back to setTimeout when window.requestIdleCallback is absent', () => {
+    vi.useFakeTimers();
+    // @ts-expect-error -- minimal window stub with no requestIdleCallback
+    globalThis.window = {};
+    const callback = vi.fn();
+
+    onIdle(callback);
+
+    expect(callback).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

Three independent fixes so opening the Git Changes view (and a busy repo generally) never freezes the renderer or stalls the main process:

- **Renderer:** the Changes panel's lazy chunk (and its Monaco `monaco-editor` import graph) is now idle-warmed once per session right after a task detail opens, instead of paying for a synchronous parse/eval on the first click. A two-pane skeleton replaces the bare spinner Suspense fallback for a cold, unwarmed open. Monaco's diff options are now picked by content size (`diff-render-options.ts`): a large diff drops from the `advanced` word-level algorithm to `legacy` with a tighter `maxComputationTime`, so a huge diff resolves faster.
- **Main process:** `DiffService.getDiffFiles` used to count every untracked file's newlines with a synchronous byte-by-byte loop over the whole buffer, fanned across all untracked files at once - a large or numerous untracked tree could block the main event loop, which owns better-sqlite3, the PTYs, and every IPC call. Untracked counting now runs through a bounded, `indexOf`-based scanner (`count-lines.ts`, capped at 20MB per file) and delegates batches over a 2MB aggregate threshold to a new `line-count` `utilityProcess` worker (mirrors the embedding worker's fork/crash-cap/idle-shutdown pattern), falling back to inline counting if the worker is unavailable.
- **Renderer cascade:** `ChangesPanel`'s fs.watch-driven refetch cascade is hardened against a write burst - `fetchFiles` now guards against overlapping calls (in-flight + pending-rerun instead of concurrent fan-out) and derives the Uncommitted-row count from its own result when scope is `'working'`, eliminating a redundant second `diffFiles` call on every watcher fire in the common case.

## Why

Opening the Changes view could feel like it froze the UI, and a repo with a large/numerous untracked tree (a generated `resources/`, a build artifact) could stall the whole app - every IPC call, PTY, and DB write goes through the same main-process event loop the byte-scan was blocking.

## How

Verified empirically in a live preview rather than relying on synthetic assumptions: reverted `diff-service.ts` to the old synchronous scan and hit it with a 150MB untracked file via `window.electronAPI.git.diffFiles` - a clean 78ms main-process event-loop lag spike appeared. The fixed code scans the identical file (correctly truncated to the 20MB cap) with zero measurable lag, including under 3 concurrent calls simulating an agent write burst.

Trade-offs:
- Untracked files over the 20MB cap report a floor line count, not an exact one (acceptable for a display-only insertions badge).
- The worker adds real lifecycle surface (spawn/crash-cap/idle-shutdown), justified by the explicit ask to offload rather than only bound the inline scan.

## Breaking changes

None.

## Tests

- New unit tests: `count-lines.test.ts` (bounded read/scan, binary detection, truncation, short-read handling), `line-count-client.test.ts` (worker lifecycle: fork/round-trip/timeout/crash-cap/dispose/idle-recycle/stale-exit guard), `diff-render-options.test.ts` (algorithm/threshold selection), `on-idle.test.ts` (idle-scheduling fallback).
- `diff-service.test.ts` updated for the new stat/open-based untracked counting path, plus a `beforeEach` fix (`vi.resetAllMocks()` instead of `vi.clearAllMocks()`) that was leaking a mocked file-read implementation between tests.
- New UI test `changes-panel-fetch-guard.spec.ts` covers `fetchFiles`'s overlapping-call guard (a burst of `onDiffChanged` fires coalesces to zero extra calls; a scope change mid-flight is picked up by the single queued rerun with the latest params).
- CI: typecheck, lint, unit, UI, and the Linux Electron E2E shards.

Generated with [Claude Code](https://claude.com/claude-code)
