### PR TITLE
fix(terminal): refit Command Terminal xterm on container-only size changes

### DIFF
--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -28,6 +28,7 @@ import { CommandPalettePopover } from '../dialogs/task-detail/CommandPalettePopo
 import { useHeaderPillOverflow, type HeaderPillSpec } from '../dialogs/task-detail/useHeaderPillOverflow';
 import { WindowLayoutMenu } from '../dialogs/WindowLayoutMenu';
 import { TERMINAL_BACKGROUND, useTerminal } from '../../hooks/useTerminal';
+import { useTerminalRefit } from '../../hooks/useTerminalRefit';
 import { useKeybinding, useFormattedCombo } from '../../hooks/useKeybinding';
 import { useTerminalFileDrop } from '../../hooks/useTerminalFileDrop';
 import { FileDropOverlay } from '../terminal/FileDropOverlay';
@@ -146,7 +147,6 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
 
   const maximizeCombo = useFormattedCombo('panel.maximize');
   const spawnedRef = useRef(false);
-  const terminalPaneRef = useRef<HTMLDivElement>(null);
   // The branch picker can fold into the kebab; this drives the kebab-anchored
   // fallback dropdown ("Switch branch").
   const [branchMenuOpen, setBranchMenuOpen] = useState(false);
@@ -355,25 +355,21 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
     };
   }, [effectiveSessionId, initTerminal, terminalRef, fit, focus]);
 
-  // Refit when the frame's settled size changes. The engine commits a drag/resize/
-  // maximize/snap/tile geometry ONCE and dispatches a single coalesced
-  // `terminal-panel-resize`; the xterm is never remounted, so fitting in place is
-  // all that is needed.
-  useEffect(() => {
-    const onPanelResize = () => {
-      // fit() reflows xterm; flushResize() lands the PTY SIGWINCH immediately rather
-      // than 200ms later, so Claude's redraw arrives with the reflow (no resize
-      // flash). Mirrors the task-detail terminal's immediatePanelResize path.
-      if (initialized.current) { fit(); flushResize(); }
-    };
-    window.addEventListener('terminal-panel-resize', onPanelResize);
-    return () => window.removeEventListener('terminal-panel-resize', onPanelResize);
-  }, [fit, flushResize]);
-
-  // Refit when the changes panel toggles (the terminal column width changes).
-  useEffect(() => {
-    if (initialized.current) requestAnimationFrame(() => fit());
-  }, [changesOpen, fit]);
+  // Refit on any size change, shared with TerminalTab via useTerminalRefit so
+  // the two hosts cannot drift:
+  // - Engine commits (drag/resize/maximize/snap/tile) dispatch one coalesced
+  //   `terminal-panel-resize`, handled synchronously (fit + immediate SIGWINCH).
+  // - Container-only changes (the footer ContextBar growing as pills populate or
+  //   wrap, the Changes panel toggling the column width) are caught by the hook's
+  //   persistent ResizeObserver, which the old hand-rolled paths missed - that
+  //   gap clipped the fullscreen TUI's bottom rows under the pane edge.
+  useTerminalRefit({
+    terminalRef,
+    initializedRef: initialized,
+    fit,
+    flushResize,
+    immediatePanelResize: true,
+  });
 
   // Restore terminal focus after a maximize/restore toggle (the button, Ctrl+Shift+M,
   // and the header double-click all flip `isMaximized`), so the next keystroke lands
@@ -692,7 +688,7 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
             to the terminal's column width, so it overflows the window and fit() reads
             the stale (too-wide) size and never reduces columns. overflow-hidden clips
             the brief pre-fit overflow. Mirrors the Changes panel sibling. */}
-        <div ref={terminalPaneRef} className={`${changesOpen ? 'w-1/2' : 'flex-1'} relative min-w-0 overflow-hidden`} style={{ backgroundColor: TERMINAL_BACKGROUND }}>
+        <div className={`${changesOpen ? 'w-1/2' : 'flex-1'} relative min-w-0 overflow-hidden`} style={{ backgroundColor: TERMINAL_BACKGROUND }}>
           {!terminalReady && <LaunchOverlay label="Starting Command Terminal..." />}
           <FileDropOverlay {...fileDrop} />
           <div

