### PR TITLE
feat(terminal): near-black background, real ANSI palette, custom colors

### DIFF
--- a/.claude/agents/marketing-captures.md
+++ b/.claude/agents/marketing-captures.md
@@ -108,6 +108,7 @@ window.__mockConfigOverrides = {
     panelHeight: 280,
     scrollbackLines: 5000,
     cursorStyle: 'block',
+    colors: {},
   },
   terminalPanelVisible: false,  // Hide for board-only captures
 };

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,7 @@ These settings appear only in App Settings and cannot be overridden per-project:
 - `agent.cliPaths`, `agent.maxConcurrentSessions`, `agent.queueOverflow`, `agent.autoResumeSessionsOnRestart`
 - `agent.executionServers` (per-agent remote-server url + auth; the Agent tab's Server URL / Authentication fields, shown when the selected agent declares remote-execution support)
 - `agent.launchOptions` (per-agent boolean startup toggles; the Agent tab's Launch Options rows, shown when the selected agent declares launch-option capability)
-- `terminal.panelHeight`, `terminal.showPreview`
+- `terminal.panelHeight`, `terminal.showPreview`, `terminal.colors`
 - `autoFocusIdleSession`
 - `skipBoardConfigConfirm`
 - `windowLightDismiss`
@@ -114,6 +114,7 @@ These settings appear in both App Settings (as defaults) and Project Settings (a
 | `terminal.panelCollapsed` | boolean | `false` | Whether the bottom terminal panel is collapsed. Global-only. |
 | `terminal.scrollbackLines` | number | `5000` | Lines kept in the visible xterm scrollback (1000-100000). Full session history is preserved separately by the main-process PTY buffer for replay regardless of this value. |
 | `terminal.cursorStyle` | `'block'` \| `'underline'` \| `'bar'` | `'block'` | Terminal cursor appearance |
+| `terminal.colors` | `TerminalColorOverrides` | `{}` | Custom terminal background, foreground, and cursor color, edited via color swatches in the Layout settings tab's Terminal section. Any slot left unset falls back to the built-in default: background `#0c0c0c`, foreground/cursor `#e4e4e7`. The 16-color ANSI palette (based on Windows Terminal's "Campbell" scheme) is a fixed built-in scheme, not exposed for per-color editing. `cursorAccent` always tracks the resolved background (for cursor legibility) and `selectionBackground` is a fixed app accent; neither is user-customizable. A dictionary-style field (`CONFIG_DICTIONARY_PATHS`): saved wholesale so resetting a slot actually deletes it. Global-only. |
 
 ### agent.*
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -355,7 +355,7 @@ Choose from 10 themes:
 
 ### Terminal Colors
 
-The Layout tab's **Terminal** section (not Theme - this is a global setting, not per-project) lets you customize the terminal's background, foreground, and cursor color. Click a swatch to open the color picker; any color left at its default shows the built-in value (near-black `#0c0c0c` background, `#e4e4e7` foreground/cursor). The 16-color ANSI palette (used by shell tools like `git diff` and `ls --color`) is a fixed scheme based on Windows Terminal's Campbell, not individually customizable. "Reset to default" clears every customization. Applies globally across all projects.
+The Layout tab's **Terminal** section (not Theme - this is a global setting, not per-project) lets you customize the terminal's background, foreground, and cursor color. Click a swatch to open the color picker; any color left at its default shows the built-in value (near-black `#0c0c0c` background, `#e4e4e7` foreground/cursor). The preset grid offers the built-in default first, then a color matching your current app theme (skipped if it would duplicate the default), then curated generic presets. The 16-color ANSI palette (used by shell tools like `git diff` and `ls --color`) is a fixed scheme based on Windows Terminal's Campbell, not individually customizable. "Reset to default" clears every customization. Applies globally across all projects.
 
 ### Terminal Settings
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -353,6 +353,10 @@ Choose from 10 themes:
 - **Dark variants:** Moon, Forest, Ocean, Ember
 - **Light variants:** Sand, Mint, Sky, Peach
 
+### Terminal Colors
+
+The Layout tab's **Terminal** section (not Theme - this is a global setting, not per-project) lets you customize the terminal's background, foreground, and cursor color. Click a swatch to open the color picker; any color left at its default shows the built-in value (near-black `#0c0c0c` background, `#e4e4e7` foreground/cursor). The 16-color ANSI palette (used by shell tools like `git diff` and `ls --color`) is a fixed scheme based on Windows Terminal's Campbell, not individually customizable. "Reset to default" clears every customization. Applies globally across all projects.
+
 ### Terminal Settings
 
 | Setting | Description |

--- a/src/main/config/config-manager.ts
+++ b/src/main/config/config-manager.ts
@@ -21,6 +21,7 @@ const CONFIG_DICTIONARY_PATHS = [
   'workspaceByProject',
   'commandTerminalWorkspace',
   'popOutBounds',
+  'terminal.colors',
 ] as const;
 
 /** Drop keys whose value is undefined. Returns undefined when nothing is left,

--- a/src/renderer/components/backlog/manage-labels/ColorPickerPopover.tsx
+++ b/src/renderer/components/backlog/manage-labels/ColorPickerPopover.tsx
@@ -22,16 +22,21 @@ export function ColorPickerPopover({
   triggerRef,
   onChange,
   onClose,
+  presetColors = PRESET_COLORS,
 }: {
   color: string;
   triggerRef: React.RefObject<HTMLElement | null>;
   onChange: (color: string) => void;
   onClose: () => void;
+  /** Override the preset swatch grid. Defaults to the generic label-color
+   *  presets; callers with a meaningful per-field default (e.g. a terminal
+   *  color slot) should pass that default first. */
+  presetColors?: string[];
 }) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const [showCustomPicker, setShowCustomPicker] = useState(false);
   const [hexInput, setHexInput] = useState(color);
-  const isCustomColor = !PRESET_COLORS.includes(color);
+  const isCustomColor = !presetColors.includes(color);
 
   const [position, setPosition] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
 
