### PR TITLE
perf(terminal): budget WebGL contexts and gate off-view PTY writes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -674,7 +674,8 @@ On project open (`src/main/transition-engine/session-startup/`):
 
 ## Performance
 
-- **WebGL xterm** -- attempts WebGL renderer first, falls back to canvas on context loss
+- **WebGL xterm with an attachment budget** - attempts the WebGL renderer first and recovers from context loss (2s/10s retries, then permanent DOM fallback). Live WebGL attachments are capped at `WEBGL_ATTACH_BUDGET` (8) page-wide, below Chromium's ~16-context limit: a coordinator (`useFocusedSessionsSync`) keeps the most-recently-focused terminal windows on WebGL and temporarily suspends the rest to the DOM renderer (`suspendedByBudget` in the renderer report - not a context loss, never escalates to the permanent fallback), re-attaching on focus (`src/renderer/utils/terminal-webgl.ts`, `terminal-visibility.ts`)
+- **Parked-window write gating** - a terminal window that is off-view (board layer parked on the Backlog view, or occluded by a maximized same-layer window) leaves the focused-session set, so main stops emitting its PTY data at the source; any stragglers are acked-and-dropped by the renderer queue (never parsed, never wedging backpressure). On reveal the terminal repaints from the scrollback ring via `reloadScrollback` (`src/renderer/utils/parked-terminals.ts`, `focused-sessions.ts`)
 - **Resize debouncing** -- PTY resize calls debounced at 200ms, suppressed during panel drag
 - **Repaint-settled scrollback** - after a width-changing resize, `getScrollback` waits for the agent TUI's async repaint to land before sampling, so a restored terminal never replays a stale narrow frame (see [session-lifecycle](session-lifecycle.md))
 - **Activity log** -- plain DOM list instead of xterm. Events flow through JSONL files, not terminal output.

--- a/src/renderer/hooks/useFocusedSessionsSync.ts
+++ b/src/renderer/hooks/useFocusedSessionsSync.ts
@@ -1,17 +1,43 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSessionStore } from '../stores/session-store';
 import { useBoardStore } from '../stores/board-store';
 import { useConfigStore } from '../stores/config-store';
 import { useProjectStore } from '../stores/project-store';
 import { deriveFocusedSessionIds, derivePanelSessionId } from '../utils/focused-sessions';
-import { selectCurrentProjectTransientSessionIds } from '../stores/session-store/transient-session-slice';
+import { selectCurrentProjectTransientSessionIds, transientKey } from '../stores/session-store/transient-session-slice';
+import { boardWindowManager, commandWindowManager } from '../window-manager/store/window-store';
+import {
+  planTerminalVisibility,
+  type TerminalVisibilityWindowInput,
+} from '../utils/terminal-visibility';
+import { syncParkedTerminals } from '../utils/parked-terminals';
+import {
+  WEBGL_ATTACH_BUDGET,
+  applyWebglAttachmentPlan,
+  onWebglAttachmentsChanged,
+  type WebglAttachmentPlan,
+} from '../utils/terminal-webgl';
 
 /**
- * Pushes the set of "focused" session IDs to the main process whenever the
- * relevant UI state changes. The main process drops PTY data IPC for any
- * session not in this set (see src/main/pty/session-manager.ts), so any
- * terminal visible to the user must be listed here or its output will be
- * silently suppressed.
+ * The terminal-visibility coordinator. On every relevant UI-state change it
+ * derives one visibility plan (utils/terminal-visibility.ts) and applies its
+ * three outputs in order:
+ *
+ * 1. The PARKED set (utils/parked-terminals.ts): sessions whose terminal
+ *    window is off-view (board layer parked on Backlog, or occluded by a
+ *    maximized same-layer window). Publishing the set fires reveal listeners
+ *    for parked -> visible edges, which trigger each terminal's scrollback
+ *    catch-up repaint.
+ * 2. The FOCUSED set, pushed to the main process. Main drops PTY data IPC for
+ *    any session not in this set (see src/main/pty/session-manager.ts), so any
+ *    terminal visible to the user must be listed here or its output will be
+ *    silently suppressed. Parked sessions are filtered out so main stops
+ *    emitting for them at the source.
+ * 3. The WebGL attachment plan (utils/terminal-webgl.ts): the budgeted top-K
+ *    terminals by focus recency keep live WebGL contexts; the rest are
+ *    temporarily suspended to the DOM renderer. A second subscription
+ *    re-applies the last plan whenever an attachment registers (terminal init
+ *    is ResizeObserver-deferred, so a terminal can mount after the plan ran).
  *
  * This must live in an always-mounted component (AppLayout). Previously this
  * effect lived inside TerminalPanel, which is unmounted on the Backlog view -
@@ -24,8 +50,9 @@ import { selectCurrentProjectTransientSessionIds } from '../stores/session-store
  * (pointing at a session that just exited) doesn't leak into the focused
  * set for the ~1-render-cycle window before TerminalPanel syncs the store.
  *
- * The derivation logic is extracted into pure helpers in
- * src/renderer/utils/focused-sessions.ts for unit testability.
+ * The derivation logic is extracted into pure helpers
+ * (utils/focused-sessions.ts, utils/terminal-visibility.ts) for unit
+ * testability.
  */
 export function useFocusedSessionsSync(): void {
   const activeView = useBoardStore((s) => s.activeView);
@@ -38,6 +65,30 @@ export function useFocusedSessionsSync(): void {
   // Zustand skip re-renders when the set is unchanged (mirrors panelSessionId).
   const transientSessionIdsKey = useSessionStore((s) =>
     selectCurrentProjectTransientSessionIds(s.transientSessions, currentProjectId).join(','),
+  );
+
+  // Per-layer window fingerprints (same joined-primitive idiom): re-run the
+  // effect when a window opens/closes/focuses/maximizes or its session binding
+  // changes, but not on unrelated store churn (geometry drags, titles). Order
+  // in the fingerprint IS the store's MRU `order`, so a focus change reorders
+  // the string. The effect reads the full window state via getState().
+  const boardWindowsKey = boardWindowManager.store((s) =>
+    s.order
+      .map((windowId) => {
+        const managedWindow = s.windows[windowId];
+        if (!managedWindow) return windowId;
+        return `${windowId}|${managedWindow.sessionId ?? ''}|${managedWindow.kind}|${managedWindow.state}|${managedWindow.zIndex}`;
+      })
+      .join(';'),
+  );
+  const commandWindowsKey = commandWindowManager.store((s) =>
+    s.order
+      .map((windowId) => {
+        const managedWindow = s.windows[windowId];
+        if (!managedWindow) return windowId;
+        return `${windowId}|${managedWindow.anchor}|${managedWindow.state}|${managedWindow.zIndex}`;
+      })
+      .join(';'),
   );
 
   // Single derived selector: returns the primitive panel session id. The
@@ -54,7 +105,76 @@ export function useFocusedSessionsSync(): void {
     }),
   );
 