--- a/src/renderer/components/terminal/TerminalTab.tsx
+++ b/src/renderer/components/terminal/TerminalTab.tsx
@@ -8,7 +8,7 @@ import { useBoardStore } from '../../stores/board-store';
 import { LaunchOverlay } from '../LaunchOverlay';
 import { getIsHmrReload } from '../../utils/hmr-flag';
 import { useTerminalOverlay } from '../../utils/task-progress';
-import { isManagerResizeInProgress } from '../../window-manager/terminal/manager-resize-gate';
+import { useTerminalRefit } from '../../hooks/useTerminalRefit';
 
 const FIT_DELAY_MS = 100;
 
@@ -191,11 +191,10 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
     }
   }, [sessionStatus, terminalReady, taskId, pendingCommandLabel]);
 
-  // Re-fit and focus when tab becomes active or container resizes.
-  // Always set up the ResizeObserver when active -- even if the terminal
-  // hasn't initialized yet. Tabs that start with display:none initialize
-  // late (via the init effect's ResizeObserver), so we guard fit() calls
-  // with initialized checks inside the callbacks instead of bailing early.
+  // Re-fit and focus when the tab becomes active. Tabs that start with
+  // display:none initialize late (via the init effect's ResizeObserver), so we
+  // guard fit() calls with initialized checks inside the callbacks instead of
+  // bailing early.
   useEffect(() => {
     if (!active) return;
 
@@ -220,87 +219,29 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
       }
     }, FIT_DELAY_MS);
 
-    const el = terminalRef.current;
-    if (!el) return () => {
-      cancelAnimationFrame(initRafId);
-      clearTimeout(delayedFitId);
-    };
-
-    // Unified debounced resize mechanism. One timer, two entry points:
-    // - ResizeObserver debounces at 200ms (handles drag without scrollback
-    //   eviction: timer resets every frame during drag, fires once after).
-    // - terminal-panel-resize event uses 50ms (faster for explicit triggers
-    //   like sidebar resize, dialog edit-mode toggle, drag mouseUp).
-    let resizeTimer: ReturnType<typeof setTimeout> | null = null;
-    const scheduleRefit = (delayMs: number) => {
-      if (!initialized.current) return;
-      if (resizeTimer) clearTimeout(resizeTimer);
-      resizeTimer = setTimeout(() => {
-        resizeTimer = null;
-        fit();
-      }, delayMs);
-    };
-
-    const observer = new ResizeObserver(() => {
-      // Window-manager terminals defer container-driven fits: the window manager
-      // owns sizing and dispatches a single settle-debounced terminal-panel-resize,
-      // so rapid snap/maximize/restore resizes the PTY once (one clean SIGWINCH).
-      //
-      // While a window-manager imperative resize gesture is in progress (seam drag,
-      // footprint resize, 8-handle window resize) this observer fires per frame as
-      // the frame's DOM box is rewritten. Refitting per frame would send a SIGWINCH
-      // per frame, and a full-screen TUI re-emits its whole banner on each - stacking
-      // duplicates in scrollback. Suppress the per-frame refit during the gesture; the
-      // store commit on release dispatches a single terminal-panel-resize that refits
-      // once. The gate is OFF for container-only changes (Changes/Browser pane toggle),
-      // so those still refit normally.
-      if (!deferContainerResize && !isManagerResizeInProgress()) scheduleRefit(200);
-    });
-    observer.observe(el);
-
-    // A full-screen TUI re-emits its frame on each SIGWINCH; while the width is
-    // changing those redraws stack as duplicated banners in xterm's history.
-    // Once resizing fully settles, replay the buffer ONCE at the now-stable
-    // width (skipResize: no new SIGWINCH, so it cannot re-pollute). This is the
-    // same clean-up an HMR reload performs. Window terminals only.
-    let cleanupTimer: ReturnType<typeof setTimeout> | null = null;
-    const handlePanelResize = () => {
-      // Window-hosted terminals fit SYNCHRONOUSLY. The window engine dispatches
-      // this from a layout effect via a microtask (before the browser paints), so
-      // fitting here fills the committed size in the SAME frame as the resized
-      // window - no letterbox lag. Clear any pending debounced fit so it cannot
-      // run a redundant second fit afterward.
-      if (immediatePanelResize) {
-        if (resizeTimer) { clearTimeout(resizeTimer); resizeTimer = null; }
-        // Fit synchronously, then flush the PTY resize immediately (don't wait out
-        // the 200ms debounce) so Claude's redraw lands with the reflow instead of
-        // a beat later - minimizes the resize "flash". The manager-resize gate
-        // already guarantees one resize per gesture, so there's nothing to coalesce.
-        if (initialized.current) { fit(); flushResize(); }
-        return;
-      }
-      // Window terminals (deferContainerResize) fit on the next tick; other
-      // surfaces keep the 50ms debounce to batch their own events.
-      scheduleRefit(deferContainerResize ? 0 : 50);
-      if (deferContainerResize) {
-        if (cleanupTimer) clearTimeout(cleanupTimer);
-        cleanupTimer = setTimeout(() => {
-          cleanupTimer = null;
-          if (initialized.current) reloadScrollback({ skipResize: true });
-        }, 800);
-      }
-    };
-    window.addEventListener('terminal-panel-resize', handlePanelResize);
-
     return () => {
       cancelAnimationFrame(initRafId);
       clearTimeout(delayedFitId);
-      if (resizeTimer) clearTimeout(resizeTimer);
-      if (cleanupTimer) clearTimeout(cleanupTimer);
-      observer.disconnect();
-      window.removeEventListener('terminal-panel-resize', handlePanelResize);
     };