@@ -76,7 +81,7 @@ export function ColorPickerPopover({
       onClick={(event) => event.stopPropagation()}
     >
       <div className="grid grid-cols-6 gap-1.5 place-items-center">
-        {PRESET_COLORS.map((presetColor) => (
+        {presetColors.map((presetColor) => (
           <button
             key={presetColor}
             type="button"

--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -27,7 +27,7 @@ import { KebabMenu, KebabMenuItem, KebabMenuDivider } from '../KebabMenu';
 import { CommandPalettePopover } from '../dialogs/task-detail/CommandPalettePopover';
 import { useHeaderPillOverflow, type HeaderPillSpec } from '../dialogs/task-detail/useHeaderPillOverflow';
 import { WindowLayoutMenu } from '../dialogs/WindowLayoutMenu';
-import { TERMINAL_BACKGROUND, useTerminal } from '../../hooks/useTerminal';
+import { resolveTerminalBackground, useTerminal } from '../../hooks/useTerminal';
 import { useTerminalRefit } from '../../hooks/useTerminalRefit';
 import { useKeybinding, useFormattedCombo } from '../../hooks/useKeybinding';
 import { useTerminalFileDrop } from '../../hooks/useTerminalFileDrop';
@@ -315,6 +315,7 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
     fontSize: config.terminal.fontSize,
     scrollbackLines: config.terminal.scrollbackLines,
     cursorStyle: config.terminal.cursorStyle,
+    colors: config.terminal.colors,
     shellName: commandTerminalShell ?? undefined,
     pasteImageTemplate,
   });
@@ -688,7 +689,7 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
             to the terminal's column width, so it overflows the window and fit() reads
             the stale (too-wide) size and never reduces columns. overflow-hidden clips
             the brief pre-fit overflow. Mirrors the Changes panel sibling. */}
-        <div className={`${changesOpen ? 'w-1/2' : 'flex-1'} relative min-w-0 overflow-hidden`} style={{ backgroundColor: TERMINAL_BACKGROUND }}>
+        <div className={`${changesOpen ? 'w-1/2' : 'flex-1'} relative min-w-0 overflow-hidden`} style={{ backgroundColor: resolveTerminalBackground(config.terminal.colors) }}>
           {!terminalReady && <LaunchOverlay label="Starting Command Terminal..." />}
           <FileDropOverlay {...fileDrop} />
           <div

--- a/src/renderer/components/settings/AppSettingsPanel.tsx
+++ b/src/renderer/components/settings/AppSettingsPanel.tsx
@@ -112,7 +112,7 @@ export function SettingsContent({ activeTab, isSearching, searchQuery, matchingT
       case 'browser': return <BrowserTab config={effectiveConfig} />;
       case 'shortcuts': return <ShortcutsTab />;
       case 'developer': return <DeveloperTab globalConfig={globalConfig} />;
-      case 'layout': return <LayoutTab globalConfig={globalConfig} />;
+      case 'layout': return <LayoutTab config={effectiveConfig} globalConfig={globalConfig} />;
       case 'behavior': return <BehaviorTab globalConfig={globalConfig} />;
       case 'dictation': return <DictationTab globalConfig={globalConfig} onOpenHotkeys={() => navigateToTab('hotkeys')} />;
       case 'hotkeys': return <HotkeysTab globalConfig={globalConfig} />;

--- a/src/renderer/components/settings/settings-registry.ts
+++ b/src/renderer/components/settings/settings-registry.ts
@@ -42,6 +42,9 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
   { id: 'diffFileSort', tabId: 'layout', label: 'File Sort', description: 'How the Changes panel orders files: by name, by status (added / modified / deleted), or by size (most changes first).', scope: 'global', section: 'Diff', keywords: ['sort', 'order', 'name', 'status', 'size', 'files', 'diff', 'changes'] },
   { id: 'diffFlatList', tabId: 'layout', label: 'Flat File List', description: 'Show changed files as a flat list of full paths instead of a nested directory tree.', scope: 'global', section: 'Diff', keywords: ['flat', 'list', 'tree', 'directory', 'folder', 'nested', 'files', 'diff', 'changes'] },
 
+  // ── Layout > Terminal ──
+  { id: 'terminal.colors', tabId: 'layout', label: 'Terminal Colors', description: 'Customize the terminal background, foreground, and cursor color', scope: 'global', section: 'Terminal', keywords: ['colors', 'background', 'foreground', 'cursor', 'custom', 'terminal'] },
+
   // ── Terminal ──
   { id: 'terminal.shell', tabId: 'terminal', label: 'Shell', description: 'Terminal shell used for agent sessions', scope: 'project', keywords: ['bash', 'powershell', 'zsh', 'fish'] },
   { id: 'terminal.fontSize', tabId: 'terminal', label: 'Font Size', description: 'Terminal text size in pixels', scope: 'project', keywords: ['px', 'text size'] },

--- a/src/renderer/components/settings/tabs/LayoutTab.tsx
+++ b/src/renderer/components/settings/tabs/LayoutTab.tsx
@@ -16,7 +16,7 @@ type TerminalColorKey = keyof TerminalColorOverrides;
  *  theme). `cursor` mirrors `foreground`: the terminal's cursor has never
  *  been a distinct app-theme concept, and its own default already always
  *  equals foreground's default. */
-function getThemeMatchColor(key: TerminalColorKey, theme: ThemeMode): string {
+export function getThemeMatchColor(key: TerminalColorKey, theme: ThemeMode): string {
   return key === 'background' ? THEME_BACKGROUNDS[theme] : THEME_FOREGROUNDS[theme];
 }
 
@@ -34,7 +34,7 @@ function getThemeMatchColor(key: TerminalColorKey, theme: ThemeMode): string {
  *  The two-row result is therefore tied to PRESET_COLORS staying a multiple of
  *  the grid's 6 columns minus one; that array is shared with the label-color
  *  picker, so re-check the row math if its length ever changes. */
-function presetsWithDefaultFirst(defaultColor: string, themeMatchColor: string): string[] {
+export function presetsWithDefaultFirst(defaultColor: string, themeMatchColor: string): string[] {
   if (themeMatchColor === defaultColor) return [defaultColor, ...PRESET_COLORS.slice(0, -1)];
   return [defaultColor, themeMatchColor, ...PRESET_COLORS.slice(1, -1)];
 }

--- a/src/renderer/components/settings/tabs/LayoutTab.tsx
+++ b/src/renderer/components/settings/tabs/LayoutTab.tsx
@@ -1,9 +1,96 @@
-import type { AppConfig } from '../../../../shared/types';
+import { useRef, useState } from 'react';
+import { RotateCcw } from 'lucide-react';
+import type { AppConfig, ThemeMode, TerminalColorOverrides } from '../../../../shared/types';
+import { THEME_BACKGROUNDS, THEME_FOREGROUNDS } from '../../../../shared/types';
+import { TERMINAL_DEFAULT_COLORS } from '../../../hooks/useTerminal';
 import { SectionHeader, SettingRow, SettingToggleRow, Select, useScopedUpdate } from '../shared';
 import { settingProps } from '../settings-registry';
+import { ColorPickerPopover, PRESET_COLORS } from '../../backlog/manage-labels/ColorPickerPopover';
+import { Pill } from '../../Pill';
 
-export function LayoutTab({ globalConfig }: { globalConfig: AppConfig }) {
+type TerminalColorKey = keyof TerminalColorOverrides;
+
+/** What the currently-selected app theme's surface/text color would put in
+ *  this terminal color slot - i.e. "what this used to look like" before the
+ *  terminal had its own fixed color scheme (it was byte-identical to the app
+ *  theme). `cursor` mirrors `foreground`: the terminal's cursor has never
+ *  been a distinct app-theme concept, and its own default already always
+ *  equals foreground's default. */
+function getThemeMatchColor(key: TerminalColorKey, theme: ThemeMode): string {
+  return key === 'background' ? THEME_BACKGROUNDS[theme] : THEME_FOREGROUNDS[theme];
+}
+
+/** Curated preset swatches for a terminal color field: that field's built-in
+ *  default first (a one-click way back to it), then the current app theme's
+ *  matching color (skipped if it's identical to the default - e.g.
+ *  foreground/cursor on the Dark theme - so slot 2 is never a visible
+ *  duplicate of slot 1), then the generic label-color presets. Both branches
+ *  yield PRESET_COLORS.length presets (11 today, + the custom-color toggle =
+ *  12 cells = a clean two rows in the picker's 6-column grid), regardless of
+ *  whether the theme-match slot is shown: PRESET_COLORS's trailing stone gray
+ *  (#78716c) is always dropped as a near-duplicate of the leading gray
+ *  (#6b7280); when the theme-match slot is ALSO shown, the leading gray is
+ *  dropped too, so a third preset never spills onto its own near-empty row.
+ *  The two-row result is therefore tied to PRESET_COLORS staying a multiple of
+ *  the grid's 6 columns minus one; that array is shared with the label-color
+ *  picker, so re-check the row math if its length ever changes. */
+function presetsWithDefaultFirst(defaultColor: string, themeMatchColor: string): string[] {
+  if (themeMatchColor === defaultColor) return [defaultColor, ...PRESET_COLORS.slice(0, -1)];
+  return [defaultColor, themeMatchColor, ...PRESET_COLORS.slice(1, -1)];
+}
+
+/** A single terminal color slot: a swatch button that opens the shared color
+ *  picker, showing the effective (override or default) color. */
+function ColorSwatchField({
+  colorKey, label, value, defaultColor, themeMatchColor, onChange,
+}: {
+  colorKey: TerminalColorKey;
+  label: string;
+  value: string;
+  defaultColor: string;
+  themeMatchColor: string;
+  onChange: (color: string) => void;
+}) {
+  const [showPicker, setShowPicker] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  return (
+    <div className="flex flex-col items-center gap-1.5 w-16">
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setShowPicker(!showPicker)}
+        title={`Change ${label}`}
+        data-testid={`terminal-color-swatch-${colorKey}`}
+        className="w-8 h-8 rounded-md border border-edge-input hover:border-fg-muted hover:scale-105 transition-all shadow-sm"
+        style={{ backgroundColor: value }}
+      />
+      <span className="text-[11px] text-fg-faint text-center leading-tight">{label}</span>
+      {showPicker && (
+        <ColorPickerPopover
+          color={value}
+          triggerRef={buttonRef}
+          onChange={onChange}
+          onClose={() => setShowPicker(false)}
+          presetColors={presetsWithDefaultFirst(defaultColor, themeMatchColor)}
+        />
+      )}
+    </div>
+  );
+}
+
+const TERMINAL_COLOR_FIELDS: { key: TerminalColorKey; label: string }[] = [
+  { key: 'background', label: 'Background' },
+  { key: 'foreground', label: 'Foreground' },
+  { key: 'cursor', label: 'Cursor' },
+];
+
+export function LayoutTab({ config, globalConfig }: { config: AppConfig; globalConfig: AppConfig }) {
   const updateGlobal = useScopedUpdate('global');
+  // `?? {}` mirrors the optional-chaining every other reader of this field uses
+  // (resolveTerminalBackground, useTerminal): the indexed reads below would
+  // throw on a config source that predates the field or shallow-merges the
+  // `terminal` block rather than deep-merging DEFAULT_CONFIG.
+  const terminalColors = globalConfig.terminal.colors ?? {};
   return (
     <>
       <SettingRow {...settingProps('cardDensity')}>
@@ -97,6 +184,35 @@ export function LayoutTab({ globalConfig }: { globalConfig: AppConfig }) {
         checked={globalConfig.diffFlatList}
         onChange={(value) => updateGlobal({ diffFlatList: value })}
       />
+
+      <SectionHeader label="Terminal" searchIds={['terminal.colors']} />
+      <SettingRow
+        {...settingProps('terminal.colors')}
+        trailing={
+          <Pill
+            size="sm"
+            onClick={() => updateGlobal({ terminal: { colors: {} } })}
+            className="text-fg-muted bg-surface-hover/50 hover:bg-surface-hover hover:text-fg-secondary transition-colors"
+            data-testid="terminal-colors-reset-all"
+          >
+            <RotateCcw size={14} /> Reset to default
+          </Pill>
+        }
+      >
+        <div className="flex flex-wrap gap-x-2 gap-y-3">
+          {TERMINAL_COLOR_FIELDS.map(({ key, label }) => (
+            <ColorSwatchField
+              key={key}
+              colorKey={key}
+              label={label}
+              value={terminalColors[key] || TERMINAL_DEFAULT_COLORS[key]}
+              defaultColor={TERMINAL_DEFAULT_COLORS[key]}
+              themeMatchColor={getThemeMatchColor(key, config.theme)}
+              onChange={(color) => updateGlobal({ terminal: { colors: { ...terminalColors, [key]: color } } })}
+            />
+          ))}
+        </div>
+      </SettingRow>
     </>
   );
 }

--- a/src/renderer/components/settings/tabs/TerminalTab.tsx
+++ b/src/renderer/components/settings/tabs/TerminalTab.tsx
@@ -73,7 +73,6 @@ export function TerminalTab({ config, globalConfig, shells }: {
           <option value="bar">Bar</option>
         </Select>
       </SettingRow>
-
       <SectionHeader
         label="Context Bar"
         searchIds={[

--- a/src/renderer/components/terminal/TerminalTab.tsx
+++ b/src/renderer/components/terminal/TerminalTab.tsx
@@ -248,7 +248,7 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
   const terminalBackground = resolveTerminalBackground(config.terminal.colors);
 
   return (
-    <div ref={containerRef} className="h-full w-full relative" style={{ backgroundColor: terminalBackground }}>
+    <div ref={containerRef} data-testid="terminal-tab-container" className="h-full w-full relative" style={{ backgroundColor: terminalBackground }}>
       <div ref={terminalRef} className="h-full w-full" />
       <FileDropOverlay {...fileDrop} />
       {/* Replay veil: covers the mount-time replay window (first fit, chunked

--- a/src/renderer/components/terminal/TerminalTab.tsx
+++ b/src/renderer/components/terminal/TerminalTab.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { TERMINAL_BACKGROUND, useTerminal } from '../../hooks/useTerminal';
+import { resolveTerminalBackground, useTerminal } from '../../hooks/useTerminal';
 import { useTerminalFileDrop } from '../../hooks/useTerminalFileDrop';
 import { FileDropOverlay } from './FileDropOverlay';
 import { useConfigStore } from '../../stores/config-store';
@@ -97,6 +97,7 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
     fontSize: config.terminal.fontSize,
     scrollbackLines: config.terminal.scrollbackLines,
     cursorStyle: config.terminal.cursorStyle,
+    colors: config.terminal.colors,
     shellName: sessionShell,
     releaseEscapeWhenPointerOutside,
     pasteImageTemplate,
@@ -244,24 +245,25 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
   });
 
   const fileDrop = useTerminalFileDrop(sessionId, focus, sessionShell, pasteImageTemplate);
+  const terminalBackground = resolveTerminalBackground(config.terminal.colors);
 
   return (
-    <div ref={containerRef} className="h-full w-full bg-surface relative">
+    <div ref={containerRef} className="h-full w-full relative" style={{ backgroundColor: terminalBackground }}>
       <div ref={terminalRef} className="h-full w-full" />
       <FileDropOverlay {...fileDrop} />
       {/* Replay veil: covers the mount-time replay window (first fit, chunked
           scrollback write, afterWrite refit, held-byte flush, DOM-to-WebGL
           promotion) so a warm session's terminal appears once, settled, with
-          no intermediate frame. Same fixed color as the terminal background,
-          so it reads as the empty terminal, not a flash of its own; no
-          transition, per restore-no-animation-replay. Rendered BEFORE
-          LaunchOverlay so the cold-start overlay (same z-10, later sibling)
-          paints above it. */}
+          no intermediate frame. Same color as the terminal background (tracks
+          the user's custom override, if any), so it reads as the empty
+          terminal, not a flash of its own; no transition, per
+          restore-no-animation-replay. Rendered BEFORE LaunchOverlay so the
+          cold-start overlay (same z-10, later sibling) paints above it. */}
       {!replaySettled && (
         <div
           data-testid="terminal-replay-veil"
           className="pointer-events-none absolute inset-0 z-10"
-          style={{ backgroundColor: TERMINAL_BACKGROUND }}
+          style={{ backgroundColor: terminalBackground }}
         />
       )}
       {/* Placeholder overlay while Claude CLI is loading (before first usage report).

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -82,7 +82,7 @@ export function resolveTerminalBackground(colors: TerminalColorOverrides | undef
  *  `cursorAccent` always tracks the resolved `background` (not a fixed value)
  *  so the glyph under a block cursor stays legible even when the user picks a
  *  custom background. */
-function buildTerminalTheme(colors: TerminalColorOverrides | undefined) {
+export function buildTerminalTheme(colors: TerminalColorOverrides | undefined) {
   const background = resolveTerminalBackground(colors);
   return {
     ...TERMINAL_DEFAULT_COLORS,

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -9,6 +9,7 @@ import { isBoardDragActive, onBoardDragEnd } from '../lib/session-update-coalesc
 import { isTerminalParked, onTerminalReveal } from '../utils/parked-terminals';
 import { noteTerminalFocus } from '../utils/dictation-target';
 import { registerTerminalCapture, unregisterTerminalCapture, type TerminalCaptureReader } from '../utils/terminal-capture-registry';
+import type { TerminalColorOverrides } from '../../shared/types';
 import '@xterm/xterm/css/xterm.css';
 
 /** Delay before forwarding a resize to the PTY. Coalesces rapid resizes
@@ -46,38 +47,51 @@ function nextTransientRendererKey(): number {
   return transientRendererKeyCounter;
 }
 
-/** Fixed terminal background, exported for surfaces that must match it exactly
- *  (e.g. TerminalTab's replay veil). NOT a theme token: the terminal stays dark
- *  on every app theme, so a veil using a theme surface color would flash. */
-export const TERMINAL_BACKGROUND = '#18181b';
-
-/** Fixed dark terminal theme -- Claude Code's TUI is designed for dark backgrounds. */
-const TERMINAL_THEME = {
-  background: TERMINAL_BACKGROUND,
+/** Built-in terminal colors, used whenever the user hasn't customized a given
+ *  slot (see TerminalColorOverrides in shared/types.ts). The ANSI 16 default to
+ *  Windows Terminal's real "Campbell" scheme (learn.microsoft.com/windows/terminal
+ *  /customize-settings/color-schemes) so an unconfigured terminal still reads as
+ *  a real terminal, not an app panel with text in it. `black` is deliberately
+ *  NOT Campbell's native black (`#0C0C0C`, identical to the default background):
+ *  that would make black-on-default text and black fills invisible, so it's
+ *  kept at the old zinc-900 tone instead, subdued but present. */
+export const TERMINAL_DEFAULT_COLORS = {
+  background: '#0c0c0c',
   foreground: '#e4e4e7',
-  // Light cursor. It was the background color (#18181b) - i.e. invisible - which is
-  // why no cursor ever showed. cursorAccent is the dark background so the character
-  // under a block cursor stays readable (dark glyph on the light block).
   cursor: '#e4e4e7',
-  cursorAccent: '#18181b',
   selectionBackground: 'rgba(58, 130, 246, 0.35)',
   black: '#18181b',
-  red: '#ef4444',
-  green: '#22c55e',
-  yellow: '#eab308',
-  blue: '#3b82f6',
-  magenta: '#a855f7',
-  cyan: '#06b6d4',
-  white: '#e4e4e7',
-  brightBlack: '#52525b',
-  brightRed: '#f87171',
-  brightGreen: '#4ade80',
-  brightYellow: '#facc15',
-  brightBlue: '#60a5fa',
-  brightMagenta: '#c084fc',
-  brightCyan: '#22d3ee',
-  brightWhite: '#fafafa',
+  red: '#C50F1F', green: '#13A10E', yellow: '#C19C00', blue: '#0037DA', magenta: '#881798', cyan: '#3A96DD', white: '#CCCCCC',
+  brightBlack: '#767676', brightRed: '#E74856', brightGreen: '#16C60C', brightYellow: '#F9F1A5', brightBlue: '#3B78FF', brightMagenta: '#B4009E', brightCyan: '#61D6D6', brightWhite: '#F2F2F2',
 } as const;
+
+/** Resolves the effective terminal background: the user's custom override, or
+ *  the built-in default. Exported so surfaces that must paint the identical
+ *  color BEFORE (or independent of) the xterm instance itself - the host
+ *  container, the replay veil - stay in lockstep with whatever the user has
+ *  configured, instead of drifting from a stale fixed constant. A veil or
+ *  container using a different color than the live xterm theme would show a
+ *  visible seam/flash; see TerminalTab.tsx and CommandTerminalWindow.tsx. */
+export function resolveTerminalBackground(colors: TerminalColorOverrides | undefined): string {
+  return colors?.background || TERMINAL_DEFAULT_COLORS.background;
+}
+
+/** Builds the full xterm theme: background/foreground/cursor layer the user's
+ *  overrides over the defaults; the 16-color ANSI palette is always the fixed
+ *  built-in scheme (not user-customizable - see TerminalColorOverrides).
+ *  `cursorAccent` always tracks the resolved `background` (not a fixed value)
+ *  so the glyph under a block cursor stays legible even when the user picks a
+ *  custom background. */
+function buildTerminalTheme(colors: TerminalColorOverrides | undefined) {
+  const background = resolveTerminalBackground(colors);
+  return {
+    ...TERMINAL_DEFAULT_COLORS,
+    background,
+    foreground: colors?.foreground || TERMINAL_DEFAULT_COLORS.foreground,
+    cursor: colors?.cursor || TERMINAL_DEFAULT_COLORS.cursor,
+    cursorAccent: background,
+  };
+}
 
 interface UseTerminalOptions {
   sessionId: string | null;
@@ -85,6 +99,9 @@ interface UseTerminalOptions {
   fontSize?: number;
   scrollbackLines?: number;
   cursorStyle?: 'block' | 'underline' | 'bar';
+  /** Global-only setting: per-slot custom terminal colors. Any unset slot
+   *  falls back to TERMINAL_DEFAULT_COLORS. */
+  colors?: TerminalColorOverrides;
   shellName?: string;
   /** Let Escape bubble (to close the containing dialog) when the mouse pointer
    *  is outside the terminal. Used by the task detail dialog. */
@@ -169,10 +186,26 @@ export function useTerminal(options: UseTerminalOptions) {
     onScrollbackSettledRef.current?.();
   }, []);
 
+  // Destructured to PRIMITIVES, deliberately: `config.terminal.colors` is a
+  // fresh object on every config refetch (updateConfig -> refreshConfigs
+  // re-fetches the whole tree over IPC), so depending on the OBJECT would churn
+  // initTerminal's identity on any unrelated settings write - including
+  // background ones like model-discovery telemetry - and retrigger the callers'
+  // mount effects (overlay flash + scrollback reload in TerminalTab, focus theft
+  // in CommandTerminalWindow). Every other entry in those dep arrays is already
+  // a primitive for the same reason.
+  const customBackground = options.colors?.background;
+  const customForeground = options.colors?.foreground;
+  const customCursor = options.colors?.cursor;
+
   const initTerminal = useCallback(() => {
     if (!terminalRef.current || xtermRef.current) return;
 
-    const xtermTheme = TERMINAL_THEME;
+    const xtermTheme = buildTerminalTheme({
+      background: customBackground,
+      foreground: customForeground,
+      cursor: customCursor,
+    });
 
     const terminal = new Terminal({
       fontFamily: options.fontFamily || 'Menlo, Consolas, "Courier New", monospace',
@@ -351,7 +384,7 @@ export function useTerminal(options: UseTerminalOptions) {
       // No session -- just fit immediately
       fitAddon.fit();
     }
-  }, [options.sessionId, options.fontFamily, options.fontSize, options.scrollbackLines, options.cursorStyle, options.shellName, options.releaseEscapeWhenPointerOutside, settleScrollback]);
+  }, [options.sessionId, options.fontFamily, options.fontSize, options.scrollbackLines, options.cursorStyle, customBackground, customForeground, customCursor, options.shellName, options.releaseEscapeWhenPointerOutside, settleScrollback]);
 
   // Set up data listener. Inbound PTY data flows through a bounded queue that
   // writes capped slices paced by xterm.write's completion callback, yielding
@@ -514,6 +547,38 @@ export function useTerminal(options: UseTerminalOptions) {
       xtermRef.current.scrollToBottom();
     }
   }, []);
+
+  // Live-apply display settings to an already-mounted terminal, mirroring how
+  // an app theme change applies immediately (rather than requiring the
+  // terminal to be reopened). xterm.js exposes `options` as a live-settable
+  // object post-construction; `theme` specifically needs a FRESH object on
+  // every assignment (a reference-equal object is a no-op per xterm's docs),
+  // which buildTerminalTheme always returns. A no-op (xtermRef.current is
+  // null) before initTerminal has run; initTerminal reads the same options
+  // directly, so there is no gap once it does. Re-fit goes through the shared
+  // fit() (not the raw addon) so a terminal pinned to the bottom stays pinned
+  // when a font-size change alters the row count, and it picks up the cell-size
+  // change through the existing debounced onResize -> PTY resize path (a no-op
+  // if cols/rows did not change). Declared AFTER fit() so the callback is
+  // initialized before this effect's dependency array references it. `shell` is
+  // deliberately excluded: switching it means killing and respawning the PTY
+  // process, not a rendering change, and is out of scope here.
+  useEffect(() => {
+    const terminal = xtermRef.current;
+    if (!terminal) return;
+    terminal.options = {
+      fontFamily: options.fontFamily || 'Menlo, Consolas, "Courier New", monospace',
+      fontSize: options.fontSize || 14,
+      cursorStyle: options.cursorStyle || 'block',
+      scrollback: options.scrollbackLines || 5000,
+      theme: buildTerminalTheme({
+        background: customBackground,
+        foreground: customForeground,
+        cursor: customCursor,
+      }),
+    };
+    fit();
+  }, [options.fontFamily, options.fontSize, options.cursorStyle, options.scrollbackLines, customBackground, customForeground, customCursor, fit]);
 
   // Flush a pending (debounced) PTY resize immediately, instead of waiting out
   // PTY_RESIZE_DEBOUNCE_MS. Window-hosted terminals fit synchronously on the

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -402,16 +402,22 @@
   height: 100%;
 }
 
-/* Match the viewport background to the terminal theme so leftover pixels
-   below the last rendered row blend in (xterm.css defaults to #000). */
+/* Let the host container's resolved terminal background (near-black by
+   default, user-customizable via the Terminal Colors setting) show through
+   (xterm.css defaults this to #000) so leftover sub-cell pixels below/right of
+   the last rendered row blend into one continuous terminal surface instead of
+   a theme-tracking color. Transparent, not a duplicated hex, so there is one
+   source of truth (resolveTerminalBackground in useTerminal.ts) for the
+   terminal background. */
 .xterm .xterm-viewport {
-  background-color: var(--kng-surface) !important;
+  background-color: transparent !important;
 }
 
 /* Terminal scrollbar visibility: the global thumb color (--kng-edge, #3f3f46) is
-   nearly invisible against the dark terminal background (#18181b), so the scrollbar
-   reads as missing. Use a brighter translucent thumb so it is discoverable. Width is
-   left at the global 8px so the fit-addon's DEFAULT_SCROLLBAR_WIDTH assumption holds. */
+   nearly invisible against the terminal's near-black default background, so the
+   scrollbar reads as missing. Use a brighter translucent thumb so it is
+   discoverable. Width is left at the global 8px so the fit-addon's
+   DEFAULT_SCROLLBAR_WIDTH assumption holds. */
 .xterm .xterm-viewport::-webkit-scrollbar-thumb {
   background: rgba(228, 228, 231, 0.28);
   border-radius: 4px;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1677,6 +1677,18 @@ export const THEME_BACKGROUNDS: Record<ThemeMode, string> = {
   sand: '#f5f0e8', mint: '#eef5f0', sky: '#edf3f8', peach: '#f8f0ec',
 };
 
+/** Per-theme foreground color (mirrors index.css's `--kng-fg-secondary`,
+ *  renderer-only need so not read live from CSS). Used by the Layout settings
+ *  tab to offer "match my current app theme" as a terminal color preset:
+ *  the terminal's foreground/cursor default (#e4e4e7) is byte-identical to
+ *  the dark theme's value here, since that is literally where it came from
+ *  before the terminal had its own fixed color scheme. */
+export const THEME_FOREGROUNDS: Record<ThemeMode, string> = {
+  dark: '#e4e4e7', light: '#292524',
+  moon: '#c6c8d0', forest: '#c6cac4', ocean: '#c0c6ce', ember: '#ccc8c4',
+  sand: '#3d3228', mint: '#1e3028', sky: '#1a2a3a', peach: '#3a2520',
+};
+
 /** UI metadata for the settings dropdown. */
 export const NAMED_THEMES: { id: ThemeMode; label: string; base: 'dark' | 'light' }[] = [
   { id: 'moon', label: 'Moon', base: 'dark' },
@@ -1688,6 +1700,27 @@ export const NAMED_THEMES: { id: ThemeMode; label: string; base: 'dark' | 'light
   { id: 'sky', label: 'Sky', base: 'light' },
   { id: 'peach', label: 'Peach', base: 'light' },
 ];
+
+/** Custom terminal color overrides, editable in the Layout settings tab's
+ *  Terminal section. Any
+ *  slot left unset falls back to the built-in default (see
+ *  TERMINAL_DEFAULT_COLORS in useTerminal.ts, renderer-only since only xterm
+ *  rendering needs the concrete hex values). Deliberately just these three:
+ *  the 16-color ANSI palette (used by shell tools like `git diff`/`ls
+ *  --color`) is a fixed built-in scheme, not exposed for per-color editing -
+ *  most users want to set their overall look, not tune individual ANSI
+ *  slots. `cursorAccent` and `selectionBackground` are also NOT here:
+ *  cursorAccent always tracks whatever `background` resolves to (so the
+ *  glyph under a block cursor stays legible), and selectionBackground is a
+ *  fixed app accent, not a terminal color a user would pick independently.
+ *  A dictionary-style field (CONFIG_DICTIONARY_PATHS in config-manager.ts):
+ *  saved wholesale so resetting a slot (deleting its key) actually takes
+ *  effect. Global-only. */
+export interface TerminalColorOverrides {
+  background?: string;
+  foreground?: string;
+  cursor?: string;
+}
 
 /** Recursively makes all properties optional. Arrays are kept whole (not element-partial). */
 export type DeepPartial<T> = {
@@ -1876,6 +1909,7 @@ export interface AppConfig {
     panelCollapsed: boolean; // persisted collapsed state
     scrollbackLines: number;
     cursorStyle: 'block' | 'underline' | 'bar';
+    colors: TerminalColorOverrides; // global-only: applies across every project
   };
 
   agent: {
@@ -2253,6 +2287,7 @@ export const DEFAULT_CONFIG: AppConfig = {
     panelCollapsed: false,
     scrollbackLines: 5000,
     cursorStyle: 'block',
+    colors: {},
   },
   agent: {
     permissionMode: 'acceptEdits',

--- a/tests/captures/features/walkthrough.capture.ts
+++ b/tests/captures/features/walkthrough.capture.ts
@@ -127,6 +127,7 @@ test('full product walkthrough', async () => {
         panelHeight: 280,
         scrollbackLines: 5000,
         cursorStyle: 'block',
+        colors: {},
       },
     };
   `);

--- a/tests/captures/helpers/capture-page.ts
+++ b/tests/captures/helpers/capture-page.ts
@@ -73,6 +73,7 @@ export async function launchCapturePage(options: CaptureOptions): Promise<Captur
       panelHeight: 280,
       scrollbackLines: 5000,
       cursorStyle: 'block',
+      colors: {},
     },
     terminalPanelVisible: !options.hideTerminal,
   };

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -88,6 +88,7 @@
       panelHeight: 250,
       scrollbackLines: 5000,
       cursorStyle: 'block',
+      colors: {},
     },
     sidebar: {
       width: 224,
@@ -1835,9 +1836,15 @@
         if (partial && Object.prototype.hasOwnProperty.call(partial, 'commandTerminalWorkspace')) {
           config.commandTerminalWorkspace = partial.commandTerminalWorkspace;
         }
+        // terminal.colors is a nested dictionary-style map (CONFIG_DICTIONARY_PATHS:
+        // 'terminal.colors'): the real save REPLACES it wholesale so resetting a
+        // single color slot (deleting its key) actually takes effect.
+        if (partial && partial.terminal && Object.prototype.hasOwnProperty.call(partial.terminal, 'colors')) {
+          config.terminal.colors = Object.assign({}, partial.terminal.colors);
+        }
       },
       // Synchronous sibling of set() for the quit/unload flush. Mirrors the real
-      // configManager.save dictionary-path replace semantics (hotkeyOverrides + workspaceByProject + commandTerminalWorkspace).
+      // configManager.save dictionary-path replace semantics (hotkeyOverrides + workspaceByProject + commandTerminalWorkspace + terminal.colors).
       setSync: function (partial) {
         config = deepMerge(config, partial);
         if (partial && Object.prototype.hasOwnProperty.call(partial, 'hotkeyOverrides')) {
@@ -1848,6 +1855,9 @@
         }
         if (partial && Object.prototype.hasOwnProperty.call(partial, 'commandTerminalWorkspace')) {
           config.commandTerminalWorkspace = partial.commandTerminalWorkspace;
+        }
+        if (partial && partial.terminal && Object.prototype.hasOwnProperty.call(partial.terminal, 'colors')) {
+          config.terminal.colors = Object.assign({}, partial.terminal.colors);
         }
       },
       getProjectOverrides: async function () {

--- a/tests/ui/settings-panel.spec.ts
+++ b/tests/ui/settings-panel.spec.ts
@@ -101,6 +101,26 @@ test.describe('Settings Panel', () => {
     await closeSettings();
   });
 
+  test('Layout tab Terminal Colors offers customizable background, foreground, and cursor swatches', async () => {
+    await openSettings();
+    await page.getByRole('button', { name: 'Layout' }).click();
+
+    const colorsRow = page.locator('[data-testid="setting-row-terminal.colors"]');
+    await expect(colorsRow.getByTestId('terminal-color-swatch-background')).toBeVisible();
+    await expect(colorsRow.getByTestId('terminal-color-swatch-foreground')).toBeVisible();
+    await expect(colorsRow.getByTestId('terminal-color-swatch-cursor')).toBeVisible();
+
+    // Opening a swatch shows the shared color picker popover.
+    await colorsRow.getByTestId('terminal-color-swatch-background').click();
+    await expect(page.getByTitle('Custom color')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByTitle('Custom color')).toHaveCount(0);
+
+    await expect(colorsRow.getByTestId('terminal-colors-reset-all')).toBeVisible();
+
+    await closeSettings();
+  });
+
   test('shows Notifications tab with event grid and delivery settings', async () => {
     await openSettings();
     await page.getByRole('button', { name: 'Notifications' }).click();

--- a/tests/ui/terminal-image-paste-reference.spec.ts
+++ b/tests/ui/terminal-image-paste-reference.spec.ts
@@ -174,7 +174,7 @@ test.describe('Image paste/drop on a real task terminal - adapter reference temp
 
       await page.evaluate(() => {
         const textarea = document.querySelector('.xterm-helper-textarea');
-        const overlay = textarea?.closest('.bg-surface.relative')?.querySelector('.z-20');
+        const overlay = textarea?.closest('[data-testid="terminal-tab-container"]')?.querySelector('.z-20');
         if (!overlay) throw new Error('file-drop overlay not found');
 
         const file = new File(['fake-png-bytes'], 'screenshot.png', { type: 'image/png' });
@@ -217,7 +217,7 @@ test.describe('Image paste/drop on a real task terminal - adapter reference temp
 
       await page.evaluate(() => {
         const textarea = document.querySelector('.xterm-helper-textarea');
-        const overlay = textarea?.closest('.bg-surface.relative')?.querySelector('.z-20');
+        const overlay = textarea?.closest('[data-testid="terminal-tab-container"]')?.querySelector('.z-20');
         if (!overlay) throw new Error('file-drop overlay not found');
 
         const file = new File(['fake-png-bytes'], 'screenshot.png', { type: '' });
@@ -254,7 +254,7 @@ test.describe('Image paste/drop on a real task terminal - adapter reference temp
 
       await page.evaluate(() => {
         const textarea = document.querySelector('.xterm-helper-textarea');
-        const overlay = textarea?.closest('.bg-surface.relative')?.querySelector('.z-20');
+        const overlay = textarea?.closest('[data-testid="terminal-tab-container"]')?.querySelector('.z-20');
         if (!overlay) throw new Error('file-drop overlay not found');
 
         const file = new File(['plain text'], 'notes.txt', { type: 'text/plain' });

--- a/tests/ui/terminal-replay-veil.spec.ts
+++ b/tests/ui/terminal-replay-veil.spec.ts
@@ -193,6 +193,17 @@ test.describe('TerminalTab replay veil', () => {
       await expect(veil).toBeVisible();
       await expect(dialog.locator('[data-testid="launch-overlay"]')).toHaveCount(0);
 
+      // The viewport must not paint its own (theme-tracking) background - it
+      // is transparent so the host container's resolved terminal background
+      // (near-black by default, user-customizable) shows through as one
+      // continuous surface, with no seam along the sub-cell strip xterm
+      // itself doesn't paint.
+      const viewportBackground = await dialog
+        .locator('.xterm-viewport')
+        .first()
+        .evaluate((element) => getComputedStyle(element).backgroundColor);
+      expect(viewportBackground).toBe('rgba(0, 0, 0, 0)');
+
       // Resolve the replay.
       await page.evaluate(() => {
         const resolvers = (window as unknown as { __mockScrollbackResolvers: Array<(value: string) => void> })

--- a/tests/unit/build-terminal-theme.test.ts
+++ b/tests/unit/build-terminal-theme.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for buildTerminalTheme (src/renderer/hooks/useTerminal.ts).
+ *
+ * Builds the full xterm theme object passed to `new Terminal({ theme })` and to
+ * the live-apply effect's `terminal.options = { theme: ... }` reassignment.
+ * resolveTerminalBackground's own fallback/empty-string edge cases are already
+ * covered by resolve-terminal-background.test.ts; this file covers what
+ * buildTerminalTheme adds on top: cursorAccent tracking the resolved
+ * background, foreground/cursor override fallback, and the ANSI 16 palette
+ * staying fixed regardless of user overrides.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildTerminalTheme, TERMINAL_DEFAULT_COLORS } from '../../src/renderer/hooks/useTerminal';
+
+describe('buildTerminalTheme', () => {
+  it('tracks cursorAccent to the resolved (default) background when unset', () => {
+    const theme = buildTerminalTheme(undefined);
+    expect(theme.background).toBe(TERMINAL_DEFAULT_COLORS.background);
+    expect(theme.cursorAccent).toBe(theme.background);
+  });
+
+  it('tracks cursorAccent to a custom background override', () => {
+    const theme = buildTerminalTheme({ background: '#123456' });
+    expect(theme.background).toBe('#123456');
+    expect(theme.cursorAccent).toBe('#123456');
+  });
+
+  it('honors a foreground override', () => {
+    const theme = buildTerminalTheme({ foreground: '#abcdef' });
+    expect(theme.foreground).toBe('#abcdef');
+  });
+
+  it('falls back foreground to the default when the override is an empty string', () => {
+    // Same `||` (not `??`) semantics as resolveTerminalBackground's background
+    // fallback - an empty string is not a valid CSS color.
+    const theme = buildTerminalTheme({ foreground: '' });
+    expect(theme.foreground).toBe(TERMINAL_DEFAULT_COLORS.foreground);
+  });
+
+  it('honors a cursor override', () => {
+    const theme = buildTerminalTheme({ cursor: '#fedcba' });
+    expect(theme.cursor).toBe('#fedcba');
+  });
+
+  it('falls back cursor to the default when unset', () => {
+    const theme = buildTerminalTheme({});
+    expect(theme.cursor).toBe(TERMINAL_DEFAULT_COLORS.cursor);
+  });
+
+  it('keeps the fixed ANSI 16 palette regardless of user overrides', () => {
+    const theme = buildTerminalTheme({
+      background: '#000001',
+      foreground: '#000002',
+      cursor: '#000003',
+    });
+    // The 16-color ANSI palette is not user-customizable (see
+    // TerminalColorOverrides docs) - it must stay the built-in scheme.
+    expect(theme.red).toBe(TERMINAL_DEFAULT_COLORS.red);
+    expect(theme.green).toBe(TERMINAL_DEFAULT_COLORS.green);
+    expect(theme.black).toBe(TERMINAL_DEFAULT_COLORS.black);
+    expect(theme.brightWhite).toBe(TERMINAL_DEFAULT_COLORS.brightWhite);
+  });
+});

--- a/tests/unit/config-manager.test.ts
+++ b/tests/unit/config-manager.test.ts
@@ -376,3 +376,38 @@ describe('Config Manager -- agent.launchOptions replace semantics', () => {
     expect('claude' in raw.agent.launchOptions).toBe(false);
   });
 });
+
+describe('Config Manager -- terminal.colors replace semantics', () => {
+  it('removing a slot key from a later save() actually clears it, not deep-merges it back', async () => {
+    const cm = await createConfigManager();
+
+    cm.save({ terminal: { colors: { background: '#fff', foreground: '#000' } } });
+    const afterFirstWrite = cm.load();
+    expect(afterFirstWrite.terminal.colors).toEqual({ background: '#fff', foreground: '#000' });
+
+    // Save again WITHOUT foreground. With dictionaryPaths replace semantics the
+    // whole terminal.colors map is swapped out, so foreground is gone. With
+    // deep-merge semantics (replaceFlatMaps: false, no dictionaryPaths entry)
+    // the previous foreground would survive the merge instead.
+    cm.save({ terminal: { colors: { background: '#fff' } } });
+    const afterSecondWrite = cm.load();
+    expect(afterSecondWrite.terminal.colors.foreground).toBeUndefined();
+    expect(afterSecondWrite.terminal.colors.background).toBe('#fff');
+
+    const raw = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(raw.terminal.colors).not.toHaveProperty('foreground');
+  });
+
+  it('saving an empty colors map clears every previously-set slot', async () => {
+    const cm = await createConfigManager();
+
+    cm.save({ terminal: { colors: { background: '#fff', foreground: '#000', cursor: '#abc' } } });
+    cm.save({ terminal: { colors: {} } });
+
+    const config = cm.load();
+    expect(config.terminal.colors).toEqual({});
+
+    const raw = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(raw.terminal.colors).toEqual({});
+  });
+});

--- a/tests/unit/config-overridable-subset.test.ts
+++ b/tests/unit/config-overridable-subset.test.ts
@@ -72,6 +72,25 @@ describe('pickOverridableSubset', () => {
     expect(pickOverridableSubset(source)).toEqual({});
   });
 
+  it('drops terminal.colors - it is documented global-only, never per-project', () => {
+    // terminal.colors (TerminalColorOverrides) is a global-only setting (see
+    // its doc comment in shared/types.ts); it must never be cloned into a new
+    // project's overrides or snapshotted as a project default alongside the
+    // other terminal.* fields.
+    const source = {
+      terminal: {
+        shell: 'bash',
+        fontSize: 13,
+        colors: { background: '#111111', foreground: '#eeeeee', cursor: '#eeeeee' },
+      },
+    } as unknown as Parameters<typeof pickOverridableSubset>[0];
+
+    const result = pickOverridableSubset(source) as Record<string, unknown>;
+
+    expect(result.terminal).toEqual({ shell: 'bash', fontSize: 13 });
+    expect(result.terminal).not.toHaveProperty('colors');
+  });
+
   it('tolerates a sparse source and omits empty nested objects', () => {
     const result = pickOverridableSubset({ theme: 'ember' } as Parameters<typeof pickOverridableSubset>[0]);
 

--- a/tests/unit/layout-tab-terminal-color-presets.test.ts
+++ b/tests/unit/layout-tab-terminal-color-presets.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for the LayoutTab terminal-color preset helpers
+ * (src/renderer/components/settings/tabs/LayoutTab.tsx):
+ * `getThemeMatchColor` and `presetsWithDefaultFirst`.
+ *
+ * Both are pure functions previously exercised only indirectly, by clicking
+ * through a real theme in tests/ui/settings-panel.spec.ts. Direct unit tests
+ * pin the two edge cases the docstring calls out: the theme-match slot is
+ * skipped when it duplicates the default (so the picker never shows the same
+ * color twice), and the resulting preset list always has exactly
+ * PRESET_COLORS.length entries regardless of which branch runs (the "two
+ * clean rows in a 6-column grid" invariant).
+ */
+import { describe, it, expect } from 'vitest';
+import { getThemeMatchColor, presetsWithDefaultFirst } from '../../src/renderer/components/settings/tabs/LayoutTab';
+import { THEME_BACKGROUNDS, THEME_FOREGROUNDS } from '../../src/shared/types';
+import { PRESET_COLORS } from '../../src/renderer/components/backlog/manage-labels/ColorPickerPopover';
+
+describe('getThemeMatchColor', () => {
+  it('resolves the background key against THEME_BACKGROUNDS', () => {
+    expect(getThemeMatchColor('background', 'dark')).toBe(THEME_BACKGROUNDS.dark);
+    expect(getThemeMatchColor('background', 'light')).toBe(THEME_BACKGROUNDS.light);
+  });
+
+  it('resolves the foreground key against THEME_FOREGROUNDS', () => {
+    expect(getThemeMatchColor('foreground', 'dark')).toBe(THEME_FOREGROUNDS.dark);
+    expect(getThemeMatchColor('foreground', 'light')).toBe(THEME_FOREGROUNDS.light);
+  });
+
+  it('resolves the cursor key against THEME_FOREGROUNDS (mirrors foreground)', () => {
+    expect(getThemeMatchColor('cursor', 'dark')).toBe(THEME_FOREGROUNDS.dark);
+    expect(getThemeMatchColor('cursor', 'light')).toBe(THEME_FOREGROUNDS.light);
+  });
+});
+
+describe('presetsWithDefaultFirst', () => {
+  it('puts the default first and drops the theme-match slot when it duplicates the default', () => {
+    const result = presetsWithDefaultFirst('#e4e4e7', '#e4e4e7');
+    expect(result[0]).toBe('#e4e4e7');
+    // The leading PRESET_COLORS gray is retained (only the trailing one is dropped)
+    // when the theme-match slot is skipped.
+    expect(result).toEqual(['#e4e4e7', ...PRESET_COLORS.slice(0, -1)]);
+  });
+
+  it('puts the default then the theme-match color first when they differ', () => {
+    const result = presetsWithDefaultFirst('#0c0c0c', '#18181b');
+    expect(result[0]).toBe('#0c0c0c');
+    expect(result[1]).toBe('#18181b');
+    // Both the leading and trailing PRESET_COLORS gray are dropped so a third
+    // preset never spills onto its own near-empty row.
+    expect(result).toEqual(['#0c0c0c', '#18181b', ...PRESET_COLORS.slice(1, -1)]);
+  });
+
+  it('always yields exactly PRESET_COLORS.length entries, regardless of branch', () => {
+    const equalBranch = presetsWithDefaultFirst('#e4e4e7', '#e4e4e7');
+    const differingBranch = presetsWithDefaultFirst('#0c0c0c', '#18181b');
+    expect(equalBranch).toHaveLength(PRESET_COLORS.length);
+    expect(differingBranch).toHaveLength(PRESET_COLORS.length);
+  });
+
+  it('never contains a duplicate color in either branch', () => {
+    const equalBranch = presetsWithDefaultFirst('#e4e4e7', '#e4e4e7');
+    const differingBranch = presetsWithDefaultFirst('#0c0c0c', '#18181b');
+    expect(new Set(equalBranch).size).toBe(equalBranch.length);
+    expect(new Set(differingBranch).size).toBe(differingBranch.length);
+  });
+});

--- a/tests/unit/resolve-terminal-background.test.ts
+++ b/tests/unit/resolve-terminal-background.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for resolveTerminalBackground (src/renderer/hooks/useTerminal.ts).
+ *
+ * Surfaces that must paint the identical background color BEFORE (or
+ * independent of) the live xterm instance - the host container, the replay
+ * veil (see TerminalTab.tsx, CommandTerminalWindow.tsx) - call this function
+ * so they never drift from the user's configured terminal background. It
+ * must return the user's override when set, and fall back to the built-in
+ * default whenever the override is absent OR is an empty string (an empty
+ * string is not a valid CSS color and must not be honored - see the `||`
+ * fallback in the source, not `??`).
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveTerminalBackground, TERMINAL_DEFAULT_COLORS } from '../../src/renderer/hooks/useTerminal';
+
+describe('resolveTerminalBackground', () => {
+  it('falls back to the built-in default when overrides is undefined', () => {
+    expect(resolveTerminalBackground(undefined)).toBe(TERMINAL_DEFAULT_COLORS.background);
+  });
+
+  it('falls back to the built-in default when overrides is empty', () => {
+    expect(resolveTerminalBackground({})).toBe(TERMINAL_DEFAULT_COLORS.background);
+  });
+
+  it('falls back to the built-in default when background is an empty string', () => {
+    // Deliberately NOT honored: an empty string is an invalid color, so the
+    // `||` fallback (not `??`) must treat it the same as "unset".
+    expect(resolveTerminalBackground({ background: '' })).toBe(TERMINAL_DEFAULT_COLORS.background);
+  });
+
+  it('honors the user override when set', () => {
+    expect(resolveTerminalBackground({ background: '#ff0000' })).toBe('#ff0000');
+  });
+
+  it('pins the built-in default hex value itself', () => {
+    // Locks the actual default so a change to TERMINAL_DEFAULT_COLORS.background
+    // is a deliberate, visible diff in this test rather than silently drifting.
+    expect(TERMINAL_DEFAULT_COLORS.background).toBe('#0c0c0c');
+  });
+});


### PR DESCRIPTION
## What

Replaces the terminal's app-theme-tracking background (`#18181b`, byte-identical to `--kng-surface` on the Dark theme) and ad-hoc Tailwind ANSI colors with:

- A fixed near-black background (`#0c0c0c`) and a 16-color ANSI palette based on Windows Terminal's Campbell scheme, so the terminal reads as a real terminal rather than an app panel.
- A fix for the container/viewport seam: the host container and replay veil now resolve the same background as the live xterm theme via `resolveTerminalBackground()`, and `.xterm-viewport` is transparent, so no sub-cell strip along the right/bottom edge shows a mismatched color during resize.
- User-customizable Background/Foreground/Cursor colors, in Settings > Layout tab's "Terminal" section (global across all projects - the 16-color ANSI palette itself stays a fixed built-in scheme, not exposed for per-color editing).
- Live-apply: font family/size, cursor style, scrollback lines, and the new colors now apply to an already-open terminal immediately, matching how the app theme applies live, instead of requiring the terminal to be reopened.
- Color picker presets show the field's actual default first, then the current app theme's matching color (skipped when it would duplicate the default), then curated generic presets - always exactly 11 presets so the grid never spills a third row.

Affected components: `useTerminal.ts` (theme construction + live-apply), `TerminalTab.tsx` / `CommandTerminalWindow.tsx` (background resolution), the Settings `LayoutTab`/`AppSettingsPanel`/`settings-registry` (new Terminal Colors UI), `ColorPickerPopover` (added an optional `presetColors` override, reused rather than rebuilt), `config-manager.ts` (`terminal.colors` as a dictionary-style config field).

## Why

The terminal background was never a deliberate choice - it inherited the app's zinc-900 surface color from before the theming system existed, and the ANSI palette was Tailwind hues rather than a real terminal scheme.

## How

- `background`/`foreground`/`cursor` are the only user-customizable slots; the ANSI palette is fixed (most users want to set their overall look, not tune individual ANSI codes - confirmed via primary-source research that xterm.js's renderer bypasses the theme entirely for truecolor (`CM_RGB`) cells anyway, which is most of what Claude Code emits, so per-ANSI-color customization would have limited visible effect for that agent).
- Terminal Colors lives in the Layout tab (a `SYSTEM`-categorized, always-global tab) rather than Theme (a `PROJECT`-categorized tab), after discovering a global-only setting placed in a project tab is both mis-categorized and unreachable when no project is open.
- `THEME_FOREGROUNDS` was added alongside the existing `THEME_BACKGROUNDS` so the color-picker presets can offer "match my current app theme" as a quick pick, mirroring how the terminal's colors historically *were* just the app theme's colors before this feature existed.
- A follow-up task was filed on the Kangentic board to reconsider the broader Settings tab organization (Project vs System split), since this work surfaced that Layout has accumulated several unrelated concerns over time.

## Breaking changes

None. `terminal.colors` defaults to `{}` (falls back to the new built-in near-black/Campbell-based scheme) for all existing configs.

## Tests

- Unit: `resolve-terminal-background.test.ts`, `build-terminal-theme.test.ts`, `layout-tab-terminal-color-presets.test.ts` (new); `config-manager.test.ts` and `config-overridable-subset.test.ts` extended for `terminal.colors` dictionary-replace and global-only-scope semantics.
- UI: `settings-panel.spec.ts` extended for the Layout tab's Terminal Colors swatches and picker; `terminal-replay-veil.spec.ts` extended to assert the viewport's computed background is transparent.
- Manually verified in a live preview: background/foreground/cursor customization, live-apply to an already-open terminal, theme-match preset behavior across multiple app themes, and the Settings tab relocation.

Generated with [Claude Code](https://claude.com/claude-code)
