### PR TITLE
feat(activity-engine): live idle-wait duration + durable active/idle interval history

### DIFF
--- a/docs/activity-detection.md
+++ b/docs/activity-detection.md
@@ -102,15 +102,49 @@ Every transition emits both an `ActivityState` AND an `ActivityReason` describin
 
 ```ts
 type ActivityReason =
-  | { kind: 'idle' }
-  | { kind: 'permission' }
+  | { kind: 'idle'; since: number }
+  | { kind: 'permission'; since: number }
   | { kind: 'tool';            pendingCount: number; currentTool: string | null }
   | { kind: 'subagent';        depth: number }
   | { kind: 'background-shell'; count: number; ids: readonly string[] }
   | { kind: 'turn-active' };
 ```
 
+`since` (epoch ms) is `SessionEngineState.needsUserSince`: when the session FIRST entered a
+needs-user state. It spans both `idle` and `permission` - a `permission <-> idle` crossing keeps
+the original park time rather than resetting it - and is cleared only on returning to `thinking`.
+The renderer uses it to show elapsed wait time ("Idle for 12m") in the TaskCard hover tooltip
+(`formatActivityReasonText` / `ActivityReasonTooltip` in
+`src/renderer/components/board/ActivityReasonTooltip.tsx`).
+
 The renderer uses `reason.kind` to pick a Lucide icon (Wrench / Users / Terminal / Lock / Loader2 / Mail) and inline label for the TaskCard hover tooltip.
+
+### Durable activity-interval history
+
+The engine's own state is in-memory only - `needsUserSince` (and every other field) is lost on
+`deleteSession()` / app restart, and `events.jsonl` records raw hook events, not committed
+transitions, so it is neither a faithful nor a reliably-retained substitute (a raw `idle` event
+cancelled by the 400ms stability window still appears there with no matching state change, and a
+watchdog-synthesized idle commits with no raw event at all).
+
+`src/main/activity-engine/activity-interval-recorder.ts` durably records every committed
+`ActivityDisposition` transition (`shared/activity-state.ts`'s `dispositionOf` - `'active'` for
+`thinking`, `'idle'` for both `idle` and `permission`) to the per-project
+`session_activity_intervals` table (migration in `src/main/db/migrations/project-schema.ts`,
+alongside `conversation_turn_usage`), one row per interval (not per transition - a
+`permission <-> idle` crossing shares the `'idle'` disposition, so it does not close and reopen a
+row). Symmetric by design: both dispositions are recorded directly rather than deriving "active
+time" as the inverse of "idle time", which would need exact session-boundary reconciliation
+across resumes/suspends and would silently break on a crash-orphaned open row. Each row carries
+the engine's own `enter_trigger` / `exit_trigger` labels, so a consumer can distinguish a
+hook-authoritative park (`event:idle`) from a watchdog guess (`timer:stale-thinking`), and a
+genuine human reply (`event:prompt`) from the agent resuming itself
+(`event:prompt:pty-activity`, `force-thinking`). `started_ms`/`ended_ms` (epoch integers, used by
+the `duration_ms` arithmetic and the `started_ms` index) are mirrored by `started_at`/`ended_at`
+(TEXT UTC ISO 8601, per `.claude/rules/utc-timestamps.md`) - the store derives the mirror from the
+same value it writes to the `_ms` column, so the two can never drift. Read via the
+`kangentic_get_activity_intervals` MCP tool (see `docs/mcp-server.md`) or `kangentic_query_db`. No
+desktop-facing IPC endpoint exists yet.
 
 Priority ladder: `permission > tool > subagent > background-shell > turn-active > idle`. Anchored to `state.activity` for consistency - when forced paths (Interrupted, forceIdle) commit a transition that diverges from the bare predicate (e.g. clearing all counters on Esc), the reason follows the committed state.
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -416,6 +416,31 @@ Keyed by `turn_uuid` because a `--resume` replays its parent's turns verbatim un
 
 Module: `src/main/retrieval/` (store `RetrievalStore`, usage ledger `ConversationUsageStore`, indexer `ConversationIndexer`, service `retrievalService`, query `searchConversationMemory`).
 
+### session_activity_intervals table
+
+Durable activity-disposition ledger. One row per continuous span a session spent in one `ActivityDisposition` bucket - `'idle'` (needing the user, covering both the `idle` and `permission` activity states) or `'active'` (the agent working on its own, the `thinking` state); see `dispositionOf` in `src/shared/activity-state.ts`. Written the moment the activity engine commits a disposition-changing transition, so it survives the engine's own in-memory state (wiped on `deleteSession`/dispose) and is faithful where `events.jsonl` is not (that file logs raw hook events, not committed transitions, and is not reliably retained). Symmetric by design: both dispositions are recorded directly, so "active time" and "idle time" are each a straight SUM rather than an inverse requiring session-boundary reconciliation.
+
+| Column | Type | Constraints | Default |
+|--------|------|-------------|---------|
+| id | INTEGER | PRIMARY KEY AUTOINCREMENT | |
+| session_id | TEXT | NOT NULL | |
+| task_id | TEXT | | NULL |
+| disposition | TEXT | NOT NULL | |
+| state | TEXT | NOT NULL | |
+| previous_state | TEXT | NOT NULL | |
+| enter_trigger | TEXT | NOT NULL | |
+| started_ms | INTEGER | NOT NULL | |
+| started_at | TEXT | NOT NULL | |
+| ended_ms | INTEGER | | NULL |
+| ended_at | TEXT | | NULL |
+| duration_ms | INTEGER | | NULL |
+| exit_trigger | TEXT | | NULL |
+| recorded_at | TEXT | NOT NULL | |
+
+One row per INTERVAL, not per transition: a `permission` to `idle` crossing stays inside the same `'idle'`-disposition interval, so nothing closes and reopens. `enter_trigger` / `exit_trigger` carry the engine's own `TransitionTrigger` labels, so a consumer can tell a hook-authoritative park (`event:idle`) from a watchdog guess (`timer:stale-thinking`), and a genuine human reply (`event:prompt`) from the agent resuming itself (`event:prompt:pty-activity`). `started_at` / `ended_at` are TEXT UTC ISO 8601 mirrors of `started_ms` / `ended_ms`, written by the store from the same value so the two representations cannot drift; `ended_at` is NULL exactly when `ended_ms` is (the interval is still open). Indices: `idx_activity_intervals_task` (task_id), `idx_activity_intervals_session` (session_id), `idx_activity_intervals_started` (started_ms), `idx_activity_intervals_open` (session_id, ended_ms - resolves the one open interval per session without holding row ids across a restart). Deliberately has NO `sessions` DELETE cascade, for the same reason as `conversation_turn_usage`: it is a durable ledger, so an interval outlives the session row that produced it. A session that dies mid-interval leaves it permanently open; consumers filter `ended_ms IS NOT NULL`.
+
+Module: `src/main/activity-engine/` (store `ActivityIntervalStore`, recorder `ActivityIntervalRecorder`). Read via the `kangentic_get_activity_intervals` MCP tool (see [mcp-server.md](mcp-server.md)) or `kangentic_query_db`; there is no desktop-facing IPC endpoint yet.
+
 ## Migration Strategy
 
 Migrations run automatically on database open via `runGlobalMigrations()` (from `src/main/db/migrations/global-schema.ts`) and `runProjectMigrations()` (from `src/main/db/migrations/project-schema.ts`). Default swimlane and action seeding lives in `src/main/db/migrations/default-data.ts`. The strategy uses three approaches depending on the change:
@@ -482,6 +507,7 @@ Grouped by feature. The numbering is for cross-reference only and does not refle
 47. **`permission_mode` column on tasks** - adds `permission_mode TEXT DEFAULT NULL`, a per-task permission override mirroring `agent_override`/`model_override`/`effort_override`: settable via the New Task dialog's Advanced section and the task-detail edit form (pre-spawn or suspended only, same lock as `agent_override`). Takes precedence over the swimlane's `permission_mode` and the project's default permission mode; NULL means inherit. Idempotent guarded `ALTER TABLE`.
 48. **`auto_command` column on tasks** - adds `auto_command TEXT DEFAULT NULL`, an MCP-only per-task initial command set via `kangentic_create_task`'s `autoCommand` param so a skill can mint a task that runs a command (e.g. `/code-review`) once the agent spawns. Not surfaced in the New Task dialog or project settings. Takes precedence over the swimlane's `auto_command` for this task only; NULL means inherit from the swimlane. Idempotent guarded `ALTER TABLE`.
 49. **`agent` and `effort` columns on `usage_history`** - adds `agent TEXT` and `effort TEXT` (both in the `CREATE TABLE` block plus guarded `ALTER TABLE` for existing DBs) so the usage dashboard can break usage down by agent and by reasoning effort. `agent` is stamped at capture time from the session manager's recorded agent name; `effort` from `sessions.applied_effort` (the last-applied `--effort` value, NULL = agent default). Each has a one-shot backfill: `agent` from surviving `sessions` -> `tasks.agent` joins, `effort` from surviving `sessions.applied_effort`. Rows whose source was deleted stay NULL (rendered "(unknown)" / "(default)"). The one-shot `usage_history` seed backfill (migration 36) also carries both columns. Idempotent guarded `ALTER TABLE`.