-  }, [active, fit, flushResize, focus, deferContainerResize, immediatePanelResize, reloadScrollback, terminalRef, scrollbackPending]);
+  }, [active, fit, focus, scrollbackPending]);
+
+  // Container refit while active: persistent gate-aware ResizeObserver plus the
+  // terminal-panel-resize handling, shared with CommandTerminalWindow via
+  // useTerminalRefit so the two hosts cannot drift.
+  const handleDeferredResizeSettled = useCallback(
+    () => reloadScrollback({ skipResize: true }),
+    [reloadScrollback],
+  );
+  useTerminalRefit({
+    terminalRef,
+    initializedRef: initialized,
+    fit,
+    flushResize,
+    enabled: active,
+    deferContainerResize,
+    immediatePanelResize,
+    onDeferredResizeSettled: handleDeferredResizeSettled,
+  });
 
   const fileDrop = useTerminalFileDrop(sessionId, focus, sessionShell, pasteImageTemplate);
 

--- a/src/renderer/hooks/useTerminalRefit.ts
+++ b/src/renderer/hooks/useTerminalRefit.ts
@@ -1,0 +1,187 @@
+import { useEffect } from 'react';
+import type { RefObject } from 'react';
+import { isManagerResizeInProgress } from '../window-manager/terminal/manager-resize-gate';
+
+/**
+ * Shared container-refit logic for every xterm host (task-detail TerminalTab,
+ * bottom-panel TerminalTab, CommandTerminalWindow). Extracted so hosts cannot
+ * drift: the Command Terminal's hand-rolled subset was missing the persistent
+ * ResizeObserver, so container-only height changes (its footer ContextBar
+ * growing) silently clipped the TUI's bottom rows.
+ *
+ * Unified debounced resize mechanism. One timer, two entry points:
+ * - ResizeObserver debounces at 200ms (handles drag without scrollback
+ *   eviction: timer resets every frame during drag, fires once after).
+ * - terminal-panel-resize event uses 50ms (faster for explicit triggers
+ *   like sidebar resize, dialog edit-mode toggle, drag mouseUp), 0ms for
+ *   deferContainerResize hosts, or a synchronous fit for
+ *   immediatePanelResize hosts.
+ */
+
+export const OBSERVER_REFIT_DEBOUNCE_MS = 200;
+export const PANEL_EVENT_REFIT_DEBOUNCE_MS = 50;
+export const DEFERRED_RESIZE_SETTLE_MS = 800;
+
+/**
+ * Whether a ResizeObserver notification should schedule a debounced refit.
+ *
+ * Window-manager terminals defer container-driven fits: the window manager
+ * owns sizing and dispatches a single settle-debounced terminal-panel-resize,
+ * so rapid snap/maximize/restore resizes the PTY once (one clean SIGWINCH).
+ *
+ * While a window-manager imperative resize gesture is in progress (seam drag,
+ * footprint resize, 8-handle window resize) the observer fires per frame as
+ * the frame's DOM box is rewritten. Refitting per frame would send a SIGWINCH
+ * per frame, and a full-screen TUI re-emits its whole banner on each - stacking
+ * duplicates in scrollback. Suppress the per-frame refit during the gesture; the
+ * store commit on release dispatches a single terminal-panel-resize that refits
+ * once. The gate is OFF for container-only changes (Changes/Browser pane toggle,
+ * the Command Terminal's ContextBar growing), so those still refit normally.
+ */
+export function shouldObserverScheduleRefit(
+  deferContainerResize: boolean,
+  managerResizeInProgress: boolean,
+): boolean {
+  return !deferContainerResize && !managerResizeInProgress;
+}
+
+export type PanelResizeAction =
+  | { kind: 'immediate-fit-flush' }
+  | { kind: 'debounced-fit'; delayMs: number; scheduleSettleCleanup: boolean };
+
+/**
+ * How a `terminal-panel-resize` event is handled for a given host mode.
+ *
+ * - immediatePanelResize hosts fit SYNCHRONOUSLY: the window engine dispatches
+ *   the event from a layout effect via a microtask (before the browser paints),
+ *   so fitting fills the committed size in the SAME frame as the resized
+ *   window - no letterbox lag.
+ * - deferContainerResize hosts fit on the next tick (0ms) and schedule the
+ *   settle cleanup (scrollback reload) once resizing fully stops.
+ * - Other surfaces keep the 50ms debounce to batch their own events.
+ */
+export function resolvePanelResizeAction(
+  deferContainerResize: boolean,
+  immediatePanelResize: boolean,
+): PanelResizeAction {
+  if (immediatePanelResize) return { kind: 'immediate-fit-flush' };
+  return {
+    kind: 'debounced-fit',
+    delayMs: deferContainerResize ? 0 : PANEL_EVENT_REFIT_DEBOUNCE_MS,
+    scheduleSettleCleanup: deferContainerResize,
+  };
+}
+
+export interface TerminalRefitOptions {
+  /** The xterm host element to observe (useTerminal's terminalRef). Must be
+   *  mounted unconditionally for the effect's lifetime: the effect reads
+   *  `.current` once on run and bails if it is null, and since the ref identity
+   *  is stable it will not re-attach when a later-mounted element appears. Every
+   *  current host renders the ref'd div unconditionally. */
+  terminalRef: RefObject<HTMLDivElement | null>;
+  /** Host-owned "xterm initialized" flag, read at fire time (not a dep) so a
+   *  session-respawn reset suppresses refits without re-running the effect. */
+  initializedRef: RefObject<boolean>;
+  fit: () => void;
+  flushResize: () => void;
+  /** Attach the observer/listener only while true (TerminalTab's `active`).
+   *  Defaults to true. */
+  enabled?: boolean;
+  /** See TerminalTab's prop JSDoc: skip the per-container ResizeObserver
+   *  auto-fit and reload scrollback after a resize settles. */
+  deferContainerResize?: boolean;
+  /** See TerminalTab's prop JSDoc: refit synchronously on
+   *  `terminal-panel-resize`; the ResizeObserver stays ON. */
+  immediatePanelResize?: boolean;
+  /** deferContainerResize only: runs once resizing has settled (800ms). A
+   *  full-screen TUI re-emits its frame on each SIGWINCH; while the width is
+   *  changing those redraws stack as duplicated banners in xterm's history.
+   *  Hosts pass a reloadScrollback({ skipResize: true }) so the buffer is
+   *  replayed ONCE at the now-stable width. */
+  onDeferredResizeSettled?: () => void;
+}
+
+export function useTerminalRefit(options: TerminalRefitOptions): void {
+  const {
+    terminalRef,
+    initializedRef,
+    fit,
+    flushResize,
+    enabled = true,
+    deferContainerResize = false,
+    immediatePanelResize = false,
+    onDeferredResizeSettled,
+  } = options;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const element = terminalRef.current;
+    if (!element) return;
+
+    let resizeTimer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleRefit = (delayMs: number) => {
+      if (!initializedRef.current) return;
+      if (resizeTimer) clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => {
+        resizeTimer = null;
+        fit();
+      }, delayMs);
+    };
+
+    // Persistent: stays connected for the effect's lifetime so container-only
+    // size changes keep refitting long after init.
+    const observer = new ResizeObserver(() => {
+      if (shouldObserverScheduleRefit(deferContainerResize, isManagerResizeInProgress())) {
+        scheduleRefit(OBSERVER_REFIT_DEBOUNCE_MS);
+      }
+    });
+    observer.observe(element);
+
+    let cleanupTimer: ReturnType<typeof setTimeout> | null = null;
+    const handlePanelResize = () => {
+      const action = resolvePanelResizeAction(deferContainerResize, immediatePanelResize);
+      if (action.kind === 'immediate-fit-flush') {
+        // Clear any pending debounced fit so it cannot run a redundant second
+        // fit afterward. Fit synchronously, then flush the PTY resize
+        // immediately (don't wait out the 200ms debounce) so Claude's redraw
+        // lands with the reflow instead of a beat later - minimizes the resize
+        // "flash". The manager-resize gate already guarantees one resize per
+        // gesture, so there's nothing to coalesce.
+        if (resizeTimer) {
+          clearTimeout(resizeTimer);
+          resizeTimer = null;
+        }
+        if (initializedRef.current) {
+          fit();
+          flushResize();
+        }
+        return;
+      }
+      scheduleRefit(action.delayMs);
+      if (action.scheduleSettleCleanup) {
+        if (cleanupTimer) clearTimeout(cleanupTimer);
+        cleanupTimer = setTimeout(() => {
+          cleanupTimer = null;
+          if (initializedRef.current) onDeferredResizeSettled?.();
+        }, DEFERRED_RESIZE_SETTLE_MS);
+      }
+    };
+    window.addEventListener('terminal-panel-resize', handlePanelResize);
+
+    return () => {
+      if (resizeTimer) clearTimeout(resizeTimer);
+      if (cleanupTimer) clearTimeout(cleanupTimer);
+      observer.disconnect();
+      window.removeEventListener('terminal-panel-resize', handlePanelResize);
+    };
+  }, [
+    enabled,
+    terminalRef,
+    initializedRef,
+    fit,
+    flushResize,
+    deferContainerResize,
+    immediatePanelResize,
+    onDeferredResizeSettled,
+  ]);
+}

