### PR TITLE
fix(terminal): paint LaunchOverlay with the resolved terminal background

### DIFF
--- a/src/renderer/components/LaunchOverlay.tsx
+++ b/src/renderer/components/LaunchOverlay.tsx
@@ -1,20 +1,57 @@
 import { Loader2 } from 'lucide-react';
+import { useConfigStore } from '../stores/config-store';
+import { resolveTerminalBackground, resolveTerminalForeground } from '../hooks/useTerminal';
 
 interface LaunchOverlayProps {
   label: string;
+  /** 'surface' (default): the board card's launch treatment - a muted spinner
+   *  + label on the app's theme surface color. Used for the two pre-terminal
+   *  panes in TaskDetailBody.tsx, which have no terminal underneath.
+   *  'terminal': paints the resolved terminal background/foreground instead,
+   *  so a surface covering a not-yet-ready terminal (TerminalTab,
+   *  CommandTerminalWindow) matches the terminal it is about to reveal - no
+   *  color swap when the overlay lifts. */
+  variant?: 'surface' | 'terminal';
 }
 
+/** Dim applied to the label in the 'terminal' variant. The surface variant gets
+ *  its muted look from the `text-fg-muted` theme token, but the terminal palette
+ *  has no muted counterpart (TerminalColorOverrides exposes only background /
+ *  foreground / cursor), so the resolved foreground is dimmed instead to read the
+ *  same way. Tuned against the default #e4e4e7-on-#0c0c0c pairing. */
+const TERMINAL_LABEL_MUTED_OPACITY = 0.7;
+
 /**
- * Full-size, muted loading overlay for a terminal surface that is still starting
- * up: worktree creation, CLI boot, command-terminal spawn, or a resume. Mirrors
+ * Full-size loading overlay for a terminal surface that is still starting up:
+ * worktree creation, CLI boot, command-terminal spawn, or a resume. Mirrors
  * the board card's launch treatment - a centered muted spinner + the status
- * label on the terminal's surface background - so the dialog and the card read
- * the same during launch.
+ * label - so the dialog and the card read the same during launch. The
+ * 'terminal' variant paints the resolved terminal background/foreground
+ * (see useTerminal.ts) instead of the theme surface, for call sites that
+ * directly precede a terminal in the same spot.
  */
-export function LaunchOverlay({ label }: LaunchOverlayProps) {
+export function LaunchOverlay({ label, variant = 'surface' }: LaunchOverlayProps) {
+  const terminalColors = useConfigStore((state) => state.config.terminal.colors);
+  // The two variants share the same markup and differ only in how the two color
+  // slots are sourced: theme tokens (Tailwind classes) vs the resolved terminal
+  // palette (inline styles). Kept as one tree so a change to the spinner, the
+  // spacing, or the test id cannot land on only one of them.
+  const paintsTerminalColors = variant === 'terminal';
+
   return (
-    <div data-testid="launch-overlay" className="absolute inset-0 z-10 flex items-center justify-center bg-surface">
-      <span className="flex items-center gap-2 text-sm text-fg-muted">
+    <div
+      data-testid="launch-overlay"
+      className={`absolute inset-0 z-10 flex items-center justify-center${paintsTerminalColors ? '' : ' bg-surface'}`}
+      style={paintsTerminalColors ? { backgroundColor: resolveTerminalBackground(terminalColors) } : undefined}
+    >
+      <span
+        className={`flex items-center gap-2 text-sm${paintsTerminalColors ? '' : ' text-fg-muted'}`}
+        style={
+          paintsTerminalColors
+            ? { color: resolveTerminalForeground(terminalColors), opacity: TERMINAL_LABEL_MUTED_OPACITY }
+            : undefined
+        }
+      >
         <Loader2 size={14} className="animate-spin" />
         {label}
       </span>

--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -690,7 +690,7 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
             the stale (too-wide) size and never reduces columns. overflow-hidden clips
             the brief pre-fit overflow. Mirrors the Changes panel sibling. */}
         <div className={`${changesOpen ? 'w-1/2' : 'flex-1'} relative min-w-0 overflow-hidden`} style={{ backgroundColor: resolveTerminalBackground(config.terminal.colors) }}>
-          {!terminalReady && <LaunchOverlay label="Starting Command Terminal..." />}
+          {!terminalReady && <LaunchOverlay label="Starting Command Terminal..." variant="terminal" />}
           <FileDropOverlay {...fileDrop} />
           <div
             ref={terminalRef}

--- a/src/renderer/components/terminal/TerminalTab.tsx
+++ b/src/renderer/components/terminal/TerminalTab.tsx
@@ -269,7 +269,7 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
       {/* Placeholder overlay while Claude CLI is loading (before first usage report).
           Stays visible until scrollback replay + clear are both done.
           z-10 ensures it paints above xterm's WebGL canvas layers. */}
-      {!terminalReady && <LaunchOverlay label={overlayLabel} />}
+      {!terminalReady && <LaunchOverlay label={overlayLabel} variant="terminal" />}
     </div>
   );
 }

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -76,6 +76,14 @@ export function resolveTerminalBackground(colors: TerminalColorOverrides | undef
   return colors?.background || TERMINAL_DEFAULT_COLORS.background;
 }
 
