### PR TITLE
fix(overrides): lock all per-task Advanced overrides at first spawn

### DIFF
--- a/src/main/ipc/handlers/task-crud.ts
+++ b/src/main/ipc/handlers/task-crud.ts
@@ -15,6 +15,7 @@ import {
   createTransitionEngine,
   cleanupTaskResources,
   resolveSpawnOverrides,
+  freezeAdvancedOverridesOnFirstSpawn,
 } from '../helpers';
 import { resolveProjectContext } from '../helpers/project-repos';
 import { guardActiveNonWorktreeSessions } from './task-move';
@@ -132,6 +133,20 @@ export function registerTaskCrudHandlers(context: IpcContext): void {
         const sessionRepo = new SessionRepository(db);
         const engine = createTransitionEngine(context, actions, tasks, sessionRepo, attachments, projectId, projectPath);
         const project = context.projectRepo.getById(projectId);
+
+        // A task created directly in a spawn column spawns via
+        // executeTransition below without going through spawnAgent, so this
+        // path needs its own freeze call. The New Task dialog displayed
+        // inherit values against the creation column itself, so the creation
+        // column IS the settings lane here.
+        freezeAdvancedOverridesOnFirstSpawn({
+          task,
+          hasSessionRecord: false,
+          settingsLane: toLane,
+          project,
+          globalPermissionMode: () => context.configManager.getEffectiveConfig(projectPath).agent.permissionMode,
+          tasks,
+        });
 
         const overrides = resolveSpawnOverrides(task, toLane, project);
         try {

--- a/src/main/ipc/handlers/task-move.ts
+++ b/src/main/ipc/handlers/task-move.ts
@@ -147,6 +147,14 @@ export function abortTaskMove(taskId: string): boolean {
 type MoveSpawnPlan = {
   task: Task;
   fromSwimlaneId: string;
+  /**
+   * The SOURCE lane the task lived in before this move, captured at Phase 1.
+   * Threaded to spawnAgent as `settingsSourceLane`: the freeze-on-first-spawn
+   * resolves still-inherited Advanced fields against the lane the user
+   * configured the task in, never the destination column. Required (not
+   * optional) so every plan-return site threads it through explicitly.
+   */
+  fromLane: Swimlane | undefined;
   originalPosition: number;
   toLane: Swimlane | undefined;
   skipPromptTemplate: boolean;
@@ -496,6 +504,7 @@ export async function handleTaskMove(
           return {
             task,
             fromSwimlaneId,
+            fromLane,
             originalPosition,
             toLane,
             skipPromptTemplate,
@@ -624,6 +633,7 @@ export async function handleTaskMove(
             return {
               task,
               fromSwimlaneId,
+              fromLane,
               originalPosition,
               toLane,
               skipPromptTemplate,
@@ -689,6 +699,7 @@ export async function handleTaskMove(
             return {
               task,
               fromSwimlaneId,
+              fromLane,
               originalPosition,
               toLane,
               skipPromptTemplate,
@@ -756,6 +767,7 @@ export async function handleTaskMove(
       return {
         task: planTask,
         fromSwimlaneId,
+        fromLane,
         originalPosition,
         toLane,
         skipPromptTemplate,
@@ -773,7 +785,7 @@ export async function handleTaskMove(
     // will spawn for the destination column.
     if (isShuttingDown()) return;
 
-    const { task, fromSwimlaneId, originalPosition, toLane, skipPromptTemplate, resolvedProjectId, resolvedProjectPath, continuationPrompt, suppressAutoCommand } = plan;
+    const { task, fromSwimlaneId, fromLane, originalPosition, toLane, skipPromptTemplate, resolvedProjectId, resolvedProjectPath, continuationPrompt, suppressAutoCommand } = plan;
 
     // === Phase 2 (unlocked, slow) ===
     // All async operations below receive the abort signal so a newer move
@@ -883,7 +895,7 @@ export async function handleTaskMove(
           const sessionRepoPhase3 = new SessionRepository(dbPhase3);
           const engine = createTransitionEngine(context, actionsPhase3, tasksPhase3, sessionRepoPhase3, attachmentsPhase3, resolvedProjectId, resolvedProjectPath);
           if (toLane) {
-            await spawnAgent({ context, engine, tasks: tasksPhase3, sessionRepo: sessionRepoPhase3, task: current, fromSwimlaneId, toLane, skipPromptTemplate, signal, projectId: resolvedProjectId, projectPath: resolvedProjectPath, continuationPrompt, suppressAutoCommand });
+            await spawnAgent({ context, engine, tasks: tasksPhase3, sessionRepo: sessionRepoPhase3, task: current, fromSwimlaneId, toLane, skipPromptTemplate, signal, projectId: resolvedProjectId, projectPath: resolvedProjectPath, continuationPrompt, suppressAutoCommand, settingsSourceLane: fromLane ?? null });
           }
         } finally {
           clearSpawnProgress(context.mainWindow, task.id);

--- a/src/main/ipc/helpers/agent-spawn.ts
+++ b/src/main/ipc/helpers/agent-spawn.ts
@@ -10,7 +10,7 @@ import { interpolateTemplate } from '../../agent/shared';
 import { agentRegistry } from '../../agent/agent-registry';
 import { buildSessionHistoryReference } from '../../agent/handoff/session-history-reference';
 import { DEFAULT_AGENT } from '../../../shared/types';
-import type { Task, Swimlane, Project } from '../../../shared/types';
+import type { Task, Swimlane, Project, PermissionMode } from '../../../shared/types';
 import type { IpcContext } from '../ipc-context';
 import { isAbortError } from '../../../shared/abort-utils';
 import { resolveTargetAgent } from '../../transition-engine/agent-resolver';
@@ -63,6 +63,82 @@ export function resolveSpawnOverrides(
     isolatedSwimlaneId: resolveIsolatedSwimlaneId(lane),
     forceFresh: resolveForceFresh(lane),
   };
+}
+
+/**
+ * Freeze the Advanced (Agent / Model / Effort / Permission) overrides on a
+ * task's very first ever spawn.
+ *
+ * A task that already carries at least one explicit override but leaves the
+ * others on "inherit" gets ALL FOUR fields frozen to the values the Advanced
+ * tab displayed when the user configured it: task override -> the lane the
+ * task lived in at config time (`settingsLane`) -> project default (global
+ * permission mode for Permission). The DESTINATION column's settings never
+ * leak into the frozen contract - the user never saw them in the dialog. A
+ * destination lane forcing `permission_mode: 'plan'` still wins at spawn
+ * resolution (transition-engine.ts / prepare-spawn.ts); the frozen permission
+ * is what the task runs under everywhere else.
+ *
+ * A task with NO overrides at all is untouched - it keeps following
+ * column/project defaults for its whole life.
+ *
+ * "First ever spawn" = no session record exists AND task.agent is still null.
+ * task.agent is set once, at first successful spawn (see transition-engine.ts),
+ * and is NOT cleared by a To-Do reset (cleanupTaskResources wipes session rows
+ * but never touches task.agent), so a task that spawned once, was reset to To
+ * Do, and is redragged forward is correctly not treated as fresh.
+ *
+ * Mutates the passed `task` object in place (in addition to persisting) so the
+ * spawn already in flight resolves against the frozen values without a re-read.
+ */
+export function freezeAdvancedOverridesOnFirstSpawn(options: {
+  task: Task;
+  /** Whether any session row exists for the task (first-ever-spawn detection). */
+  hasSessionRecord: boolean;
+  /**
+   * The lane whose inherited settings the New Task / Edit dialog displayed
+   * when the user configured the task: the lane the task lived in before this
+   * spawn (a drag move passes the SOURCE lane), or the creation column for a
+   * task created directly in a spawn column. Null when that lane no longer
+   * resolves - inherited fields then freeze to project/global defaults.
+   */
+  settingsLane: Pick<Swimlane, 'agent_override' | 'model_override' | 'effort_override' | 'permission_mode'> | null;
+  project: Pick<Project, 'default_agent' | 'default_model' | 'default_effort'> | null | undefined;
+  /**
+   * Lazy accessor for the global permission-mode default. Invoked only when
+   * the freeze actually proceeds AND the global fallback is reached, so a
+   * no-op spawn (the common case) never pays for the synchronous project-config
+   * disk read behind `getEffectiveConfig`.
+   */
+  globalPermissionMode: () => PermissionMode;
+  tasks: Pick<TaskRepository, 'update'>;
+}): void {
+  const { task, hasSessionRecord, settingsLane, project, globalPermissionMode, tasks } = options;
+  const isFirstEverSpawn = !hasSessionRecord && task.agent === null;
+  const hasAnyOverrideSet = task.agent_override !== null || task.model_override !== null
+    || task.effort_override !== null || task.permission_mode !== null;
+  if (!isFirstEverSpawn || !hasAnyOverrideSet) return;
+
+  const frozenAgent = task.agent_override ?? settingsLane?.agent_override ?? project?.default_agent ?? DEFAULT_AGENT;
+  const frozenModel = task.model_override ?? settingsLane?.model_override ?? project?.default_model ?? null;
+  const frozenEffort = task.effort_override ?? settingsLane?.effort_override ?? project?.default_effort ?? null;
+  const frozenPermission = task.permission_mode ?? settingsLane?.permission_mode ?? globalPermissionMode();
+
+  tasks.update({
+    id: task.id,
+    agent_override: frozenAgent,
+    model_override: frozenModel,
+    effort_override: frozenEffort,
+    permission_mode: frozenPermission,
+  });
+  task.agent_override = frozenAgent;
+  task.model_override = frozenModel;
+  task.effort_override = frozenEffort;
+  task.permission_mode = frozenPermission;
+  console.log(
+    `[spawnAgent] Froze Advanced overrides for task ${task.id.slice(0, 8)} on first spawn:`
+    + ` agent=${frozenAgent} model=${frozenModel ?? 'null'} effort=${frozenEffort ?? 'null'} permission=${frozenPermission}`,
+  );
 }
 
 /** Create a TransitionEngine wired to explicit project context (not singletons). */
@@ -134,6 +210,16 @@ export interface AgentSpawnOptions {
    * task-archive.ts and startup recovery in resume-suspended.ts.
    */
   suppressAutoCommand?: boolean;
+  /**
+   * The lane whose inherited settings the New Task / Edit dialog displayed
+   * when the user configured the task. The freeze-on-first-spawn resolves
+   * still-inherited fields against THIS lane, never the destination column
+   * (whose settings the user never saw in the dialog). Drag moves pass the
+   * SOURCE lane (null when it no longer resolves); omit to fall back to
+   * `toLane` (promotion / MCP creation directly into a spawn column, where
+   * the task was configured against the destination itself).
+   */
+  settingsSourceLane?: Swimlane | null;
 }
 
 /**
@@ -169,6 +255,19 @@ export async function spawnAgent(options: AgentSpawnOptions): Promise<void> {
     console.log(`[spawnAgent] Skipping auto-spawn for task ${task.id.slice(0, 8)} (manually paused by user)`);
     return;
   }
+
+  // Freeze Advanced overrides on the task's very first ever spawn (see
+  // freezeAdvancedOverridesOnFirstSpawn). Runs BEFORE agent resolution so a
+  // just-frozen agent_override is what resolveTargetAgent picks up, and the
+  // in-flight spawn below already resolves against the frozen values.
+  freezeAdvancedOverridesOnFirstSpawn({
+    task,
+    hasSessionRecord: latestSession !== undefined,
+    settingsLane: options.settingsSourceLane === undefined ? toLane : options.settingsSourceLane,
+    project,
+    globalPermissionMode: () => context.configManager.getEffectiveConfig(options.projectPath || undefined).agent.permissionMode,
+    tasks,
+  });
 
   // --- Resolve target agent ONCE (single source of truth) ---
   const { agent: targetAgent, isHandoff } = resolveTargetAgent({

--- a/src/main/ipc/helpers/index.ts
+++ b/src/main/ipc/helpers/index.ts
@@ -7,6 +7,6 @@ export { getProjectRepos } from './project-repos';
 // implementation instead of forcing every mock to re-declare it.
 export { ensureGitignore } from './project-setup';
 export { ensureTaskWorktree, ensureTaskBranchCheckout } from './task-git';
-export { buildAutoCommandVars, createTransitionEngine, spawnAgent, autoSpawnForTask, resolveSpawnOverrides } from './agent-spawn';
+export { buildAutoCommandVars, createTransitionEngine, spawnAgent, autoSpawnForTask, resolveSpawnOverrides, freezeAdvancedOverridesOnFirstSpawn } from './agent-spawn';
 export type { AgentSpawnOptions } from './agent-spawn';
 export { cleanupTaskSession, cleanupTaskResources, deleteTaskWorktree } from './task-cleanup';

--- a/src/main/transition-engine/session-startup/prepare-spawn.ts
+++ b/src/main/transition-engine/session-startup/prepare-spawn.ts
@@ -55,7 +55,9 @@ export type PrepareResult =
  *   2. Detect the agent CLI binary (skipped or errored → skip signal).
  *   3. Ensure the CLI trusts the working directory so no trust prompt
  *      blocks the spawn.
- *   4. Resolve the effective permission mode (lane → global).
+ *   4. Resolve the effective permission mode (task → lane → global, EXCEPT a
+ *      lane forcing 'plan' always wins - a genuine safety guarantee, not
+ *      just a default).
  *   5. Generate a session record UUID (used as the PTY session ID and
  *      the on-disk session directory name).
  *   6. Generate the agent CLI session UUID - only for adapters that
@@ -99,7 +101,16 @@ export async function prepareAgentSpawn(input: {
 
   await adapter.ensureTrust(cwd);
 
-  const permissionMode = task.permission_mode ?? swimlane?.permission_mode ?? config.agent.permissionMode;
+  // Plan mode is the one column-level permission setting that is a genuine
+  // safety guarantee (never let a task's Auto-Classifier/Accept-Edits pin
+  // bypass a deliberate read-only phase), so a column explicitly configured
+  // to force 'plan' always wins, regardless of any task-level override.
+  // Every OTHER permission_mode is an ordinary column default - same
+  // precedence as model/effort: task override wins when set, the column's
+  // setting is only a fallback for a task that leaves permission_mode null.
+  const permissionMode = swimlane?.permission_mode === 'plan'
+    ? 'plan'
+    : task.permission_mode ?? swimlane?.permission_mode ?? config.agent.permissionMode;
 
   let agentSessionId: string | null;
   const canResume = input.resume !== null;

--- a/src/main/transition-engine/transition-engine.ts
+++ b/src/main/transition-engine/transition-engine.ts
@@ -192,8 +192,14 @@ export class TransitionEngine {
     }
     console.log(`[spawnAgent] ${agentName} CLI found at ${detection.path} (v${detection.version})`);
 
-    // Resolution order: task override → swimlane override → global setting
-    const permissionMode = task.permission_mode ?? permissionOverride ?? appConfig.permissionMode;
+    // Resolution order: task override → swimlane override → global setting,
+    // EXCEPT a swimlane forcing 'plan' always wins regardless of the task
+    // override - plan mode is a genuine safety guarantee (never let a
+    // task's Auto-Classifier/Accept-Edits pin bypass a deliberate read-only
+    // phase), not just an ordinary column default like every other mode.
+    const permissionMode = permissionOverride === 'plan'
+      ? 'plan'
+      : task.permission_mode ?? permissionOverride ?? appConfig.permissionMode;
     const cwd = task.worktree_path || appConfig.projectPath || process.cwd();
 
     // Pre-populate trust so the agent doesn't block on the trust dialog.

--- a/src/renderer/components/dialogs/AdvancedOverridesSection.tsx
+++ b/src/renderer/components/dialogs/AdvancedOverridesSection.tsx
@@ -33,14 +33,28 @@ interface AdvancedOverridesSectionProps {
  * (`TaskDetailEditForm`).
  *
  * Resolution + locking contract:
- *   - The inherit option (empty string) defers to the destination column's
- *     overrides and the project default at spawn time. Its label IS the
- *     concrete value that resolves to today (e.g. "Opus 4.8", no "Use
- *     default (...)" framing - the value is self-evident) - leaving it as-is
- *     stores no override, so a later project-default change still applies.
- *   - A concrete pick wins over the column for the task's lifetime;
- *     column moves cannot change it (see `resolveTargetAgent` and the
- *     cross-agent guards in `task-move.ts`).
+ *   - The inherit state (empty string) shows the concrete value it resolves
+ *     to today as a MUTED placeholder (the bare value, no "Inherit (...)"
+ *     framing, no clear-X) - the muted weight alone signals "inherited, not
+ *     pinned". A concrete pick renders at full weight with a clear-X.
+ *     Leaving a field on inherit stores no override, so a later
+ *     column/project-default change still applies - until first spawn (see
+ *     below). Applies to all four fields (Agent/Model/Effort/Permission).
+ *   - A concrete pick wins over the column for the task's lifetime; column
+ *     moves cannot change it (see `resolveTargetAgent` and the cross-agent
+ *     guards in `task-move.ts`). If the task has ANY of the four fields set
+ *     when it spawns for the very first time ever, the other
+ *     (still-inherited) fields are frozen too, to exactly the values this
+ *     dialog displayed - resolved against the lane the task was configured
+ *     in, never the destination column
+ *     (`freezeAdvancedOverridesOnFirstSpawn` in `agent-spawn.ts`). So a
+ *     value that already matched its inherited default gets locked, not
+ *     silently left dynamic, and the whole Advanced tab is the task's
+ *     contract from then on. One exception: a column that forces
+ *     `permission_mode: 'plan'` always wins over the task's (picked or
+ *     frozen) permission while the task is in that column - plan mode is a
+ *     genuine safety guarantee, not just an ordinary column default (see
+ *     `transition-engine.ts` / `prepare-spawn.ts`).
  *
  * Behaviour notes:
  *   - The Agent picker is hidden when only one agent is `found` (nothing
@@ -92,10 +106,10 @@ export function AdvancedOverridesSection({
   const showAdvancedSection = showAgentPicker || showModelPicker || showEffortPicker || showPermissionPicker;
 
   // Resolved values below the task tier - what each field would actually
-  // spawn with if left on the inherit option. Surfaced directly as that
-  // option's label (no "Use default (...)" framing) so the picker just
-  // shows the real value that will be used - self-evident, no extra text
-  // needed to explain it.
+  // spawn with if left on the inherit state. Shown as the BARE value in the
+  // muted placeholder weight (see placeholderVariant below): the muted
+  // rendering plus the absent clear-X is what distinguishes "inherited" from
+  // a concrete pick, with no "Inherit (...)" text framing.
   const fallbackAgentDisplayName = availableAgents.find((entry) => entry.name === fallbackAgent)?.displayName ?? fallbackAgent;
   const fallbackModel = destinationSwimlane?.model_override ?? currentProject?.default_model ?? null;
   const fallbackModelLabel = fallbackModel ? modelRowLabel(fallbackModel, modelDisplayNames) : null;
@@ -135,6 +149,7 @@ export function AdvancedOverridesSection({
               onChange={handleAgentChange}
               options={availableAgents.map((entry) => ({ value: entry.name, label: entry.displayName ?? entry.name }))}
               placeholder={agentInheritLabel}
+              placeholderVariant="muted"
               testId="task-agent-override"
             />
           </div>
@@ -149,7 +164,7 @@ export function AdvancedOverridesSection({
                   onChange={setModelOverride}
                   availableModels={advancedModelOptions}
                   placeholder={modelInheritLabel}
-                  placeholderVariant={fallbackModelLabel ? 'resolved' : 'muted'}
+                  placeholderVariant="muted"
                   testId="task-model-override"
                   onOpen={() => useConfigStore.getState().rescanModels()}
                   contextWindows={modelContextWindows}
@@ -165,7 +180,7 @@ export function AdvancedOverridesSection({
                   onChange={setEffortOverride}
                   options={advancedEffortOptions.map((level) => ({ value: level, label: level }))}
                   placeholder={effortInheritLabel}
-                  placeholderVariant={fallbackEffort ? 'resolved' : 'muted'}
+                  placeholderVariant="muted"
                   testId="task-effort-override"
                 />
               </div>
@@ -180,6 +195,7 @@ export function AdvancedOverridesSection({
               onChange={setPermissionOverride}
               options={permissionOptions.map((entry) => ({ value: entry.mode, label: entry.label }))}
               placeholder={permissionInheritLabel}
+              placeholderVariant="muted"
               testId="task-permission-override"
             />
           </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -208,13 +208,13 @@ export interface Task {
   use_worktree: number | null;
   labels: string[];
   priority: number;
-  /** Per-task model override set via the ContextBar popover. Takes precedence over the swimlane's `model_override`; null inherits the swimlane (or agent default). */
+  /** Per-task model override set via the ContextBar popover or frozen at first spawn (see `freezeAdvancedOverridesOnFirstSpawn`). Takes precedence over the swimlane's `model_override`; null inherits the swimlane (or agent default). */
   model_override: string | null;
-  /** Per-task effort override set via the ContextBar popover. Takes precedence over the swimlane's `effort_override`; null inherits the swimlane (or agent default). */
+  /** Per-task effort override set via the ContextBar popover or frozen at first spawn (see `freezeAdvancedOverridesOnFirstSpawn`). Takes precedence over the swimlane's `effort_override`; null inherits the swimlane (or agent default). */
   effort_override: string | null;
-  /** Per-task agent override set at task creation. When non-null, wins over the swimlane's `agent_override` and the project default for the task's entire lifetime - column moves cannot change the agent. Set only via the New Task dialog's Advanced section; the ContextBar popover does not edit this. */
+  /** Per-task agent override set at task creation. When non-null, wins over the swimlane's `agent_override` and the project default for the task's entire lifetime - column moves cannot change the agent. Set via the New Task dialog's Advanced section or frozen at first spawn (`freezeAdvancedOverridesOnFirstSpawn`); the ContextBar popover does not edit this. */
   agent_override: string | null;
-  /** Per-task permission mode override. Takes precedence over the swimlane's `permission_mode` and the project's default permission mode; null inherits. Set via the New Task dialog's Advanced section or the task-detail edit form (pre-spawn or suspended only - same lock as `agent_override`). */
+  /** Per-task permission mode override. Takes precedence over the swimlane's `permission_mode` and the project's default permission mode, same as `model_override`/`effort_override` - EXCEPT when the destination swimlane forces `permission_mode: 'plan'`, which always wins regardless of this field: plan mode is a genuine safety guarantee (never let a task's Auto-Classifier/Accept-Edits pin bypass a deliberate read-only phase), not just an ordinary column default like every other permission mode. Null inherits. Set via the New Task dialog's Advanced section / the task-detail edit form, or frozen at first spawn alongside agent/model/effort (`freezeAdvancedOverridesOnFirstSpawn`) so a task with ANY Advanced override runs under the permission the dialog displayed, not the destination column's. */
   permission_mode: PermissionMode | null;
   /** Per-task initial command, injected once the agent spawns for this task. MCP-only (set via `kangentic_create_task`'s `autoCommand` param); not surfaced in the UI. Takes precedence over the swimlane's `auto_command` for this task only; null inherits the swimlane. */
   auto_command: string | null;

--- a/tests/ui/task-level-overrides.spec.ts
+++ b/tests/ui/task-level-overrides.spec.ts
@@ -87,10 +87,10 @@ test.describe('NewTaskDialog Advanced section', () => {
 
     // Model: free-text combobox seeded by `useKnownModels` (capabilities.models
     // union discoveredModelsByAgent cache). Empty value shows the resolved
-    // fallback directly, no "Use ... default" framing (column override ->
-    // project default -> agent default; this fixture has neither of the
-    // first two set, so plain "Agent default"); focusing the input reveals
-    // the suggestion list.
+    // fallback (column override -> project default -> agent default; this
+    // fixture has neither of the first two set, so plain "Agent default" -
+    // a concrete fallback would show that bare value, muted, instead);
+    // focusing the input reveals the suggestion list.
     const modelRow = page.locator('div:has(> input[data-testid="task-model-override"])');
     const modelInput = page.locator('input[data-testid="task-model-override"]');
     await expect(modelInput).toBeVisible();
@@ -105,6 +105,35 @@ test.describe('NewTaskDialog Advanced section', () => {
     await closeDialog();
   });
 
+  test('Permission picker shows a bare, muted inherit placeholder with no clear button until a value is picked', async () => {
+    await openNewTaskDialog();
+
+    await page.locator('[data-testid="task-advanced-toggle"]').click();
+
+    const permissionRow = page.locator('div:has(> input[data-testid="task-permission-override"])');
+    const permissionInput = page.locator('input[data-testid="task-permission-override"]');
+    await expect(permissionInput).toBeVisible();
+    // Mock fixture's global default permission mode is 'acceptEdits' -> "Accept
+    // Edits", shown bare (no "Inherit (...)" framing): the muted weight plus
+    // the absent clear-X are the inherited-not-pinned signals.
+    await expect(permissionInput).toHaveAttribute('placeholder', 'Accept Edits');
+    await expect(permissionRow.locator('button[title="Clear"]')).toHaveCount(0);
+
+    await permissionInput.click();
+    const permissionOptions = page.locator('[data-combobox-option]');
+    await expect(permissionOptions.first()).toBeVisible();
+    await page.locator('[data-testid="task-permission-override-option-plan"]').click();
+
+    // A concrete pick shows the bare value at full weight with a visible clear button.
+    await expect(permissionInput).toHaveValue('Plan (Read-Only)');
+    await expect(permissionRow.locator('button[title="Clear"]')).toBeVisible();
+
+    // The form is now dirty (a real override was committed): Escape opens the discard confirm.
+    await page.keyboard.press('Escape');
+    await page.locator('button:has-text("Discard")').click();
+    await page.locator('input[placeholder="Task title"]').waitFor({ state: 'hidden', timeout: 2000 });
+  });
+
   test('selected overrides persist on the created task row', async () => {
     await openNewTaskDialog();
 
@@ -116,6 +145,7 @@ test.describe('NewTaskDialog Advanced section', () => {
     await page.locator('[data-model-option]:has-text("opus")').click();
 
     await selectCombobox(page, 'task-effort-override', 'high');
+    await selectCombobox(page, 'task-permission-override', 'plan');
 
     await page.locator('button[type="submit"]:has-text("Create")').click();
     await page.locator('input[placeholder="Task title"]').waitFor({ state: 'hidden', timeout: 3000 });
@@ -125,6 +155,7 @@ test.describe('NewTaskDialog Advanced section', () => {
     expect(task).toBeDefined();
     expect(task!.model_override).toBe('opus');
     expect(task!.effort_override).toBe('high');
+    expect(task!.permission_mode).toBe('plan');
   });
 
   test('leaving overrides on column default omits them from the row', async () => {
@@ -132,7 +163,7 @@ test.describe('NewTaskDialog Advanced section', () => {
 
     await page.locator('input[placeholder="Task title"]').fill('Default Override Task');
     await page.locator('[data-testid="task-advanced-toggle"]').click();
-    // Don't change either select - keep "Use column default"
+    // Don't change any select - keep "Inherit"
 
     await page.locator('button[type="submit"]:has-text("Create")').click();
     await page.locator('input[placeholder="Task title"]').waitFor({ state: 'hidden', timeout: 3000 });
@@ -142,6 +173,7 @@ test.describe('NewTaskDialog Advanced section', () => {
     expect(task).toBeDefined();
     expect(task!.model_override).toBeNull();
     expect(task!.effort_override).toBeNull();
+    expect(task!.permission_mode).toBeNull();
   });
 });
 
@@ -304,8 +336,8 @@ test.describe('NewTaskDialog Advanced - Agent picker (multi-agent fixture)', () 
     await expect(agentInput).toBeVisible();
 
     // No column or project agent override is set in this fixture, so the
-    // inherit placeholder resolves to the app default (Claude Code) and
-    // shows that value directly, no "Use default (...)" framing.
+    // inherit placeholder resolves to the app default (Claude Code), shown
+    // bare and muted - no "Inherit (...)" framing.
     await expect(agentInput).toHaveAttribute('placeholder', 'Claude Code');
 
     await agentInput.click();
@@ -1096,8 +1128,13 @@ test.describe('Combobox (Effort field) - typing filters, never auto-commits', ()
  * reliable, non-flaky structural signal. Covers both the AgentTab call site
  * (Settings > Agent's Default Model/Effort are hardcoded 'muted' - top of the
  * resolution chain) and the AdvancedOverridesSection call site (New Task's
- * Model/Effort flip to 'resolved' once a project default gives them a real
- * fallback value), closing the gap that neither call site had any coverage.
+ * Agent/Model/Effort are ALWAYS muted, regardless of whether a concrete
+ * fallback exists - only the placeholder TEXT changes, from the generic
+ * "Agent default" to the bare resolved value once a project/column default
+ * resolves to something concrete. The muted weight plus the absent clear-X
+ * are what distinguish an inherited value from one the user actually picked,
+ * which is what let a task's Advanced overrides go unset while looking
+ * pinned), closing the gap that neither call site had any coverage.
  * Own browser instance: mutates the project's default_model/default_effort,
  * which no other test in this file may observe.
  */
@@ -1157,7 +1194,7 @@ test.describe('placeholderVariant: muted vs resolved', () => {
     await variantPage.locator('input[placeholder="Task title"]').waitFor({ state: 'hidden', timeout: 2000 });
   }
 
-  test('with no project default set, Settings > Agent Default Model/Effort are always muted, and New Task Advanced Model/Effort start muted while Agent stays resolved', async () => {
+  test('with no project default set, Settings > Agent Default Model/Effort and New Task Advanced Model/Effort are all muted', async () => {
     await openSettingsAgentTab();
 
     const settingsModelInput = variantPage.locator('input[data-testid="project-default-model"]');
@@ -1173,13 +1210,12 @@ test.describe('placeholderVariant: muted vs resolved', () => {
     const taskModelInput = variantPage.locator('input[data-testid="task-model-override"]');
     const taskEffortInput = variantPage.locator('input[data-testid="task-effort-override"]');
 
-    // Agent's inherit label is always a resolved app default (there is
-    // always SOME agent, even with nothing configured), so
-    // AdvancedOverridesSection never passes a placeholderVariant for it -
-    // the Agent field is out of scope here (it needs a multi-agent fixture
-    // to render at all; see the "Agent picker" describe block above).
     // Model/Effort have no column or project default here, so their
-    // fallback computation bottoms out with no concrete value: muted.
+    // fallback computation bottoms out with no concrete value: plain
+    // "Agent default", muted. (Agent's inherit label always resolves to a
+    // concrete app default and is muted too, but the Agent field needs a
+    // multi-agent fixture to render at all; see the "Agent picker" describe
+    // block above.)
     await expect(taskModelInput).toHaveAttribute('placeholder', 'Agent default');
     await expect(taskEffortInput).toHaveAttribute('placeholder', 'Agent default');
     expect(await placeholderVariantOf(taskModelInput)).toBe('muted');
@@ -1188,7 +1224,7 @@ test.describe('placeholderVariant: muted vs resolved', () => {
     await closeNewTaskDialog();
   });
 
-  test('setting a project default model/effort flips the New Task Advanced placeholders to resolved with the concrete value', async () => {
+  test('setting a project default model/effort shows the bare resolved values as New Task Advanced placeholders, still muted', async () => {
     await openSettingsAgentTab();
 
     // Pick a project default model (raw id 'opus', no display-name fixture
@@ -1204,15 +1240,30 @@ test.describe('placeholderVariant: muted vs resolved', () => {
     const taskModelInput = variantPage.locator('input[data-testid="task-model-override"]');
     const taskEffortInput = variantPage.locator('input[data-testid="task-effort-override"]');
 
-    // The inherit placeholder now names the concrete project default
-    // directly - no "Use ... default" framing - and is styled at full
-    // weight (resolved) since it is exactly what will run.
+    // The inherit placeholder now names the concrete project default as the
+    // bare value - muted, since leaving the field alone still means "not
+    // pinned"; the muted weight (not any text framing) is the signal.
     await expect(taskModelInput).toHaveAttribute('placeholder', 'opus');
     await expect(taskEffortInput).toHaveAttribute('placeholder', 'medium');
-    expect(await placeholderVariantOf(taskModelInput)).toBe('resolved');
-    expect(await placeholderVariantOf(taskEffortInput)).toBe('resolved');
+    expect(await placeholderVariantOf(taskModelInput)).toBe('muted');
+    expect(await placeholderVariantOf(taskEffortInput)).toBe('muted');
 
-    await closeNewTaskDialog();
+    // Distinguishing guard: while inherited, neither field renders a clear
+    // (X) button (its value is still ''). Picking a concrete option shows
+    // the bare value in the input AND a visible clear button - the one
+    // signal that actually separates "not pinned" from "pinned", since the
+    // muted placeholder alone is no longer visible once a value is set.
+    const effortRow = variantPage.locator('div:has(> input[data-testid="task-effort-override"])');
+    await expect(effortRow.locator('button[title="Clear"]')).toHaveCount(0);
+    await selectCombobox(variantPage, 'task-effort-override', 'high');
+    await expect(taskEffortInput).toHaveValue('high');
+    await expect(effortRow.locator('button[title="Clear"]')).toBeVisible();
+
+    // A real override was committed, so the form is dirty: Escape opens the
+    // discard confirm instead of closing directly.
+    await variantPage.keyboard.press('Escape');
+    await variantPage.locator('button:has-text("Discard")').click();
+    await variantPage.locator('input[placeholder="Task title"]').waitFor({ state: 'hidden', timeout: 2000 });
 
     // Cleanup: clear both project defaults directly via IPC + a store
     // reload (mirroring AgentTab's own refreshCurrentProject() call), rather

--- a/tests/unit/injection-plan.test.ts
+++ b/tests/unit/injection-plan.test.ts
@@ -528,6 +528,27 @@ describe('prepareInjectionPlan -- per-task override wins over column override', 
     expect(plan).toBeNull();
   });
 
+  it('does not emit /effort when a pinned effort differs from applied, column, and project defaults', () => {
+    let capturedSpec: SettingsChangeSpec | null = null;
+    const adapter = fakeAdapter({
+      getInjectionSequence: (spec) => {
+        capturedSpec = spec;
+        return spec.effortChanged ? [`/effort ${spec.effort}`] : [];
+      },
+    });
+    const plan = prepareInjectionPlan({
+      adapter,
+      // Source (applied), destination column, and project default are all
+      // different from the pin - none of them may leak into the delta.
+      sessionRepo: sessionRepoWith({ applied_effort: 'low' }),
+      task: { id: 't1', agent: 'fake', model_override: null, effort_override: 'xhigh' },
+      toLane: lane({ effort_override: 'high' }),
+      project: { default_model: null, default_effort: 'medium' },
+    });
+    expect(capturedSpec).toMatchObject({ effort: 'xhigh', effortChanged: false });
+    expect(plan).toBeNull();
+  });
+
   it('restarts for a model change while a pinned effort fires no slash (mixed override)', () => {
     let capturedSpec: SettingsChangeSpec | null = null;
     const adapter = fakeAdapter({

--- a/tests/unit/prepare-agent-spawn.test.ts
+++ b/tests/unit/prepare-agent-spawn.test.ts
@@ -379,7 +379,7 @@ describe('prepareAgentSpawn - model/effort override passthrough', () => {
 });
 
 describe('prepareAgentSpawn - permission_mode resolution', () => {
-  it('resolves permissionMode from task.permission_mode, winning over a differing swimlane.permission_mode', async () => {
+  it('resolves permissionMode from task.permission_mode, winning over a differing NON-plan swimlane.permission_mode', async () => {
     const { adapter, capturedCommandOptions } = makeCaptureAdapter();
     agentRegistryGetMock.mockReturnValue(adapter);
 
@@ -400,6 +400,52 @@ describe('prepareAgentSpawn - permission_mode resolution', () => {
     expect(result.data.permissionMode).toBe('plan');
     expect(capturedCommandOptions).toHaveLength(1);
     expect(capturedCommandOptions[0].permissionMode).toBe('plan');
+  });
+
+  it('a swimlane forcing plan mode ALWAYS wins, regardless of a differing task.permission_mode', async () => {
+    const { adapter, capturedCommandOptions } = makeCaptureAdapter();
+    agentRegistryGetMock.mockReturnValue(adapter);
+
+    const taskWithPermissionOverride = makeTask({ permission_mode: 'auto' } as Partial<Task>);
+    const laneForcingPlan = makeSwimlane({ permission_mode: 'plan' } as Partial<Swimlane>);
+    const configWithDifferentDefault = makeAppConfig({
+      agent: { cliPaths: {}, permissionMode: 'default', maxConcurrentSessions: 5, queueOverflow: 'queue', autoResumeSessionsOnRestart: true },
+    });
+
+    const result = await prepareAgentSpawn(makeSpawnInput({
+      task: taskWithPermissionOverride,
+      swimlane: laneForcingPlan,
+      effectiveConfig: configWithDifferentDefault,
+    }));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('Expected ok:true');
+    expect(result.data.permissionMode).toBe('plan');
+    expect(capturedCommandOptions).toHaveLength(1);
+    expect(capturedCommandOptions[0].permissionMode).toBe('plan');
+  });
+
+  it('falls through to task.permission_mode when the swimlane has no permission_mode set', async () => {
+    const { adapter, capturedCommandOptions } = makeCaptureAdapter();
+    agentRegistryGetMock.mockReturnValue(adapter);
+
+    const taskWithPermissionOverride = makeTask({ permission_mode: 'auto' } as Partial<Task>);
+    const laneWithNoOverride = makeSwimlane({ permission_mode: null } as Partial<Swimlane>);
+    const configWithDifferentDefault = makeAppConfig({
+      agent: { cliPaths: {}, permissionMode: 'default', maxConcurrentSessions: 5, queueOverflow: 'queue', autoResumeSessionsOnRestart: true },
+    });
+
+    const result = await prepareAgentSpawn(makeSpawnInput({
+      task: taskWithPermissionOverride,
+      swimlane: laneWithNoOverride,
+      effectiveConfig: configWithDifferentDefault,
+    }));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('Expected ok:true');
+    expect(result.data.permissionMode).toBe('auto');
+    expect(capturedCommandOptions).toHaveLength(1);
+    expect(capturedCommandOptions[0].permissionMode).toBe('auto');
   });
 });
 

--- a/tests/unit/spawn-agent-continuation-prompt.test.ts
+++ b/tests/unit/spawn-agent-continuation-prompt.test.ts
@@ -132,7 +132,10 @@ function makeDeps(args: { resumeRecord: SessionRecord | undefined }) {
     resumeSuspendedSession: vi.fn(async () => {}),
   };
   const scheduleKeystrokes = vi.fn();
-  const context = { terminalSubmitScheduler: { scheduleKeystrokes } };
+  const context = {
+    terminalSubmitScheduler: { scheduleKeystrokes },
+    configManager: { getEffectiveConfig: vi.fn(() => ({ agent: { permissionMode: 'acceptEdits' } })) },
+  };
 
   return { tasks, sessionRepo, engine, scheduleKeystrokes, context };
 }

--- a/tests/unit/spawn-agent-freeze-overrides.test.ts
+++ b/tests/unit/spawn-agent-freeze-overrides.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for the "freeze Advanced overrides on first spawn" behavior in
+ * `spawnAgent` / `freezeAdvancedOverridesOnFirstSpawn`
+ * (src/main/ipc/helpers/agent-spawn.ts).
+ *
+ * A task that already carries at least one explicit Agent/Model/Effort/
+ * Permission override but leaves the others on "inherit" gets ALL FOUR
+ * fields frozen, the moment it spawns for the very first time ever, to the
+ * values the Advanced tab displayed when the user configured it: task
+ * override -> the lane the task lived in at config time (the settings lane;
+ * a drag move passes the SOURCE lane) -> project default / global permission
+ * mode. The DESTINATION column's settings never leak into the frozen
+ * contract. A task with NO overrides at all is untouched.
+ *
+ * Harness mirrors spawn-agent-continuation-prompt.test.ts: the real
+ * spawnAgent runs end to end with injected engine/repos/context mocks.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Task, Swimlane } from '../../src/shared/types';
+
+const resolveTargetAgentMock = vi.fn(() => ({ agent: 'claude', isHandoff: false }));
+
+vi.mock('../../src/main/transition-engine/agent-resolver', () => ({
+  resolveTargetAgent: (...args: unknown[]) => resolveTargetAgentMock(...args),
+}));
+
+vi.mock('../../src/main/agent/agent-registry', () => ({
+  agentRegistry: { get: vi.fn(() => ({ sessionType: 'claude_agent' })) },
+}));
+
+import { spawnAgent } from '../../src/main/ipc/helpers/agent-spawn';
+
+const TASK_ID = 'task-freeze-001';
+const TO_LANE_ID = 'lane-executing';
+const FROM_LANE_ID = 'lane-todo';
+const PROJECT_ID = 'project-001';
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: TASK_ID,
+    display_id: 1,
+    title: 'My Task',
+    description: 'Do the thing',
+    swimlane_id: TO_LANE_ID,
+    position: 0,
+    agent: null,
+    agent_override: null,
+    model_override: null,
+    effort_override: null,
+    permission_mode: null,
+    session_id: null,
+    worktree_path: '/mock/project/.kangentic/worktrees/my-task',
+    branch_name: 'my-task',
+    pr_number: null,
+    pr_url: null,
+    base_branch: null,
+    use_worktree: null,
+    labels: [],
+    priority: 0,
+    attachment_count: 0,
+    archived_at: null,
+    created_at: '2025-01-01T00:00:00.000Z',
+    updated_at: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  } as Task;
+}
+
+function makeSwimlane(overrides: Partial<Swimlane> = {}): Swimlane {
+  return {
+    id: TO_LANE_ID,
+    name: 'Executing',
+    role: null,
+    position: 0,
+    color: '#888',
+    icon: null,
+    is_archived: false,
+    is_ghost: false,
+    permission_mode: null,
+    auto_spawn: true,
+    auto_command: null,
+    plan_exit_target_id: null,
+    agent_override: null,
+    model_override: null,
+    effort_override: null,
+    handoff_context: false,
+    session_target: 'main',
+    session_spawn_strategy: 'create_or_resume',
+    created_at: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  } as Swimlane;
+}
+
+/**
+ * The destination column deliberately differs from the project defaults in
+ * EVERY field, so any leak of destination settings into the frozen values is
+ * caught by every test below.
+ */
+function makeDestinationLane(): Swimlane {
+  return makeSwimlane({
+    agent_override: null,
+    model_override: 'sonnet-5',
+    effort_override: 'high',
+    permission_mode: 'acceptEdits',
+  });
+}
+
+const PROJECT_ROW = {
+  id: PROJECT_ID,
+  name: 'Mock Project',
+  path: '/mock/project',
+  default_agent: 'claude',
+  default_model: 'claude-opus-4-8',
+  default_effort: 'xhigh',
+};
+
+function makeDeps(args: { latestSession: unknown; task: Task }) {
+  const update = vi.fn();
+  const getById = vi.fn(() => args.task);
+  const tasks = { getById, update };
+  const sessionRepo = {
+    getLatestForTask: vi.fn(() => args.latestSession),
+    getLatestForTaskByTypeAndIsolation: vi.fn(() => undefined),
+  };
+  const engine = {
+    executeTransition: vi.fn(async () => {}),
+    resumeSuspendedSession: vi.fn(async () => {}),
+  };
+  const context = {
+    mainWindow: { isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } },
+    terminalSubmitScheduler: { scheduleKeystrokes: vi.fn() },
+    projectRepo: { getById: vi.fn(() => PROJECT_ROW) },
+    configManager: { getEffectiveConfig: vi.fn(() => ({ agent: { permissionMode: 'auto' } })) },
+  };
+  return { tasks, sessionRepo, engine, context };
+}
+
+async function runSpawn(
+  task: Task,
+  toLane: Swimlane,
+  deps: ReturnType<typeof makeDeps>,
+  settingsSourceLane?: Swimlane | null,
+) {
+  await spawnAgent({
+    context: deps.context as never,
+    engine: deps.engine as never,
+    tasks: deps.tasks as never,
+    sessionRepo: deps.sessionRepo as never,
+    task,
+    fromSwimlaneId: FROM_LANE_ID,
+    toLane,
+    projectId: PROJECT_ID,
+    projectPath: '/mock/project',
+    ...(settingsSourceLane !== undefined ? { settingsSourceLane } : {}),
+  });
+}
+
+describe('spawnAgent freeze-Advanced-overrides-on-first-spawn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveTargetAgentMock.mockReturnValue({ agent: 'claude', isHandoff: false });
+  });
+
+  it('freezes ALL FOUR fields to the settings-lane/project/global chain, never the destination column', async () => {
+    const task = makeTask({ model_override: 'fable-5' });
+    // Drag move: the source lane (To Do) has no overrides of its own, so the
+    // dialog displayed project defaults + the global permission mode.
+    const sourceLane = makeSwimlane({ id: FROM_LANE_ID, name: 'To Do', role: 'todo', auto_spawn: false });
+    const deps = makeDeps({ latestSession: undefined, task });
+
+    await runSpawn(task, makeDestinationLane(), deps, sourceLane);
+
+    expect(deps.tasks.update).toHaveBeenCalledWith({
+      id: TASK_ID,
+      agent_override: 'claude',
+      model_override: 'fable-5',
+      effort_override: 'xhigh',
+      permission_mode: 'auto',
+    });
+    // The in-memory task is updated too, so the spawn already in flight
+    // resolves against the frozen values (not the destination column's).
+    expect(task.effort_override).toBe('xhigh');
+    expect(task.permission_mode).toBe('auto');
+  });
+
+  it('resolves inherited fields against the settings lane when it has its own overrides', async () => {
+    const task = makeTask({ model_override: 'fable-5' });
+    const sourceLane = makeSwimlane({
+      id: FROM_LANE_ID,
+      name: 'Staging',
+      effort_override: 'low',
+      permission_mode: 'plan',
+    });
+    const deps = makeDeps({ latestSession: undefined, task });
+
+    await runSpawn(task, makeDestinationLane(), deps, sourceLane);
+
+    expect(deps.tasks.update).toHaveBeenCalledWith({
+      id: TASK_ID,
+      agent_override: 'claude',
+      model_override: 'fable-5',
+      effort_override: 'low',
+      permission_mode: 'plan',
+    });
+  });
+
+  it('falls back to the destination lane as settings lane when settingsSourceLane is omitted (creation/promotion into a spawn column)', async () => {
+    const task = makeTask({ model_override: 'fable-5' });
+    const deps = makeDeps({ latestSession: undefined, task });
+
+    await runSpawn(task, makeDestinationLane(), deps);
+
+    expect(deps.tasks.update).toHaveBeenCalledWith({
+      id: TASK_ID,
+      agent_override: 'claude',
+      model_override: 'fable-5',
+      effort_override: 'high',
+      permission_mode: 'acceptEdits',
+    });
+  });
+
+  it('falls back to project/global defaults when the settings lane is null (source lane no longer resolves)', async () => {
+    const task = makeTask({ effort_override: 'max' });
+    const deps = makeDeps({ latestSession: undefined, task });
+
+    await runSpawn(task, makeDestinationLane(), deps, null);
+
+    expect(deps.tasks.update).toHaveBeenCalledWith({
+      id: TASK_ID,
+      agent_override: 'claude',
+      model_override: 'claude-opus-4-8',
+      effort_override: 'max',
+      permission_mode: 'auto',
+    });
+  });
+
+  it('a permission-only pin also triggers the freeze', async () => {
+    const task = makeTask({ permission_mode: 'plan' });
+    const sourceLane = makeSwimlane({ id: FROM_LANE_ID, name: 'To Do', role: 'todo', auto_spawn: false });
+    const deps = makeDeps({ latestSession: undefined, task });
+
+    await runSpawn(task, makeDestinationLane(), deps, sourceLane);
+
+    expect(deps.tasks.update).toHaveBeenCalledWith({
+      id: TASK_ID,
+      agent_override: 'claude',
+      model_override: 'claude-opus-4-8',
+      effort_override: 'xhigh',
+      permission_mode: 'plan',
+    });
+  });
+
+  it('does not freeze anything on first ever spawn when no override is set', async () => {
+    const task = makeTask();
+    const deps = makeDeps({ latestSession: undefined, task });
+
+    await runSpawn(task, makeDestinationLane(), deps, makeSwimlane({ id: FROM_LANE_ID, role: 'todo' }));
+
+    expect(deps.tasks.update).not.toHaveBeenCalled();
+  });
+
+  it('does not re-freeze a task reset to To Do and redragged (task.agent survives the reset)', async () => {
+    // No session record (wiped by the To-Do reset), but task.agent is still
+    // set from its original first spawn - this must NOT be mistaken for a
+    // fresh first-ever spawn.
+    const task = makeTask({ agent: 'claude', model_override: 'fable-5' });
+    const deps = makeDeps({ latestSession: undefined, task });
+
+    await runSpawn(task, makeDestinationLane(), deps, makeSwimlane({ id: FROM_LANE_ID, role: 'todo' }));
+
+    expect(deps.tasks.update).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/spawn-agent-isolated-auto-command.test.ts
+++ b/tests/unit/spawn-agent-isolated-auto-command.test.ts
@@ -193,6 +193,7 @@ function makeDeps(args: {
     terminalSubmitScheduler: { scheduleKeystrokes },
     mainWindow: { isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } },
     projectRepo: { getById: vi.fn(() => null) },
+    configManager: { getEffectiveConfig: vi.fn(() => ({ agent: { permissionMode: 'acceptEdits' } })) },
   };
 
   return { tasks, sessionRepo, engine, scheduleKeystrokes, context };

--- a/tests/unit/task-create-handler.test.ts
+++ b/tests/unit/task-create-handler.test.ts
@@ -111,6 +111,7 @@ const mockEnsureTaskBranchCheckout = vi.fn(async () => {});
 const mockBuildAutoCommandVars = vi.fn(() => ({}));
 const mockCreateTransitionEngine = vi.fn();
 const mockCleanupTaskResources = vi.fn(async () => {});
+const mockFreezeAdvancedOverridesOnFirstSpawn = vi.fn();
 
 vi.mock('../../src/main/ipc/helpers', () => ({
   getProjectRepos: (...args: unknown[]) => mockGetProjectRepos(...args),
@@ -124,7 +125,7 @@ vi.mock('../../src/main/ipc/helpers', () => ({
     model: task?.model_override ?? lane?.model_override,
     effort: task?.effort_override ?? lane?.effort_override,
   })),
-  freezeAdvancedOverridesOnFirstSpawn: vi.fn(),
+  freezeAdvancedOverridesOnFirstSpawn: (...args: unknown[]) => mockFreezeAdvancedOverridesOnFirstSpawn(...args),
 }));
 
 vi.mock('../../src/main/agent/shared', () => ({
@@ -382,6 +383,7 @@ describe('TASK_CREATE handler', () => {
     expect(mockEnsureTaskWorktree).not.toHaveBeenCalled();
     expect(mockCreateTransitionEngine).not.toHaveBeenCalled();
     expect(context.terminalSubmitScheduler.scheduleKeystrokes).not.toHaveBeenCalled();
+    expect(mockFreezeAdvancedOverridesOnFirstSpawn).not.toHaveBeenCalled();
   });
 
   it('skips lock block when currentProjectPath is null', async () => {
@@ -475,6 +477,45 @@ describe('TASK_CREATE handler', () => {
       // (undefined here because the mock swimlane fixture doesn't set them).
       { model: targetLane.model_override, effort: targetLane.effort_override },
     );
+  });
+
+  // =========================================================================
+  // Freeze Advanced overrides call site (freeze-on-first-spawn wiring)
+  //
+  // A task created directly in a spawn column reaches executeTransition
+  // without ever going through spawnAgent, so task-crud.ts calls
+  // freezeAdvancedOverridesOnFirstSpawn itself, ahead of resolveSpawnOverrides.
+  // The New Task dialog displayed inherit values against the CREATION column,
+  // so that column (not some other lane) must be the settingsLane, and
+  // hasSessionRecord must be false (a brand-new task can never have a prior
+  // session row). Red-green: commenting out the freeze call in task-crud.ts
+  // makes this test fail (mockFreezeAdvancedOverridesOnFirstSpawn never
+  // called); restoring it makes it pass again.
+  // =========================================================================
+
+  it('calls freezeAdvancedOverridesOnFirstSpawn with the creation column as settingsLane and hasSessionRecord:false', async () => {
+    await callCreateHandler(context, {
+      swimlane_id: 'lane-doing',
+      title: 'Freeze wiring task',
+    });
+
+    expect(mockFreezeAdvancedOverridesOnFirstSpawn).toHaveBeenCalledTimes(1);
+    const freezeArg = mockFreezeAdvancedOverridesOnFirstSpawn.mock.calls[0][0] as {
+      task: { id: string };
+      hasSessionRecord: boolean;
+      settingsLane: MockSwimlane;
+      project: { id: string } | null;
+      globalPermissionMode: () => string;
+      tasks: MockTaskRepo;
+    };
+    expect(freezeArg.task).toMatchObject({ id: 'task-new' });
+    expect(freezeArg.hasSessionRecord).toBe(false);
+    // The creation column IS the settings lane - not some other lane.
+    expect(freezeArg.settingsLane).toBe(targetLane);
+    expect(freezeArg.project).toMatchObject({ id: 'proj-123' });
+    expect(freezeArg.tasks).toBe(taskRepo);
+    // globalPermissionMode is a lazy accessor reading the effective config.
+    expect(freezeArg.globalPermissionMode()).toBe('acceptEdits');
   });
 
   // =========================================================================

--- a/tests/unit/task-create-handler.test.ts
+++ b/tests/unit/task-create-handler.test.ts
@@ -124,6 +124,7 @@ vi.mock('../../src/main/ipc/helpers', () => ({
     model: task?.model_override ?? lane?.model_override,
     effort: task?.effort_override ?? lane?.effort_override,
   })),
+  freezeAdvancedOverridesOnFirstSpawn: vi.fn(),
 }));
 
 vi.mock('../../src/main/agent/shared', () => ({
@@ -295,7 +296,7 @@ function createMockContext(overrides: Partial<MockContext> = {}): MockContext {
       getActivityCache: vi.fn(() => ({})),
     },
     configManager: {
-      getEffectiveConfig: vi.fn(() => ({ git: { defaultBaseBranch: 'main' } })),
+      getEffectiveConfig: vi.fn(() => ({ git: { defaultBaseBranch: 'main' }, agent: { permissionMode: 'acceptEdits' } })),
     },
     boardConfigManager: {
       getDefaultBaseBranch: vi.fn(() => null),

--- a/tests/unit/task-move-settings-restart.test.ts
+++ b/tests/unit/task-move-settings-restart.test.ts
@@ -403,6 +403,47 @@ describe('handleTaskMove model/effort restart and live-injection', () => {
   });
 
   // =========================================================================
+  // settingsSourceLane threading (fromLane, not toLane, reaches spawnAgent)
+  //
+  // freezeAdvancedOverridesOnFirstSpawn resolves still-inherited Advanced
+  // fields against the lane the task left, never the destination the New
+  // Task / Edit dialog never showed the user. task-move.ts must thread the
+  // SOURCE lane (captured once at Phase 1 as `fromLane`) through every
+  // MoveSpawnPlan return site to the eventual spawnAgent call as
+  // `settingsSourceLane`. Red-green: reverting task-move.ts's
+  // `settingsSourceLane: fromLane ?? null` to omit the field (or pass toLane)
+  // makes this test fail; restoring it makes it pass.
+  // =========================================================================
+
+  it('threads the SOURCE lane (Planning), not the destination (Executing), to spawnAgent as settingsSourceLane', async () => {
+    const { planningLane, swimlaneRepo } = makeLanes();
+    setActiveRecord('plan');
+    const taskRepo = makeTaskRepo();
+    const context = makeContext(taskRepo, swimlaneRepo);
+    vi.mocked(prepareInjectionPlan).mockReturnValue({
+      sequence: [],
+      verifier: null,
+      verifiedPrefixLength: 0,
+      needsRestartForModel: true,
+    });
+
+    await handleTaskMove(context as never, {
+      taskId: 'task-aaa00001',
+      targetSwimlaneId: EXECUTING_LANE_ID,
+      targetPosition: 0,
+    });
+
+    expect(mockSpawnAgent).toHaveBeenCalledTimes(1);
+    const spawnArg = mockSpawnAgent.mock.calls[0][0] as {
+      settingsSourceLane?: Swimlane | null;
+      toLane: Swimlane;
+    };
+    expect(spawnArg.settingsSourceLane?.id).toBe(PLANNING_LANE_ID);
+    expect(spawnArg.settingsSourceLane?.id).toBe(planningLane.id);
+    expect(spawnArg.settingsSourceLane?.id).not.toBe(spawnArg.toLane.id);
+  });
+
+  // =========================================================================
   // continuationPrompt threading (model-change restart path)
   // =========================================================================
 

--- a/tests/unit/transition-engine.test.ts
+++ b/tests/unit/transition-engine.test.ts
@@ -406,10 +406,11 @@ describe('TransitionEngine - permission_mode resolution precedence', () => {
     });
   });
 
-  it('task.permission_mode wins over the passed permissionOverride (swimlane) argument', async () => {
-    // Resolution order in executeSpawnAgent is task -> swimlane override -> global
-    // default. The `permissionOverride` argument here is the caller-resolved
-    // swimlane permission_mode; a task-level pin must win over it.
+  it('task.permission_mode wins over a differing NON-plan permissionOverride (swimlane) argument', async () => {
+    // Resolution order in executeSpawnAgent is task -> swimlane override ->
+    // global default, EXCEPT a swimlane forcing 'plan' (see next test).
+    // 'acceptEdits' here is an ordinary column default, not a safety lock,
+    // so the task-level pin still wins.
     const task = makeTask({ permission_mode: 'plan' });
     const sessionRepo = makeSessionRepo();
 
@@ -419,6 +420,26 @@ describe('TransitionEngine - permission_mode resolution precedence', () => {
       'todo',
       'doing',
       'acceptEdits', // permissionOverride from the destination swimlane
+    );
+
+    expect(sessionRepo.insert).toHaveBeenCalledTimes(1);
+    const inserted = sessionRepo.insert.mock.calls[0][0] as { permission_mode?: string };
+    expect(inserted.permission_mode).toBe('plan');
+  });
+
+  it('a swimlane forcing plan mode ALWAYS wins, regardless of a differing task.permission_mode', async () => {
+    // Plan mode is a genuine safety guarantee (never let a task's
+    // Auto-Classifier/Accept-Edits pin bypass a deliberate read-only phase),
+    // so it wins even over an explicit, differing task-level pin.
+    const task = makeTask({ permission_mode: 'auto' });
+    const sessionRepo = makeSessionRepo();
+
+    const { engine } = makeEngine({ sessionRepo });
+    await engine.executeTransition(
+      task as Parameters<typeof engine.executeTransition>[0],
+      'todo',
+      'doing',
+      'plan', // permissionOverride from the destination swimlane
     );
 
     expect(sessionRepo.insert).toHaveBeenCalledTimes(1);
@@ -441,6 +462,25 @@ describe('TransitionEngine - permission_mode resolution precedence', () => {
     expect(sessionRepo.insert).toHaveBeenCalledTimes(1);
     const inserted = sessionRepo.insert.mock.calls[0][0] as { permission_mode?: string };
     expect(inserted.permission_mode).toBe('acceptEdits');
+  });
+
+  it('falls through to task.permission_mode when the swimlane has no permission_mode set', async () => {
+    // The column left permission_mode null (no permissionOverride argument),
+    // so the task's own pin is still a valid fallback tier.
+    const task = makeTask({ permission_mode: 'auto' });
+    const sessionRepo = makeSessionRepo();
+
+    const { engine } = makeEngine({ sessionRepo });
+    await engine.executeTransition(
+      task as Parameters<typeof engine.executeTransition>[0],
+      'todo',
+      'doing',
+      null,
+    );
+
+    expect(sessionRepo.insert).toHaveBeenCalledTimes(1);
+    const inserted = sessionRepo.insert.mock.calls[0][0] as { permission_mode?: string };
+    expect(inserted.permission_mode).toBe('auto');
   });
 });
 


### PR DESCRIPTION
## What

Makes a per-task Advanced override (Agent / Model / Effort / Permission), set in the New Task dialog or the task-detail edit form, actually lock for the task's lifetime instead of silently drifting on a column move.

Affected components:
- `src/main/ipc/helpers/agent-spawn.ts` - new `freezeAdvancedOverridesOnFirstSpawn` helper + call in the main spawn path
- `src/main/ipc/handlers/task-move.ts` - threads the source lane through the move plan as the freeze's settings lane
- `src/main/ipc/handlers/task-crud.ts` - freezes on the direct-create-into-a-spawn-column path
- `src/main/transition-engine/transition-engine.ts`, `src/main/transition-engine/session-startup/prepare-spawn.ts` - permission precedence (plan-column supremacy)
- `src/renderer/components/dialogs/AdvancedOverridesSection.tsx` - inherit placeholder treatment
- `src/shared/types.ts` - `Task` field doc comments

## Why

Closes #401.

A user pins Model to Fable 5, leaves Effort showing `xhigh` and Permission showing `Auto (Classifier)` (both inherited values that already matched what they wanted), and assumes everything is locked. Two things then went wrong:

1. Only Model actually got stored - Effort/Agent stayed dynamically inherited, so a later column move could inject a different `/effort` or resolve a different value.
2. Permission was never part of the lock at all, so dragging the task into an Executing column with `permission_mode: acceptEdits` spawned it under Accept Edits instead of the Auto (Classifier) the dialog showed.

The visual "inherit vs pinned" ambiguity was the root of (1): the inherited value rendered indistinguishably from a real pick, so the user had no reason to click it.

## How

- **Freeze on first spawn.** The first time a task ever spawns, if it carries any explicit Advanced override, all four fields (agent/model/effort/permission) are resolved and written onto the task row - so a value that merely matched its inherited default gets locked too. "First ever spawn" = no session record AND `task.agent` still null (survives a To-Do reset, which wipes session rows but not `task.agent`, so a reset-and-redragged task is not re-frozen).
- **Freeze against the settings lane, not the destination.** Inherited fields resolve against the lane the user configured the task in (the source lane on a drag, the creation column on a direct create), never the destination column whose settings the dialog never displayed. `task-move.ts` threads the source lane through the move plan; `spawnAgent` falls back to the destination lane only for promotion / MCP-creation directly into a spawn column.
- **Permission plan-column supremacy stays.** A destination column forcing `permission_mode: 'plan'` always wins at spawn resolution, over a picked or frozen permission - plan mode is a genuine read-only safety guarantee, not an ordinary column default. Every other permission mode follows the same task-wins-when-set precedence as model/effort.
- **Closed a bypass.** Tasks created directly in a spawn column spawn via `TASK_CREATE` -> `executeTransition`, not `spawnAgent`, and skipped the freeze; that path now freezes against the creation column.
- **UI.** Dropped the `Inherit (<value>)` text framing on all four pickers. Inherited = bare resolved value, muted, no clear-X; pinned = full weight with a clear-X. The muted weight plus the absent clear-X are the only signals distinguishing inherited from picked.

Trade-off worth noting (unchanged from the design discussion): a permission-only delta on an already-live session stays a deliberate no-op - permission applies at the next spawn/respawn, so it never clobbers a manual in-session plan-mode exit.

## Breaking changes

None. Behavior change only for tasks that carry an Advanced override; a task with zero overrides is untouched and keeps following column/project defaults for its whole life.

## Tests

- New `tests/unit/spawn-agent-freeze-overrides.test.ts`: freezes all four fields; resolves against the settings lane (with and without its own overrides); falls back to the destination lane when the source lane is omitted; falls back to project/global defaults when the settings lane is null; a permission-only pin triggers the freeze; zero overrides is untouched; a To-Do-reset-then-redragged task is not re-frozen.
- Updated `tests/unit/prepare-agent-spawn.test.ts` and `tests/unit/transition-engine.test.ts`: plan-column supremacy plus the task-wins and column-fallback permission cases.
- Updated `tests/unit/injection-plan.test.ts`: a pinned effort injects nothing even when applied/column/project values all differ.
- Updated `tests/ui/task-level-overrides.spec.ts`: the bare-muted inherit placeholder contract across all four pickers, with the clear-X distinction guard.
- Local gate green (typecheck + lint); CI runs the full unit / UI / Electron E2E tiers.

Generated with [Claude Code](https://claude.com/claude-code)