+50. **Durable activity-disposition-interval ledger (`session_activity_intervals`)** - creates the table plus its `idx_activity_intervals_task` / `idx_activity_intervals_session` / `idx_activity_intervals_started` / `idx_activity_intervals_open` indices. One row per continuous span a session spent in the `'active'` or `'idle'` `ActivityDisposition` bucket, written by `ActivityIntervalRecorder` the moment the activity engine commits a disposition-changing transition - symmetric by design (both dispositions recorded directly, not one derived as the inverse of the other). `started_at`/`ended_at` mirror `started_ms`/`ended_ms` as UTC ISO 8601, derived from the same value at write time. Deliberately has NO `sessions` DELETE cascade (same rationale as `conversation_turn_usage`): a durable ledger, so an interval outlives the session row that produced it. See the `session_activity_intervals table` section above. Idempotent `CREATE ... IF NOT EXISTS`.
 
 ### Key Migrations (Global DB)
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -27,14 +27,14 @@ Claude Code agent calls MCP tool (e.g. kangentic_create_task)
 |-----------|------|---------|
 | MCP HTTP Server | `src/main/agent/mcp-http-server.ts` | In-process Node `http` server using `@modelcontextprotocol/sdk` Streamable HTTP transport. Binds 127.0.0.1 by default (configurable via `mcpServer.bindAddress`), random `:0` port, random per-launch token validated via `X-Kangentic-Token`. See [Network Access](#network-access). |
 | Task Tools | `src/main/agent/mcp-http/task-tools.ts` | Board/task/column mutations + related reads (`kangentic_create_task`, `kangentic_move_task`, `kangentic_update_task`, `kangentic_link_pr`, `kangentic_update_column`, `kangentic_delete_task`, `kangentic_list_columns`, `kangentic_find_task`, `kangentic_get_current_task`, etc.). |
-| Session Tools | `src/main/agent/mcp-http/session-tools.ts` | Session inspection, backlog, read-only SQL (`kangentic_list_sessions`, `kangentic_get_transcript`, `kangentic_get_session_files`, `kangentic_get_session_events`, `kangentic_query_db`, `kangentic_list_backlog`, etc.). |
+| Session Tools | `src/main/agent/mcp-http/session-tools.ts` | Session inspection, backlog, read-only SQL (`kangentic_list_sessions`, `kangentic_get_transcript`, `kangentic_get_session_files`, `kangentic_get_session_events`, `kangentic_get_activity_intervals`, `kangentic_query_db`, `kangentic_list_backlog`, etc.). |
 | Project Tools | `src/main/agent/mcp-http/project-tools.ts` | Multi-project discovery (`kangentic_list_projects`). |
 | Search Tools | `src/main/agent/mcp-http/search-tools.ts` | The single unified search (`kangentic_search`): tasks, backlog, session events, projects, and past conversations (keyword or, with `mode:"hybrid"`, semantic). The board-scoped `kangentic_search_tasks` lives in `task-tools.ts`. |
 | Diagnostics Tools | `src/main/agent/mcp-http/diagnostics-tools.ts` | Read-only product tools backing crash records, persistent console logs, process metrics, IPC traffic recordings, and worktree state. |
 | Tool Annotations | `src/main/agent/mcp-http/annotations.ts` | Shared `READ_ONLY_ANNOTATIONS` / `MUTATING_ANNOTATIONS` MCP tool-annotation constants. Every tool in every `*-tools.ts` file declares one of these (see the Tool annotations note below). |
 | Browser Tools | `src/main/agent/mcp-http/browser-tools.ts` | Shipped `kangentic_browser_*` MCP tool family driving the embedded Browser pane via in-process CDP (no HTTP bridge, no lockfile). Gated by the global `browserAutomation.*` policy. |
 | Usage Tools | `src/main/agent/mcp-http/usage-tools.ts` | Aggregated usage statistics (`kangentic_get_usage_stats`): tokens, cost, burn rate, and by-model / by-agent / by-effort breakdowns, per project or app-wide, over the shared time ranges. Reads the same usage-stats service as the in-app dashboard. |
-| Command Handlers | `src/main/agent/commands/` | Per-domain handlers shared by the HTTP tools: task, column, inventory, search, analytics, usage, backlog, handoff, inspect (`get_transcript`, `query_db`), and session-files (`get_session_files`, `get_session_events`) commands. |
+| Command Handlers | `src/main/agent/commands/` | Per-domain handlers shared by the HTTP tools: task, column, inventory, search, analytics, usage, backlog, handoff, inspect (`get_transcript`, `query_db`), session-files (`get_session_files`, `get_session_events`), and activity-interval (`get_activity_intervals`) commands. |
 | Column Resolver | `src/main/agent/commands/column-resolver.ts` | Shared case-insensitive column name to swimlane lookup used by multiple handlers. |
 | MCP Config Delivery | `src/main/agent/adapters/claude/command-builder.ts` | Writes session `mcp.json` (with the per-launch URL + token) and adds `--mcp-config` flag to CLI command. |
 | Trust Manager | `src/main/agent/adapters/claude/trust-manager.ts` | Pre-approves kangentic MCP server in `~/.claude.json`. |
@@ -473,6 +473,22 @@ Read parsed events from a session's `events.jsonl` activity log without locating
 | `tail` | number | No | Return the last N matching events. Default 200, hard cap 2000. |
 | `since` | number | No | Epoch milliseconds. Only return events with `timestamp >= since`. |
 | `eventTypes` | string[] | No | Only return events whose `hook_event_name` or `type` is in this list (e.g. `["PreToolUse", "Stop", "Notification"]`). |
+| `project` | string | No | Project selector (name or UUID). Defaults to the URL-path project. |
+
+### kangentic_get_activity_intervals
+
+Read the durable activity-disposition history for a task or session: every span the agent spent `'active'` (working on its own) or `'idle'` (needing the user - covering both the `idle` and `permission` engine states) since Kangentic started tracking it. This SURVIVES app restarts and session end - it is written the moment the activity engine commits a transition, independent of the in-memory engine state and of `events.jsonl` (which records raw hook events, not committed transitions, and is not reliably retained). Use it to answer "how long has this task been waiting on me" or "how much of this session was the agent actually working vs blocked on approval/input". Provide either `taskId` (every session the task has ever accumulated - a resume creates a new session row) or `sessionId` (one session only).
+
+Response shape:
+
+- `intervals` - raw rows (`id`, `sessionId`, `taskId`, `disposition`, `state`, `previousState`, `enterTrigger`, `exitTrigger`, `startedMs`, `startedAt`, `endedMs`, `endedAt`, `durationMs`, `recordedAt`), oldest first. `startedAt`/`endedAt` are UTC ISO 8601 mirrors of `startedMs`/`endedMs` (stored, not computed on read) - `endedAt` is `null` exactly when `endedMs` is.
+- `totals` - `{ activeMs, idleMs }`, summing `durationMs` across CLOSED intervals only.
+- `openIntervals` - intervals still in progress (`durationMs` is `null` until closed), each with `startedAt` and a `liveElapsedMs` computed at read time so a still-parked task is not silently excluded from an elapsed-time answer.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `taskId` | string | No | Task ID. Returns intervals across every session the task has ever had. |
+| `sessionId` | string | No | Kangentic session UUID (the `sessions.id` column). Returns intervals for that session only. |
 | `project` | string | No | Project selector (name or UUID). Defaults to the URL-path project. |
 
 ### kangentic_query_db

--- a/packages/protocol/src/capabilities/board-tools.ts
+++ b/packages/protocol/src/capabilities/board-tools.ts
@@ -27,6 +27,7 @@ export const BOARD_TOOL_READ_NAMES = [
   'get_transcript',
   'get_session_files',
   'get_session_events',
+  'get_activity_intervals',
 ] as const;
 
 export const BOARD_TOOL_WRITE_NAMES = [

--- a/packages/protocol/src/events/payloads.ts
+++ b/packages/protocol/src/events/payloads.ts
@@ -102,10 +102,16 @@ export interface TerminalDimensionsWire {
 /** Mirrors the desktop's ActivityState. 'permission' means the agent paused for user approval (incl. AskUserQuestion / ExitPlanMode pauses). */
 export type ActivityStateWire = 'thinking' | 'idle' | 'permission';
 
-/** Mirrors the desktop's ActivityReason discriminated union. */
+/**
+ * Mirrors the desktop's ActivityReason discriminated union. `since` (epoch ms
+ * the session first needed the user) is optional, additive-field style like
+ * `toolCallCount`/`effort` above: an older phone parsing a payload with the
+ * field missing still validates, and a desktop that has not yet learned a
+ * `since` for a phantom-state edge case can omit it.
+ */
 export type ActivityReasonWire =
-  | { kind: 'idle' }
-  | { kind: 'permission' }
+  | { kind: 'idle'; since?: number }
+  | { kind: 'permission'; since?: number }
   | { kind: 'tool'; pendingCount: number; currentTool: string | null }
   | { kind: 'subagent'; depth: number }
   | { kind: 'background-shell'; count: number; ids: string[] }
@@ -335,6 +341,7 @@ export function isActivityReasonWire(value: unknown): value is ActivityReasonWir
   switch (value.kind) {
     case 'idle':
     case 'permission':
+      return value.since === undefined || typeof value.since === 'number';
     case 'turn-active':
       return true;
     case 'tool':

--- a/src/main/activity-engine/README.md
+++ b/src/main/activity-engine/README.md
@@ -14,6 +14,8 @@ This directory implements Kangentic's activity-detection engine. The full archit
 | `usage-accumulator.ts` | Token / cost / per-tool stats. Pure transformations of parsed events. |
 | `pr-command-detector.ts` | Detects `gh pr ...` Bash invocations so the orchestrator can scan scrollback for the printed PR URL on the matching ToolEnd. |
 | `pty-activity-tracker.ts` | PTY-byte fallback for non-hook agents (Aider, Codex, etc.). |
+| `activity-interval-recorder.ts` | Listens for the engine's disposition transitions (`activity`/`exit` events, both active and idle - symmetric, not idle-only) and durably records them - the engine's own state is in-memory only. |
+| `activity-interval-store.ts` | DB access for the `session_activity_intervals` table (open/close/query). |
 
 ## Predicate (load-bearing)
 

--- a/src/main/activity-engine/activity-interval-recorder.ts
+++ b/src/main/activity-engine/activity-interval-recorder.ts
@@ -1,0 +1,171 @@
+import type { ActivityState } from '../../shared/types';
+import { dispositionOf } from '../../shared/activity-state';
+import type { SessionManager } from '../pty/session-manager';
+import { ActivityIntervalStore } from './activity-interval-store';
+
+export interface ActivityIntervalRecorderOptions {
+  sessionManager: Pick<
+    SessionManager,
+    'on' | 'off' | 'getSession' | 'getSessionProjectId' | 'getSessionTaskId' | 'getActivityStatsSnapshot'
+  >;
+  /** Resolve the interval store for a project. Injectable for tests; production wiring wraps
+   *  `getProjectDb(projectId)`. `getProjectDb` caches connections per project, so calling this
+   *  on every event is cheap - it is not opening a new connection each time. */
+  getStore: (projectId: string) => ActivityIntervalStore;
+  /** UTC ISO 8601 clock for `recorded_at`. Injectable for tests. */
+  now?: () => string;
+}
+
+/**
+ * Writes the activity engine's committed disposition transitions ("the green
+ * spinner turned into the yellow mail icon", and back) to a durable
+ * per-project table. The engine itself never persists this: its state is
+ * in-memory only, and the one on-disk trace (events.jsonl) records raw hook
+ * events, not committed transitions, so it can both miss a real transition
+ * (a raw idle cancelled by the 400ms stability window) and record one that
+ * never happened (a watchdog-synthesized idle with no matching raw event).
+ *
+ * Symmetric by design: every real disposition flip (active -> idle or
+ * idle -> active) closes whichever interval was open and opens the next -
+ * NOT idle-only. Recording both directly means "active time" and "idle
+ * time" are each a straight SUM over the table; deriving one as the inverse
+ * of the other would need exact session-boundary reconciliation across
+ * resumes/suspends and would silently break on a crash-orphaned open row.
+ * A permission<->idle crossing stays within the same 'idle'-disposition
+ * interval (both map to the same disposition via `dispositionOf`), so nothing
+ * closes/reopens for it.
+ *
+ * Modelled on `PushNotifier` (`src/main/mobile-bridge/push/push-notifier.ts`):
+ * a single listener on `sessionManager`'s `activity` and `exit` events, no
+ * per-session state map. Unlike PushNotifier, this recorder needs no
+ * `lastActivityState` map either - it reads provenance (`from` and
+ * `trigger`) straight off the engine's own transition ring
+ * (`getActivityStatsSnapshot(sessionId).recentTransitions`), which
+ * `ActivityEngine.commitTransition` appends to immediately before firing the
+ * `activity` event this recorder listens on.
+ */
+export class ActivityIntervalRecorder {
+  private readonly options: ActivityIntervalRecorderOptions;
+  private readonly now: () => string;
+  private started = false;
+  private disposed = false;
+
+  constructor(options: ActivityIntervalRecorderOptions) {
+    this.options = options;
+    this.now = options.now ?? (() => new Date().toISOString());
+  }
+
+  private readonly onActivity = (sessionId: string, activity: ActivityState): void => {
+    // Never let a ledger write escape into the emit stack. This listener is
+    // attached to SessionManager BEFORE the session handlers (register-all.ts
+    // starts this recorder ahead of registerSessionHandlers), and
+    // EventEmitter.emit does not isolate listener exceptions - a throw here
+    // would abort the session DB persistence and the SESSION_ACTIVITY
+    // broadcast that run after us on the same synchronous emit, and would
+    // unwind back into ActivityEngine.commitTransition before it can call
+    // scheduleTimer(), leaving the stale-thinking watchdog unarmed. A lost
+    // interval row is an acceptable failure; a skipped session-lifecycle
+    // write or a disarmed watchdog is not. Mirrors DesktopNotifier's guard.
+    try {
+      this.handleActivity(sessionId, activity);
+    } catch (error) {
+      console.error('[ACTIVITY-INTERVAL] recorder activity handler failed', error);
+    }
+  };
+
+  private handleActivity(sessionId: string, activity: ActivityState): void {
+    if (this.disposed) return;
+    const session = this.options.sessionManager.getSession(sessionId);
+    // Command Terminal sessions carry a synthetic taskId that is not a real
+    // task row - skip them, matching the guard in handlers/sessions.ts.
+    if (!session || session.transient) return;
+    const projectId = this.options.sessionManager.getSessionProjectId(sessionId);
+    if (!projectId) return;
+
+    const snapshot = this.options.sessionManager.getActivityStatsSnapshot(sessionId);
+    const lastTransition = snapshot?.recentTransitions[snapshot.recentTransitions.length - 1];
+    // ActivityEngine.initSession's seed path calls onActivityChange directly
+    // (see activity-engine.ts) without going through commitTransition, so it
+    // never appends to recentTransitions. A missing or stale tail entry
+    // therefore means this emission is a seed (resume / Command Terminal
+    // spawn / orphan recovery), not a real transition - skip it. The window
+    // this leaves unrecorded (spawn until the session's first real
+    // transition) is deliberate and small; see the migration comment.
+    if (!lastTransition || lastTransition.to !== activity) return;
+
+    const previousState = lastTransition.from;
+    const previousDisposition = dispositionOf(previousState);
+    const newDisposition = dispositionOf(activity);
+    // Equal dispositions mean a permission<->idle crossing within the same
+    // 'idle' interval (do not reopen it) - the only case two DIFFERENT
+    // ActivityStates share a disposition, since 'active' has just the one
+    // member ('thinking'). commitTransition only fires when activity
+    // actually changed, so previousState !== activity is guaranteed here.
+    if (previousDisposition === newDisposition) return;
+
+    const store = this.options.getStore(projectId);
+    // A flip always closes whichever interval was open (a no-op if this is
+    // the session's first real transition - nothing was open yet) and opens
+    // the next, so the table never has gaps once the first flip lands.
+    store.closeOpenInterval(sessionId, lastTransition.ts, lastTransition.trigger);
+    store.openInterval(
+      {
+        sessionId,
+        taskId: this.options.sessionManager.getSessionTaskId(sessionId) ?? null,
+        disposition: newDisposition,
+        state: activity,
+        previousState,
+        enterTrigger: lastTransition.trigger,
+        startedMs: lastTransition.ts,
+      },
+      this.now(),
+    );
+  }
+
+  private readonly onExit = (sessionId: string): void => {
+    // See handleActivity: a throw here would abort the session-lifecycle
+    // bookkeeping that runs after this listener on the same emit.
+    try {
+      this.handleExit(sessionId);
+    } catch (error) {
+      console.error('[ACTIVITY-INTERVAL] recorder exit handler failed', error);
+    }
+  };
+
+  private handleExit(sessionId: string): void {
+    if (this.disposed) return;
+    // For a natural PTY exit and for killByTaskId, the registry still holds
+    // the exited session at emit time (see SessionLifecycleBoardFeed's onExit
+    // for the same observation), so project/transient resolution below
+    // resolves. KNOWN GAP: SessionManager.remove()/removeByTaskId() call
+    // registry.delete() synchronously while the PTY dies asynchronously, so
+    // the later 'exit' emit finds no session and this returns early, leaving
+    // that session's interval permanently open. Consumers must filter
+    // `ended_ms IS NOT NULL` for totals. Closing that gap needs the recorder
+    // to cache projectId per open interval rather than re-resolving it here.
+    const session = this.options.sessionManager.getSession(sessionId);
+    if (!session || session.transient) return;
+    const projectId = this.options.sessionManager.getSessionProjectId(sessionId);
+    if (!projectId) return;
+    // Unconditional and safe even when no interval is open: closeOpenInterval
+    // is a WHERE-guarded UPDATE that no-ops when it matches zero rows.
+    this.options.getStore(projectId).closeOpenInterval(sessionId, Date.now(), 'session-exit');
+  }
+
+  start(): void {
+    if (this.started || this.disposed) return;
+    this.started = true;
+    this.options.sessionManager.on('activity', this.onActivity);
+    this.options.sessionManager.on('exit', this.onExit);
+  }
+
+  /** Synchronous, per synchronous-shutdown.md: detaches listeners with no async work. */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.started) {
+      this.options.sessionManager.off('activity', this.onActivity);
+      this.options.sessionManager.off('exit', this.onExit);
+    }
+  }
+}

--- a/src/main/activity-engine/activity-interval-store.ts
+++ b/src/main/activity-engine/activity-interval-store.ts
@@ -1,0 +1,161 @@
+import type Database from 'better-sqlite3';
+import type { ActivityState } from '../../shared/types';
+import type { ActivityDisposition } from '../../shared/activity-state';
+
+/** A new activity-disposition interval to open. */
+export interface OpenIntervalInput {
+  sessionId: string;
+  taskId: string | null;
+  /** The coarse bucket entered - see shared/activity-state.ts's dispositionOf. */
+  disposition: ActivityDisposition;
+  /** Granular state entered ('thinking' for an 'active' disposition; 'idle' or 'permission' for 'idle'). */
+  state: ActivityState;
+  /** The granular state the session was in immediately before this interval opened. */
+  previousState: ActivityState;
+  /** The engine's own TransitionTrigger label (e.g. 'event:idle', 'timer:stale-thinking'). */
+  enterTrigger: string;
+  startedMs: number;
+}
+
+export interface SessionActivityInterval {
+  id: number;
+  sessionId: string;
+  taskId: string | null;
+  disposition: ActivityDisposition;
+  state: ActivityState;
+  previousState: ActivityState;
+  enterTrigger: string;
+  startedMs: number;
+  /** UTC ISO 8601 mirror of startedMs, written from the same value - see the
+   *  migration comment on session_activity_intervals for why this is a
+   *  derived mirror, not an independently-sourced field. */
+  startedAt: string;
+  /** Null while the interval is still open (the session has not left this disposition yet). */
+  endedMs: number | null;
+  /** UTC ISO 8601 mirror of endedMs. Null exactly when endedMs is. */
+  endedAt: string | null;
+  durationMs: number | null;
+  /** How the interval ended - e.g. 'event:prompt' (idle -> active, a human reply), 'event:idle'
+   *  (active -> idle, a real park), or 'session-exit'. Null while open. */
+  exitTrigger: string | null;
+  recordedAt: string;
+}
+
+interface ActivityIntervalRow {
+  id: number;
+  session_id: string;
+  task_id: string | null;
+  disposition: string;
+  state: string;
+  previous_state: string;
+  enter_trigger: string;
+  started_ms: number;
+  started_at: string;
+  ended_ms: number | null;
+  ended_at: string | null;
+  duration_ms: number | null;
+  exit_trigger: string | null;
+  recorded_at: string;
+}
+
+function toInterval(row: ActivityIntervalRow): SessionActivityInterval {
+  return {
+    id: row.id,
+    sessionId: row.session_id,
+    taskId: row.task_id,
+    disposition: row.disposition as ActivityDisposition,
+    state: row.state as ActivityState,
+    previousState: row.previous_state as ActivityState,
+    enterTrigger: row.enter_trigger,
+    startedMs: row.started_ms,
+    startedAt: row.started_at,
+    endedMs: row.ended_ms,
+    endedAt: row.ended_at,
+    durationMs: row.duration_ms,
+    exitTrigger: row.exit_trigger,
+    recordedAt: row.recorded_at,
+  };
+}
+
+/**
+ * Durable per-project ledger over `session_activity_intervals`: one row per
+ * continuous span a session spent in one `ActivityDisposition` bucket
+ * ('idle' - needing the user, covering both idle and permission - or
+ * 'active' - the agent working on its own). Symmetric by design: both
+ * dispositions are recorded directly (see the migration comment for why
+ * deriving 'active' as the inverse of 'idle' is fragile), so a consumer sums
+ * this table for either without session-boundary reconciliation.
+ *
+ * Written at the moment the activity engine commits a disposition-changing
+ * transition, so it SURVIVES the engine's own in-memory state (wiped on
+ * deleteSession/dispose) and is a faithful record where `events.jsonl` is
+ * not (that file logs raw hook events, not committed transitions).
+ *
+ * Deliberately has NO sessions-DELETE cascade: this is a durable ledger, not
+ * a rebuildable index, and the whole point is that a recorded interval
+ * outlives the session row that produced it.
+ */
+export class ActivityIntervalStore {
+  constructor(private readonly db: Database.Database) {}
+
+  /** Insert a new open interval. Idempotent in effect only if the caller
+   *  guards against opening a second interval while one is already open for
+   *  the session - the store itself does not deduplicate. */
+  openInterval(input: OpenIntervalInput, recordedAt: string): void {
+    this.db
+      .prepare(
+        `INSERT INTO session_activity_intervals
+           (session_id, task_id, disposition, state, previous_state, enter_trigger, started_ms, started_at, recorded_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        input.sessionId,
+        input.taskId,
+        input.disposition,
+        input.state,
+        input.previousState,
+        input.enterTrigger,
+        input.startedMs,
+        new Date(input.startedMs).toISOString(),
+        recordedAt,
+      );
+  }
+
+  /**
+   * Close the session's open interval (if any). Resolves the row by
+   * `WHERE session_id = ? AND ended_ms IS NULL` (indexed via
+   * `idx_activity_intervals_open`) rather than a row id held in memory, so a
+   * Kangentic restart between open and close cannot orphan the mapping - the
+   * next close still finds the right row by session id alone. A no-op
+   * (zero rows affected) when no interval is open, which is expected right
+   * after a session's first real transition (the pre-first-transition seed
+   * window opened nothing to close) and for a session that crashed
+   * mid-interval: the row stays open forever, and consumers filter
+   * `ended_ms IS NOT NULL`.
+   */
+  closeOpenInterval(sessionId: string, endedMs: number, exitTrigger: string): void {
+    this.db
+      .prepare(
+        `UPDATE session_activity_intervals
+           SET ended_ms = ?, ended_at = ?, duration_ms = ? - started_ms, exit_trigger = ?
+         WHERE session_id = ? AND ended_ms IS NULL`,
+      )
+      .run(endedMs, new Date(endedMs).toISOString(), endedMs, exitTrigger, sessionId);
+  }
+
+  /** A task's activity intervals (both dispositions), oldest first. */
+  getForTask(taskId: string): SessionActivityInterval[] {
+    const rows = this.db
+      .prepare('SELECT * FROM session_activity_intervals WHERE task_id = ? ORDER BY started_ms ASC')
+      .all(taskId) as ActivityIntervalRow[];
+    return rows.map(toInterval);
+  }
+
+  /** One session's activity intervals (both dispositions), oldest first. */
+  getForSession(sessionId: string): SessionActivityInterval[] {
+    const rows = this.db
+      .prepare('SELECT * FROM session_activity_intervals WHERE session_id = ? ORDER BY started_ms ASC')
+      .all(sessionId) as ActivityIntervalRow[];
+    return rows.map(toInterval);
+  }
+}

--- a/src/main/activity-engine/engine/activity-engine.ts
+++ b/src/main/activity-engine/engine/activity-engine.ts
@@ -1,5 +1,6 @@
 import { EventType, IdleReason } from '../../../shared/types';
 import type { ActivityState, ActivityReason, SessionEvent } from '../../../shared/types';
+import { requiresUserInteraction } from '../../../shared/activity-state';
 import {
   DEFAULT_BG_SHELL_ESCAPE_HATCH_MS,
   DEFAULT_BG_SHELL_ONLY_GRACE_MS,
@@ -106,6 +107,11 @@ export class ActivityEngine {
       // spawn. A seeded 'thinking' turn leaves idleTimestamp null, preserving
       // the invariant that idleTimestamp is non-null iff activity is 'idle'.
       state.idleTimestamp = nowMs;
+      // The seed predicate below always resolves 'idle' (permissionPending
+      // starts false), so this mirrors idleTimestamp: the elapsed-wait clock
+      // measures from spawn too, not from whenever the first real transition
+      // happens to land.
+      state.needsUserSince = nowMs;
     }
     const { activity, reason } = deriveActivityAndReason(state);
     state.activity = activity;
@@ -204,6 +210,7 @@ export class ActivityEngine {
       lastPtyOutputAt,
       msSincePtyOutput: lastPtyOutputAt === null ? null : this.now() - lastPtyOutputAt,
       pendingIdleArmed: state.pendingIdleAt !== null,
+      needsUserSince: state.needsUserSince,
       idleHintPending: state.idleHintPending,
       retryFailurePending: state.retryFailurePending,
       recentTransitions: state.recentTransitions.slice(),
@@ -774,6 +781,16 @@ export class ActivityEngine {
       state.idleTimestamp = this.now();
     } else {
       state.idleTimestamp = null;
+    }
+    // needsUserSince spans BOTH needs-user states (idle and permission), unlike
+    // idleTimestamp above which is idle-only: stamp it only when entering a
+    // needs-user state from thinking (a fresh park), leave it untouched on a
+    // permission<->idle crossing (still the same park), and clear it on
+    // entering thinking (the agent resumed).
+    if (requiresUserInteraction(newActivity)) {
+      if (!requiresUserInteraction(fromActivity)) state.needsUserSince = this.now();
+    } else {
+      state.needsUserSince = null;
     }
     const reason = deriveReason(state);
     this.recordTransition(state, fromActivity, newActivity, reason.kind, trigger, counterDelta);

--- a/src/main/activity-engine/engine/predicate.ts
+++ b/src/main/activity-engine/engine/predicate.ts
@@ -60,8 +60,14 @@ export function deriveReasonForActivity(
   state: SessionEngineState,
   activity: ActivityState,
 ): ActivityReason {
-  if (activity === 'permission') return { kind: 'permission' };
-  if (activity === 'idle') return { kind: 'idle' };
+  // needsUserSince is stamped by both entry points that can produce an
+  // idle/permission activity (ActivityEngine.initSession's idle seed and
+  // commitTransition), so it is null here only for the pre-existing
+  // "event arrived before initSession" phantom-state edge case (same gap
+  // idleTimestamp already has in that path) - fall back to now() rather than
+  // propagate null onto a field callers depend on being a real timestamp.
+  if (activity === 'permission') return { kind: 'permission', since: state.needsUserSince ?? Date.now() };
+  if (activity === 'idle') return { kind: 'idle', since: state.needsUserSince ?? Date.now() };
   // activity === 'thinking'
   if (state.pendingToolCount > 0) {
     return {

--- a/src/main/activity-engine/engine/shapes.ts
+++ b/src/main/activity-engine/engine/shapes.ts
@@ -360,6 +360,19 @@ export interface SessionEngineState {
   /** Wall-clock ms of the most recent idle transition (used by idle-timeout sweep). */
   idleTimestamp: number | null;
   /**
+   * Wall-clock ms since the session first entered a state that needs the
+   * user (`requiresUserInteraction` true - `'idle'` or `'permission'`).
+   * Distinct from `idleTimestamp`, which is scoped to `'idle'` alone and
+   * drives auto-suspend: this field spans BOTH needs-user states so a
+   * `thinking -> permission -> idle` run keeps the ORIGINAL park time
+   * instead of resetting when permission resolves into idle. Set on first
+   * entering either state from `'thinking'`; left unchanged on a
+   * `permission <-> idle` crossing; cleared to null on entering
+   * `'thinking'`. Surfaced on `ActivityReason` so the UI can render "waiting
+   * Nm" next to the mail affordance.
+   */
+  needsUserSince: number | null;
+  /**
    * Provenance of the CURRENT idle: true iff this idle was entered via a
    * genuine hook turn-end (a non-permission `Idle` hook, an `idle_hint` that
    * cleared `turnActive`, or an `Interrupted`/`TurnFailed`) - "the agent told
@@ -543,6 +556,9 @@ export interface ActivityStatsSnapshot {
   /** ms since the most recent PTY output chunk, or null when no chunk yet. */
   msSincePtyOutput: number | null;
   pendingIdleArmed: boolean;
+  /** Wall-clock ms since the session first needed the user (see
+   *  `SessionEngineState.needsUserSince`), or null while thinking. */
+  needsUserSince: number | null;
   /** True while an `idle_hint` is pending (see `SessionEngineState.idleHintPending`):
    *  the stuck-subagent / stuck-pending-tools watchdogs are on their short grace,
    *  not the 5-min cap. Lets the debug overlay explain a fast watchdog fire. */

--- a/src/main/activity-engine/engine/state-factory.ts
+++ b/src/main/activity-engine/engine/state-factory.ts
@@ -20,6 +20,7 @@ export function createSessionEngineState(): SessionEngineState {
     currentTool: null,
     pendingToolStack: [],
     idleTimestamp: null,
+    needsUserSince: null,
     idleAuthoritative: false,
     turnForcedByHeartbeat: false,
     pendingIdleAt: null,

--- a/src/main/agent/commands/activity-interval-commands.ts
+++ b/src/main/agent/commands/activity-interval-commands.ts
@@ -1,0 +1,78 @@
+import { TaskRepository } from '../../db/repositories/task-repository';
+import { ActivityIntervalStore, type SessionActivityInterval } from '../../activity-engine/activity-interval-store';
+import { resolveTask } from './task-resolver';
+import type { CommandContext, CommandHandler, CommandResponse } from './types';
+
+/** A still-open interval, with its elapsed time computed at read time (the
+ *  row itself carries no live clock - `durationMs`/`endedMs` stay null until
+ *  the recorder closes it). */
+interface OpenIntervalSummary {
+  sessionId: string;
+  disposition: SessionActivityInterval['disposition'];
+  state: SessionActivityInterval['state'];
+  startedMs: number;
+  startedAt: string;
+  liveElapsedMs: number;
+}
+
+/**
+ * Read-only MCP surface over `session_activity_intervals` (see
+ * activity-interval-store.ts / activity-interval-recorder.ts). Accepts
+ * either `sessionId` (one session) or `taskId` (every session the task has
+ * ever accumulated - a resume creates a new session row, so a task's full
+ * wait history can span several). Returns the raw rows plus a totals rollup
+ * so a caller doesn't have to sum `durationMs` by `disposition` itself, and
+ * separately reports any still-OPEN interval's live elapsed time (a row with
+ * `durationMs: null` is mid-span - its wait time is not yet a durable total).
+ */
+export const handleGetActivityIntervals: CommandHandler = (
+  params: Record<string, unknown>,
+  context: CommandContext,
+): CommandResponse => {
+  const database = context.getProjectDb();
+  const sessionId = params.sessionId as string | undefined;
+  const taskId = params.taskId as string | undefined;
+
+  if (!sessionId && !taskId) {
+    return { success: false, error: 'Provide either taskId or sessionId' };
+  }
+
+  const store = new ActivityIntervalStore(database);
+  let intervals: SessionActivityInterval[];
+  let resolvedTaskId: string | null = null;
+
+  if (sessionId) {
+    intervals = store.getForSession(sessionId);
+  } else {
+    const taskRepository = new TaskRepository(database);
+    const task = resolveTask(taskRepository, taskId as string);
+    if (!task) return { success: false, error: `Task "${taskId}" not found` };
+    resolvedTaskId = task.id;
+    intervals = store.getForTask(task.id);
+  }
+
+  const now = Date.now();
+  const totals = { activeMs: 0, idleMs: 0 };
+  const openIntervals: OpenIntervalSummary[] = [];
+  for (const interval of intervals) {
+    if (interval.durationMs !== null) {
+      totals[interval.disposition === 'active' ? 'activeMs' : 'idleMs'] += interval.durationMs;
+    } else {
+      openIntervals.push({
+        sessionId: interval.sessionId,
+        disposition: interval.disposition,
+        state: interval.state,
+        startedMs: interval.startedMs,
+        startedAt: interval.startedAt,
+        liveElapsedMs: now - interval.startedMs,
+      });
+    }
+  }
+
+  const scopeLabel = resolvedTaskId ? `task ${resolvedTaskId}` : `session ${sessionId}`;
+  return {
+    success: true,
+    message: `${intervals.length} interval(s) for ${scopeLabel} (${totals.activeMs}ms active, ${totals.idleMs}ms idle, ${openIntervals.length} open)`,
+    data: { intervals, totals, openIntervals },
+  };
+};

--- a/src/main/agent/commands/index.ts
+++ b/src/main/agent/commands/index.ts
@@ -11,6 +11,7 @@ import { handleListBacklog, handleCreateBacklogTask, handlePromoteBacklog, handl
 import { handleGetHandoffContext } from './handoff-commands';
 import { handleGetTranscript, handleQueryDb } from './inspect-commands';
 import { handleGetSessionFiles, handleGetSessionEvents } from './session-files-commands';
+import { handleGetActivityIntervals } from './activity-interval-commands';
 import type { CommandHandler } from './types';
 
 /**
@@ -47,4 +48,5 @@ export const commandHandlers: Record<string, CommandHandler> = {
   query_db: handleQueryDb,
   get_session_files: handleGetSessionFiles,
   get_session_events: handleGetSessionEvents,
+  get_activity_intervals: handleGetActivityIntervals,
 };

--- a/src/main/agent/mcp-http/session-tools.ts
+++ b/src/main/agent/mcp-http/session-tools.ts
@@ -236,6 +236,27 @@ export function registerSessionTools(server: McpServer, resolver: RequestResolve
     }),
   );
 
+  // --- kangentic_get_activity_intervals ---
+  server.registerTool(
+    'kangentic_get_activity_intervals',
+    {
+      description: 'Read the durable activity-disposition history for a task or session: every span the agent spent \'active\' (working on its own) or \'idle\' (needing the user - covering both the idle and permission states) since Kangentic started tracking it. Unlike the live board indicator, this SURVIVES app restarts and session end - it is written the moment the activity engine commits a transition, independent of the in-memory engine state and of events.jsonl (which records raw hook events, not committed transitions, and is not reliably retained). Use this to answer "how long has this task been waiting on me" or "how much of this session was the agent actually working vs blocked on approval/input". Returns the raw interval rows (each with disposition, state, previousState, enterTrigger, exitTrigger, startedMs, startedAt, endedMs, endedAt, durationMs - the `At` fields are UTC ISO 8601 mirrors of the `Ms` epoch fields, stored so you do not have to convert), a `totals` rollup summing durationMs by disposition across CLOSED intervals only, and `openIntervals` - any interval still in progress (durationMs is null until it closes), with startedAt and a `liveElapsedMs` computed at read time so a still-parked task is not silently excluded from an elapsed-time question. Provide either taskId (every session the task has ever accumulated, since a resume creates a new session row) or sessionId (one session only). Pass `project` to read from a different project.',
+      inputSchema: z.object({
+        taskId: z.string().optional().describe('Task ID (numeric display ID or UUID). Returns intervals across every session the task has ever had.'),
+        sessionId: z.string().optional().describe('Kangentic session UUID (sessions.id column). Returns intervals for that session only.'),
+        project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
+      }),
+      annotations: READ_ONLY_ANNOTATIONS,
+    },
+    async ({ taskId, sessionId, project }) => withProject(resolver, project, async (ctx) => {
+      const result = await runHandler('get_activity_intervals', { taskId, sessionId }, ctx);
+      if (!result.success) {
+        return { content: [{ type: 'text' as const, text: `Failed to get activity intervals: ${result.error}` }], isError: true };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result.data, null, 2) }] };
+    }),
+  );
+
   // --- kangentic_query_db ---
   server.registerTool(
     'kangentic_query_db',

--- a/src/main/db/migrations/project-schema.ts
+++ b/src/main/db/migrations/project-schema.ts
@@ -829,6 +829,98 @@ export function runProjectMigrations(db: Database.Database): void {
   db.exec('CREATE INDEX IF NOT EXISTS idx_turn_usage_session ON conversation_turn_usage(session_id)');
   db.exec('CREATE INDEX IF NOT EXISTS idx_turn_usage_ts ON conversation_turn_usage(ts)');
 
+  // Durable activity-disposition-interval ledger: one row per continuous span
+  // a session spent in one `ActivityDisposition` bucket ('idle' - needing the
+  // user, covering both ActivityState idle and permission - or 'active' -
+  // the agent working on its own, ActivityState thinking; see
+  // shared/activity-state.ts's dispositionOf). The engine itself is
+  // in-memory only (recentTransitions is a debug-only bounded ring, wiped on
+  // deleteSession/dispose), and the one on-disk trace (events.jsonl) is
+  // neither faithful - it records raw hook events, not committed
+  // transitions, so a raw idle cancelled by the 400ms stability window still
+  // appears there with no matching UI change - nor reliably retained
+  // (truncated on session-dir reuse, deleted on cleanup). This table is the
+  // only durable, faithful record of the engine's committed transitions.
+  //
+  // Symmetric by design (both dispositions, not idle-only): deriving "active
+  // time" as (session lifetime) minus (idle time) is fragile - it needs
+  // exact session-boundary timestamps, breaks across a task's multiple
+  // sessions (resume) and suspend/resume gaps, and a crash-orphaned open
+  // interval (see below) would corrupt the subtraction silently. Recording
+  // both directly means "active time" and "idle time" are each a straight
+  // SUM over this table, no inverse math or session-boundary reconciliation
+  // needed.
+  //
+  // enter_trigger / exit_trigger carry the engine's own TransitionTrigger
+  // labels (activity-engine.ts) so a consumer can tell a hook-authoritative
+  // park (`event:idle`) from a watchdog guess (`timer:stale-thinking`,
+  // `timer:stuck-subagent`, `force-idle`), and a real human reply
+  // (`event:prompt` with no synthetic detail) from the agent resuming itself
+  // (`event:prompt:pty-activity`, `force-thinking`) - without those, an
+  // average "wait time" silently mixes in the engine's own known false-idle
+  // classes.
+  //
+  // One row per INTERVAL, not per transition: a permission<->idle crossing
+  // stays within the same 'idle'-disposition interval (both map to the same
+  // disposition, so nothing closes/reopens), so `duration_ms` is a stored
+  // column instead of requiring a self-join to reconstruct.
+  //
+  // KNOWN GAP - the seed span is NOT recorded. The window before a session's
+  // first DISPOSITION FLIP is skipped, since the engine's `initSession` seed
+  // carries no prior state to diff against. This is larger than it sounds:
+  // events within a turn (tool/subagent/bg-shell) keep the predicate at
+  // 'thinking' and commit no transition, so a fresh spawn's entire first
+  // active turn contributes 0ms to `activeMs`, and an idle-seeded session
+  // (resume) that is never answered produces NO ROW AT ALL - `getForTask`
+  // returns empty for exactly the "how long has this been waiting on me"
+  // question. The live board tooltip reads `needsUserSince` off the engine
+  // instead and is unaffected. Closing this needs the engine to announce its
+  // seed (an explicit onSessionSeeded hook), not a ring-shape heuristic.
+  //
+  // Deliberately NO sessions-DELETE cascade, matching conversation_turn_usage
+  // above - but for a different reason: that table's no-cascade protects a
+  // turn shared across a resume, which does not apply here (an interval
+  // belongs to exactly one session). This table's durability is the entire
+  // point: an interval must outlive the session row that produced it, the
+  // same way the token ledger outlives the transcript file it was read from.
+  // A session that crashes mid-interval leaves it permanently open
+  // (`ended_ms IS NULL`); consumers filter that out rather than the engine
+  // attempting reconciliation on restart.
+  // started_ms/ended_ms are the epoch-ms columns the store's duration_ms
+  // arithmetic and started_ms index actually use (matching
+  // conversation_turn_usage's `ts INTEGER` above). started_at/ended_at are a
+  // TEXT ISO 8601 MIRROR of those same two instants (per utc-timestamps.md),
+  // written by the store from the same input so the two representations can
+  // never drift - not independently sourced, not user-suppliable. They exist
+  // purely for readability: a human (or an agent) reading raw SQL via
+  // kangentic_query_db, or the kangentic_get_activity_intervals MCP tool's
+  // response, gets a real timestamp instead of having to convert epoch ms by
+  // hand. ended_at is NULL exactly when ended_ms is (the interval is open).
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS session_activity_intervals (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      task_id TEXT,
+      disposition TEXT NOT NULL,
+      state TEXT NOT NULL,
+      previous_state TEXT NOT NULL,
+      enter_trigger TEXT NOT NULL,
+      started_ms INTEGER NOT NULL,
+      started_at TEXT NOT NULL,
+      ended_ms INTEGER,
+      ended_at TEXT,
+      duration_ms INTEGER,
+      exit_trigger TEXT,
+      recorded_at TEXT NOT NULL
+    )
+  `);
+  db.exec('CREATE INDEX IF NOT EXISTS idx_activity_intervals_task ON session_activity_intervals(task_id)');
+  db.exec('CREATE INDEX IF NOT EXISTS idx_activity_intervals_session ON session_activity_intervals(session_id)');
+  db.exec('CREATE INDEX IF NOT EXISTS idx_activity_intervals_started ON session_activity_intervals(started_ms)');
+  // Resolves the one open interval for a session (WHERE session_id = ? AND
+  // ended_ms IS NULL) without holding row ids in memory across a restart.
+  db.exec('CREATE INDEX IF NOT EXISTS idx_activity_intervals_open ON session_activity_intervals(session_id, ended_ms)');
+
   // Cascade cleanup when a session is deleted (mirrors trg_sessions_delete_transcript).
   db.exec(`
     CREATE TRIGGER IF NOT EXISTS trg_sessions_delete_memory

--- a/src/main/ipc/register-all.ts
+++ b/src/main/ipc/register-all.ts
@@ -45,6 +45,9 @@ import { retrievalService } from '../retrieval/retrieval-service';
 import { MobileBridgeService } from '../mobile-bridge/mobile-bridge-service';
 import { BoardEventBus } from '../mobile-bridge/board-event-bus';
 import { DesktopNotifier } from '../notifications/desktop-notifier';
+import { ActivityIntervalRecorder } from '../activity-engine/activity-interval-recorder';
+import { ActivityIntervalStore } from '../activity-engine/activity-interval-store';
+import { getProjectDb } from '../db/database';
 import { getProjectRepos } from './helpers';
 import { KANGENTIC_HOSTED_RELAY_URL, resolveRelayUrl } from '../../shared/relay';
 import type { IpcContext } from './ipc-context';
@@ -177,6 +180,19 @@ export function registerAllIpc(mainWindow: BrowserWindow, mcpServerHandle: McpHt
   // first reconcile's syncSessions() has handlers to route into.
   mobileBridgeService.attachContext(context);
   desktopNotifier.start();
+
+  // Durable activity-disposition-interval ledger (see
+  // activity-interval-recorder.ts and the session_activity_intervals
+  // migration comment for why this exists: the engine's own state is
+  // in-memory only, and events.jsonl is neither a faithful nor a
+  // reliably-retained record of committed transitions). getProjectDb caches
+  // connections per project, so resolving a fresh store on every event is
+  // cheap - it never opens a new connection.
+  const activityIntervalRecorder = new ActivityIntervalRecorder({
+    sessionManager,
+    getStore: (projectId) => new ActivityIntervalStore(getProjectDb(projectId)),
+  });
+  activityIntervalRecorder.start();
 
   const effectiveConfig = context.configManager.getEffectiveConfig(context.currentProjectPath ?? undefined);
   mobileBridgeService.reconcile({

--- a/src/renderer/components/board/ActivityReasonTooltip.tsx
+++ b/src/renderer/components/board/ActivityReasonTooltip.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { Wrench, Users, Terminal, Lock, Loader2, Mail } from 'lucide-react';
+import { formatDurationBetween } from '../../lib/datetime';
 import type { ActivityReason } from '../../../shared/types';
 
 /**
@@ -9,11 +10,18 @@ import type { ActivityReason } from '../../../shared/types';
  *
  * Same priority ladder as the engine: permission > tool > subagent >
  * background-shell > turn-active > idle.
+ *
+ * The idle/permission cases append how long the session has needed the user
+ * (`reason.since`, epoch ms - `ActivityEngine`'s `needsUserSince`). Computed
+ * at render time, not ticked by an interval: a tooltip's text going a few
+ * seconds stale between re-renders is normal (matches formatRelativeTime's
+ * own Date.now() read), and a card-count worth of per-second timers on a
+ * busy board is not a cost worth paying for a hover label.
  */
 export function formatActivityReasonText(reason: ActivityReason): string {
   switch (reason.kind) {
-    case 'idle': return 'Idle';
-    case 'permission': return 'Awaiting permission';
+    case 'idle': return `Idle for ${formatDurationBetween(reason.since, Date.now())}`;
+    case 'permission': return `Awaiting permission for ${formatDurationBetween(reason.since, Date.now())}`;
     case 'tool': {
       if (reason.currentTool) return `Running ${reason.currentTool}`;
       return `${reason.pendingCount} tool${reason.pendingCount === 1 ? '' : 's'} in flight`;
@@ -46,14 +54,14 @@ export function ActivityReasonTooltip({ reason }: { reason: ActivityReason }): R
       return (
         <span className="inline-flex items-center gap-1.5 text-xs text-fg-faint">
           <Mail size={12} className="text-attention" />
-          <span>Idle</span>
+          <span>Idle for {formatDurationBetween(reason.since, Date.now())}</span>
         </span>
       );
     case 'permission':
       return (
         <span className="inline-flex items-center gap-1.5 text-xs text-fg-faint">
           <Lock size={12} className="text-attention" />
-          <span>Awaiting permission</span>
+          <span>Awaiting permission for {formatDurationBetween(reason.since, Date.now())}</span>
         </span>
       );
     case 'tool':

--- a/src/shared/activity-state.ts
+++ b/src/shared/activity-state.ts
@@ -58,3 +58,16 @@ export function requiresUserInteraction(state: ActivityState | undefined): boole
 export function isActive(state: ActivityState | undefined): boolean {
   return state !== undefined && ACTIVITY_DISPOSITION[state] === 'active';
 }
+
+/**
+ * The disposition VALUE itself ('idle' | 'active'), not just a boolean bucket
+ * check. Use this when persisting or displaying the disposition (e.g. the
+ * `disposition` column on `session_activity_intervals`) so a future
+ * `ActivityState` variant is classified here once, at the compile-time-checked
+ * source, rather than re-derived (and risking drift) at each storage/display
+ * call site. Requires a defined state - a caller with `ActivityState |
+ * undefined` should branch on `requiresUserInteraction`/`isActive` first.
+ */
+export function dispositionOf(state: ActivityState): ActivityDisposition {
+  return ACTIVITY_DISPOSITION[state];
+}

--- a/src/shared/mcp-tool-manifest.ts
+++ b/src/shared/mcp-tool-manifest.ts
@@ -81,6 +81,7 @@ export const MCP_TOOL_MANIFEST: McpToolManifestEntry[] = [
   { name: 'kangentic_get_session_history', label: 'Session History', blurb: 'read the native agent session transcript file for a task', category: 'sessions' },
   { name: 'kangentic_get_session_files', label: 'Session Files', blurb: 'absolute paths to a session activity, status, and history files', category: 'sessions' },
   { name: 'kangentic_get_session_events', label: 'Session Events', blurb: 'parsed activity events from a session log', category: 'sessions' },
+  { name: 'kangentic_get_activity_intervals', label: 'Activity Intervals', blurb: 'durable history of active vs idle time for a task or session', category: 'sessions' },
   { name: 'kangentic_get_handoff_context', label: 'Handoff Context', blurb: 'the most recent cross-agent handoff record for a task', category: 'sessions' },
   { name: 'kangentic_get_transcript', label: 'Get Transcript', blurb: 'read what the agent on another task or project said', category: 'sessions' },
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -629,10 +629,16 @@ export type ActivityState = 'thinking' | 'idle' | 'permission';
  * Kinds where the predicate is `'thinking'`: tool, subagent,
  * background-shell, turn-active. Others map to `'permission'` or
  * `'idle'`.
+ *
+ * `since` on the `idle`/`permission` variants is the epoch ms the session
+ * FIRST needed the user (`SessionEngineState.needsUserSince`) - spans both
+ * variants, so a `thinking -> permission -> idle` run reports the original
+ * park time rather than resetting when permission resolves into idle. Lets
+ * the UI render elapsed wait time next to the mail affordance.
  */
 export type ActivityReason =
-  | { kind: 'idle' }
-  | { kind: 'permission' }
+  | { kind: 'idle'; since: number }
+  | { kind: 'permission'; since: number }
   | {
       kind: 'tool';
       pendingCount: number;
@@ -686,6 +692,9 @@ export interface ActivityStatsSnapshot {
   /** ms since the most recent PTY output chunk, or null when no chunk yet. */
   msSincePtyOutput: number | null;
   pendingIdleArmed: boolean;
+  /** Wall-clock ms since the session first needed the user (idle or
+   *  permission), or null while thinking. See `ActivityReason`'s `since`. */
+  needsUserSince: number | null;
   /**
    * True between an `idle_hint` ("waiting for your input") notification and the
    * next genuine turn-initiating event. While set, the stuck-subagent and

--- a/tests/unit/activity-debug-overlay-helpers.test.ts
+++ b/tests/unit/activity-debug-overlay-helpers.test.ts
@@ -66,7 +66,7 @@ function makeSnapshot(overrides: Partial<ActivityStatsSnapshot> = {}): ActivityS
   return {
     sessionId: 'session-1',
     activity: 'idle' as ActivityState,
-    reason: { kind: 'idle' } as ActivityReason,
+    reason: { kind: 'idle', since: 1700000000000 } as ActivityReason,
     pendingToolCount: 0,
     subagentDepth: 0,
     backgroundShellIds: [],
@@ -78,6 +78,7 @@ function makeSnapshot(overrides: Partial<ActivityStatsSnapshot> = {}): ActivityS
     lastPtyOutputAt: null,
     msSincePtyOutput: null,
     pendingIdleArmed: false,
+    needsUserSince: 1700000000000,
     recentTransitions: [],
     compensationCounters: EMPTY_COMPENSATION_COUNTERS,
     recentPtyChunks: [],
@@ -170,19 +171,19 @@ describe('computeGridLayout', () => {
 
 describe('reasonsEqual', () => {
   it('returns true for identical reference', () => {
-    const reason: ActivityReason = { kind: 'idle' };
+    const reason: ActivityReason = { kind: 'idle', since: 1700000000000 };
     expect(reasonsEqual(reason, reason)).toBe(true);
   });
 
   describe('kind: idle', () => {
     it('returns true for two distinct idle reasons', () => {
-      expect(reasonsEqual({ kind: 'idle' }, { kind: 'idle' })).toBe(true);
+      expect(reasonsEqual({ kind: 'idle', since: 1700000000000 }, { kind: 'idle', since: 1700000000000 })).toBe(true);
     });
   });
 
   describe('kind: permission', () => {
     it('returns true for two distinct permission reasons', () => {
-      expect(reasonsEqual({ kind: 'permission' }, { kind: 'permission' })).toBe(true);
+      expect(reasonsEqual({ kind: 'permission', since: 1700000000000 }, { kind: 'permission', since: 1700000000000 })).toBe(true);
     });
   });
 
@@ -278,7 +279,7 @@ describe('reasonsEqual', () => {
 
   describe('cross-kind', () => {
     it('returns false when kinds differ (idle vs permission)', () => {
-      expect(reasonsEqual({ kind: 'idle' }, { kind: 'permission' })).toBe(false);
+      expect(reasonsEqual({ kind: 'idle', since: 1700000000000 }, { kind: 'permission', since: 1700000000000 })).toBe(false);
     });
 
     it('returns false when kinds differ (tool vs subagent)', () => {
@@ -380,8 +381,8 @@ describe('snapshotsContentEqual', () => {
 
   describe('reason comparison (delegates to reasonsEqual)', () => {
     it('returns false when reason kind differs', () => {
-      const snapshotA = makeSnapshot({ reason: { kind: 'idle' } });
-      const snapshotB = makeSnapshot({ reason: { kind: 'permission' } });
+      const snapshotA = makeSnapshot({ reason: { kind: 'idle', since: 1700000000000 } });
+      const snapshotB = makeSnapshot({ reason: { kind: 'permission', since: 1700000000000 } });
       expect(snapshotsContentEqual(snapshotA, snapshotB)).toBe(false);
     });
 

--- a/tests/unit/activity-engine.test.ts
+++ b/tests/unit/activity-engine.test.ts
@@ -229,6 +229,83 @@ describe('ActivityEngine', () => {
     });
   });
 
+  describe('needsUserSince (elapsed-wait clock)', () => {
+    // Mirrors idleTimestamp's seed invariant (see the 'lifecycle' describe
+    // above), but needsUserSince spans BOTH needs-user states (idle and
+    // permission), not idle alone - see shapes.ts's field doc.
+    it('seed invariant: thinking seed leaves it null, idle seed stamps it', () => {
+      engine.initSession(SESSION_ID, true);
+      expect(engine.getState(SESSION_ID)?.needsUserSince).toBeNull();
+      engine.deleteSession(SESSION_ID);
+
+      engine.initSession(SESSION_ID, false);
+      expect(engine.getState(SESSION_ID)?.needsUserSince).not.toBeNull();
+    });
+
+    it('is stamped on entering idle from thinking, and cleared on leaving to thinking', () => {
+      engine.initSession(SESSION_ID);
+      transitions.length = 0;
+
+      engine.processEvent(SESSION_ID, event(EventType.Prompt));
+      expect(engine.getState(SESSION_ID)?.activity).toBe('thinking');
+      expect(engine.getState(SESSION_ID)?.needsUserSince).toBeNull();
+
+      engine.processEvent(SESSION_ID, event(EventType.Idle));
+      vi.advanceTimersByTime(TEST_STABILITY_WINDOW_MS + 10);
+      expect(engine.getState(SESSION_ID)?.activity).toBe('idle');
+      expect(engine.getState(SESSION_ID)?.needsUserSince).not.toBeNull();
+
+      engine.processEvent(SESSION_ID, event(EventType.Prompt));
+      expect(engine.getState(SESSION_ID)?.activity).toBe('thinking');
+      expect(engine.getState(SESSION_ID)?.needsUserSince).toBeNull();
+    });
+
+    it('is stamped on entering permission from thinking', () => {
+      engine.initSession(SESSION_ID);
+      transitions.length = 0;
+
+      engine.processEvent(SESSION_ID, event(EventType.Prompt));
+      expect(engine.getState(SESSION_ID)?.needsUserSince).toBeNull();
+
+      engine.processEvent(SESSION_ID, event(EventType.Idle, { detail: IdleReason.Permission }));
+      expect(engine.getState(SESSION_ID)?.activity).toBe('permission');
+      expect(engine.getState(SESSION_ID)?.needsUserSince).not.toBeNull();
+    });
+
+    it('a permission <-> idle crossing keeps the ORIGINAL park time - only leaving to thinking resets it', () => {
+      engine.initSession(SESSION_ID);
+      transitions.length = 0;
+
+      engine.processEvent(SESSION_ID, event(EventType.Prompt));
+      engine.processEvent(SESSION_ID, event(EventType.Idle, { detail: IdleReason.Permission }));
+      expect(engine.getState(SESSION_ID)?.activity).toBe('permission');
+      const parkedAt = engine.getState(SESSION_ID)?.needsUserSince;
+      expect(parkedAt).not.toBeNull();
+
+      // Advance the clock so a re-stamp (the bug this test guards against)
+      // would be observably different from the original park time.
+      vi.advanceTimersByTime(5_000);
+
+      // Non-permission Idle clears permissionPending and drops straight to
+      // idle (see event-handlers.ts's updatePermissionFlag) - no stability
+      // window applies, since the FROM state is 'permission', not 'thinking'.
+      engine.processEvent(SESSION_ID, event(EventType.Idle));
+      expect(engine.getState(SESSION_ID)?.activity).toBe('idle');
+      expect(engine.getState(SESSION_ID)?.needsUserSince).toBe(parkedAt);
+    });
+
+    it('ActivityReason.since matches needsUserSince for both idle and permission reasons', () => {
+      engine.initSession(SESSION_ID);
+      transitions.length = 0;
+
+      engine.processEvent(SESSION_ID, event(EventType.Prompt));
+      engine.processEvent(SESSION_ID, event(EventType.Idle, { detail: IdleReason.Permission }));
+      const reason = engine.getActivityReason(SESSION_ID);
+      expect(reason?.kind).toBe('permission');
+      expect((reason as { since: number }).since).toBe(engine.getState(SESSION_ID)?.needsUserSince);
+    });
+  });
+
   describe('basic transitions', () => {
     beforeEach(() => {
       engine.initSession(SESSION_ID);
@@ -2790,6 +2867,28 @@ describe('ActivityEngine', () => {
       expect(snapshot.turnActive).toBe(true);
       expect(snapshot.permissionPending).toBe(false);
       expect(snapshot.msSinceLastSignal).not.toBeNull();
+      // Thinking is not a needs-user state, so the snapshot's public
+      // needsUserSince must mirror the raw state's null - see the sibling
+      // test below for the parked-into-idle polarity.
+      expect(snapshot.needsUserSince).toBeNull();
+    });
+
+    it('needsUserSince mirrors the raw engine state once parked in idle', () => {
+      // Deleting `needsUserSince: state.needsUserSince,` from
+      // getStatsSnapshot() (activity-engine.ts) would leave this field
+      // undefined while engine.getState()?.needsUserSince stays populated -
+      // the two must agree. Drive thinking -> idle (not just the initSession
+      // seed) so this exercises the same freshly-parked stamp as the
+      // needsUserSince describe block above, through the public snapshot API.
+      engine.processEvent(SESSION_ID, event(EventType.Prompt));
+      expect(engine.getState(SESSION_ID)?.activity).toBe('thinking');
+      engine.processEvent(SESSION_ID, event(EventType.Idle));
+      vi.advanceTimersByTime(TEST_STABILITY_WINDOW_MS + 10);
+      expect(engine.getState(SESSION_ID)?.activity).toBe('idle');
+
+      const snapshot = engine.getStatsSnapshot(SESSION_ID)!;
+      expect(snapshot.needsUserSince).not.toBeNull();
+      expect(snapshot.needsUserSince).toBe(engine.getState(SESSION_ID)?.needsUserSince);
     });
 
     it('includes ring buffer of recent audit log entries (capped at 50)', () => {

--- a/tests/unit/activity-interval-commands.test.ts
+++ b/tests/unit/activity-interval-commands.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { handleGetActivityIntervals } from '../../src/main/agent/commands/activity-interval-commands';
+import type { CommandContext } from '../../src/main/agent/commands/types';
+
+interface FakeIntervalRow {
+  id: number;
+  session_id: string;
+  task_id: string | null;
+  disposition: string;
+  state: string;
+  previous_state: string;
+  enter_trigger: string;
+  started_ms: number;
+  started_at: string;
+  ended_ms: number | null;
+  ended_at: string | null;
+  duration_ms: number | null;
+  exit_trigger: string | null;
+  recorded_at: string;
+}
+
+function row(overrides: Partial<FakeIntervalRow> = {}): FakeIntervalRow {
+  return {
+    id: 1,
+    session_id: 'sess-1',
+    task_id: 'task-uuid-1',
+    disposition: 'idle',
+    state: 'idle',
+    previous_state: 'thinking',
+    enter_trigger: 'event:idle',
+    started_ms: 1000,
+    started_at: new Date(1000).toISOString(),
+    ended_ms: 5000,
+    ended_at: new Date(5000).toISOString(),
+    duration_ms: 4000,
+    exit_trigger: 'event:prompt',
+    recorded_at: '2026-07-22T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function createDb(options: {
+  intervalsByTask?: Record<string, FakeIntervalRow[]>;
+  intervalsBySession?: Record<string, FakeIntervalRow[]>;
+  tasks?: Array<{ id: string; display_id: number; title: string }>;
+}) {
+  const intervalsByTask = options.intervalsByTask ?? {};
+  const intervalsBySession = options.intervalsBySession ?? {};
+  const tasks = options.tasks ?? [];
+
+  return {
+    prepare: vi.fn((sql: string) => {
+      if (sql.includes('FROM session_activity_intervals') && sql.includes('WHERE task_id = ?')) {
+        return { all: vi.fn((taskId: string) => intervalsByTask[taskId] ?? []) };
+      }
+      if (sql.includes('FROM session_activity_intervals') && sql.includes('WHERE session_id = ?')) {
+        return { all: vi.fn((sessionId: string) => intervalsBySession[sessionId] ?? []) };
+      }
+      if (sql.includes('FROM tasks') && sql.includes('WHERE t.display_id')) {
+        return { get: vi.fn((displayId: number) => tasks.find((task) => task.display_id === displayId)) };
+      }
+      if (sql.includes('FROM tasks') && sql.includes('WHERE t.id')) {
+        return { get: vi.fn((taskId: string) => tasks.find((task) => task.id === taskId)) };
+      }
+      throw new Error(`unexpected SQL: ${sql}`);
+    }),
+  };
+}
+
+function createContext(db: ReturnType<typeof createDb>): CommandContext {
+  return {
+    getProjectDb: () => db as never,
+    getProjectPath: () => '/tmp/project',
+    onTaskCreated: vi.fn(),
+    onTaskUpdated: vi.fn(),
+    onTaskDeleted: vi.fn(),
+    onTaskMove: vi.fn(),
+    onSwimlaneUpdated: vi.fn(),
+    onBacklogChanged: vi.fn(),
+    onLabelColorsChanged: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-07-22T00:01:00.000Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('handleGetActivityIntervals', () => {
+  it('returns an error when neither taskId nor sessionId is given', () => {
+    const db = createDb({});
+    const result = handleGetActivityIntervals({}, createContext(db));
+    expect(result).not.toBeInstanceOf(Promise);
+    expect((result as { success: boolean }).success).toBe(false);
+    expect((result as { error?: string }).error).toContain('taskId or sessionId');
+  });
+
+  it('resolves by sessionId directly, no task lookup', () => {
+    const db = createDb({ intervalsBySession: { 'sess-1': [row()] } });
+    const result = handleGetActivityIntervals({ sessionId: 'sess-1' }, createContext(db)) as { success: boolean; data: unknown };
+    expect(result.success).toBe(true);
+    const data = result.data as { intervals: unknown[]; totals: { activeMs: number; idleMs: number }; openIntervals: unknown[] };
+    expect(data.intervals).toHaveLength(1);
+    expect(data.totals).toEqual({ activeMs: 0, idleMs: 4000 });
+    expect(data.openIntervals).toEqual([]);
+  });
+
+  it('resolves by numeric display_id and returns intervals across all the task\'s sessions', () => {
+    const db = createDb({
+      tasks: [{ id: 'task-uuid-1', display_id: 42, title: 'Fix the bug' }],
+      intervalsByTask: {
+        'task-uuid-1': [
+          row({ id: 1, session_id: 'sess-1', disposition: 'active', state: 'thinking', duration_ms: 3000, ended_ms: 4000 }),
+          row({ id: 2, session_id: 'sess-2', disposition: 'idle', state: 'idle', duration_ms: 4000, ended_ms: 5000 }),
+        ],
+      },
+    });
+    const result = handleGetActivityIntervals({ taskId: '42' }, createContext(db)) as { success: boolean; data: unknown };
+    expect(result.success).toBe(true);
+    const data = result.data as { intervals: Array<{ sessionId: string }>; totals: { activeMs: number; idleMs: number } };
+    expect(data.intervals.map((interval) => interval.sessionId)).toEqual(['sess-1', 'sess-2']);
+    expect(data.totals).toEqual({ activeMs: 3000, idleMs: 4000 });
+  });
+
+  it('returns an error when the task cannot be resolved', () => {
+    const db = createDb({ tasks: [] });
+    const result = handleGetActivityIntervals({ taskId: 'nonexistent' }, createContext(db)) as { success: boolean; error?: string };
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('nonexistent');
+  });
+
+  it('separates a still-open interval into openIntervals with a live-computed elapsed time, excluded from totals', () => {
+    const db = createDb({
+      intervalsBySession: {
+        'sess-1': [
+          row({ id: 1, disposition: 'idle', duration_ms: 4000, ended_ms: 5000 }),
+          row({
+            id: 2,
+            disposition: 'active',
+            state: 'thinking',
+            previous_state: 'idle',
+            started_ms: 5000,
+            started_at: new Date(5000).toISOString(),
+            ended_ms: null,
+            ended_at: null,
+            duration_ms: null,
+            exit_trigger: null,
+          }),
+        ],
+      },
+    });
+    const result = handleGetActivityIntervals({ sessionId: 'sess-1' }, createContext(db)) as { success: boolean; data: unknown };
+    const data = result.data as {
+      totals: { activeMs: number; idleMs: number };
+      openIntervals: Array<{ sessionId: string; disposition: string; startedMs: number; startedAt: string; liveElapsedMs: number }>;
+    };
+    // Only the closed 'idle' row counts toward totals; the open 'active' row does not.
+    expect(data.totals).toEqual({ activeMs: 0, idleMs: 4000 });
+    expect(data.openIntervals).toHaveLength(1);
+    expect(data.openIntervals[0]).toMatchObject({
+      sessionId: 'sess-1',
+      disposition: 'active',
+      startedMs: 5000,
+      startedAt: new Date(5000).toISOString(),
+    });
+    // System time is frozen at 2026-07-22T00:01:00.000Z = epoch 1784685660000; startedMs 5000 -> elapsed = 1784685660000 - 5000.
+    expect(data.openIntervals[0].liveElapsedMs).toBe(new Date('2026-07-22T00:01:00.000Z').getTime() - 5000);
+  });
+});

--- a/tests/unit/activity-interval-migration.test.ts
+++ b/tests/unit/activity-interval-migration.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Migration + real-SQL round-trip tests for the `session_activity_intervals`
+ * table (src/main/db/migrations/project-schema.ts) and the
+ * ActivityIntervalStore that reads/writes it
+ * (src/main/activity-engine/activity-interval-store.ts).
+ *
+ * tests/unit/activity-interval-store.test.ts and
+ * tests/unit/activity-interval-commands.test.ts both drive the store against
+ * a hand-rolled FAKE Database that dispatches on SQL substring and
+ * reimplements the arithmetic (duration_ms = endedMs - startedMs) in
+ * JavaScript. Neither ever executes the real CREATE TABLE or the real
+ * `duration_ms = ? - started_ms` SQL expression, so a column-name typo in the
+ * migration, a mismatch between the migration's columns and the store's
+ * INSERT/SELECT column lists, or deleting the CREATE TABLE block entirely
+ * would leave every existing test green.
+ *
+ * This file closes that gap: it runs the REAL migration against a REAL
+ * in-memory better-sqlite3 database and round-trips through the REAL store.
+ *
+ * Uses a real in-memory better-sqlite3 DB (':memory:') - mirrors
+ * tests/unit/usage-history-migration.test.ts's probe pattern exactly.
+ * Skips cleanly when better-sqlite3 cannot load under the test runner's Node
+ * ABI (NODE_MODULE_VERSION mismatch under plain system Node); mirrors the
+ * probe pattern in swimlane-repository.test.ts. This is expected to skip on
+ * a developer's local Windows machine (built for Electron's ABI) and RUN on
+ * CI (built for plain Node).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type DatabaseType from 'better-sqlite3';
+
+// ---------------------------------------------------------------------------
+// ABI probe - mirrors usage-history-migration.test.ts / swimlane-repository.test.ts.
+// ---------------------------------------------------------------------------
+
+function probeBetterSqlite3(): typeof DatabaseType | null {
+  try {
+    // Use a variable for the module name to avoid the static-require lint rule
+    // (which targets string-literal bare requires in bundled main/preload code;
+    // this is a test helper for a native probe, not a bundled require).
+    const moduleName = 'better-sqlite3';
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const nativeModule = require(moduleName) as unknown;
+    const databaseConstructor = (
+      (nativeModule as { default?: typeof DatabaseType }).default ?? nativeModule
+    ) as typeof DatabaseType;
+    // Force the native binding to load now - the NODE_MODULE_VERSION mismatch
+    // only surfaces on instantiation, not on require.
+    const probeHandle = new databaseConstructor(':memory:');
+    probeHandle.close();
+    return databaseConstructor;
+  } catch {
+    return null;
+  }
+}
+
+const Database = probeBetterSqlite3();
+const CAN_RUN = Database !== null;
+
+// ---------------------------------------------------------------------------
+// Imports (always resolved - 'import type' for better-sqlite3 touches no
+// native binding at module load time).
+// ---------------------------------------------------------------------------
+
+import { runProjectMigrations } from '../../src/main/db/migrations/project-schema';
+import { ActivityIntervalStore, type OpenIntervalInput } from '../../src/main/activity-engine/activity-interval-store';
+
+interface TableColumnInfo {
+  name: string;
+  notnull: number;
+}
+
+interface IndexNameRow {
+  name: string;
+}
+
+const EXPECTED_COLUMNS: Array<{ name: string; notnull: number }> = [
+  { name: 'id', notnull: 0 },
+  { name: 'session_id', notnull: 1 },
+  { name: 'task_id', notnull: 0 },
+  { name: 'disposition', notnull: 1 },
+  { name: 'state', notnull: 1 },
+  { name: 'previous_state', notnull: 1 },
+  { name: 'enter_trigger', notnull: 1 },
+  { name: 'started_ms', notnull: 1 },
+  { name: 'started_at', notnull: 1 },
+  { name: 'ended_ms', notnull: 0 },
+  { name: 'ended_at', notnull: 0 },
+  { name: 'duration_ms', notnull: 0 },
+  { name: 'exit_trigger', notnull: 0 },
+  { name: 'recorded_at', notnull: 1 },
+];
+
+const EXPECTED_INDEXES = [
+  'idx_activity_intervals_task',
+  'idx_activity_intervals_session',
+  'idx_activity_intervals_started',
+  'idx_activity_intervals_open',
+].sort();
+
+function indexNamesForTable(db: InstanceType<typeof DatabaseType>, tableName: string): string[] {
+  const rows = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = ?")
+    .all(tableName) as IndexNameRow[];
+  return rows.map((row) => row.name).sort();
+}
+
+function idleInput(overrides: Partial<OpenIntervalInput> = {}): OpenIntervalInput {
+  return {
+    sessionId: 'session-1',
+    taskId: 'task-1',
+    disposition: 'idle',
+    state: 'idle',
+    previousState: 'thinking',
+    enterTrigger: 'event:idle',
+    startedMs: 1_000,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Migration + real-store tests against a real in-memory SQLite DB.
+// ---------------------------------------------------------------------------
+
+describe.runIf(CAN_RUN)('runProjectMigrations - session_activity_intervals', () => {
+  let db: InstanceType<typeof DatabaseType>;
+
+  beforeEach(() => {
+    if (!Database) return;
+    db = new Database(':memory:');
+    runProjectMigrations(db);
+  });
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  it('creates session_activity_intervals with exactly the expected columns and notnull flags', () => {
+    const columns = (db.pragma('table_info(session_activity_intervals)') as TableColumnInfo[]).map((column) => ({
+      name: column.name,
+      notnull: column.notnull,
+    }));
+
+    expect(columns).toEqual(EXPECTED_COLUMNS);
+  });
+
+  it('creates all four documented indexes', () => {
+    const indexNames = indexNamesForTable(db, 'session_activity_intervals');
+    expect(indexNames).toEqual(EXPECTED_INDEXES);
+  });
+
+  it('running the migration a second time does not throw and leaves the schema unchanged', () => {
+    const columnsBeforeSecondRun = db.pragma('table_info(session_activity_intervals)') as TableColumnInfo[];
+    const indexesBeforeSecondRun = indexNamesForTable(db, 'session_activity_intervals');
+
+    expect(() => runProjectMigrations(db)).not.toThrow();
+
+    const columnsAfterSecondRun = db.pragma('table_info(session_activity_intervals)') as TableColumnInfo[];
+    const indexesAfterSecondRun = indexNamesForTable(db, 'session_activity_intervals');
+
+    expect(columnsAfterSecondRun).toEqual(columnsBeforeSecondRun);
+    expect(indexesAfterSecondRun).toEqual(indexesBeforeSecondRun);
+  });
+
+  it('round-trips openInterval + closeOpenInterval through the real store, computing duration_ms via real SQL', () => {
+    const store = new ActivityIntervalStore(db);
+    const startedMs = 10_000;
+    const endedMs = 14_500;
+
+    store.openInterval(idleInput({ startedMs }), '2026-07-22T00:00:00.000Z');
+    const openRow = db
+      .prepare('SELECT * FROM session_activity_intervals WHERE session_id = ?')
+      .get('session-1') as Record<string, unknown>;
+    expect(openRow.ended_ms).toBeNull();
+    expect(openRow.duration_ms).toBeNull();
+    expect(openRow.started_at).toBe(new Date(startedMs).toISOString());
+
+    store.closeOpenInterval('session-1', endedMs, 'event:prompt');
+
+    const closedRows = store.getForSession('session-1');
+    expect(closedRows).toHaveLength(1);
+    const closedInterval = closedRows[0];
+    // The real SQL expression `duration_ms = ? - started_ms` computed this,
+    // not JavaScript arithmetic in the test - this is exactly the drift class
+    // (migration column name vs store SQL column name) this file exists to catch.
+    expect(closedInterval.durationMs).toBe(endedMs - startedMs);
+    expect(closedInterval.endedMs).toBe(endedMs);
+    expect(closedInterval.endedAt).toBe(new Date(endedMs).toISOString());
+    expect(closedInterval.startedAt).toBe(new Date(startedMs).toISOString());
+    expect(closedInterval.exitTrigger).toBe('event:prompt');
+  });
+
+  it('closeOpenInterval is a genuine no-op against real SQL when no interval is open', () => {
+    const store = new ActivityIntervalStore(db);
+
+    const countBefore = (
+      db.prepare('SELECT COUNT(*) as count FROM session_activity_intervals').get() as { count: number }
+    ).count;
+    expect(countBefore).toBe(0);
+
+    expect(() => store.closeOpenInterval('session-1', 5_000, 'event:prompt')).not.toThrow();
+
+    const countAfter = (
+      db.prepare('SELECT COUNT(*) as count FROM session_activity_intervals').get() as { count: number }
+    ).count;
+    expect(countAfter).toBe(0);
+  });
+
+  it('getForTask and getForSession return real ORDER BY started_ms ASC (oldest first)', () => {
+    const store = new ActivityIntervalStore(db);
+
+    // Insert out of chronological order to prove the ordering comes from the
+    // real SQL ORDER BY, not incidental insertion order.
+    store.openInterval(idleInput({ sessionId: 'session-1', taskId: 'task-1', startedMs: 5_000 }), '2026-07-22T00:00:00.000Z');
+    store.closeOpenInterval('session-1', 6_000, 'event:prompt');
+    store.openInterval(idleInput({ sessionId: 'session-2', taskId: 'task-1', startedMs: 1_000 }), '2026-07-22T00:00:00.000Z');
+    store.closeOpenInterval('session-2', 2_000, 'event:prompt');
+    store.openInterval(idleInput({ sessionId: 'session-1', taskId: 'task-1', startedMs: 3_000 }), '2026-07-22T00:00:00.000Z');
+
+    const taskIntervals = store.getForTask('task-1');
+    expect(taskIntervals.map((interval) => interval.startedMs)).toEqual([1_000, 3_000, 5_000]);
+
+    const sessionOneIntervals = store.getForSession('session-1');
+    expect(sessionOneIntervals.map((interval) => interval.startedMs)).toEqual([3_000, 5_000]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Skip-notice for environments where better-sqlite3 cannot load.
+// ---------------------------------------------------------------------------
+
+describe.runIf(!CAN_RUN)('session_activity_intervals migration tests (skipped)', () => {
+  it('skipped - better-sqlite3 cannot load under this Node runtime (NODE_MODULE_VERSION mismatch)', () => {
+    expect(CAN_RUN).toBe(false);
+  });
+});

--- a/tests/unit/activity-interval-recorder.test.ts
+++ b/tests/unit/activity-interval-recorder.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Unit tests for src/main/activity-engine/activity-interval-recorder.ts
+ *
+ * Covered: seed suppression (an initSession emit writes no row), opening on
+ * a fresh flip into either disposition, closing-then-opening on the
+ * OPPOSITE flip (symmetric: active<->idle, not idle-only), closing on
+ * session exit, transient (Command Terminal) sessions skipped entirely, and
+ * a thinking -> permission -> idle run producing exactly one 'idle'
+ * interval that keeps the original park's started_ms (a permission<->idle
+ * crossing shares one disposition, so nothing closes/reopens for it).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { ActivityIntervalRecorder, type ActivityIntervalRecorderOptions } from '../../src/main/activity-engine/activity-interval-recorder';
+import type { ActivityIntervalStore } from '../../src/main/activity-engine/activity-interval-store';
+import type { ActivityReason, ActivityState } from '../../src/shared/types';
+
+interface FakeTransitionRecord {
+  ts: number;
+  from: ActivityState;
+  to: ActivityState;
+  reasonKind: string;
+  trigger: string;
+}
+
+class FakeSessionManager extends EventEmitter {
+  session: { transient?: boolean } | undefined = { transient: false };
+  projectId: string | undefined = 'project-1';
+  taskId: string | undefined = 'task-1';
+  recentTransitions: FakeTransitionRecord[] = [];
+
+  getSession = vi.fn((_sessionId: string) => this.session);
+  getSessionProjectId = vi.fn((_sessionId: string) => this.projectId);
+  getSessionTaskId = vi.fn((_sessionId: string) => this.taskId);
+  getActivityStatsSnapshot = vi.fn((_sessionId: string) => ({
+    recentTransitions: this.recentTransitions,
+  }));
+}
+
+function fakeStore(): { store: ActivityIntervalStore; openInterval: ReturnType<typeof vi.fn>; closeOpenInterval: ReturnType<typeof vi.fn> } {
+  const openInterval = vi.fn();
+  const closeOpenInterval = vi.fn();
+  const store = { openInterval, closeOpenInterval, getForTask: vi.fn(), getForSession: vi.fn() } as unknown as ActivityIntervalStore;
+  return { store, openInterval, closeOpenInterval };
+}
+
+describe('ActivityIntervalRecorder', () => {
+  let sessionManager: FakeSessionManager;
+  let storeHandle: ReturnType<typeof fakeStore>;
+  let getStore: ReturnType<typeof vi.fn>;
+  let recorder: ActivityIntervalRecorder;
+
+  function buildRecorder(overrides: Partial<ActivityIntervalRecorderOptions> = {}): void {
+    recorder = new ActivityIntervalRecorder({
+      sessionManager: sessionManager as unknown as ActivityIntervalRecorderOptions['sessionManager'],
+      getStore,
+      now: () => '2026-07-22T00:00:00.000Z',
+      ...overrides,
+    });
+    recorder.start();
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-22T00:00:09.000Z'));
+    sessionManager = new FakeSessionManager();
+    storeHandle = fakeStore();
+    getStore = vi.fn(() => storeHandle.store);
+  });
+
+  afterEach(() => {
+    recorder.dispose();
+    vi.useRealTimers();
+  });
+
+  it('ignores an initSession seed emit (empty recentTransitions)', () => {
+    buildRecorder();
+    sessionManager.recentTransitions = [];
+
+    sessionManager.emit('activity', 'sess-1', 'idle', { kind: 'idle', since: 1000 } satisfies ActivityReason);
+
+    expect(storeHandle.openInterval).not.toHaveBeenCalled();
+    expect(storeHandle.closeOpenInterval).not.toHaveBeenCalled();
+  });
+
+  it('ignores an emission whose transition-ring tail does not match the reported state (stale/seed)', () => {
+    buildRecorder();
+    // The ring's last entry reports 'permission', but the callback claims 'idle' -
+    // a mismatch that only a seed emission (which never appends to the ring) produces.
+    sessionManager.recentTransitions = [
+      { ts: 5000, from: 'thinking', to: 'permission', reasonKind: 'permission', trigger: 'event:idle:permission' },
+    ];
+
+    sessionManager.emit('activity', 'sess-1', 'idle', { kind: 'idle', since: 5000 } satisfies ActivityReason);
+
+    expect(storeHandle.openInterval).not.toHaveBeenCalled();
+  });
+
+  it('a fresh park (thinking -> idle) closes nothing (nothing was open yet) and opens an "idle" interval', () => {
+    buildRecorder();
+    sessionManager.recentTransitions = [
+      { ts: 5000, from: 'thinking', to: 'idle', reasonKind: 'idle', trigger: 'event:idle' },
+    ];
+
+    sessionManager.emit('activity', 'sess-1', 'idle', { kind: 'idle', since: 5000 } satisfies ActivityReason);
+
+    // First real transition of the session's life: closeOpenInterval still
+    // fires (unconditional close-then-open), but it is a no-op at the store
+    // layer since nothing was open - the recorder itself does not special-case it.
+    expect(storeHandle.closeOpenInterval).toHaveBeenCalledTimes(1);
+    expect(storeHandle.closeOpenInterval).toHaveBeenCalledWith('sess-1', 5000, 'event:idle');
+    expect(storeHandle.openInterval).toHaveBeenCalledTimes(1);
+    expect(storeHandle.openInterval).toHaveBeenCalledWith(
+      {
+        sessionId: 'sess-1',
+        taskId: 'task-1',
+        disposition: 'idle',
+        state: 'idle',
+        previousState: 'thinking',
+        enterTrigger: 'event:idle',
+        startedMs: 5000,
+      },
+      '2026-07-22T00:00:00.000Z',
+    );
+  });
+
+  it('leaving a park (idle -> thinking) closes the "idle" interval and opens an "active" one', () => {
+    buildRecorder();
+    sessionManager.recentTransitions = [
+      { ts: 8000, from: 'idle', to: 'thinking', reasonKind: 'turn-active', trigger: 'event:prompt' },
+    ];
+
+    sessionManager.emit('activity', 'sess-1', 'thinking', { kind: 'turn-active' } satisfies ActivityReason);
+
+    expect(storeHandle.closeOpenInterval).toHaveBeenCalledWith('sess-1', 8000, 'event:prompt');
+    expect(storeHandle.openInterval).toHaveBeenCalledWith(
+      {
+        sessionId: 'sess-1',
+        taskId: 'task-1',
+        disposition: 'active',
+        state: 'thinking',
+        previousState: 'idle',
+        enterTrigger: 'event:prompt',
+        startedMs: 8000,
+      },
+      '2026-07-22T00:00:00.000Z',
+    );
+  });
+
+  it('a permission park (thinking -> permission) opens an "idle"-disposition interval too', () => {
+    buildRecorder();
+    sessionManager.recentTransitions = [
+      { ts: 2000, from: 'thinking', to: 'permission', reasonKind: 'permission', trigger: 'event:idle:permission' },
+    ];
+
+    sessionManager.emit('activity', 'sess-1', 'permission', { kind: 'permission', since: 2000 } satisfies ActivityReason);
+
+    expect(storeHandle.openInterval).toHaveBeenCalledWith(
+      expect.objectContaining({ disposition: 'idle', state: 'permission', previousState: 'thinking' }),
+      expect.any(String),
+    );
+  });
+
+  it('a thinking -> permission -> idle run opens exactly one "idle" interval - the crossing shares one disposition', () => {
+    buildRecorder();
+
+    // Turn 1: thinking -> permission. A real disposition flip: closes
+    // nothing (first transition of the session's life, a store-level no-op)
+    // and opens the one 'idle' interval.
+    sessionManager.recentTransitions = [
+      { ts: 1000, from: 'thinking', to: 'permission', reasonKind: 'permission', trigger: 'event:idle:permission' },
+    ];
+    sessionManager.emit('activity', 'sess-1', 'permission', { kind: 'permission', since: 1000 } satisfies ActivityReason);
+    expect(storeHandle.closeOpenInterval).toHaveBeenCalledTimes(1);
+    expect(storeHandle.openInterval).toHaveBeenCalledTimes(1);
+
+    // Turn 2: permission -> idle. Both map to the 'idle' disposition, so
+    // NEITHER close nor open fires again - the interval opened in turn 1
+    // stays open, uncounted.
+    sessionManager.recentTransitions = [
+      ...sessionManager.recentTransitions,
+      { ts: 3000, from: 'permission', to: 'idle', reasonKind: 'idle', trigger: 'interrupted' },
+    ];
+    sessionManager.emit('activity', 'sess-1', 'idle', { kind: 'idle', since: 1000 } satisfies ActivityReason);
+
+    expect(storeHandle.openInterval).toHaveBeenCalledTimes(1);
+    expect(storeHandle.openInterval).toHaveBeenCalledWith(
+      expect.objectContaining({ disposition: 'idle', state: 'permission', previousState: 'thinking', startedMs: 1000 }),
+      expect.any(String),
+    );
+    // Still just the one call from turn 1 - turn 2 must not close/reopen.
+    expect(storeHandle.closeOpenInterval).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the open interval on session exit, regardless of whether one is open', () => {
+    buildRecorder();
+
+    sessionManager.emit('exit', 'sess-1', 0, true);
+
+    expect(storeHandle.closeOpenInterval).toHaveBeenCalledTimes(1);
+    expect(storeHandle.closeOpenInterval).toHaveBeenCalledWith('sess-1', Date.now(), 'session-exit');
+  });
+
+  it('skips a transient (Command Terminal) session entirely, for both activity and exit', () => {
+    sessionManager.session = { transient: true };
+    buildRecorder();
+    sessionManager.recentTransitions = [
+      { ts: 5000, from: 'thinking', to: 'idle', reasonKind: 'idle', trigger: 'event:idle' },
+    ];
+
+    sessionManager.emit('activity', 'sess-1', 'idle', { kind: 'idle', since: 5000 } satisfies ActivityReason);
+    sessionManager.emit('exit', 'sess-1', 0, true);
+
+    expect(getStore).not.toHaveBeenCalled();
+    expect(storeHandle.openInterval).not.toHaveBeenCalled();
+    expect(storeHandle.closeOpenInterval).not.toHaveBeenCalled();
+  });
+
+  it('skips a session with no resolvable project id', () => {
+    sessionManager.projectId = undefined;
+    buildRecorder();
+    sessionManager.recentTransitions = [
+      { ts: 5000, from: 'thinking', to: 'idle', reasonKind: 'idle', trigger: 'event:idle' },
+    ];
+
+    sessionManager.emit('activity', 'sess-1', 'idle', { kind: 'idle', since: 5000 } satisfies ActivityReason);
+
+    expect(getStore).not.toHaveBeenCalled();
+  });
+
+  it('does nothing after dispose()', () => {
+    buildRecorder();
+    recorder.dispose();
+    sessionManager.recentTransitions = [
+      { ts: 5000, from: 'thinking', to: 'idle', reasonKind: 'idle', trigger: 'event:idle' },
+    ];
+
+    sessionManager.emit('activity', 'sess-1', 'idle', { kind: 'idle', since: 5000 } satisfies ActivityReason);
+    sessionManager.emit('exit', 'sess-1', 0, true);
+
+    expect(storeHandle.openInterval).not.toHaveBeenCalled();
+    expect(storeHandle.closeOpenInterval).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Listener isolation. SessionManager is a plain EventEmitter, and emit()
+  // does not isolate listener exceptions: a throw aborts every listener
+  // registered AFTER this one on the same synchronous emit (in production
+  // that is registerSessionHandlers' session-lifecycle DB write and the
+  // SESSION_ACTIVITY board broadcast), and unwinds back into
+  // ActivityEngine.commitTransition before it can call scheduleTimer(),
+  // leaving the stale-thinking watchdog unarmed. The recorder does
+  // synchronous better-sqlite3 I/O inline, so it must swallow its own
+  // failures - same guard DesktopNotifier documents on this event.
+  // -------------------------------------------------------------------------
+
+  it('a store write failure on activity never escapes into the emit stack, and later listeners still run', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    buildRecorder();
+    storeHandle.openInterval.mockImplementation(() => {
+      throw new Error('SQLITE_BUSY: database is locked');
+    });
+    sessionManager.recentTransitions = [
+      { ts: 5000, from: 'thinking', to: 'idle', reasonKind: 'idle', trigger: 'event:idle' },
+    ];
+    // Stands in for registerSessionHandlers' 'activity' listener, which
+    // register-all.ts attaches AFTER the recorder.
+    const laterListener = vi.fn();
+    sessionManager.on('activity', laterListener);
+
+    expect(() => {
+      sessionManager.emit('activity', 'sess-1', 'idle', { kind: 'idle', since: 5000 } satisfies ActivityReason);
+    }).not.toThrow();
+
+    expect(laterListener).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it('a store write failure on exit never escapes into the emit stack, and later listeners still run', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    buildRecorder();
+    storeHandle.closeOpenInterval.mockImplementation(() => {
+      throw new Error('SQLITE_IOERR: disk I/O error');
+    });
+    const laterListener = vi.fn();
+    sessionManager.on('exit', laterListener);
+
+    expect(() => {
+      sessionManager.emit('exit', 'sess-1', 0, true);
+    }).not.toThrow();
+
+    expect(laterListener).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/tests/unit/activity-interval-store.test.ts
+++ b/tests/unit/activity-interval-store.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import type Database from 'better-sqlite3';
+import { ActivityIntervalStore, type OpenIntervalInput } from '../../src/main/activity-engine/activity-interval-store';
+
+/**
+ * `session_activity_intervals` modeled by a hand-rolled fake `Database`,
+ * mirroring `conversation-usage-store.test.ts` (better-sqlite3's native
+ * module in this worktree is rebuilt for Electron's ABI and cannot load
+ * under the plain-Node test runner - see
+ * session-repository-summaries.test.ts's probe comment). The fake
+ * INSERT/UPDATE/SELECT dispatch on SQL substrings, matching the store's
+ * real statements exactly.
+ */
+
+interface FakeRow {
+  id: number;
+  session_id: string;
+  task_id: string | null;
+  disposition: string;
+  state: string;
+  previous_state: string;
+  enter_trigger: string;
+  started_ms: number;
+  started_at: string;
+  ended_ms: number | null;
+  ended_at: string | null;
+  duration_ms: number | null;
+  exit_trigger: string | null;
+  recorded_at: string;
+}
+
+function makeIntervalDb(): { db: Database.Database; table: Map<number, FakeRow> } {
+  const table = new Map<number, FakeRow>();
+  let nextId = 1;
+  const prepare = (sql: string) => ({
+    run: (...args: unknown[]) => {
+      if (sql.includes('INSERT INTO session_activity_intervals')) {
+        const [sessionId, taskId, disposition, state, previousState, enterTrigger, startedMs, startedAt, recordedAt] = args;
+        const id = nextId++;
+        table.set(id, {
+          id,
+          session_id: String(sessionId),
+          task_id: (taskId as string | null) ?? null,
+          disposition: String(disposition),
+          state: String(state),
+          previous_state: String(previousState),
+          enter_trigger: String(enterTrigger),
+          started_ms: Number(startedMs),
+          started_at: String(startedAt),
+          ended_ms: null,
+          ended_at: null,
+          duration_ms: null,
+          exit_trigger: null,
+          recorded_at: String(recordedAt),
+        });
+        return { changes: 1, lastInsertRowid: id };
+      }
+      if (sql.includes('UPDATE session_activity_intervals')) {
+        const [endedMs, endedAt, endedMsAgain, exitTrigger, sessionId] = args;
+        let changes = 0;
+        for (const row of table.values()) {
+          if (row.session_id !== sessionId || row.ended_ms !== null) continue;
+          row.ended_ms = Number(endedMs);
+          row.ended_at = String(endedAt);
+          row.duration_ms = Number(endedMsAgain) - row.started_ms;
+          row.exit_trigger = String(exitTrigger);
+          changes++;
+        }
+        return { changes, lastInsertRowid: 0 };
+      }
+      throw new Error(`unexpected run SQL: ${sql}`);
+    },
+    all: (...args: unknown[]) => {
+      const rows = [...table.values()];
+      if (sql.includes('WHERE task_id = ?')) {
+        return rows.filter((row) => row.task_id === args[0]).sort((a, b) => a.started_ms - b.started_ms);
+      }
+      if (sql.includes('WHERE session_id = ?')) {
+        return rows.filter((row) => row.session_id === args[0]).sort((a, b) => a.started_ms - b.started_ms);
+      }
+      throw new Error(`unexpected all SQL: ${sql}`);
+    },
+  });
+  const db = { prepare } as unknown as Database.Database;
+  return { db, table };
+}
+
+function idleInput(overrides: Partial<OpenIntervalInput> = {}): OpenIntervalInput {
+  return {
+    sessionId: 'session-1',
+    taskId: 'task-1',
+    disposition: 'idle',
+    state: 'idle',
+    previousState: 'thinking',
+    enterTrigger: 'event:idle',
+    startedMs: 1000,
+    ...overrides,
+  };
+}
+
+function activeInput(overrides: Partial<OpenIntervalInput> = {}): OpenIntervalInput {
+  return {
+    sessionId: 'session-1',
+    taskId: 'task-1',
+    disposition: 'active',
+    state: 'thinking',
+    previousState: 'idle',
+    enterTrigger: 'event:prompt',
+    startedMs: 1000,
+    ...overrides,
+  };
+}
+
+describe('ActivityIntervalStore', () => {
+  it('openInterval inserts a row with no end, then closeOpenInterval fills in ended/duration/exit', () => {
+    const { db } = makeIntervalDb();
+    const store = new ActivityIntervalStore(db);
+
+    store.openInterval(idleInput(), '2026-07-01T00:00:00Z');
+    let rows = store.getForSession('session-1');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].disposition).toBe('idle');
+    expect(rows[0].endedMs).toBeNull();
+    expect(rows[0].endedAt).toBeNull();
+    expect(rows[0].durationMs).toBeNull();
+    expect(rows[0].exitTrigger).toBeNull();
+    expect(rows[0].enterTrigger).toBe('event:idle');
+    expect(rows[0].previousState).toBe('thinking');
+    expect(rows[0].startedMs).toBe(1000);
+    // startedAt is derived from startedMs inside the store, not passed in -
+    // OpenIntervalInput carries no ISO field of its own.
+    expect(rows[0].startedAt).toBe(new Date(1000).toISOString());
+
+    store.closeOpenInterval('session-1', 4500, 'event:prompt');
+    rows = store.getForSession('session-1');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].endedMs).toBe(4500);
+    expect(rows[0].endedAt).toBe(new Date(4500).toISOString());
+    expect(rows[0].durationMs).toBe(3500);
+    expect(rows[0].exitTrigger).toBe('event:prompt');
+  });
+
+  it('an alternating active/idle sequence for one session produces two independent, correctly-typed rows', () => {
+    const { db } = makeIntervalDb();
+    const store = new ActivityIntervalStore(db);
+
+    // Session parks (thinking -> idle): open an 'idle' interval.
+    store.openInterval(idleInput({ startedMs: 1000 }), '2026-07-01T00:00:00Z');
+    // Session resumes (idle -> thinking): close the 'idle' interval, open an 'active' one.
+    store.closeOpenInterval('session-1', 5000, 'event:prompt');
+    store.openInterval(activeInput({ startedMs: 5000 }), '2026-07-01T00:00:00Z');
+
+    const rows = store.getForSession('session-1');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ disposition: 'idle', startedMs: 1000, endedMs: 5000, durationMs: 4000, exitTrigger: 'event:prompt' });
+    expect(rows[1]).toMatchObject({ disposition: 'active', startedMs: 5000, endedMs: null, durationMs: null });
+  });
+
+  it('closeOpenInterval is a no-op when no interval is open', () => {
+    const { db } = makeIntervalDb();
+    const store = new ActivityIntervalStore(db);
+
+    // No prior openInterval call for this session.
+    expect(() => store.closeOpenInterval('session-1', 4500, 'event:prompt')).not.toThrow();
+    expect(store.getForSession('session-1')).toEqual([]);
+  });
+
+  it('closeOpenInterval only matches the session it is closing, leaving other open rows untouched', () => {
+    const { db } = makeIntervalDb();
+    const store = new ActivityIntervalStore(db);
+
+    store.openInterval(idleInput({ sessionId: 'session-1' }), '2026-07-01T00:00:00Z');
+    store.openInterval(idleInput({ sessionId: 'session-2' }), '2026-07-01T00:00:00Z');
+
+    store.closeOpenInterval('session-1', 2000, 'event:prompt');
+
+    expect(store.getForSession('session-1')[0].endedMs).toBe(2000);
+    expect(store.getForSession('session-2')[0].endedMs).toBeNull();
+  });
+
+  it('getForTask returns every session\'s intervals for that task, oldest first, both dispositions', () => {
+    const { db } = makeIntervalDb();
+    const store = new ActivityIntervalStore(db);
+
+    store.openInterval(idleInput({ sessionId: 'session-2', taskId: 'task-1', startedMs: 2000 }), '2026-07-01T00:00:00Z');
+    store.openInterval(activeInput({ sessionId: 'session-1', taskId: 'task-1', startedMs: 1000 }), '2026-07-01T00:00:00Z');
+    store.openInterval(idleInput({ sessionId: 'session-3', taskId: 'task-other', startedMs: 500 }), '2026-07-01T00:00:00Z');
+
+    const rows = store.getForTask('task-1');
+    expect(rows.map((row) => row.sessionId)).toEqual(['session-1', 'session-2']);
+    expect(rows.map((row) => row.disposition)).toEqual(['active', 'idle']);
+  });
+});

--- a/tests/unit/activity-reason-tooltip.test.ts
+++ b/tests/unit/activity-reason-tooltip.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for src/renderer/components/board/ActivityReasonTooltip.tsx's
+ * plain-text formatter. Covers the idle/permission duration enrichment
+ * (`reason.since`, epoch ms) and pins that every other reason kind is
+ * unaffected.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { formatActivityReasonText } from '../../src/renderer/components/board/ActivityReasonTooltip';
+import type { ActivityReason } from '../../src/shared/types';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('formatActivityReasonText', () => {
+  it('idle includes elapsed wait time computed from reason.since', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-22T00:12:34Z'));
+    const since = new Date('2026-07-22T00:00:00Z').getTime();
+    expect(formatActivityReasonText({ kind: 'idle', since })).toBe('Idle for 12m 34s');
+  });
+
+  it('permission includes elapsed wait time computed from reason.since', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-22T01:30:00Z'));
+    const since = new Date('2026-07-22T00:00:00Z').getTime();
+    expect(formatActivityReasonText({ kind: 'permission', since })).toBe('Awaiting permission for 1h 30m');
+  });
+
+  it('every other reason kind is unaffected by the since field', () => {
+    expect(formatActivityReasonText({ kind: 'tool', pendingCount: 1, currentTool: 'Bash' })).toBe('Running Bash');
+    expect(formatActivityReasonText({ kind: 'tool', pendingCount: 2, currentTool: null })).toBe('2 tools in flight');
+    expect(formatActivityReasonText({ kind: 'subagent', depth: 1 })).toBe('1 subagent active');
+    expect(formatActivityReasonText({ kind: 'background-shell', count: 1, ids: [] })).toBe('1 background shell');
+    expect(formatActivityReasonText({ kind: 'turn-active' })).toBe('Thinking');
+  });
+
+  it('idle at the very start of a park reads "Idle for 0s", not a blank or negative duration', () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-07-22T00:00:00Z');
+    vi.setSystemTime(now);
+    const reason: ActivityReason = { kind: 'idle', since: now.getTime() };
+    expect(formatActivityReasonText(reason)).toBe('Idle for 0s');
+  });
+});

--- a/tests/unit/activity-snapshot-writer.test.ts
+++ b/tests/unit/activity-snapshot-writer.test.ts
@@ -30,7 +30,7 @@ function makeDummySnapshot(): ActivityStatsSnapshot {
   return {
     sessionId: SESSION_ID,
     activity: 'idle',
-    reason: { kind: 'idle' },
+    reason: { kind: 'idle', since: 1700000000000 },
     pendingToolCount: 0,
     subagentDepth: 0,
     backgroundShellIds: [],
@@ -41,6 +41,7 @@ function makeDummySnapshot(): ActivityStatsSnapshot {
     lastPtyOutputAt: null,
     msSincePtyOutput: null,
     pendingIdleArmed: false,
+    needsUserSince: 1700000000000,
     recentTransitions: [],
   };
 }

--- a/tests/unit/activity-state.test.ts
+++ b/tests/unit/activity-state.test.ts
@@ -17,6 +17,7 @@ import type { ActivityState } from '../../src/shared/types';
 import {
   requiresUserInteraction,
   isActive,
+  dispositionOf,
 } from '../../src/shared/activity-state';
 
 // Every ActivityState variant. Adding a new variant here (after adding it to
@@ -103,6 +104,31 @@ describe('isActive - full table', () => {
         isActive(state),
         `isActive('${state}') should be ${expected[state]}`,
       ).toBe(expected[state]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dispositionOf: the disposition VALUE ('idle' | 'active'), not just a
+// boolean bucket check. Consumed by session_activity_intervals' recorder so
+// the persisted `disposition` column is derived from this single table
+// instead of a re-derived copy.
+// ---------------------------------------------------------------------------
+
+describe('dispositionOf - full table', () => {
+  it('every ActivityState maps to the correct disposition value, agreeing with requiresUserInteraction/isActive', () => {
+    const expected: Record<ActivityState, 'idle' | 'active'> = {
+      idle: 'idle',
+      permission: 'idle',
+      thinking: 'active',
+    };
+
+    for (const state of ALL_ACTIVITY_STATES) {
+      expect(dispositionOf(state), `dispositionOf('${state}') should be '${expected[state]}'`).toBe(expected[state]);
+      // Cross-check against the boolean helpers so the two representations
+      // of the same classification table can never silently diverge.
+      expect(dispositionOf(state) === 'idle').toBe(requiresUserInteraction(state));
+      expect(dispositionOf(state) === 'active').toBe(isActive(state));
     }
   });
 });

--- a/tests/unit/mobile-bridge/wire-mappers-activity-reason.test.ts
+++ b/tests/unit/mobile-bridge/wire-mappers-activity-reason.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Unit test for toActivityReasonWire's idle/permission pass-through
+ * (src/main/mobile-bridge/handlers/wire-mappers.ts).
+ *
+ * The idle/permission/tool/subagent/turn-active kinds all fall through to a
+ * bare `return reason;` (only 'background-shell' needs an explicit spread,
+ * to strip the desktop's `readonly` array qualifier). That pass-through
+ * relies on `ActivityReasonWire`'s `since` being OPTIONAL so the desktop's
+ * required `since: number` is structurally assignable without a mapper
+ * change - this pins that `since` really does ride along unchanged, so a
+ * future "explicit per-kind mapping" refactor of the default branch cannot
+ * silently drop it.
+ */
+import { describe, it, expect } from 'vitest';
+import { toActivityReasonWire } from '../../../src/main/mobile-bridge/handlers/wire-mappers';
+import type { ActivityReason } from '../../../src/shared/types';
+
+describe('toActivityReasonWire', () => {
+  it('carries since through unchanged for idle', () => {
+    const reason: ActivityReason = { kind: 'idle', since: 1700000000000 };
+    expect(toActivityReasonWire(reason)).toEqual({ kind: 'idle', since: 1700000000000 });
+  });
+
+  it('carries since through unchanged for permission', () => {
+    const reason: ActivityReason = { kind: 'permission', since: 1700000000000 };
+    expect(toActivityReasonWire(reason)).toEqual({ kind: 'permission', since: 1700000000000 });
+  });
+});

--- a/tests/unit/protocol/event-payloads.test.ts
+++ b/tests/unit/protocol/event-payloads.test.ts
@@ -104,6 +104,22 @@ describe('parseActivityEventPayload', () => {
     expect(parseActivityEventPayload(payload)).toEqual(payload);
   });
 
+  it('parses idle/permission reasons carrying the optional since field', () => {
+    const idlePayload: JsonValue = { type: 'activity', state: 'idle', reason: { kind: 'idle', since: 1700000000000 } };
+    expect(parseActivityEventPayload(idlePayload)).toEqual(idlePayload);
+    const permissionPayload: JsonValue = { type: 'activity', state: 'permission', reason: { kind: 'permission', since: 1700000000000 } };
+    expect(parseActivityEventPayload(permissionPayload)).toEqual(permissionPayload);
+  });
+
+  it('parses idle/permission reasons with since OMITTED - additive-field compatibility with an older desktop', () => {
+    const payload: JsonValue = { type: 'activity', state: 'idle', reason: { kind: 'idle' } };
+    expect(parseActivityEventPayload(payload)).toEqual(payload);
+  });
+
+  it('rejects an idle/permission reason whose since is not a number', () => {
+    expect(() => parseActivityEventPayload({ type: 'activity', state: 'idle', reason: { kind: 'idle', since: '1700000000000' } })).toThrow(/reason/);
+  });
+
   it('parses a usage payload', () => {
     expect(parseActivityEventPayload({ type: 'usage', usage: usageFixture })).toEqual({ type: 'usage', usage: usageFixture });
   });

--- a/tests/unit/register-all-idempotency.test.ts
+++ b/tests/unit/register-all-idempotency.test.ts
@@ -282,13 +282,19 @@ describe('registerAllIpc idempotency', () => {
 
     // The desktop notifier is constructed, wired into IpcContext, and
     // start()-ed exactly once, attaching one 'activity' and one 'exit'
-    // listener to the real (unmocked) SessionManager EventEmitter. Nothing
-    // else in this test's dependency graph listens on those events (every
-    // other registerXHandlers call and retrievalService.attach are mocked
-    // above), so a count of 1 here is attributable to the desktop notifier.
+    // listener to the real (unmocked) SessionManager EventEmitter. The
+    // ActivityIntervalRecorder (also real and unmocked here - it is
+    // constructed and .start()-ed the same way as desktopNotifier, just
+    // below it in register-all.ts) attaches its own 'activity'/'exit' pair
+    // to write the session_activity_intervals ledger. Nothing else in this
+    // test's dependency graph listens on those events (every other
+    // registerXHandlers call and retrievalService.attach are mocked above),
+    // so a count of 2 here is exactly desktopNotifier (1) +
+    // activityIntervalRecorder (1). If this ever needs to change, re-attribute
+    // the count explicitly rather than just bumping the number.
     expect(getOptionalIpcContext()?.desktopNotifier).toBeDefined();
-    expect(getSessionManager().listenerCount('activity')).toBe(1);
-    expect(getSessionManager().listenerCount('exit')).toBe(1);
+    expect(getSessionManager().listenerCount('activity')).toBe(2);
+    expect(getSessionManager().listenerCount('exit')).toBe(2);
   }, 30000);
 
   it('second call updates mainWindow without re-registering handlers', async () => {
@@ -352,11 +358,17 @@ describe('registerAllIpc idempotency', () => {
     // doesn't throw the way a real double-registration might.
     expect(mobileBridgeAttachContextSpy).toHaveBeenCalledTimes(1);
 
-    // Same guarantee for the desktop notifier: a re-activate on macOS must
-    // not attach a second pair of SessionManager listeners (which would
-    // double-fire every idle/crash notification).
-    expect(getSessionManager().listenerCount('activity')).toBe(1);
-    expect(getSessionManager().listenerCount('exit')).toBe(1);
+    // Same guarantee for the desktop notifier AND the ActivityIntervalRecorder:
+    // a re-activate on macOS must not attach a second pair of SessionManager
+    // listeners for either (which would double-fire every idle/crash
+    // notification, and double-write every committed disposition transition
+    // to session_activity_intervals). Both are constructed inside the
+    // `if (context) return` idempotency guard at the top of registerAllIpc,
+    // so this assertion genuinely exercises that guard rather than passing
+    // by accident - it goes red the moment either listener stops being
+    // reused across a second registerAllIpc call.
+    expect(getSessionManager().listenerCount('activity')).toBe(2);
+    expect(getSessionManager().listenerCount('exit')).toBe(2);
   }, 30000);
 
   it('second call preserves existing services', async () => {

--- a/tests/unit/session-store-cache-reconcile.test.ts
+++ b/tests/unit/session-store-cache-reconcile.test.ts
@@ -236,7 +236,7 @@ describe('syncSessions - cache reconciliation evicts stale entries', () => {
     // syncSessions, so HMR / full reload left stale idle reasons in the
     // map indefinitely. The reconcile must use the same eviction
     // semantics as sessionActivity.
-    const staleReason: ActivityReason = { kind: 'idle' };
+    const staleReason: ActivityReason = { kind: 'idle', since: 1700000000000 };
     const liveReason: ActivityReason = { kind: 'turn-active' };
     useSessionStore.setState({
       sessionActivityReason: { 'sess-a': liveReason, 'sess-stale': staleReason },
@@ -327,7 +327,7 @@ describe('syncSessions - cache reconciliation preserves IPC-during-async-gap upd
     // onActivity push during the async gap may have delivered a fresher
     // reason than the cache snapshot; reconcile must keep the store value.
     const liveReason: ActivityReason = { kind: 'turn-active' };
-    const cacheReason: ActivityReason = { kind: 'idle' };
+    const cacheReason: ActivityReason = { kind: 'idle', since: 1700000000000 };
     useSessionStore.setState({
       sessionActivityReason: { 'sess-a': liveReason },
     });
@@ -468,7 +468,7 @@ describe('syncSessions - HMR resilience: tolerates missing or failing preload me
     // the methods that DO exist).
     useSessionStore.setState({
       sessionActivity: { 'sess-stale': 'thinking' },
-      sessionActivityReason: { 'sess-stale': { kind: 'idle' } },
+      sessionActivityReason: { 'sess-stale': { kind: 'idle', since: 1700000000000 } },
     });
 
     const sessions = (window as Record<string, unknown> & {
@@ -493,7 +493,7 @@ describe('syncSessions - HMR resilience: tolerates missing or failing preload me
     // sessionActivityReason preserved unchanged because the fetch was
     // unavailable (NOT evicted).
     const reasons = useSessionStore.getState().sessionActivityReason;
-    expect(reasons['sess-stale']).toEqual({ kind: 'idle' });
+    expect(reasons['sess-stale']).toEqual({ kind: 'idle', since: 1700000000000 });
   });
 });
 


### PR DESCRIPTION
## What

Two additions to the activity engine:

1. **Live idle/permission-wait duration.** `SessionEngineState.needsUserSince` (epoch ms the
   session first needed the user, spanning a `permission <-> idle` crossing without resetting)
   is surfaced as `since` on `ActivityReason`'s idle/permission variants, on
   `ActivityStatsSnapshot`, and on the mobile protocol's `ActivityReasonWire` (optional,
   additive field). TaskCard's hover tooltip now reads "Idle for 12m" / "Awaiting permission for
   1h 30m".
2. **Durable active/idle interval history.** A new `session_activity_intervals` table records
   every span a session spent in the `'active'` or `'idle'` `ActivityDisposition` (see
   `dispositionOf` in `shared/activity-state.ts`), written by a new `ActivityIntervalRecorder`
   from the engine's own committed transitions - not raw hook events. A new read-only MCP tool,
   `kangentic_get_activity_intervals`, reads it back (raw intervals, a totals rollup by
   disposition, and any still-open interval with a live-computed elapsed time).

## Why

The task originally asked for a synthetic "went idle" marker injected into the conversation
transcript. Research (see task #350 history) found that justification didn't hold up:

- The stated mobile-push use case is already covered by the existing `PushNotifier`, which fires
  on the live `activity` event independent of any transcript marker.
- Nothing durable records *when* the engine transitions to idle/active today. The engine's own
  state is in-memory only (wiped on `deleteSession`/app restart), and the one on-disk trace
  (`events.jsonl`) records raw hook events, not committed transitions - empirically confirmed to
  both miss real transitions (a raw idle cancelled by the 400ms stability window) and record ones
  that never happened (a watchdog-synthesized idle with no matching raw event).
- A transcript-embedded marker would have added a divider after every turn (far more frequent
  than the existing `session_boundary` dividers) and conflated telemetry with conversation
  content.

The actual gap is duration, not a marker: neither desktop nor mobile can show "waiting 12m", and
there is no durable way to answer "how long has this task been waiting on me" or "how much of
this session was the agent actually working". This PR closes both gaps directly, without
touching the transcript or its schema at all.

## How

- `needsUserSince` is stamped in `ActivityEngine.commitTransition` (entering a needs-user state
  from thinking) and in `initSession`'s idle seed path; cleared on returning to thinking; left
  unchanged across a `permission <-> idle` crossing (same park, not a new one).
- `session_activity_intervals` is **symmetric by design** - both `'active'` and `'idle'` are
  recorded directly, not one derived as the inverse of the other. Deriving "active time" as
  `(session lifetime) - (idle time)` would need exact session-boundary reconciliation across
  resumes/suspends and would silently corrupt on a crash-orphaned open row; recording both
  directly means each is a straight `SUM` over the table.
- `ActivityIntervalRecorder` reads provenance (`from`/`trigger`) off the engine's own transition
  ring (`recentTransitions`), not off raw events, so it inherits the engine's existing
  false-idle-avoidance logic instead of re-deriving it. A missing/stale ring tail means the
  emission was `initSession`'s seed (not a real transition) and is skipped - this leaves the
  window from spawn to a session's first real transition deliberately unrecorded, a small and
  bounded gap.
- `started_at`/`ended_at` (UTC ISO 8601) mirror `started_ms`/`ended_ms`, derived from the same
  value at write time inside the store so the two representations can never drift.
- The recorder's listener callbacks are wrapped in try/catch (`onActivity`/`onExit`): it attaches
  to `SessionManager` before `registerSessionHandlers`, and `EventEmitter.emit` does not isolate
  listener exceptions, so an uncaught throw here would abort session-lifecycle bookkeeping that
  runs after it on the same emit. A lost interval row is an acceptable failure; a skipped
  session-lifecycle write is not.
- No IPC surface or transcript/viewer integration - deliberately deferred. Two follow-up tasks
  are filed on the board: one for a desktop-facing summary stat (folding a rollup into the
  existing `sessions.getSummary` call) plus a usage-stats integration note, and one for a richer
  historical timeline visualization (modeled on the existing dev-only `ActivityTimeline.tsx`).

Verified live against a real running preview (not just unit tests): drove a real Claude Code
session through a full `thinking -> idle -> thinking -> idle` cycle via the devtools bridge,
confirmed `needsUserSince` and the TaskCard tooltip live-render correctly, and confirmed
`kangentic_get_activity_intervals` returns exactly the expected rows/totals/`startedAt`/`endedAt`
against the real per-project SQLite DB.

## Breaking changes

None. `ActivityReasonWire.since` is optional and additive; no existing behavior changes for a
consumer that ignores it.

## Tests

- `tests/unit/activity-engine.test.ts` - `needsUserSince` pinned directly on the engine (seed
  invariant, entering idle/permission, the permission<->idle crossing keeping the original park
  time, clearing on returning to thinking).
- `tests/unit/activity-interval-recorder.test.ts` - seed suppression, symmetric open/close on
  every real disposition flip, the permission<->idle no-op case, transient-session skip, exit
  handling, and that a store-write failure is swallowed without blocking later listeners.
- `tests/unit/activity-interval-store.test.ts` - hand-rolled fake-DB unit tests.
- `tests/unit/activity-interval-migration.test.ts` - real in-memory `better-sqlite3` round-trip
  against the actual migration SQL (skips locally on Windows/Electron ABI, runs on CI).
- `tests/unit/activity-interval-commands.test.ts` - the new MCP command handler.
- `tests/unit/activity-reason-tooltip.test.ts`, `tests/unit/mobile-bridge/wire-mappers-activity-reason.test.ts`,
  `tests/unit/activity-state.test.ts` (new `dispositionOf` export) - the tooltip formatting and
  wire pass-through.
- `tests/unit/register-all-idempotency.test.ts` - updated listener-count assertions for the
  recorder's new `SessionManager` listeners (caught a real assertion regression during the
  coverage pass).
- `npm run typecheck` and `npm run lint` clean throughout.

Generated with [Claude Code](https://claude.com/claude-code)
