### PR TITLE
fix(linux): use soname capabilities for rpm dependencies

### DIFF
--- a/.claude/agents/platform-guard.md
+++ b/.claude/agents/platform-guard.md
@@ -81,6 +81,14 @@ Scan the changed files (or the full codebase if no specific scope is given) for 
 - Shell-parameterized tests should run for all detected terminals
 - **Severity: Low** -- causes test failures on other platforms
 
+### 7. Linux Package Dependencies
+- `electron-builder.yml`'s `rpm.depends` entries must be soname capabilities
+  (`libfoo.so.1()(64bit)`) or a rich-dependency boolean (`(libXtst or libXtst6)`), never a bare
+  package name - RPM package names differ per distro (Fedora `libxshmfence` vs. openSUSE
+  `libxshmfence1`). See `.claude/rules/linux-package-dependencies.md`.
+- **Severity: High** - a bad dependency name fails the RPM install outright on every user's
+  machine, not just in CI.
+
 ## Output Format
 
 ### Findings

--- a/.claude/rules/linux-package-dependencies.md
+++ b/.claude/rules/linux-package-dependencies.md
@@ -1,0 +1,65 @@
+---
+paths:
+  - "electron-builder.yml"
+---
+# Rule: rpm dependencies are sonames, not package names
+
+`electron-builder.yml`'s `rpm.depends` declared `libXShmfence`, the package name Chromium's
+own build scripts use. No RPM distro has ever shipped a package by that exact name: Fedora and
+RHEL call it `libxshmfence`, openSUSE calls it `libxshmfence1`. `rpm -i` enforces `Requires`
+without resolving them, so `npx kangentic` on Fedora 44 failed outright even though the library
+was already installed - only its package name didn't match.
+
+RPM package *names* vary per distro; `.so` sonames do not - `libxshmfence.so.1` is
+`libxshmfence.so.1` everywhere, and every distro's rpmbuild auto-generates a `Provides:` for
+it. Depending on the soname instead of the package name is the fix upstream Electron itself
+recommends for this exact class of bug
+([electron#41677](https://github.com/electron/electron/issues/41677)).
+
+## The rule
+
+- **`rpm.depends` entries are soname capabilities**, in the form `<soname>()(64bit)`
+  (e.g. `libxshmfence.so.1()(64bit)`), never a bare package name (`libXShmfence`, `nss`,
+  `gtk3`, ...). Get the exact soname string empirically - `rpm -q --provides <package>` on a
+  real Fedora/RHEL system, filtered to the `()(64bit)` capability lines - never type one from
+  memory or copy it from another project's config.
+- If a soname genuinely cannot express the dependency, fall back to RPM's rich-dependency
+  boolean form (`(libXtst or libXtst6)`), which is electron-builder's own default style for
+  exactly this situation. Do not fall back to a plain package name.
+- **`deb.depends` entries stay package names** - Debian has no soname-capability equivalent
+  through fpm. Where a distro has renamed a package (Ubuntu 24.04+ renamed `libasound2` to
+  `libasound2t64`), use alternation (`libasound2t64 | libasound2`) rather than picking one name
+  and breaking the other release.
+- Do not hand-derive a new dependency list from memory or from another Electron app's config.
+  If you need to add or audit an entry, verify it against the actual built payload (see the
+  Linux-CI install gate below) or a real distro package database - both `rpm -q --provides` and
+  `objdump -p <binary> | grep NEEDED` are read-only and fast to run in a throwaway container.
+
+## Enforcement (self-maintaining)
+
+- **Test (shape only):** `tests/unit/linux-package-deps.test.ts` parses `electron-builder.yml`
+  and fails if any `rpm.depends` entry is not a soname-capability or rich-dependency-boolean
+  string. Runs in CI via `npm run test:unit`. This catches a package name creeping back in, but
+  cannot catch a soname that is spelled wrong or genuinely absent - it is a shape check, not a
+  correctness check.
+- **CI (correctness):** the `release` workflow's Linux job actually installs the built `.rpm`
+  and `.deb` via `dnf` / `zypper` / `apt-get install` in clean Fedora, openSUSE, Debian, and
+  Ubuntu containers after building, one step per distro so all four report independently. A
+  dependency that does not resolve on a real system fails the release before it ships. This is the check that would have caught the original bug, and the
+  one that matters most - the unit test only catches the *shape* of a regression, not whether
+  the string is actually correct.
+- **Review:** `platform-guard` and `/code-review` flag a bare package name in `rpm.depends`
+  during review of `electron-builder.yml` changes.
+
+An earlier draft of this rule proposed deriving `rpm.depends` automatically from
+`objdump -p`'s `NEEDED` entries across the built payload, diffed in CI. That was rejected:
+Chromium loads some runtime dependencies (`libxshmfence` itself, among others) via `dlopen()`
+rather than linking them, so they never appear as `NEEDED` - a pure link-time diff would have
+silently deleted the one dependency this rule exists to keep correct. Do not resurrect that
+approach without also covering `dlopen`'d dependencies.
+
+## Scope
+
+`electron-builder.yml`'s `linux`, `rpm`, and `deb` sections. Does not cover the launcher's
+choice of installer command (`packages/launcher/bin/kangentic.js`) or which packages Electron
+itself requires at runtime - only how already-decided dependencies are named.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,55 @@ jobs:
           }
           Write-Host "Found $manifest"
 
+      # Actually installs the built .rpm/.deb on clean distro containers. A hand-maintained
+      # dependency name can look correct and still fail on a real system - this is what would
+      # have caught the libXShmfence bug (a package name no RPM distro has ever shipped) before
+      # release. See .claude/rules/linux-package-dependencies.md.
+      # Each distro is its OWN step so all four report independently. Chained under one `set -e`,
+      # a failure in the first container aborts before the second ever runs, so a single CI run
+      # could only ever prove the first distro of a pair - the gate would claim four-distro
+      # coverage while delivering two.
+      #
+      # --nogpgcheck / --no-gpg-checks: electron-builder emits an UNSIGNED rpm. Fedora 45 flips
+      # RPM's %_pkgverify_level from "digest" to "all", so without the override an unsigned local
+      # package is refused outright and every release would fail here on a signature error rather
+      # than on the dependency resolution this gate actually tests.
+      - name: Verify rpm installs on Fedora
+        if: matrix.platform == 'linux'
+        run: |
+          set -e
+          rpm_file=$(ls out/kangentic-*.x86_64.rpm)
+          echo "Testing $rpm_file"
+          docker run --rm -v "$PWD/out:/out:ro" fedora:latest \
+            dnf install -y --nogpgcheck "/out/$(basename "$rpm_file")"
+
+      - name: Verify rpm installs on openSUSE
+        if: matrix.platform == 'linux'
+        run: |
+          set -e
+          rpm_file=$(ls out/kangentic-*.x86_64.rpm)
+          echo "Testing $rpm_file"
+          docker run --rm -v "$PWD/out:/out:ro" opensuse/tumbleweed:latest \
+            zypper --non-interactive --no-gpg-checks install "/out/$(basename "$rpm_file")"
+
+      - name: Verify deb installs on Debian
+        if: matrix.platform == 'linux'
+        run: |
+          set -e
+          deb_file=$(ls out/kangentic_*_amd64.deb)
+          echo "Testing $deb_file"
+          docker run --rm -v "$PWD/out:/out:ro" debian:stable sh -c \
+            "apt-get update -qq && apt-get install -y \"/out/$(basename "$deb_file")\""
+
+      - name: Verify deb installs on Ubuntu
+        if: matrix.platform == 'linux'
+        run: |
+          set -e
+          deb_file=$(ls out/kangentic_*_amd64.deb)
+          echo "Testing $deb_file"
+          docker run --rm -v "$PWD/out:/out:ro" ubuntu:24.04 sh -c \
+            "apt-get update -qq && apt-get install -y \"/out/$(basename "$deb_file")\""
+
   # Only publish the draft release when ALL platform builds succeed.
   # This prevents partial releases (e.g. missing macOS artifacts) from
   # reaching users. If any platform fails, the release stays as a draft.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,7 @@ session; rules with one load when you touch matching files. Each rule names its 
 - `central-embedding-engine.md` - only `embed-engine.ts` embeds; lifecycle/IPC call sites index and `markDirty()`, never embed inline (`src/main/retrieval/**`, `src/main/ipc/handlers/**`).
 - `pop-out-surface-registry.md` - every OS `BrowserWindow` is created only in `createWindow` or the pop-out window manager; every detachable surface goes through the shared + renderer registries (`src/main/pop-out/**`, `src/shared/pop-out.ts`, `src/renderer/pop-out/**`).
 - `spawn-entry-point-parity.md` - every agent-spawn entry point routes through `spawnAgent` / `prepareAgentSpawn` and the shared `runSpawnPreamble` (first-spawn override lock + agent resolution); no direct engine spawn calls in handlers (`src/main/ipc/**`, `src/main/transition-engine/**`).
+- `linux-package-dependencies.md` - rpm dependencies are soname capabilities, never package names, since RPM package names differ per distro (`electron-builder.yml`).
 
 **Local overrides:** there is no per-rule local file. Put machine-specific instruction
 overrides in a gitignored `CLAUDE.local.md` at the project root.

--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -108,7 +108,7 @@ macOS builds use hardened runtime with `build/entitlements.plist` providing JIT,
 
 ## Linux System Dependencies
 
-The deb package declares `depends` on Electron's required system libraries (`libnss3`, `libatk-bridge2.0-0`, `libgtk-3-0`, `libgbm1`, `libasound2`, `libdrm2`, `libxshmfence1`). The rpm package uses equivalent `requires` (`nss`, `atk`, `gtk3`, `mesa-libgbm`, `alsa-lib`, `libdrm`, `libXShmfence`). Without these, the app crashes on launch on fresh Linux installations.
+The deb package declares `depends` on Electron's required system libraries (`libnss3`, `libatk-bridge2.0-0`, `libgtk-3-0`, `libgbm1`, `libasound2t64 | libasound2`, `libdrm2`, `libxshmfence1`); the alternation covers Ubuntu 24.04+'s rename of `libasound2` to `libasound2t64`. The rpm package declares `depends` as `.so` soname capabilities (`libnss3.so()(64bit)`, `libatk-1.0.so.0()(64bit)`, `libgtk-3.so.0()(64bit)`, `libgbm.so.1()(64bit)`, `libasound.so.2()(64bit)`, `libdrm.so.2()(64bit)`, `libxshmfence.so.1()(64bit)`) rather than package names, because RPM package names differ per distro (Fedora `libxshmfence` vs. openSUSE `libxshmfence1`) while every distro's rpmbuild auto-generates a `Provides:` for the soname itself. See `.claude/rules/linux-package-dependencies.md`. Without these, the app crashes on launch, or fails to install at all, on fresh Linux installations.
 
 ## Auto-Update Platform Guard
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,8 +33,8 @@ Download the latest release for your platform from [GitHub Releases](https://git
 |----------|------|-------|
 | Windows | `Kangentic Setup X.Y.Z.exe` | NSIS installer. Auto-updates. |
 | macOS | `Kangentic-X.Y.Z.dmg` | Drag to Applications. See [Gatekeeper note](#macos-gatekeeper). |
-| Linux (Debian/Ubuntu) | `kangentic_X.Y.Z_amd64.deb` | `sudo dpkg -i kangentic_*.deb` |
-| Linux (Fedora/RHEL) | `kangentic-X.Y.Z-1.x86_64.rpm` | `sudo rpm -i kangentic-*.rpm` |
+| Linux (Debian/Ubuntu) | `kangentic_X.Y.Z_amd64.deb` | `sudo apt install ./kangentic_*.deb` |
+| Linux (Fedora/RHEL/openSUSE) | `kangentic-X.Y.Z-1.x86_64.rpm` | `sudo dnf install kangentic-*.rpm` |
 
 ### Windows
 
@@ -64,11 +64,18 @@ Install with your package manager:
 
 ```bash
 # Debian/Ubuntu
-sudo dpkg -i kangentic_X.Y.Z_amd64.deb
+sudo apt install ./kangentic_X.Y.Z_amd64.deb
 
 # Fedora/RHEL
-sudo rpm -i kangentic-X.Y.Z-1.x86_64.rpm
+sudo dnf install kangentic-X.Y.Z-1.x86_64.rpm
+
+# openSUSE
+sudo zypper install kangentic-X.Y.Z-1.x86_64.rpm
 ```
+
+`apt install` and `dnf install` resolve and fetch missing dependencies automatically. `dpkg -i`
+and `rpm -i` (still supported) do not - a missing library fails with a raw dependency error
+instead of being installed.
 
 Linux does not have built-in auto-updates. Download new releases manually from GitHub.
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -109,7 +109,7 @@ deb:
     - libatk-bridge2.0-0
     - libgtk-3-0
     - libgbm1
-    - libasound2
+    - libasound2t64 | libasound2
     - libdrm2
     - libxshmfence1
 
@@ -117,14 +117,21 @@ rpm:
   # Pin filename to match what the launcher (packages/launcher/bin/kangentic.js) expects.
   # electron-builder's default may or may not include the -1 release number.
   artifactName: "${name}-${version}-1.${arch}.rpm"
+  # Soname capabilities, not package names: RPM package names for these libraries
+  # differ per distro (Fedora "libxshmfence" / openSUSE "libxshmfence1"; Fedora "nss" /
+  # openSUSE "mozilla-nss"), but every distro's rpm auto-generates a Provides: for the
+  # soname itself, so it resolves everywhere. Each string below was confirmed against
+  # a real Fedora 44 package's `rpm -q --provides` output and confirmed to survive the
+  # electron-builder -> fpm -> rpmbuild pipeline unmodified via `rpm -qpR`.
+  # See .claude/rules/linux-package-dependencies.md
   depends:
-    - nss
-    - atk
-    - gtk3
-    - mesa-libgbm
-    - alsa-lib
-    - libdrm
-    - libXShmfence
+    - libnss3.so()(64bit)
+    - libatk-1.0.so.0()(64bit)
+    - libgtk-3.so.0()(64bit)
+    - libgbm.so.1()(64bit)
+    - libasound.so.2()(64bit)
+    - libdrm.so.2()(64bit)
+    - libxshmfence.so.1()(64bit)
 
 publish:
   provider: github

--- a/packages/launcher/README.md
+++ b/packages/launcher/README.md
@@ -25,7 +25,9 @@ npx kangentic /path/to/your/project
 3. Installs per platform:
    - **Windows:** Runs NSIS installer silently to `%LOCALAPPDATA%\Programs\Kangentic\`
    - **macOS:** Extracts .zip to `~/Applications/Kangentic.app`
-   - **Linux:** Installs .deb via `sudo dpkg -i` (prompts for password)
+   - **Linux:** Installs .rpm on RPM-family systems (`sudo dnf install` on Fedora/RHEL,
+     `sudo zypper install` on openSUSE, falling back to `sudo rpm -i`) or .deb elsewhere
+     (`sudo apt install`, falling back to `sudo dpkg -i`); prompts for password
 4. Launches the app
 
 ## Updates

--- a/packages/launcher/bin/kangentic.js
+++ b/packages/launcher/bin/kangentic.js
@@ -31,7 +31,7 @@ function getPlatformInfo() {
     return { platform: 'darwin', arch, extension: 'zip' };
   }
   if (platform === 'linux') {
-    return { platform: 'linux', arch: 'x64', extension: 'deb' };
+    return { platform: 'linux', arch: 'x64' };
   }
 
   return null;
@@ -83,22 +83,8 @@ function getArtifactFilename(platformInfo) {
     return `Kangentic-${version}-${platformInfo.arch}-mac.zip`;
   }
   if (platformInfo.platform === 'linux') {
-    // Check if rpm-based system
-    try {
-      execFileSync('which', ['rpm'], { stdio: 'ignore' });
-      const hasApt = (() => {
-        try {
-          execFileSync('which', ['apt'], { stdio: 'ignore' });
-          return true;
-        } catch {
-          return false;
-        }
-      })();
-      if (!hasApt) {
-        return `kangentic-${version}-1.x86_64.rpm`;
-      }
-    } catch {
-      // not rpm-based, use deb
+    if (commandExists('rpm') && !commandExists('apt')) {
+      return `kangentic-${version}-1.x86_64.rpm`;
     }
     return `kangentic_${version}_amd64.deb`;
   }
@@ -206,14 +192,39 @@ function installMacOS(artifactPath) {
   console.log('Installation complete.');
 }
 
+function commandExists(command) {
+  try {
+    execFileSync('which', [command], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function installLinux(artifactPath) {
   console.log('Installing Kangentic...');
   if (artifactPath.endsWith('.deb')) {
-    console.log('Running: sudo dpkg -i (you may be prompted for your password)');
-    execFileSync('sudo', ['dpkg', '-i', artifactPath], { stdio: 'inherit' });
+    if (commandExists('apt')) {
+      console.log('Running: sudo apt install (you may be prompted for your password)');
+      execFileSync('sudo', ['apt', 'install', '-y', artifactPath], { stdio: 'inherit' });
+    } else {
+      console.log('Running: sudo dpkg -i (you may be prompted for your password)');
+      execFileSync('sudo', ['dpkg', '-i', artifactPath], { stdio: 'inherit' });
+    }
   } else if (artifactPath.endsWith('.rpm')) {
-    console.log('Running: sudo rpm -i (you may be prompted for your password)');
-    execFileSync('sudo', ['rpm', '-i', artifactPath], { stdio: 'inherit' });
+    if (commandExists('dnf')) {
+      console.log('Running: sudo dnf install (you may be prompted for your password)');
+      execFileSync('sudo', ['dnf', 'install', '-y', artifactPath], { stdio: 'inherit' });
+    } else if (commandExists('zypper')) {
+      // openSUSE ships zypper, not dnf. Without this branch it falls through to `rpm -i`,
+      // which enforces Requires without resolving them - the exact install failure this
+      // launcher path exists to avoid.
+      console.log('Running: sudo zypper install (you may be prompted for your password)');
+      execFileSync('sudo', ['zypper', '--non-interactive', 'install', artifactPath], { stdio: 'inherit' });
+    } else {
+      console.log('Running: sudo rpm -i (you may be prompted for your password)');
+      execFileSync('sudo', ['rpm', '-i', artifactPath], { stdio: 'inherit' });
+    }
   }
   console.log('Installation complete.');
 }
@@ -432,4 +443,13 @@ if (require.main === module) {
 }
 
 // Exported for testing
-module.exports = { isInstalled, getVersionMarkerPath, writeVersionMarker, getInstallPath, getTempDir };
+module.exports = {
+  isInstalled,
+  getVersionMarkerPath,
+  writeVersionMarker,
+  getInstallPath,
+  getTempDir,
+  getPlatformInfo,
+  getArtifactFilename,
+  installLinux,
+};

--- a/tests/unit/launcher-linux-artifact-selection.test.ts
+++ b/tests/unit/launcher-linux-artifact-selection.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for the launcher's Linux rpm-vs-deb artifact selection.
+ *
+ * getArtifactFilename() was previously unexported and untested - the deb/rpm branch that
+ * shipped the broken libXShmfence dependency (see
+ * .claude/rules/linux-package-dependencies.md) had zero coverage. kangentic.js destructures
+ * execFileSync from child_process once at require time, so the spy's behavior is driven by a
+ * mutable variable read on every call, not by re-spying per test (a fresh vi.spyOn().mockImplementation()
+ * per test does not take effect here because the module is only required once). Spies on
+ * execFileSync so this runs identically regardless of whether `which`/`rpm`/`apt` exist on the
+ * host (see .claude/rules/cross-platform-parity.md) - Git Bash on Windows ships a real
+ * which.exe, so an unmocked run would silently pass through to it.
+ */
+import { describe, it, expect, afterAll, beforeAll, beforeEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- must be require(), not import: the spy has to be installed on the live module object before kangentic.js destructures execFileSync off it.
+const childProcess: typeof import('node:child_process') = require('child_process');
+
+let launcherModule: {
+  getPlatformInfo: () => { platform: string; arch?: string } | null;
+  getArtifactFilename: (platformInfo: { platform: string; arch?: string }) => string | null;
+  installLinux: (artifactPath: string) => void;
+};
+
+const launcherPackageJsonPath = path.resolve(__dirname, '../../packages/launcher/package.json');
+const launcherVersion = JSON.parse(fs.readFileSync(launcherPackageJsonPath, 'utf-8')).version;
+
+let mockAvailableCommands: string[] = [];
+
+// Records every `sudo` invocation so tests can assert the exact argv installLinux() chose,
+// without a second competing spy - the same execFileSync mock below both answers `which`
+// lookups and records `sudo` calls.
+let sudoInvocations: string[][] = [];
+
+beforeAll(() => {
+  vi.spyOn(childProcess, 'execFileSync').mockImplementation(((command: string, args: readonly string[]) => {
+    if (command === 'which' && !mockAvailableCommands.includes(args[0])) {
+      throw new Error(`command not found: ${args[0]}`);
+    }
+    if (command === 'sudo') {
+      sudoInvocations.push([...args]);
+    }
+    return '';
+  }) as typeof childProcess.execFileSync);
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- the launcher is plain CommonJS with no type declarations; it must also be required AFTER the spy above is installed.
+  launcherModule = require('../../packages/launcher/bin/kangentic.js');
+});
+
+// child_process is a shared Node singleton, so the spy mutates global state that outlives this
+// file. Without this restore, any later test in the same worker calling the real execFileSync
+// would silently get the mock (every `which` throwing, every other command returning '').
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  mockAvailableCommands = [];
+  sudoInvocations = [];
+});
+
+describe('Launcher Linux artifact selection', () => {
+  describe('getPlatformInfo', () => {
+    it('linux platform info has no extension field (rpm vs deb is decided later)', () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      try {
+        const platformInfo = launcherModule.getPlatformInfo();
+        expect(platformInfo).toEqual({ platform: 'linux', arch: 'x64' });
+        expect(platformInfo).not.toHaveProperty('extension');
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform });
+      }
+    });
+  });
+
+  describe('getArtifactFilename on linux', () => {
+    it('selects the rpm artifact when rpm is present and apt is absent (Fedora/RHEL)', () => {
+      mockAvailableCommands = ['rpm'];
+      const filename = launcherModule.getArtifactFilename({ platform: 'linux', arch: 'x64' });
+      expect(filename).toBe(`kangentic-${launcherVersion}-1.x86_64.rpm`);
+    });
+
+    it('selects the deb artifact when both rpm and apt are present', () => {
+      mockAvailableCommands = ['rpm', 'apt'];
+      const filename = launcherModule.getArtifactFilename({ platform: 'linux', arch: 'x64' });
+      expect(filename).toBe(`kangentic_${launcherVersion}_amd64.deb`);
+    });
+
+    it('selects the deb artifact when rpm is absent (Debian/Ubuntu)', () => {
+      mockAvailableCommands = ['apt'];
+      const filename = launcherModule.getArtifactFilename({ platform: 'linux', arch: 'x64' });
+      expect(filename).toBe(`kangentic_${launcherVersion}_amd64.deb`);
+    });
+  });
+
+  describe('getArtifactFilename on other platforms', () => {
+    it('returns the NSIS installer filename on win32', () => {
+      const filename = launcherModule.getArtifactFilename({ platform: 'win32' });
+      expect(filename).toBe(`Kangentic-Setup-${launcherVersion}.exe`);
+    });
+
+    it('returns the mac zip filename on darwin', () => {
+      const filename = launcherModule.getArtifactFilename({ platform: 'darwin', arch: 'arm64' });
+      expect(filename).toBe(`Kangentic-${launcherVersion}-arm64-mac.zip`);
+    });
+  });
+
+  describe('installLinux command selection', () => {
+    const debArtifactPath = '/tmp/kangentic.deb';
+    const rpmArtifactPath = '/tmp/kangentic.rpm';
+
+    it('runs sudo apt install when apt is present (.deb)', () => {
+      mockAvailableCommands = ['apt'];
+      launcherModule.installLinux(debArtifactPath);
+      expect(sudoInvocations).toEqual([['apt', 'install', '-y', debArtifactPath]]);
+    });
+
+    it('falls back to sudo dpkg -i when apt is absent (.deb)', () => {
+      mockAvailableCommands = [];
+      launcherModule.installLinux(debArtifactPath);
+      expect(sudoInvocations).toEqual([['dpkg', '-i', debArtifactPath]]);
+    });
+
+    it('runs sudo dnf install when dnf is present (.rpm)', () => {
+      mockAvailableCommands = ['dnf'];
+      launcherModule.installLinux(rpmArtifactPath);
+      expect(sudoInvocations).toEqual([['dnf', 'install', '-y', rpmArtifactPath]]);
+    });
+
+    it('runs sudo zypper install when dnf is absent and zypper is present (.rpm, openSUSE)', () => {
+      // The most important branch: before it existed, openSUSE fell through to `rpm -i`, which
+      // enforces Requires without resolving them - the exact install failure this change fixes.
+      mockAvailableCommands = ['zypper'];
+      launcherModule.installLinux(rpmArtifactPath);
+      expect(sudoInvocations).toEqual([['zypper', '--non-interactive', 'install', rpmArtifactPath]]);
+    });
+
+    it('falls back to sudo rpm -i when neither dnf nor zypper is present (.rpm)', () => {
+      mockAvailableCommands = [];
+      launcherModule.installLinux(rpmArtifactPath);
+      expect(sudoInvocations).toEqual([['rpm', '-i', rpmArtifactPath]]);
+    });
+  });
+});

--- a/tests/unit/linux-package-deps.test.ts
+++ b/tests/unit/linux-package-deps.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// electron-builder.yml's rpm.depends once listed a bare package name (libXShmfence) that no
+// RPM distro has ever shipped - Fedora/RHEL call it libxshmfence, openSUSE libxshmfence1. `rpm
+// -i` enforces Requires without resolving them, so `npx kangentic` failed outright on Fedora
+// even though the library was already installed. See .claude/rules/linux-package-dependencies.md.
+//
+// A soname capability ("libxshmfence.so.1()(64bit)") is identical on every RPM distro and every
+// distro's rpmbuild auto-generates a Provides: for it, so this guard fails on any bare package
+// name creeping back into rpm.depends. It cannot verify a soname is spelled correctly or still
+// needed - that is the Linux release-CI install gate's job, not this test's.
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const SONAME_CAPABILITY_PATTERN = /^lib[\w.-]+\.so(?:\.\d+)*\(\)\(64bit\)$/;
+const RICH_DEPENDENCY_BOOLEAN_PATTERN = /^\(.+ or .+\)$/;
+
+/** Extract the full indented body of a top-level YAML key - every line following "<key>:\n"
+ *  up to (not including) the next unindented line. Mirrors branding-assets.test.ts. */
+function extractTopLevelBlock(yamlSource: string, topLevelKey: string): string {
+  const match = yamlSource.match(new RegExp(`\\n${topLevelKey}:\\n((?:[ \\t].*\\n?)*)`));
+  if (!match) {
+    throw new Error(`electron-builder.yml: could not find top-level key "${topLevelKey}:"`);
+  }
+  return match[1];
+}
+
+/** Extract the `- entry` strings of a nested "depends:" list within an already-extracted block.
+ *  Comment lines are consumed as part of the run and then filtered out: matching only `- ` lines
+ *  would silently TRUNCATE the list at the first interleaved comment, and every entry after it
+ *  would escape validation while the test still passed. A guard that quietly stops guarding is
+ *  worse than no guard, so the comment case is matched explicitly rather than left to chance. */
+function extractDependsList(block: string): string[] {
+  const match = block.match(/depends:\n((?:[ \t]+[-#].*\n?)*)/);
+  if (!match) {
+    throw new Error('electron-builder.yml: could not find "depends:" list within the block');
+  }
+  return match[1]
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('- '))
+    .map((line) => line.slice(2).trim());
+}
+
+describe('extractDependsList', () => {
+  // Pins the fix for a truncation bug in the guard itself. The original regex matched only a
+  // contiguous run of "- " lines, so a comment between two entries ended the run and dropped
+  // every entry below it -- the shape assertion then validated a short list and passed while a
+  // bare package name sat in the file unchecked.
+  it('does not truncate the list at an interleaved comment', () => {
+    const blockWithInterleavedComment = [
+      '  depends:',
+      '    - libnss3.so()(64bit)',
+      '    # added for the at-spi bridge, see the linux-package-dependencies rule',
+      '    - libbadname',
+      '',
+    ].join('\n');
+
+    expect(extractDependsList(blockWithInterleavedComment)).toEqual([
+      'libnss3.so()(64bit)',
+      'libbadname',
+    ]);
+  });
+});
+
+describe('electron-builder.yml rpm.depends', () => {
+  const electronBuilderConfig = fs.readFileSync(path.join(REPO_ROOT, 'electron-builder.yml'), 'utf-8');
+  const rpmBlock = extractTopLevelBlock(electronBuilderConfig, 'rpm');
+  const rpmDepends = extractDependsList(rpmBlock);
+
+  it('declares at least one dependency', () => {
+    expect(rpmDepends.length).toBeGreaterThan(0);
+  });
+
+  it('every entry is a soname capability or a rich-dependency boolean, never a bare package name', () => {
+    const invalid = rpmDepends.filter(
+      (entry) => !SONAME_CAPABILITY_PATTERN.test(entry) && !RICH_DEPENDENCY_BOOLEAN_PATTERN.test(entry),
+    );
+    expect(
+      invalid,
+      `rpm.depends has bare package name(s), which do not resolve on every RPM distro:\n${invalid.join('\n')}\n` +
+        'Use a soname capability (e.g. libxshmfence.so.1()(64bit)) instead. See .claude/rules/linux-package-dependencies.md',
+    ).toEqual([]);
+  });
+
+  it('includes the xshmfence soname (the originally-reported dependency)', () => {
+    const hasXshmfence = rpmDepends.some((entry) => entry.includes('libxshmfence.so.1()(64bit)'));
+    expect(hasXshmfence, 'rpm.depends should declare libxshmfence.so.1()(64bit)').toBe(true);
+  });
+});
+
+describe('electron-builder.yml deb.depends', () => {
+  const electronBuilderConfig = fs.readFileSync(path.join(REPO_ROOT, 'electron-builder.yml'), 'utf-8');
+  const debBlock = extractTopLevelBlock(electronBuilderConfig, 'deb');
+  const debDepends = extractDependsList(debBlock);
+
+  it('uses alternation for the Ubuntu 24.04 libasound2 -> libasound2t64 rename', () => {
+    const alsaEntry = debDepends.find((entry) => entry.includes('asound'));
+    expect(alsaEntry, 'deb.depends should declare an alsa dependency').toBeDefined();
+    expect(
+      alsaEntry?.includes('libasound2t64') && alsaEntry?.includes('libasound2'),
+      `deb.depends alsa entry ("${alsaEntry}") should alternate libasound2t64 | libasound2 - ` +
+        'Ubuntu 24.04+ renamed the package and only libasound2t64 is installable there.',
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Fixes `npx kangentic` failing to install the RPM on Fedora 44 ("libXShmfence is needed" even
though `libxshmfence` was already installed). `electron-builder.yml`'s `rpm.depends` declared a
package name (`libXShmfence`) that no RPM distro has ever shipped - Fedora/RHEL call the package
`libxshmfence`, openSUSE calls it `libxshmfence1`. `rpm -i` enforces `Requires` without
resolving them, so the install failed outright.

Affected components: `electron-builder.yml` (Linux packaging config), the `npx kangentic`
launcher (`packages/launcher/bin/kangentic.js`), the release CI workflow, and a new
convention rule.

## Why

RPM package *names* differ per distro, so a hand-maintained name list is inherent
whack-a-mole - the reported bug was one instance, but four more entries in the same list were
also Fedora-only names that would silently break on openSUSE. This is a known
electron-builder-wide issue; see
[electron#41677](https://github.com/electron/electron/issues/41677), which recommends exactly
the fix applied here.

Closes the reported Fedora 44 RPM install failure.

## How

**Soname capabilities instead of package names.** A `.so` soname (e.g. `libxshmfence.so.1`) is
an ELF property, not a packaging choice - it's identical on every distro, and every distro's
rpmbuild auto-generates a `Provides:` for it. Replaced all seven `rpm.depends` entries with
soname capability strings (`libxshmfence.so.1()(64bit)`, etc.), each verified against real
Fedora package data (`rpm -q --provides`) and confirmed via `rpm -qpR` to survive the
electron-builder -> fpm -> rpmbuild pipeline unmodified. Also fixed `deb.depends`' alsa entry to
alternate `libasound2t64 | libasound2`, since Ubuntu 24.04+ renamed the package.

Rejected alternative: letting rpmbuild auto-generate `Requires` from the binaries (`AutoReqProv`).
fpm disables this by default because it "almost always makes incorrect decisions about
dependencies," and it would bake the build host's glibc symbol versions into the package,
narrowing which distros could install it.

**Verified end-to-end**, not just by reading docs: built the actual `.rpm` and `.deb` through
the real toolchain (electron-builder -> fpm -> rpmbuild, in a Fedora container) and installed
them cleanly on Fedora, openSUSE Tumbleweed, Debian stable, and Ubuntu 24.04.

**Launcher hardening:** `installLinux()` now prefers the dependency-resolving installer
(`dnf install` / `zypper install` / `apt install`) over the non-resolving `rpm -i` / `dpkg -i`,
with a fallback if the resolving tool isn't present. The openSUSE `zypper` branch matters here -
without it, openSUSE would fall through to `rpm -i`, hitting the same class of failure this PR
fixes.

**Guardrails so this can't silently recur:**
- New rule `.claude/rules/linux-package-dependencies.md`: rpm dependencies must be soname
  capabilities (or a rich-dependency boolean), never a bare package name.
- `tests/unit/linux-package-deps.test.ts`: fails if a bare package name creeps back into
  `rpm.depends`.
- Four new release-CI steps (one per distro, so each reports independently) that actually
  install the built `.rpm`/`.deb` on Fedora, openSUSE, Debian, and Ubuntu containers before a
  release can publish - this is the check that would have caught the original bug.
- `platform-guard` agent updated with a new check for this pattern.

An earlier design tried deriving `rpm.depends` automatically from `objdump -p`'s `NEEDED`
entries across the built payload. That was deliberately rejected: Chromium loads some runtime
dependencies (`libxshmfence` itself, among others) via `dlopen()` rather than linking them, so
they never appear as `NEEDED` - a pure link-time diff would have silently deleted the one
dependency this fix exists to keep correct.

**Known limitation** (documented in the rule, not hidden): the CI install gate proves declared
dependencies *resolve*, not that the list is *complete*. A future Electron upgrade needing a new
library would still install cleanly and crash at launch, since nothing scans the binary for
that. Closing that gap would require also covering `dlopen`'d dependencies, which the rejected
approach above did not solve.

## Breaking changes

None. `deb.depends` package names are unchanged in kind (still names, one alternation added);
`rpm.depends` values change, but this only affects packaging metadata for a not-yet-installable
target, not any runtime API or config surface.

## Tests

- `tests/unit/linux-package-deps.test.ts` - `electron-builder.yml`'s `rpm.depends` entries are
  soname capabilities; `deb.depends` alsa entry alternates for Ubuntu 24.04+. Confirmed
  red/green by temporarily reintroducing the old `libXShmfence` value.
- `tests/unit/launcher-linux-artifact-selection.test.ts` - `getPlatformInfo()`,
  `getArtifactFilename()`'s rpm-vs-deb selection, and `installLinux()`'s dnf/zypper/apt-with-fallback
  branching, all five install paths asserted on exact argv.
- Manually verified end-to-end in Docker: built the real `.rpm`/`.deb` and installed them
  cleanly on Fedora, openSUSE Tumbleweed, Debian stable, and Ubuntu 24.04 containers.
- CI: `typecheck`, `lint`, and this PR's own checks (unit/UI/E2E shards, the new Linux
  install-gate steps run at release time, not on every PR).

Generated with [Claude Code](https://claude.com/claude-code)