--- a/tests/ui/command-terminal.spec.ts
+++ b/tests/ui/command-terminal.spec.ts
@@ -2416,4 +2416,210 @@ test.describe('Command Terminal', () => {
       ).toBe(true);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Container-only pane resize refit - regression tests for the clipped TUI
+  // bottom rows. The Command Terminal's terminal pane is overflow-hidden, so a
+  // pane-height change that is NOT a window-engine commit (the footer ContextBar
+  // growing as its pills populate or wrap) used to leave the xterm too tall and
+  // silently clip its bottom rows - exactly where the fullscreen Claude TUI
+  // anchors its input box and the model-switch prompt. The fix is the shared
+  // useTerminalRefit hook's persistent ResizeObserver. These tests assert on the
+  // instrumented sessions.resize IPC (programmatic state, relative comparisons)
+  // rather than pixels, per cross-platform-parity.
+  // ---------------------------------------------------------------------------
+  test.describe('Container-only pane resize refit', () => {
+    const REFIT_PROJECT_ID = 'proj-refit-test';
+    const REFIT_SESSION_ID = 'sess-refit-test-1';
+
+    interface RefitInstrumentation {
+      __terminalResizeCalls: Array<{ sessionId: string; cols: number; rows: number }>;
+      __panelResizeEventCount: number;
+    }
+
+    function refitPreConfig(): string {
+      return `
+        window.__mockPreConfigure(function (state) {
+          var ts = new Date().toISOString();
+          state.projects.push({
+            id: '${REFIT_PROJECT_ID}',
+            name: 'Refit Test Project',
+            path: '/mock/refit-test',
+            github_url: null,
+            default_agent: 'claude',
+            last_opened: ts,
+            created_at: ts,
+          });
+          state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+            state.swimlanes.push(Object.assign({}, s, {
+              id: 'lane-refit-' + i,
+              position: i,
+              created_at: ts,
+            }));
+          });
+          return { currentProjectId: '${REFIT_PROJECT_ID}' };
+        });
+
+        // Deterministic spawn so markFirstOutput can target a known session id.
+        window.electronAPI.sessions.spawnTransient = async function (input) {
+          return {
+            session: {
+              id: '${REFIT_SESSION_ID}',
+              taskId: '${REFIT_SESSION_ID}',
+              projectId: input.projectId,
+              pid: null,
+              status: 'running',
+              shell: '/bin/bash',
+              cwd: '/mock/refit-test',
+              startedAt: new Date().toISOString(),
+              exitCode: null,
+              resuming: false,
+              transient: true,
+            },
+            branch: 'main',
+          };
+        };
+
+        // Record every PTY resize forward so the tests can assert refits on
+        // programmatic state instead of pixels.
+        window.__terminalResizeCalls = [];
+        var originalResize = window.electronAPI.sessions.resize;
+        window.electronAPI.sessions.resize = async function (sessionId, cols, rows) {
+          window.__terminalResizeCalls.push({ sessionId: sessionId, cols: cols, rows: rows });
+          return originalResize.call(this, sessionId, cols, rows);
+        };
+
+        // Count engine-commit dispatches so the tests can prove a refit came
+        // from the ResizeObserver path, not a terminal-panel-resize event.
+        window.__panelResizeEventCount = 0;
+        window.addEventListener('terminal-panel-resize', function () {
+          window.__panelResizeEventCount += 1;
+        });
+      `;
+    }
+
+    /**
+     * Open the Command Terminal, mount xterm (markFirstOutput lifts the shimmer,
+     * same pattern as the Maximize focus restore group), wait for the initial
+     * resize-first replay to record a baseline, then clear the instrumentation
+     * so the next recorded call is caused by the test's own container change.
+     * Returns the baseline cols/rows.
+     */
+    async function openTerminalAndSettleBaseline(page: Page): Promise<{ cols: number; rows: number }> {
+      await page.keyboard.press('Control+Shift+P');
+      await expect(page.getByTestId('command-terminal-window')).toBeVisible();
+
+      await page.evaluate((sessionId) => {
+        const stores = (window as unknown as {
+          __zustandStores?: {
+            session?: { getState: () => { markFirstOutput: (id: string) => void } };
+          };
+        }).__zustandStores;
+        stores?.session?.getState().markFirstOutput(sessionId);
+      }, REFIT_SESSION_ID);
+
+      await expect(
+        page.getByTestId('command-terminal-window').locator('.xterm-helper-textarea').first(),
+      ).toBeAttached({ timeout: 8000 });
+
+      // initTerminal's resize-first replay always records at least one call.
+      await expect.poll(
+        () => page.evaluate(
+          () => (window as unknown as RefitInstrumentation).__terminalResizeCalls.length,
+        ),
+        { timeout: 8000, intervals: [100, 100, 200, 200, 500] },
+      ).toBeGreaterThan(0);
+
+      const baseline = await page.evaluate(() => {
+        const calls = (window as unknown as RefitInstrumentation).__terminalResizeCalls;
+        const lastCall = calls[calls.length - 1];
+        return { cols: lastCall.cols, rows: lastCall.rows };
+      });
+
+      await page.evaluate(() => {
+        const instrumentation = window as unknown as RefitInstrumentation;
+        instrumentation.__terminalResizeCalls.length = 0;
+        instrumentation.__panelResizeEventCount = 0;
+      });
+
+      return baseline;
+    }
+
+    /** Rows (or cols) of the most recent recorded resize call, or a sentinel
+     *  larger than any real terminal dimension while none has arrived yet. */
+    function lastResizeDimension(page: Page, dimension: 'cols' | 'rows'): Promise<number> {
+      return page.evaluate((dimensionKey) => {
+        const calls = (window as unknown as {
+          __terminalResizeCalls: Array<{ cols: number; rows: number }>;
+        }).__terminalResizeCalls;
+        const lastCall = calls[calls.length - 1];
+        return lastCall ? lastCall[dimensionKey] : Number.MAX_SAFE_INTEGER;
+      }, dimension);
+    }
+
+    test('footer ContextBar growth refits the terminal via the ResizeObserver path', async () => {
+      const { browser, page } = await launchWithState(refitPreConfig());
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+        const baseline = await openTerminalAndSettleBaseline(page);
+
+        // Container-only change: grow the footer ContextBar (as when its pills
+        // populate or wrap to a second row), shrinking the flex-1 terminal pane
+        // while the window frame's own rect stays identical - so no
+        // terminal-panel-resize event can fire; only the persistent
+        // ResizeObserver can catch it.
+        await page.evaluate(() => {
+          const contextBar = document.querySelector<HTMLElement>(
+            '[data-testid="command-terminal-window"] [data-testid="usage-bar"]',
+          );
+          if (!contextBar) throw new Error('ContextBar (usage-bar) not found in the command terminal window');
+          contextBar.style.minHeight = '160px';
+        });
+
+        // Observer debounce (200ms) + PTY forward debounce (200ms), so poll for
+        // the resulting resize call. Strictly-fewer-rows, never an exact value.
+        await expect.poll(
+          () => lastResizeDimension(page, 'rows'),
+          { timeout: 8000, intervals: [100, 200, 200, 500, 500] },
+        ).toBeLessThan(baseline.rows);
+
+        // Prove the refit came from the ResizeObserver path: no engine commit
+        // dispatched a terminal-panel-resize during the container-only change.
+        const panelResizeEvents = await page.evaluate(
+          () => (window as unknown as RefitInstrumentation).__panelResizeEventCount,
+        );
+        expect(panelResizeEvents).toBe(0);
+      } finally {
+        await browser.close();
+      }
+    });
+
+    test('Changes panel toggle refits via the observer (pane width change)', async () => {
+      // Covers the responsibility of the deleted bespoke changesOpen effect: the
+      // pane flips flex-1 -> w-1/2, and the shared observer must catch the
+      // width change (no terminal-panel-resize fires for it either).
+      const { browser, page } = await launchWithState(refitPreConfig());
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+        const baseline = await openTerminalAndSettleBaseline(page);
+
+        // Toggle via the kebab menu (always reachable, unlike the header pill
+        // which can fold at narrow widths).
+        await page.getByTestId('command-terminal-window').getByTitle('Actions').click();
+        await page.getByText('Show changes', { exact: true }).click();
+
+        await expect.poll(
+          () => lastResizeDimension(page, 'cols'),
+          { timeout: 8000, intervals: [100, 200, 200, 500, 500] },
+        ).toBeLessThan(baseline.cols);
+
+        const panelResizeEvents = await page.evaluate(
+          () => (window as unknown as RefitInstrumentation).__panelResizeEventCount,
+        );
+        expect(panelResizeEvents).toBe(0);
+      } finally {
+        await browser.close();
+      }
+    });
+  });
 });