+/** Resolves the effective terminal foreground: the user's custom override, or
+ *  the built-in default. Mirrors resolveTerminalBackground so a surface that
+ *  must paint terminal-matching text (e.g. LaunchOverlay's terminal variant)
+ *  stays in lockstep with the live xterm theme instead of a stale constant. */
+export function resolveTerminalForeground(colors: TerminalColorOverrides | undefined): string {
+  return colors?.foreground || TERMINAL_DEFAULT_COLORS.foreground;
+}
+
 /** Builds the full xterm theme: background/foreground/cursor layer the user's
  *  overrides over the defaults; the 16-color ANSI palette is always the fixed
  *  built-in scheme (not user-customizable - see TerminalColorOverrides).
@@ -87,7 +95,7 @@ export function buildTerminalTheme(colors: TerminalColorOverrides | undefined) {
   return {
     ...TERMINAL_DEFAULT_COLORS,
     background,
-    foreground: colors?.foreground || TERMINAL_DEFAULT_COLORS.foreground,
+    foreground: resolveTerminalForeground(colors),
     cursor: colors?.cursor || TERMINAL_DEFAULT_COLORS.cursor,
     cursorAccent: background,
   };

--- a/tests/ui/command-terminal.spec.ts
+++ b/tests/ui/command-terminal.spec.ts
@@ -1154,6 +1154,43 @@ test.describe('Command Terminal', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Launch overlay (terminal variant) - CommandTerminalWindow.tsx passes
+  // variant="terminal" to LaunchOverlay so the pre-terminal shimmer is painted
+  // with the resolved terminal background instead of the theme's bg-surface (no
+  // flash when the overlay lifts and the real terminal is revealed). This is a
+  // SEPARATE call site from TerminalTab.tsx (covered by
+  // launch-overlay-terminal-surface.spec.ts) - reverting variant="terminal" here
+  // alone would go undetected by that spec.
+  // ---------------------------------------------------------------------------
+  test.describe('Launch overlay (terminal variant)', () => {
+    test('a cold command-terminal spawn paints the launch overlay with the resolved terminal background', async () => {
+      // multiTerminalPreConfig's spawnTransient never fires onFirstOutput or
+      // onUsage, so `terminalReady` (CommandTerminalWindow.tsx) stays false and
+      // the launch overlay stays mounted after the window opens - mirrors the
+      // cold-session setup in launch-overlay-terminal-surface.spec.ts.
+      const { browser, page } = await launchWithState(multiTerminalPreConfig());
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+        await page.getByTestId('quick-session-button').click();
+        const commandWindow = page.getByTestId('command-terminal-window');
+        await expect(commandWindow).toBeVisible();
+
+        const overlay = commandWindow.locator('[data-testid="launch-overlay"]');
+        await expect(overlay).toBeVisible();
+
+        // Resolved default (#0c0c0c), not the theme-tracking bg-surface color -
+        // this is the property that goes red if variant="terminal" is dropped
+        // from the CommandTerminalWindow.tsx call site.
+        const overlayBackground = await overlay.evaluate((element) => getComputedStyle(element).backgroundColor);
+        expect(overlayBackground).toBe('rgb(12, 12, 12)');
+      } finally {
+        await browser.close();
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Window population reconciliation (per project) - the headline bug fix: the
   // GLOBAL window store's population is reconciled to the CURRENT project's live
   // transient sessions on open, so a window count carried from one project never

--- a/tests/ui/launch-overlay-surface-variant.spec.ts
+++ b/tests/ui/launch-overlay-surface-variant.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * UI regression coverage for LaunchOverlay's DEFAULT `variant="surface"` at
+ * the TaskDetailBody.tsx pre-terminal pane (the "preparing" launch state -
+ * worktree creation / CLI boot before a session exists).
+ *
+ * Mirrors launch-overlay-terminal-surface.spec.ts, which proves the
+ * `variant="terminal"` wiring at TerminalTab.tsx / CommandTerminalWindow.tsx.
+ * This spec proves the OTHER side: the untouched call sites in
+ * TaskDetailBody.tsx (the `spawnLabel` pane) still get the theme-tracking
+ * `bg-surface` treatment with no inline terminal-color style. Without this
+ * test, nothing exercises LaunchOverlay's default/surface branch at all -
+ * every existing LaunchOverlay test (unit + UI) passes `variant="terminal"`
+ * explicitly, so a change to the default (or an edit to the surface branch)
+ * that silently started painting terminal colors on these panes would go
+ * undetected.
+ *
+ * Assertions target the class/inline-style discriminator (the `bg-surface`
+ * class is present; no inline backgroundColor/color/opacity style is set),
+ * not a computed rgb - `bg-surface` is a theme CSS variable that differs
+ * across the app's themes, so asserting a computed color would be
+ * theme-fragile (see .claude/rules/cross-platform-parity.md's
+ * no-pixel-exact-assertions guidance). The terminal-variant spec can assert
+ * exact rgb values because the terminal palette default is a fixed constant;
+ * the surface variant's color is not.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-overlay-surface-variant';
+const TASK_ID = 'task-overlay-surface-variant';
+const TASK_TITLE = 'Overlay Surface Variant Task';
+
+/**
+ * Launch a headless page with a project and a task pre-seeded in Code
+ * Review, with NO session (session_id null, no sessions[] entry) - the
+ * pre-session "preparing" state that TaskDetailBody.tsx's spawnLabel pane
+ * covers.
+ */
+async function launchWithState(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(`
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+
+      state.projects.push({
+        id: '${PROJECT_ID}',
+        name: 'Launch Overlay Surface Variant Test',
+        path: '/mock/${PROJECT_ID}',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+
+      var laneIds = {};
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        var id = 'lane-overlay-surface-' + i;
+        laneIds[s.name] = id;
+        state.swimlanes.push(Object.assign({}, s, { id: id, position: i, created_at: ts }));
+      });
+
+      state.tasks.push({
+        id: '${TASK_ID}',
+        display_id: 1,
+        title: '${TASK_TITLE}',
+        description: 'Task used for the launch overlay surface-variant regression test',
+        swimlane_id: laneIds['Code Review'],
+        position: 0,
+        agent: 'claude',
+        session_id: null,
+        worktree_path: null,
+        branch_name: null,
+        pr_number: null,
+        pr_url: null,
+        base_branch: null,
+        archived_at: null,
+        created_at: ts,
+        updated_at: ts,
+      });
+
+      return { currentProjectId: '${PROJECT_ID}' };
+    });
+  `);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+  return { browser, page };
+}
+
+/**
+ * Seed spawnProgress on the session store directly, driving displayKind to
+ * 'preparing' (task-progress.ts: spawnProgressLabel truthy + no session)
+ * without needing a real spawn/IPC round trip.
+ */
+async function seedSpawnProgress(page: Page, taskId: string, label: string): Promise<void> {
+  await page.evaluate(
+    ({ tid, label }) => {
+      const stores = (window as unknown as {
+        __zustandStores?: {
+          session: { getState: () => { setSpawnProgress: (id: string, label: string | null) => void } };
+        };
+      }).__zustandStores;
+      if (!stores?.session) throw new Error('session store not exposed on __zustandStores');
+      stores.session.getState().setSpawnProgress(tid, label);
+    },
+    { tid: taskId, label },
+  );
+}
+
+async function openTaskDialog(page: Page, laneName: string, taskTitle: string): Promise<ReturnType<Page['locator']>> {
+  await page.locator(`[data-swimlane-name="${laneName}"]`).waitFor({ state: 'visible', timeout: 15000 });
+  const card = page.locator(`[data-swimlane-name="${laneName}"]`).locator(`text=${taskTitle}`).first();
+  await card.click();
+  const dialog = page.locator('[data-testid="task-detail-dialog"]');
+  await dialog.waitFor({ state: 'visible', timeout: 5000 });
+  return dialog;
+}
+
+test.describe('LaunchOverlay surface-variant (default) regression', () => {
+  test('the pre-session pane keeps the theme bg-surface treatment, not inline terminal colors', async () => {
+    const { browser, page } = await launchWithState();
+    try {
+      // Seed the pre-session "preparing" state before opening the dialog so
+      // it renders the LaunchOverlay pane on first paint (no post-open wait
+      // needed).
+      await seedSpawnProgress(page, TASK_ID, 'Starting agent...');
+
+      const dialog = await openTaskDialog(page, 'Code Review', TASK_TITLE);
+      const overlay = dialog.locator('[data-testid="launch-overlay"]');
+      await expect(overlay).toBeVisible();
+      await expect(overlay).toContainText('Starting agent...');
+
+      // The default/surface variant must keep the theme-tracking class and
+      // must NOT set an inline backgroundColor - this is the property that
+      // goes red if the default variant is flipped to 'terminal' (or the
+      // surface branch starts painting inline colors).
+      const overlayClass = await overlay.evaluate((element) => element.className);
+      expect(overlayClass).toContain('bg-surface');
+      const overlayInlineBackground = await overlay.evaluate((element) => (element as HTMLElement).style.backgroundColor);
+      expect(overlayInlineBackground).toBe('');
+
+      // Same discriminator on the label: theme-tracking text-fg-muted class,
+      // no inline color/opacity style (the terminal variant's dimming trick).
+      const label = overlay.locator('span');
+      const labelClass = await label.evaluate((element) => element.className);
+      expect(labelClass).toContain('text-fg-muted');
+      const labelInlineColor = await label.evaluate((element) => (element as HTMLElement).style.color);
+      expect(labelInlineColor).toBe('');
+      const labelInlineOpacity = await label.evaluate((element) => (element as HTMLElement).style.opacity);
+      expect(labelInlineOpacity).toBe('');
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/ui/launch-overlay-terminal-surface.spec.ts
+++ b/tests/ui/launch-overlay-terminal-surface.spec.ts
@@ -1,0 +1,257 @@
+/**
+ * UI coverage for LaunchOverlay's `variant="terminal"` (TerminalTab.tsx),
+ * which paints the resolved terminal background/foreground
+ * (useTerminal.ts's resolveTerminalBackground / resolveTerminalForeground)
+ * instead of the theme-tracking `bg-surface`, so a cold terminal launch
+ * shows one continuous surface color instead of a flash when the overlay
+ * lifts and the settled xterm underneath is revealed.
+ *
+ * The session is deliberately left COLD (no markFirstOutput) so the launch
+ * overlay stays mounted and inspectable, mirroring the cold-session setup
+ * in terminal-replay-veil.spec.ts.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+interface SessionFixture {
+  projectId: string;
+  taskId: string;
+  sessionId: string;
+  taskTitle: string;
+  laneIdPrefix: string;
+}
+
+/** Wraps electronAPI.config.get/getGlobal to inject a custom terminal
+ *  background - the mock's config closure isn't exposed to __mockPreConfigure,
+ *  so this intercepts at the API boundary instead (mirrors
+ *  remember-active-task.spec.ts's configOverrides pattern). Must run BEFORE
+ *  React mounts (addInitScript), same as the pre-configure call itself. */
+function customTerminalBackgroundScript(background: string): string {
+  return `
+    (function () {
+      function injectBackground(result) {
+        result.terminal = Object.assign({}, result.terminal, {
+          colors: Object.assign({}, result.terminal && result.terminal.colors, { background: '${background}' }),
+        });
+        return result;
+      }
+      var originalGet = window.electronAPI.config.get;
+      window.electronAPI.config.get = async function () {
+        return injectBackground(await originalGet());
+      };
+      var originalGetGlobal = window.electronAPI.config.getGlobal;
+      window.electronAPI.config.getGlobal = async function () {
+        return injectBackground(await originalGetGlobal());
+      };
+    })();
+  `;
+}
+
+/** Same interception as customTerminalBackgroundScript, for the foreground slot -
+ *  proves LaunchOverlay's terminal-variant label color is wired to
+ *  resolveTerminalForeground (a live user override) rather than a hardcoded
+ *  constant that happens to match the default. */
+function customTerminalForegroundScript(foreground: string): string {
+  return `
+    (function () {
+      function injectForeground(result) {
+        result.terminal = Object.assign({}, result.terminal, {
+          colors: Object.assign({}, result.terminal && result.terminal.colors, { foreground: '${foreground}' }),
+        });
+        return result;
+      }
+      var originalGet = window.electronAPI.config.get;
+      window.electronAPI.config.get = async function () {
+        return injectForeground(await originalGet());
+      };
+      var originalGetGlobal = window.electronAPI.config.getGlobal;
+      window.electronAPI.config.getGlobal = async function () {
+        return injectForeground(await originalGetGlobal());
+      };
+    })();
+  `;
+}
+
+function basePreConfigScript(fixture: SessionFixture, extraConfig: string = ''): string {
+  return `
+    ${extraConfig}
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+
+      state.projects.push({
+        id: '${fixture.projectId}',
+        name: 'Launch Overlay Terminal Surface Test',
+        path: '/mock/${fixture.projectId}',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+
+      var laneIds = {};
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        var id = '${fixture.laneIdPrefix}-' + i;
+        laneIds[s.name] = id;
+        state.swimlanes.push(Object.assign({}, s, { id: id, position: i, created_at: ts }));
+      });
+
+      // A running session so TerminalTab mounts a real xterm (displayKind ===
+      // 'running' inside TaskDetailBody), left cold (no markFirstOutput) so
+      // the launch overlay stays showing.
+      state.sessions.push({
+        id: '${fixture.sessionId}',
+        taskId: '${fixture.taskId}',
+        projectId: '${fixture.projectId}',
+        pid: 9999,
+        status: 'running',
+        shell: 'bash',
+        cwd: '/mock/${fixture.projectId}',
+        startedAt: ts,
+        exitCode: null,
+      });
+
+      state.tasks.push({
+        id: '${fixture.taskId}',
+        display_id: 1,
+        title: '${fixture.taskTitle}',
+        description: 'Task used for the launch overlay terminal surface test',
+        swimlane_id: laneIds['Code Review'],
+        position: 0,
+        agent: 'claude',
+        session_id: '${fixture.sessionId}',
+        worktree_path: null,
+        branch_name: null,
+        pr_number: null,
+        pr_url: null,
+        base_branch: null,
+        archived_at: null,
+        created_at: ts,
+        updated_at: ts,
+      });
+
+      return { currentProjectId: '${fixture.projectId}' };
+    });
+  `;
+}
+
+async function launchWithState(extraScript: string): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(extraScript);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+  return { browser, page };
+}
+
+async function openTaskDialog(page: Page, laneName: string, taskTitle: string): Promise<ReturnType<Page['locator']>> {
+  await page.locator(`[data-swimlane-name="${laneName}"]`).waitFor({ state: 'visible', timeout: 15000 });
+  const card = page.locator(`[data-swimlane-name="${laneName}"]`).locator(`text=${taskTitle}`).first();
+  await card.click();
+  const dialog = page.locator('[data-testid="task-detail-dialog"]');
+  await dialog.waitFor({ state: 'visible', timeout: 5000 });
+  return dialog;
+}
+
+test.describe('LaunchOverlay terminal-variant surface', () => {
+  test('matches the resolved default terminal background, not the theme surface', async () => {
+    const fixture: SessionFixture = {
+      projectId: 'proj-overlay-terminal-default',
+      taskId: 'task-overlay-terminal-default',
+      sessionId: 'sess-overlay-terminal-default',
+      taskTitle: 'Overlay Terminal Default Task',
+      laneIdPrefix: 'lane-lots-default',
+    };
+    const { browser, page } = await launchWithState(basePreConfigScript(fixture));
+    try {
+      const dialog = await openTaskDialog(page, 'Code Review', fixture.taskTitle);
+      const overlay = dialog.locator('[data-testid="launch-overlay"]');
+      await expect(overlay).toBeVisible();
+
+      // Resolved default (#0c0c0c), not the theme-tracking bg-surface color -
+      // this is the property that goes red if variant="terminal" is dropped.
+      const overlayBackground = await overlay.evaluate((element) => getComputedStyle(element).backgroundColor);
+      expect(overlayBackground).toBe('rgb(12, 12, 12)');
+
+      // The overlay must match the host container it sits on top of, so
+      // there is no seam/flash the instant the overlay unmounts.
+      const container = dialog.locator('[data-testid="terminal-tab-container"]');
+      const containerBackground = await container.evaluate((element) => getComputedStyle(element).backgroundColor);
+      expect(overlayBackground).toBe(containerBackground);
+
+      // The label's resolved default foreground (#e4e4e7), not the theme-tracking
+      // text-fg-muted color - this is the property that goes red if the span's
+      // inline style is reverted to the surface variant's Tailwind class.
+      const label = overlay.locator('span');
+      const labelColor = await label.evaluate((element) => getComputedStyle(element).color);
+      expect(labelColor).toBe('rgb(228, 228, 231)');
+
+      // The terminal variant dims the label via inline opacity (no muted token
+      // in the terminal palette) - pins TERMINAL_LABEL_MUTED_OPACITY.
+      const labelOpacity = await label.evaluate((element) => getComputedStyle(element).opacity);
+      expect(labelOpacity).toBe('0.7');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('tracks a custom terminal foreground override', async () => {
+    const fixture: SessionFixture = {
+      projectId: 'proj-overlay-terminal-fg-custom',
+      taskId: 'task-overlay-terminal-fg-custom',
+      sessionId: 'sess-overlay-terminal-fg-custom',
+      taskTitle: 'Overlay Terminal Foreground Custom Task',
+      laneIdPrefix: 'lane-lots-fg-custom',
+    };
+    const { browser, page } = await launchWithState(
+      basePreConfigScript(fixture, customTerminalForegroundScript('#00ff00')),
+    );
+    try {
+      const dialog = await openTaskDialog(page, 'Code Review', fixture.taskTitle);
+      const overlay = dialog.locator('[data-testid="launch-overlay"]');
+      await expect(overlay).toBeVisible();
+
+      const label = overlay.locator('span');
+      const labelColor = await label.evaluate((element) => getComputedStyle(element).color);
+      expect(labelColor).toBe('rgb(0, 255, 0)');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('tracks a custom terminal background override', async () => {
+    const fixture: SessionFixture = {
+      projectId: 'proj-overlay-terminal-custom',
+      taskId: 'task-overlay-terminal-custom',
+      sessionId: 'sess-overlay-terminal-custom',
+      taskTitle: 'Overlay Terminal Custom Task',
+      laneIdPrefix: 'lane-lots-custom',
+    };
+    const { browser, page } = await launchWithState(
+      basePreConfigScript(fixture, customTerminalBackgroundScript('#ff00ff')),
+    );
+    try {
+      const dialog = await openTaskDialog(page, 'Code Review', fixture.taskTitle);
+      const overlay = dialog.locator('[data-testid="launch-overlay"]');
+      await expect(overlay).toBeVisible();
+
+      const overlayBackground = await overlay.evaluate((element) => getComputedStyle(element).backgroundColor);
+      expect(overlayBackground).toBe('rgb(255, 0, 255)');
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/ui/task-activity-indicators.spec.ts
+++ b/tests/ui/task-activity-indicators.spec.ts
@@ -260,8 +260,24 @@ test.describe('Task Activity Indicators', () => {
       // The old status-bar usage strip was replaced by the dashboard; the live
       // KPI layering reads the same in-memory sessionUsage. Self-cleaning for
       // the shared page: closes the dashboard before finishing.
+      //
+      // This is the only test in the file that opens the usage dashboard, so
+      // it is the first hit on the StatsDashboardBody lazy chunk in this
+      // browser (see LazyStatsDashboard.tsx / stats-lazy-retry.spec.ts). The
+      // idle warm (AppLayout's warmStatsDashboardOnIdle) races the click
+      // under CI worker/shard contention, so a genuinely cold chunk
+      // compile/fetch can leave the Suspense skeleton showing well past this
+      // test's default 15s budget - that is what produced the CI flake
+      // ("element(s) not found" on kpi-tokens, not a content mismatch: the
+      // real dashboard body, and kpi-tokens with it, simply hadn't mounted
+      // yet). Raise the test's own timeout and poll for the real body to
+      // mount (kpi-tiles only exists in the real body, never the skeleton)
+      // before asserting content, instead of assuming the chunk is warm.
+      test.setTimeout(60_000);
+
       await page.locator('[data-testid="usage-stats-button"]').click();
       await page.locator('[data-testid="stats-page"]').waitFor({ state: 'visible', timeout: 10000 });
+      await page.locator('[data-testid="kpi-tiles"]').waitFor({ state: 'visible', timeout: 40000 });
 
       const tokens = page.locator('[data-testid="kpi-tokens"]');
       const cost = page.locator('[data-testid="kpi-cost-value"]');

--- a/tests/unit/resolve-terminal-foreground.test.ts
+++ b/tests/unit/resolve-terminal-foreground.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for resolveTerminalForeground (src/renderer/hooks/useTerminal.ts).
+ *
+ * Mirrors resolve-terminal-background.test.ts: a surface that must paint
+ * terminal-matching text (e.g. LaunchOverlay's terminal variant) calls this
+ * function so it never drifts from the user's configured terminal
+ * foreground. It must return the user's override when set, and fall back to
+ * the built-in default whenever the override is absent OR is an empty string
+ * (an empty string is not a valid CSS color and must not be honored - see
+ * the `||` fallback in the source, not `??`).
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveTerminalForeground, TERMINAL_DEFAULT_COLORS } from '../../src/renderer/hooks/useTerminal';
+
+describe('resolveTerminalForeground', () => {
+  it('falls back to the built-in default when overrides is undefined', () => {
+    expect(resolveTerminalForeground(undefined)).toBe(TERMINAL_DEFAULT_COLORS.foreground);
+  });
+
+  it('falls back to the built-in default when overrides is empty', () => {
+    expect(resolveTerminalForeground({})).toBe(TERMINAL_DEFAULT_COLORS.foreground);
+  });
+
+  it('falls back to the built-in default when foreground is an empty string', () => {
+    // Deliberately NOT honored: an empty string is an invalid color, so the
+    // `||` fallback (not `??`) must treat it the same as "unset".
+    expect(resolveTerminalForeground({ foreground: '' })).toBe(TERMINAL_DEFAULT_COLORS.foreground);
+  });
+
+  it('honors the user override when set', () => {
+    expect(resolveTerminalForeground({ foreground: '#ff0000' })).toBe('#ff0000');
+  });
+
+  it('pins the built-in default hex value itself', () => {
+    // Locks the actual default so a change to TERMINAL_DEFAULT_COLORS.foreground
+    // is a deliberate, visible diff in this test rather than silently drifting.
+    expect(TERMINAL_DEFAULT_COLORS.foreground).toBe('#e4e4e7');
+  });
+});


### PR DESCRIPTION
## What

`LaunchOverlay` (`src/renderer/components/LaunchOverlay.tsx`) now supports a `variant?: 'surface' | 'terminal'` prop:

- `'surface'` (default, unchanged) - today's theme-tracking `bg-surface` + `text-fg-muted`, used at the two pre-terminal panes in `TaskDetailBody.tsx` (worktree creation / command-terminal pending states), where there is no terminal underneath.
- `'terminal'` - resolves both background and foreground from the live terminal color config (default or user-customized), via a new `resolveTerminalForeground()` helper that mirrors the existing `resolveTerminalBackground()` in `src/renderer/hooks/useTerminal.ts`.

Wired `variant="terminal"` at the two call sites that directly precede a live terminal: `src/renderer/components/terminal/TerminalTab.tsx` and `src/renderer/components/command-bar/CommandTerminalWindow.tsx`.

## Why

Follow-up from #417 (near-black terminal background + real ANSI palette). That change made the xterm background a fixed near-black (`#0c0c0c`) that no longer tracks the app theme, but `LaunchOverlay` was deliberately left painting the theme surface (`bg-surface`, e.g. `#18181b` on Dark). The result: the instant a cold terminal's overlay lifted, the surface visibly flashed from the theme color to near-black - a jump on Dark, and a much starker light-to-near-black flash on light themes.

Closes #422.

## How

`LaunchOverlay` reads `config.terminal.colors` itself (rather than taking a color prop), so there's one resolution point and no duplication across the two terminal call sites. The two pre-terminal `TaskDetailBody.tsx` panes are untouched by design (board-card launch parity, no terminal underneath to match).

Known, deliberate limitation: the task-detail `preparing` pane occupies the same visual slot the terminal later fills, so the color step there *relocates* to the `preparing` -> `running` boundary rather than disappearing. That pane intentionally keeps the theme surface (per #417's original call), and reversing it later is a one-line change now that the readability concern is solved by `resolveTerminalForeground`.

## Breaking changes

None.

## Tests

- `tests/unit/resolve-terminal-foreground.test.ts` - new resolver, mirrors `resolve-terminal-background.test.ts` (default/empty/override cases).
- `tests/ui/launch-overlay-terminal-surface.spec.ts` - TerminalTab.tsx call site: overlay's computed background/foreground match the resolved terminal colors (default and custom override), and match the host container's background (the property that catches the flash).
- `tests/ui/command-terminal.spec.ts` - new describe block covering the CommandTerminalWindow.tsx call site.
- `tests/ui/launch-overlay-surface-variant.spec.ts` - regression coverage for the untouched default `'surface'` variant on the pre-terminal `TaskDetailBody.tsx` panes.
- Plus CI's standard lint, typecheck, unit, UI (sharded), and Linux Electron E2E (sharded) checks.

Generated with [Claude Code](https://claude.com/claude-code)