+  const lastWebglPlanRef = useRef<WebglAttachmentPlan | null>(null);
+
   useEffect(() => {
+    const boardState = boardWindowManager.store.getState();
+    const commandState = commandWindowManager.store.getState();
+    const transientSessions = useSessionStore.getState().transientSessions;
+    const sessions = useSessionStore.getState().sessions;
+
+    const windows: TerminalVisibilityWindowInput[] = [];
+    boardState.order.forEach((windowId, orderIndex) => {
+      const managedWindow = boardState.windows[windowId];
+      if (!managedWindow) return;
+      // Resolve the window's LIVE session id by anchor (its taskId), not the
+      // window store's `sessionId` field: that field is captured at open time
+      // and never updated, so it goes stale after a session respawn (an
+      // isolated-swimlane switch, or a suspend/respawn). The live terminal
+      // registers its WebGL controller, parked-drop gate, and reveal listener
+      // under the live id (useTerminal's rendererKey = the live session id), so
+      // keying the plan off the stale field would silently miss it. Mirrors the
+      // anchor-based resolution in useWindowSessionClaims.
+      const boardSessionId =
+        managedWindow.kind === 'task-detail'
+          ? (sessions.find((candidate) => candidate.taskId === managedWindow.anchor)?.id ?? null)
+          : managedWindow.sessionId;
+      windows.push({
+        windowId,
+        sessionId: boardSessionId,
+        hasTerminal: managedWindow.kind !== 'conversation',
+        state: managedWindow.state,
+        zIndex: managedWindow.zIndex,
+        orderIndex,
+        layer: 'board',
+      });
+    });
+    // Command windows participate only while their layer is mounted: when the
+    // command bar is hidden, every command xterm is unmounted (no queue, no
+    // WebGL attachment), and rule 4 of deriveFocusedSessionIds already drops
+    // the transient sessions from the focused set. Including them here would
+    // only waste WebGL budget slots on unmounted terminals.
+    if (commandBarVisible && currentProjectId) {
+      commandState.order.forEach((windowId, orderIndex) => {
+        const managedWindow = commandState.windows[windowId];
+        if (!managedWindow) return;
+        const transientEntry = transientSessions[transientKey(currentProjectId, managedWindow.anchor)];
+        windows.push({
+          windowId,
+          sessionId: transientEntry?.sessionId ?? null,
+          hasTerminal: true,
+          state: managedWindow.state,
+          zIndex: managedWindow.zIndex,
+          orderIndex,
+          layer: 'command',
+        });
+      });
+    }
+
+    const plan = planTerminalVisibility({
+      boardLayerParked: activeView !== 'board',
+      windows,
+      panelSessionId,
+      webglBudget: WEBGL_ATTACH_BUDGET,
+    });
+    const parkedSessionIds = new Set(plan.parkedSessionIds);
+
+    // Order matters: publish the parked set FIRST so reveal listeners kick off
+    // their scrollback catch-up (their scrollbackPendingRef holds any live
+    // bytes until the replay paints), THEN re-focus the sessions so main
+    // resumes emitting, THEN swap the WebGL attachments.
+    syncParkedTerminals(parkedSessionIds);
+
     const focusedIds = deriveFocusedSessionIds({
       activeView,
       terminalPanelVisible,
@@ -62,8 +182,33 @@ export function useFocusedSessionsSync(): void {
       dialogSessionIds,
       commandBarVisible,
       transientSessionIds: transientSessionIdsKey ? transientSessionIdsKey.split(',') : [],
+      parkedSessionIds,
     });
-
     window.electronAPI.sessions.setFocused(focusedIds);
-  }, [activeView, terminalPanelVisible, panelSessionId, dialogSessionIds, commandBarVisible, transientSessionIdsKey]);
+
+    lastWebglPlanRef.current = {
+      attachKeys: new Set(plan.webglAttachSessionIds),
+      suspendKeys: new Set(plan.webglSuspendSessionIds),
+    };
+    applyWebglAttachmentPlan(lastWebglPlanRef.current);
+  }, [
+    activeView,
+    terminalPanelVisible,
+    panelSessionId,
+    dialogSessionIds,
+    commandBarVisible,
+    transientSessionIdsKey,
+    boardWindowsKey,
+    commandWindowsKey,
+    currentProjectId,
+  ]);
+
+  // A terminal that mounts AFTER the plan ran starts suspended when the page
+  // is over budget; re-applying the last plan resumes it if the plan names it
+  // in the attach set (a newly opened window is the MRU front, so it does).
+  useEffect(() => {
+    return onWebglAttachmentsChanged(() => {
+      if (lastWebglPlanRef.current) applyWebglAttachmentPlan(lastWebglPlanRef.current);
+    });
+  }, []);
 }

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -6,6 +6,7 @@ import { copySelectionToClipboard, enableTerminalClipboard, stripOsc52Sequences 
 import { createWriteBatcher, type WriteBatcher } from '../utils/write-batcher';
 import { createIncomingWriteQueue, writeChunkedToTerminal } from '../utils/incoming-write-queue';
 import { isBoardDragActive, onBoardDragEnd } from '../lib/session-update-coalescer';
+import { isTerminalParked, onTerminalReveal } from '../utils/parked-terminals';
 import { noteTerminalFocus } from '../utils/dictation-target';
 import { registerTerminalCapture, unregisterTerminalCapture, type TerminalCaptureReader } from '../utils/terminal-capture-registry';
 import '@xterm/xterm/css/xterm.css';
@@ -336,11 +337,15 @@ export function useTerminal(options: UseTerminalOptions) {
 
     const queue = createIncomingWriteQueue({
       getTerminal: () => xtermRef.current,
-      // Only an overlay (agent startup) drops onData - it can last many
-      // seconds and is recovered by the overlay-lift reloadScrollback, so
-      // holding it would pause the PTY for the whole startup. Dropped slices
-      // are still acked inside the queue.
-      shouldDrop: () => suppressDataRef.current,
+      // Drop (ack-and-discard) for states that can last indefinitely, where
+      // holding would pause the PTY at the backpressure high-water and block
+      // the agent's stdout: an overlay (agent startup) and a PARKED terminal
+      // (window off-view on Backlog or occluded by a maximized window - see
+      // parked-terminals.ts). Both are recovered by a reloadScrollback (on
+      // overlay lift / on reveal): the main process keeps accumulating the
+      // dropped bytes in the per-session scrollback ring. Dropped slices are
+      // still acked inside the queue.
+      shouldDrop: () => suppressDataRef.current || isTerminalParked(sessionId),
       // While a board drag OR a scrollback replay is in flight, HOLD (not
       // drop) inbound writes. For a replay, getScrollback() drains the
       // server-side pending buffer, so anything still arriving here is either
@@ -507,9 +512,15 @@ export function useTerminal(options: UseTerminalOptions) {
   // full-screen TUI's accumulated resize redraws AFTER resizing has settled:
   // the PTY is already the right size, so a resize here would only trigger more
   // TUI redraws (re-polluting the buffer with duplicated frames).
-  const reloadScrollback = useCallback((reloadOptions?: { skipResize?: boolean }) => {
+  //
+  // `skipFocus` suppresses the end-of-reload focus steal. Used by the
+  // parked -> visible reveal catch-up: a Backlog -> Board switch can reveal
+  // many windows at once, and N terminals must not fight over focus (and a
+  // quiet arrival should not move focus at all - restore-no-animation-replay).
+  const reloadScrollback = useCallback((reloadOptions?: { skipResize?: boolean; skipFocus?: boolean }) => {
     if (!options.sessionId || !xtermRef.current || !fitAddonRef.current) return;
     const skipResize = reloadOptions?.skipResize ?? false;
+    const skipFocus = reloadOptions?.skipFocus ?? false;
     scrollbackPendingRef.current = true;
     const scrollbackGeneration = ++scrollbackGenerationRef.current;
     if (scrollbackWatchdogRef.current) clearTimeout(scrollbackWatchdogRef.current);
@@ -572,12 +583,14 @@ export function useTerminal(options: UseTerminalOptions) {
           // (see shouldHold in the queue effect below) now that the replay
           // frame is fully painted, so they apply strictly after it.
           incomingResumeRef.current?.();
-          // Focus after the reload completes. No corrective resize: when a
-          // resize was sent above, main sampled the settled frame; a same-dims
-          // resize is a no-op either way.
-          requestAnimationFrame(() => {
-            xtermRef.current?.focus();
-          });
+          // Focus after the reload completes (unless the caller opted out).
+          // No corrective resize: when a resize was sent above, main sampled
+          // the settled frame; a same-dims resize is a no-op either way.
+          if (!skipFocus) {
+            requestAnimationFrame(() => {
+              xtermRef.current?.focus();
+            });
+          }
         };
         if (scrollback && xtermRef.current) {
           // Chunked so a 512KB replay (tab/window switch, resize) doesn't parse
@@ -599,6 +612,22 @@ export function useTerminal(options: UseTerminalOptions) {
         scrollbackPendingRef.current = false;
       });
   }, [options.sessionId]);
+
+  // Reveal catch-up: when this session's terminal transitions parked ->
+  // visible, repaint from scrollback. While parked, main dropped the session's
+  // PTY data at the emit gate (focused-set narrowing) and this queue
+  // acked-and-discarded any stragglers, so the xterm's content is stale; the
+  // ring buffer has the truth. skipResize: the PTY was never resized while
+  // parked (the window stayed mounted at its size). If the terminal has not
+  // initialized yet, reloadScrollback's guards make this a no-op and the
+  // mount-time replay paints instead.
+  useEffect(() => {
+    const sessionId = options.sessionId;
+    if (!sessionId) return;
+    return onTerminalReveal(sessionId, () => {
+      reloadScrollback({ skipResize: true, skipFocus: true });
+    });
+  }, [options.sessionId, reloadScrollback]);
 
   const focus = useCallback(() => {
     xtermRef.current?.focus();

--- a/src/renderer/utils/focused-sessions.ts
+++ b/src/renderer/utils/focused-sessions.ts
@@ -13,6 +13,12 @@ export interface DeriveFocusedSessionIdsInput {
   /** Every Command Terminal session for the current project. Each visible terminal
    *  must be focused or its PTY output is suppressed by the main process. */
   transientSessionIds: string[];
+  /** Sessions whose terminal window is parked off-view (Backlog-parked board
+   *  layer, or occluded by a maximized same-layer window). Parked sessions are
+   *  removed from the focused set so main stops emitting their PTY data; the
+   *  bytes accumulate in the scrollback ring and the reveal-time
+   *  reloadScrollback repaints them. See terminal-visibility.ts. */
+  parkedSessionIds?: ReadonlySet<string>;
 }
 
 /**
@@ -33,12 +39,23 @@ export interface DeriveFocusedSessionIdsInput {
  * 3. Backlog view / panel hidden / no window - no panel session is focused.
  * 4. Command bar visible - every current-project transient session is appended
  *    (unless already in the set).
+ *
+ * Parked sessions (`parkedSessionIds`) are filtered out of rules 1 and 4: an
+ * off-view terminal must not receive live PTY data. NOTE: an all-parked state
+ * (e.g. Backlog with task-detail windows open) therefore derives an EMPTY set,
+ * which the main process treats as "no focus filter - emit everything"
+ * (focusedSessionIds.size === 0 in session-manager). That is safe because
+ * every parked session's mounted incoming-write-queue acks-and-drops without
+ * parsing (see useTerminal's shouldDrop), and it matches the already-reachable
+ * empty-set state (Backlog, no windows, no command bar).
  */
 export function deriveFocusedSessionIds(input: DeriveFocusedSessionIdsInput): string[] {
   const focusedIds: string[] = [];
+  const isParked = (sessionId: string): boolean => input.parkedSessionIds?.has(sessionId) ?? false;
 
   if (input.dialogSessionIds.length > 0) {
     for (const sessionId of input.dialogSessionIds) {
+      if (isParked(sessionId)) continue;
       if (!focusedIds.includes(sessionId)) focusedIds.push(sessionId);
     }
   } else if (
@@ -51,6 +68,7 @@ export function deriveFocusedSessionIds(input: DeriveFocusedSessionIdsInput): st
 
   if (input.commandBarVisible) {
     for (const sessionId of input.transientSessionIds) {
+      if (isParked(sessionId)) continue;
       if (!focusedIds.includes(sessionId)) focusedIds.push(sessionId);
     }
   }

--- a/src/renderer/utils/parked-terminals.ts
+++ b/src/renderer/utils/parked-terminals.ts
@@ -1,0 +1,90 @@
+/**
+ * Parked-terminal registry: which sessions' terminals are currently off-view
+ * (their window layer is parked on the Backlog view, or a maximized window in
+ * the same layer covers them).
+ *
+ * The coordinator (useFocusedSessionsSync) derives the parked set from the
+ * window-manager stores and publishes it here. Consumers:
+ *
+ * - useTerminal's incoming write queue reads `isTerminalParked` in its
+ *   `shouldDrop` gate, so a parked terminal acks-and-discards inbound PTY bytes
+ *   instead of parsing them (the bytes are not lost: the main process keeps
+ *   accumulating them in the per-session scrollback ring).
+ * - useTerminal subscribes to `onTerminalReveal` and repaints from scrollback
+ *   (`reloadScrollback`) when its session transitions parked -> visible.
+ *
+ * Reveal notifications are edge-triggered (fired only for sessions that were
+ * parked in the previous sync and are not in the new one), so republishing an
+ * unchanged set never causes reload storms.
+ *
+ * This mirrors the board-drag gate in session-update-coalescer.ts: a module
+ * predicate plus a notify-listener set, with reset-on-HMR being harmless.
+ */
+
+// Preserved across HMR (Pattern A, mirroring terminal-capture-registry.ts and
+// useTerminal.ts's savedScrollPositions). A components-only Fast Refresh does
+// NOT remount an already-mounted useTerminal (its effect deps are unchanged),
+// so resetting these registries would orphan every already-registered reveal
+// listener in the discarded module instance - the parked terminal would then
+// never get its scrollback catch-up on reveal. Preserve the live Set/Map.
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+const parkedSessionIds: Set<string> = import.meta.hot?.data?.parkedSessionIds ?? new Set<string>();
+// @ts-expect-error -- Vite handles import.meta.hot
+const revealListenersBySession: Map<string, Set<() => void>> = import.meta.hot?.data?.revealListenersBySession ?? new Map();
+
+// @ts-expect-error -- Vite handles import.meta.hot
+if (import.meta.hot) {
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.dispose((data: Record<string, unknown>) => {
+    data.parkedSessionIds = parkedSessionIds;
+    data.revealListenersBySession = revealListenersBySession;
+  });
+}
+
+/** True while `sessionId`'s terminal is parked off-view. */
+export function isTerminalParked(sessionId: string): boolean {
+  return parkedSessionIds.has(sessionId);
+}
+
+/**
+ * Replace the parked set. Fires the reveal listeners of every session that
+ * transitioned parked -> visible; newly parked and still-parked sessions fire
+ * nothing.
+ */
+export function syncParkedTerminals(parked: ReadonlySet<string>): void {
+  const revealed: string[] = [];
+  for (const sessionId of parkedSessionIds) {
+    if (!parked.has(sessionId)) revealed.push(sessionId);
+  }
+
+  parkedSessionIds.clear();
+  for (const sessionId of parked) parkedSessionIds.add(sessionId);
+
+  for (const sessionId of revealed) {
+    const listeners = revealListenersBySession.get(sessionId);
+    if (!listeners) continue;
+    for (const listener of [...listeners]) {
+      try {
+        listener();
+      } catch {
+        // One throwing listener must not block the others.
+      }
+    }
+  }
+}
+
+/** Subscribe to `sessionId`'s parked -> visible edge. Returns an unsubscribe. */
+export function onTerminalReveal(sessionId: string, listener: () => void): () => void {
+  let listeners = revealListenersBySession.get(sessionId);
+  if (!listeners) {
+    listeners = new Set();
+    revealListenersBySession.set(sessionId, listeners);
+  }
+  listeners.add(listener);
+  return () => {
+    const registered = revealListenersBySession.get(sessionId);
+    if (!registered) return;
+    registered.delete(listener);
+    if (registered.size === 0) revealListenersBySession.delete(sessionId);
+  };
+}

--- a/src/renderer/utils/terminal-visibility.ts
+++ b/src/renderer/utils/terminal-visibility.ts
@@ -1,0 +1,147 @@
+import type { WindowState } from '../window-manager/store/types';
+
+/**
+ * Pure planner for terminal visibility across the windowed-terminal surfaces:
+ * which sessions are PARKED (off-view, so their PTY stream should be dropped
+ * at the main-process emit gate and their queue should ack-and-discard), and
+ * which terminals get one of the page's budgeted live WebGL attachments.
+ *
+ * Extracted from useFocusedSessionsSync (the coordinator) so the policy can be
+ * unit-tested with plain fixtures, mirroring planCommandWindowReconciliation.
+ *
+ * Parking scope (v1, deliberately conservative):
+ * - The whole board layer is parked while the Backlog view is active (the
+ *   overlay is visibility:hidden but every window stays mounted).
+ * - A window is occluded when a maximized window with a higher zIndex exists
+ *   in the SAME layer. No rect-containment math: full coverage by a floating
+ *   window is rare, and a false negative just keeps today's behavior.
+ * - Cross-layer occlusion is out: the command layer's backdrop is translucent,
+ *   so board windows behind it remain partially visible.
+ *
+ * WebGL budget: visible terminals are ranked by focus recency - the command
+ * layer stacks above the board layer, and within a layer the window store's
+ * `order` array is an exact MRU (front-most last, so a higher order index is
+ * more recent). The bottom panel's single collapsed xterm is always attached
+ * and never parked. Parked terminals are always suspended. Sessions the
+ * planner does not know about appear in neither output set, so applying the
+ * plan leaves them untouched.
+ */
+
+export interface TerminalVisibilityWindowInput {
+  windowId: string;
+  /** Live PTY session id; null when suspended/closed/not yet spawned. */
+  sessionId: string | null;
+  /** False for windows without an xterm (conversation); they still occlude. */
+  hasTerminal: boolean;
+  state: WindowState;
+  zIndex: number;
+  /** Index in the layer store's MRU `order` array (front-most = highest). */
+  orderIndex: number;
+  layer: 'board' | 'command';
+}
+
+export interface TerminalVisibilityInput {
+  /** True when the board overlay is off-view (activeView !== 'board'). */
+  boardLayerParked: boolean;
+  windows: TerminalVisibilityWindowInput[];
+  /**
+   * The bottom panel's mounted terminal session (already N->1 collapsed);
+   * always attached, never parked. Null when the panel renders no terminal.
+   */
+  panelSessionId: string | null;
+  /** Max live WebGL attachments (WEBGL_ATTACH_BUDGET). */
+  webglBudget: number;
+}
+
+export interface TerminalVisibilityPlan {
+  parkedSessionIds: string[];
+  webglAttachSessionIds: string[];
+  webglSuspendSessionIds: string[];
+}
+
+/**
+ * A window is occluded when a maximized window with a higher zIndex exists in
+ * its layer. Windows without a terminal still occlude; multiple maximized
+ * windows occlude the lower-z ones.
+ */
+export function computeOccludedWindowIds(
+  windows: readonly TerminalVisibilityWindowInput[],
+): Set<string> {
+  const occluded = new Set<string>();
+  for (const layer of ['board', 'command'] as const) {
+    const layerWindows = windows.filter((candidate) => candidate.layer === layer);
+    let topMaximizedZIndex: number | null = null;
+    for (const candidate of layerWindows) {
+      if (candidate.state !== 'maximized') continue;
+      if (topMaximizedZIndex === null || candidate.zIndex > topMaximizedZIndex) {
+        topMaximizedZIndex = candidate.zIndex;
+      }
+    }
+    if (topMaximizedZIndex === null) continue;
+    for (const candidate of layerWindows) {
+      if (candidate.zIndex < topMaximizedZIndex) occluded.add(candidate.windowId);
+    }
+  }
+  return occluded;
+}
+
+export function planTerminalVisibility(input: TerminalVisibilityInput): TerminalVisibilityPlan {
+  const occludedWindowIds = computeOccludedWindowIds(input.windows);
+
+  interface VisibleTerminal {
+    sessionId: string;
+    layer: 'board' | 'command';
+    orderIndex: number;
+  }
+
+  const parkedSessionIds: string[] = [];
+  const visibleTerminals: VisibleTerminal[] = [];
+  for (const window of input.windows) {
+    if (!window.hasTerminal || window.sessionId === null) continue;
+    const layerParked = window.layer === 'board' && input.boardLayerParked;
+    if (layerParked || occludedWindowIds.has(window.windowId)) {
+      parkedSessionIds.push(window.sessionId);
+    } else {
+      visibleTerminals.push({
+        sessionId: window.sessionId,
+        layer: window.layer,
+        orderIndex: window.orderIndex,
+      });
+    }
+  }
+
+  // Focus recency: command layer stacks above the board layer; within a layer
+  // a higher MRU order index is more recent.
+  visibleTerminals.sort((first, second) => {
+    if (first.layer !== second.layer) return first.layer === 'command' ? -1 : 1;
+    return second.orderIndex - first.orderIndex;
+  });
+
+  const webglAttachSessionIds: string[] = [];
+  // The panel session is force-attached first, but only when it is not parked.
+  // derivePanelSessionId is window-blind and can resolve to a session a
+  // task-detail window already owns, and that window may be parked or occluded.
+  // Attaching a parked session would keep its off-view WebGL context live,
+  // wasting a budget slot and contradicting "parked terminals are always
+  // suspended" - so a parked panel session falls through to the suspend set.
+  if (input.panelSessionId !== null && !parkedSessionIds.includes(input.panelSessionId)) {
+    webglAttachSessionIds.push(input.panelSessionId);
+  }
+  for (const terminal of visibleTerminals) {
+    if (webglAttachSessionIds.length >= input.webglBudget) break;
+    if (!webglAttachSessionIds.includes(terminal.sessionId)) {
+      webglAttachSessionIds.push(terminal.sessionId);
+    }
+  }
+
+  const webglSuspendSessionIds: string[] = [];
+  const collectSuspend = (sessionId: string): void => {
+    if (!webglAttachSessionIds.includes(sessionId) && !webglSuspendSessionIds.includes(sessionId)) {
+      webglSuspendSessionIds.push(sessionId);
+    }
+  };
+  for (const sessionId of parkedSessionIds) collectSuspend(sessionId);
+  for (const terminal of visibleTerminals) collectSuspend(terminal.sessionId);
+
+  return { parkedSessionIds, webglAttachSessionIds, webglSuspendSessionIds };
+}

--- a/src/renderer/utils/terminal-webgl.ts
+++ b/src/renderer/utils/terminal-webgl.ts
@@ -2,7 +2,8 @@ import type { Terminal, ITerminalAddon } from '@xterm/xterm';
 import { WebglAddon } from '@xterm/addon-webgl';
 
 /**
- * WebGL renderer attachment with context-loss recovery.
+ * WebGL renderer attachment with context-loss recovery and a page-wide
+ * attachment budget.
  *
  * xterm's WebGL renderer is 10-50x faster than its DOM fallback for output
  * bursts. The GPU can drop the WebGL context (driver reset, tab throttling,
@@ -12,6 +13,17 @@ import { WebglAddon } from '@xterm/addon-webgl';
  * burst became far more expensive with nothing recorded. This module retries
  * re-initializing WebGL after a loss (with a short backoff), logs what happened,
  * and tracks the live renderer type so devtools can observe a degraded terminal.
+ *
+ * The budget exists because Chromium caps live WebGL contexts per page (~16)
+ * and silently drops the OLDEST when a new one is created - which lands here as
+ * a context loss on some other terminal and, after the retries re-trip the cap,
+ * a permanent DOM fallback. With windowed terminals the page can host far more
+ * xterms than the cap, so attachments above `WEBGL_ATTACH_BUDGET` start
+ * suspended, and a coordinator (useFocusedSessionsSync) applies an LRU plan via
+ * `applyWebglAttachmentPlan` to keep the most-recently-focused terminals on
+ * WebGL. A budget-driven suspend is NOT a context loss: it never touches
+ * `contextLossCount` or `permanentDomFallback`, and the terminal re-attaches on
+ * its next `resume()`.
  */
 
 export type TerminalRendererType = 'webgl' | 'dom';
@@ -23,6 +35,12 @@ export interface TerminalRendererStatus {
   contextLossCount: number;
   /** True once retries are exhausted and the terminal is DOM-only for good. */
   permanentDomFallback: boolean;
+  /**
+   * True while the WebGL attachment budget has this terminal temporarily on
+   * the DOM renderer. Not a failure state: the coordinator resumes the
+   * attachment when the terminal climbs back into the top-K by focus recency.
+   */
+  suspendedByBudget: boolean;
 }
 
 /** The subset of `WebglAddon` this module uses. Narrowed so tests can fake it. */
@@ -40,14 +58,105 @@ interface AttachWebglOptions {
    * Default: retry once after 2s, once more after 10s, then give up.
    */
   retryDelaysMs?: number[];
+  /** Live-attachment cap, injectable for tests. Defaults to WEBGL_ATTACH_BUDGET. */
+  attachBudget?: number;
 }
 
 const DEFAULT_RETRY_DELAYS_MS = [2_000, 10_000];
 
-// hmr-safe: transient per-terminal renderer status; terminals dispose and
-// re-register their entry across an HMR remount, and a devtools snapshot
-// reading a stale map after a Fast Refresh is a harmless diagnostic read.
-const rendererStatusByKey = new Map<string, TerminalRendererStatus>();
+/**
+ * Max simultaneous live WebGL attachments on this page. Chromium's own cap is
+ * ~16 per page; terminals are the page's only WebGL consumers (pop-outs are
+ * separate pages and never host terminals; the changes panel is Monaco). 8
+ * covers every realistic fully-visible layout (task-detail windows + max 4
+ * command terminals + the bottom panel's single collapsed xterm) while leaving
+ * half of Chromium's budget as headroom for suspend/resume transitions, so
+ * Chromium's silent oldest-context eviction never engages.
+ */
+export const WEBGL_ATTACH_BUDGET = 8;
+
+interface WebglAttachmentController {
+  suspend(): void;
+  resume(): boolean;
+}
+
+export interface WebglAttachmentPlan {
+  /** Keys that should hold a live WebGL context (top-K by focus recency). */
+  attachKeys: ReadonlySet<string>;
+  /** Keys to temporarily suspend. Keys in NEITHER set are left untouched. */
+  suspendKeys: ReadonlySet<string>;
+}
+
+// Preserved across HMR (Pattern A, mirroring terminal-capture-registry.ts).
+// These three must round-trip as a UNIT: countLiveWebgl() reads
+// rendererStatusByKey for budget headroom while applyWebglAttachmentPlan looks
+// up already-mounted terminals in attachmentControllersByKey, so resetting one
+// independently would desync them (a live terminal invisible to the budget
+// count, or uncontrollable by the coordinator) after a components-only Fast
+// Refresh that does not remount already-mounted terminals.
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+const rendererStatusByKey: Map<string, TerminalRendererStatus> = import.meta.hot?.data?.rendererStatusByKey ?? new Map();
+// @ts-expect-error -- Vite handles import.meta.hot
+const attachmentControllersByKey: Map<string, WebglAttachmentController> = import.meta.hot?.data?.attachmentControllersByKey ?? new Map();
+// @ts-expect-error -- Vite handles import.meta.hot
+const webglAttachmentListeners: Set<() => void> = import.meta.hot?.data?.webglAttachmentListeners ?? new Set();
+
+// @ts-expect-error -- Vite handles import.meta.hot
+if (import.meta.hot) {
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.dispose((data: Record<string, unknown>) => {
+    data.rendererStatusByKey = rendererStatusByKey;
+    data.attachmentControllersByKey = attachmentControllersByKey;
+    data.webglAttachmentListeners = webglAttachmentListeners;
+  });
+}
+
+function countLiveWebgl(): number {
+  let liveCount = 0;
+  for (const status of rendererStatusByKey.values()) {
+    if (status.renderer === 'webgl') liveCount += 1;
+  }
+  return liveCount;
+}
+
+function notifyWebglAttachmentsChanged(): void {
+  for (const listener of [...webglAttachmentListeners]) {
+    try {
+      listener();
+    } catch {
+      // One throwing listener must not block the others.
+    }
+  }
+}
+
+/**
+ * Subscribe to attachment registry changes (a terminal attaching or disposing).
+ * The coordinator uses this to re-apply its last plan when a terminal mounts
+ * after the plan ran (terminal init is ResizeObserver-deferred), so an over-cap
+ * newcomer that started suspended converges to WebGL once the plan's suspends
+ * have freed a context.
+ */
+export function onWebglAttachmentsChanged(listener: () => void): () => void {
+  webglAttachmentListeners.add(listener);
+  return () => {
+    webglAttachmentListeners.delete(listener);
+  };
+}
+
+/**
+ * Apply an attachment plan. Suspends run BEFORE resumes so contexts are freed
+ * before new ones are acquired - the live count never overshoots the budget
+ * mid-application. Keys that are not currently registered, and registered keys
+ * the plan does not name, are left untouched.
+ */
+export function applyWebglAttachmentPlan(plan: WebglAttachmentPlan): void {
+  for (const key of plan.suspendKeys) {
+    attachmentControllersByKey.get(key)?.suspend();
+  }
+  for (const key of plan.attachKeys) {
+    attachmentControllersByKey.get(key)?.resume();
+  }
+}
 
 /**
  * Attach the WebGL renderer to `terminal`, recovering from context loss. Returns
@@ -62,13 +171,20 @@ export function attachWebglRenderer(
 ): () => void {
   const createAddon = options?.createAddon ?? (() => new WebglAddon());
   const retryDelaysMs = options?.retryDelaysMs ?? DEFAULT_RETRY_DELAYS_MS;
+  const attachBudget = options?.attachBudget ?? WEBGL_ATTACH_BUDGET;
 
-  const status: TerminalRendererStatus = { renderer: 'dom', contextLossCount: 0, permanentDomFallback: false };
+  const status: TerminalRendererStatus = {
+    renderer: 'dom',
+    contextLossCount: 0,
+    permanentDomFallback: false,
+    suspendedByBudget: false,
+  };
   rendererStatusByKey.set(rendererKey, status);
 
   let currentAddon: WebglAddonLike | null = null;
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
   let disposed = false;
+  let suspended = false;
 
   const clearRetryTimer = (): void => {
     if (retryTimer !== null) {
@@ -96,7 +212,7 @@ export function attachWebglRenderer(
     clearRetryTimer();
     retryTimer = setTimeout(() => {
       retryTimer = null;
-      if (disposed) return;
+      if (disposed || suspended) return;
       if (tryAttach()) {
         console.warn(`[terminal-webgl] WebGL renderer recovered for ${rendererKey}`);
         return;
@@ -116,7 +232,10 @@ export function attachWebglRenderer(
   }
 
   function handleContextLoss(): void {
-    if (disposed) return;
+    // A loss event during/after a budget suspend is not counted: the suspend
+    // already disposed the addon and moved the terminal to DOM deliberately,
+    // and it must never escalate toward permanentDomFallback.
+    if (disposed || suspended) return;
     if (currentAddon) {
       try { currentAddon.dispose(); } catch { /* addon may already be gone */ }
       currentAddon = null;
@@ -135,13 +254,55 @@ export function attachWebglRenderer(
     scheduleReattach(lossNumber);
   }
 
-  // Initial attach. A construction throw means WebGL is unavailable in this
-  // environment (headless, blocklisted GPU): stay on DOM, but now logged rather
-  // than silently swallowed.
-  if (!tryAttach()) {
+  const suspend = (): void => {
+    // A permanently-DOM terminal has no context to free; marking it
+    // budget-suspended would only make the renderer report lie about why it
+    // is on DOM.
+    if (disposed || suspended || status.permanentDomFallback) return;
+    suspended = true;
+    clearRetryTimer();
+    if (currentAddon) {
+      try { currentAddon.dispose(); } catch { /* best-effort */ }
+      currentAddon = null;
+    }
+    status.renderer = 'dom';
+    status.suspendedByBudget = true;
+  };
+
+  const resume = (): boolean => {
+    if (disposed || status.permanentDomFallback) return false;
+    if (!suspended) return true;
+    suspended = false;
+    if (tryAttach()) {
+      status.suspendedByBudget = false;
+      return true;
+    }
+    // Stay budget-suspended rather than escalating: the coordinator re-applies
+    // its plan on the next window/store change, which is the retry. Arming the
+    // context-loss backoff ladder here would conflate a transient acquisition
+    // failure with a real loss.
+    suspended = true;
+    console.warn(`[terminal-webgl] WebGL re-attach after budget suspend failed for ${rendererKey}; staying suspended`);
+    return false;
+  };
+
+  if (countLiveWebgl() >= attachBudget) {
+    // Over budget: start suspended WITHOUT requesting a context, so this page
+    // never asks Chromium for a context past the cap (which would silently
+    // evict the oldest). Not a fallback: the coordinator resumes this terminal
+    // if it is top-K by recency (a newly opened window is the MRU front).
+    suspended = true;
+    status.suspendedByBudget = true;
+  } else if (!tryAttach()) {
+    // Initial attach failed. A construction throw means WebGL is unavailable in
+    // this environment (headless, blocklisted GPU): stay on DOM, but now logged
+    // rather than silently swallowed.
     status.permanentDomFallback = true;
     console.warn(`[terminal-webgl] WebGL unavailable for ${rendererKey}; using the DOM renderer`);
   }
+
+  attachmentControllersByKey.set(rendererKey, { suspend, resume });
+  notifyWebglAttachmentsChanged();
 
   return () => {
     disposed = true;
@@ -150,7 +311,9 @@ export function attachWebglRenderer(
       try { currentAddon.dispose(); } catch { /* best-effort */ }
       currentAddon = null;
     }
+    attachmentControllersByKey.delete(rendererKey);
     rendererStatusByKey.delete(rendererKey);
+    notifyWebglAttachmentsChanged();
   };
 }
 

--- a/tests/ui/window-park-reveal.spec.ts
+++ b/tests/ui/window-park-reveal.spec.ts
@@ -93,7 +93,15 @@ interface TestWindow {
   __scrollbackValue?: string;
   __mockFireSessionData?: (sessionId: string, data: string) => void;
   __zustandStores?: {
-    session?: { getState: () => { markFirstOutput: (id: string) => void } };
+    session?: {
+      getState: () => {
+        markFirstOutput: (id: string) => void;
+        resumeSession: (taskId: string) => Promise<{ id: string }>;
+      };
+    };
+    window?: {
+      getState: () => { windows: Record<string, { anchor: string; sessionId: string | null }> };
+    };
   };
   electronAPI?: {
     sessions: {
@@ -103,7 +111,7 @@ interface TestWindow {
   };
 }
 
-async function launchWithState(): Promise<{ browser: Browser; page: Page }> {
+async function launchWithState(preConfigScript: string): Promise<{ browser: Browser; page: Page }> {
   await waitForViteReady(VITE_URL);
   // Disable WebGL so xterm renders through its DOM renderer (`.xterm-rows`
   // text nodes) and terminal CONTENT is assertable as text. With WebGL
@@ -115,7 +123,7 @@ async function launchWithState(): Promise<{ browser: Browser; page: Page }> {
   const page = await context.newPage();
 
   await page.addInitScript({ path: MOCK_SCRIPT });
-  await page.addInitScript(preConfig);
+  await page.addInitScript(preConfigScript);
 
   await page.goto(VITE_URL);
   await page.waitForLoadState('load');
@@ -126,7 +134,7 @@ async function launchWithState(): Promise<{ browser: Browser; page: Page }> {
 
 test.describe('Parked window: PTY drop while parked, scrollback catch-up on reveal', () => {
   test('backlog-parked terminal drops live bytes and repaints from scrollback on reveal', async () => {
-    const { browser, page } = await launchWithState();
+    const { browser, page } = await launchWithState(preConfig);
     try {
       await page.locator('[data-swimlane-name="Code Review"]').waitFor({ state: 'visible', timeout: 15000 });
 
@@ -221,6 +229,160 @@ test.describe('Parked window: PTY drop while parked, scrollback catch-up on reve
           { timeout: 5000 },
         )
         .toContain(SESSION_ID);
+    } finally {
+      await browser.close();
+    }
+  });
+});
+
+/**
+ * Coordinator regression coverage: `useFocusedSessionsSync` resolves a board
+ * task-detail window's LIVE session by anchor (the taskId) from the CURRENT
+ * session list, not from the window store's `sessionId` field - that field is
+ * captured once at `openWindow` time and never updated (see window-store.ts's
+ * `OpenWindowInput`), so it goes stale the moment the task's session respawns
+ * (an isolated-swimlane switch, or a suspend/resume) while the window stays
+ * open. A regression back to keying the visibility plan off the stale field
+ * would silently keep parking/focusing the OLD (superseded) session id
+ * instead of the new live one.
+ *
+ * `dialogSessionIds` (which gates the setFocused IPC directly) is resolved
+ * correctly by a SEPARATE hook (`useWindowSessionClaims`), so a plain "is the
+ * new session focused" check would pass even with the coordinator bug - the
+ * bug only shows up in the PARK gate: `deriveFocusedSessionIds` excludes a
+ * dialogSessionIds entry from the focused set only when the coordinator's OWN
+ * resolution placed that same session id in `parkedSessionIds`. So the
+ * discriminating assertion is "the respawned session drops out of the focused
+ * set once its window is parked" - with the stale-field bug, the OLD
+ * (superseded) session id gets parked instead, and the new live session never
+ * leaves the focused set.
+ */
+const RESPAWN_PROJECT_ID = 'proj-window-park-respawn';
+const RESPAWN_TASK_ID = 'task-window-park-respawn';
+const RESPAWN_SESSION_ID_INITIAL = 'sess-window-park-respawn-initial';
+const RESPAWN_TASK_TITLE = 'Respawn Anchor Task';
+
+const respawnPreConfig = `
+  window.__mockPreConfigure(function (state) {
+    var ts = new Date().toISOString();
+
+    state.projects.push({
+      id: '${RESPAWN_PROJECT_ID}',
+      name: 'Window Park Respawn Test',
+      path: '/mock/window-park-respawn-test',
+      github_url: null,
+      default_agent: 'claude',
+      last_opened: ts,
+      created_at: ts,
+    });
+
+    var laneIds = {};
+    state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+      var id = 'lane-' + s.name.toLowerCase().replace(/\\s+/g, '-');
+      laneIds[s.name] = id;
+      state.swimlanes.push(Object.assign({}, s, { id: id, position: i, created_at: ts }));
+    });
+
+    // Running session so the task-detail window opens with a live terminal.
+    state.sessions.push({
+      id: '${RESPAWN_SESSION_ID_INITIAL}',
+      taskId: '${RESPAWN_TASK_ID}',
+      projectId: '${RESPAWN_PROJECT_ID}',
+      pid: 9999,
+      status: 'running',
+      shell: 'bash',
+      cwd: '/mock/window-park-respawn-test',
+      startedAt: ts,
+      exitCode: null,
+    });
+
+    state.tasks.push({
+      id: '${RESPAWN_TASK_ID}',
+      display_id: 1,
+      title: '${RESPAWN_TASK_TITLE}',
+      description: 'Task used to verify the coordinator resolves the live session by anchor',
+      swimlane_id: laneIds['Code Review'],
+      position: 0,
+      agent: 'claude',
+      session_id: '${RESPAWN_SESSION_ID_INITIAL}',
+      worktree_path: null,
+      branch_name: null,
+      pr_number: null,
+      pr_url: null,
+      base_branch: 'main',
+      archived_at: null,
+      created_at: ts,
+      updated_at: ts,
+    });
+
+    return { currentProjectId: '${RESPAWN_PROJECT_ID}' };
+  });
+`;
+
+test.describe('Parked window: board session resolved by anchor, not the stale window field', () => {
+  test('a respawned session parks/focuses by its live id, ignoring the window store\'s stale captured sessionId', async () => {
+    const { browser, page } = await launchWithState(respawnPreConfig);
+    try {
+      await page.locator('[data-swimlane-name="Code Review"]').waitFor({ state: 'visible', timeout: 15000 });
+
+      // Open the task-detail window; it captures the INITIAL live session id
+      // into the window store's `sessionId` field (never updated again).
+      await page
+        .locator('[data-swimlane-name="Code Review"]')
+        .locator(`text=${RESPAWN_TASK_TITLE}`)
+        .first()
+        .click();
+      const dialog = page.locator('[data-testid="task-detail-dialog"]');
+      await dialog.waitFor({ state: 'visible', timeout: 5000 });
+
+      const lastSetFocusedCall = async (): Promise<string[] | null> =>
+        page.evaluate(() => {
+          const calls = (window as unknown as TestWindow).electronAPI?.sessions.__setFocusedCalls ?? [];
+          return calls.length > 0 ? calls[calls.length - 1] : null;
+        });
+
+      // Baseline: the initial session is focused before any respawn.
+      await expect.poll(lastSetFocusedCall, { timeout: 5000 }).toContain(RESPAWN_SESSION_ID_INITIAL);
+
+      // Respawn: drive the same store action a real Resume click fires. This
+      // replaces the task's live session with a brand-new id (mirrors an
+      // isolated-swimlane switch or a suspend/resume while the window is open).
+      const respawnedSessionId = await page.evaluate(async (taskId) => {
+        const sessionStore = (window as unknown as TestWindow).__zustandStores?.session;
+        if (!sessionStore) throw new Error('session store not exposed for testing');
+        const newSession = await sessionStore.getState().resumeSession(taskId);
+        return newSession.id;
+      }, RESPAWN_TASK_ID);
+      expect(respawnedSessionId).not.toBe(RESPAWN_SESSION_ID_INITIAL);
+
+      // The new live session becomes focused (dialogSessionIds is resolved by
+      // anchor in a separate hook, useWindowSessionClaims, so this much would
+      // pass even with the coordinator bug this test targets).
+      await expect.poll(lastSetFocusedCall, { timeout: 5000 }).toContain(respawnedSessionId);
+
+      // Sanity check on the premise: the window store's OWN `sessionId` field
+      // is still the OLD id - proving this scenario actually exercises the
+      // anchor-resolution code path rather than coincidentally matching.
+      const staleWindowSessionId = await page.evaluate((taskId) => {
+        const windowStore = (window as unknown as TestWindow).__zustandStores?.window;
+        const windows = windowStore?.getState().windows ?? {};
+        const match = Object.values(windows).find((candidate) => candidate.anchor === taskId);
+        return match ? match.sessionId : undefined;
+      }, RESPAWN_TASK_ID);
+      expect(staleWindowSessionId).toBe(RESPAWN_SESSION_ID_INITIAL);
+
+      // Park: switch to Backlog. The coordinator must resolve the window's
+      // LIVE session (the respawned id) - not the stale captured field - so
+      // the RESPAWNED session is the one that leaves the focused set.
+      await page.locator('[data-testid="view-toggle-backlog"]').click();
+      await expect(page.locator('[data-testid="backlog-view"]')).toBeVisible();
+      await expect(dialog).toBeAttached();
+      await expect.poll(lastSetFocusedCall, { timeout: 5000 }).not.toContain(respawnedSessionId);
+
+      // Reveal: switch back to Board. The respawned session is focused again.
+      await page.locator('[data-testid="view-toggle-board"]').click();
+      await expect(dialog).toBeVisible();
+      await expect.poll(lastSetFocusedCall, { timeout: 5000 }).toContain(respawnedSessionId);
     } finally {
       await browser.close();
     }

--- a/tests/ui/window-park-reveal.spec.ts
+++ b/tests/ui/window-park-reveal.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * UI test for parked-terminal PTY write gating with scrollback catch-up on
+ * reveal (the windowed-terminals scaling defense).
+ *
+ * A task-detail window parked on the Backlog view must: (1) drop out of the
+ * focused-session set pushed to main (main stops emitting its PTY data), (2)
+ * ack-and-discard any live bytes that still reach its incoming write queue
+ * (never parse them into the hidden xterm), and (3) on reveal (switching back
+ * to Board), repaint the terminal from scrollback exactly once - correct
+ * content, no blank terminal, no duplicated frames.
+ *
+ * The WebGL LRU budget is unit-tested in tests/unit/terminal-webgl.test.ts;
+ * this spec launches with WebGL disabled (see launchWithState) so xterm uses
+ * its DOM renderer and terminal content is assertable as text. It asserts
+ * content, store state, and the setFocused IPC log - never pixels.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-window-park-reveal';
+const TASK_ID = 'task-window-park-reveal';
+const SESSION_ID = 'sess-window-park-reveal';
+
+const INITIAL_CONTENT = 'INITIAL-SCROLLBACK-FRAME';
+const CAUGHT_UP_CONTENT = 'CAUGHT-UP-WHILE-PARKED';
+const LIVE_WHILE_PARKED = 'LIVE-BYTES-WHILE-PARKED';
+
+const preConfig = `
+  window.__mockPreConfigure(function (state) {
+    var ts = new Date().toISOString();
+
+    state.projects.push({
+      id: '${PROJECT_ID}',
+      name: 'Window Park Reveal Test',
+      path: '/mock/window-park-reveal-test',
+      github_url: null,
+      default_agent: 'claude',
+      last_opened: ts,
+      created_at: ts,
+    });
+
+    var laneIds = {};
+    state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+      var id = 'lane-' + s.name.toLowerCase().replace(/\\s+/g, '-');
+      laneIds[s.name] = id;
+      state.swimlanes.push(Object.assign({}, s, { id: id, position: i, created_at: ts }));
+    });
+
+    // Running session so the task-detail window opens with a live terminal.
+    state.sessions.push({
+      id: '${SESSION_ID}',
+      taskId: '${TASK_ID}',
+      projectId: '${PROJECT_ID}',
+      pid: 9999,
+      status: 'running',
+      shell: 'bash',
+      cwd: '/mock/window-park-reveal-test',
+      startedAt: ts,
+      exitCode: null,
+    });
+
+    state.tasks.push({
+      id: '${TASK_ID}',
+      display_id: 1,
+      title: 'Park Reveal Task',
+      description: 'Task used to verify park -> reveal scrollback catch-up',
+      swimlane_id: laneIds['Code Review'],
+      position: 0,
+      agent: 'claude',
+      session_id: '${SESSION_ID}',
+      worktree_path: '/mock/worktrees/window-park-reveal',
+      branch_name: 'feature/window-park-reveal',
+      pr_number: null,
+      pr_url: null,
+      base_branch: 'main',
+      archived_at: null,
+      created_at: ts,
+      updated_at: ts,
+    });
+
+    return { currentProjectId: '${PROJECT_ID}' };
+  });
+`;
+
+interface TestWindow {
+  __scrollbackValue?: string;
+  __mockFireSessionData?: (sessionId: string, data: string) => void;
+  __zustandStores?: {
+    session?: { getState: () => { markFirstOutput: (id: string) => void } };
+  };
+  electronAPI?: {
+    sessions: {
+      getScrollback: (sessionId: string) => Promise<string>;
+      __setFocusedCalls: string[][];
+    };
+  };
+}
+
+async function launchWithState(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  // Disable WebGL so xterm renders through its DOM renderer (`.xterm-rows`
+  // text nodes) and terminal CONTENT is assertable as text. With WebGL
+  // available (headless Chromium ships SwiftShader), xterm paints to a canvas
+  // and innerText is empty. The WebGL budget itself is unit-tested in
+  // tests/unit/terminal-webgl.test.ts; this spec is about park/reveal content.
+  const browser = await chromium.launch({ headless: true, args: ['--disable-webgl', '--disable-webgl2'] });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(preConfig);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+  return { browser, page };
+}
+
+test.describe('Parked window: PTY drop while parked, scrollback catch-up on reveal', () => {
+  test('backlog-parked terminal drops live bytes and repaints from scrollback on reveal', async () => {
+    const { browser, page } = await launchWithState();
+    try {
+      await page.locator('[data-swimlane-name="Code Review"]').waitFor({ state: 'visible', timeout: 15000 });
+
+      // Flip terminalReady (lifts the startup overlay so xterm mounts
+      // unsuppressed) and point getScrollback at a mutable value the test
+      // updates to model main's ring buffer accumulating while parked.
+      await page.evaluate(
+        ({ sessionId, initialContent }) => {
+          const testWindow = window as unknown as TestWindow;
+          testWindow.__zustandStores?.session?.getState().markFirstOutput(sessionId);
+          testWindow.__scrollbackValue = `${initialContent}\r\n`;
+          if (testWindow.electronAPI) {
+            testWindow.electronAPI.sessions.getScrollback = async () =>
+              (window as unknown as TestWindow).__scrollbackValue ?? '';
+          }
+        },
+        { sessionId: SESSION_ID, initialContent: INITIAL_CONTENT },
+      );
+
+      // Open the task-detail window; the mount-time replay paints the initial frame.
+      await page
+        .locator('[data-swimlane-name="Code Review"]')
+        .locator('text=Park Reveal Task')
+        .first()
+        .click();
+      const dialog = page.locator('[data-testid="task-detail-dialog"]');
+      await dialog.waitFor({ state: 'visible', timeout: 5000 });
+      await dialog.locator('.xterm-helper-textarea').first().waitFor({ state: 'attached', timeout: 10000 });
+      await expect
+        .poll(async () => dialog.locator('.xterm').first().innerText(), { timeout: 10000 })
+        .toContain(INITIAL_CONTENT);
+
+      // Park: switch to Backlog. The window stays attached (PTY alive) but the
+      // session must leave the focused set (main stops emitting its data).
+      await page.locator('[data-testid="view-toggle-backlog"]').click();
+      await expect(page.locator('[data-testid="backlog-view"]')).toBeVisible();
+      await expect(dialog).toBeAttached();
+      await expect
+        .poll(
+          async () =>
+            page.evaluate(() => {
+              const calls = (window as unknown as TestWindow).electronAPI?.sessions.__setFocusedCalls ?? [];
+              return calls.length > 0 ? calls[calls.length - 1] : null;
+            }),
+          { timeout: 5000 },
+        )
+        .not.toContain(SESSION_ID);
+
+      // Live bytes still reaching the renderer while parked (the mock has no
+      // focus gate, which conveniently exercises the renderer's own drop gate):
+      // the parked queue must ack-and-discard them, never write them to xterm.
+      // Model main's ring accumulating by extending the scrollback the reveal
+      // will fetch.
+      await page.evaluate(
+        ({ sessionId, liveData, initialContent, caughtUpContent }) => {
+          const testWindow = window as unknown as TestWindow;
+          testWindow.__mockFireSessionData?.(sessionId, `${liveData}\r\n`);
+          testWindow.__scrollbackValue = `${initialContent}\r\n${caughtUpContent}\r\n`;
+        },
+        {
+          sessionId: SESSION_ID,
+          liveData: LIVE_WHILE_PARKED,
+          initialContent: INITIAL_CONTENT,
+          caughtUpContent: CAUGHT_UP_CONTENT,
+        },
+      );
+
+      // Reveal: switch back to Board. The reveal-edge reloadScrollback must
+      // repaint from the (updated) scrollback: catch-up content present, the
+      // initial frame exactly once (xterm.reset() before replay - no
+      // duplicated frames), and the dropped live bytes absent (superseded by
+      // the drained scrollback).
+      await page.locator('[data-testid="view-toggle-board"]').click();
+      await expect(dialog).toBeVisible();
+      await expect
+        .poll(async () => dialog.locator('.xterm').first().innerText(), { timeout: 10000 })
+        .toContain(CAUGHT_UP_CONTENT);
+
+      const revealedText = await dialog.locator('.xterm').first().innerText();
+      expect(revealedText).not.toContain(LIVE_WHILE_PARKED);
+      const initialOccurrences = revealedText.split(INITIAL_CONTENT).length - 1;
+      expect(initialOccurrences).toBe(1);
+
+      // The session is focused again (main resumes emitting for it).
+      await expect
+        .poll(
+          async () =>
+            page.evaluate(() => {
+              const calls = (window as unknown as TestWindow).electronAPI?.sessions.__setFocusedCalls ?? [];
+              return calls.length > 0 ? calls[calls.length - 1] : null;
+            }),
+          { timeout: 5000 },
+        )
+        .toContain(SESSION_ID);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/unit/focused-sessions.test.ts
+++ b/tests/unit/focused-sessions.test.ts
@@ -247,6 +247,49 @@ describe('deriveFocusedSessionIds', () => {
     );
     expect(result).toEqual([]);
   });
+
+  it('filters parked sessions out of the dialog set (rule 1)', () => {
+    const result = deriveFocusedSessionIds(
+      makeFocusedInput({
+        dialogSessionIds: ['sess-a', 'sess-b', 'sess-c'],
+        parkedSessionIds: new Set(['sess-b']),
+      }),
+    );
+    expect(result).toEqual(['sess-a', 'sess-c']);
+  });
+
+  it('filters parked sessions out of the transient set (rule 4)', () => {
+    const result = deriveFocusedSessionIds(
+      makeFocusedInput({
+        commandBarVisible: true,
+        transientSessionIds: ['sess-t1', 'sess-t2'],
+        parkedSessionIds: new Set(['sess-t1']),
+      }),
+    );
+    expect(result).toEqual(['sess-t2']);
+  });
+
+  it('derives an empty set when every window session is parked (main emits everything; parked queues ack-and-drop)', () => {
+    const result = deriveFocusedSessionIds(
+      makeFocusedInput({
+        activeView: 'backlog',
+        dialogSessionIds: ['sess-a', 'sess-b'],
+        parkedSessionIds: new Set(['sess-a', 'sess-b']),
+      }),
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('behaves as before when parkedSessionIds is omitted', () => {
+    const result = deriveFocusedSessionIds(
+      makeFocusedInput({
+        dialogSessionIds: ['sess-a'],
+        commandBarVisible: true,
+        transientSessionIds: ['sess-t1'],
+      }),
+    );
+    expect(result).toEqual(['sess-a', 'sess-t1']);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/incoming-write-queue.test.ts
+++ b/tests/unit/incoming-write-queue.test.ts
@@ -226,6 +226,36 @@ describe('createIncomingWriteQueue', () => {
     expect(totalAcked).toBe(expected.length);
   });
 
+  // useTerminal.ts wiring: shouldDrop also includes isTerminalParked(sessionId)
+  // (parked-terminals.ts). A parked (off-view) terminal must ack-and-drop -
+  // never hold - so an indefinitely-parked window cannot wedge the main-process
+  // backpressure watermarks; the dropped bytes accumulate in main's scrollback
+  // ring and the reveal-time reloadScrollback repaints them.
+  it('a parked terminal acks-and-drops live bytes, then writes live bytes again once revealed', async () => {
+    const { term, writes } = fakeTerminal();
+    const ack = vi.fn();
+    let parked = true;
+    const queue = createIncomingWriteQueue({
+      getTerminal: () => term,
+      shouldDrop: () => parked,
+      ack,
+      chunkSize: 4,
+    });
+
+    queue.push('streamed-while-parked');
+    await flush();
+    expect(writes).toEqual([]);
+    const ackedWhileParked = ack.mock.calls.reduce((sum, call) => sum + call[0], 0);
+    expect(ackedWhileParked).toBe('streamed-while-parked'.length);
+
+    // Reveal: the stale frame is repainted by reloadScrollback (not the queue);
+    // new live bytes flow through normally again.
+    parked = false;
+    queue.push('live');
+    await flush();
+    expect(writes.join('')).toBe('live');
+  });
+
   it('an overlay with no active replay still drops-and-acks immediately (unaffected by the replay-hold change)', async () => {
     const { term, writes } = fakeTerminal();
     const ack = vi.fn();

--- a/tests/unit/parked-terminals.test.ts
+++ b/tests/unit/parked-terminals.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for `src/renderer/utils/parked-terminals.ts`.
+ *
+ * The parked registry is module-scope state shared across the file, so every
+ * test ends by syncing an empty set to leave the module clean for the next.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  isTerminalParked,
+  syncParkedTerminals,
+  onTerminalReveal,
+} from '../../src/renderer/utils/parked-terminals';
+
+afterEach(() => {
+  syncParkedTerminals(new Set());
+});
+
+describe('parked-terminals', () => {
+  it('flips the predicate with each sync', () => {
+    expect(isTerminalParked('s1')).toBe(false);
+
+    syncParkedTerminals(new Set(['s1']));
+    expect(isTerminalParked('s1')).toBe(true);
+    expect(isTerminalParked('s2')).toBe(false);
+
+    syncParkedTerminals(new Set(['s2']));
+    expect(isTerminalParked('s1')).toBe(false);
+    expect(isTerminalParked('s2')).toBe(true);
+  });
+
+  it('fires reveal exactly once per parked -> visible edge', () => {
+    const reveal = vi.fn();
+    const unsubscribe = onTerminalReveal('s1', reveal);
+
+    syncParkedTerminals(new Set(['s1']));
+    expect(reveal).not.toHaveBeenCalled();
+
+    // Republishing the same parked set is not an edge.
+    syncParkedTerminals(new Set(['s1']));
+    expect(reveal).not.toHaveBeenCalled();
+
+    syncParkedTerminals(new Set());
+    expect(reveal).toHaveBeenCalledTimes(1);
+
+    // Republishing the same visible state is not an edge either.
+    syncParkedTerminals(new Set());
+    expect(reveal).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+  });
+
+  it('fires reveal again after a re-park and re-reveal', () => {
+    const reveal = vi.fn();
+    const unsubscribe = onTerminalReveal('s1', reveal);
+
+    syncParkedTerminals(new Set(['s1']));
+    syncParkedTerminals(new Set());
+    syncParkedTerminals(new Set(['s1']));
+    syncParkedTerminals(new Set());
+    expect(reveal).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+
+  it('only notifies the revealed session, not sessions that stay parked', () => {
+    const revealFirst = vi.fn();
+    const revealSecond = vi.fn();
+    const unsubscribeFirst = onTerminalReveal('s1', revealFirst);
+    const unsubscribeSecond = onTerminalReveal('s2', revealSecond);
+
+    syncParkedTerminals(new Set(['s1', 's2']));
+    syncParkedTerminals(new Set(['s2']));
+    expect(revealFirst).toHaveBeenCalledTimes(1);
+    expect(revealSecond).not.toHaveBeenCalled();
+
+    unsubscribeFirst();
+    unsubscribeSecond();
+  });
+
+  it('unsubscribe stops reveal notifications', () => {
+    const reveal = vi.fn();
+    const unsubscribe = onTerminalReveal('s1', reveal);
+    unsubscribe();
+
+    syncParkedTerminals(new Set(['s1']));
+    syncParkedTerminals(new Set());
+    expect(reveal).not.toHaveBeenCalled();
+  });
+
+  it('a throwing listener does not block the others', () => {
+    const throwing = vi.fn(() => {
+      throw new Error('listener exploded');
+    });
+    const surviving = vi.fn();
+    const unsubscribeThrowing = onTerminalReveal('s1', throwing);
+    const unsubscribeSurviving = onTerminalReveal('s1', surviving);
+
+    syncParkedTerminals(new Set(['s1']));
+    expect(() => syncParkedTerminals(new Set())).not.toThrow();
+    expect(throwing).toHaveBeenCalledTimes(1);
+    expect(surviving).toHaveBeenCalledTimes(1);
+
+    unsubscribeThrowing();
+    unsubscribeSurviving();
+  });
+});

--- a/tests/unit/terminal-visibility.test.ts
+++ b/tests/unit/terminal-visibility.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Unit tests for the pure terminal-visibility planner
+ * (`src/renderer/utils/terminal-visibility.ts`): which sessions are parked
+ * (Backlog-parked board layer, maximized-over occlusion) and which terminals
+ * win one of the budgeted live WebGL attachments (panel first, then top-K by
+ * focus recency: command layer over board layer, MRU order index within one).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeOccludedWindowIds,
+  planTerminalVisibility,
+  type TerminalVisibilityWindowInput,
+  type TerminalVisibilityInput,
+} from '../../src/renderer/utils/terminal-visibility';
+
+function makeWindow(
+  overrides: Partial<TerminalVisibilityWindowInput> = {},
+): TerminalVisibilityWindowInput {
+  return {
+    windowId: 'w-default',
+    sessionId: 'sess-default',
+    hasTerminal: true,
+    state: 'floating',
+    zIndex: 1,
+    orderIndex: 0,
+    layer: 'board',
+    ...overrides,
+  };
+}
+
+function makeInput(overrides: Partial<TerminalVisibilityInput> = {}): TerminalVisibilityInput {
+  return {
+    boardLayerParked: false,
+    windows: [],
+    panelSessionId: null,
+    webglBudget: 8,
+    ...overrides,
+  };
+}
+
+describe('computeOccludedWindowIds', () => {
+  it('returns nothing when no window is maximized', () => {
+    const occluded = computeOccludedWindowIds([
+      makeWindow({ windowId: 'w1', zIndex: 1 }),
+      makeWindow({ windowId: 'w2', zIndex: 2 }),
+    ]);
+    expect(occluded.size).toBe(0);
+  });
+
+  it('occludes only lower-z windows in the same layer as the maximized window', () => {
+    const occluded = computeOccludedWindowIds([
+      makeWindow({ windowId: 'w-under', zIndex: 1 }),
+      makeWindow({ windowId: 'w-max', state: 'maximized', zIndex: 2 }),
+      makeWindow({ windowId: 'w-above', zIndex: 3 }),
+      makeWindow({ windowId: 'w-other-layer', zIndex: 0, layer: 'command' }),
+    ]);
+    expect([...occluded]).toEqual(['w-under']);
+  });
+
+  it('a maximized window occludes a lower-z maximized window', () => {
+    const occluded = computeOccludedWindowIds([
+      makeWindow({ windowId: 'w-max-low', state: 'maximized', zIndex: 1 }),
+      makeWindow({ windowId: 'w-max-high', state: 'maximized', zIndex: 2 }),
+    ]);
+    expect([...occluded]).toEqual(['w-max-low']);
+  });
+
+  it('a maximized window without a terminal still occludes', () => {
+    const occluded = computeOccludedWindowIds([
+      makeWindow({ windowId: 'w-term', zIndex: 1 }),
+      makeWindow({ windowId: 'w-conversation', hasTerminal: false, state: 'maximized', zIndex: 2 }),
+    ]);
+    expect([...occluded]).toEqual(['w-term']);
+  });
+
+  it('evaluates layers independently', () => {
+    const occluded = computeOccludedWindowIds([
+      makeWindow({ windowId: 'b-under', zIndex: 1, layer: 'board' }),
+      makeWindow({ windowId: 'b-max', state: 'maximized', zIndex: 2, layer: 'board' }),
+      makeWindow({ windowId: 'c-under', zIndex: 1, layer: 'command' }),
+      makeWindow({ windowId: 'c-max', state: 'maximized', zIndex: 2, layer: 'command' }),
+    ]);
+    expect([...occluded].sort()).toEqual(['b-under', 'c-under']);
+  });
+});
+
+describe('planTerminalVisibility', () => {
+  it('parks every board-layer terminal session while the board layer is parked', () => {
+    const plan = planTerminalVisibility(
+      makeInput({
+        boardLayerParked: true,
+        windows: [
+          makeWindow({ windowId: 'b1', sessionId: 'sess-b1', layer: 'board' }),
+          makeWindow({ windowId: 'b2', sessionId: 'sess-b2', layer: 'board' }),
+          makeWindow({ windowId: 'c1', sessionId: 'sess-c1', layer: 'command' }),
+        ],
+      }),
+    );
+    expect(plan.parkedSessionIds.sort()).toEqual(['sess-b1', 'sess-b2']);
+    expect(plan.webglAttachSessionIds).toEqual(['sess-c1']);
+    expect(plan.webglSuspendSessionIds.sort()).toEqual(['sess-b1', 'sess-b2']);
+  });
+
+  it('parks sessions occluded by a maximized same-layer window', () => {
+    const plan = planTerminalVisibility(
+      makeInput({
+        windows: [
+          makeWindow({ windowId: 'w-under', sessionId: 'sess-under', zIndex: 1 }),
+          makeWindow({ windowId: 'w-max', sessionId: 'sess-max', state: 'maximized', zIndex: 2 }),
+        ],
+      }),
+    );
+    expect(plan.parkedSessionIds).toEqual(['sess-under']);
+    expect(plan.webglAttachSessionIds).toEqual(['sess-max']);
+    expect(plan.webglSuspendSessionIds).toEqual(['sess-under']);
+  });
+
+  it('conversation windows occlude but never enter the park or attach sets', () => {
+    const plan = planTerminalVisibility(
+      makeInput({
+        windows: [
+          makeWindow({ windowId: 'w-term', sessionId: 'sess-term', zIndex: 1 }),
+          makeWindow({
+            windowId: 'w-conversation',
+            sessionId: null,
+            hasTerminal: false,
+            state: 'maximized',
+            zIndex: 2,
+          }),
+        ],
+      }),
+    );
+    expect(plan.parkedSessionIds).toEqual(['sess-term']);
+    expect(plan.webglAttachSessionIds).toEqual([]);
+    expect(plan.webglSuspendSessionIds).toEqual(['sess-term']);
+  });
+
+  it('ignores windows with no live session', () => {
+    const plan = planTerminalVisibility(
+      makeInput({
+        boardLayerParked: true,
+        windows: [makeWindow({ windowId: 'w-suspended', sessionId: null })],
+      }),
+    );
+    expect(plan.parkedSessionIds).toEqual([]);
+    expect(plan.webglAttachSessionIds).toEqual([]);
+    expect(plan.webglSuspendSessionIds).toEqual([]);
+  });
+
+  it('ranks command-layer terminals above board-layer terminals for the budget', () => {
+    const plan = planTerminalVisibility(
+      makeInput({
+        webglBudget: 2,
+        windows: [
+          makeWindow({ windowId: 'b1', sessionId: 'sess-b1', layer: 'board', orderIndex: 5 }),
+          makeWindow({ windowId: 'c1', sessionId: 'sess-c1', layer: 'command', orderIndex: 0 }),
+          makeWindow({ windowId: 'c2', sessionId: 'sess-c2', layer: 'command', orderIndex: 1 }),
+        ],
+      }),
+    );
+    expect(plan.webglAttachSessionIds).toEqual(['sess-c2', 'sess-c1']);
+    expect(plan.webglSuspendSessionIds).toEqual(['sess-b1']);
+  });
+
+  it('picks top-K by MRU order index within a layer (front-most never evicted)', () => {
+    const plan = planTerminalVisibility(
+      makeInput({
+        webglBudget: 2,
+        windows: [
+          makeWindow({ windowId: 'w1', sessionId: 'sess-1', orderIndex: 0 }),
+          makeWindow({ windowId: 'w2', sessionId: 'sess-2', orderIndex: 1 }),
+          makeWindow({ windowId: 'w3', sessionId: 'sess-3', orderIndex: 2 }),
+        ],
+      }),
+    );
+    // orderIndex 2 is the front-most (most recently focused) window.
+    expect(plan.webglAttachSessionIds).toEqual(['sess-3', 'sess-2']);
+    expect(plan.webglSuspendSessionIds).toEqual(['sess-1']);
+  });
+
+  it('always attaches the panel session first and never parks it', () => {
+    const plan = planTerminalVisibility(
+      makeInput({
+        webglBudget: 2,
+        panelSessionId: 'sess-panel',
+        windows: [
+          makeWindow({ windowId: 'w1', sessionId: 'sess-1', orderIndex: 0 }),
+          makeWindow({ windowId: 'w2', sessionId: 'sess-2', orderIndex: 1 }),
+        ],
+      }),
+    );
+    expect(plan.webglAttachSessionIds).toEqual(['sess-panel', 'sess-2']);
+    expect(plan.parkedSessionIds).toEqual([]);
+    expect(plan.webglSuspendSessionIds).toEqual(['sess-1']);
+  });
+
+  it('never plans more attachments than the budget', () => {
+    const windows = Array.from({ length: 12 }, (unused, index) =>
+      makeWindow({ windowId: `w${index}`, sessionId: `sess-${index}`, orderIndex: index }),
+    );
+    const plan = planTerminalVisibility(makeInput({ webglBudget: 8, windows }));
+    expect(plan.webglAttachSessionIds).toHaveLength(8);
+    expect(plan.webglSuspendSessionIds).toHaveLength(4);
+    // Attach + suspend together cover every known session exactly once.
+    const union = [...plan.webglAttachSessionIds, ...plan.webglSuspendSessionIds].sort();
+    expect(union).toEqual(windows.map((window) => window.sessionId).sort());
+  });
+
+  it('parked sessions are never in the attach set even when the budget has room', () => {
+    const plan = planTerminalVisibility(
+      makeInput({
+        boardLayerParked: true,
+        webglBudget: 8,
+        windows: [makeWindow({ windowId: 'w1', sessionId: 'sess-1' })],
+      }),
+    );
+    expect(plan.webglAttachSessionIds).toEqual([]);
+    expect(plan.webglSuspendSessionIds).toEqual(['sess-1']);
+  });
+
+  it('does not attach the panel session when it is also a parked window session (parked wins over panel-first)', () => {
+    const plan = planTerminalVisibility(
+      makeInput({
+        boardLayerParked: true,
+        webglBudget: 8,
+        // derivePanelSessionId is window-blind, so panelSessionId can resolve to
+        // a session a task-detail window already owns - here that window is
+        // Backlog-parked. The parked classification must win: no live WebGL
+        // context for an off-view terminal.
+        panelSessionId: 'sess-shared',
+        windows: [makeWindow({ windowId: 'w1', sessionId: 'sess-shared' })],
+      }),
+    );
+    expect(plan.parkedSessionIds).toEqual(['sess-shared']);
+    expect(plan.webglAttachSessionIds).not.toContain('sess-shared');
+    expect(plan.webglSuspendSessionIds).toContain('sess-shared');
+  });
+});

--- a/tests/unit/terminal-webgl.test.ts
+++ b/tests/unit/terminal-webgl.test.ts
@@ -11,6 +11,8 @@ import type { Terminal } from '@xterm/xterm';
 import {
   attachWebglRenderer,
   getTerminalRendererReport,
+  applyWebglAttachmentPlan,
+  onWebglAttachmentsChanged,
 } from '../../src/renderer/utils/terminal-webgl';
 
 interface FakeAddon {
@@ -235,5 +237,248 @@ describe('attachWebglRenderer', () => {
     // Advancing past the would-be retry does nothing (no new addon).
     vi.advanceTimersByTime(10_000);
     expect(addons).toHaveLength(1);
+  });
+});
+
+describe('budget suspend/resume', () => {
+  const emptyPlan = { attachKeys: new Set<string>(), suspendKeys: new Set<string>() };
+  const suspendPlan = (...keys: string[]) => ({ ...emptyPlan, suspendKeys: new Set(keys) });
+  const attachPlan = (...keys: string[]) => ({ ...emptyPlan, attachKeys: new Set(keys) });
+
+  it('suspend keeps the status entry and never counts as a context loss', () => {
+    const { createAddon, addons } = makeAddonFactory(['ok']);
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-suspend', {
+      createAddon,
+      retryDelaysMs: RETRY_DELAYS,
+    });
+    expect(getTerminalRendererReport()['k-suspend'].renderer).toBe('webgl');
+
+    applyWebglAttachmentPlan(suspendPlan('k-suspend'));
+    const status = getTerminalRendererReport()['k-suspend'];
+    expect(status.renderer).toBe('dom');
+    expect(status.suspendedByBudget).toBe(true);
+    expect(status.contextLossCount).toBe(0);
+    expect(status.permanentDomFallback).toBe(false);
+    expect(addons[0].disposed).toBe(true);
+    dispose();
+  });
+
+  it('suspend cancels a pending context-loss retry so it cannot fire while suspended', () => {
+    const { createAddon, addons } = makeAddonFactory(['ok']);
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-suspend-retry', {
+      createAddon,
+      retryDelaysMs: RETRY_DELAYS,
+    });
+
+    addons[0].triggerLoss(); // arms the +2000ms retry
+    expect(vi.getTimerCount()).toBe(1);
+
+    applyWebglAttachmentPlan(suspendPlan('k-suspend-retry'));
+    expect(vi.getTimerCount()).toBe(0);
+
+    // Advancing past every backoff slot re-attaches nothing.
+    vi.advanceTimersByTime(20_000);
+    expect(addons).toHaveLength(1);
+    const status = getTerminalRendererReport()['k-suspend-retry'];
+    expect(status.renderer).toBe('dom');
+    expect(status.suspendedByBudget).toBe(true);
+    expect(status.permanentDomFallback).toBe(false);
+    dispose();
+  });
+
+  it('ignores a loss event that fires after a suspend', () => {
+    const { createAddon, addons } = makeAddonFactory(['ok']);
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-late-loss', {
+      createAddon,
+      retryDelaysMs: RETRY_DELAYS,
+    });
+
+    applyWebglAttachmentPlan(suspendPlan('k-late-loss'));
+    addons[0].triggerLoss(); // stray loss from the already-disposed addon
+
+    const status = getTerminalRendererReport()['k-late-loss'];
+    expect(status.contextLossCount).toBe(0);
+    expect(status.permanentDomFallback).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+    dispose();
+  });
+
+  it('resume re-attaches a suspended terminal', () => {
+    const { createAddon, addons } = makeAddonFactory(['ok', 'ok']);
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-resume', {
+      createAddon,
+      retryDelaysMs: RETRY_DELAYS,
+    });
+
+    applyWebglAttachmentPlan(suspendPlan('k-resume'));
+    applyWebglAttachmentPlan(attachPlan('k-resume'));
+
+    const status = getTerminalRendererReport()['k-resume'];
+    expect(status.renderer).toBe('webgl');
+    expect(status.suspendedByBudget).toBe(false);
+    expect(addons).toHaveLength(2);
+    dispose();
+  });
+
+  it('a failed resume stays budget-suspended without escalating, and a later resume recovers', () => {
+    const { createAddon, addons } = makeAddonFactory(['ok', 'throw', 'ok']);
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-resume-fail', {
+      createAddon,
+      retryDelaysMs: RETRY_DELAYS,
+    });
+
+    applyWebglAttachmentPlan(suspendPlan('k-resume-fail'));
+    applyWebglAttachmentPlan(attachPlan('k-resume-fail')); // tryAttach throws
+
+    const afterFailure = getTerminalRendererReport()['k-resume-fail'];
+    expect(afterFailure.renderer).toBe('dom');
+    expect(afterFailure.suspendedByBudget).toBe(true);
+    expect(afterFailure.permanentDomFallback).toBe(false);
+    expect(afterFailure.contextLossCount).toBe(0);
+    // No retry ladder armed: the coordinator's next plan application retries.
+    expect(vi.getTimerCount()).toBe(0);
+
+    applyWebglAttachmentPlan(attachPlan('k-resume-fail')); // succeeds
+    const afterRecovery = getTerminalRendererReport()['k-resume-fail'];
+    expect(afterRecovery.renderer).toBe('webgl');
+    expect(afterRecovery.suspendedByBudget).toBe(false);
+    expect(addons).toHaveLength(2);
+    dispose();
+  });
+
+  it('suspend and resume are no-ops for a permanently-DOM terminal', () => {
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-permanent-plan', {
+      createAddon: () => { throw new Error('WebGL unavailable'); },
+      retryDelaysMs: RETRY_DELAYS,
+    });
+    expect(getTerminalRendererReport()['k-permanent-plan'].permanentDomFallback).toBe(true);
+
+    applyWebglAttachmentPlan(suspendPlan('k-permanent-plan'));
+    expect(getTerminalRendererReport()['k-permanent-plan'].suspendedByBudget).toBe(false);
+
+    applyWebglAttachmentPlan(attachPlan('k-permanent-plan'));
+    const status = getTerminalRendererReport()['k-permanent-plan'];
+    expect(status.renderer).toBe('dom');
+    expect(status.permanentDomFallback).toBe(true);
+    dispose();
+  });
+
+  it('an over-budget initial attach starts suspended without requesting a context', () => {
+    const first = makeAddonFactory(['ok']);
+    const disposeFirst = attachWebglRenderer(fakeTerminal, 'k-cap-1', {
+      createAddon: first.createAddon,
+      retryDelaysMs: RETRY_DELAYS,
+      attachBudget: 1,
+    });
+    expect(getTerminalRendererReport()['k-cap-1'].renderer).toBe('webgl');
+
+    const secondFactory = vi.fn(makeFakeAddon);
+    const disposeSecond = attachWebglRenderer(fakeTerminal, 'k-cap-2', {
+      createAddon: secondFactory,
+      retryDelaysMs: RETRY_DELAYS,
+      attachBudget: 1,
+    });
+
+    const status = getTerminalRendererReport()['k-cap-2'];
+    expect(status.renderer).toBe('dom');
+    expect(status.suspendedByBudget).toBe(true);
+    expect(status.permanentDomFallback).toBe(false);
+    expect(secondFactory).not.toHaveBeenCalled();
+
+    disposeFirst();
+    disposeSecond();
+  });
+
+  it('applies suspends before resumes so the live count never overshoots the cap', () => {
+    const first = makeAddonFactory(['ok']);
+    const disposeFirst = attachWebglRenderer(fakeTerminal, 'k-swap-1', {
+      createAddon: first.createAddon,
+      retryDelaysMs: RETRY_DELAYS,
+      attachBudget: 1,
+    });
+    // Second starts suspended (over the cap of 1); its factory records whether
+    // the first addon was already freed when the resume acquires.
+    const secondAddons: FakeAddon[] = [];
+    let firstFreedAtAcquire = false;
+    const disposeSecond = attachWebglRenderer(fakeTerminal, 'k-swap-2', {
+      createAddon: () => {
+        firstFreedAtAcquire = first.addons[0].disposed;
+        const addon = makeFakeAddon();
+        secondAddons.push(addon);
+        return addon;
+      },
+      retryDelaysMs: RETRY_DELAYS,
+      attachBudget: 1,
+    });
+    expect(getTerminalRendererReport()['k-swap-2'].suspendedByBudget).toBe(true);
+
+    applyWebglAttachmentPlan({ attachKeys: new Set(['k-swap-2']), suspendKeys: new Set(['k-swap-1']) });
+
+    expect(getTerminalRendererReport()['k-swap-1'].renderer).toBe('dom');
+    expect(getTerminalRendererReport()['k-swap-1'].suspendedByBudget).toBe(true);
+    expect(getTerminalRendererReport()['k-swap-2'].renderer).toBe('webgl');
+    expect(secondAddons).toHaveLength(1);
+    expect(firstFreedAtAcquire).toBe(true);
+
+    disposeFirst();
+    disposeSecond();
+  });
+
+  it('leaves keys the plan does not name untouched', () => {
+    const { createAddon } = makeAddonFactory(['ok']);
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-unnamed', {
+      createAddon,
+      retryDelaysMs: RETRY_DELAYS,
+    });
+
+    applyWebglAttachmentPlan(suspendPlan('k-some-other-key'));
+    expect(getTerminalRendererReport()['k-unnamed'].renderer).toBe('webgl');
+    expect(getTerminalRendererReport()['k-unnamed'].suspendedByBudget).toBe(false);
+    dispose();
+  });
+
+  it('notifies attachment listeners on register and dispose, and unsubscribes cleanly', () => {
+    const listener = vi.fn();
+    const unsubscribe = onWebglAttachmentsChanged(listener);
+
+    const { createAddon } = makeAddonFactory(['ok']);
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-notify', {
+      createAddon,
+      retryDelaysMs: RETRY_DELAYS,
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    dispose();
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    const { createAddon: createAgain } = makeAddonFactory(['ok']);
+    const disposeAgain = attachWebglRenderer(fakeTerminal, 'k-notify-2', {
+      createAddon: createAgain,
+      retryDelaysMs: RETRY_DELAYS,
+    });
+    disposeAgain();
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('resume on an already-attached terminal is a no-op (does not rebuild the live WebGL context)', () => {
+    const { createAddon, addons } = makeAddonFactory(['ok']);
+    const dispose = attachWebglRenderer(fakeTerminal, 'k-resume-noop', {
+      createAddon,
+      retryDelaysMs: RETRY_DELAYS,
+    });
+    expect(getTerminalRendererReport()['k-resume-noop'].renderer).toBe('webgl');
+    expect(addons).toHaveLength(1);
+
+    // The coordinator re-applies its plan on every run, so attachKeys usually
+    // still names terminals that are already live. Resuming an already-attached
+    // terminal must NOT dispose and rebuild its addon (the common hot path).
+    applyWebglAttachmentPlan(attachPlan('k-resume-noop'));
+    applyWebglAttachmentPlan(attachPlan('k-resume-noop'));
+
+    expect(getTerminalRendererReport()['k-resume-noop'].renderer).toBe('webgl');
+    expect(addons).toHaveLength(1);
+    expect(addons[0].disposed).toBe(false);
+    dispose();
   });
 });

--- a/tests/unit/use-terminal-park-reveal.test.ts
+++ b/tests/unit/use-terminal-park-reveal.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Cross-module contract test for the parked-terminal write gating in
+ * useTerminal.ts: the REAL incoming-write-queue composed with the REAL
+ * parked-terminals registry, plus a mirror of reloadScrollback's observable
+ * contract (set pending -> fetch -> write -> clear pending -> kick), exactly
+ * as useTerminal wires them:
+ *
+ *   shouldDrop: () => suppressDataRef.current || isTerminalParked(sessionId)
+ *   shouldHold: () => isBoardDragActive() || scrollbackPendingRef.current
+ *   onTerminalReveal(sessionId, () => reloadScrollback({ skipResize, skipFocus }))
+ *
+ * Locks the three-phase transition: while parked, live bytes are
+ * acked-and-dropped (never held - an indefinitely-parked window must not
+ * wedge the main-process backpressure watermarks); the reveal edge triggers
+ * exactly one scrollback reload; bytes arriving DURING the reveal replay are
+ * held and flush strictly after the replayed frame.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Terminal } from '@xterm/xterm';
+import { createIncomingWriteQueue } from '../../src/renderer/utils/incoming-write-queue';
+import {
+  isTerminalParked,
+  syncParkedTerminals,
+  onTerminalReveal,
+} from '../../src/renderer/utils/parked-terminals';
+
+function fakeTerminal(): { term: Terminal; writes: string[] } {
+  const writes: string[] = [];
+  const term = {
+    write(data: string, callback?: () => void): void {
+      writes.push(data);
+      if (callback) queueMicrotask(callback);
+    },
+  } as unknown as Terminal;
+  return { term, writes };
+}
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  syncParkedTerminals(new Set());
+});
+
+describe('park -> ack-and-drop -> reveal -> scrollback catch-up', () => {
+  it('drops-and-acks while parked, reloads once on reveal, and holds mid-replay bytes until after the replayed frame', async () => {
+    const sessionId = 'sess-parked';
+    const { term, writes } = fakeTerminal();
+    const ack = vi.fn();
+    const scrollbackPendingRef = { current: false };
+
+    const queue = createIncomingWriteQueue({
+      getTerminal: () => term,
+      shouldDrop: () => isTerminalParked(sessionId),
+      shouldHold: () => scrollbackPendingRef.current,
+      ack,
+      chunkSize: 64,
+    });
+
+    // Mirror of reloadScrollback's observable contract for the reveal path.
+    let reloadCount = 0;
+    let releaseReplay: (() => void) | null = null;
+    const reloadScrollback = () => {
+      reloadCount += 1;
+      scrollbackPendingRef.current = true;
+      // The chunked scrollback write completes when the test releases it,
+      // then afterWrite clears pending and kicks the queue.
+      releaseReplay = () => {
+        term.write('REPLAYED-FRAME', () => {
+          scrollbackPendingRef.current = false;
+          queue.kick();
+        });
+      };
+    };
+    const unsubscribe = onTerminalReveal(sessionId, reloadScrollback);
+
+    // Phase 1: parked. Live bytes are acked-and-dropped, never held.
+    syncParkedTerminals(new Set([sessionId]));
+    queue.push('streamed-while-parked');
+    await flush();
+    expect(writes).toEqual([]);
+    const ackedWhileParked = ack.mock.calls.reduce((sum, call) => sum + call[0], 0);
+    expect(ackedWhileParked).toBe('streamed-while-parked'.length);
+
+    // Phase 2: reveal. Exactly one reload fires and pending now holds the queue.
+    syncParkedTerminals(new Set());
+    expect(reloadCount).toBe(1);
+    expect(scrollbackPendingRef.current).toBe(true);
+
+    // Live bytes arriving mid-replay are held (not written, not acked).
+    ack.mockClear();
+    queue.push('live-during-replay');
+    await flush();
+    expect(writes).toEqual([]);
+    expect(ack).not.toHaveBeenCalled();
+
+    // Phase 3: the replay frame paints, pending clears, held bytes flush after.
+    releaseReplay?.();
+    await flush();
+    expect(writes).toEqual(['REPLAYED-FRAME', 'live-during-replay']);
+    const ackedAfterReveal = ack.mock.calls.reduce((sum, call) => sum + call[0], 0);
+    expect(ackedAfterReveal).toBe('live-during-replay'.length);
+
+    // Republishing the same visible state fires no second reload.
+    syncParkedTerminals(new Set());
+    expect(reloadCount).toBe(1);
+
+    unsubscribe();
+  });
+});


### PR DESCRIPTION
## What

Two renderer-only scaling defenses for the "many terminal windows open" workload (task #403), sharing one coordinator:

- **WebGL attachment budget** (`src/renderer/utils/terminal-webgl.ts`): live WebGL contexts are capped at `WEBGL_ATTACH_BUDGET` (8) page-wide. Each attachment exposes `suspend()`/`resume()` controllers and a new `suspendedByBudget` status flag; `applyWebglAttachmentPlan` suspends before resuming so the live count never overshoots the cap.
- **Off-view PTY write gating** (`src/renderer/utils/parked-terminals.ts`, `terminal-visibility.ts`, `focused-sessions.ts`): a pure planner marks a terminal window parked when its layer is off-view (Backlog) or a maximized same-layer window occludes it. Parked sessions leave the focused-session set, the write queue acks-and-drops stragglers, and the terminal repaints from scrollback on reveal.
- **Coordinator** (`src/renderer/hooks/useFocusedSessionsSync.ts`): subscribes to both window-manager stores, resolves each board window's live session by task anchor (not the stale captured field), and applies the parked set, focused set, and WebGL plan in order. `useTerminal.ts` wires the parked drop gate, the reveal-edge `reloadScrollback`, and a new `skipFocus` option.

## Why

At scale (the live instance runs 34 sessions across 4+ projects plus command terminals and task-detail windows) every open window mounts its own xterm + WebGL context. Chromium caps live WebGL contexts per page at ~16 and silently drops the oldest; the old code treated that as a context loss, retried twice, then set `permanentDomFallback` and reverted the terminal to the DOM renderer (10-50x slower on bursts) for good, exactly when many agents are streaming. Separately, windows parked on Backlog or buried under a maximized window kept parsing their agent's full PTY output on the single UI thread. Closes #403.

## How

- The budget never requests a 17th context (an over-cap mount starts suspended), so Chromium's own oldest-context evictor never engages. A budget suspend is explicitly not a context loss: it never bumps `contextLossCount` and never sets `permanentDomFallback`, so the degradation the acceptance criteria forbid cannot happen.
- Problem 2 needs zero main-process changes: the existing main-process focused-session gate already drops PTY data IPC for non-focused sessions and accumulates them in the 512KB scrollback ring, with `getScrollback` draining the pending buffer (the dedup guard). We narrow the renderer derivation that feeds it. The renderer queue acks-and-drops (never holds) so an indefinitely-parked window cannot wedge the backpressure watermarks. Occlusion scope for v1 is deliberately conservative (parked layer + maximized-over only; rect-containment is a noted follow-up).
- Recency for the LRU rides the window store's existing MRU `order` array and the two layers' stacking, so no new focus-tracking state is introduced. New module-scope state uses Pattern A HMR preservation.

## Breaking changes

None. Renderer-only; no IPC, config, or schema changes.

## Tests

- Unit: `terminal-webgl` (suspend/resume/over-cap/notify, no context-loss escalation), `terminal-visibility` (occlusion, parking, LRU, budget cap, panel), `parked-terminals` (edge-triggered reveal), `focused-sessions` (parked filtering + all-parked empty-set semantics), `incoming-write-queue` (parked drop-and-ack), `use-terminal-park-reveal` (cross-module park -> ack-drop -> reveal -> catch-up contract).
- UI: `window-park-reveal.spec.ts` - park-on-Backlog drops the session from `setFocused`, live bytes are dropped, reveal repaints from scrollback (correct content, no duplicated banners), and (added in coverage pass, red-green verified) a respawned session is parked/focused by its live id, ignoring the window store's stale field.
- The full unit, UI, and Linux Electron E2E tiers run as this PR's CI checks.

Generated with [Claude Code](https://claude.com/claude-code)