--- a/tests/unit/use-terminal-refit.test.ts
+++ b/tests/unit/use-terminal-refit.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit coverage for useTerminalRefit's pure decision helpers.
+ *
+ * The hook itself is timer/observer wiring exercised by the UI tier
+ * (tests/ui/command-terminal.spec.ts, container-only pane resize refit). These
+ * matrices lock the two decisions the wiring switches on:
+ *
+ * - shouldObserverScheduleRefit: a ResizeObserver notification schedules a
+ *   debounced refit only when the host does not defer container resizes AND no
+ *   window-manager resize gesture is in progress. This is the contract the
+ *   Command Terminal clipping fix depends on: container-only changes (its
+ *   ContextBar growing) happen with the gate closed, so they refit.
+ * - resolvePanelResizeAction: how a terminal-panel-resize event is handled per
+ *   host mode (synchronous fit+flush for immediatePanelResize, 0ms + settle
+ *   cleanup for deferContainerResize, 50ms debounce otherwise).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  shouldObserverScheduleRefit,
+  resolvePanelResizeAction,
+  PANEL_EVENT_REFIT_DEBOUNCE_MS,
+} from '../../src/renderer/hooks/useTerminalRefit';
+
+describe('shouldObserverScheduleRefit', () => {
+  it('schedules for a plain container change (no defer, gate closed)', () => {
+    expect(shouldObserverScheduleRefit(false, false)).toBe(true);
+  });
+
+  it('suppresses while a window-manager resize gesture is in progress', () => {
+    // The imperative resizers rewrite the frame's box per frame; refitting per
+    // frame would SIGWINCH per frame and stack duplicate TUI banners.
+    expect(shouldObserverScheduleRefit(false, true)).toBe(false);
+  });
+
+  it('suppresses for deferContainerResize hosts regardless of the gate', () => {
+    expect(shouldObserverScheduleRefit(true, false)).toBe(false);
+    expect(shouldObserverScheduleRefit(true, true)).toBe(false);
+  });
+});
+
+describe('resolvePanelResizeAction', () => {
+  it('fits synchronously for immediatePanelResize hosts', () => {
+    expect(resolvePanelResizeAction(false, true)).toEqual({ kind: 'immediate-fit-flush' });
+  });
+
+  it('immediatePanelResize wins even if deferContainerResize is also set', () => {
+    expect(resolvePanelResizeAction(true, true)).toEqual({ kind: 'immediate-fit-flush' });
+  });
+
+  it('fits on the next tick and schedules the settle cleanup for deferContainerResize hosts', () => {
+    expect(resolvePanelResizeAction(true, false)).toEqual({
+      kind: 'debounced-fit',
+      delayMs: 0,
+      scheduleSettleCleanup: true,
+    });
+  });
+
+  it('keeps the 50ms debounce with no settle cleanup for default hosts', () => {
+    expect(resolvePanelResizeAction(false, false)).toEqual({
+      kind: 'debounced-fit',
+      delayMs: PANEL_EVENT_REFIT_DEBOUNCE_MS,
+      scheduleSettleCleanup: false,
+    });
+  });
+});


