### PR TITLE
feat(mobile-bridge): resolved relay default with custom and local override

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -249,17 +249,18 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 | `boardConfig:shortcutsChanged` | on | Event: shortcuts file changed |
 | `boardConfig:setDefaultBaseBranch` | invoke | Set the team-shared default base branch in `kangentic.json` |
 
-### Mobile Bridge (10 channels)
+### Mobile Bridge (11 channels)
 Machine-global (like Config), not project-scoped - backs the Mobile Devices settings tab. See [Mobile Bridge](mobile-bridge.md) for the pairing ceremony, roster, capability verbs, and relay transport this group fronts.
 | Channel | Pattern | Purpose |
 |---------|---------|---------|
-| `mobile:getStatus` | invoke | Report bridge status: enabled, secure-storage availability, identity fingerprint, relay URL, paired device count, pairing-in-progress |
+| `mobile:getStatus` | invoke | Report bridge status: enabled, secure-storage availability, identity fingerprint, relay URL, relay transport state, paired device count, pairing-in-progress |
 | `mobile:startPairing` | invoke | Mint a pairing token, connect the pairing relay slot, and return the QR payload URI |
 | `mobile:confirmPairing` | invoke | Confirm the SAS matched; signs the phone's static key into the roster with the given display name and capabilities |
 | `mobile:cancelPairing` | invoke | Cancel an in-progress pairing ceremony |
 | `mobile:listDevices` | invoke | List paired devices (id, display name, capabilities, paired-at) |
 | `mobile:revokeDevice` | invoke | Revoke a paired device: drop it from the signed roster and tear down its session |
 | `mobile:setDeviceCapabilities` | invoke | Update a paired device's granted capability verbs (re-signs the roster entry) |
