### PR TITLE
feat(mobile-bridge): copy pairing link + gate the bridge to dev builds

### DIFF
--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -76,7 +76,8 @@ export function registerSystemHandlers(context: IpcContext): void {
     if (config.mobileBridge) {
       const effectiveConfig = context.configManager.getEffectiveConfig(context.currentProjectPath || undefined);
       context.mobileBridgeService.reconcile({
-        enabled: effectiveConfig.mobileBridge?.enabled ?? false,
+        // Dev-only until the mobile app launches (mirrors register-all.ts).
+        enabled: __KANGENTIC_DEV__ && (effectiveConfig.mobileBridge?.enabled ?? false),
         relayUrl: effectiveConfig.mobileBridge?.relayUrl ?? '',
       });
     }

--- a/src/main/ipc/register-all.ts
+++ b/src/main/ipc/register-all.ts
@@ -147,7 +147,10 @@ export function registerAllIpc(mainWindow: BrowserWindow, mcpServerHandle: McpHt
 
   const effectiveConfig = context.configManager.getEffectiveConfig(context.currentProjectPath ?? undefined);
   mobileBridgeService.reconcile({
-    enabled: effectiveConfig.mobileBridge?.enabled ?? false,
+    // Dev-only until the mobile app launches: a production build never
+    // enables the bridge regardless of persisted config (paired gates:
+    // system.ts's config:set reconcile and the renderer's settings tab).
+    enabled: __KANGENTIC_DEV__ && (effectiveConfig.mobileBridge?.enabled ?? false),
     relayUrl: effectiveConfig.mobileBridge?.relayUrl ?? '',
   });
 

--- a/src/renderer/components/settings/AppSettingsPanel.tsx
+++ b/src/renderer/components/settings/AppSettingsPanel.tsx
@@ -52,7 +52,11 @@ export const APP_TABS: SettingsTabDefinition[] = [
   { id: 'mcpServer', label: 'MCP Server', icon: Plug, tooltip: 'Applies to all projects' },
   { id: 'browserAutomation', label: 'Agent Browser', icon: MousePointerClick, tooltip: 'Applies to all projects' },
   { id: 'notifications', label: 'Notifications', icon: Bell, tooltip: 'Applies to all projects' },
-  { id: 'mobile', label: 'Mobile Devices', icon: Smartphone, tooltip: 'Applies to all projects' },
+  // Dev-only until the mobile app launches (paired gates: settings-registry
+  // entries, and the service reconcile in register-all.ts / system.ts).
+  ...(__KANGENTIC_DEV__
+    ? ([{ id: 'mobile', label: 'Mobile Devices', icon: Smartphone, tooltip: 'Applies to all projects' }] satisfies SettingsTabDefinition[])
+    : []),
   { id: 'privacy', label: 'Privacy', icon: ShieldCheck, tooltip: 'Applies to all projects' },
   { id: 'developer', label: 'Developer', icon: Bug, tooltip: 'Applies to all projects' },
 ];

--- a/src/renderer/components/settings/settings-registry.ts
+++ b/src/renderer/components/settings/settings-registry.ts
@@ -139,10 +139,17 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
   { id: 'developer.activityDebugOverlay', tabId: 'developer', label: 'Activity Engine Debug Overlay', description: 'Show a floating panel with live activity-engine state for every running session. Useful for diagnosing spinner / idle bugs.', scope: 'global', keywords: ['debug', 'overlay', 'diagnostic', 'engine', 'activity', 'thinking', 'idle', 'subagent', 'background', 'shell', 'reason'] },
 
   // ── Mobile Devices ──
-  { id: 'mobileBridge.enabled', tabId: 'mobile', label: 'Mobile Bridge', description: 'Let a paired phone connect to this desktop through an end-to-end encrypted relay.', scope: 'global', keywords: ['mobile', 'phone', 'companion', 'pair', 'pairing', 'qr', 'relay', 'bridge', 'remote'] },
-  { id: 'mobileBridge.relayUrl', tabId: 'mobile', label: 'Relay Address', description: 'The relay this desktop connects to (self-hosted or Kangentic-hosted). The relay only ever sees encrypted traffic.', scope: 'global', keywords: ['relay', 'server', 'url', 'address', 'self-host', 'websocket', 'mobile'] },
-  { id: 'mobileBridge.pairing', tabId: 'mobile', label: 'Pair a Device', description: 'Scan a QR code with the Kangentic mobile app to pair a new phone.', scope: 'global', keywords: ['pair', 'pairing', 'qr', 'scan', 'phone', 'mobile', 'sas', 'code'] },
-  { id: 'mobileBridge.devices', tabId: 'mobile', label: 'Paired Devices', description: 'Phones paired to this desktop, their granted capabilities, and revocation.', scope: 'global', keywords: ['paired', 'devices', 'phone', 'revoke', 'capabilities', 'mobile'] },
+  // Dev-only until the mobile app launches: compiled out of production
+  // builds (with the tab in AppSettingsPanel and the service gate in
+  // register-all.ts / system.ts) so the bridge cannot leak into a release.
+  ...(__KANGENTIC_DEV__
+    ? ([
+        { id: 'mobileBridge.enabled', tabId: 'mobile', label: 'Mobile Bridge', description: 'Let a paired phone connect to this desktop through an end-to-end encrypted relay.', scope: 'global', keywords: ['mobile', 'phone', 'companion', 'pair', 'pairing', 'qr', 'relay', 'bridge', 'remote'] },
+        { id: 'mobileBridge.relayUrl', tabId: 'mobile', label: 'Relay Address', description: 'The relay this desktop connects to (self-hosted or Kangentic-hosted). The relay only ever sees encrypted traffic.', scope: 'global', keywords: ['relay', 'server', 'url', 'address', 'self-host', 'websocket', 'mobile'] },
+        { id: 'mobileBridge.pairing', tabId: 'mobile', label: 'Pair a Device', description: 'Scan a QR code with the Kangentic mobile app to pair a new phone.', scope: 'global', keywords: ['pair', 'pairing', 'qr', 'scan', 'phone', 'mobile', 'sas', 'code'] },
+        { id: 'mobileBridge.devices', tabId: 'mobile', label: 'Paired Devices', description: 'Phones paired to this desktop, their granted capabilities, and revocation.', scope: 'global', keywords: ['paired', 'devices', 'phone', 'revoke', 'capabilities', 'mobile'] },
+      ] satisfies SettingDefinition[])
+    : []),
 ];
 
 /** Lookup by ID for O(1) access. */

--- a/src/renderer/components/settings/tabs/MobileDevicesTab.tsx
+++ b/src/renderer/components/settings/tabs/MobileDevicesTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { QrCode, Smartphone, Trash2 } from 'lucide-react';
+import { Check, Copy, QrCode, Smartphone, Trash2 } from 'lucide-react';
 import QRCode from 'qrcode';
 import { MOBILE_CAPABILITY_VERBS, type AppConfig, type MobileCapabilityVerb, type MobilePairedDevice } from '../../../../shared/types';
 import { CompactToggleList, INPUT_CLASS, SectionHeader, SettingRow, SettingToggleRow, useScopedUpdate } from '../shared';
@@ -43,6 +43,7 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
 
   const [qrUri, setQrUri] = useState<string | null>(null);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const [linkCopied, setLinkCopied] = useState(false);
   const [deviceNameDraft, setDeviceNameDraft] = useState('');
   const [revokeTarget, setRevokeTarget] = useState<{ deviceId: string; displayName: string } | null>(null);
 
@@ -85,10 +86,23 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
     };
   }, [qrUri]);
 