### PR DESCRIPTION
## What

Extract the terminal container-refit logic into a shared `useTerminalRefit` hook and consume it from both xterm hosts (`TerminalTab` and `CommandTerminalWindow`), so the Command Terminal gains the persistent, gate-aware `ResizeObserver` it was missing.

- New `src/renderer/hooks/useTerminalRefit.ts`: the single-timer debounced refit, the persistent `ResizeObserver` gated by `isManagerResizeInProgress()`, and the `terminal-panel-resize` handler in all three host modes (synchronous fit+flush for `immediatePanelResize`, 0ms + 800ms scrollback-settle for `deferContainerResize`, 50ms default). The two decisions are exported as pure helpers (`shouldObserverScheduleRefit`, `resolvePanelResizeAction`) for unit testing.
- `TerminalTab.tsx` consumes the hook (behavior unchanged; the activation fits stay host-side).
- `CommandTerminalWindow.tsx` consumes it in `immediatePanelResize` mode; its two bespoke refit effects (the `terminal-panel-resize` listener and the `changesOpen` rAF) and an unused `terminalPaneRef` are deleted.

## Why

In the Command Terminal only, the fullscreen Claude TUI's bottom rows clipped below the visible pane - most visibly the model-switch prompt and the Select-model menu, which drew off-screen. The Command Terminal hosted its own xterm and refit only on window-engine `terminal-panel-resize` commits, the Changes toggle, and init. With no persistent `ResizeObserver`, a container-only height change - the footer `ContextBar` growing after init (spinner to pills, rate-limits pill arriving, `flex-wrap` to a second row) - shrank the `overflow-hidden` terminal pane without ever refitting the xterm, so the now-too-tall canvas was silently clipped. `TerminalTab` (task detail) already had this observer; this brings the Command Terminal to parity. It is also the second divergence of this kind (the Changes toggle previously needed its own bespoke effect), so sharing the logic prevents the two hosts drifting again.