+| `mobile:testRelay` | invoke | Reachability probe for a candidate relay URL ("Test connection"); validates server-side and never throws |
 | `mobile:pairingSas` | on | Event: the SAS (digits + emoji) to display for the current pairing ceremony |
 | `mobile:pairingEnded` | on | Event: pairing cancelled or failed, with a reason |
 | `mobile:stateChanged` | on | Event: status or device list changed (confirm/revoke/capability update) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -324,8 +324,9 @@ The Mobile Devices tab hosts the desktop half of the mobile companion app's pair
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `mobileBridge.enabled` | boolean | `false` | Master switch. When `false`, no relay connection is held and pairing is unavailable; the relay URL input and pairing controls are disabled in the UI. |
-| `mobileBridge.relayUrl` | string | `''` | The relay address to dial (self-hosted or Kangentic's hosted relay), e.g. `wss://relay.kangentic.com`. |
+| `mobileBridge.enabled` | boolean | `false` | Master switch. When `false`, no relay connection is held and pairing is unavailable; the relay Select and pairing controls are disabled in the UI. |
+| `mobileBridge.relayMode` | `'hosted' \| 'local' \| 'custom'` | `'hosted'` | `'hosted'` always dials the Kangentic-hosted relay (`wss://relay.kangentic.com`), in every build. `'local'` dials `ws://127.0.0.1:8080` - a dev-only option, only offered by the Select in a dev build (see `src/shared/relay.ts`'s `LOCAL_DEV_RELAY_URL`). `'custom'` dials `relayUrl` instead, for self-hosters. |
+| `mobileBridge.relayUrl` | string | `''` | The self-hosted relay to dial. Only consulted when `relayMode === 'custom'`; resolve the actual dial address through `resolveRelayUrl()` rather than reading this key directly - it normalizes the value and falls back to the hosted relay if this is empty or fails validation, so it never resolves to `''`. |
 
 **Actions (not config keys):** the Mobile Devices tab also exposes two settings-registry entries that are UI surfaces, not `AppConfig` keys: **Pair a Device** (registry id `mobileBridge.pairing`) starts the QR pairing ceremony described in [Mobile Bridge](mobile-bridge.md#pairing-ceremony), and **Paired Devices** (registry id `mobileBridge.devices`) lists currently paired phones with their granted capabilities and a revoke action. Both are backed by the `mobile:*` IPC channels and the signed device roster (`src/main/mobile-bridge/roster-store.ts`), not persisted in `AppConfig`.
 

--- a/docs/mobile-bridge.md
+++ b/docs/mobile-bridge.md
@@ -213,7 +213,7 @@ Even a correctly-implemented blind relay is not metadata-invisible. A relay oper
 - Signed device roster with revoke-drop (rekey-on-revoke is scaffolded but the full multi-device re-provisioning flow is deferred).
 - QR pairing ceremony (token-bound Noise PSK + SAS confirmation) with desktop settings UI.
 - The desktop's outbound relay CLIENT connection with reconnect/backoff.
-- Mobile Devices settings tab: enable toggle, relay URL, pairing flow, paired-device list, revoke.
+- Mobile Devices settings tab: enable toggle, relay mode (resolved default vs. custom override) with a Test connection probe, pairing flow, paired-device list, revoke.
 
 **Shipped (Bridge Phase 2 - data feeds, interactive control & capabilities):**
 
@@ -241,6 +241,6 @@ Even a correctly-implemented blind relay is not metadata-invisible. A relay oper
 ## See Also
 
 - [Mobile Companion App Research](research/mobile-companion-app.md) - Full product rationale, transport decision (relay-first), security architecture, notification design, and phasing this doc summarizes.
-- [Architecture > Mobile Bridge](architecture.md#mobile-bridge-10-channels) - IPC channel table.
-- [Configuration](configuration.md) - `AppConfig.mobileBridge` (`enabled`, `relayUrl`).
+- [Architecture > Mobile Bridge](architecture.md#mobile-bridge-11-channels) - IPC channel table.
+- [Configuration](configuration.md) - `AppConfig.mobileBridge` (`enabled`, `relayMode`, `relayUrl`) and `src/shared/relay.ts`'s resolver/validator.
 - [Board Integration](board-integration.md) - The analogous per-provider adapter pattern this bridge's `Transport` swap point mirrors in spirit.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -516,7 +516,7 @@ The Settings > Notifications panel exposes three configurable events: **Agent Id
 
 ### Mobile Devices
 
-The Mobile Devices tab is the desktop half of the mobile companion app's pairing link - global (applies to this desktop installation, not any one project) and off by default. Enable the **Mobile Bridge** toggle and set a **Relay Address** (a self-hosted or Kangentic-hosted relay) before pairing.
+The Mobile Devices tab is the desktop half of the mobile companion app's pairing link - global (applies to this desktop installation, not any one project) and off by default. Enable the **Mobile Bridge** toggle, then pick a **Relay**: *Kangentic Cloud* (the default hosted relay) or *Custom Relay* (your own self-hosted address, entered in the field that appears below). Dev builds also offer a *Local* option pointing at a relay on localhost. The address actually being dialed is shown beneath the picker, and **Test connection** probes it for reachability before you pair. The relay only ever sees encrypted traffic. A custom address must use `wss://`, or `ws://` for localhost only, since the phone refuses to pair over an untrusted transport.
 
 Click **Pair a Device** to display a QR code; scanning it with the Kangentic mobile app starts an end-to-end encrypted pairing handshake. Once the handshake completes, both the desktop and the phone show a short code and emoji sequence - confirm they match on both screens before tapping "Codes match" to finish pairing. This catches a photographed or relayed QR, since an attacker cannot make both sides show the same code. If the codes don't match, or you want to back out, cancel and start over.
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -93,6 +93,8 @@ export {
   type PairingQrPayload,
 } from './pairing/qr';
 
+export { MAX_RELAY_ADDRESS_LENGTH, isSecureRelayAddress } from './pairing/relay-address';
+
 export {
   signRosterEntry,
   verifyRosterEntry,

--- a/packages/protocol/src/pairing/qr.ts
+++ b/packages/protocol/src/pairing/qr.ts
@@ -11,11 +11,13 @@
  */
 import { X25519_KEY_LENGTH, concatBytes } from '../crypto/primitives';
 import { base64UrlDecode, base64UrlEncode } from '../wire/base64url';
+import { MAX_RELAY_ADDRESS_LENGTH } from './relay-address';
+
+export { MAX_RELAY_ADDRESS_LENGTH, isSecureRelayAddress } from './relay-address';
 
 export const PAIRING_URI_SCHEME = 'kangentic-pair';
 const PAYLOAD_VERSION = 1;
 const PAIRING_TOKEN_LENGTH = 32;
-const MAX_RELAY_ADDRESS_LENGTH = 512;
 /** Generous cap on the whole decoded payload - defends against a QR/URI crafted to trigger unbounded allocation before any other validation runs. */
 const MAX_PAYLOAD_LENGTH = 4096;
 

--- a/packages/protocol/src/pairing/relay-address.ts
+++ b/packages/protocol/src/pairing/relay-address.ts
@@ -1,0 +1,29 @@
+/**
+ * Relay address rules shared, byte-for-byte, with the mobile app's
+ * src/pairing/qr.ts. This module imports nothing on purpose: it is
+ * deep-imported by the desktop's src/shared/relay.ts, which the RENDERER
+ * bundles, and pulling in the rest of this package (crypto/primitives ->
+ * @noble/*) would drag Noise crypto into that bundle for no reason. Keep it
+ * dependency-free.
+ */
+
+export const MAX_RELAY_ADDRESS_LENGTH = 512;
+
+const LOOPBACK_WS_PREFIXES = ['ws://localhost', 'ws://127.0.0.1', 'ws://[::1]'];
+
+/**
+ * True if the phone's pairing QR scanner will accept this relay address.
+ * wss:// is always secure; ws:// is accepted only for loopback, since the
+ * pairing token doubles as the Noise PSK and is dialed verbatim as
+ * `?slot=`. Prefix-based (not hostname-based) with an explicit boundary
+ * check, so `ws://localhost.evil.com` - a hostname that merely starts with
+ * the string "localhost" - is rejected rather than treated as loopback.
+ */
+export function isSecureRelayAddress(relayAddress: string): boolean {
+  if (relayAddress.startsWith('wss://')) return true;
+  return LOOPBACK_WS_PREFIXES.some((prefix) => {
+    if (!relayAddress.startsWith(prefix)) return false;
+    const boundaryChar = relayAddress.charAt(prefix.length);
+    return boundaryChar === '' || boundaryChar === ':' || boundaryChar === '/' || boundaryChar === '?' || boundaryChar === '#';
+  });
+}

--- a/src/main/ipc/handlers/mobile-bridge.ts
+++ b/src/main/ipc/handlers/mobile-bridge.ts
@@ -1,5 +1,6 @@
 import { ipcMain } from 'electron';
 import { IPC } from '../../../shared/ipc-channels';
+import { relayHealthUrl, validateRelayUrl } from '../../../shared/relay';
 import type {
   MobileBridgeStatus,
   MobileCapabilityVerb,
@@ -7,8 +8,12 @@ import type {
   MobilePairingEndedPayload,
   MobilePairingSasPayload,
   MobileStartPairingResult,
+  RemoteServerStatus,
 } from '../../../shared/types';
 import type { IpcContext } from '../ipc-context';
+
+/** "Test connection" in the Mobile Devices tab must never hang against a black-holed relay. */
+const RELAY_TEST_TIMEOUT_MS = 5000;
 
 /**
  * Machine-global, not project-scoped - these channels take no trailing
@@ -41,6 +46,32 @@ export function registerMobileBridgeHandlers(context: IpcContext): void {
 
   ipcMain.handle(IPC.MOBILE_SET_DEVICE_CAPABILITIES, (_event, deviceId: string, capabilities: MobileCapabilityVerb[]) => {
     service.setDeviceCapabilities(deviceId, capabilities);
+  });
+
+  // Structurally a probe (mirrors AGENT_PROBE_EXECUTION_SERVER in
+  // handlers/system.ts), not a service delegation like this file's other
+  // handlers - it validates and fetches a candidate URL rather than reading
+  // or touching MobileBridgeService state. Takes the URL as an argument
+  // since testing BEFORE committing a save is the point, so it re-runs
+  // validateRelayUrl server-side rather than trusting the renderer's input.
+  // Never throws: every failure mode resolves to { reachable: false, reason }.
+  ipcMain.handle(IPC.MOBILE_TEST_RELAY, async (_event, relayUrl: string): Promise<RemoteServerStatus> => {
+    const validation = validateRelayUrl(relayUrl);
+    if (!validation.ok) return { reachable: false, reason: validation.reason };
+    try {
+      const response = await fetch(relayHealthUrl(validation.normalized), {
+        method: 'GET',
+        signal: AbortSignal.timeout(RELAY_TEST_TIMEOUT_MS),
+      });
+      if (!response.ok) return { reachable: false, reason: `Relay responded with HTTP ${response.status}` };
+      // Any 2xx counts as reachable: the relay's documented /healthz contract
+      // is `{"status":"ok"}` with no version field, so requiring one would
+      // report a working relay as unreachable.
+      const body = (await response.json().catch(() => null)) as { version?: string } | null;
+      return { reachable: true, version: body?.version ?? null };
+    } catch (error) {
+      return { reachable: false, reason: error instanceof Error ? error.message : 'Unknown error' };
+    }
   });
 
   const sendIfWindowAlive = (channel: string, ...args: unknown[]): void => {

--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -15,6 +15,7 @@ import { applyRuntimeConfig } from '../../config/apply-runtime-config';
 import { listAgents, invalidateAgentListCache } from '../../agent/agent-list';
 import { agentRegistry } from '../../agent/agent-registry';
 import { broadcast } from '../../pop-out/window-broadcast';
+import { resolveRelayUrl } from '../../../shared/relay';
 import type {
   NotificationInput,
   AgentCommand,
@@ -136,7 +137,7 @@ export function registerSystemHandlers(context: IpcContext): void {
       context.mobileBridgeService.reconcile({
         // Dev-only until the mobile app launches (mirrors register-all.ts).
         enabled: __KANGENTIC_DEV__ && (effectiveConfig.mobileBridge?.enabled ?? false),
-        relayUrl: effectiveConfig.mobileBridge?.relayUrl ?? '',
+        relayUrl: resolveRelayUrl(effectiveConfig.mobileBridge),
       });
     }
     // Bare-signal broadcast so every open pop-out window re-fetches via config:get and

--- a/src/main/ipc/register-all.ts
+++ b/src/main/ipc/register-all.ts
@@ -46,6 +46,7 @@ import { MobileBridgeService } from '../mobile-bridge/mobile-bridge-service';
 import { BoardEventBus } from '../mobile-bridge/board-event-bus';
 import { DesktopNotifier } from '../notifications/desktop-notifier';
 import { getProjectRepos } from './helpers';
+import { KANGENTIC_HOSTED_RELAY_URL, resolveRelayUrl } from '../../shared/relay';
 import type { IpcContext } from './ipc-context';
 import type { McpHttpServerHandle } from '../agent/mcp-http-server';
 
@@ -94,7 +95,7 @@ export function registerAllIpc(mainWindow: BrowserWindow, mcpServerHandle: McpHt
   // after `context` (and its configManager getter) is constructed below,
   // since MobileBridgeService's constructor needs a config synchronously
   // but configManager itself is only available once `context` exists.
-  const mobileBridgeService = new MobileBridgeService({ enabled: false, relayUrl: '' });
+  const mobileBridgeService = new MobileBridgeService({ enabled: false, relayUrl: KANGENTIC_HOSTED_RELAY_URL });
   const boardEvents = new BoardEventBus();
   // Owns the desktop idle/crash notification decision (cooldown, focus gate,
   // active-project gate, title assembly). Every option closure goes through
@@ -183,7 +184,7 @@ export function registerAllIpc(mainWindow: BrowserWindow, mcpServerHandle: McpHt
     // enables the bridge regardless of persisted config (paired gates:
     // system.ts's config:set reconcile and the renderer's settings tab).
     enabled: __KANGENTIC_DEV__ && (effectiveConfig.mobileBridge?.enabled ?? false),
-    relayUrl: effectiveConfig.mobileBridge?.relayUrl ?? '',
+    relayUrl: resolveRelayUrl(effectiveConfig.mobileBridge),
   });
 
   registerProjectHandlers(context);

--- a/src/main/mobile-bridge/mobile-bridge-service.ts
+++ b/src/main/mobile-bridge/mobile-bridge-service.ts
@@ -12,6 +12,8 @@ import {
   type ShortAuthenticationString,
 } from '@kangentic/protocol';
 import { isGenuineEncryptionAvailable } from '../boards/shared/auth';
+import { validateRelayUrl } from '../../shared/relay';
+import type { MobileBridgeStatus, MobileBridgeTransportState } from '../../shared/types';
 import { DevQuickPair } from './dev-quick-pair';
 import { DiffWatcher } from '../git/diff-watcher';
 import { loadBridgeIdentity, loadOrCreateBridgeIdentity, type BridgeIdentity } from './identity';
@@ -38,15 +40,17 @@ export interface MobileBridgeConfig {
   relayUrl: string;
 }
 
-export interface MobileBridgeStatus {
-  enabled: boolean;
-  secureStorageAvailable: boolean;
-  /** Hex-encoded static public key, for display/verification - never the private key. */
-  identityFingerprint: string | null;
-  relayUrl: string;
-  pairedDeviceCount: number;
-  pairingInProgress: boolean;
-}
+/** MobileBridgeStatus is defined once, in src/shared/types.ts (the renderer needs the same shape) - this file only builds and returns it. */
+
+/**
+ * RelayClient cycles connecting<->reconnecting on a 500ms backoff while a
+ * relay is unreachable; without coalescing, every device's transport flap
+ * would fire 'stateChanged' (which the renderer answers with a status +
+ * devices re-fetch) up to twice a second. A device's relayState is always
+ * readable synchronously via getStatus() regardless of this window - only
+ * the CHANGE NOTIFICATION is throttled, not the value itself.
+ */
+const RELAY_STATE_EMIT_WINDOW_MS = 500;
 
 export interface PairedDeviceSummary {
   deviceId: string;
@@ -95,7 +99,7 @@ export class MobileBridgeService extends EventEmitter {
     getRelayUrl: () => this.config.relayUrl,
     onRosterChanged: () => {
       void this.syncSessions();
-      this.emit('stateChanged');
+      this.emitStateChanged();
     },
   });
   private ipcContext: IpcContext | null = null;
@@ -107,6 +111,9 @@ export class MobileBridgeService extends EventEmitter {
   private pushNotifier: PushNotifier | null = null;
   /** Fires PushNotifier.notifyTaskStalled() when a task's spawn sits in-flight past the stall threshold. */
   private spawnStallWatcher: SpawnStallWatcher | null = null;
+  /** The aggregate relayState most recently emitted via 'stateChanged', so RELAY_STATE_EMIT_WINDOW_MS only re-emits on an actual value change, not on every transport flap. */
+  private lastEmittedRelayState: MobileBridgeTransportState | null = null;
+  private relayStateEmitTimer: ReturnType<typeof setTimeout> | null = null;
   private disposed = false;
 
   constructor(config: MobileBridgeConfig) {
@@ -202,7 +209,10 @@ export class MobileBridgeService extends EventEmitter {
     const wasEnabled = this.config.enabled;
     this.config = config;
     if (__KANGENTIC_DEV__) {
-      this.devQuickPair.reconcile(config.enabled && config.relayUrl.length > 0 && isGenuineEncryptionAvailable());
+      // config.relayUrl is always resolved (see src/shared/relay.ts's
+      // resolveRelayUrl at both reconcile() call sites) and therefore never
+      // '', so there is no longer a meaningful empty-URL case to gate on here.
+      this.devQuickPair.reconcile(config.enabled && isGenuineEncryptionAvailable());
     }
     if (!config.enabled && wasEnabled) {
       this.cancelPairing('Mobile bridge disabled');
@@ -333,6 +343,63 @@ export class MobileBridgeService extends EventEmitter {
       this.subscriptionsByDevice.get(deviceId)?.dispose();
       this.subscriptionsByDevice.delete(deviceId);
     });
+    session.on('transportState', () => this.scheduleRelayStateEmit());
+  }
+
+  /**
+   * Precedence connected > connecting > reconnecting > closed, so any one
+   * healthy device reads as healthy overall; 'idle' when there are no
+   * sessions. Deliberately excludes the ephemeral pairing transport (see
+   * startPairing()) - it has its own error surface via 'pairingEnded', and
+   * including it would flap this steady-state field during every pairing
+   * ceremony.
+   */
+  private aggregateRelayState(): MobileBridgeTransportState {
+    if (this.sessions.size === 0) return 'idle';
+    const states = new Set<MobileBridgeTransportState>();
+    for (const session of this.sessions.values()) states.add(session.transportState);
+    if (states.has('connected')) return 'connected';
+    if (states.has('connecting')) return 'connecting';
+    if (states.has('reconnecting')) return 'reconnecting';
+    if (states.has('closed')) return 'closed';
+    return 'idle';
+  }
+
+  /**
+   * Coalesces bursts of per-session transport-state churn into at most one
+   * 'stateChanged' emission per RELAY_STATE_EMIT_WINDOW_MS, and only when
+   * the AGGREGATE actually changed - not a plain debounce (which would
+   * reset on every flap and could delay delivery indefinitely under
+   * sustained backoff churn), a throttle: the first change in a window
+   * schedules a check at the end of that window, and further changes
+   * during the window are absorbed into it.
+   */
+  private scheduleRelayStateEmit(): void {
+    if (this.relayStateEmitTimer) return;
+    this.relayStateEmitTimer = setTimeout(() => {
+      this.relayStateEmitTimer = null;
+      if (this.aggregateRelayState() === this.lastEmittedRelayState) return;
+      this.emitStateChanged();
+    }, RELAY_STATE_EMIT_WINDOW_MS);
+    this.relayStateEmitTimer.unref?.();
+  }
+
+  /**
+   * The ONLY way this service emits 'stateChanged'. Rebaselines
+   * lastEmittedRelayState so the throttle above always compares against what
+   * the renderer was last actually told.
+   *
+   * A bare this.emit('stateChanged') leaves that baseline stale, and the
+   * throttle then suppresses a later REAL transition as a no-op change. The
+   * concrete failure: connect device A (baseline := 'connected'), revoke it
+   * (direct emit, aggregate now 'idle', baseline still 'connected'), pair
+   * device B - when B reaches 'connected' the throttle compares 'connected'
+   * against the stale 'connected', suppresses, and the indicator stays stuck
+   * on "Connecting..." forever.
+   */
+  private emitStateChanged(): void {
+    this.lastEmittedRelayState = this.aggregateRelayState();
+    this.emit('stateChanged');
   }
 
   private disposeSession(deviceId: string): void {
@@ -379,6 +446,9 @@ export class MobileBridgeService extends EventEmitter {
       relayUrl: this.config.relayUrl,
       pairedDeviceCount,
       pairingInProgress: this.activePairing !== null,
+      // Computed fresh every call - only the CHANGE NOTIFICATION
+      // ('stateChanged') is throttled, never the value itself.
+      relayState: this.aggregateRelayState(),
     };
   }
 
@@ -410,7 +480,7 @@ export class MobileBridgeService extends EventEmitter {
     // flow for any remaining paired devices is Phase 2/3 scope once there
     // is more than a single paired device to reason about in practice.
     // Phase 1 ships the roster-side "drop" half.
-    this.emit('stateChanged');
+    this.emitStateChanged();
   }
 
   setDeviceCapabilities(deviceId: string, capabilities: CapabilityVerb[]): void {
@@ -419,12 +489,18 @@ export class MobileBridgeService extends EventEmitter {
     setDeviceCapabilitiesInRoster(identity, deviceId, capabilities);
     const session = this.sessions.get(deviceId);
     if (session) session.capabilities = capabilitySetFromArray(capabilities);
-    this.emit('stateChanged');
+    this.emitStateChanged();
   }
 
   async startPairing(): Promise<{ qrPayload: PairingQrPayload; qrUri: string }> {
     if (!this.config.enabled) throw new Error('Mobile bridge is not enabled');
     if (this.activePairing) throw new Error('A pairing ceremony is already in progress');
+    // Both reconcile() call sites resolve relayUrl through resolveRelayUrl()
+    // before it ever reaches this.config, so this should be unreachable in
+    // practice - it is insurance against minting a QR the phone will refuse,
+    // not the primary validation path.
+    const relayValidation = validateRelayUrl(this.config.relayUrl);
+    if (!relayValidation.ok) throw new Error(`Cannot start pairing: ${relayValidation.reason}`);
 
     const identity = this.ensureIdentity();
     const pairingService = new PairingService(identity);
@@ -442,7 +518,7 @@ export class MobileBridgeService extends EventEmitter {
     pairingService.once('confirmed', () => {
       this.activePairing = null;
       this.pendingPairingDeviceId = null;
-      this.emit('stateChanged');
+      this.emitStateChanged();
       // The freshly-paired device is now in the roster; open its
       // BridgeSession immediately rather than waiting for the next
       // config-driven reconcile() (which may not happen again this run).
@@ -509,6 +585,10 @@ export class MobileBridgeService extends EventEmitter {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    if (this.relayStateEmitTimer) {
+      clearTimeout(this.relayStateEmitTimer);
+      this.relayStateEmitTimer = null;
+    }
     this.devQuickPair.stop();
     this.sessionLifecycleFeed?.dispose();
     this.sessionLifecycleFeed = null;

--- a/src/main/mobile-bridge/session/bridge-session.ts
+++ b/src/main/mobile-bridge/session/bridge-session.ts
@@ -80,6 +80,11 @@ export class BridgeSession extends EventEmitter {
     return this.streams !== null;
   }
 
+  /** The underlying transport's current connection state, for the service's aggregate MobileBridgeStatus.relayState. */
+  get transportState(): TransportState {
+    return this.transport.state;
+  }
+
   start(): void {
     if (this.unsubscribeFrame) throw new Error('BridgeSession.start() called twice');
     this.unsubscribeFrame = this.transport.onFrame((frame) => this.onFrame(frame));
@@ -98,6 +103,10 @@ export class BridgeSession extends EventEmitter {
 
   private onTransportState(state: TransportState): void {
     if (this.disposed) return;
+    // Emitted before the branch below (and its early return) so every
+    // transition - including into 'connected' - reaches the service's
+    // relayState aggregation, not just the ones that fall through.
+    this.emit('transportState', state);
     if (state === 'connected') {
       // A reconnect (the initial connect was handled in start()). Re-initiate
       // immediately so the phone re-establishes in ~1s instead of waiting out

--- a/src/main/mobile-bridge/transport/relay-client.ts
+++ b/src/main/mobile-bridge/transport/relay-client.ts
@@ -70,7 +70,20 @@ export class RelayClient implements Transport {
 
   private dial(): Promise<void> {
     this.setState(this.currentState === 'idle' ? 'connecting' : 'reconnecting');
-    const url = `${this.relayUrl}${this.relayUrl.includes('?') ? '&' : '?'}slot=${encodeURIComponent(this.slotId)}`;
+
+    let url: URL;
+    try {
+      url = new URL(this.relayUrl);
+    } catch (error) {
+      // A malformed relayUrl is a configuration bug, not a transient network
+      // hiccup - src/shared/relay.ts's resolveRelayUrl() guarantees a valid
+      // URL reaches every real caller, so this should be unreachable in
+      // practice. Fail the connect() immediately rather than entering the
+      // 500ms->30s backoff loop against a URL that can never parse.
+      this.setState('closed');
+      return Promise.reject(error instanceof Error ? error : new Error(`Invalid relay URL: ${String(error)}`));
+    }
+    url.searchParams.set('slot', this.slotId);
 
     return new Promise<void>((resolve, reject) => {
       // Wrap resolve/reject so the pendingDialReject pointer is cleared once
@@ -91,7 +104,7 @@ export class RelayClient implements Transport {
 
       let socket: WebSocket;
       try {
-        socket = new WebSocket(url);
+        socket = new WebSocket(url.href);
       } catch (error) {
         this.scheduleReconnect();
         rejectOnce(error instanceof Error ? error : new Error(String(error)));

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -449,6 +449,7 @@ const api: ElectronAPI = {
     listDevices: () => ipcRenderer.invoke(IPC.MOBILE_LIST_DEVICES),
     revokeDevice: (deviceId) => ipcRenderer.invoke(IPC.MOBILE_REVOKE_DEVICE, deviceId),
     setDeviceCapabilities: (deviceId, capabilities) => ipcRenderer.invoke(IPC.MOBILE_SET_DEVICE_CAPABILITIES, deviceId, capabilities),
+    testRelay: (relayUrl) => ipcRenderer.invoke(IPC.MOBILE_TEST_RELAY, relayUrl),
     onPairingSas: (callback) => {
       const handler = (_event: Electron.IpcRendererEvent, payload: MobilePairingSasPayload) => callback(payload);
       ipcRenderer.on(IPC.MOBILE_PAIRING_SAS, handler);

--- a/src/renderer/components/settings/settings-registry.ts
+++ b/src/renderer/components/settings/settings-registry.ts
@@ -154,7 +154,8 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
   ...(__KANGENTIC_DEV__
     ? ([
         { id: 'mobileBridge.enabled', tabId: 'mobile', label: 'Mobile Bridge', description: 'Let a paired phone connect to this desktop through an end-to-end encrypted relay.', scope: 'global', keywords: ['mobile', 'phone', 'companion', 'pair', 'pairing', 'qr', 'relay', 'bridge', 'remote'] },
-        { id: 'mobileBridge.relayUrl', tabId: 'mobile', label: 'Relay Address', description: 'The relay this desktop connects to (self-hosted or Kangentic-hosted). The relay only ever sees encrypted traffic.', scope: 'global', keywords: ['relay', 'server', 'url', 'address', 'self-host', 'websocket', 'mobile'] },
+        { id: 'mobileBridge.relayMode', tabId: 'mobile', label: 'Relay', description: 'Where this desktop connects for mobile pairing. The relay only ever sees encrypted traffic.', scope: 'global', keywords: ['relay', 'server', 'hosted', 'local', 'custom', 'self-host', 'cloud', 'mobile', 'kangentic cloud'] },
+        { id: 'mobileBridge.relayUrl', tabId: 'mobile', label: 'Custom Relay Address', description: 'The self-hosted relay to dial when Relay above is set to Custom Relay.', scope: 'global', keywords: ['relay', 'server', 'url', 'address', 'self-host', 'websocket', 'mobile', 'custom'] },
         { id: 'mobileBridge.pairing', tabId: 'mobile', label: 'Pair a Device', description: 'Scan a QR code with the Kangentic mobile app to pair a new phone.', scope: 'global', keywords: ['pair', 'pairing', 'qr', 'scan', 'phone', 'mobile', 'sas', 'code'] },
         { id: 'mobileBridge.devices', tabId: 'mobile', label: 'Paired Devices', description: 'Phones paired to this desktop, their granted capabilities, and revocation.', scope: 'global', keywords: ['paired', 'devices', 'phone', 'revoke', 'capabilities', 'mobile'] },
       ] satisfies SettingDefinition[])

--- a/src/renderer/components/settings/tabs/MobileDevicesTab.tsx
+++ b/src/renderer/components/settings/tabs/MobileDevicesTab.tsx
@@ -1,11 +1,33 @@
-import { useEffect, useState } from 'react';
-import { Check, Copy, QrCode, Smartphone, Trash2 } from 'lucide-react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { Check, CircleAlert, Copy, Loader2, QrCode, Server, Smartphone, Trash2 } from 'lucide-react';
 import QRCode from 'qrcode';
-import { MOBILE_CAPABILITY_VERBS, type AppConfig, type MobileCapabilityVerb, type MobilePairedDevice } from '../../../../shared/types';
-import { CompactToggleList, INPUT_CLASS, SectionHeader, SettingRow, SettingToggleRow, useScopedUpdate } from '../shared';
+import { MOBILE_CAPABILITY_VERBS, type AppConfig, type MobileBridgeTransportState, type MobileCapabilityVerb, type MobilePairedDevice, type RemoteServerStatus } from '../../../../shared/types';
+import { inferRelayMode, resolveRelayUrl, validateRelayUrl } from '../../../../shared/relay';
+import { CompactToggleList, INPUT_CLASS, SectionHeader, Select, SettingRow, SettingToggleRow, useScopedUpdate } from '../shared';
+import { Pill } from '../../Pill';
 import { settingProps } from '../settings-registry';
 import { ConfirmDialog } from '../../dialogs/ConfirmDialog';
 import { useMobileStore } from '../../../stores/mobile-store';
+
+/**
+ * 'idle' means no paired device has a session open yet (nothing to report -
+ * the "Paired Devices" list is empty), so it renders nothing rather than a
+ * confusing "Disconnected" for a desktop with no devices at all.
+ */
+function relayStatusDisplay(relayState: MobileBridgeTransportState): { label: string; className: string; icon: ReactNode } | null {
+  switch (relayState) {
+    case 'connected':
+      return { label: 'Connected', className: 'text-green-400', icon: <Check size={12} /> };
+    case 'connecting':
+      return { label: 'Connecting…', className: 'text-amber-400', icon: <Loader2 size={12} className="animate-spin" /> };
+    case 'reconnecting':
+      return { label: 'Reconnecting…', className: 'text-amber-400', icon: <Loader2 size={12} className="animate-spin" /> };
+    case 'closed':
+      return { label: 'Disconnected', className: 'text-danger', icon: <CircleAlert size={12} /> };
+    case 'idle':
+      return null;
+  }
+}
 
 /** Short label + blurb per verb, for the per-device capability toggle list. Keyed off MOBILE_CAPABILITY_VERBS so a new verb is a compile error here until classified. */
 const CAPABILITY_LABELS: Record<MobileCapabilityVerb, { label: string; description: string }> = {
@@ -24,7 +46,19 @@ const CAPABILITY_LABELS: Record<MobileCapabilityVerb, { label: string; descripti
 export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) {
   const updateGlobal = useScopedUpdate('global');
   const enabled = globalConfig.mobileBridge?.enabled ?? false;
-  const relayUrl = globalConfig.mobileBridge?.relayUrl ?? '';
+  const relayMode = inferRelayMode(globalConfig.mobileBridge);
+  const resolvedRelayUrl = resolveRelayUrl(globalConfig.mobileBridge);
+
+  // Local draft with a commit boundary (blur/Enter), not a per-keystroke write:
+  // each committed relayUrl change disposes and redials every bridge session
+  // (mobile-bridge-service.ts's reconcile()), so typing a URL character by
+  // character used to do that on every keystroke.
+  const [relayDraft, setRelayDraft] = useState(globalConfig.mobileBridge?.relayUrl ?? '');
+  const [relayDraftError, setRelayDraftError] = useState<string | null>(null);
+  const [testingRelay, setTestingRelay] = useState(false);
+  const [relayTestResult, setRelayTestResult] = useState<RemoteServerStatus | null>(null);
+  /** Identifies the in-flight "Test connection" probe so a reply for a relay the user has since navigated away from is discarded rather than shown. Bumped on every retarget. */
+  const relayTestRequestRef = useRef(0);
 
   const status = useMobileStore((state) => state.status);
   const devices = useMobileStore((state) => state.devices);
@@ -122,6 +156,51 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
     setDeviceNameDraft('');
   };
 
+  const commitRelayDraft = () => {
+    const trimmed = relayDraft.trim();
+    if (trimmed.length === 0) {
+      // Empty draft: resolveRelayUrl falls back to the built-in default, so
+      // this is a valid "no custom URL yet" state, not an error.
+      setRelayDraftError(null);
+      updateGlobal({ mobileBridge: { relayMode: 'custom', relayUrl: '' } });
+      return;
+    }
+    const validation = validateRelayUrl(trimmed);
+    if (!validation.ok) {
+      setRelayDraftError(validation.reason);
+      return;
+    }
+    setRelayDraftError(null);
+    setRelayDraft(validation.normalized);
+    updateGlobal({ mobileBridge: { relayMode: 'custom', relayUrl: validation.normalized } });
+  };
+
+  const handleTestRelay = async () => {
+    const urlToTest = relayMode === 'custom' ? relayDraft.trim() : resolvedRelayUrl;
+    const requestId = ++relayTestRequestRef.current;
+    setTestingRelay(true);
+    try {
+      const result = await window.electronAPI.mobile.testRelay(urlToTest);
+      // Neither the mode Select nor the URL input is disabled during a probe,
+      // and the probe has a 5s timeout budget, so the user can retarget while
+      // one is in flight. Their onChange already cleared the result slot and
+      // invalidated this request; without the guard the late reply would
+      // repopulate that slot with a verdict for a URL they navigated away from.
+      if (relayTestRequestRef.current !== requestId) return;
+      setRelayTestResult(result);
+    } finally {
+      // Unconditional on purpose. The button is disabled while testingRelay is
+      // true, so there is only ever one probe in flight and it always owns the
+      // spinner. Guarding this on requestId (as the result assignment above
+      // correctly is) would strand testingRelay=true forever whenever the user
+      // retargets mid-probe, leaving the button disabled and spinning until
+      // the tab remounts.
+      setTestingRelay(false);
+    }
+  };
+
+  const relayStatus = status ? relayStatusDisplay(status.relayState) : null;
+
   return (
     <div className="space-y-4">
       <SettingToggleRow
@@ -132,16 +211,96 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
       />
 
       <div className={enabled ? 'space-y-4' : 'space-y-4 opacity-40 pointer-events-none'}>
-        <SettingRow {...settingProps('mobileBridge.relayUrl')}>
-          <input
-            type="text"
-            className={INPUT_CLASS}
-            value={relayUrl}
-            placeholder="wss://relay.example.com"
-            disabled={!enabled}
-            onChange={(event) => updateGlobal({ mobileBridge: { relayUrl: event.target.value } })}
-          />
+        <SettingRow {...settingProps('mobileBridge.relayMode')}>
+          <div className="flex gap-2 items-start">
+            <div className="flex-1 flex flex-col gap-2">
+              <Select
+                value={relayMode}
+                onChange={(event) => {
+                  // A stale reachability result from the previous mode must not
+                  // linger next to a mode/URL it was never actually run against.
+                  // Bumping the ref also discards a probe still in flight for
+                  // the old mode, which would otherwise land after this clear.
+                  relayTestRequestRef.current++;
+                  setRelayTestResult(null);
+                  updateGlobal({ mobileBridge: { relayMode: event.target.value as 'hosted' | 'local' | 'custom' } });
+                }}
+                disabled={!enabled}
+                data-testid="mobile-relay-mode"
+              >
+                {__KANGENTIC_DEV__ && <option value="local">Local</option>}
+                <option value="hosted">Kangentic Cloud</option>
+                <option value="custom">Custom Relay</option>
+              </Select>
+              {relayMode !== 'custom' && (
+                <Pill size="sm" className="self-start bg-surface-hover/60 text-fg-faint font-mono" data-testid="mobile-relay-resolved-url">
+                  {resolvedRelayUrl}
+                </Pill>
+              )}
+            </div>
+            <div className="shrink-0 flex flex-col items-start gap-1">
+              <button
+                type="button"
+                onClick={() => void handleTestRelay()}
+                disabled={testingRelay || !enabled || (relayMode === 'custom' && relayDraft.trim().length === 0)}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded border border-edge-input bg-surface-hover text-fg-secondary hover:text-fg disabled:opacity-50 disabled:cursor-not-allowed"
+                data-testid="mobile-relay-test-connection"
+              >
+                {testingRelay ? <Loader2 size={13} className="animate-spin" /> : <Server size={13} />}
+                Test connection
+              </button>
+              {/* Fixed-height slot, always present: the result pill must not
+                  reflow the resolved-URL row next to it when a test result
+                  appears/disappears or flips between the two pill widths. */}
+              <div className="h-6 flex items-center">
+                {relayTestResult && (
+                  relayTestResult.reachable ? (
+                    <Pill size="sm" className="bg-green-500/15 text-green-400">
+                      <Check size={11} />
+                      {relayTestResult.version ? `v${relayTestResult.version}` : 'Reachable'}
+                    </Pill>
+                  ) : (
+                    <Pill size="sm" className="bg-amber-500/15 text-amber-400" title={relayTestResult.reason}>
+                      <CircleAlert size={11} />
+                      No response
+                    </Pill>
+                  )
+                )}
+              </div>
+            </div>
+          </div>
         </SettingRow>
+
+        {relayMode === 'custom' && (
+          <SettingRow {...settingProps('mobileBridge.relayUrl')}>
+            <div className="ml-1 space-y-2 border-l border-edge pl-3" data-testid="mobile-relay-custom-fields">
+              <input
+                type="text"
+                className={INPUT_CLASS}
+                value={relayDraft}
+                placeholder="wss://relay.example.com"
+                disabled={!enabled}
+                data-testid="mobile-relay-url-input"
+                onChange={(event) => {
+                  setRelayDraft(event.target.value);
+                  setRelayDraftError(null);
+                  // Same in-flight invalidation as the mode Select above.
+                  relayTestRequestRef.current++;
+                  setRelayTestResult(null);
+                }}
+                onBlur={commitRelayDraft}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') event.currentTarget.blur();
+                }}
+              />
+              {relayDraftError && (
+                <p className="text-xs text-danger" data-testid="mobile-relay-url-error">
+                  {relayDraftError}
+                </p>
+              )}
+            </div>
+          </SettingRow>
+        )}
 
         {status && !status.secureStorageAvailable && (
           <p className="text-xs text-danger">
@@ -225,6 +384,12 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
         )}
 
         <SectionHeader label="Paired Devices" searchIds={['mobileBridge.devices']} />
+        {devices.length > 0 && relayStatus && (
+          <p className={`text-xs flex items-center gap-1 -mt-1 ${relayStatus.className}`} data-testid="mobile-relay-status">
+            {relayStatus.icon}
+            Relay: {relayStatus.label}
+          </p>
+        )}
         {devices.length === 0 ? (
           <p className="text-sm text-fg-faint">No devices paired yet.</p>
         ) : (

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -225,6 +225,7 @@ export const IPC = {
   MOBILE_LIST_DEVICES: 'mobile:listDevices',
   MOBILE_REVOKE_DEVICE: 'mobile:revokeDevice',
   MOBILE_SET_DEVICE_CAPABILITIES: 'mobile:setDeviceCapabilities',
+  MOBILE_TEST_RELAY: 'mobile:testRelay',
   MOBILE_PAIRING_SAS: 'mobile:pairingSas',
   MOBILE_PAIRING_ENDED: 'mobile:pairingEnded',
   MOBILE_STATE_CHANGED: 'mobile:stateChanged',

--- a/src/shared/relay.ts
+++ b/src/shared/relay.ts
@@ -1,0 +1,125 @@
+/**
+ * Relay address resolution and validation, shared by the renderer (Mobile
+ * Devices settings tab) and the main process (mobile-bridge reconcile,
+ * pairing, dial). Deep-imports the dependency-free
+ * @kangentic/protocol/pairing/relay-address leaf rather than the package
+ * root, so the renderer bundle does not pull in the rest of the protocol
+ * package's crypto (@noble/*) - see relay-address.ts's own header.
+ */
+import { MAX_RELAY_ADDRESS_LENGTH, isSecureRelayAddress } from '@kangentic/protocol/pairing/relay-address';
+import type { AppConfig } from './types';
+
+export const KANGENTIC_HOSTED_RELAY_URL = 'wss://relay.kangentic.com';
+export const LOCAL_DEV_RELAY_URL = 'ws://127.0.0.1:8080';
+
+export type RelayUrlValidation = { ok: true; normalized: string } | { ok: false; reason: string };
+
+/**
+ * Mirrors the phone's pairing QR scanner exactly (see
+ * @kangentic/protocol/pairing/relay-address's isSecureRelayAddress), applied
+ * to the NORMALIZED value rather than the raw draft. That ordering matters:
+ * `new URL()` canonicalizes IPv4/IPv6 spellings (`ws://127.1` ->
+ * `ws://127.0.0.1/`) before the TLS/loopback check runs, so the value that
+ * passes here, gets persisted, and gets embedded in the pairing QR is always
+ * the exact string the phone will independently accept. Checking the raw
+ * string instead would accept encodings the phone rejects.
+ */
+export function validateRelayUrl(raw: string): RelayUrlValidation {
+  if (raw.includes('\\')) {
+    return { ok: false, reason: 'Relay address cannot contain a backslash.' };
+  }
+  // Byte length, not character length, to agree with the protocol package's
+  // own cap (packages/protocol/src/pairing/qr.ts encodes relayAddress with
+  // the same TextEncoder byte count) - a multi-byte URL that passes a
+  // character-length check can still overflow the QR payload.
+  if (new TextEncoder().encode(raw).length > MAX_RELAY_ADDRESS_LENGTH) {
+    return { ok: false, reason: `Relay address is too long (max ${MAX_RELAY_ADDRESS_LENGTH} bytes).` };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(raw.trim());
+  } catch {
+    return { ok: false, reason: 'Enter a full relay URL, e.g. wss://relay.example.com.' };
+  }
+
+  if (url.hash) {
+    return { ok: false, reason: 'Relay address cannot include a #fragment; the pairing slot is carried in the query string.' };
+  }
+  if (url.username || url.password) {
+    return { ok: false, reason: 'Relay address cannot include a username or password.' };
+  }
+
+  const normalized = url.href;
+  // Re-check the cap against the NORMALIZED value, not just the raw draft.
+  // Normalization can grow the string (an authority-only URL gains a trailing
+  // '/'), so a raw input at exactly the cap can normalize past it. `normalized`
+  // is what gets persisted and embedded in the pairing QR, so letting an
+  // over-cap value through here would both overflow the QR payload and fail
+  // this same check on every later resolveRelayUrl() - silently falling back
+  // to the hosted relay with no error surfaced anywhere in the UI.
+  if (new TextEncoder().encode(normalized).length > MAX_RELAY_ADDRESS_LENGTH) {
+    return { ok: false, reason: `Relay address is too long (max ${MAX_RELAY_ADDRESS_LENGTH} bytes).` };
+  }
+  if (!isSecureRelayAddress(normalized)) {
+    return {
+      ok: false,
+      reason: 'Your phone will refuse to pair with a relay that is not using TLS. Use wss://, or ws:// only for localhost, 127.0.0.1, or [::1].',
+    };
+  }
+
+  return { ok: true, normalized };
+}
+
+/**
+ * The relay mode a config actually behaves as. `relayMode` missing but
+ * `relayUrl` set means the value was saved under the pre-relayMode schema, so
+ * it is treated as 'custom' rather than silently dropped - that inference is
+ * the ONLY thing keeping an upgrading self-hoster on their own relay, since
+ * DEFAULT_CONFIG deliberately does not seed a relayMode (see the comment on
+ * DEFAULT_CONFIG.mobileBridge in src/shared/types.ts).
+ *
+ * Shared rather than duplicated on purpose: the settings tab's Select and the
+ * dialer must agree on the mode, or the UI reports a relay the bridge is not
+ * actually connected to.
+ */
+export function inferRelayMode(bridge: AppConfig['mobileBridge']): 'hosted' | 'local' | 'custom' {
+  if (bridge?.relayMode) return bridge.relayMode;
+  return (bridge?.relayUrl ?? '').length > 0 ? 'custom' : 'hosted';
+}
+
+/**
+ * Resolves the relay URL a bridge session should actually dial. Always
+ * returns a normalized, valid URL - never the stored `relayUrl` verbatim,
+ * and never ''. An empty or invalid custom URL falls back to the hosted relay
+ * rather than reaching a WebSocket dial.
+ *
+ * 'local' is unconditional (not gated on __KANGENTIC_DEV__ here) because the
+ * whole mobile-bridge feature - the settings tab, the registry entry that
+ * lets 'local' be selected, and the reconcile sites that read this config -
+ * is already __KANGENTIC_DEV__-gated end to end. A stray 'local' value can
+ * only exist in a dev build's config.
+ */
+export function resolveRelayUrl(bridge: AppConfig['mobileBridge']): string {
+  const storedUrl = bridge?.relayUrl ?? '';
+  switch (inferRelayMode(bridge)) {
+    case 'local':
+      return LOCAL_DEV_RELAY_URL;
+    case 'custom': {
+      const validation = validateRelayUrl(storedUrl);
+      return validation.ok ? validation.normalized : KANGENTIC_HOSTED_RELAY_URL;
+    }
+    case 'hosted':
+    default:
+      return KANGENTIC_HOSTED_RELAY_URL;
+  }
+}
+
+/** ws -> http, wss -> https, path fixed to /healthz (the relay's health endpoint lives at the server root regardless of the dial path), query preserved. */
+export function relayHealthUrl(relayUrl: string): string {
+  const url = new URL(relayUrl);
+  url.protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
+  url.pathname = '/healthz';
+  url.hash = '';
+  return url.href;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2062,7 +2062,13 @@ export interface AppConfig {
   mobileBridge?: {
     /** Master switch. When false, no relay connection is held and pairing is unavailable. Default false. */
     enabled?: boolean;
-    /** The relay address to dial (self-hosted or Kangentic's hosted relay), e.g. "wss://relay.kangentic.com". */
+    /**
+     * 'hosted' dials the Kangentic-hosted relay; 'local' dials a relay
+     * running on 127.0.0.1 (dev builds only - see src/shared/relay.ts's
+     * LOCAL_DEV_RELAY_URL); 'custom' uses relayUrl. Default 'hosted'.
+     */
+    relayMode?: 'hosted' | 'local' | 'custom';
+    /** The relay address to dial. Only consulted when relayMode === 'custom'; resolve through src/shared/relay.ts's resolveRelayUrl rather than reading this directly. */
     relayUrl?: string;
   };
 
@@ -2312,6 +2318,18 @@ export const DEFAULT_CONFIG: AppConfig = {
     experience: 'popup',
   },
   mobileBridge: {
+    // relayMode is deliberately ABSENT, not 'hosted'. ConfigManager.load()
+    // deep-merges this default with the parsed config file key-by-key
+    // (mobileBridge is not a CONFIG_DICTIONARY_PATHS entry, so it is not
+    // replaced wholesale), which means any value set here fills in over a
+    // config written before relayMode existed. Seeding 'hosted' therefore
+    // defeated resolveRelayUrl's "relayMode missing but relayUrl set =>
+    // custom" compat inference (src/shared/relay.ts) for exactly the users it
+    // was written for: a self-hoster upgrading from the pre-relayMode schema
+    // would silently be switched onto the Kangentic-hosted relay. Leaving it
+    // undefined lets that inference run. An explicit user choice still
+    // persists a concrete mode, and a fresh config with no relayUrl resolves
+    // to hosted anyway.
     enabled: false,
     relayUrl: '',
   },
@@ -2556,7 +2574,20 @@ export interface MobileBridgeStatus {
   relayUrl: string;
   pairedDeviceCount: number;
   pairingInProgress: boolean;
+  /**
+   * Aggregate transport state across every paired device's live relay
+   * connection: 'connected' if any is connected, else 'connecting' if any
+   * is connecting, else 'reconnecting' if any is reconnecting, else
+   * 'closed' if any is closed, else 'idle' when there are no sessions.
+   * Excludes the ephemeral pairing transport, which has its own error
+   * surface via the pairingEnded event. So a paired device whose relay is
+   * unreachable does not render as healthy.
+   */
+  relayState: MobileBridgeTransportState;
 }
+
+/** Mirrors @kangentic/protocol's TransportState - re-declared here (not re-exported) so src/shared/types.ts stays free of a protocol-package runtime dependency; only the string union shape needs to match. */
+export type MobileBridgeTransportState = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'closed';
 
 export interface MobileStartPairingResult {
   /** The `kangentic-pair://...` URI to render as a QR code. */
@@ -3882,6 +3913,10 @@ export interface ElectronAPI {
     listDevices: () => Promise<MobilePairedDevice[]>;
     revokeDevice: (deviceId: string) => Promise<void>;
     setDeviceCapabilities: (deviceId: string, capabilities: MobileCapabilityVerb[]) => Promise<void>;
+    /** Reachability probe for a candidate relay URL ("Test connection" in the Mobile Devices
+     *  tab). Takes the URL as an argument rather than reading it from config, since testing
+     *  BEFORE committing a save is the point; never throws. */
+    testRelay: (relayUrl: string) => Promise<RemoteServerStatus>;
     onPairingSas: (callback: (payload: MobilePairingSasPayload) => void) => () => void;
     onPairingEnded: (callback: (payload: MobilePairingEndedPayload) => void) => () => void;
     onStateChanged: (callback: () => void) => () => void;

--- a/tests/ui/mobile-devices-settings.spec.ts
+++ b/tests/ui/mobile-devices-settings.spec.ts
@@ -1,19 +1,32 @@
 /**
  * UI tests for the Mobile Devices settings tab.
  *
- * Covers the shared/global (below-separator) surface: the enable toggle and
- * relay URL input persisting to global config, the pairing ceremony (start
- * pairing -> QR render -> simulated SAS -> confirm), and the paired-device
- * list with revoke-via-ConfirmDialog. Mirrors the structure of
- * browser-settings.spec.ts and hotkeys-settings.spec.ts, the closest
- * precedents for a global settings tab with a toggle + input + list +
- * destructive action.
+ * Covers the shared/global (below-separator) surface: the enable toggle, the
+ * relay mode Select (resolved default vs. custom override) and its draft
+ * relay URL input, the pairing ceremony (start pairing -> QR render ->
+ * simulated SAS -> confirm), and the paired-device list with
+ * revoke-via-ConfirmDialog. Mirrors the structure of browser-settings.spec.ts
+ * and hotkeys-settings.spec.ts, the closest precedents for a global settings
+ * tab with a toggle + input + list + destructive action.
  *
- * Every test resets mobileBridge.enabled/relayUrl in beforeEach (never
- * afterEach) so the first test to run in a worker does not depend on a
- * prior test having already set a baseline - the mock's default config
- * omits `mobileBridge` entirely, so the component's `?? false` / `?? ''`
- * fallbacks are what a fresh page actually renders.
+ * The UI tier's webServer runs plain `vite` (development mode), so
+ * __KANGENTIC_DEV__ is always true here and the relay mode Select renders
+ * all three options ("Local", "Kangentic Cloud", "Custom Relay") - "Local"
+ * is a dev-only Select option, gated behind __KANGENTIC_DEV__ in the
+ * component, but is always offered under this tier's dev webServer. Unlike
+ * an earlier version of this module, "hosted" resolves to
+ * KANGENTIC_HOSTED_RELAY_URL unconditionally (not build-mode-dependent), so
+ * this tier actually exercises the "Kangentic Cloud" label and its resolved
+ * URL, not just "Local". These literals are hard-coded rather than imported
+ * from src/shared/relay.ts, since playwright.config.ts sets no `define` and
+ * importing a runtime export from that module into a .spec.ts throws at
+ * module load.
+ *
+ * Every test resets mobileBridge.enabled/relayMode/relayUrl in beforeEach
+ * (never afterEach) so the first test to run in a worker does not depend on
+ * a prior test having already set a baseline - the mock's default config
+ * omits `mobileBridge` entirely, so the component's `?? false` / inferred
+ * 'hosted' mode fallbacks are what a fresh page actually renders.
  */
 import { test, expect } from '@playwright/test';
 import { launchPage, createProject } from './helpers';
@@ -65,7 +78,7 @@ async function getGlobalConfig(): Promise<AppConfig> {
  * subscribes to, leaving the rendered UI stale until some other event
  * happens to trigger a refetch.
  */
-async function setMobileBridgeConfig(partial: { enabled?: boolean; relayUrl?: string }): Promise<void> {
+async function setMobileBridgeConfig(partial: { enabled?: boolean; relayMode?: 'hosted' | 'local' | 'custom'; relayUrl?: string }): Promise<void> {
   await page.evaluate(async (mobileBridgePartial) => {
     const stores = (window as unknown as {
       __zustandStores: { config: { getState: () => { updateConfig: (partial: { mobileBridge: typeof mobileBridgePartial }) => Promise<void> } } };
@@ -104,12 +117,14 @@ async function revokeDevice(displayName: string): Promise<void> {
 
 test.describe('Mobile Devices settings tab', () => {
   test.beforeEach(async () => {
-    // Known baseline before every test: bridge enabled, empty relay URL, no
-    // list/status overrides left over from a previous test.
-    await setMobileBridgeConfig({ enabled: true, relayUrl: '' });
+    // Known baseline before every test: bridge enabled, hosted relay mode,
+    // empty custom relay URL, no list/status/testRelay overrides left over
+    // from a previous test.
+    await setMobileBridgeConfig({ enabled: true, relayMode: 'hosted', relayUrl: '' });
     await page.evaluate(() => {
       delete (window as unknown as { __mockMobileDevices?: MobilePairedDevice[] }).__mockMobileDevices;
       delete (window as unknown as { __mockMobileBridgeStatus?: object }).__mockMobileBridgeStatus;
+      delete (window as unknown as { __mockTestRelay?: unknown }).__mockTestRelay;
     });
   });
 
@@ -129,12 +144,39 @@ test.describe('Mobile Devices settings tab', () => {
     }
   });
 
-  test('renders the enable toggle, relay URL input, and section headers', async () => {
+  test('hosted mode renders the enable toggle, relay mode select, resolved URL, and section headers', async () => {
     await openMobileTab();
     await expect(page.getByRole('switch')).toBeVisible();
-    await expect(page.locator('input[placeholder="wss://relay.example.com"]')).toBeVisible();
+    await expect(page.locator('[data-testid="mobile-relay-mode"]')).toHaveValue('hosted');
+    await expect(page.locator('[data-testid="mobile-relay-mode"]')).toContainText('Kangentic Cloud');
+    // Read-only resolved URL, not an editable input - the whole point of a
+    // resolved mode is that a normal user never sees a text field here. The
+    // hosted-relay constant is returned verbatim (not passed through
+    // new URL() normalization, unlike a saved custom value).
+    await expect(page.locator('[data-testid="mobile-relay-resolved-url"]')).toHaveText('wss://relay.kangentic.com');
+    await expect(page.locator('[data-testid="mobile-relay-url-input"]')).toHaveCount(0);
     await expect(page.getByRole('heading', { name: 'Pair a Device' })).toBeVisible();
     await expect(page.getByText('Paired Devices')).toBeVisible();
+    await closeSettings();
+  });
+
+  test('the relay mode select offers Local, Kangentic Cloud, and Custom Relay in a dev build', async () => {
+    await openMobileTab();
+    const select = page.locator('[data-testid="mobile-relay-mode"]');
+    const optionLabels = await select.locator('option').allTextContents();
+    expect(optionLabels).toEqual(['Local', 'Kangentic Cloud', 'Custom Relay']);
+    await closeSettings();
+  });
+
+  test('selecting Local resolves to the local dev relay address', async () => {
+    await openMobileTab();
+
+    await page.locator('[data-testid="mobile-relay-mode"]').selectOption('local');
+
+    await expect.poll(async () => (await getGlobalConfig()).mobileBridge?.relayMode).toBe('local');
+    await expect(page.locator('[data-testid="mobile-relay-resolved-url"]')).toHaveText('ws://127.0.0.1:8080');
+    await expect(page.locator('[data-testid="mobile-relay-url-input"]')).toHaveCount(0);
+
     await closeSettings();
   });
 
@@ -155,24 +197,188 @@ test.describe('Mobile Devices settings tab', () => {
     await closeSettings();
   });
 
-  test('editing the relay URL persists mobileBridge.relayUrl to global config', async () => {
+  test('selecting Custom Relay reveals the relay URL input and hides the resolved-default line', async () => {
     await openMobileTab();
 
-    const urlInput = page.locator('input[placeholder="wss://relay.example.com"]');
-    await urlInput.fill('wss://relay.mock.dev');
+    await expect(page.locator('[data-testid="mobile-relay-resolved-url"]')).toBeVisible();
+    await expect(page.locator('[data-testid="mobile-relay-url-input"]')).toHaveCount(0);
+
+    await page.locator('[data-testid="mobile-relay-mode"]').selectOption('custom');
+
+    await expect(page.locator('[data-testid="mobile-relay-url-input"]')).toBeVisible();
+    await expect.poll(async () => (await getGlobalConfig()).mobileBridge?.relayMode).toBe('custom');
+    // Regression check: with an empty custom draft, resolveRelayUrl falls
+    // back to the hosted relay internally, but that fallback must never be
+    // surfaced next to a Select that reads "Custom Relay" - it read as
+    // "picking Custom didn't do anything" (the hosted relay address was
+    // still shown underneath). The line is hidden in custom mode now.
+    await expect(page.locator('[data-testid="mobile-relay-resolved-url"]')).toHaveCount(0);
+
+    await closeSettings();
+  });
+
+  test('editing the relay URL persists the normalized value once, on blur', async () => {
+    await setMobileBridgeConfig({ relayMode: 'custom', relayUrl: '' });
+    await openMobileTab();
+
+    const urlInput = page.locator('[data-testid="mobile-relay-url-input"]');
+    // Typing alone (no blur yet) must not write to config - the whole point
+    // of a commit boundary is that each keystroke does not dispose/redial
+    // every bridge session.
+    await urlInput.pressSequentially('wss://relay.mock.dev');
+    await expect.poll(async () => (await getGlobalConfig()).mobileBridge?.relayUrl).toBe('');
+
+    await urlInput.blur();
+    await expect.poll(async () => (await getGlobalConfig()).mobileBridge?.relayUrl).toBe('wss://relay.mock.dev/');
+
+    await closeSettings();
+  });
+
+  test('an invalid relay URL shows an inline error and blocks the save', async () => {
+    await setMobileBridgeConfig({ relayMode: 'custom', relayUrl: '' });
+    await openMobileTab();
+
+    const urlInput = page.locator('[data-testid="mobile-relay-url-input"]');
+    await urlInput.fill('http://relay.mock.dev');
     await urlInput.blur();
 
-    await expect.poll(async () => (await getGlobalConfig()).mobileBridge?.relayUrl).toBe('wss://relay.mock.dev');
+    await expect(page.locator('[data-testid="mobile-relay-url-error"]')).toBeVisible();
+    await expect.poll(async () => (await getGlobalConfig()).mobileBridge?.relayUrl).toBe('');
 
     await closeSettings();
   });
 
   test('the relay URL input is disabled when mobileBridge.enabled === false', async () => {
-    await setMobileBridgeConfig({ enabled: false });
+    await setMobileBridgeConfig({ enabled: false, relayMode: 'custom' });
     await openMobileTab();
 
-    const urlInput = page.locator('input[placeholder="wss://relay.example.com"]');
+    const urlInput = page.locator('[data-testid="mobile-relay-url-input"]');
     await expect(urlInput).toBeDisabled();
+
+    await closeSettings();
+  });
+
+  test('Test connection renders the reachable and no-response trailing states', async () => {
+    await openMobileTab();
+
+    await page.evaluate(() => {
+      (window as unknown as { __mockTestRelay: (relayUrl: string) => Promise<{ reachable: boolean; version?: string | null; reason?: string }> }).__mockTestRelay =
+        () => Promise.resolve({ reachable: true, version: '0.4.0' });
+    });
+    await page.locator('[data-testid="mobile-relay-test-connection"]').click();
+    await expect(page.getByText('v0.4.0')).toBeVisible();
+
+    await page.evaluate(() => {
+      (window as unknown as { __mockTestRelay: (relayUrl: string) => Promise<{ reachable: boolean; version?: string | null; reason?: string }> }).__mockTestRelay =
+        () => Promise.resolve({ reachable: false, reason: 'ECONNREFUSED' });
+    });
+    await page.locator('[data-testid="mobile-relay-test-connection"]').click();
+    const noResponse = page.getByText('No response');
+    await expect(noResponse).toBeVisible();
+    await expect(noResponse).toHaveAttribute('title', 'ECONNREFUSED');
+
+    await closeSettings();
+  });
+
+  test('a test result does not shift the resolved-URL pill below it', async () => {
+    await openMobileTab();
+
+    const resolvedUrl = page.locator('[data-testid="mobile-relay-resolved-url"]');
+    const before = await resolvedUrl.boundingBox();
+    expect(before).not.toBeNull();
+
+    await page.evaluate(() => {
+      (window as unknown as { __mockTestRelay: (relayUrl: string) => Promise<{ reachable: boolean; version?: string | null; reason?: string }> }).__mockTestRelay =
+        () => Promise.resolve({ reachable: false, reason: 'ECONNREFUSED' });
+    });
+    await page.locator('[data-testid="mobile-relay-test-connection"]').click();
+    await expect(page.getByText('No response')).toBeVisible();
+
+    const after = await resolvedUrl.boundingBox();
+    expect(after).not.toBeNull();
+    // Sub-pixel tolerance rather than exact equality: font metrics and
+    // fractional layout rounding differ between local Windows and the headless
+    // Linux CI runner, and the invariant under test is "the fixed-height slot
+    // stops the pill from reflowing", not "the float is bit-identical".
+    expect(Math.abs((after?.y ?? 0) - (before?.y ?? 0))).toBeLessThan(1);
+
+    await closeSettings();
+  });
+
+  test('switching relay mode clears a stale test result rather than showing it next to the new mode', async () => {
+    await openMobileTab();
+
+    await page.evaluate(() => {
+      (window as unknown as { __mockTestRelay: (relayUrl: string) => Promise<{ reachable: boolean; version?: string | null; reason?: string }> }).__mockTestRelay =
+        () => Promise.resolve({ reachable: false, reason: 'ECONNREFUSED' });
+    });
+    await page.locator('[data-testid="mobile-relay-test-connection"]').click();
+    await expect(page.getByText('No response')).toBeVisible();
+
+    await page.locator('[data-testid="mobile-relay-mode"]').selectOption('custom');
+    await expect(page.getByText('No response')).toHaveCount(0);
+
+    await closeSettings();
+  });
+
+  test('retargeting mid-probe discards the stale reply AND resets the spinner (does not strand the button disabled)', async () => {
+    // Regression coverage for the requestId-generation guard in
+    // handleTestRelay(): a probe that resolves AFTER the user has already
+    // edited the relay URL must not (a) repopulate the result slot with a
+    // verdict for the abandoned URL, or (b) leave testingRelay stuck true
+    // (which the earlier, buggier version did by guarding the `finally`
+    // reset on the same requestId check as the result assignment).
+    await setMobileBridgeConfig({ relayMode: 'custom', relayUrl: 'wss://relay-one.mock.dev' });
+    await openMobileTab();
+
+    const testConnectionButton = page.locator('[data-testid="mobile-relay-test-connection"]');
+    const urlInput = page.locator('[data-testid="mobile-relay-url-input"]');
+
+    // A deferred mock: the probe never resolves until the test explicitly
+    // releases it via window.__resolveTestRelay, so the test can hold the
+    // in-flight window open long enough to retarget underneath it.
+    await page.evaluate(() => {
+      let release: ((result: { reachable: boolean; reason?: string }) => void) | null = null;
+      (window as unknown as {
+        __mockTestRelay: (relayUrl: string) => Promise<{ reachable: boolean; reason?: string }>;
+        __resolveTestRelay: (result: { reachable: boolean; reason?: string }) => void;
+      }).__mockTestRelay = () => new Promise((resolve) => { release = resolve; });
+      (window as unknown as { __resolveTestRelay: (result: { reachable: boolean; reason?: string }) => void }).__resolveTestRelay = (result) => {
+        release?.(result);
+      };
+    });
+
+    await testConnectionButton.click();
+    await expect(testConnectionButton).toBeDisabled();
+
+    // Retarget while the probe is still in flight: fill (not append) so the
+    // draft stays non-empty throughout, keeping the button's OTHER disable
+    // condition (empty custom draft) out of play - this isolates the
+    // testingRelay-stuck bug from that unrelated disable reason.
+    await urlInput.fill('wss://relay-two.mock.dev');
+
+    // Release the now-abandoned probe with a verdict for relay-one.
+    await page.evaluate(() => {
+      (window as unknown as { __resolveTestRelay: (result: { reachable: boolean; reason?: string }) => void }).__resolveTestRelay({
+        reachable: false,
+        reason: 'STALE_PROBE_FOR_RELAY_ONE',
+      });
+    });
+
+    // Half 2 FIRST, as the gate for half 1: the button recovering to
+    // enabled/non-spinning is the only observable signal that the async
+    // try/finally chain has actually settled. Checking the negative (half 1)
+    // before this would race - a `toHaveCount(0)` sampled before React
+    // flushes the (buggy) setRelayTestResult(result) call would pass for the
+    // wrong reason, on a mutation that DOES render the stale result a moment
+    // later. Waiting for this positive signal first guarantees the try
+    // block already ran (and either set or skipped the result) before we
+    // inspect it below.
+    await expect(testConnectionButton).toBeEnabled();
+    await expect(testConnectionButton.locator('svg.animate-spin')).toHaveCount(0);
+
+    // Half 1: the stale verdict must never have rendered.
+    await expect(page.getByText('No response')).toHaveCount(0);
 
     await closeSettings();
   });
@@ -310,6 +516,104 @@ test.describe('Mobile Devices settings tab', () => {
     await expect(deviceRow.getByRole('switch', { name: 'Live output', exact: true })).toHaveAttribute('aria-checked', 'true');
     await expect(deviceRow.getByRole('switch', { name: 'Board', exact: true })).toHaveAttribute('aria-checked', 'true');
     await expect(deviceRow.getByRole('switch', { name: 'Interactive terminal', exact: true })).toHaveAttribute('aria-checked', 'false');
+
+    await closeSettings();
+  });
+
+  test('shows a relay status indicator next to Paired Devices once a device is paired', async () => {
+    await page.evaluate(() => {
+      (window as unknown as { __mockMobileDevices: MobilePairedDevice[] }).__mockMobileDevices = [
+        { deviceId: 'status-device-1', displayName: 'Status Device', capabilities: [], pairedAt: new Date().toISOString() },
+      ];
+      (window as unknown as { __mockMobileBridgeStatus: object }).__mockMobileBridgeStatus = { relayState: 'connected' };
+    });
+
+    await openMobileTab();
+
+    const indicator = page.locator('[data-testid="mobile-relay-status"]');
+    await expect(indicator).toBeVisible();
+    await expect(indicator).toContainText('Connected');
+
+    await closeSettings();
+  });
+
+  test('does not show a relay status indicator when there are no paired devices', async () => {
+    await openMobileTab();
+    await expect(page.locator('[data-testid="mobile-relay-status"]')).toHaveCount(0);
+    await closeSettings();
+  });
+
+  test('renders no relay status indicator for "idle", even with a device paired (a device-less desktop must never read "Disconnected")', async () => {
+    // relayStatusDisplay('idle') deliberately returns null: the aggregate is
+    // 'idle' only because no BridgeSession exists yet for this device (e.g.
+    // mid-sync), and showing "Disconnected" here would misreport a desktop
+    // that in fact has no live-session problem to report.
+    await page.evaluate(() => {
+      (window as unknown as { __mockMobileDevices: MobilePairedDevice[] }).__mockMobileDevices = [
+        { deviceId: 'idle-device-1', displayName: 'Idle Device', capabilities: [], pairedAt: new Date().toISOString() },
+      ];
+      (window as unknown as { __mockMobileBridgeStatus: object }).__mockMobileBridgeStatus = { relayState: 'idle' };
+    });
+
+    await openMobileTab();
+
+    await expect(page.locator('li', { hasText: 'Idle Device' })).toBeVisible();
+    await expect(page.locator('[data-testid="mobile-relay-status"]')).toHaveCount(0);
+
+    await closeSettings();
+  });
+
+  test('shows the "Connecting…" state in amber while a session is dialing', async () => {
+    await page.evaluate(() => {
+      (window as unknown as { __mockMobileDevices: MobilePairedDevice[] }).__mockMobileDevices = [
+        { deviceId: 'connecting-device-1', displayName: 'Connecting Device', capabilities: [], pairedAt: new Date().toISOString() },
+      ];
+      (window as unknown as { __mockMobileBridgeStatus: object }).__mockMobileBridgeStatus = { relayState: 'connecting' };
+    });
+
+    await openMobileTab();
+
+    const indicator = page.locator('[data-testid="mobile-relay-status"]');
+    await expect(indicator).toBeVisible();
+    await expect(indicator).toContainText('Connecting…');
+    await expect(indicator).toHaveClass(/text-amber-400/);
+
+    await closeSettings();
+  });
+
+  test('shows the "Reconnecting…" state in amber, distinct from "Connecting…"', async () => {
+    await page.evaluate(() => {
+      (window as unknown as { __mockMobileDevices: MobilePairedDevice[] }).__mockMobileDevices = [
+        { deviceId: 'reconnecting-device-1', displayName: 'Reconnecting Device', capabilities: [], pairedAt: new Date().toISOString() },
+      ];
+      (window as unknown as { __mockMobileBridgeStatus: object }).__mockMobileBridgeStatus = { relayState: 'reconnecting' };
+    });
+
+    await openMobileTab();
+
+    const indicator = page.locator('[data-testid="mobile-relay-status"]');
+    await expect(indicator).toBeVisible();
+    await expect(indicator).toContainText('Reconnecting…');
+    await expect(indicator).not.toContainText('Connecting…');
+    await expect(indicator).toHaveClass(/text-amber-400/);
+
+    await closeSettings();
+  });
+
+  test('shows the "Disconnected" state in the danger color when the relay is closed', async () => {
+    await page.evaluate(() => {
+      (window as unknown as { __mockMobileDevices: MobilePairedDevice[] }).__mockMobileDevices = [
+        { deviceId: 'closed-device-1', displayName: 'Closed Device', capabilities: [], pairedAt: new Date().toISOString() },
+      ];
+      (window as unknown as { __mockMobileBridgeStatus: object }).__mockMobileBridgeStatus = { relayState: 'closed' };
+    });
+
+    await openMobileTab();
+
+    const indicator = page.locator('[data-testid="mobile-relay-status"]');
+    await expect(indicator).toBeVisible();
+    await expect(indicator).toContainText('Disconnected');
+    await expect(indicator).toHaveClass(/text-danger/);
 
     await closeSettings();
   });

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -2704,6 +2704,9 @@
             relayUrl: state.relayUrl,
             pairedDeviceCount: state.devices.length,
             pairingInProgress: state.pairingInProgress,
+            // No live transport in the mock, so 'idle' (no sessions) unless
+            // a spec overrides via window.__mockMobileBridgeStatus.
+            relayState: 'idle',
           }, overrides);
         },
         startPairing: async function () {
@@ -2741,6 +2744,14 @@
           state.devices = state.devices.map(function (device) {
             return device.deviceId === deviceId ? Object.assign({}, device, { capabilities: capabilities }) : device;
           });
+        },
+        // Tests can set window.__mockTestRelay = function (relayUrl) { ... }
+        // to control the "Test connection" result; default is a reachable stub.
+        testRelay: async function (relayUrl) {
+          if (typeof window !== 'undefined' && typeof window.__mockTestRelay === 'function') {
+            return window.__mockTestRelay(relayUrl);
+          }
+          return { reachable: true, version: null };
         },
         onPairingSas: function (callback) {
           sasListeners.push(callback);

--- a/tests/unit/config-handler-wiring.test.ts
+++ b/tests/unit/config-handler-wiring.test.ts
@@ -115,6 +115,7 @@ vi.mock('../../src/main/retrieval/retrieval-service', () => ({
 // ---------------------------------------------------------------------------
 
 import { registerSystemHandlers } from '../../src/main/ipc/handlers/system';
+import { KANGENTIC_HOSTED_RELAY_URL, LOCAL_DEV_RELAY_URL } from '../../src/shared/relay';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -274,20 +275,22 @@ describe('CONFIG_SET IPC handler - mobileBridgeService reconcile wiring', () => 
   // Regression guard: toggling mobileBridge.enabled or editing relayUrl in
   // Settings must take effect immediately (no app/project reopen), by
   // calling mobileBridgeService.reconcile() with the freshly-saved
-  // EFFECTIVE config's mobileBridge fields - not the raw partial `config`
-  // argument, which may omit relayUrl entirely on an enabled-only toggle.
+  // EFFECTIVE config's mobileBridge fields resolved through resolveRelayUrl()
+  // (src/shared/relay.ts) - not the raw stored relayUrl verbatim, and not the
+  // raw partial `config` argument, which may omit relayUrl entirely on an
+  // enabled-only toggle.
   beforeEach(() => {
     capturedHandlers.clear();
     capturedOnHandlers.clear();
     applyRuntimeConfigSpy.mockClear();
   });
 
-  it('calls mobileBridgeService.reconcile() with the effective config when the saved config includes a mobileBridge key', () => {
+  it('calls mobileBridgeService.reconcile() with the effective config\'s relayUrl resolved and normalized when relayMode is "custom"', () => {
     const context = makeContext({ currentProjectPath: '/repo/main' });
     context.configManager.getEffectiveConfig.mockReturnValue({
       agent: { maxConcurrentSessions: 5, idleTimeoutMinutes: 30 },
       terminal: { shell: null },
-      mobileBridge: { enabled: true, relayUrl: 'wss://relay.example.com' },
+      mobileBridge: { enabled: true, relayMode: 'custom', relayUrl: 'wss://relay.example.com' },
     });
     registerSystemHandlers(context as Parameters<typeof registerSystemHandlers>[0]);
 
@@ -298,14 +301,33 @@ describe('CONFIG_SET IPC handler - mobileBridgeService reconcile wiring', () => 
     // launches, and this suite compiles with __KANGENTIC_DEV__ = false
     // (vitest.config.ts) - i.e. the production build. So even a persisted
     // enabled:true must reconcile to enabled:false here; relayUrl still
-    // flows from the EFFECTIVE config (not the raw partial argument).
+    // flows from the EFFECTIVE config through resolveRelayUrl(), which
+    // normalizes the URL (new URL().href adds the trailing slash on an
+    // authority-only URL) - not the stored string verbatim.
     expect(context.mobileBridgeService.reconcile).toHaveBeenCalledWith({
       enabled: false,
-      relayUrl: 'wss://relay.example.com',
+      relayUrl: new URL('wss://relay.example.com').href,
     });
   });
 
-  it('defaults enabled to false and relayUrl to empty string when the effective config omits mobileBridge fields', () => {
+  it('resolves relayUrl to the local dev relay when relayMode is "local"', () => {
+    const context = makeContext({ currentProjectPath: '/repo/main' });
+    context.configManager.getEffectiveConfig.mockReturnValue({
+      agent: { maxConcurrentSessions: 5, idleTimeoutMinutes: 30 },
+      terminal: { shell: null },
+      mobileBridge: { enabled: true, relayMode: 'local', relayUrl: '' },
+    });
+    registerSystemHandlers(context as Parameters<typeof registerSystemHandlers>[0]);
+
+    invokeHandler('config:set', { mobileBridge: { enabled: true } });
+
+    expect(context.mobileBridgeService.reconcile).toHaveBeenCalledWith({
+      enabled: false,
+      relayUrl: LOCAL_DEV_RELAY_URL,
+    });
+  });
+
+  it('defaults enabled to false and relayUrl to the hosted relay when the effective config omits mobileBridge fields', () => {
     const context = makeContext({ currentProjectPath: '/repo/main' });
     context.configManager.getEffectiveConfig.mockReturnValue({
       agent: { maxConcurrentSessions: 5, idleTimeoutMinutes: 30 },
@@ -316,9 +338,12 @@ describe('CONFIG_SET IPC handler - mobileBridgeService reconcile wiring', () => 
 
     invokeHandler('config:set', { mobileBridge: { enabled: false } });
 
+    // resolveRelayUrl() never returns '' - an unset mobileBridge (no
+    // relayMode, no relayUrl) infers 'hosted' mode and falls back to the
+    // hosted relay, per src/shared/relay.ts's inferRelayMode().
     expect(context.mobileBridgeService.reconcile).toHaveBeenCalledWith({
       enabled: false,
-      relayUrl: '',
+      relayUrl: KANGENTIC_HOSTED_RELAY_URL,
     });
   });
 

--- a/tests/unit/config-manager.test.ts
+++ b/tests/unit/config-manager.test.ts
@@ -127,6 +127,53 @@ describe('Config Manager -- Permission Mode Migration', () => {
   });
 });
 
+describe('Config Manager -- mobileBridge relay resolution across the default merge', () => {
+  // Regression: DEFAULT_CONFIG.mobileBridge used to seed relayMode: 'hosted'.
+  // mobileBridge is not a CONFIG_DICTIONARY_PATHS entry, so load() merges it
+  // key-by-key with the parsed file rather than replacing it wholesale - which
+  // meant that seeded 'hosted' filled in over a config written before
+  // relayMode existed, defeating resolveRelayUrl's "relayMode missing but
+  // relayUrl set => custom" inference and silently moving every upgrading
+  // self-hoster onto the Kangentic-hosted relay.
+  //
+  // These assert through ConfigManager.load() on purpose. tests/unit/relay-url.test.ts
+  // covers the same inference, but it hand-builds the mobileBridge object and so
+  // never sees the default merge - it stayed green while the shipped path was broken.
+
+  it('keeps dialing a pre-relayMode custom relay after the default merge', async () => {
+    fs.writeFileSync(configPath, JSON.stringify({
+      mobileBridge: { enabled: true, relayUrl: 'wss://self-hosted.example.com' },
+    }));
+
+    const cm = await createConfigManager();
+    const config = cm.load();
+    const { resolveRelayUrl } = await import('../../src/shared/relay');
+
+    expect(config.mobileBridge?.relayMode).toBeUndefined();
+    expect(resolveRelayUrl(config.mobileBridge)).toBe('wss://self-hosted.example.com/');
+  });
+
+  it('resolves to the hosted relay for a fresh config with no relay settings', async () => {
+    const cm = await createConfigManager();
+    const config = cm.load();
+    const { KANGENTIC_HOSTED_RELAY_URL, resolveRelayUrl } = await import('../../src/shared/relay');
+
+    expect(resolveRelayUrl(config.mobileBridge)).toBe(KANGENTIC_HOSTED_RELAY_URL);
+  });
+
+  it('honors an explicit hosted choice even when a stale relayUrl is still on disk', async () => {
+    fs.writeFileSync(configPath, JSON.stringify({
+      mobileBridge: { enabled: true, relayMode: 'hosted', relayUrl: 'wss://self-hosted.example.com' },
+    }));
+
+    const cm = await createConfigManager();
+    const config = cm.load();
+    const { KANGENTIC_HOSTED_RELAY_URL, resolveRelayUrl } = await import('../../src/shared/relay');
+
+    expect(resolveRelayUrl(config.mobileBridge)).toBe(KANGENTIC_HOSTED_RELAY_URL);
+  });
+});
+
 describe('Config Manager -- claude.* to agent.* namespace migration', () => {
   it('migrates legacy claude.* to agent.* on load', async () => {
     fs.writeFileSync(configPath, JSON.stringify({

--- a/tests/unit/mobile-bridge/bridge-session.test.ts
+++ b/tests/unit/mobile-bridge/bridge-session.test.ts
@@ -428,6 +428,70 @@ describe('BridgeSession', () => {
     session.dispose();
   });
 
+  it('transportState getter reflects the underlying transport\'s current state, including through a reconnect', () => {
+    const desktopIdentity = testIdentity();
+    const deviceStatic = generateX25519KeyPair();
+    const { desktop, device, setDesktopState } = createReconnectableLoopback();
+
+    new ReestablishingResponder(deviceStatic, desktopIdentity.staticKeyPair.publicKey, device);
+    const session = new BridgeSession({
+      identity: desktopIdentity,
+      deviceId: 'device-1',
+      remoteStaticPublicKey: deviceStatic.publicKey,
+      capabilities: new Set(),
+      transport: desktop,
+    });
+
+    session.start();
+    expect(session.transportState).toBe('connected');
+
+    setDesktopState('reconnecting');
+    expect(session.transportState).toBe('reconnecting');
+
+    setDesktopState('connected');
+    expect(session.transportState).toBe('connected');
+
+    session.dispose();
+  });
+
+  it('emits "transportState" on every transport-state transition, including a reconnect back into "connected"', () => {
+    // Pins the ordering documented in bridge-session.ts's onTransportState():
+    // the emit happens BEFORE the `state === 'connected'` branch's early
+    // return, so a re-connect edge (not just reconnecting/closed) also
+    // reaches the service's relayState aggregation. If the emit were moved
+    // below that branch, the 'connected' transition below would silently
+    // stop appearing in transportStateEvents.
+    const desktopIdentity = testIdentity();
+    const deviceStatic = generateX25519KeyPair();
+    const { desktop, device, setDesktopState } = createReconnectableLoopback();
+
+    new ReestablishingResponder(deviceStatic, desktopIdentity.staticKeyPair.publicKey, device);
+    const session = new BridgeSession({
+      identity: desktopIdentity,
+      deviceId: 'device-1',
+      remoteStaticPublicKey: deviceStatic.publicKey,
+      capabilities: new Set(),
+      transport: desktop,
+    });
+
+    const transportStateEvents: TransportState[] = [];
+    session.on('transportState', (state: TransportState) => transportStateEvents.push(state));
+
+    // The INITIAL connect at start() bypasses onTransportState entirely (see
+    // start()'s "kick" comment: the transport was already 'connected' before
+    // the onStateChange listener was subscribed, so no transition fired).
+    session.start();
+    expect(transportStateEvents).toEqual([]);
+
+    setDesktopState('reconnecting');
+    expect(transportStateEvents).toEqual(['reconnecting']);
+
+    setDesktopState('connected');
+    expect(transportStateEvents).toEqual(['reconnecting', 'connected']);
+
+    session.dispose();
+  });
+
   it('recovers from a garbled handshake frame with a fast retry instead of wedging', () => {
     vi.useFakeTimers();
     try {

--- a/tests/unit/mobile-bridge/mobile-bridge-ipc-handler.test.ts
+++ b/tests/unit/mobile-bridge/mobile-bridge-ipc-handler.test.ts
@@ -16,7 +16,7 @@
  * methods), then invoke the captured handlers directly.
  */
 import { EventEmitter } from 'node:events';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { IPC } from '../../../src/shared/ipc-channels';
 
 // ---------------------------------------------------------------------------
@@ -52,6 +52,7 @@ class FakeMobileBridgeService extends EventEmitter {
     relayUrl: 'wss://relay.example.com',
     pairedDeviceCount: 0,
     pairingInProgress: false,
+    relayState: 'idle' as const,
   }));
   startPairing = vi.fn(async () => ({
     qrPayload: { expiresAt: '2026-01-01T00:10:00.000Z' } as { expiresAt: string },
@@ -233,5 +234,111 @@ describe('registerMobileBridgeHandlers - push events', () => {
     context.mobileBridgeService.emit('stateChanged');
 
     expect(context.mainWindow.webContents.send).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MOBILE_TEST_RELAY: structurally a probe (mirrors handlers/system.ts's
+// AGENT_PROBE_EXECUTION_SERVER), not a service delegation - it validates and
+// fetches a candidate URL directly, using the real validateRelayUrl /
+// relayHealthUrl from src/shared/relay.ts (pure functions, safe to exercise
+// for real) with a stubbed global fetch. Every case below must resolve, never
+// throw or hang.
+// ---------------------------------------------------------------------------
+
+describe('registerMobileBridgeHandlers - MOBILE_TEST_RELAY', () => {
+  beforeEach(() => {
+    capturedHandlers.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects an invalid relay URL server-side without ever calling fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    const result = await invokeHandler(IPC.MOBILE_TEST_RELAY, 'not a url');
+
+    expect(result).toMatchObject({ reachable: false });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-loopback ws:// relay URL server-side, even if the renderer sent it', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    const result = (await invokeHandler(IPC.MOBILE_TEST_RELAY, 'ws://not-loopback.example.com')) as { reachable: boolean; reason?: string };
+
+    expect(result.reachable).toBe(false);
+    expect(result.reason).toMatch(/TLS/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reports unreachable when fetch rejects (host unreachable)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    const result = await invokeHandler(IPC.MOBILE_TEST_RELAY, 'wss://relay.example.com');
+
+    expect(result).toEqual({ reachable: false, reason: 'ECONNREFUSED' });
+  });
+
+  it('reports unreachable when the request times out (AbortSignal fires)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new DOMException('The operation was aborted.', 'AbortError'); }));
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    const result = (await invokeHandler(IPC.MOBILE_TEST_RELAY, 'wss://relay.example.com')) as { reachable: boolean; reason?: string };
+
+    expect(result.reachable).toBe(false);
+    expect(result.reason).toBeTruthy();
+  });
+
+  it('reports unreachable with the HTTP status on a non-2xx response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 503, json: async () => ({}) })));
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    const result = await invokeHandler(IPC.MOBILE_TEST_RELAY, 'wss://relay.example.com');
+
+    expect(result).toEqual({ reachable: false, reason: 'Relay responded with HTTP 503' });
+  });
+
+  it('reports reachable with a null version when the body is not JSON (the documented /healthz contract has no version field)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, json: async () => { throw new Error('Unexpected token'); } })));
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    const result = await invokeHandler(IPC.MOBILE_TEST_RELAY, 'wss://relay.example.com');
+
+    expect(result).toEqual({ reachable: true, version: null });
+  });
+
+  it('reports reachable with the version when the body provides one', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ version: '0.4.0' }) })));
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    const result = await invokeHandler(IPC.MOBILE_TEST_RELAY, 'wss://relay.example.com');
+
+    expect(result).toEqual({ reachable: true, version: '0.4.0' });
+  });
+
+  it('probes relayHealthUrl(normalized), not the raw input', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) }));
+    vi.stubGlobal('fetch', fetchMock);
+    const context = makeContext();
+    registerMobileBridgeHandlers(context);
+
+    await invokeHandler(IPC.MOBILE_TEST_RELAY, 'WSS://Relay.Example.com');
+
+    expect(fetchMock).toHaveBeenCalledWith('https://relay.example.com/healthz', expect.anything());
   });
 });

--- a/tests/unit/mobile-bridge/mobile-bridge-relay-state.test.ts
+++ b/tests/unit/mobile-bridge/mobile-bridge-relay-state.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Unit tests for MobileBridgeService's relay-state aggregation, added by the
+ * configurable-relay-URL diff:
+ *
+ *  - aggregateRelayState()'s precedence (connected > connecting > reconnecting
+ *    > closed, 'idle' only when there are no sessions at all), and its
+ *    documented exclusion of the ephemeral pairing transport.
+ *  - scheduleRelayStateEmit()'s THROTTLE semantics for the 'stateChanged'
+ *    notification: a burst of changes within one window coalesces to one
+ *    emission, an unchanged aggregate never re-emits, and a mid-window flap
+ *    does not push the emission further out (which would make it a debounce).
+ *
+ * Neither path is reached by mobile-bridge-service.test.ts (which never opens
+ * a session) nor mobile-bridge-session-lifecycle.test.ts (whose FakeBridgeSession
+ * has no transportState and never emits 'transportState'). BridgeSession is
+ * faked here as a real EventEmitter with a settable `transportState` and a
+ * `setTransportState()` helper that updates the property THEN emits, mirroring
+ * the "emit before the branch" ordering pinned separately in
+ * bridge-session.test.ts. This test exercises the SERVICE's aggregation and
+ * throttle only; the session's own emit-ordering guarantee is out of scope
+ * here.
+ *
+ * Mocking mirrors mobile-bridge-session-lifecycle.test.ts's pattern (mock
+ * electron/analytics/paths/identity/roster-store/bridge-session/transport),
+ * with a two-device roster so the precedence chain can be driven directly by
+ * setting each session's transportState independently.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { RosterDeviceEntry, TransportState } from '@kangentic/protocol';
+
+vi.mock('electron', () => ({
+  app: { isReady: () => true, whenReady: () => Promise.resolve() },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`encrypted:${plaintext}`, 'utf8'),
+    decryptString: (buffer: Buffer) => buffer.toString('utf8').replace(/^encrypted:/, ''),
+    getSelectedStorageBackend: () => 'keychain',
+  },
+  ipcMain: { handle: vi.fn(), on: vi.fn(), removeHandler: vi.fn() },
+}));
+
+vi.mock('../../../src/main/analytics/analytics', () => ({
+  trackEvent: vi.fn(),
+  sanitizeErrorMessage: (message: string) => message,
+}));
+
+vi.mock('../../../src/main/config/paths', () => ({
+  PATHS: { configDir: '/mock/config' },
+}));
+
+const fakeIdentity = {
+  staticKeyPair: { publicKey: new Uint8Array(32).fill(1), secretKey: new Uint8Array(32).fill(2) },
+  masterSigningKeyPair: { publicKey: new Uint8Array(32).fill(9), secretKey: new Uint8Array(32).fill(8) },
+  createdAt: new Date(0).toISOString(),
+};
+
+function rosterDevice(deviceId: string, fillByte: number): RosterDeviceEntry {
+  return {
+    deviceId,
+    displayName: deviceId,
+    staticPublicKey: new Uint8Array(32).fill(fillByte),
+    capabilities: ['read-board'],
+    pairedAt: new Date(0).toISOString(),
+    expiresAt: null,
+    signature: new Uint8Array(64),
+  };
+}
+
+const deviceA = rosterDevice('device-A', 3);
+const deviceB = rosterDevice('device-B', 4);
+
+// Mutable so individual tests can run with either a two-device roster
+// (precedence tests) or a one-device roster (throttle tests).
+let rosterDevices: RosterDeviceEntry[] = [deviceA, deviceB];
+
+vi.mock('../../../src/main/mobile-bridge/identity', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/main/mobile-bridge/identity')>()),
+  loadBridgeIdentity: () => fakeIdentity,
+  loadOrCreateBridgeIdentity: () => fakeIdentity,
+}));
+
+// revokeDevice/setDeviceCapabilities are mocked as no-op spies (not passed
+// through to the real implementation, which touches real fs) because the
+// Fix C regression test below calls service.revokeDevice() directly.
+const revokeDeviceInRosterSpy = vi.fn();
+const setDeviceCapabilitiesInRosterSpy = vi.fn();
+vi.mock('../../../src/main/mobile-bridge/roster-store', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/main/mobile-bridge/roster-store')>()),
+  loadRoster: () => ({ devices: rosterDevices }),
+  revokeDevice: (...args: unknown[]) => revokeDeviceInRosterSpy(...args),
+  setDeviceCapabilities: (...args: unknown[]) => setDeviceCapabilitiesInRosterSpy(...args),
+}));
+
+const createdSessions: FakeBridgeSession[] = [];
+class FakeBridgeSession extends EventEmitter {
+  readonly deviceId: string;
+  transportState: TransportState = 'connecting';
+  start = vi.fn();
+  dispose = vi.fn();
+  sendMessage = vi.fn();
+  constructor(options: { deviceId: string }) {
+    super();
+    this.deviceId = options.deviceId;
+    createdSessions.push(this);
+  }
+  /**
+   * Mirrors bridge-session.ts's onTransportState(): updates the value the
+   * transportState getter reads, then emits 'transportState' - the same
+   * order the real session uses so the service's aggregate always reflects
+   * the newly-set value by the time its listener runs.
+   */
+  setTransportState(state: TransportState): void {
+    this.transportState = state;
+    this.emit('transportState', state);
+  }
+}
+vi.mock('../../../src/main/mobile-bridge/session/bridge-session', () => ({
+  BridgeSession: FakeBridgeSession,
+}));
+
+vi.mock('../../../src/main/mobile-bridge/transport/transport-factory', () => ({
+  // A fresh object per call: openSessionForDevice() and startPairing() must
+  // never observe each other's transport, since the pairing-exclusion test
+  // needs the pairing ceremony's transport to be provably distinct from any
+  // roster session's transport.
+  createTransport: vi.fn(() => ({
+    state: 'connected' as TransportState,
+    connect: vi.fn(async () => undefined),
+    send: vi.fn(),
+    close: vi.fn(),
+    onFrame: vi.fn(() => () => undefined),
+    onStateChange: vi.fn(() => () => undefined),
+  })),
+}));
+
+const { MobileBridgeService } = await import('../../../src/main/mobile-bridge/mobile-bridge-service');
+type MobileBridgeServiceInstance = InstanceType<typeof MobileBridgeService>;
+
+/** Settle the microtask chain reconcile() -> syncSessions() -> runSyncSessions() -> openSessionForDevice() kicks off. */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+/** Opens one BridgeSession per roster device and returns them keyed by deviceId. */
+async function openSessions(service: MobileBridgeServiceInstance): Promise<Map<string, FakeBridgeSession>> {
+  service.attachContext({ sessionManager: new EventEmitter(), boardEvents: { emitBoardChanged: vi.fn() } } as never);
+  service.reconcile({ enabled: true, relayUrl: 'wss://relay.example.com' });
+  await flushMicrotasks();
+  const byDeviceId = new Map<string, FakeBridgeSession>();
+  for (const session of createdSessions) byDeviceId.set(session.deviceId, session);
+  return byDeviceId;
+}
+
+beforeEach(() => {
+  createdSessions.length = 0;
+  rosterDevices = [deviceA, deviceB];
+});
+
+describe('MobileBridgeService.getStatus().relayState precedence', () => {
+  it('reports "connected" when at least one session is connected, regardless of the others', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const sessions = await openSessions(service);
+    sessions.get('device-A')?.setTransportState('connecting');
+    sessions.get('device-B')?.setTransportState('connected');
+
+    expect(service.getStatus().relayState).toBe('connected');
+
+    service.dispose();
+  });
+
+  it('reports "connecting" when nothing is connected but something is connecting', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const sessions = await openSessions(service);
+    sessions.get('device-A')?.setTransportState('reconnecting');
+    sessions.get('device-B')?.setTransportState('connecting');
+
+    expect(service.getStatus().relayState).toBe('connecting');
+
+    service.dispose();
+  });
+
+  it('reports "reconnecting" when nothing is connected or connecting but something is reconnecting', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const sessions = await openSessions(service);
+    sessions.get('device-A')?.setTransportState('closed');
+    sessions.get('device-B')?.setTransportState('reconnecting');
+
+    expect(service.getStatus().relayState).toBe('reconnecting');
+
+    service.dispose();
+  });
+
+  it('reports "closed" only once every session is closed', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const sessions = await openSessions(service);
+    sessions.get('device-A')?.setTransportState('closed');
+    sessions.get('device-B')?.setTransportState('closed');
+
+    expect(service.getStatus().relayState).toBe('closed');
+
+    service.dispose();
+  });
+
+  it('excludes the ephemeral pairing transport: an active pairing ceremony does not move the aggregate off the roster sessions state', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const sessions = await openSessions(service);
+    sessions.get('device-A')?.setTransportState('closed');
+    sessions.get('device-B')?.setTransportState('closed');
+    expect(service.getStatus().relayState).toBe('closed');
+
+    // startPairing() dials a brand-new, distinct 'connected' transport for
+    // the ceremony (see the transport-factory mock above) - it is never
+    // inserted into `this.sessions`, so the aggregate must stay 'closed'
+    // rather than flip to 'connected' for the duration of the pairing.
+    await service.startPairing();
+
+    expect(service.getStatus().relayState).toBe('closed');
+
+    service.dispose();
+  });
+});
+
+describe('MobileBridgeService.scheduleRelayStateEmit() throttle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('coalesces a burst of transport-state changes within one window into a single stateChanged emission', async () => {
+    rosterDevices = [deviceA];
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const sessions = await openSessions(service);
+    const session = sessions.get('device-A');
+    if (!session) throw new Error('device-A session was not opened');
+    const stateChanged = vi.fn();
+    service.on('stateChanged', stateChanged);
+
+    session.setTransportState('connecting');
+    session.setTransportState('reconnecting');
+    session.setTransportState('connecting');
+    // All three flaps land inside one window: not even the first check has
+    // run yet, so no emission has fired.
+    expect(stateChanged).not.toHaveBeenCalled();
+
+    // RELAY_STATE_EMIT_WINDOW_MS mirrors the private constant of the same
+    // name in mobile-bridge-service.ts (not exported, so re-stated here).
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(stateChanged).toHaveBeenCalledTimes(1);
+    expect(service.getStatus().relayState).toBe('connecting');
+
+    service.dispose();
+  });
+
+  it('does not emit again when the aggregate has not actually changed', async () => {
+    rosterDevices = [deviceA];
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const sessions = await openSessions(service);
+    const session = sessions.get('device-A');
+    if (!session) throw new Error('device-A session was not opened');
+
+    session.setTransportState('connecting');
+    await vi.advanceTimersByTimeAsync(500);
+
+    const stateChanged = vi.fn();
+    service.on('stateChanged', stateChanged);
+    session.setTransportState('connecting'); // Same value: no real change.
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(stateChanged).not.toHaveBeenCalled();
+
+    service.dispose();
+  });
+
+  it('throttles rather than debounces: a flap partway through the window does not push the emission further out', async () => {
+    rosterDevices = [deviceA];
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const sessions = await openSessions(service);
+    const session = sessions.get('device-A');
+    if (!session) throw new Error('device-A session was not opened');
+    const stateChanged = vi.fn();
+    service.on('stateChanged', stateChanged);
+
+    session.setTransportState('connecting');
+    await vi.advanceTimersByTimeAsync(300);
+    expect(stateChanged).not.toHaveBeenCalled();
+
+    // A debounce implementation would reset the window here, pushing the
+    // emission out to t=800ms from the FIRST change; the throttle must not,
+    // so it still fires within 200ms more (t=500ms from the first change).
+    session.setTransportState('reconnecting');
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(stateChanged).toHaveBeenCalledTimes(1);
+
+    service.dispose();
+  });
+});
+
+describe('MobileBridgeService.emitStateChanged() rebaselines the throttle on every direct emission', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('a later real transition still emits after revokeDevice()\'s direct emit changed the aggregate outside the throttle', async () => {
+    // Pins the concrete failure emitStateChanged() fixes: revokeDevice(),
+    // setDeviceCapabilities(), the pairing 'confirmed' handler, and
+    // dev-quick-pair's onRosterChanged all emit 'stateChanged' directly,
+    // bypassing scheduleRelayStateEmit()'s timer entirely. If any of those
+    // paths does not ALSO rebaseline lastEmittedRelayState (the bug this
+    // guards), the throttle's next real transition gets compared against a
+    // stale baseline and is silently swallowed.
+    rosterDevices = [deviceA];
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const sessions = await openSessions(service);
+    const sessionA = sessions.get('device-A');
+    if (!sessionA) throw new Error('device-A session was not opened');
+
+    // Baseline: A connects, the throttle's window elapses, and 'connected'
+    // is emitted (and captured as lastEmittedRelayState) through the normal
+    // scheduleRelayStateEmit() path.
+    sessionA.setTransportState('connected');
+    await vi.advanceTimersByTimeAsync(500);
+    expect(service.getStatus().relayState).toBe('connected');
+
+    // Direct-emit path: revokeDevice() disposes A's session (no sessions
+    // remain, so the aggregate is now 'idle') and emits 'stateChanged'
+    // WITHOUT ever going through scheduleRelayStateEmit()'s timer.
+    service.revokeDevice('device-A');
+    expect(service.getStatus().relayState).toBe('idle');
+
+    // Pair device B: add it to the roster and let syncSessions() open its
+    // session, mirroring what a completed pairing ceremony's 'confirmed'
+    // handler does to the roster/sessions map. The ceremony's own Noise
+    // handshake is out of scope here; only the emitStateChanged()
+    // rebaseline is under test.
+    rosterDevices = [deviceB];
+    service.reconcile({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    await flushMicrotasks();
+    const sessionB = createdSessions.find((session) => session.deviceId === 'device-B');
+    if (!sessionB) throw new Error('device-B session was not opened');
+
+    const stateChanged = vi.fn();
+    service.on('stateChanged', stateChanged);
+
+    // B reaches 'connected': the aggregate is 'connected' again - the SAME
+    // value as the pre-revoke baseline. Before the fix, the throttle's check
+    // compared this fresh 'connected' against that STALE, never-rebaselined
+    // 'connected' and swallowed the emission, leaving the renderer's
+    // indicator stuck forever. With the fix, revokeDevice()'s direct emit
+    // rebaselined lastEmittedRelayState to 'idle', so this transition is
+    // correctly recognized as a real change and emitted.
+    sessionB.setTransportState('connected');
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(stateChanged).toHaveBeenCalledTimes(1);
+    expect(service.getStatus().relayState).toBe('connected');
+
+    service.dispose();
+  });
+});

--- a/tests/unit/mobile-bridge/mobile-bridge-service.test.ts
+++ b/tests/unit/mobile-bridge/mobile-bridge-service.test.ts
@@ -128,6 +128,11 @@ describe('MobileBridgeService read paths never create an identity', () => {
     expect(status.enabled).toBe(false);
   });
 
+  it('getStatus() reports relayState "idle" when there are no roster devices to open a session for', () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    expect(service.getStatus().relayState).toBe('idle');
+  });
+
   it('listDevices() returns an empty array without persisting an identity when none exists', () => {
     const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
     const devices = service.listDevices();
@@ -180,6 +185,16 @@ describe('MobileBridgeService.startPairing() is the deliberate identity-creation
     const service = new MobileBridgeService({ enabled: false, relayUrl: '' });
     await expect(service.startPairing()).rejects.toThrow(/not enabled/);
     expect(writeFileSyncSpy).not.toHaveBeenCalled();
+  });
+
+  it('refuses to start pairing on an invalid relay URL rather than minting a QR the phone will reject', async () => {
+    // This should be unreachable via the real reconcile() call sites (both
+    // resolve through resolveRelayUrl() before it reaches config), but a
+    // directly-constructed service with a bad URL still must not proceed.
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'ws://not-loopback.example.com' });
+    await expect(service.startPairing()).rejects.toThrow(/TLS/);
+    expect(writeFileSyncSpy).not.toHaveBeenCalled();
+    expect(fakeTransport.connect).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/mobile-bridge/relay-client.test.ts
+++ b/tests/unit/mobile-bridge/relay-client.test.ts
@@ -141,6 +141,18 @@ describe('RelayClient', () => {
     expect(client.state).toBe('closed');
   });
 
+  it('rejects immediately on a malformed relayUrl instead of entering the reconnect backoff loop', async () => {
+    const client = new RelayClient({ relayUrl: 'not a url', slotId: 'test-slot' });
+    activeClients.push(client);
+
+    await expect(client.connect()).rejects.toThrow();
+    expect(client.state).toBe('closed');
+
+    // No reconnect timer was armed: state stays 'closed' rather than cycling into 'reconnecting'.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(client.state).toBe('closed');
+  });
+
   it('send() throws when called before connecting', () => {
     const client = new RelayClient({ relayUrl: 'ws://127.0.0.1:1', slotId: 'test-slot' });
     activeClients.push(client);

--- a/tests/unit/mobile-bridge/transport-factory.test.ts
+++ b/tests/unit/mobile-bridge/transport-factory.test.ts
@@ -25,7 +25,9 @@ describe('createTransport()', () => {
     // is observed indirectly: the dial URL RelayClient builds embeds both
     // (see relay-client.ts's `dial()`), which surfaces as the actual
     // WebSocket connection target. We assert this via the connect-time URL
-    // rather than reaching into RelayClient internals.
+    // rather than reaching into RelayClient internals. dial() parses with
+    // new URL() and sets the slot via searchParams, so a bare-host input
+    // gains a normalized trailing slash before the query string.
     const capturedUrls: string[] = [];
     class RecordingWebSocket {
       binaryType = 'blob';
@@ -50,7 +52,7 @@ describe('createTransport()', () => {
       // to have run, which happens before any await point.
       void transport.connect().catch(() => undefined);
 
-      expect(capturedUrls).toEqual(['ws://relay.example.com?slot=my-slot-id']);
+      expect(capturedUrls).toEqual(['ws://relay.example.com/?slot=my-slot-id']);
       transport.close();
     } finally {
       (globalThis as unknown as { WebSocket: unknown }).WebSocket = originalWebSocket;

--- a/tests/unit/mobile-store.test.ts
+++ b/tests/unit/mobile-store.test.ts
@@ -68,6 +68,7 @@ function makeStatus(overrides: Partial<MobileBridgeStatus> = {}): MobileBridgeSt
     secureStorageAvailable: true,
     identityFingerprint: 'deadbeef',
     relayUrl: 'wss://relay.example.com',
+    relayState: 'idle',
     pairedDeviceCount: 0,
     pairingInProgress: false,
     ...overrides,

--- a/tests/unit/protocol/qr.test.ts
+++ b/tests/unit/protocol/qr.test.ts
@@ -45,6 +45,14 @@ describe('pairing QR payload', () => {
     expect(() => encodePairingQrPayload(payload)).toThrow();
   });
 
+  it('rejects a relay address under 512 characters but over 512 bytes (multi-byte) - proves the cap is byte-based like src/shared/relay.ts validateRelayUrl', () => {
+    // Euro sign is 3 bytes in UTF-8: 200 of them is 600 bytes but only 206 characters.
+    const relayAddress = 'wss://' + '€'.repeat(200);
+    expect(relayAddress.length).toBeLessThan(512);
+    const payload = samplePayload({ relayAddress });
+    expect(() => encodePairingQrPayload(payload)).toThrow();
+  });
+
   it('rejects a corrupted/truncated payload at decode time', () => {
     const uri = encodePairingQrPayload(samplePayload());
     const truncated = uri.slice(0, uri.length - 40);

--- a/tests/unit/protocol/relay-address.test.ts
+++ b/tests/unit/protocol/relay-address.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for packages/protocol/src/pairing/relay-address.ts.
+ *
+ * This module mirrors the mobile app's src/pairing/qr.ts relay-address
+ * check byte-for-byte, and MUST stay dependency-free: it is deep-imported
+ * by src/shared/relay.ts, which the renderer bundles, and pulling in the
+ * rest of the protocol package (crypto/primitives -> @noble/*) would drag
+ * Noise crypto into the renderer bundle for no reason. The import-list
+ * assertion below is what actually keeps that true - nothing else does.
+ */
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isSecureRelayAddress, MAX_RELAY_ADDRESS_LENGTH } from '../../../packages/protocol/src/pairing/relay-address';
+
+describe('MAX_RELAY_ADDRESS_LENGTH', () => {
+  it('equals the protocol package byte cap', () => {
+    expect(MAX_RELAY_ADDRESS_LENGTH).toBe(512);
+  });
+});
+
+describe('isSecureRelayAddress', () => {
+  it('accepts any wss:// address', () => {
+    expect(isSecureRelayAddress('wss://relay.kangentic.com')).toBe(true);
+    expect(isSecureRelayAddress('wss://relay.kangentic.com/?slot=abc')).toBe(true);
+    expect(isSecureRelayAddress('wss://my-self-hosted-relay.example.com:9443')).toBe(true);
+  });
+
+  it('accepts ws:// only for an exact loopback host, with a boundary check', () => {
+    expect(isSecureRelayAddress('ws://localhost')).toBe(true);
+    expect(isSecureRelayAddress('ws://localhost:8080')).toBe(true);
+    expect(isSecureRelayAddress('ws://localhost/path')).toBe(true);
+    expect(isSecureRelayAddress('ws://localhost?slot=abc')).toBe(true);
+    expect(isSecureRelayAddress('ws://127.0.0.1')).toBe(true);
+    expect(isSecureRelayAddress('ws://127.0.0.1:8080')).toBe(true);
+    expect(isSecureRelayAddress('ws://[::1]')).toBe(true);
+    expect(isSecureRelayAddress('ws://[::1]:8080')).toBe(true);
+  });
+
+  it('rejects a hostname that merely starts with a loopback prefix (the boundary case)', () => {
+    expect(isSecureRelayAddress('ws://localhost.evil.com')).toBe(false);
+    expect(isSecureRelayAddress('ws://127.0.0.1.evil.com')).toBe(false);
+    expect(isSecureRelayAddress('ws://[::1]evil.com')).toBe(false);
+  });
+
+  it('rejects a plain non-loopback ws:// address', () => {
+    expect(isSecureRelayAddress('ws://relay.kangentic.com')).toBe(false);
+    expect(isSecureRelayAddress('ws://my-server.example.com')).toBe(false);
+    expect(isSecureRelayAddress('ws://0.0.0.0')).toBe(false);
+    expect(isSecureRelayAddress('ws://127.0.0.2')).toBe(false);
+  });
+
+  it('rejects a non-ws(s) scheme entirely', () => {
+    expect(isSecureRelayAddress('https://relay.kangentic.com')).toBe(false);
+    expect(isSecureRelayAddress('http://localhost:8080')).toBe(false);
+    expect(isSecureRelayAddress('not a url')).toBe(false);
+    expect(isSecureRelayAddress('')).toBe(false);
+  });
+});
+
+describe('relay-address.ts dependency-free leaf invariant', () => {
+  it('imports nothing', () => {
+    const filePath = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../../packages/protocol/src/pairing/relay-address.ts');
+    const source = fs.readFileSync(filePath, 'utf-8');
+    const importLines = source.split('\n').filter((line) => /^\s*import\s/.test(line));
+    expect(importLines).toEqual([]);
+  });
+});

--- a/tests/unit/register-all-idempotency.test.ts
+++ b/tests/unit/register-all-idempotency.test.ts
@@ -7,6 +7,7 @@
  * re-registering ipcMain.handle handlers (which throws on duplicates).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { KANGENTIC_HOSTED_RELAY_URL } from '../../src/shared/relay';
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────
 
@@ -257,12 +258,19 @@ describe('registerAllIpc idempotency', () => {
     expect(retrievalService.attach).toHaveBeenCalledTimes(1);
 
     // MobileBridgeService.reconcile() is called once at startup with the
-    // real effective config's mobileBridge fields (defaulted, since the
-    // mocked ConfigManager.getEffectiveConfig() here returns no mobileBridge
-    // key) - not left at the { enabled: false, relayUrl: '' } placeholder
-    // the constructor takes before configManager is available.
+    // real effective config's mobileBridge fields resolved through
+    // resolveRelayUrl() (defaulted, since the mocked
+    // ConfigManager.getEffectiveConfig() here returns no mobileBridge key) -
+    // not left at the { enabled: false, relayUrl: '' } placeholder the
+    // constructor takes before configManager is available, and not the raw
+    // '' relayUrl either: resolveRelayUrl() never returns '', it infers
+    // 'hosted' mode from the missing mobileBridge key and falls back to the
+    // hosted relay (src/shared/relay.ts).
     expect(mobileBridgeReconcileSpy).toHaveBeenCalledTimes(1);
-    expect(mobileBridgeReconcileSpy).toHaveBeenCalledWith({ enabled: false, relayUrl: '' });
+    expect(mobileBridgeReconcileSpy).toHaveBeenCalledWith({
+      enabled: false,
+      relayUrl: KANGENTIC_HOSTED_RELAY_URL,
+    });
 
     // attachContext() wires the capability-verb handlers and must run once,
     // before reconcile() (which drives syncSessions()) so the first sync has

--- a/tests/unit/relay-url.test.ts
+++ b/tests/unit/relay-url.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for src/shared/relay.ts.
+ *
+ * Two invariants are load-bearing here and get their own dedicated cases:
+ * (1) validateRelayUrl delegates its TLS/loopback decision to the protocol
+ * package's isSecureRelayAddress rather than reimplementing it with
+ * new URL().hostname comparisons - a hostname-based rewrite would silently
+ * accept relay addresses the shipped mobile app rejects, which is the exact
+ * "QR the phone silently refuses" bug this module exists to prevent. (2)
+ * resolveRelayUrl always returns either a normalized-and-valid URL or a
+ * hardcoded constant, never a raw/un-normalized stored string - so a value
+ * saved before this schema existed, or written with WHATWG's IPv4/IPv6
+ * canonicalizations, can never reach the pairing QR unnormalized.
+ *
+ * Unlike an earlier version of this module, KANGENTIC_HOSTED_RELAY_URL and
+ * LOCAL_DEV_RELAY_URL are both build-mode-independent constants now - only
+ * the Select's list of *offered* modes varies by build (Local is dev-only),
+ * not what a given mode resolves to. So every case below runs identically
+ * regardless of vitest.config.ts's __KANGENTIC_DEV__ setting.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  KANGENTIC_HOSTED_RELAY_URL,
+  LOCAL_DEV_RELAY_URL,
+  relayHealthUrl,
+  resolveRelayUrl,
+  validateRelayUrl,
+} from '../../src/shared/relay';
+import { MAX_RELAY_ADDRESS_LENGTH, isSecureRelayAddress } from '../../packages/protocol/src/pairing/relay-address';
+import type { AppConfig } from '../../src/shared/types';
+
+describe('relay constants', () => {
+  it('are each a secure relay address', () => {
+    expect(isSecureRelayAddress(KANGENTIC_HOSTED_RELAY_URL)).toBe(true);
+    expect(isSecureRelayAddress(LOCAL_DEV_RELAY_URL)).toBe(true);
+  });
+});
+
+describe('validateRelayUrl', () => {
+  describe('accepts', () => {
+    it.each([
+      ['trailing slash', 'wss://relay.kangentic.com/', 'wss://relay.kangentic.com/'],
+      ['explicit port', 'wss://relay.kangentic.com:8443', 'wss://relay.kangentic.com:8443/'],
+      ['a path', 'wss://relay.kangentic.com/relay', 'wss://relay.kangentic.com/relay'],
+      ['an existing query string', 'wss://relay.kangentic.com?token=abc', 'wss://relay.kangentic.com/?token=abc'],
+      ['ws:// localhost', 'ws://localhost:8080', 'ws://localhost:8080/'],
+      ['ws:// 127.0.0.1', 'ws://127.0.0.1:8080', 'ws://127.0.0.1:8080/'],
+      ['ws:// bracketed IPv6 loopback', 'ws://[::1]:8080', 'ws://[::1]:8080/'],
+      ['surrounding whitespace', '  wss://relay.kangentic.com  ', 'wss://relay.kangentic.com/'],
+      ['uppercase scheme', 'WSS://relay.kangentic.com', 'wss://relay.kangentic.com/'],
+    ])('%s', (_label, input, expectedNormalized) => {
+      const result = validateRelayUrl(input);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.normalized).toBe(expectedNormalized);
+    });
+  });
+
+  describe('accepts and normalizes WHATWG IPv4/IPv6 canonicalizations', () => {
+    // These are exactly the cases where checking the RAW string would accept
+    // something the phone's isSecureRelayAddress prefix rule then rejects -
+    // normalizing first (and persisting/embedding the normalized form) is
+    // what keeps the desktop and the phone in agreement.
+    it.each([
+      ['decimal IPv4', 'ws://2130706433', 'ws://127.0.0.1/'],
+      ['hex IPv4', 'ws://0x7f.0.0.1', 'ws://127.0.0.1/'],
+      ['short-form IPv4', 'ws://127.1', 'ws://127.0.0.1/'],
+      ['trailing-dot IPv4', 'ws://127.0.0.1.', 'ws://127.0.0.1/'],
+      ['expanded IPv6 loopback', 'ws://[0:0:0:0:0:0:0:1]:8080', 'ws://[::1]:8080/'],
+    ])('%s', (_label, input, expectedNormalized) => {
+      const result = validateRelayUrl(input);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.normalized).toBe(expectedNormalized);
+        expect(isSecureRelayAddress(result.normalized)).toBe(true);
+      }
+    });
+  });
+
+  describe('applies the byte cap to the normalized value, not just the raw draft', () => {
+    // Regression: the cap was checked only against `raw`. Normalization can
+    // GROW the string (an authority-only URL gains a trailing '/'), so a raw
+    // input sitting exactly at the cap normalized to one byte over it and was
+    // still returned as ok. That over-cap value got persisted and embedded in
+    // the pairing QR, and then failed this very check on every later
+    // resolveRelayUrl() - silently falling back to the hosted relay with no
+    // error anywhere in the UI, because the custom-mode branch does not render
+    // the resolved-URL pill and the draft error was cleared at commit time.
+    it('rejects a raw input at the cap whose normalized form exceeds it', () => {
+      const rawAtExactlyTheCap = 'wss://' + 'a'.repeat(MAX_RELAY_ADDRESS_LENGTH - 'wss://'.length);
+      expect(new TextEncoder().encode(rawAtExactlyTheCap).length).toBe(MAX_RELAY_ADDRESS_LENGTH);
+      expect(new TextEncoder().encode(new URL(rawAtExactlyTheCap).href).length).toBe(MAX_RELAY_ADDRESS_LENGTH + 1);
+
+      expect(validateRelayUrl(rawAtExactlyTheCap).ok).toBe(false);
+    });
+
+    it('still accepts a raw input whose normalized form lands exactly on the cap', () => {
+      const rawOneUnderTheCap = 'wss://' + 'a'.repeat(MAX_RELAY_ADDRESS_LENGTH - 'wss://'.length - 1);
+      const result = validateRelayUrl(rawOneUnderTheCap);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(new TextEncoder().encode(result.normalized).length).toBe(MAX_RELAY_ADDRESS_LENGTH);
+      }
+    });
+  });
+
+  describe('rejects', () => {
+    it.each([
+      ['a hostname that merely starts with localhost (the boundary case)', 'ws://localhost.evil.com'],
+      ['a trailing-dot domain (dot preserved, unlike IPv4)', 'ws://localhost.'],
+      ['userinfo even when the host is loopback', 'ws://evil.com@localhost/'],
+      ['a plain non-loopback ws:// address', 'ws://evil.com'],
+      ['127.0.0.2 (in 127/8 but outside the exact loopback allowlist)', 'ws://127.0.0.2'],
+      ['0.0.0.0', 'ws://0.0.0.0'],
+      ['https scheme', 'https://relay.kangentic.com'],
+      ['http scheme, even for localhost', 'http://localhost:8080'],
+      ['a #fragment', 'wss://relay.kangentic.com/#frag'],
+      ['a raw backslash', 'ws:\\\\localhost\\'],
+      ['no scheme', 'relay.kangentic.com'],
+      ['empty string', ''],
+      ['whitespace only', '   '],
+      ['unparseable garbage', 'not a url'],
+    ])('%s', (_label, input) => {
+      const result = validateRelayUrl(input);
+      expect(result.ok).toBe(false);
+    });
+
+    it('an oversized URL (over 512 bytes)', () => {
+      const result = validateRelayUrl('wss://' + 'a'.repeat(600));
+      expect(result.ok).toBe(false);
+    });
+
+    it('a URL under 512 characters but over 512 bytes (multi-byte)', () => {
+      const relayUrl = 'wss://' + '€'.repeat(200);
+      expect(relayUrl.length).toBeLessThan(512);
+      const result = validateRelayUrl(relayUrl);
+      expect(result.ok).toBe(false);
+    });
+  });
+});
+
+describe('resolveRelayUrl', () => {
+  it('resolves to the hosted relay when mobileBridge is undefined', () => {
+    expect(resolveRelayUrl(undefined)).toBe(KANGENTIC_HOSTED_RELAY_URL);
+  });
+
+  it('resolves to the hosted relay when relayMode is unset and relayUrl is empty', () => {
+    const bridge: AppConfig['mobileBridge'] = { enabled: true };
+    expect(resolveRelayUrl(bridge)).toBe(KANGENTIC_HOSTED_RELAY_URL);
+  });
+
+  it('resolves to the hosted relay when relayMode is explicitly "hosted", even with a relayUrl set', () => {
+    const bridge: AppConfig['mobileBridge'] = { relayMode: 'hosted', relayUrl: 'wss://ignored.example.com' };
+    expect(resolveRelayUrl(bridge)).toBe(KANGENTIC_HOSTED_RELAY_URL);
+  });
+
+  it('resolves to the local dev relay when relayMode is "local", regardless of relayUrl', () => {
+    const bridge: AppConfig['mobileBridge'] = { relayMode: 'local', relayUrl: 'wss://ignored.example.com' };
+    expect(resolveRelayUrl(bridge)).toBe(LOCAL_DEV_RELAY_URL);
+  });
+
+  it('infers "custom" when relayMode is unset but relayUrl is a saved value (pre-resolver schema)', () => {
+    const bridge: AppConfig['mobileBridge'] = { relayUrl: 'wss://legacy.example.com' };
+    expect(resolveRelayUrl(bridge)).toBe('wss://legacy.example.com/');
+  });
+
+  it('falls back to the hosted relay when the inferred-custom legacy value is invalid, rather than returning it raw', () => {
+    const bridge: AppConfig['mobileBridge'] = { relayUrl: 'not-a-url' };
+    expect(resolveRelayUrl(bridge)).toBe(KANGENTIC_HOSTED_RELAY_URL);
+  });
+
+  it('falls back to the hosted relay when relayMode is "custom" but relayUrl is empty - never returns ""', () => {
+    const bridge: AppConfig['mobileBridge'] = { relayMode: 'custom', relayUrl: '' };
+    const resolved = resolveRelayUrl(bridge);
+    expect(resolved).not.toBe('');
+    expect(resolved).toBe(KANGENTIC_HOSTED_RELAY_URL);
+  });
+
+  it('falls back to the hosted relay when relayMode is "custom" but relayUrl is invalid', () => {
+    const bridge: AppConfig['mobileBridge'] = { relayMode: 'custom', relayUrl: 'ws://not-loopback.example.com' };
+    expect(resolveRelayUrl(bridge)).toBe(KANGENTIC_HOSTED_RELAY_URL);
+  });
+
+  it('returns the normalized custom URL, not the stored value verbatim', () => {
+    const bridge: AppConfig['mobileBridge'] = { relayMode: 'custom', relayUrl: 'WSS://Relay.Example.com' };
+    expect(resolveRelayUrl(bridge)).toBe('wss://relay.example.com/');
+  });
+
+  it('resolves a raw un-normalized stored value to its normalized form - the invariant that keeps a raw string out of the QR', () => {
+    const bridge: AppConfig['mobileBridge'] = { relayMode: 'custom', relayUrl: 'ws://127.1' };
+    expect(resolveRelayUrl(bridge)).toBe('ws://127.0.0.1/');
+  });
+});
+
+describe('relayHealthUrl', () => {
+  it('maps wss -> https and appends /healthz', () => {
+    expect(relayHealthUrl('wss://relay.kangentic.com')).toBe('https://relay.kangentic.com/healthz');
+  });
+
+  it('maps ws -> http and preserves the port', () => {
+    expect(relayHealthUrl('ws://127.0.0.1:8080')).toBe('http://127.0.0.1:8080/healthz');
+  });
+
+  it('does not produce a double slash for a trailing-slash input', () => {
+    expect(relayHealthUrl('wss://relay.kangentic.com/')).toBe('https://relay.kangentic.com/healthz');
+  });
+
+  it('preserves an existing query string (a self-hosted relay may be token-gated)', () => {
+    expect(relayHealthUrl('wss://relay.kangentic.com?token=abc')).toBe('https://relay.kangentic.com/healthz?token=abc');
+  });
+});


### PR DESCRIPTION
## What

Replaces the Mobile Devices settings tab's raw, empty-by-default relay URL text field with a resolved-default + explicit-override design:

- The Relay picker now offers three explicit modes: **Kangentic Cloud** (always dials `wss://relay.kangentic.com`), **Local** (dev-build only, dials `ws://127.0.0.1:8080`), and **Custom Relay** (self-hosted, user-entered). The resolved address renders as a muted, read-only pill; a **Test Connection** probe reports Reachable/No response without reflowing the layout when a result appears.
- New `src/shared/relay.ts`: `validateRelayUrl` (delegates its TLS/loopback decision to the phone's own `isSecureRelayAddress` rather than reimplementing it), `inferRelayMode`, `resolveRelayUrl` (always returns a normalized, valid URL - never `''`), and `relayHealthUrl`.
- New `packages/protocol/src/pairing/relay-address.ts`: a dependency-free leaf carrying `MAX_RELAY_ADDRESS_LENGTH` and `isSecureRelayAddress`, so the desktop's validator can't drift from the phone's, and the renderer bundle doesn't pull in the rest of the protocol package's `@noble/*` crypto.
- New `mobile:testRelay` IPC endpoint: validates server-side and probes the relay's `/healthz` with a 5s timeout; never throws.
- `MobileBridgeStatus` gained `relayState`, an aggregate of every paired device's live transport state, throttled to one `stateChanged` emission per 500ms window, so a paired device whose relay is unreachable no longer renders as healthy.
- `RelayClient.dial()` now parses the URL up front and fails fast on a malformed address instead of entering the reconnect backoff loop.

## Why

`relay.kangentic.com` is now live. A normal user should never have to type a URL to use Mobile Bridge; the desktop should just work against the hosted relay. A self-hoster still needs an override, and a developer needs a low-friction way to point at a local relay during `kangentic-relay` development - without that meaning "type the exact hosted URL into Custom" every time.

## How

`mobileBridge.relayMode` (`'hosted' | 'local' | 'custom'`) is new. `DEFAULT_CONFIG` deliberately **omits** it rather than seeding `'hosted'`: `mobileBridge` merges key-by-key with the parsed config file (it isn't a `CONFIG_DICTIONARY_PATHS` entry), so seeding a literal default would fill in over a config saved before `relayMode` existed and silently move an upgrading self-hoster off their own relay. Leaving it undefined lets `inferRelayMode`'s "relayMode missing but relayUrl set => custom" backward-compat inference run - a real regression a test-builder coverage pass caught and fixed via a `ConfigManager.load()`-level regression test (`tests/unit/config-manager.test.ts`), since the resolver's own unit tests hand-build the `mobileBridge` object and never exercise the default-merge path.

Trade-off worth flagging: a fresh dev checkout with Mobile Bridge enabled now dials the live production relay by default, not a local one - "Local" is an explicit, always-visible-in-dev opt-in rather than an implicit build-mode branch. That was a deliberate product decision, not an oversight: it removes the "what does 'default' mean right now" ambiguity a two-mode scheme had.

## Breaking changes

None. This feature has never shipped (the whole Mobile Bridge surface is `__KANGENTIC_DEV__`-gated end to end), so there is no migration for real users. The config schema change (`relayMode` addition, `MobileBridgeStatus.relayState` addition) is additive and optional.

## Tests

- `tests/unit/relay-url.test.ts` (46 cases): `validateRelayUrl` accept/reject/normalize including WHATWG IPv4/IPv6 canonicalization and the byte-cap-after-normalization edge case, `resolveRelayUrl` across every mode/value combination, `relayHealthUrl` scheme mapping.
- `tests/unit/protocol/relay-address.test.ts`: the validator at the protocol layer, plus a static "imports nothing" purity check for the dependency-free leaf.
- `tests/unit/mobile-bridge/mobile-bridge-relay-state.test.ts` (9 cases, new): `relayState` aggregation precedence, pairing-transport exclusion, and the `scheduleRelayStateEmit` throttle (coalesce, no-op-on-unchanged, and the `emitStateChanged` baseline-rebase fix for a real bug this diff found - a direct `stateChanged` emit outside the throttle left the comparison baseline stale, silently swallowing the next real transition).
- `tests/unit/mobile-bridge/bridge-session.test.ts`, `relay-client.test.ts`, `transport-factory.test.ts`, `mobile-bridge-ipc-handler.test.ts`, `mobile-bridge-service.test.ts`: transport-state event ordering, fail-fast on a malformed dial URL, the `mobile:testRelay` handler's 8 failure/success cases, and the `startPairing()` invalid-URL guard.
- `tests/unit/config-manager.test.ts`: the `DEFAULT_CONFIG`/legacy-relayUrl-inference regression, asserted through the real `ConfigManager.load()` merge path.
- `tests/unit/config-handler-wiring.test.ts`, `register-all-idempotency.test.ts`: fixed by a coverage-pass audit - both pinned `mobileBridgeService.reconcile()`'s `relayUrl` to the pre-resolver raw-passthrough behavior; updated to the resolver's actual contract (normalized, never `''`).
- `tests/ui/mobile-devices-settings.spec.ts` (23 cases): the three-option Select, the resolved-address pill, Test Connection's Reachable/No response states, no layout shift when a result appears, and stale-result-clearing on a mode switch.
- CI: typecheck, lint, unit, UI, and the sharded Linux Electron E2E tier, all as required PR checks.

Generated with [Claude Code](https://claude.com/claude-code)