+  useEffect(() => {
+    if (!linkCopied) return;
+    const timer = setTimeout(() => setLinkCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [linkCopied]);
+
   const handleStartPairing = async () => {
     clearPairingEnded();
+    setLinkCopied(false);
     const result = await startPairing();
     setQrUri(result.qrUri);
+  };
+
+  const handleCopyLink = async () => {
+    if (!qrUri) return;
+    await navigator.clipboard.writeText(qrUri);
+    setLinkCopied(true);
   };
 
   const handleCancelPairing = async () => {
@@ -181,17 +195,31 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
           </div>
         ) : (
           <div className="space-y-3 rounded-md border border-edge bg-surface-hover/40 p-4">
-            <p className="text-sm text-fg-secondary">Scan this code with the Kangentic mobile app.</p>
+            <p className="text-sm text-fg-secondary">
+              Scan this code with the Kangentic mobile app, or copy the pairing link and paste it
+              into the app&apos;s &quot;paste pairing link&quot; field (for devices without a
+              camera on this screen, like an emulator).
+            </p>
             {qrDataUrl && (
               <img src={qrDataUrl} alt="Pairing QR code" className="rounded-md border border-edge" width={220} height={220} />
             )}
-            <button
-              type="button"
-              className="rounded-md border border-edge px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-hover transition-colors"
-              onClick={() => void handleCancelPairing()}
-            >
-              Cancel
-            </button>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="inline-flex items-center gap-1.5 rounded-md border border-edge px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-hover transition-colors"
+                onClick={() => void handleCopyLink()}
+              >
+                {linkCopied ? <Check size={14} /> : <Copy size={14} />}
+                {linkCopied ? 'Copied' : 'Copy pairing link'}
+              </button>
+              <button
+                type="button"
+                className="rounded-md border border-edge px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-hover transition-colors"
+                onClick={() => void handleCancelPairing()}
+              >
+                Cancel
+              </button>
+            </div>
           </div>
         )}
 

--- a/tests/ui/mobile-devices-settings.spec.ts
+++ b/tests/ui/mobile-devices-settings.spec.ts
@@ -190,6 +190,37 @@ test.describe('Mobile Devices settings tab', () => {
     await closeSettings();
   });
 
+  test('"Copy pairing link" writes the pairing URI to the clipboard and shows Copied feedback', async () => {
+    await openMobileTab();
+
+    await page.getByRole('button', { name: 'Pair a device' }).click();
+    await expect(page.getByAltText('Pairing QR code')).toBeVisible();
+
+    // Capture instead of hitting the real clipboard: headless clipboard
+    // permissions vary by platform, and the captured value is the assertion
+    // that matters (the exact URI the phone would paste).
+    await page.evaluate(() => {
+      const captured: string[] = [];
+      (window as unknown as { __copiedPairingLinks: string[] }).__copiedPairingLinks = captured;
+      navigator.clipboard.writeText = (text: string) => {
+        captured.push(text);
+        return Promise.resolve();
+      };
+    });
+
+    await page.getByRole('button', { name: 'Copy pairing link' }).click();
+    await expect(page.getByRole('button', { name: 'Copied' })).toBeVisible();
+    const copied = await page.evaluate(
+      () => (window as unknown as { __copiedPairingLinks: string[] }).__copiedPairingLinks,
+    );
+    expect(copied).toEqual(['kangentic-pair://mock']);
+
+    // The feedback label reverts so the link can be copied again.
+    await expect(page.getByRole('button', { name: 'Copy pairing link' })).toBeVisible({ timeout: 5000 });
+
+    await closeSettings();
+  });
+
   test('cancelling an in-progress pairing clears the QR and returns to the start button', async () => {
     await openMobileTab();
 

--- a/tests/unit/config-handler-wiring.test.ts
+++ b/tests/unit/config-handler-wiring.test.ts
@@ -294,8 +294,13 @@ describe('CONFIG_SET IPC handler - mobileBridgeService reconcile wiring', () => 
     invokeHandler('config:set', { mobileBridge: { enabled: true } });
 
     expect(context.mobileBridgeService.reconcile).toHaveBeenCalledTimes(1);
+    // The mobile bridge is gated to dev builds until the mobile app
+    // launches, and this suite compiles with __KANGENTIC_DEV__ = false
+    // (vitest.config.ts) - i.e. the production build. So even a persisted
+    // enabled:true must reconcile to enabled:false here; relayUrl still
+    // flows from the EFFECTIVE config (not the raw partial argument).
     expect(context.mobileBridgeService.reconcile).toHaveBeenCalledWith({
-      enabled: true,
+      enabled: false,
       relayUrl: 'wss://relay.example.com',
     });
   });


### PR DESCRIPTION
## What

Two mobile-bridge changes that came out of pairing the Android emulator against a live dev instance:

**1. Copy pairing link button.** The pairing URI previously existed only as a rendered QR image, which a device without a camera pointed at this screen (an Android emulator, a desktop-adjacent tablet) cannot consume, even though the mobile app has a paste-pairing-link field. A `Copy pairing link` button with transient `Copied` feedback now sits beside Cancel, and the QR caption mentions the paste path. Verified end to end: copy on desktop, host-clipboard sync into the emulator, paste, SAS confirm, session established. (The URI is base64url and can contain underscores, which `adb shell input text` cannot type, so the clipboard path is the only automatable one.)

**2. Dev-only gate.** The mobile companion app is pre-release, and mobile work must never block a kangentic release. Everything mobile-bridge is now gated behind the compile-time `__KANGENTIC_DEV__` constant, so production builds drop it:
- The Mobile Devices settings tab and its settings-registry (search) entries disappear from production builds.
- Both `reconcile` call sites (startup in `register-all.ts`, config:set in `system.ts`) force `enabled: false` in production regardless of persisted config, so even a hand-edited config file cannot enable the bridge.
- `MobileBridgeService` itself stays ungated so its unit tests (which run with `__KANGENTIC_DEV__ = false`) keep exercising real behavior.

Un-gating for launch is tracked as a board task on the kangentic project.

## Testing

- `npx playwright test --project=ui tests/ui/mobile-devices-settings.spec.ts` (14 passed, including a new spec for the copied URI and the `Copied` label reverting; the ui project runs on the vite dev server where `__KANGENTIC_DEV__` is true)
- `npm run typecheck`, `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)