Closes #407.

## How

The hook is a behavior-preserving port of `TerminalTab`'s resize block, parameterized by the same `deferContainerResize` / `immediatePanelResize` modes the existing prop contract already documents. `initializedRef` is read at fire time (not a dependency) so a session respawn that resets it suppresses refits without re-running the effect. The Command Terminal keeps its init-only observer (a separate concern: waiting for nonzero dimensions), and the refit hook is a no-op until initialized, so the two never fight. The `changesOpen` width refit is now caught by the persistent observer - a deliberate next-frame-to-200ms-debounce trade that matches the task-detail terminal's shipped behavior for its own Changes toggle.

Rebased onto `main`; resolved a trivial two-hunk conflict in `CommandTerminalWindow.tsx` (kept `main`'s new `TERMINAL_BACKGROUND` constant and this branch's unused-ref removal).

## Breaking changes

None.

## Tests

- New `tests/unit/use-terminal-refit.test.ts`: full matrices for the two pure decision helpers.
- New "Container-only pane resize refit" group in `tests/ui/command-terminal.spec.ts`: a container-only `ContextBar` height grow (and the Changes toggle) refits via the observer path, asserting on the instrumented `sessions.resize` IPC with strictly-fewer rows/cols and a `terminal-panel-resize` event counter that stays at zero (proving the observer, not the window event, did the refit). Programmatic-state assertions per `cross-platform-parity.md`, no pixel-exact checks.
- Verified end-to-end in a live preview: `ContextBar` grow/shrink, the Changes toggle, fresh spawns, and the model-switch menu all refit on-screen now.

Generated with [Claude Code](https://claude.com/claude-code)
