### PR TITLE
fix(transition-engine): resolve {{baseBranch}} to the effective default, unify task template vars

### DIFF
--- a/.claude/rules/task-template-vars-parity.md
+++ b/.claude/rules/task-template-vars-parity.md
@@ -1,0 +1,84 @@
+---
+paths:
+  - "src/shared/task-template-vars.ts"
+  - "src/main/agent/shared/task-template-resolvers.ts"
+  - "src/main/agent/shared/template-utils.ts"
+  - "src/main/ipc/helpers/agent-spawn.ts"
+  - "src/main/transition-engine/transition-engine.ts"
+  - "src/renderer/components/dialogs/BoardManagerDialog.tsx"
+  - "docs/transition-engine.md"
+  - "docs/architecture.md"
+---
+# Rule: task-template-variable parity (chips + resolvers + docs track one catalog)
+
+Two template contexts (a column/per-task `auto_command` and a `spawn_agent` action's
+`promptTemplate`) both interpolate `{{keyword}}` placeholders against a task. The keyword set used
+to be declared four times with no link between them: `buildAutoCommandVars` (6 keys, in
+`agent-spawn.ts`), the engine's inline `templateVars` object (10 keys, duplicated at two call
+sites in `transition-engine.ts`), the UI chip list (`TEMPLATE_VARIABLES` in
+`BoardManagerDialog.tsx`, 5 keys), and two docs tables. They drifted silently: the UI never
+surfaced `{{baseBranch}}`, and `{{baseBranch}}` itself resolved to `task.base_branch || ''` -
+empty for the ~99% of tasks with no per-task override, instead of falling through to the
+project's configured default. Every automated Code Review auto-command silently ran with no base
+ref for over a week before anyone noticed.
+
+The fix is one source of truth: `src/shared/task-template-vars.ts` (`TASK_TEMPLATE_VAR_NAMES` /
+`TASK_TEMPLATE_VARS`) declares the 10 keywords once; `src/main/agent/shared/task-template-resolvers.ts`
+(`TASK_TEMPLATE_RESOLVERS`, a `Record<TaskTemplateVarName, ...>`) resolves each one exactly once;
+the UI chips render from the shared catalog; and both docs tables are checked against it.
+
+## The rule
+
+When you add, rename, or remove a task-template keyword:
+
+1. **Catalog:** add/rename/remove the entry in `TASK_TEMPLATE_VAR_NAMES` and `TASK_TEMPLATE_VARS`
+   (`src/shared/task-template-vars.ts`). This is the only hand-edited list.
+2. **Resolver:** add/rename/remove the matching key in `TASK_TEMPLATE_RESOLVERS`
+   (`src/main/agent/shared/task-template-resolvers.ts`). The `Record<TaskTemplateVarName, ...>`
+   shape makes a missing resolver a `tsc` failure, not a silent gap.
+3. **UI:** nothing to edit - `BoardManagerDialog.tsx`'s chip list renders
+   `TASK_TEMPLATE_VARS.map((templateVar) => templateVar.chip)` directly from the catalog.
+4. **Docs:** document the new keyword in both `docs/transition-engine.md` (Template Variables)
+   and `docs/architecture.md` (Action Types). This couples to [[docs-stay-in-sync]].
+5. **Resolution semantics are per-keyword, not a blanket rule.** `{{baseBranch}}` resolves to the
+   EFFECTIVE base (`task.base_branch ?? defaultBaseBranch ?? 'main'`); `{{worktreePath}}` and
+   `{{branchName}}` stay raw reads of the task column (empty is correct for a task with no
+   worktree/branch, and must NOT fall back to a project-level value). Do not "fix" a raw-read
+   keyword to match `{{baseBranch}}`'s fallback behavior.
+6. **`auto_command` and `promptTemplate` share drop-and-collapse interpolation**
+   (`interpolateTaskTemplate` in `template-utils.ts`): an empty-valued or unknown `{{key}}` is
+   dropped and horizontal whitespace collapses (newlines are preserved). The collapse applies to
+   ALL literal text in the template, not only the run a dropped placeholder left behind, so a
+   hand-aligned `/foo  --flag` delivers as `/foo --flag`; substituted values are exempt and are
+   inserted verbatim. This is deliberately scoped - `send_command` / `run_script` / `webhook` keep
+   the general `interpolateTemplate` (unknown left as a literal placeholder), so do not switch
+   them to `interpolateTaskTemplate` without a considered reason.
+7. **Only the interpolation MECHANICS are scoped, not the resolved VALUES.** `executeAction`
+   builds one `resolveTaskTemplateVars` object and feeds every action type from it, so
+   `send_command` / `run_script` / `webhook` also see `{{baseBranch}}` resolved to the effective
+   default (they previously saw `task.base_branch || ''`). That uniformity is intended - a base
+   ref should mean the same thing in every action - but it means a change to a resolver's
+   semantics fans out beyond the two drop-and-collapse contexts. Weigh that blast radius when
+   editing `TASK_TEMPLATE_RESOLVERS`.
+
+## Enforcement (self-maintaining)
+
+- **Compile-time:** `TASK_TEMPLATE_RESOLVERS: Record<TaskTemplateVarName, ...>` fails
+  `npm run typecheck` the moment a catalog name has no resolver.
+- **Test (mechanical, CI):** `tests/unit/task-template-vars-parity.test.ts` asserts (a) every
+  catalog name has a resolver and vice versa; (b) `TASK_TEMPLATE_VARS` covers exactly the catalog
+  names; (c) every chip is documented in both `docs/transition-engine.md` and
+  `docs/architecture.md`; plus red-green coverage of the `{{baseBranch}}` effective-default fix
+  and the `interpolateTaskTemplate` drop-and-collapse semantics (including that a substituted
+  value containing literal `{{...}}` text is never re-scanned). Runs in CI via `npm run test:unit`.
+- **Review:** `/code-review` flags a new task-template keyword added to only one of the catalog /
+  resolver / docs, and the `doc-auditor` agent reports a chip missing from the docs tables.
+
+## Scope
+
+The task-template keyword system (`auto_command` and `spawn_agent` `promptTemplate`) and its two
+enumerating surfaces (the Automation tab's chip list, and the two docs tables). The Shortcut
+command template system (`src/shared/template-vars.ts`, `{{cwd}}` / `{{branchName}}` /
+`{{taskTitle}}` / `{{projectPath}}`) is a separate, unrelated system and out of scope. The general
+`interpolateTemplate` used by `send_command` / `run_script` / `webhook` keeps its own (unscoped,
+literal-passthrough) behavior and is not governed by the drop-and-collapse rule above.

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -140,6 +140,7 @@ Anchors are enumerable source-code structures that must be exhaustively listed i
 | Anchor | Source file | Target doc |
 |--------|-----------|------------|
 | Template variables | `src/shared/template-vars.ts` | configuration.md (canonical), transition-engine.md and agent-integration.md (cross-reference only) |
+| Task template variables (auto_command / promptTemplate) | `src/shared/task-template-vars.ts` | transition-engine.md (canonical, "Template Variables"), architecture.md (cross-reference only) |
 
 ### Verification Procedures
 
@@ -188,6 +189,9 @@ Each entry has a one-line rationale so future edits know what the entry was prot
 
 - `src/shared/template-vars.ts`
   WHY: template variable list is mirrored in configuration.md (canonical) and cross-referenced in transition-engine.md and agent-integration.md.
+
+- `src/shared/task-template-vars.ts`
+  WHY: the 10-keyword auto_command / spawn_agent promptTemplate catalog (title, description, task_xml, taskId, worktreePath, branchName, baseBranch, prUrl, prNumber, attachments) is tabulated in transition-engine.md "Template Variables" and cross-referenced in architecture.md. Mechanically enforced by tests/unit/task-template-vars-parity.test.ts; see .claude/rules/task-template-vars-parity.md. Distinct from src/shared/template-vars.ts (the unrelated Shortcut command system). agent-integration.md's "Prompt Templates" section also names the full keyword list in prose (linking back to transition-engine.md as canonical) - not mechanically checked, spot-check it by hand on a keyword add/rename.
 
 - `src/main/agent/agent-adapter.ts`
   WHY: AgentAdapter interface methods (discoverCapabilities, getInjectionSequence, getCommandInjectionVerifier, summarize, locateSessionHistoryFile, getExitSequence, detectFirstOutput) are tabulated in agent-integration.md. Catches drift that types.ts re-exports miss.

--- a/.claude/skills/sync-docs/references/verification-procedures.md
+++ b/.claude/skills/sync-docs/references/verification-procedures.md
@@ -103,10 +103,22 @@ When an anchor maps to multiple target docs, one doc is the **canonical** locati
 4. Find the settings section
 5. Compare: report missing registry entries
 
-## Template Variable Anchors
+## Shortcut Template Variable Anchors
 
 1. Read `src/shared/template-vars.ts`
-2. Extract all exported template variable names and their descriptions
-3. Read `docs/transition-engine.md` and `docs/agent-integration.md`
-4. Find sections documenting template variables
-5. Compare: report missing variables
+2. Extract all exported template variable names (`{{cwd}}`, `{{branchName}}`, `{{taskTitle}}`,
+   `{{projectPath}}`) and their descriptions
+3. Read `docs/configuration.md#shortcuts` (canonical)
+4. Compare: report missing variables. `docs/transition-engine.md` and `docs/agent-integration.md`
+   only cross-reference this system with a link - they do not enumerate it.
+
+## Task Template Variable Anchors (auto_command / spawn_agent promptTemplate)
+
+1. Read `src/shared/task-template-vars.ts` (`TASK_TEMPLATE_VAR_NAMES` / `TASK_TEMPLATE_VARS`)
+2. Extract all 10 keyword names and their `chip`/`description` fields
+3. Read `docs/transition-engine.md` ("## Template Variables", canonical) and
+   `docs/architecture.md` (the "Template variables available" line, cross-reference)
+4. Compare: report any chip missing from either doc, or documented with stale prose (e.g.
+   describing `{{baseBranch}}` as resolving empty rather than falling back to the effective
+   project default). `tests/unit/task-template-vars-parity.test.ts` runs this same check
+   mechanically in CI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,7 @@ session; rules with one load when you touch matching files. Each rule names its 
 - `pop-out-surface-registry.md` - every OS `BrowserWindow` is created only in `createWindow` or the pop-out window manager; every detachable surface goes through the shared + renderer registries (`src/main/pop-out/**`, `src/shared/pop-out.ts`, `src/renderer/pop-out/**`).
 - `spawn-entry-point-parity.md` - every agent-spawn entry point routes through `spawnAgent` / `prepareAgentSpawn` and the shared `runSpawnPreamble` (first-spawn override lock + agent resolution); no direct engine spawn calls in handlers (`src/main/ipc/**`, `src/main/transition-engine/**`).
 - `linux-package-dependencies.md` - rpm dependencies are soname capabilities, never package names, since RPM package names differ per distro (`electron-builder.yml`).
+- `task-template-vars-parity.md` - the 10 auto_command / spawn_agent promptTemplate keywords are declared once in `TASK_TEMPLATE_VARS` and drive the resolver map, UI chips, and docs tables (`src/shared/task-template-vars.ts`, `src/main/agent/shared/task-template-resolvers.ts`, `src/renderer/components/dialogs/BoardManagerDialog.tsx`).
 
 **Local overrides:** there is no per-rule local file. Put machine-specific instruction
 overrides in a gitignored `CLAUDE.local.md` at the project root.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -496,7 +496,7 @@ Transitions only fire for case 5. The action chain runs in `execution_order`: ty
 | `create_pr` | Reserved. Not yet implemented. |
 | `webhook` | POST to URL with interpolated body |
 
-Template variables available: `{{title}}`, `{{description}}`, `{{task_xml}}`, `{{taskId}}`, `{{worktreePath}}`, `{{branchName}}`, `{{baseBranch}}`, `{{prUrl}}`, `{{prNumber}}`, `{{attachments}}`.
+Template variables available: `{{title}}`, `{{description}}`, `{{task_xml}}`, `{{taskId}}`, `{{worktreePath}}`, `{{branchName}}`, `{{baseBranch}}`, `{{prUrl}}`, `{{prNumber}}`, `{{attachments}}`. One declaration (`src/shared/task-template-vars.ts`) drives the `auto_command` field, the `spawn_agent` promptTemplate, and the Automation tab's chip list - see [Transition Engine](transition-engine.md#template-variables).
 
 ## PTY Session Manager
 

--- a/docs/transition-engine.md
+++ b/docs/transition-engine.md
@@ -135,7 +135,14 @@ Content-Type defaults to `application/json`. Failures are logged but don't block
 
 ## Template Variables
 
-All action types that accept templates can use these placeholders:
+One declaration (`src/shared/task-template-vars.ts`) drives every consumer: the
+`auto_command` field (column and per-task), the `spawn_agent` action's
+`promptTemplate`, the Automation tab's chip list, and this table - see
+`tests/unit/task-template-vars-parity.test.ts`. All 10 keywords resolve
+identically in both `auto_command` and `promptTemplate`; `send_command` /
+`run_script` / `webhook` use the same values but keep literal, non-collapsing
+substitution (an unknown or empty `{{key}}` is left as-is, matching
+`interpolateTemplate`'s general behavior).
 
 | Variable | Value |
 |----------|-------|
@@ -143,12 +150,17 @@ All action types that accept templates can use these placeholders:
 | `{{description}}` | Task description with `: ` prefix when non-empty |
 | `{{task_xml}}` | Task title and description wrapped in a `<task>` envelope (`<title>` / `<description>` children). Default seeded prompt template is `{{task_xml}}{{attachments}}`, which gives the agent a structured envelope without forcing the user to template it manually. |
 | `{{taskId}}` | Task UUID |
-| `{{worktreePath}}` | Worktree directory path (empty if none) |
-| `{{branchName}}` | Git branch name (empty if none) |
-| `{{baseBranch}}` | Base branch the task forked from (empty if unset) |
+| `{{worktreePath}}` | Worktree directory path (empty if none) - a raw read, never falls back to a project-level path |
+| `{{branchName}}` | Git branch name (empty if none) - a raw read, never falls back to a project-level branch |
+| `{{baseBranch}}` | Effective base branch: the task's `base_branch` override, else the project's configured default (board config, then app config, then `'main'`) |
 | `{{prUrl}}` | Pull request URL (empty if none) |
 | `{{prNumber}}` | Pull request number as string (empty if none) |
 | `{{attachments}}` | Bare file paths (one per line) when present |
+
+In `auto_command` and `promptTemplate` specifically, an empty-valued or unknown
+`{{key}}` is dropped and surrounding horizontal whitespace collapses (newlines
+are preserved), so `/code-review {{baseBranch}}` with no configured default
+still yields `/code-review`, not a trailing space or a literal placeholder.
 
 Shortcut commands use a separate set of template variables. See [Configuration](configuration.md#shortcuts) for the full list.
 

--- a/src/main/agent/shared/index.ts
+++ b/src/main/agent/shared/index.ts
@@ -1,8 +1,9 @@
-export { interpolateTemplate } from './template-utils';
+export { interpolateTemplate, interpolateTaskTemplate } from './template-utils';
 export { resolveBridgeScript } from './bridge-utils';
 export { execVersion } from './exec-version';
 export { AgentDetector, type AgentDetectorConfig } from './agent-detector';
 export { escapeXml, buildTaskXml, buildHandoffXml, type TaskXmlInput, type HandoffXmlInput } from './prompt-xml';
+export { resolveTaskTemplateVars, TASK_TEMPLATE_RESOLVERS, type TaskTemplateContext } from './task-template-resolvers';
 // NOTE: relocation-utils is intentionally NOT re-exported here. Several unit
 // suites mock this barrel (`vi.mock('.../agent/shared')`); routing a
 // module-load-time `createSerialLock()` call through the barrel would break

--- a/src/main/agent/shared/task-template-resolvers.ts
+++ b/src/main/agent/shared/task-template-resolvers.ts
@@ -1,0 +1,57 @@
+import type { Task } from '../../../shared/types';
+import { sanitizeForPty } from '../../../shared/paths';
+import { TASK_TEMPLATE_VAR_NAMES, type TaskTemplateVarName } from '../../../shared/task-template-vars';
+import { buildTaskXml } from './prompt-xml';
+
+/**
+ * Everything a task-template resolver needs. `defaultBaseBranch` is the
+ * caller-resolved effective default (board config -> project/global config ->
+ * 'main'; see resolveDefaultBaseBranch in
+ * src/main/ipc/handlers/git-stats-capture.ts), never re-derived here so every
+ * call site resolves {{baseBranch}} identically. `attachmentPaths` is the
+ * task's attachment file paths, already resolved by the caller.
+ */
+export interface TaskTemplateContext {
+  task: Task;
+  defaultBaseBranch: string;
+  attachmentPaths: string[];
+}
+
+type TaskTemplateResolver = (ctx: TaskTemplateContext) => string;
+
+/**
+ * One resolver per keyword in TASK_TEMPLATE_VAR_NAMES. The Record<keyof>
+ * shape makes an unresolved keyword a compile error, not a silent gap.
+ */
+export const TASK_TEMPLATE_RESOLVERS: Record<TaskTemplateVarName, TaskTemplateResolver> = {
+  // Raw description (not sanitizeForPty'd) so multi-line markdown content
+  // survives end to end - quoteArg's `multiline: true` opt-in keeps newlines
+  // through shell delivery. The legacy {{description}} prose var stays
+  // sanitized so user-customized single-line templates don't break.
+  task_xml: ({ task }) => buildTaskXml({ title: sanitizeForPty(task.title), description: task.description }),
+  title: ({ task }) => sanitizeForPty(task.title),
+  description: ({ task }) => {
+    const clean = sanitizeForPty(task.description);
+    return clean ? `: ${clean}` : '';
+  },
+  taskId: ({ task }) => task.id,
+  // Raw reads: empty is correct for a task with no worktree/branch, and must
+  // not fall back to a project-level default the way {{baseBranch}} does.
+  worktreePath: ({ task }) => task.worktree_path || '',
+  branchName: ({ task }) => task.branch_name || '',
+  // The fix: an unset per-task override falls through to the effective
+  // project default instead of resolving empty.
+  baseBranch: ({ task, defaultBaseBranch }) => task.base_branch || defaultBaseBranch || 'main',
+  prUrl: ({ task }) => task.pr_url || '',
+  prNumber: ({ task }) => (task.pr_number ? String(task.pr_number) : ''),
+  attachments: ({ attachmentPaths }) => (attachmentPaths.length > 0 ? `\n${attachmentPaths.join('\n')}` : ''),
+};
+
+/** Resolve every task template variable for the given context. */
+export function resolveTaskTemplateVars(ctx: TaskTemplateContext): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const name of TASK_TEMPLATE_VAR_NAMES) {
+    vars[name] = TASK_TEMPLATE_RESOLVERS[name](ctx);
+  }
+  return vars;
+}

--- a/src/main/agent/shared/template-utils.ts
+++ b/src/main/agent/shared/template-utils.ts
@@ -1,10 +1,99 @@
 /**
  * Replace `{{key}}` placeholders in a template string with values from `vars`.
+ * An unknown key's `{{...}}` is left untouched in the output.
  */
 export function interpolateTemplate(template: string, vars: Record<string, string>): string {
   let result = template;
   for (const [key, value] of Object.entries(vars)) {
     result = result.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
   }
+  return result;
+}
+
+/**
+ * Task-template interpolation for auto_command and spawn_agent promptTemplate
+ * only (not the general interpolateTemplate consumers like send_command/
+ * run_script/webhook). Differs from interpolateTemplate in two ways:
+ *
+ *   1. An empty-valued OR unknown `{{key}}` is dropped instead of left as a
+ *      literal placeholder or a dangling empty string.
+ *   2. Horizontal whitespace in the template's LITERAL TEXT collapses to a
+ *      single space. That covers the run left behind by a dropped placeholder,
+ *      so `/code-review {{baseBranch}}` with an empty baseBranch yields
+ *      `/code-review`, not `/code-review ` with a trailing space. Note the
+ *      collapse is not limited to drop sites: it normalizes ALL literal
+ *      spacing in the template, so a hand-aligned `/foo  --flag` (double
+ *      space) delivers as `/foo --flag`. Substituted values are exempt.
+ *
+ * Resolves and strips against the TEMPLATE, never the interpolated output: a
+ * substituted value (e.g. a task description that itself contains the text
+ * "{{title}}") is inserted verbatim and never re-scanned for placeholders, so
+ * legitimate content in a resolved value cannot be corrupted by this pass.
+ *
+ * Newlines are preserved - only runs of spaces/tabs collapse, and only within
+ * template text (never inside a substituted value). This keeps a multi-line
+ * {{task_xml}} envelope intact, down to a markdown hard break inside the raw
+ * description, while still cleaning up a single-line auto_command whose
+ * trailing keyword resolved empty. The leading/trailing edges of the whole
+ * result are trimmed only when that edge is template text; an outermost
+ * substituted value keeps its own surrounding whitespace.
+ */
+export function interpolateTaskTemplate(template: string, vars: Record<string, string>): string {
+  const tokens = template.split(/(\{\{\w+\}\})/g);
+  const rawSegments: Array<{ type: 'text' | 'value'; content: string }> = [];
+
+  for (const token of tokens) {
+    const match = /^\{\{(\w+)\}\}$/.exec(token);
+    if (match) {
+      const value = vars[match[1]];
+      if (value) {
+        rawSegments.push({ type: 'value', content: value });
+      }
+      // Empty or unknown: dropped entirely (no segment emitted).
+    } else if (token) {
+      rawSegments.push({ type: 'text', content: token });
+    }
+  }
+
+  // Merge consecutive text segments BEFORE collapsing whitespace - this is
+  // where a dropped placeholder's two text neighbors become adjacent, and a
+  // whitespace run split across that drop point must collapse as one run,
+  // not two independently-collapsed halves. Substituted values are never
+  // merged into text and never touched by the collapse below.
+  const merged: Array<{ type: 'text' | 'value'; content: string }> = [];
+  for (const segment of rawSegments) {
+    const last = merged[merged.length - 1];
+    if (segment.type === 'text' && last?.type === 'text') {
+      last.content += segment.content;
+    } else {
+      merged.push({ ...segment });
+    }
+  }
+
+  // Every cleanup below is per-TEXT-segment and runs BEFORE concatenation.
+  // Running it on the joined string instead would reach into substituted
+  // values: a markdown hard break (a line ending in two spaces) inside a raw
+  // task description delivered via {{task_xml}} would be silently stripped -
+  // exactly the multi-line fidelity the task_xml resolver keeps the raw
+  // description to protect. Edge trimming is skipped when the outermost
+  // segment is a value, so a value's own leading/trailing whitespace survives.
+  let result = '';
+  for (let index = 0; index < merged.length; index++) {
+    const segment = merged[index];
+    if (segment.type === 'value') {
+      result += segment.content;
+      continue;
+    }
+    let text = segment.content
+      .replace(/[ \t]+/g, ' ')
+      // Trailing horizontal whitespace before a line break. The lookahead keeps
+      // the break itself untouched, so a CRLF-authored template (`" \r\n"`)
+      // loses the space without stranding a bare `\r`.
+      .replace(/[ \t]+(?=\r?\n)/g, '');
+    if (index === 0) text = text.replace(/^\s+/, '');
+    if (index === merged.length - 1) text = text.replace(/\s+$/, '');
+    result += text;
+  }
+
   return result;
 }

--- a/src/main/ipc/handlers/backlog.ts
+++ b/src/main/ipc/handlers/backlog.ts
@@ -212,7 +212,7 @@ export function registerBacklogHandlers(context: IpcContext): void {
                 const engine = createTransitionEngine(context, actions, tasks, sessionRepo, attachments, projectId, projectPath);
                 // projectId/projectPath so the spawn preamble (override lock +
                 // agent resolution) sees the project defaults instead of null.
-                await spawnAgent({ context, engine, tasks, sessionRepo, task, fromSwimlaneId: '*', toLane: targetSwimlane, signal, projectId, projectPath });
+                await spawnAgent({ context, engine, tasks, sessionRepo, task, fromSwimlaneId: '*', toLane: targetSwimlane, signal, projectId, projectPath, attachments });
               } catch (error) {
                 if (isAbortError(error)) {
                   console.log(`[BACKLOG_PROMOTE] Aborted promotion for task ${task.id.slice(0, 8)}`);

--- a/src/main/ipc/handlers/task-archive.ts
+++ b/src/main/ipc/handlers/task-archive.ts
@@ -91,6 +91,7 @@ export function registerTaskArchiveHandlers(context: IpcContext): void {
               suppressAutoCommand: true,
               projectId: resolvedProjectId,
               projectPath: resolvedProjectPath,
+              attachments: attachmentRepo,
             });
           } catch (err) {
             console.error('[TASK_UNARCHIVE] Failed to start session:', err);
@@ -158,6 +159,7 @@ export function registerTaskArchiveHandlers(context: IpcContext): void {
                 suppressAutoCommand: true,
                 projectId: resolvedProjectId,
                 projectPath: resolvedProjectPath,
+                attachments: attachmentRepo,
               });
             } catch (error) {
               console.error('[TASK_BULK_UNARCHIVE] Failed to start session:', error);

--- a/src/main/ipc/handlers/task-crud.ts
+++ b/src/main/ipc/handlers/task-crud.ts
@@ -138,7 +138,7 @@ export function registerTaskCrudHandlers(context: IpcContext): void {
         // falls back to toLane, and the New Task dialog displayed inherit
         // values against the creation column itself.
         try {
-          await spawnAgent({ context, engine, tasks, sessionRepo, task, fromSwimlaneId: '*', toLane, projectId, projectPath });
+          await spawnAgent({ context, engine, tasks, sessionRepo, task, fromSwimlaneId: '*', toLane, projectId, projectPath, attachments });
         } catch (err) {
           console.error('[TASK_CREATE] Failed to start session:', err);
         }

--- a/src/main/ipc/handlers/task-move.ts
+++ b/src/main/ipc/handlers/task-move.ts
@@ -16,11 +16,10 @@ import {
   cleanupTaskResources,
   deleteTaskWorktree,
   spawnAgent,
-  buildAutoCommandVars,
 } from '../helpers';
 import { autoLinkPRForTask } from '../../pr/pr-linking';
 import { resolveProjectContext } from '../helpers/project-repos';
-import { interpolateTemplate } from '../../agent/shared';
+import { interpolateTaskTemplate, resolveTaskTemplateVars } from '../../agent/shared';
 import { trackEvent } from '../../analytics/analytics';
 import { parseModelId } from '../../../shared/model-id';
 import { captureSessionMetrics, refineTranscriptTokens, refineTranscriptToolCounts } from './session-metrics';
@@ -219,7 +218,7 @@ export async function handleTaskMove(
       const resolvedProjectPath = projectPath !== undefined ? projectPath : context.currentProjectPath;
       if (!resolvedProjectId) throw new Error('No project is currently open');
 
-      const { tasks, swimlanes } = getProjectRepos(context, resolvedProjectId);
+      const { tasks, swimlanes, attachments } = getProjectRepos(context, resolvedProjectId);
       const task = tasks.getById(input.taskId);
       if (!task) throw new Error(`Task ${input.taskId} not found`);
 
@@ -599,7 +598,11 @@ export async function handleTaskMove(
           // model-restart policy stays in one place (agent-agnostic here).
           const adapter = task.agent ? agentRegistry.get(task.agent) : undefined;
           const interpolatedAuto = toLane?.auto_command?.trim()
-            ? interpolateTemplate(toLane.auto_command, buildAutoCommandVars(task))
+            ? interpolateTaskTemplate(toLane.auto_command, resolveTaskTemplateVars({
+                task,
+                defaultBaseBranch: effectiveDefaultBranch,
+                attachmentPaths: attachments.getPathsForTask(task.id),
+              }))
             : '';
           const plan = prepareInjectionPlan({
             adapter,
@@ -895,7 +898,7 @@ export async function handleTaskMove(
           const sessionRepoPhase3 = new SessionRepository(dbPhase3);
           const engine = createTransitionEngine(context, actionsPhase3, tasksPhase3, sessionRepoPhase3, attachmentsPhase3, resolvedProjectId, resolvedProjectPath);
           if (toLane) {
-            await spawnAgent({ context, engine, tasks: tasksPhase3, sessionRepo: sessionRepoPhase3, task: current, fromSwimlaneId, toLane, skipPromptTemplate, signal, projectId: resolvedProjectId, projectPath: resolvedProjectPath, continuationPrompt, suppressAutoCommand, settingsSourceLane: fromLane ?? null });
+            await spawnAgent({ context, engine, tasks: tasksPhase3, sessionRepo: sessionRepoPhase3, task: current, fromSwimlaneId, toLane, skipPromptTemplate, signal, projectId: resolvedProjectId, projectPath: resolvedProjectPath, continuationPrompt, suppressAutoCommand, settingsSourceLane: fromLane ?? null, attachments: attachmentsPhase3 });
           }
         } finally {
           clearSpawnProgress(context.mainWindow, task.id);

--- a/src/main/ipc/helpers/agent-spawn.ts
+++ b/src/main/ipc/helpers/agent-spawn.ts
@@ -6,7 +6,8 @@ import { SessionRepository } from '../../db/repositories/session-repository';
 import { HandoffRepository } from '../../db/repositories/handoff-repository';
 import { TransitionEngine } from '../../transition-engine/transition-engine';
 import { getProjectDb } from '../../db/database';
-import { interpolateTemplate } from '../../agent/shared';
+import { interpolateTaskTemplate, resolveTaskTemplateVars } from '../../agent/shared';
+import { resolveDefaultBaseBranch } from '../handlers/git-stats-capture';
 import { agentRegistry } from '../../agent/agent-registry';
 import { buildSessionHistoryReference } from '../../agent/handoff/session-history-reference';
 import { DEFAULT_AGENT } from '../../../shared/types';
@@ -21,18 +22,6 @@ import { ensureTaskWorktree, ensureTaskBranchCheckout } from './task-git';
 import { getProjectRepos } from './project-repos';
 import { withTaskLock } from '../task-lifecycle-lock';
 import { runWithProjectLogContext } from '../../diagnostics/project-log-context';
-
-/** Build template variables for auto-command interpolation. */
-export function buildAutoCommandVars(task: Task): Record<string, string> {
-  return {
-    title: task.title,
-    description: task.description,
-    taskId: task.id,
-    worktreePath: task.worktree_path || '',
-    branchName: task.branch_name || '',
-    baseBranch: task.base_branch || '',
-  };
-}
 
 /**
  * Resolve the column-derived spawn overrides handed to
@@ -120,6 +109,14 @@ export interface AgentSpawnOptions {
   /** Project filesystem path for handoff context resolution. */
   projectPath?: string | null;
   /**
+   * Attachment repository for the task's project, used to resolve
+   * {{attachments}} in the auto_command template context. Every spawnAgent
+   * call site already has this from getProjectRepos; omitted only where a
+   * caller has no project context, in which case {{attachments}} resolves
+   * empty.
+   */
+  attachments?: AttachmentRepository;
+  /**
    * Fallback resume prompt when the destination column has no auto_command.
    * Set by plan-exit auto-moves ("Your plan was approved...") so a respawned
    * session continues instead of resuming idle. Only delivered on a RESUME of
@@ -171,6 +168,18 @@ export async function spawnAgent(options: AgentSpawnOptions): Promise<void> {
   // without establishing a new context, inheriting any ambient tag (e.g. from
   // an enclosing task-move).
   const project = options.projectId ? context.projectRepo.getById(options.projectId) : null;
+
+  // Auto_command template vars for the current task snapshot. defaultBaseBranch
+  // is resolved once per spawn (board config -> project/global config ->
+  // 'main') so {{baseBranch}} matches resolveDefaultBaseBranch everywhere else
+  // it's used, rather than resolving empty for the ~99% of tasks with no
+  // per-task base_branch override.
+  const resolveAutoCommandVars = (currentTask: Task): Record<string, string> =>
+    resolveTaskTemplateVars({
+      task: currentTask,
+      defaultBaseBranch: resolveDefaultBaseBranch(context, options.projectPath),
+      attachmentPaths: options.attachments?.getPathsForTask(currentTask.id) ?? [],
+    });
 
   const run = async (): Promise<void> => {
   // Guard: if the target column doesn't want agents, no-op
@@ -301,8 +310,7 @@ export async function spawnAgent(options: AgentSpawnOptions): Promise<void> {
 
       const effectiveAutoCommand = currentTask.auto_command ?? toLane.auto_command;
       if (!options.suppressAutoCommand && effectiveAutoCommand?.trim()) {
-        const vars = buildAutoCommandVars(currentTask);
-        const interpolated = interpolateTemplate(effectiveAutoCommand, vars);
+        const interpolated = interpolateTaskTemplate(effectiveAutoCommand, resolveAutoCommandVars(currentTask));
         context.terminalSubmitScheduler.scheduleKeystrokes(currentTask.id, currentTask.session_id, [interpolated], { freshlySpawned: true });
       }
     }
@@ -373,7 +381,7 @@ export async function spawnAgent(options: AgentSpawnOptions): Promise<void> {
   // true for any non-To-Do source.
   const effectiveAutoCommand = currentTask.auto_command ?? toLane.auto_command;
   const interpolatedAutoCommand = !options.suppressAutoCommand && effectiveAutoCommand?.trim()
-    ? interpolateTemplate(effectiveAutoCommand, buildAutoCommandVars(currentTask))
+    ? interpolateTaskTemplate(effectiveAutoCommand, resolveAutoCommandVars(currentTask))
     : undefined;
   const deliverAutoCommandAsPrompt = interpolatedAutoCommand !== undefined
     && (canResumeDestination || skipPromptTemplate === true);
@@ -482,7 +490,7 @@ export async function autoSpawnForTask(
       const sessionRepo = new SessionRepository(db);
       const engine = createTransitionEngine(context, actions, tasks, sessionRepo, attachments, projectId, projectPath);
 
-      await spawnAgent({ context, engine, tasks, sessionRepo, task: fullTask, fromSwimlaneId: '*', toLane, projectId, projectPath });
+      await spawnAgent({ context, engine, tasks, sessionRepo, task: fullTask, fromSwimlaneId: '*', toLane, projectId, projectPath, attachments });
 
       console.log(`[MCP auto-spawn] Spawned agent for "${task.title}" in ${toLane.name}`);
     } catch (err) {

--- a/src/main/ipc/helpers/index.ts
+++ b/src/main/ipc/helpers/index.ts
@@ -7,6 +7,6 @@ export { getProjectRepos } from './project-repos';
 // implementation instead of forcing every mock to re-declare it.
 export { ensureGitignore } from './project-setup';
 export { ensureTaskWorktree, ensureTaskBranchCheckout } from './task-git';
-export { buildAutoCommandVars, createTransitionEngine, spawnAgent, autoSpawnForTask, resolveSpawnOverrides } from './agent-spawn';
+export { createTransitionEngine, spawnAgent, autoSpawnForTask, resolveSpawnOverrides } from './agent-spawn';
 export type { AgentSpawnOptions } from './agent-spawn';
 export { cleanupTaskSession, cleanupTaskResources, deleteTaskWorktree } from './task-cleanup';

--- a/src/main/transition-engine/spawn-intent.ts
+++ b/src/main/transition-engine/spawn-intent.ts
@@ -14,7 +14,7 @@
  * This is a pure function with no side effects - easy to unit test.
  */
 
-import { interpolateTemplate } from '../agent/shared';
+import { interpolateTaskTemplate } from '../agent/shared';
 import type { SessionRecord } from '../../shared/types';
 import type { SessionRepository } from '../db/repositories/session-repository';
 
@@ -119,7 +119,7 @@ export function resolveSpawnIntent(options: SpawnIntentOptions): SpawnIntent {
     // owns the prompt slot and the auto_command is injected as a post-spawn
     // keystroke instead.
     prompt: promptTemplate
-      ? interpolateTemplate(promptTemplate, templateVars)
+      ? interpolateTaskTemplate(promptTemplate, templateVars)
       : resumePrompt,
     // On a forced-fresh entry, retire the prior record we deliberately skipped so
     // it does not linger or get resumed later. (retireRecord no-ops on records

--- a/src/main/transition-engine/transition-engine.ts
+++ b/src/main/transition-engine/transition-engine.ts
@@ -5,7 +5,7 @@ import type { Task, Action, ActionConfig, AppConfig, PermissionMode } from '../.
 import { sanitizeForPty } from '../../shared/paths';
 import { SessionManager } from '../pty/session-manager';
 import type { TerminalSubmit } from '../pty/terminal-submit';
-import { interpolateTemplate, buildTaskXml } from '../agent/shared';
+import { interpolateTemplate, resolveTaskTemplateVars } from '../agent/shared';
 import { resolveExecutionTarget } from '../agent/shared/execution-target';
 import { WorktreeManager, prepareWorktreeForRemoval, GitQueuePriority } from '../git/worktree-manager';
 import { agentRegistry } from '../agent/agent-registry';
@@ -76,28 +76,20 @@ export class TransitionEngine {
   async resumeSuspendedSession(task: Task, permissionOverride?: PermissionMode | null, skipPromptTemplate?: boolean, resumePrompt?: string, signal?: AbortSignal, agentOverride?: string, handoffPromptPrefix?: string, spawnOverrides?: SpawnOverrides): Promise<void> {
     signal?.throwIfAborted();
     const attachmentPaths = this.attachmentRepo?.getPathsForTask(task.id) ?? [];
-    const cleanTitle = sanitizeForPty(task.title);
-    const cleanDesc = sanitizeForPty(task.description);
     // {{task_xml}} wraps title/description in a <task> envelope (Anthropic +
     // OpenAI guidance for clear data/instruction boundaries). The XML body
     // uses the RAW description so multi-line markdown content survives end
     // to end - quoteArg's `multiline: true` opt-in keeps newlines through
     // shell delivery. The legacy `{{description}}` prose var stays sanitized
     // so user-customized single-line templates don't break.
+    const templateVars = resolveTaskTemplateVars({
+      task,
+      defaultBaseBranch: this.getConfig().gitConfig.defaultBaseBranch,
+      attachmentPaths,
+    });
     await this.executeSpawnAgent({
       promptTemplate: skipPromptTemplate ? undefined : '{{task_xml}}{{attachments}}',
-    }, task, {
-      task_xml: buildTaskXml({ title: cleanTitle, description: task.description }),
-      title: cleanTitle,
-      description: cleanDesc ? `: ${cleanDesc}` : '',
-      taskId: task.id,
-      worktreePath: task.worktree_path || '',
-      branchName: task.branch_name || '',
-      baseBranch: task.base_branch || '',
-      attachments: attachmentPaths.length > 0
-        ? `\n${attachmentPaths.join('\n')}`
-        : '',
-    }, permissionOverride, resumePrompt, signal, agentOverride, handoffPromptPrefix, spawnOverrides);
+    }, task, templateVars, permissionOverride, resumePrompt, signal, agentOverride, handoffPromptPrefix, spawnOverrides);
   }
 
   async executeTransition(task: Task, fromSwimlaneId: string, toSwimlaneId: string, permissionOverride?: PermissionMode | null, skipPromptTemplate?: boolean, signal?: AbortSignal, agentOverride?: string, spawnOverrides?: SpawnOverrides, onProgress?: (phase: string) => void): Promise<void> {
@@ -122,24 +114,13 @@ export class TransitionEngine {
       return; // skip action with malformed config
     }
     const attachmentPaths = this.attachmentRepo?.getPathsForTask(task.id) ?? [];
-    const cleanTitle = sanitizeForPty(task.title);
-    const cleanDesc = sanitizeForPty(task.description);
     // task_xml gets the RAW description so multi-line markdown survives;
     // {{description}} stays sanitized for legacy single-line prose templates.
-    const templateVars: Record<string, string> = {
-      task_xml: buildTaskXml({ title: cleanTitle, description: task.description }),
-      title: cleanTitle,
-      description: cleanDesc ? `: ${cleanDesc}` : '',
-      taskId: task.id,
-      worktreePath: task.worktree_path || '',
-      branchName: task.branch_name || '',
-      baseBranch: task.base_branch || '',
-      prUrl: task.pr_url || '',
-      prNumber: task.pr_number ? String(task.pr_number) : '',
-      attachments: attachmentPaths.length > 0
-        ? `\n${attachmentPaths.join('\n')}`
-        : '',
-    };
+    const templateVars = resolveTaskTemplateVars({
+      task,
+      defaultBaseBranch: this.getConfig().gitConfig.defaultBaseBranch,
+      attachmentPaths,
+    });
 
     switch (action.type) {
       case 'spawn_agent':

--- a/src/renderer/components/dialogs/BoardManagerDialog.tsx
+++ b/src/renderer/components/dialogs/BoardManagerDialog.tsx
@@ -39,6 +39,7 @@ import {
   type SwimlaneCreateInput,
   type SwimlaneUpdateInput,
 } from '../../../shared/types';
+import { TASK_TEMPLATE_VARS } from '../../../shared/task-template-vars';
 
 /** Sentinel entity id keying this dialog's maximize flag in the session store. */
 const BOARD_MANAGER_ENTITY_ID = 'board-manager-dialog';
@@ -61,9 +62,10 @@ const SECTIONS: { id: SectionId; label: string; icon: typeof Sliders }[] = [
   { id: 'handoff', label: 'Handoff', icon: History },
 ];
 
-// Mirrors the keys in buildAutoCommandVars (agent-spawn.ts) - keep in sync so the
-// chips surface exactly what the auto-command interpolation actually substitutes.
-const TEMPLATE_VARIABLES = ['{{title}}', '{{description}}', '{{taskId}}', '{{worktreePath}}', '{{branchName}}'];
+// Sourced from TASK_TEMPLATE_VARS (shared/task-template-vars.ts) - the same
+// declaration the auto-command resolver and the docs-parity test read, so the
+// chips can never drift from what the interpolation actually substitutes.
+const TEMPLATE_VARIABLES = TASK_TEMPLATE_VARS.map((templateVar) => templateVar.chip);
 
 // ────────────────────────────────────────────────────────────────────────
 // Pure helpers (exported for unit tests)

--- a/src/shared/task-template-vars.ts
+++ b/src/shared/task-template-vars.ts
@@ -1,0 +1,87 @@
+/**
+ * Single declaration of the task template-variable keyword set, shared by
+ * auto_command and spawn_agent promptTemplate interpolation. Renderer-safe
+ * (metadata only - no resolution logic, which lives in
+ * src/main/agent/shared/task-template-resolvers.ts since it needs
+ * sanitizeForPty/buildTaskXml). Drives the UI chip list
+ * (BoardManagerDialog.tsx) and the docs-parity test, so adding or removing a
+ * keyword here is the only edit needed to keep every consumer in sync.
+ *
+ * This is a distinct system from src/shared/template-vars.ts, which resolves
+ * Shortcut command variables ({{cwd}}, {{branchName}}, {{taskTitle}},
+ * {{projectPath}}) and is unrelated to task template interpolation.
+ */
+
+export const TASK_TEMPLATE_VAR_NAMES = [
+  'task_xml',
+  'title',
+  'description',
+  'taskId',
+  'worktreePath',
+  'branchName',
+  'baseBranch',
+  'prUrl',
+  'prNumber',
+  'attachments',
+] as const;
+
+export type TaskTemplateVarName = (typeof TASK_TEMPLATE_VAR_NAMES)[number];
+
+export interface TaskTemplateVarInfo {
+  name: TaskTemplateVarName;
+  chip: string;
+  description: string;
+}
+
+export const TASK_TEMPLATE_VARS: readonly TaskTemplateVarInfo[] = [
+  {
+    name: 'task_xml',
+    chip: '{{task_xml}}',
+    description: 'Task title and description wrapped in a <task> XML envelope. Default seeded prompt template is {{task_xml}}{{attachments}}.',
+  },
+  {
+    name: 'title',
+    chip: '{{title}}',
+    description: 'Task title (PTY-sanitized).',
+  },
+  {
+    name: 'description',
+    chip: '{{description}}',
+    description: 'Task description with a ": " prefix when non-empty (PTY-sanitized).',
+  },
+  {
+    name: 'taskId',
+    chip: '{{taskId}}',
+    description: 'Task UUID.',
+  },
+  {
+    name: 'worktreePath',
+    chip: '{{worktreePath}}',
+    description: 'Worktree directory path (empty if the task has none).',
+  },
+  {
+    name: 'branchName',
+    chip: '{{branchName}}',
+    description: 'Git branch name (empty if the task has none).',
+  },
+  {
+    name: 'baseBranch',
+    chip: '{{baseBranch}}',
+    description: "Effective base branch: the task's override, else the project's configured default.",
+  },
+  {
+    name: 'prUrl',
+    chip: '{{prUrl}}',
+    description: 'Pull request URL (empty if none).',
+  },
+  {
+    name: 'prNumber',
+    chip: '{{prNumber}}',
+    description: 'Pull request number as a string (empty if none).',
+  },
+  {
+    name: 'attachments',
+    chip: '{{attachments}}',
+    description: 'Attached file paths, one per line (empty if none).',
+  },
+];

--- a/tests/unit/abort-task-move.test.ts
+++ b/tests/unit/abort-task-move.test.ts
@@ -117,7 +117,6 @@ vi.mock('../../src/main/ipc/helpers/index', () => ({
   ensureTaskBranchCheckout: (...args: unknown[]) => mockEnsureTaskBranchCheckout(...args),
   spawnAgent: (...args: unknown[]) => mockSpawnAgent(...args),
   createTransitionEngine: vi.fn(() => ({})),
-  buildAutoCommandVars: vi.fn(() => ({})),
   cleanupTaskResources: vi.fn(async () => {}),
   deleteTaskWorktree: vi.fn(async () => true),
   autoSpawnForTask: vi.fn(async () => {}),

--- a/tests/unit/bulk-delete-handler.test.ts
+++ b/tests/unit/bulk-delete-handler.test.ts
@@ -115,7 +115,6 @@ vi.mock('../../src/main/git/node-modules-link', () => ({
 // Mocked helpers - set up per test
 const mockGetProjectRepos = vi.fn();
 const mockCleanupTaskResources = vi.fn();
-const mockBuildAutoCommandVars = vi.fn(() => ({}));
 const mockEnsureTaskWorktree = vi.fn(async () => null);
 const mockEnsureTaskBranchCheckout = vi.fn(async () => {});
 const mockCreateTransitionEngine = vi.fn(() => ({}));
@@ -123,7 +122,6 @@ const mockCreateTransitionEngine = vi.fn(() => ({}));
 vi.mock('../../src/main/ipc/helpers', () => ({
   getProjectRepos: (...args: unknown[]) => mockGetProjectRepos(...args),
   cleanupTaskResources: (...args: unknown[]) => mockCleanupTaskResources(...args),
-  buildAutoCommandVars: (...args: unknown[]) => mockBuildAutoCommandVars(...args),
   ensureTaskWorktree: (...args: unknown[]) => mockEnsureTaskWorktree(...args),
   ensureTaskBranchCheckout: (...args: unknown[]) => mockEnsureTaskBranchCheckout(...args),
   createTransitionEngine: (...args: unknown[]) => mockCreateTransitionEngine(...args),

--- a/tests/unit/carry-uncommitted-changes.test.ts
+++ b/tests/unit/carry-uncommitted-changes.test.ts
@@ -51,7 +51,6 @@ vi.mock('../../src/main/git/worktree-manager', () => ({ WorktreeManager: vi.fn()
 vi.mock('../../src/main/db/database', () => ({ getProjectDb: vi.fn() }));
 vi.mock('../../src/main/ipc/helpers', () => ({
   getProjectRepos: vi.fn(),
-  buildAutoCommandVars: vi.fn(),
   ensureTaskWorktree: vi.fn(),
   createTransitionEngine: vi.fn(),
   cleanupTaskSession: vi.fn(),

--- a/tests/unit/drain-auto-name-asked-ids.test.ts
+++ b/tests/unit/drain-auto-name-asked-ids.test.ts
@@ -64,7 +64,6 @@ vi.mock('../../src/main/ipc/helpers', () => ({
       listByTaskId: vi.fn(() => []),
     },
   })),
-  buildAutoCommandVars: vi.fn(() => ({})),
   ensureTaskWorktree: vi.fn(async () => ({ worktreePath: '/tmp', checkoutError: undefined })),
   ensureTaskBranchCheckout: vi.fn(),
   createTransitionEngine: vi.fn(() => ({ run: vi.fn(async () => ({})) })),

--- a/tests/unit/ipc-handler-wiring.test.ts
+++ b/tests/unit/ipc-handler-wiring.test.ts
@@ -72,7 +72,6 @@ vi.mock('../../src/main/ipc/helpers', () => ({
   cleanupTaskResources: vi.fn(),
   deleteTaskWorktree: vi.fn(),
   spawnAgent: vi.fn(),
-  buildAutoCommandVars: vi.fn(),
   resolveSpawnOverrides: vi.fn(),
 }));
 vi.mock('../../src/main/ipc/handlers/task-move', () => ({

--- a/tests/unit/session-idle-timeout.test.ts
+++ b/tests/unit/session-idle-timeout.test.ts
@@ -145,7 +145,6 @@ vi.mock('../../src/main/ipc/helpers', () => ({
   })),
   cleanupTaskResources: vi.fn(async () => {}),
   deleteTaskWorktree: vi.fn(async () => true),
-  buildAutoCommandVars: vi.fn(() => ({})),
 }));
 
 // Import under test AFTER all mocks are registered.

--- a/tests/unit/session-reconcile-git-churn-wiring.test.ts
+++ b/tests/unit/session-reconcile-git-churn-wiring.test.ts
@@ -84,7 +84,6 @@ vi.mock('../../src/main/ipc/helpers', () => ({
   createTransitionEngine: vi.fn(),
   cleanupTaskResources: vi.fn(),
   deleteTaskWorktree: vi.fn(),
-  buildAutoCommandVars: vi.fn(() => ({})),
   resolveSpawnOverrides: vi.fn(() => ({})),
 }));
 

--- a/tests/unit/session-reconcile-helpers.test.ts
+++ b/tests/unit/session-reconcile-helpers.test.ts
@@ -86,7 +86,6 @@ vi.mock('../../src/main/ipc/helpers', () => ({
   createTransitionEngine: vi.fn(),
   cleanupTaskResources: vi.fn(),
   deleteTaskWorktree: vi.fn(),
-  buildAutoCommandVars: vi.fn(() => ({})),
 }));
 
 // Import under test AFTER all mocks are registered.

--- a/tests/unit/session-spawn-analytics.test.ts
+++ b/tests/unit/session-spawn-analytics.test.ts
@@ -153,7 +153,6 @@ vi.mock('../../src/main/ipc/helpers', () => ({
   })),
   cleanupTaskResources: vi.fn(async () => {}),
   deleteTaskWorktree: vi.fn(async () => true),
-  buildAutoCommandVars: vi.fn(() => ({})),
 }));
 
 // Import the module under test AFTER all vi.mock declarations.

--- a/tests/unit/spawn-agent-continuation-prompt.test.ts
+++ b/tests/unit/spawn-agent-continuation-prompt.test.ts
@@ -134,7 +134,16 @@ function makeDeps(args: { resumeRecord: SessionRecord | undefined }) {
   const scheduleKeystrokes = vi.fn();
   const context = {
     terminalSubmitScheduler: { scheduleKeystrokes },
-    configManager: { getEffectiveConfig: vi.fn(() => ({ agent: { permissionMode: 'acceptEdits' } })) },
+    configManager: {
+      getEffectiveConfig: vi.fn(() => ({
+        agent: { permissionMode: 'acceptEdits' },
+        git: { defaultBaseBranch: 'main' },
+      })),
+    },
+    // resolveDefaultBaseBranch (git-stats-capture.ts) reads this for the
+    // team-shared board default; undefined falls through to the git config
+    // default above, matching resolveAutoCommandVars in agent-spawn.ts.
+    boardConfigManager: { getDefaultBaseBranch: vi.fn(() => undefined) },
   };
 
   return { tasks, sessionRepo, engine, scheduleKeystrokes, context };

--- a/tests/unit/spawn-agent-isolated-auto-command.test.ts
+++ b/tests/unit/spawn-agent-isolated-auto-command.test.ts
@@ -29,8 +29,8 @@
  * The real spawnAgent is exercised end to end; only the engine, repos, and
  * context are injected mocks, plus resolveTargetAgent (force isHandoff=false to
  * reach the normal fallback) and agentRegistry (supply the destination
- * sessionType). resolveIsolatedSwimlaneId, isResumeEligible, interpolateTemplate,
- * and buildAutoCommandVars run for real - they are the logic under test.
+ * sessionType). resolveIsolatedSwimlaneId, isResumeEligible, interpolateTaskTemplate,
+ * and resolveTaskTemplateVars run for real - they are the logic under test.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -170,6 +170,12 @@ function makeDeps(args: {
   resumeRecord: SessionRecord | undefined;
   /** Extra task fields applied to the getById returns the auto_command interpolation reads. */
   taskFields?: Partial<Task>;
+  /**
+   * Optional attachments repo mock, forwarded to spawnAgent's `attachments`
+   * option exactly like a real getProjectRepos() call site would. Omitted by
+   * default so existing tests are unaffected ({{attachments}} resolves []).
+   */
+  attachments?: { getPathsForTask: ReturnType<typeof vi.fn> };
 }) {
   const getById = vi.fn();
   getById
@@ -193,10 +199,19 @@ function makeDeps(args: {
     terminalSubmitScheduler: { scheduleKeystrokes },
     mainWindow: { isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } },
     projectRepo: { getById: vi.fn(() => null) },
-    configManager: { getEffectiveConfig: vi.fn(() => ({ agent: { permissionMode: 'acceptEdits' } })) },
+    configManager: {
+      getEffectiveConfig: vi.fn(() => ({
+        agent: { permissionMode: 'acceptEdits' },
+        git: { defaultBaseBranch: 'main' },
+      })),
+    },
+    // resolveDefaultBaseBranch (git-stats-capture.ts) reads this for the
+    // team-shared board default; undefined falls through to the git config
+    // default above, matching resolveAutoCommandVars in agent-spawn.ts.
+    boardConfigManager: { getDefaultBaseBranch: vi.fn(() => undefined) },
   };
 
-  return { tasks, sessionRepo, engine, scheduleKeystrokes, context };
+  return { tasks, sessionRepo, engine, scheduleKeystrokes, context, attachments: args.attachments };
 }
 
 async function runSpawn(
@@ -217,6 +232,7 @@ async function runSpawn(
     skipPromptTemplate,
     suppressAutoCommand,
     projectId,
+    attachments: deps.attachments as never,
   });
 }
 
@@ -257,8 +273,8 @@ describe('spawnAgent auto_command injection (isolation-scoped resume check)', ()
   it('ISOLATED + fresh: a {{baseBranch}} placeholder in the auto_command interpolates the task base branch into the initial prompt', async () => {
     // The isolated Code Review column ships `/code-review {{baseBranch}}` so the
     // review is scoped against the branch the task actually forked from, not a
-    // guessed default. Verifies buildAutoCommandVars + interpolateTemplate wire
-    // task.base_branch through to the delivered command.
+    // guessed default. Verifies resolveTaskTemplateVars + interpolateTaskTemplate
+    // wire task.base_branch through to the delivered command.
     const isolatedLane = makeSwimlane(ISOLATED_LANE_ID, {
       session_target: 'isolated',
       auto_command: '/code-review {{baseBranch}}',
@@ -272,6 +288,51 @@ describe('spawnAgent auto_command injection (isolation-scoped resume check)', ()
     await runSpawn(isolatedLane, deps, true);
 
     expect(resumePromptArg(deps.engine)).toBe('/code-review develop');
+    expect(deps.scheduleKeystrokes).not.toHaveBeenCalled();
+  });
+
+  it('ISOLATED + fresh: a null task.base_branch falls back to the effective project default, not empty (regression: base_branch is a per-task OVERRIDE, not the resolved value)', async () => {
+    const isolatedLane = makeSwimlane(ISOLATED_LANE_ID, {
+      session_target: 'isolated',
+      auto_command: '/code-review {{baseBranch}}',
+    });
+    const deps = makeDeps({
+      manualPauseRecord: null,
+      resumeRecord: undefined,
+      taskFields: { base_branch: null },
+    });
+
+    await runSpawn(isolatedLane, deps, true);
+
+    // Not '/code-review' (empty) and not '/code-review ' (trailing space) -
+    // the default from configManager.getEffectiveConfig().git.defaultBaseBranch.
+    expect(resumePromptArg(deps.engine)).toBe('/code-review main');
+    expect(deps.scheduleKeystrokes).not.toHaveBeenCalled();
+  });
+
+  it('ISOLATED + fresh: a {{attachments}} placeholder interpolates the paths from options.attachments.getPathsForTask (regression: attachments plumbing must reach resolveTaskTemplateVars)', async () => {
+    // Verifies the AttachmentRepository option added to AgentSpawnOptions
+    // actually threads through spawnAgent -> resolveAutoCommandVars ->
+    // resolveTaskTemplateVars -> interpolateTaskTemplate, and is not silently
+    // dropped (which would leave {{attachments}} resolving to []).
+    const isolatedLane = makeSwimlane(ISOLATED_LANE_ID, {
+      session_target: 'isolated',
+      auto_command: '/code-review {{attachments}}',
+    });
+    const getPathsForTask = vi.fn(() => ['/mock/a.png', '/mock/b.png']);
+    const deps = makeDeps({
+      manualPauseRecord: null,
+      resumeRecord: undefined,
+      attachments: { getPathsForTask },
+    });
+
+    await runSpawn(isolatedLane, deps, true);
+
+    // getPathsForTask resolves attachmentPaths ({{attachments}} joins them on
+    // newlines, see TASK_TEMPLATE_RESOLVERS.attachments in
+    // task-template-resolvers.ts), called with the task's own id.
+    expect(getPathsForTask).toHaveBeenCalledWith(TASK_ID);
+    expect(resumePromptArg(deps.engine)).toBe('/code-review \n/mock/a.png\n/mock/b.png');
     expect(deps.scheduleKeystrokes).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/spawn-agent-lock-overrides.test.ts
+++ b/tests/unit/spawn-agent-lock-overrides.test.ts
@@ -128,7 +128,18 @@ function makeDeps(args: { latestSession: unknown; task: Task }) {
     mainWindow: { isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } },
     terminalSubmitScheduler: { scheduleKeystrokes: vi.fn() },
     projectRepo: { getById: vi.fn(() => PROJECT_ROW) },
-    configManager: { getEffectiveConfig: vi.fn(() => ({ agent: { permissionMode: 'auto' } })) },
+    configManager: {
+      getEffectiveConfig: vi.fn(() => ({
+        agent: { permissionMode: 'auto' },
+        git: { defaultBaseBranch: 'main' },
+      })),
+    },
+    // resolveDefaultBaseBranch (git-stats-capture.ts) reads this for the
+    // team-shared board default; undefined falls through to the git config
+    // default above, matching resolveAutoCommandVars in agent-spawn.ts. No
+    // fixture here sets a truthy auto_command today, but every real spawnAgent
+    // context carries this shape - keep the mock honest.
+    boardConfigManager: { getDefaultBaseBranch: vi.fn(() => undefined) },
   };
   return { tasks, sessionRepo, engine, context };
 }

--- a/tests/unit/split-lock-cas.test.ts
+++ b/tests/unit/split-lock-cas.test.ts
@@ -111,7 +111,6 @@ const mockSpawnAgent = vi.fn(async () => {});
 const mockCreateTransitionEngine = vi.fn();
 const mockCleanupTaskResources = vi.fn(async () => {});
 const mockDeleteTaskWorktree = vi.fn(async () => true);
-const mockBuildAutoCommandVars = vi.fn(() => ({}));
 
 vi.mock('../../src/main/ipc/helpers', () => ({
   getProjectRepos: (...args: unknown[]) => mockGetProjectRepos(...args),
@@ -121,7 +120,6 @@ vi.mock('../../src/main/ipc/helpers', () => ({
   createTransitionEngine: (...args: unknown[]) => mockCreateTransitionEngine(...args),
   cleanupTaskResources: (...args: unknown[]) => mockCleanupTaskResources(...args),
   deleteTaskWorktree: (...args: unknown[]) => mockDeleteTaskWorktree(...args),
-  buildAutoCommandVars: (...args: unknown[]) => mockBuildAutoCommandVars(...args),
 }));
 
 // Import under test AFTER all mocks are registered

--- a/tests/unit/task-move-complete-analytics.test.ts
+++ b/tests/unit/task-move-complete-analytics.test.ts
@@ -101,7 +101,6 @@ const mockEnsureTaskWorktree = vi.fn(async () => null);
 const mockEnsureTaskBranchCheckout = vi.fn(async () => {});
 const mockSpawnAgent = vi.fn(async () => {});
 const mockCreateTransitionEngine = vi.fn(() => ({}));
-const mockBuildAutoCommandVars = vi.fn(() => ({}));
 
 vi.mock('../../src/main/ipc/helpers/index', () => ({
   getProjectRepos: (...args: unknown[]) => mockGetProjectRepos(...args),
@@ -109,7 +108,6 @@ vi.mock('../../src/main/ipc/helpers/index', () => ({
   ensureTaskBranchCheckout: (...args: unknown[]) => mockEnsureTaskBranchCheckout(...args),
   spawnAgent: (...args: unknown[]) => mockSpawnAgent(...args),
   createTransitionEngine: (...args: unknown[]) => mockCreateTransitionEngine(...args),
-  buildAutoCommandVars: (...args: unknown[]) => mockBuildAutoCommandVars(...args),
   cleanupTaskResources: vi.fn(async () => {}),
   deleteTaskWorktree: vi.fn(async () => true),
   autoSpawnForTask: vi.fn(async () => {}),

--- a/tests/unit/task-move-git-churn-wiring.test.ts
+++ b/tests/unit/task-move-git-churn-wiring.test.ts
@@ -106,7 +106,6 @@ const mockEnsureTaskWorktree = vi.fn(async () => null);
 const mockEnsureTaskBranchCheckout = vi.fn(async () => {});
 const mockSpawnAgent = vi.fn(async () => {});
 const mockCreateTransitionEngine = vi.fn(() => ({}));
-const mockBuildAutoCommandVars = vi.fn(() => ({}));
 
 vi.mock('../../src/main/ipc/helpers/index', () => ({
   getProjectRepos: (...args: unknown[]) => mockGetProjectRepos(...args),
@@ -114,7 +113,6 @@ vi.mock('../../src/main/ipc/helpers/index', () => ({
   ensureTaskBranchCheckout: (...args: unknown[]) => mockEnsureTaskBranchCheckout(...args),
   spawnAgent: (...args: unknown[]) => mockSpawnAgent(...args),
   createTransitionEngine: (...args: unknown[]) => mockCreateTransitionEngine(...args),
-  buildAutoCommandVars: (...args: unknown[]) => mockBuildAutoCommandVars(...args),
   cleanupTaskResources: vi.fn(async () => {}),
   deleteTaskWorktree: vi.fn(async () => true),
   autoSpawnForTask: vi.fn(async () => {}),

--- a/tests/unit/task-move-isolation-switch.test.ts
+++ b/tests/unit/task-move-isolation-switch.test.ts
@@ -100,7 +100,6 @@ const mockEnsureTaskWorktree = vi.fn(async () => null);
 const mockEnsureTaskBranchCheckout = vi.fn(async () => {});
 const mockSpawnAgent = vi.fn(async () => {});
 const mockCreateTransitionEngine = vi.fn(() => ({}));
-const mockBuildAutoCommandVars = vi.fn(() => ({}));
 
 vi.mock('../../src/main/ipc/helpers/index', () => ({
   getProjectRepos: (...args: unknown[]) => mockGetProjectRepos(...args),
@@ -108,7 +107,6 @@ vi.mock('../../src/main/ipc/helpers/index', () => ({
   ensureTaskBranchCheckout: (...args: unknown[]) => mockEnsureTaskBranchCheckout(...args),
   spawnAgent: (...args: unknown[]) => mockSpawnAgent(...args),
   createTransitionEngine: (...args: unknown[]) => mockCreateTransitionEngine(...args),
-  buildAutoCommandVars: (...args: unknown[]) => mockBuildAutoCommandVars(...args),
   cleanupTaskResources: vi.fn(async () => {}),
   deleteTaskWorktree: vi.fn(async () => true),
   autoSpawnForTask: vi.fn(async () => {}),

--- a/tests/unit/task-move-rollback.test.ts
+++ b/tests/unit/task-move-rollback.test.ts
@@ -120,7 +120,6 @@ const mockEnsureTaskWorktree = vi.fn(async () => null);
 const mockEnsureTaskBranchCheckout = vi.fn(async () => {});
 const mockSpawnAgent = vi.fn(async () => {});
 const mockCreateTransitionEngine = vi.fn(() => ({}));
-const mockBuildAutoCommandVars = vi.fn(() => ({}));
 const mockCleanupTaskResources = vi.fn(async () => {});
 const mockDeleteTaskWorktree = vi.fn(async () => true);
 
@@ -130,7 +129,6 @@ vi.mock('../../src/main/ipc/helpers/index', () => ({
   ensureTaskBranchCheckout: (...args: unknown[]) => mockEnsureTaskBranchCheckout(...args),
   spawnAgent: (...args: unknown[]) => mockSpawnAgent(...args),
   createTransitionEngine: (...args: unknown[]) => mockCreateTransitionEngine(...args),
-  buildAutoCommandVars: (...args: unknown[]) => mockBuildAutoCommandVars(...args),
   cleanupTaskResources: (...args: unknown[]) => mockCleanupTaskResources(...args),
   deleteTaskWorktree: (...args: unknown[]) => mockDeleteTaskWorktree(...args),
   autoSpawnForTask: vi.fn(async () => {}),

--- a/tests/unit/task-move-settings-restart.test.ts
+++ b/tests/unit/task-move-settings-restart.test.ts
@@ -101,11 +101,24 @@ vi.mock('../../src/main/agent/agent-registry', () => ({
 vi.mock('../../src/main/ipc/handlers/backlog', () => ({ abortBacklogPromotion: vi.fn() }));
 vi.mock('../../src/main/ipc/handlers/session-metrics', () => ({ captureSessionMetrics: vi.fn(), refineTranscriptTokens: vi.fn(), refineTranscriptToolCounts: vi.fn() }));
 
-vi.mock('../../src/main/agent/shared', () => ({
-  interpolateTemplate: vi.fn((template: string) => template),
-  resolveBridgeScript: vi.fn(() => '/mock/bridge.js'),
-  execVersion: vi.fn(async () => '1.0.0'),
-}));
+// interpolateTaskTemplate/resolveTaskTemplateVars are the REAL implementations
+// (dynamically imported below), not stubs: the live-inject branch in
+// task-move.ts feeds toLane.auto_command through them, and a test that stubs
+// them out would only prove wiring, never the {{baseBranch}} effective-default
+// fix itself (see the "live-inject: {{baseBranch}}" describe block below).
+// Both source modules are pure (no DB/electron deps), so importing them for
+// real here is safe.
+vi.mock('../../src/main/agent/shared', async () => {
+  const { interpolateTaskTemplate } = await import('../../src/main/agent/shared/template-utils');
+  const { resolveTaskTemplateVars } = await import('../../src/main/agent/shared/task-template-resolvers');
+  return {
+    interpolateTemplate: vi.fn((template: string) => template),
+    resolveBridgeScript: vi.fn(() => '/mock/bridge.js'),
+    execVersion: vi.fn(async () => '1.0.0'),
+    interpolateTaskTemplate,
+    resolveTaskTemplateVars,
+  };
+});
 
 const mockGetProjectRepos = vi.fn();
 const mockEnsureTaskWorktree = vi.fn(async () => null);
@@ -208,7 +221,9 @@ function makeContext(taskRepo: unknown, swimlaneRepo: unknown) {
     tasks: taskRepo,
     swimlanes: swimlaneRepo,
     actions: { getTransitionsFor: vi.fn(() => []) },
-    attachments: { deleteByTaskId: vi.fn() },
+    // getPathsForTask is required by the live-inject branch (resolveTaskTemplateVars'
+    // attachmentPaths); real code always has this from getProjectRepos.
+    attachments: { deleteByTaskId: vi.fn(), getPathsForTask: vi.fn(() => []) },
   });
   return context;
 }
@@ -688,5 +703,95 @@ describe('handleTaskMove model/effort restart and live-injection', () => {
     expect(context.sessionManager.suspend).not.toHaveBeenCalled();
     expect(markRecordSuspended).not.toHaveBeenCalled();
     expect(mockSpawnAgent).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// Coverage gap (task-template-vars-parity fix): the live-inject branch above
+// (Priority 3c, "same agent, live session") builds `interpolatedAuto` by
+// calling the REAL resolveTaskTemplateVars/interpolateTaskTemplate against
+// toLane.auto_command - but every test above uses makeLanes(), whose
+// executingLane defaults `auto_command: null`, so `toLane?.auto_command?.trim()`
+// is always falsy there and this call is never reached. Two things were
+// therefore unverified: (1) the barrel mock upstream never even provided these
+// two functions (so a real call would throw "not a function"), and (2) nothing
+// pinned that {{baseBranch}} resolves to the effective project default (not
+// empty) on THIS call site, mirroring the fix already pinned for spawnAgent
+// (spawn-agent-isolated-auto-command.test.ts) and send_command
+// (transition-engine.test.ts).
+// =============================================================================
+describe('handleTaskMove live-inject: {{baseBranch}} template resolution (task-template-vars-parity fix)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.activeRecord = null;
+    hoisted.updateAppliedSettings.mockReset();
+    mockEnsureTaskWorktree.mockResolvedValue(null);
+    mockEnsureTaskBranchCheckout.mockResolvedValue(undefined);
+    mockSpawnAgent.mockResolvedValue(undefined);
+    vi.mocked(prepareInjectionPlan).mockReturnValue(null);
+  });
+
+  it('interpolates the destination auto_command with the effective default base branch, not empty', async () => {
+    // task.base_branch is null (see makeTask defaults), so the pre-fix
+    // buildAutoCommandVars/interpolateTemplate path resolved {{baseBranch}} to
+    // '' (task.base_branch || ''), leaving the literal placeholder text
+    // replaced by an empty string: '/merge-back '. The fix resolves it to the
+    // effective project default ('main', from configManager.getEffectiveConfig
+    // in makeContext) via the real interpolateTaskTemplate drop-and-collapse
+    // semantics: '/merge-back main'.
+    const { swimlaneRepo } = makeLanes({
+      permission_mode: null,
+      auto_command: '/merge-back {{baseBranch}}',
+    });
+    setActiveRecord('acceptEdits');
+    const taskRepo = makeTaskRepo();
+    const context = makeContext(taskRepo, swimlaneRepo);
+
+    await handleTaskMove(context as never, {
+      taskId: 'task-aaa00001',
+      targetSwimlaneId: EXECUTING_LANE_ID,
+      targetPosition: 0,
+    });
+
+    expect(vi.mocked(prepareInjectionPlan)).toHaveBeenCalledTimes(1);
+    const planArg = vi.mocked(prepareInjectionPlan).mock.calls[0][0] as { autoCommand?: string };
+    // Red: reverting to the old buildAutoCommandVars/interpolateTemplate shape
+    // makes this '/merge-back ' (trailing space, no branch name), never
+    // '/merge-back main'.
+    expect(planArg.autoCommand).toBe('/merge-back main');
+  });
+
+  it('threads the task attachments repo into {{attachments}} resolution via getPathsForTask', async () => {
+    const { swimlaneRepo } = makeLanes({
+      permission_mode: null,
+      auto_command: '/code-review {{attachments}}',
+    });
+    setActiveRecord('acceptEdits');
+    const taskRepo = makeTaskRepo();
+    const context = makeContext(taskRepo, swimlaneRepo);
+    const getPathsForTask = vi.fn(() => ['/mock/project/screenshot.png']);
+    mockGetProjectRepos.mockReturnValue({
+      tasks: taskRepo,
+      swimlanes: swimlaneRepo,
+      actions: { getTransitionsFor: vi.fn(() => []) },
+      attachments: { deleteByTaskId: vi.fn(), getPathsForTask },
+    });
+
+    await handleTaskMove(context as never, {
+      taskId: 'task-aaa00001',
+      targetSwimlaneId: EXECUTING_LANE_ID,
+      targetPosition: 0,
+    });
+
+    // Wiring: the destructured `attachments` repo (added by this diff to
+    // handleTaskMove's getProjectRepos call) reaches resolveTaskTemplateVars
+    // via getPathsForTask, not a stub. The exact collapse/whitespace shape of
+    // {{attachments}} interpolation is pinned separately in
+    // task-template-vars-parity.test.ts; this only proves the real path
+    // resolved (rather than an empty array from a caller that forgot to pass
+    // `attachments` through).
+    expect(getPathsForTask).toHaveBeenCalledWith('task-aaa00001');
+    const planArg = vi.mocked(prepareInjectionPlan).mock.calls[0][0] as { autoCommand?: string };
+    expect(planArg.autoCommand).toContain('/mock/project/screenshot.png');
   });
 });

--- a/tests/unit/task-move-settings-restart.test.ts
+++ b/tests/unit/task-move-settings-restart.test.ts
@@ -112,7 +112,6 @@ const mockEnsureTaskWorktree = vi.fn(async () => null);
 const mockEnsureTaskBranchCheckout = vi.fn(async () => {});
 const mockSpawnAgent = vi.fn(async () => {});
 const mockCreateTransitionEngine = vi.fn(() => ({}));
-const mockBuildAutoCommandVars = vi.fn(() => ({}));
 
 vi.mock('../../src/main/ipc/helpers/index', () => ({
   getProjectRepos: (...args: unknown[]) => mockGetProjectRepos(...args),
@@ -120,7 +119,6 @@ vi.mock('../../src/main/ipc/helpers/index', () => ({
   ensureTaskBranchCheckout: (...args: unknown[]) => mockEnsureTaskBranchCheckout(...args),
   spawnAgent: (...args: unknown[]) => mockSpawnAgent(...args),
   createTransitionEngine: (...args: unknown[]) => mockCreateTransitionEngine(...args),
-  buildAutoCommandVars: (...args: unknown[]) => mockBuildAutoCommandVars(...args),
   cleanupTaskResources: vi.fn(async () => {}),
   deleteTaskWorktree: vi.fn(async () => true),
   autoSpawnForTask: vi.fn(async () => {}),

--- a/tests/unit/task-move-shutdown.test.ts
+++ b/tests/unit/task-move-shutdown.test.ts
@@ -131,7 +131,6 @@ const mockEnsureTaskWorktree = vi.fn(async () => null);
 const mockEnsureTaskBranchCheckout = vi.fn(async () => {});
 const mockSpawnAgent = vi.fn(async () => {});
 const mockCreateTransitionEngine = vi.fn(() => ({}));
-const mockBuildAutoCommandVars = vi.fn(() => ({}));
 const mockCleanupTaskResources = vi.fn(async () => {});
 const mockDeleteTaskWorktree = vi.fn(async () => true);
 
@@ -141,7 +140,6 @@ vi.mock('../../src/main/ipc/helpers/index', () => ({
   ensureTaskBranchCheckout: (...args: unknown[]) => mockEnsureTaskBranchCheckout(...args),
   spawnAgent: (...args: unknown[]) => mockSpawnAgent(...args),
   createTransitionEngine: (...args: unknown[]) => mockCreateTransitionEngine(...args),
-  buildAutoCommandVars: (...args: unknown[]) => mockBuildAutoCommandVars(...args),
   cleanupTaskResources: (...args: unknown[]) => mockCleanupTaskResources(...args),
   deleteTaskWorktree: (...args: unknown[]) => mockDeleteTaskWorktree(...args),
   autoSpawnForTask: vi.fn(async () => {}),

--- a/tests/unit/task-template-vars-parity.test.ts
+++ b/tests/unit/task-template-vars-parity.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Task-template-variable parity guard (see .claude/rules/task-template-vars-parity.md).
+ *
+ * src/shared/task-template-vars.ts is the single declaration of the 10
+ * task-template keywords (auto_command + spawn_agent promptTemplate share it).
+ * It drives the UI chip list (BoardManagerDialog.tsx), the main-process
+ * resolver map (task-template-resolvers.ts), and the docs tables. This test
+ * makes drift unmergeable: every catalog name has a resolver and vice versa,
+ * every catalog chip is documented, and the resolver/interpolation behavior
+ * (the {{baseBranch}} bug fix and the drop-and-collapse semantics) is pinned.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { TASK_TEMPLATE_VAR_NAMES, TASK_TEMPLATE_VARS } from '../../src/shared/task-template-vars';
+import { TASK_TEMPLATE_RESOLVERS, resolveTaskTemplateVars } from '../../src/main/agent/shared/task-template-resolvers';
+import { interpolateTaskTemplate } from '../../src/main/agent/shared/template-utils';
+import type { Task } from '../../src/shared/types';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-1',
+    display_id: 1,
+    title: 'My Task',
+    description: 'Do the thing',
+    swimlane_id: 'lane-1',
+    position: 0,
+    agent: 'claude',
+    agent_override: null,
+    model_override: null,
+    effort_override: null,
+    session_id: null,
+    worktree_path: null,
+    branch_name: null,
+    pr_number: null,
+    pr_url: null,
+    base_branch: null,
+    use_worktree: null,
+    labels: [],
+    priority: 0,
+    attachment_count: 0,
+    archived_at: null,
+    created_at: '2025-01-01T00:00:00.000Z',
+    updated_at: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('task template vars: catalog <-> resolvers <-> chips <-> docs parity', () => {
+  it('every catalog name has a resolver and every resolver names a catalog entry', () => {
+    const catalogNames = [...TASK_TEMPLATE_VAR_NAMES].sort();
+    const resolverNames = Object.keys(TASK_TEMPLATE_RESOLVERS).sort();
+    expect(resolverNames).toEqual(catalogNames);
+  });
+
+  it('TASK_TEMPLATE_VARS covers exactly the names in TASK_TEMPLATE_VAR_NAMES, no more, no less', () => {
+    const varsNames = TASK_TEMPLATE_VARS.map((entry) => entry.name).sort();
+    expect(varsNames).toEqual([...TASK_TEMPLATE_VAR_NAMES].sort());
+  });
+
+  it('every chip matches the literal {{name}} form', () => {
+    for (const entry of TASK_TEMPLATE_VARS) {
+      expect(entry.chip).toBe(`{{${entry.name}}}`);
+    }
+  });
+
+  it('every chip is documented in docs/transition-engine.md', () => {
+    const docContent = fs.readFileSync(path.join(REPO_ROOT, 'docs/transition-engine.md'), 'utf-8');
+    const undocumented = TASK_TEMPLATE_VARS.map((entry) => entry.chip).filter((chip) => !docContent.includes(chip));
+    expect(
+      undocumented,
+      `These chips are not documented in docs/transition-engine.md:\n${undocumented.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('every chip is documented in docs/architecture.md', () => {
+    const docContent = fs.readFileSync(path.join(REPO_ROOT, 'docs/architecture.md'), 'utf-8');
+    const undocumented = TASK_TEMPLATE_VARS.map((entry) => entry.chip).filter((chip) => !docContent.includes(chip));
+    expect(
+      undocumented,
+      `These chips are not documented in docs/architecture.md:\n${undocumented.join('\n')}`,
+    ).toEqual([]);
+  });
+});
+
+describe('resolveTaskTemplateVars: {{baseBranch}} effective-default fix (red-green)', () => {
+  it('falls back to the effective project default when task.base_branch is null (the bug: this used to resolve empty)', () => {
+    const vars = resolveTaskTemplateVars({
+      task: makeTask({ base_branch: null }),
+      defaultBaseBranch: 'main',
+      attachmentPaths: [],
+    });
+    expect(vars.baseBranch).toBe('main');
+  });
+
+  it('the per-task override wins when set', () => {
+    const vars = resolveTaskTemplateVars({
+      task: makeTask({ base_branch: 'develop' }),
+      defaultBaseBranch: 'main',
+      attachmentPaths: [],
+    });
+    expect(vars.baseBranch).toBe('develop');
+  });
+
+  it('falls back to "main" when both the task override and defaultBaseBranch are empty', () => {
+    const vars = resolveTaskTemplateVars({
+      task: makeTask({ base_branch: null }),
+      defaultBaseBranch: '',
+      attachmentPaths: [],
+    });
+    expect(vars.baseBranch).toBe('main');
+  });
+
+  it('{{worktreePath}} and {{branchName}} stay a raw read (empty when null), unlike {{baseBranch}}', () => {
+    const vars = resolveTaskTemplateVars({
+      task: makeTask({ worktree_path: null, branch_name: null }),
+      defaultBaseBranch: 'main',
+      attachmentPaths: [],
+    });
+    expect(vars.worktreePath).toBe('');
+    expect(vars.branchName).toBe('');
+  });
+
+  it('{{attachments}} lists resolved paths, one per line, with a leading newline', () => {
+    const vars = resolveTaskTemplateVars({
+      task: makeTask(),
+      defaultBaseBranch: 'main',
+      attachmentPaths: ['/mock/a.png', '/mock/b.png'],
+    });
+    expect(vars.attachments).toBe('\n/mock/a.png\n/mock/b.png');
+  });
+});
+
+describe('interpolateTaskTemplate: drop-and-collapse semantics', () => {
+  it('drops an empty-valued placeholder along with its leading separator', () => {
+    expect(interpolateTaskTemplate('/code-review {{baseBranch}}', { baseBranch: '' })).toBe('/code-review');
+  });
+
+  it('drops an unknown placeholder identically to an empty-valued one', () => {
+    expect(interpolateTaskTemplate('/code-review {{unknownVar}}', {})).toBe('/code-review');
+  });
+
+  it('collapses a whitespace run split across two adjacent dropped placeholders', () => {
+    expect(interpolateTaskTemplate('/foo {{a}} {{b}} bar', { a: '', b: '' })).toBe('/foo bar');
+  });
+
+  it('inserts a non-empty value verbatim without collapsing its own internal whitespace', () => {
+    expect(interpolateTaskTemplate('{{x}}', { x: 'a  b' })).toBe('a  b');
+  });
+
+  it('does not corrupt a substituted value that itself contains literal "{{...}}" text', () => {
+    expect(interpolateTaskTemplate('{{description}}', { description: 'See {{title}} for context' }))
+      .toBe('See {{title}} for context');
+  });
+
+  it('preserves newlines while collapsing only horizontal whitespace, with no dangling trailing space before the newline', () => {
+    const result = interpolateTaskTemplate('Base: {{baseBranch}}\n{{body}}', { baseBranch: '', body: 'line1\nline2' });
+    expect(result).toBe('Base:\nline1\nline2');
+  });
+
+  it('keeps a literal command with no placeholders untouched', () => {
+    expect(interpolateTaskTemplate('/standup', {})).toBe('/standup');
+  });
+
+  it('keeps a multi-line {{task_xml}}-style value fully intact', () => {
+    const xml = '<task>\n  <title>x</title>\n</task>';
+    expect(interpolateTaskTemplate('{{task_xml}}{{attachments}}', { task_xml: xml, attachments: '' })).toBe(xml);
+  });
+
+  // Regression: the whitespace cleanup used to run on the CONCATENATED result,
+  // so it reached into substituted values and stripped a markdown hard break
+  // (a line ending in two spaces) out of the raw description {{task_xml}}
+  // deliberately carries unsanitized. Cleanup is now per-text-segment.
+  it('preserves a markdown hard break inside a substituted value', () => {
+    const xml = '<task>\n  <description>line one  \nline two</description>\n</task>';
+    expect(interpolateTaskTemplate('{{task_xml}}', { task_xml: xml })).toBe(xml);
+  });
+
+  it('does not trim an outermost substituted value, only template text edges', () => {
+    expect(interpolateTaskTemplate('{{attachments}}', { attachments: '\n/mock/a.png' })).toBe('\n/mock/a.png');
+    expect(interpolateTaskTemplate('  /standup  ', {})).toBe('/standup');
+  });
+
+  // Regression: /[ \t]+\n/ could not see a space sitting before a CRLF, so a
+  // Windows-authored template kept the stray space and the bare \r.
+  it('strips trailing horizontal whitespace before a CRLF line break', () => {
+    expect(interpolateTaskTemplate('/foo {{gone}} \r\nbar', { gone: '' })).toBe('/foo\r\nbar');
+  });
+});
+
+describe('BoardManagerDialog chip list is sourced from the catalog', () => {
+  // Static scan rather than importing the .tsx (which would pull in React):
+  // pins that the Automation tab renders TASK_TEMPLATE_VARS instead of a
+  // hand-maintained array that can silently drift from the resolvers.
+  it('renders TEMPLATE_VARIABLES from TASK_TEMPLATE_VARS, not a hardcoded list', () => {
+    const source = fs.readFileSync(
+      path.join(REPO_ROOT, 'src/renderer/components/dialogs/BoardManagerDialog.tsx'),
+      'utf-8',
+    );
+    expect(source).toContain("import { TASK_TEMPLATE_VARS } from '../../../shared/task-template-vars'");
+    expect(source).toMatch(/const TEMPLATE_VARIABLES = TASK_TEMPLATE_VARS\.map\(/);
+  });
+});

--- a/tests/unit/transition-engine.test.ts
+++ b/tests/unit/transition-engine.test.ts
@@ -20,7 +20,7 @@
  * to the session repo and the command built by the adapter mock to verify
  * what was interpolated.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TransitionEngine } from '../../src/main/transition-engine/transition-engine';
 import { buildTaskXml } from '../../src/main/agent/shared/prompt-xml';
 import { sanitizeForPty } from '../../src/shared/paths';
@@ -694,6 +694,13 @@ describe('TransitionEngine - executeAction builds ONE shared templateVars for ev
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    // run_script/webhook tests below stub the global fetch; unstub
+    // unconditionally so a stub never leaks into an unrelated test file run
+    // in the same worker.
+    vi.unstubAllGlobals();
+  });
+
   it('send_command: a null task.base_branch interpolates {{baseBranch}} to the effective project default, not empty', async () => {
     const task = makeTask({ base_branch: null, session_id: 'sess-abc12345' });
     const action = makeAction({
@@ -717,5 +724,51 @@ describe('TransitionEngine - executeAction builds ONE shared templateVars for ev
       ['/review main'],
       { sendCtrlC: true, source: `send_command:${task.id.slice(0, 8)}` },
     );
+  });
+
+  it('run_script: a null task.base_branch interpolates {{baseBranch}} to the effective project default, not empty', async () => {
+    // Guards the OTHER two consumers the comment above flags: run_script and
+    // webhook (this test + the next) both read the SAME executeAction-built
+    // templateVars as send_command, but a call-site-specific regression (e.g.
+    // someone passing a different/empty vars object into just this one
+    // switch-case line) would fail nothing without a dedicated assertion here.
+    const task = makeTask({ base_branch: null });
+    const action = makeAction({
+      type: 'run_script',
+      config_json: JSON.stringify({ script: 'deploy.sh {{baseBranch}}' }),
+    });
+    const sessionManager = makeSessionManager();
+
+    const { engine } = makeEngine({ action, sessionManager });
+    await engine.executeTransition(task as Parameters<typeof engine.executeTransition>[0], 'todo', 'doing');
+
+    // Red: reverting executeAction's templateVars to the pre-refactor
+    // `{ baseBranch: task.base_branch || '' }` shape makes this 'deploy.sh '
+    // (empty), never 'deploy.sh main'.
+    expect(sessionManager.spawnedSessions).toHaveLength(1);
+    expect(sessionManager.spawnedSessions[0].command).toBe('deploy.sh main');
+  });
+
+  it('webhook: a null task.base_branch interpolates {{baseBranch}} into both url and body, not empty', async () => {
+    const task = makeTask({ base_branch: null });
+    const action = makeAction({
+      type: 'webhook',
+      config_json: JSON.stringify({
+        url: 'https://example.test/notify?branch={{baseBranch}}',
+        body: JSON.stringify({ branch: '{{baseBranch}}' }),
+      }),
+    });
+    const fetchMock = vi.fn(async () => new Response(''));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { engine } = makeEngine({ action });
+    await engine.executeTransition(task as Parameters<typeof engine.executeTransition>[0], 'todo', 'doing');
+
+    // Red: reverting executeAction's templateVars to the pre-refactor shape
+    // makes both of these resolve with an empty branch, never 'main'.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://example.test/notify?branch=main');
+    expect(init.body).toBe(JSON.stringify({ branch: 'main' }));
   });
 });

--- a/tests/unit/transition-engine.test.ts
+++ b/tests/unit/transition-engine.test.ts
@@ -204,6 +204,10 @@ function makeEngine(options: {
    * caller of makeEngine. */
   executionServers?: Record<string, AgentExecutionServer>;
   execution?: Record<string, AgentProjectExecution>;
+  /** Override the default no-op terminalSubmit stub (e.g. send_command tests
+   * need submitKeystrokes to return a real Promise so its internal `.catch`
+   * doesn't throw). */
+  terminalSubmit?: ReturnType<typeof makeTerminalSubmit>;
 }) {
   const sessionManager = options.sessionManager ?? makeSessionManager();
   const sessionRepo = options.sessionRepo ?? makeSessionRepo();
@@ -231,7 +235,7 @@ function makeEngine(options: {
     execution: options.execution ?? {},
   }));
 
-  const terminalSubmit = makeTerminalSubmit();
+  const terminalSubmit = options.terminalSubmit ?? makeTerminalSubmit();
   type EngineArgs = ConstructorParameters<typeof TransitionEngine>;
   const engine = new TransitionEngine(
     sessionManager as unknown as EngineArgs[0],
@@ -243,7 +247,7 @@ function makeEngine(options: {
     attachmentRepo as unknown as EngineArgs[6],
   );
 
-  return { engine, sessionManager, sessionRepo, taskRepo, actionRepo };
+  return { engine, sessionManager, sessionRepo, taskRepo, actionRepo, terminalSubmit };
 }
 
 // ---------------------------------------------------------------------------
@@ -674,5 +678,44 @@ describe('TransitionEngine - remote execution wiring (executeSpawnAgent chokepoi
     await engine.executeTransition(task as Parameters<typeof engine.executeTransition>[0], 'todo', 'doing');
 
     expect(capturedExecutionTarget).toBeUndefined();
+  });
+});
+
+describe('TransitionEngine - executeAction builds ONE shared templateVars for every action type', () => {
+  // Coverage hole: executeAction resolves templateVars = resolveTaskTemplateVars(...) once and
+  // feeds spawn_agent, send_command, run_script, AND webhook from that single object (see
+  // .claude/rules/task-template-vars-parity.md, rule #7: "only the interpolation MECHANICS are
+  // scoped, not the resolved VALUES"). Every existing test above only drives spawn_agent, so a
+  // regression on the OTHER three consumers (e.g. reverting {{baseBranch}} back to the old
+  // `task.base_branch || ''` behavior) fails nothing. This pins send_command specifically:
+  // task.base_branch is null, so {{baseBranch}} must resolve to the effective project default
+  // ('main', from getConfig().gitConfig.defaultBaseBranch) rather than an empty string.
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('send_command: a null task.base_branch interpolates {{baseBranch}} to the effective project default, not empty', async () => {
+    const task = makeTask({ base_branch: null, session_id: 'sess-abc12345' });
+    const action = makeAction({
+      type: 'send_command',
+      config_json: JSON.stringify({ command: '/review {{baseBranch}}' }),
+    });
+    // submitKeystrokes must return a real Promise: executeSendCommand chains
+    // `.catch(...)` onto its return value, which throws synchronously against
+    // the file's default no-op `vi.fn()` stub (returns undefined).
+    const terminalSubmit = { submitKeystrokes: vi.fn(async () => {}) };
+
+    const { engine } = makeEngine({ action, terminalSubmit });
+    await engine.executeTransition(task as Parameters<typeof engine.executeTransition>[0], 'todo', 'doing');
+
+    // Red: reverting executeAction's templateVars to `{ baseBranch: task.base_branch || '' }`
+    // (the pre-refactor shape) makes this '/review' (empty, collapsed by sanitizeForPty),
+    // never '/review main'.
+    expect(terminalSubmit.submitKeystrokes).toHaveBeenCalledTimes(1);
+    expect(terminalSubmit.submitKeystrokes).toHaveBeenCalledWith(
+      'sess-abc12345',
+      ['/review main'],
+      { sendCtrlC: true, source: `send_command:${task.id.slice(0, 8)}` },
+    );
   });
 });


### PR DESCRIPTION
## What

Fixes `{{baseBranch}}` in a column's `auto_command` (and a `spawn_agent` action's `promptTemplate`)
resolving to an empty string instead of the project's configured default base branch, and unifies
the four previously-divergent declarations of the task-template keyword set behind one source of
truth.

## Why

`buildAutoCommandVars` mapped `baseBranch: task.base_branch || ''`. `tasks.base_branch` is a
per-task OVERRIDE column, null for the ~99% of tasks that never set one, so `{{baseBranch}}`
rendered empty for almost every task. The effective base branch lives in
`appConfig.gitConfig.defaultBaseBranch` (board config, then project/global config, then `'main'`),
which the interpolation never consulted. Every Code Review auto-command
(`/code-review {{baseBranch}}`) in this repo ran with no base ref for over a week before anyone
noticed.

The deeper root: the keyword set was declared four times with no link between them -
`buildAutoCommandVars` (6 keys, raw), the transition engine's inline `templateVars` object (10
keys, duplicated at two call sites), the UI chip list (5 keys, missing `{{baseBranch}}` entirely),
and two docs tables. Nothing kept them in sync.

## How

One catalog, one resolver map, one scoped interpolation function:

- `src/shared/task-template-vars.ts` - `TASK_TEMPLATE_VAR_NAMES` / `TASK_TEMPLATE_VARS`, the single
  declaration of all 10 keywords (`task_xml`, `title`, `description`, `taskId`, `worktreePath`,
  `branchName`, `baseBranch`, `prUrl`, `prNumber`, `attachments`). Renderer-safe metadata only.
- `src/main/agent/shared/task-template-resolvers.ts` - `TASK_TEMPLATE_RESOLVERS`
  (`Record<TaskTemplateVarName, ...>`, so a missing resolver fails `tsc`) and
  `resolveTaskTemplateVars(ctx)`. `{{baseBranch}}` now resolves
  `task.base_branch || defaultBaseBranch || 'main'` (the fix). `{{worktreePath}}` /
  `{{branchName}}` stay raw reads, deliberately not falling back to a project-level value.
- `src/main/agent/shared/template-utils.ts` - new `interpolateTaskTemplate`, scoped to
  `auto_command` / `promptTemplate` only: an empty-valued or unknown `{{key}}` is dropped and
  surrounding horizontal whitespace collapses (newlines preserved), resolved and stripped against
  the TEMPLATE so a substituted value is never re-scanned or corrupted. The existing
  `interpolateTemplate` is unchanged and still backs `send_command` / `run_script` / `webhook`
  (literal passthrough of an unknown placeholder) - only the interpolation *mechanics* are scoped,
  the corrected resolver *values* reach all four action types via one shared `templateVars` object
  built in `executeAction`.
- Wired into `agent-spawn.ts` (2 auto_command call sites), `task-move.ts` (live-inject
  auto_command), and `transition-engine.ts` (`resumeSuspendedSession` + `executeAction`).
- `BoardManagerDialog.tsx`'s Automation-tab chip list now renders from the shared catalog instead
  of a hardcoded 5-entry array - all 10 chips are now discoverable, including the previously-hidden
  `{{baseBranch}}`.
- Removed `buildAutoCommandVars` and updated ~16 test files that mocked it (mechanical: dead mock
  key removal only).

Verified live in a `/preview` instance: moved a real task into this repo's Code Review column
(`/code-review {{baseBranch}}`) and confirmed the spawned session's initial prompt read
`/code-review main`, not `/code-review ` or `/code-review` with a dangling space.

## Breaking changes

None. An unknown or misspelled `{{key}}` in an `auto_command` / `promptTemplate` now silently
drops instead of passing through literally - a deliberate, documented behavior change (see
`.claude/rules/task-template-vars-parity.md`), not a breaking API/config change.

## Tests

- `tests/unit/task-template-vars-parity.test.ts` (new, 22 cases): catalog<->resolver<->chip<->docs
  parity; the `{{baseBranch}}` effective-default fix (null override, explicit override, empty
  default fallback); `{{worktreePath}}`/`{{branchName}}` raw-read behavior; `{{attachments}}`
  formatting; and `interpolateTaskTemplate` behavior (drop empty/unknown, collapse across adjacent
  drops, verbatim value insertion with no re-scan, newline preservation including a markdown hard
  break inside a substituted value, literal passthrough).
- `tests/unit/spawn-agent-isolated-auto-command.test.ts`: real end-to-end `spawnAgent` coverage
  proving a null `task.base_branch` resolves to the effective project default.
- `tests/unit/transition-engine.test.ts`: `send_command`, `run_script`, and `webhook` each
  independently pin the shared `templateVars`' corrected `{{baseBranch}}` value.
- `tests/unit/task-move-settings-restart.test.ts`: the live-inject branch (same agent, live
  session) now exercises the real `interpolateTaskTemplate`/`resolveTaskTemplateVars` instead of a
  stub, pinning both the `{{baseBranch}}` fix and `{{attachments}}` wiring on that call site.
- CI: lint, typecheck, unit, UI, and the Linux Electron E2E shards.

Generated with [Claude Code](https://claude.com/claude-code)
