### PR TITLE
feat(terminal): add word-delete on Backspace setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,7 @@ These settings appear only in App Settings and cannot be overridden per-project:
 These settings appear in both App Settings (as defaults) and Project Settings (as overrides):
 
 - `theme`
-- `terminal.shell`, `terminal.fontSize`, `terminal.fontFamily`, `terminal.scrollbackLines`, `terminal.cursorStyle`
+- `terminal.shell`, `terminal.fontSize`, `terminal.fontFamily`, `terminal.scrollbackLines`, `terminal.cursorStyle`, `terminal.backspaceSendsCtrlH`
 - `agent.permissionMode`
 - `git.worktreesEnabled`, `git.autoCleanup`, `git.defaultBaseBranch`, `git.copyFiles`, `git.initScript`, `git.linkNodeModules`, `git.prRefreshIntervalMinutes`
 - `browser.enabled`, `browser.defaultUrl`
@@ -114,6 +114,7 @@ These settings appear in both App Settings (as defaults) and Project Settings (a
 | `terminal.panelCollapsed` | boolean | `false` | Whether the bottom terminal panel is collapsed. Global-only. |
 | `terminal.scrollbackLines` | number | `5000` | Lines kept in the visible xterm scrollback (1000-100000). Full session history is preserved separately by the main-process PTY buffer for replay regardless of this value. |
 | `terminal.cursorStyle` | `'block'` \| `'underline'` \| `'bar'` | `'block'` | Terminal cursor appearance |
+| `terminal.backspaceSendsCtrlH` | boolean | `true` | When enabled, plain Backspace sends Ctrl+H (`0x08`) instead of xterm's default Delete (`0x7f`), so Claude Code's TUI deletes the previous word instead of one character (Claude reads `0x08` as a modified backspace regardless of platform; `0x08` is the byte native Windows conhost happens to send for plain Backspace, but the setting's on-by-default behavior is not Windows-specific). Settings panel label: "Word delete on Backspace". On by default on all platforms; Ctrl+W, Alt+Backspace, and Ctrl+Backspace already word-delete regardless of this setting. |
 | `terminal.colors` | `TerminalColorOverrides` | `{}` | Custom terminal background, foreground, and cursor color, edited via color swatches in the Layout settings tab's Terminal section. Any slot left unset falls back to the built-in default: background `#0c0c0c`, foreground/cursor `#e4e4e7`. The 16-color ANSI palette (based on Windows Terminal's "Campbell" scheme) is a fixed built-in scheme, not exposed for per-color editing. `cursorAccent` always tracks the resolved background (for cursor legibility) and `selectionBackground` is a fixed app accent; neither is user-customizable. A dictionary-style field (`CONFIG_DICTIONARY_PATHS`): saved wholesale so resetting a slot actually deletes it. Global-only. |
 
 ### agent.*

--- a/src/main/config/config-manager.ts
+++ b/src/main/config/config-manager.ts
@@ -55,6 +55,7 @@ export function pickOverridableSubset(source: DeepPartial<AppConfig>): Partial<A
     fontFamily: source.terminal?.fontFamily,
     scrollbackLines: source.terminal?.scrollbackLines,
     cursorStyle: source.terminal?.cursorStyle,
+    backspaceSendsCtrlH: source.terminal?.backspaceSendsCtrlH,
   });
   if (terminal) result.terminal = terminal;
 

--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -318,6 +318,7 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
     colors: config.terminal.colors,
     shellName: commandTerminalShell ?? undefined,
     pasteImageTemplate,
+    backspaceSendsCtrlH: config.terminal.backspaceSendsCtrlH,
   });
 
   const fileDrop = useTerminalFileDrop(effectiveSessionId, focus, commandTerminalShell ?? undefined, pasteImageTemplate);

--- a/src/renderer/components/settings/settings-registry.ts
+++ b/src/renderer/components/settings/settings-registry.ts
@@ -51,6 +51,7 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
   { id: 'terminal.fontFamily', tabId: 'terminal', label: 'Font Family', description: 'CSS font-family for the terminal', scope: 'project', keywords: ['monospace', 'typeface'] },
   { id: 'terminal.scrollbackLines', tabId: 'terminal', label: 'Scrollback Lines', description: 'Lines kept in the visible scrollback. Full session history is preserved for replay regardless of this value.', scope: 'project', keywords: ['buffer', 'history'] },
   { id: 'terminal.cursorStyle', tabId: 'terminal', label: 'Cursor Style', description: 'Terminal cursor appearance', scope: 'project', keywords: ['block', 'underline', 'bar'] },
+  { id: 'terminal.backspaceSendsCtrlH', tabId: 'terminal', label: 'Word delete on Backspace', description: 'Backspace deletes the whole previous word instead of one character.', scope: 'project', keywords: ['ctrl+h', 'delete word', 'backspace', 'putty', 'windows'] },
 
   // ── Terminal > Context Bar ──
   { id: 'contextBar.showShell', tabId: 'terminal', label: 'Shell', description: 'Detected shell name', scope: 'global', section: 'Context Bar', keywords: ['context bar', 'status'] },

--- a/src/renderer/components/settings/tabs/TerminalTab.tsx
+++ b/src/renderer/components/settings/tabs/TerminalTab.tsx
@@ -1,6 +1,6 @@
 import type { AppConfig } from '../../../../shared/types';
 import { DEFAULT_CONFIG } from '../../../../shared/types';
-import { SectionHeader, SettingRow, Select, CompactToggleList, INPUT_CLASS, useScopedUpdate } from '../shared';
+import { SectionHeader, SettingRow, SettingToggleRow, Select, CompactToggleList, INPUT_CLASS, useScopedUpdate } from '../shared';
 import { settingProps } from '../settings-registry';
 
 export function TerminalTab({ config, globalConfig, shells }: {
@@ -73,6 +73,11 @@ export function TerminalTab({ config, globalConfig, shells }: {
           <option value="bar">Bar</option>
         </Select>
       </SettingRow>
+      <SettingToggleRow
+        {...settingProps('terminal.backspaceSendsCtrlH')}
+        checked={config.terminal.backspaceSendsCtrlH}
+        onChange={(value) => updateProject({ terminal: { backspaceSendsCtrlH: value } })}
+      />
       <SectionHeader
         label="Context Bar"
         searchIds={[

--- a/src/renderer/components/terminal/TerminalTab.tsx
+++ b/src/renderer/components/terminal/TerminalTab.tsx
@@ -101,6 +101,7 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
     shellName: sessionShell,
     releaseEscapeWhenPointerOutside,
     pasteImageTemplate,
+    backspaceSendsCtrlH: config.terminal.backspaceSendsCtrlH,
     onScrollbackSettled: handleScrollbackSettled,
   });
 

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -119,6 +119,11 @@ interface UseTerminalOptions {
    *  a ref (not captured at attach time) since the agent list loads asynchronously and can
    *  resolve after `enableTerminalClipboard` has already attached its key handler. */
   pasteImageTemplate?: string;
+  /** When true, plain Backspace sends Ctrl+H (0x08) instead of xterm's default
+   *  DEL (0x7f), matching native Windows conhost so Claude Code's TUI deletes
+   *  the previous word. Read live via a ref (same pattern as
+   *  pasteImageTemplate) so a settings toggle applies without remount. */
+  backspaceSendsCtrlH?: boolean;
   /** Fired every time a scrollback operation (mount replay, reload, watchdog
    *  force-recovery, or IPC-rejection recovery) settles, i.e. whenever
    *  scrollbackPendingRef flips back to false. TerminalTab uses the first
@@ -175,6 +180,10 @@ export function useTerminal(options: UseTerminalOptions) {
    *  asynchronously after the terminal has already initialized. */
   const pasteImageTemplateRef = useRef(options.pasteImageTemplate);
   pasteImageTemplateRef.current = options.pasteImageTemplate;
+  /** Updated every render (same pattern as pasteImageTemplateRef) so the key
+   *  handler attached once by initTerminal always reads the current setting. */
+  const backspaceSendsCtrlHRef = useRef(options.backspaceSendsCtrlH);
+  backspaceSendsCtrlHRef.current = options.backspaceSendsCtrlH;
   /** Updated every render (same pattern as pasteImageTemplateRef) so the settle
    *  paths attached by initTerminal/reloadScrollback always call the caller's
    *  current callback. */
@@ -265,6 +274,7 @@ export function useTerminal(options: UseTerminalOptions) {
       options.sessionId ?? undefined,
       options.releaseEscapeWhenPointerOutside,
       () => pasteImageTemplateRef.current,
+      () => backspaceSendsCtrlHRef.current ?? false,
     );
 
     terminal.onScroll(() => {

--- a/src/renderer/utils/terminal-clipboard.ts
+++ b/src/renderer/utils/terminal-clipboard.ts
@@ -237,6 +237,7 @@ async function handlePaste(
  * - Ctrl+V / Cmd+V pastes text or image from clipboard
  * - Ctrl+Shift+V also pastes from clipboard
  * - Ctrl+Enter / Cmd+Enter sends a newline for the Claude Code TUI
+ * - Backspace sends Ctrl+H (0x08) instead of DEL (0x7f), when enabled
  * - Right-click shows the browser's native context menu (with Copy)
  *
  * These combos are the embedded terminal's own; they are mirrored in the central
@@ -259,6 +260,7 @@ export function enableTerminalClipboard(
   sessionId?: string,
   releaseEscapeWhenPointerOutside?: boolean,
   getImageReferenceTemplate?: () => string | undefined,
+  getBackspaceSendsCtrlH?: () => boolean,
 ): void {
   // OSC 52 clipboard writes (write-only). Claude Code's TUI copies a selection by
   // emitting ESC]52;c;<base64>BEL alongside a fire-and-forget PowerShell Set-Clipboard;
@@ -317,6 +319,21 @@ export function enableTerminalClipboard(
     // as "new line in multiline input" rather than "submit prompt".
     if ((event.ctrlKey || event.metaKey) && event.key === 'Enter' && onWrite) {
       onWrite('\n');
+      return false;
+    }
+
+    // Backspace -> Ctrl+H (0x08) instead of xterm's default DEL (0x7f), when enabled.
+    // Native Windows conhost sends 0x08 for plain Backspace, which Claude Code's TUI
+    // reads as a modified backspace and routes to delete-word-before. Shells still
+    // treat ^H as a single-char backspace via readline/PSReadLine. Modified Backspace
+    // (Ctrl/Alt/Meta) is excluded so Ctrl+Backspace (already 0x08) and Alt+Backspace
+    // (ESC 0x7f) keep their existing behavior unchanged.
+    if (
+      event.key === 'Backspace' &&
+      !event.ctrlKey && !event.altKey && !event.metaKey &&
+      onWrite && getBackspaceSendsCtrlH?.()
+    ) {
+      onWrite('\x08');
       return false;
     }
 

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -497,6 +497,17 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     hidden: true,
   },
   {
+    id: 'terminal.backspaceCtrlH',
+    label: 'Backspace (Ctrl+H)',
+    description: 'Send Ctrl+H instead of Delete on Backspace, when enabled in Terminal settings. Handled by the terminal.',
+    group: 'Terminal',
+    scope: 'terminal',
+    defaultCombo: 'Backspace',
+    rebindable: false,
+    terminalUnsafe: true,
+    hidden: true,
+  },
+  {
     id: 'terminal.interrupt',
     label: 'Interrupt (Cancel)',
     description: 'Cancel the running command (sends SIGINT). Native terminal behavior.',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1910,6 +1910,7 @@ export interface AppConfig {
     scrollbackLines: number;
     cursorStyle: 'block' | 'underline' | 'bar';
     colors: TerminalColorOverrides; // global-only: applies across every project
+    backspaceSendsCtrlH: boolean; // send Ctrl+H (0x08) instead of DEL (0x7f) on plain Backspace; default true, all platforms
   };
 
   agent: {
@@ -2288,6 +2289,7 @@ export const DEFAULT_CONFIG: AppConfig = {
     scrollbackLines: 5000,
     cursorStyle: 'block',
     colors: {},
+    backspaceSendsCtrlH: true,
   },
   agent: {
     permissionMode: 'acceptEdits',

--- a/tests/captures/features/walkthrough.capture.ts
+++ b/tests/captures/features/walkthrough.capture.ts
@@ -128,6 +128,7 @@ test('full product walkthrough', async () => {
         scrollbackLines: 5000,
         cursorStyle: 'block',
         colors: {},
+        backspaceSendsCtrlH: true,
       },
     };
   `);

--- a/tests/captures/helpers/capture-page.ts
+++ b/tests/captures/helpers/capture-page.ts
@@ -74,6 +74,7 @@ export async function launchCapturePage(options: CaptureOptions): Promise<Captur
       scrollbackLines: 5000,
       cursorStyle: 'block',
       colors: {},
+      backspaceSendsCtrlH: true,
     },
     terminalPanelVisible: !options.hideTerminal,
   };

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -89,6 +89,7 @@
       scrollbackLines: 5000,
       cursorStyle: 'block',
       colors: {},
+      backspaceSendsCtrlH: true,
     },
     sidebar: {
       width: 224,
@@ -250,6 +251,7 @@
       fontFamily: terminal.fontFamily,
       scrollbackLines: terminal.scrollbackLines,
       cursorStyle: terminal.cursorStyle,
+      backspaceSendsCtrlH: terminal.backspaceSendsCtrlH,
     });
     if (pickedTerminal) result.terminal = pickedTerminal;
     // agent.execution is deliberately excluded - see the comment on

--- a/tests/ui/settings-panel.spec.ts
+++ b/tests/ui/settings-panel.spec.ts
@@ -133,7 +133,7 @@ test.describe('Settings Panel', () => {
     await closeSettings();
   });
 
-  test('shows Terminal tab with shell, font size, font family, scrollback, and cursor style', async () => {
+  test('shows Terminal tab with shell, font size, font family, scrollback, cursor style, and backspace behavior', async () => {
     await openSettings();
     await page.getByRole('button', { name: 'Terminal', exact: true }).click();
 
@@ -142,6 +142,10 @@ test.describe('Settings Panel', () => {
     await expect(page.getByText('Font Family', { exact: true })).toBeVisible();
     await expect(page.getByText('Scrollback Lines')).toBeVisible();
     await expect(page.getByText('Cursor Style')).toBeVisible();
+    // Word delete on Backspace (terminal.backspaceSendsCtrlH) - goes RED if the
+    // SettingToggleRow is removed from TerminalTab.tsx, while leaving all other
+    // assertions here green.
+    await expect(page.getByText('Word delete on Backspace')).toBeVisible();
     await expect(page.getByText('Context Bar')).toBeVisible();
 
     await closeSettings();
@@ -152,6 +156,34 @@ test.describe('Settings Panel', () => {
     await page.getByRole('button', { name: 'Terminal', exact: true }).click();
     await expect(page.getByText('Rate Limits', { exact: true })).toBeVisible();
     await expect(page.getByText('Claude 5h / weekly quota bars')).toBeVisible();
+    await closeSettings();
+  });
+
+  test('toggling Word delete on Backspace persists terminal.backspaceSendsCtrlH as a project override', async () => {
+    // DEFAULT_CONFIG.terminal.backspaceSendsCtrlH is true on all platforms
+    // (src/shared/types.ts), so the switch starts checked with no prior setup.
+    await openSettings();
+    await page.getByRole('button', { name: 'Terminal', exact: true }).click();
+
+    const toggle = page.getByRole('switch', { name: 'Word delete on Backspace' });
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+    await expect.poll(async () => {
+      const overrides = await page.evaluate(() => window.electronAPI.config.getProjectOverrides());
+      return overrides?.terminal?.backspaceSendsCtrlH;
+    }, { timeout: 3000 }).toBe(false);
+
+    // Toggle back on and confirm the override round-trips, restoring the
+    // default state so later tests in this shared-page file are unaffected.
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+    await expect.poll(async () => {
+      const overrides = await page.evaluate(() => window.electronAPI.config.getProjectOverrides());
+      return overrides?.terminal?.backspaceSendsCtrlH;
+    }, { timeout: 3000 }).toBe(true);
+
     await closeSettings();
   });
 

--- a/tests/unit/config-overridable-subset.test.ts
+++ b/tests/unit/config-overridable-subset.test.ts
@@ -108,6 +108,7 @@ describe('pickOverridableSubset', () => {
         fontFamily: 'Consolas',
         scrollbackLines: 1000,
         cursorStyle: 'block',
+        backspaceSendsCtrlH: true,
       },
       agent: { permissionMode: 'plan' },
       git: {
@@ -129,6 +130,7 @@ describe('pickOverridableSubset', () => {
         fontFamily: 'Consolas',
         scrollbackLines: 1000,
         cursorStyle: 'block',
+        backspaceSendsCtrlH: true,
       },
       agent: { permissionMode: 'plan' },
       git: {

--- a/tests/unit/keybindings-registry.test.ts
+++ b/tests/unit/keybindings-registry.test.ts
@@ -61,7 +61,7 @@ describe('keybinding registry hygiene', () => {
     // Cross-reference: these combos are handled in
     // src/renderer/utils/terminal-clipboard.ts. If that handler changes, update
     // both it and the registry's terminalUnsafe entries (defaultCombo + alt).
-    const expected = new Set(['Mod+C', 'Mod+Shift+C', 'Mod+V', 'Mod+Shift+V', 'Mod+Enter', 'Ctrl+C']);
+    const expected = new Set(['Mod+C', 'Mod+Shift+C', 'Mod+V', 'Mod+Shift+V', 'Mod+Enter', 'Backspace', 'Ctrl+C']);
     const actual = new Set(
       KEYBINDINGS.filter((definition) => definition.terminalUnsafe).flatMap((definition) =>
         definition.defaultComboAlt ? [definition.defaultCombo, definition.defaultComboAlt] : [definition.defaultCombo],

--- a/tests/unit/terminal-clipboard-backspace.test.ts
+++ b/tests/unit/terminal-clipboard-backspace.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Terminal } from '@xterm/xterm';
+import { enableTerminalClipboard } from '../../src/renderer/utils/terminal-clipboard';
+
+/**
+ * Unit coverage for the "Backspace sends Ctrl+H" terminal setting: plain
+ * Backspace remaps from xterm's default DEL (0x7f) to Ctrl+H (0x08) when
+ * enabled, matching native Windows conhost so Claude Code's TUI deletes the
+ * previous word instead of one character. Ctrl/Alt/Meta+Backspace are left
+ * untouched (they already produce the desired byte sequences today).
+ */
+
+type KeyEventHandler = (event: KeyboardEvent) => boolean;
+
+function captureKeyHandler(getBackspaceSendsCtrlH?: () => boolean): {
+  handler: KeyEventHandler;
+  onWrite: ReturnType<typeof vi.fn>;
+} {
+  let handler: KeyEventHandler | null = null;
+  const terminal = {
+    attachCustomKeyEventHandler: (keyEventHandler: KeyEventHandler) => { handler = keyEventHandler; },
+    parser: { registerOscHandler: () => ({ dispose() { /* noop */ } }) },
+    hasSelection: () => false,
+    getSelection: () => '',
+    cols: 80,
+  } as unknown as Terminal;
+
+  const el = {
+    querySelector: () => null,
+    addEventListener: () => undefined,
+    matches: () => false,
+  } as unknown as HTMLElement;
+
+  const onWrite = vi.fn();
+
+  enableTerminalClipboard(
+    terminal,
+    el,
+    onWrite,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    getBackspaceSendsCtrlH,
+  );
+  if (!handler) throw new Error('key handler was not registered');
+  return { handler, onWrite };
+}
+
+function backspaceKeydown(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
+  return {
+    type: 'keydown',
+    key: 'Backspace',
+    ctrlKey: false,
+    altKey: false,
+    metaKey: false,
+    shiftKey: false,
+    ...overrides,
+  } as unknown as KeyboardEvent;
+}
+
+describe('terminal Backspace-sends-Ctrl+H setting', () => {
+  it('sends Ctrl+H (0x08) and suppresses the default key when the setting is enabled', () => {
+    const { handler, onWrite } = captureKeyHandler(() => true);
+
+    const handled = handler(backspaceKeydown());
+
+    expect(handled).toBe(false);
+    expect(onWrite).toHaveBeenCalledWith('\x08');
+  });
+
+  it('leaves Backspace to xterm default (DEL) when the setting is disabled', () => {
+    const { handler, onWrite } = captureKeyHandler(() => false);
+
+    const handled = handler(backspaceKeydown());
+
+    expect(handled).toBe(true);
+    expect(onWrite).not.toHaveBeenCalled();
+  });
+
+  it('leaves Backspace to xterm default when no getter is supplied (backward-compatible default off)', () => {
+    const { handler, onWrite } = captureKeyHandler(undefined);
+
+    const handled = handler(backspaceKeydown());
+
+    expect(handled).toBe(true);
+    expect(onWrite).not.toHaveBeenCalled();
+  });
+
+  it('does not remap Ctrl+Backspace even when the setting is enabled (already sends 0x08 natively)', () => {
+    const { handler, onWrite } = captureKeyHandler(() => true);
+
+    const handled = handler(backspaceKeydown({ ctrlKey: true }));
+
+    expect(handled).toBe(true);
+    expect(onWrite).not.toHaveBeenCalled();
+  });
+
+  it('does not remap Alt+Backspace even when the setting is enabled (already sends ESC 0x7f)', () => {
+    const { handler, onWrite } = captureKeyHandler(() => true);
+
+    const handled = handler(backspaceKeydown({ altKey: true }));
+
+    expect(handled).toBe(true);
+    expect(onWrite).not.toHaveBeenCalled();
+  });
+
+  it('does not remap Meta+Backspace even when the setting is enabled', () => {
+    const { handler, onWrite } = captureKeyHandler(() => true);
+
+    const handled = handler(backspaceKeydown({ metaKey: true }));
+
+    expect(handled).toBe(true);
+    expect(onWrite).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Adds a new per-project Terminal setting, **"Word delete on Backspace"** (`AppConfig.terminal.backspaceSendsCtrlH`, default `true`, all platforms). When enabled, plain Backspace in the embedded xterm terminal sends Ctrl+H (`0x08`) instead of xterm's default DEL (`0x7f`).

Affected components: the embedded terminal's custom key handler (`terminal-clipboard.ts`), `useTerminal`, the Terminal settings tab, the settings registry, config seeding for new projects, and the keybindings conflict-checker registry.

## Why

In a native Windows PowerShell/conhost terminal, plain Backspace deletes the whole previous word inside Claude Code. In Kangentic's embedded terminal it only deleted one character, because xterm.js sends `0x7f` for plain Backspace while Windows conhost sends `0x08` - Claude Code's TUI reads `0x08` as a *modified* backspace and routes it to word-delete. This is a raw byte-encoding difference, not a Claude Code bug (see task #423).

`Ctrl+W`, `Alt+Backspace`, and `Ctrl+Backspace` already word-delete today and are untouched by this change.

Closes #423.

## How

- New branch in the `attachCustomKeyEventHandler` callback in `enableTerminalClipboard` (`terminal-clipboard.ts`), mirroring the existing Ctrl+Enter override: on unmodified `Backspace`, write `\x08` and suppress xterm's default. Guarded against Ctrl/Alt/Meta so `Ctrl+Backspace` (already `0x08`) and `Alt+Backspace` (`ESC 0x7f`) are unaffected.
- Threaded through `useTerminal` via a live ref/getter (same pattern as the existing `pasteImageTemplateRef`), so toggling the setting applies to an already-open terminal without remounting.
- New `AppConfig.terminal.backspaceSendsCtrlH` field, default `true`. No new IPC wiring: config is persisted as one JSON blob through the existing generic `config.set` / `config.setProjectOverridesByPath` channels.
- Per-project settings toggle (`SettingToggleRow` + `updateProject`, mirroring `GitTab`'s `worktreesEnabled`), registry entry, and `pickOverridableSubset` inclusion so new projects inherit it.
- New hidden, non-rebindable `terminalUnsafe` keybindings-registry entry (`Backspace`) so the Hotkeys conflict checker warns if a global shortcut is ever rebound onto bare Backspace, mirroring `terminal.sendNewline`. Confirmed no existing rebindable binding uses bare `Backspace` before adding it.

**Trade-off:** the setting is on by default on macOS/Linux too, not just Windows (matching the actual product decision made during review), even though `0x08` is historically a Windows-conhost convention. This is safe because (a) bash/zsh readline and PSReadLine already bind `^H` to the same `backward-delete-char` action as `DEL` by default, so plain shell usage is unaffected, and (b) Claude Code's TUI key-parsing is not platform-gated. The settings copy was iterated during review to avoid a stale platform-specific justification once the default became universal (see the follow-up task linked below).

**Follow-up filed:** task #425 tracks adding a house rule for settings-copy brevity/accuracy, based on how many rounds this PR's copy took to land.

## Breaking changes

None. New config key defaults to `true` but only changes Backspace behavior inside the embedded terminal; it does not touch any other input path, IPC surface, or DB schema.

## Tests

- `tests/unit/terminal-clipboard-backspace.test.ts` (new): the key-handler branch itself - enabled + plain Backspace sends `\x08` and suppresses the default; disabled or no getter falls through to default; Ctrl/Alt/Meta+Backspace are never remapped even when enabled.
- `tests/unit/keybindings-registry.test.ts`: updated the locked `terminalUnsafe` combo set to include `Backspace`.
- `tests/unit/config-overridable-subset.test.ts`: extended the "preserves the full overridable key set" fixture to cover the new key in both input and expected output.
- `tests/ui/settings-panel.spec.ts`: extended the Terminal-tab enumeration test and added a project-override persistence round-trip test (toggle -> poll `config.getProjectOverrides()`), mirroring `browser-settings.spec.ts`'s canonical pattern. Red-green validated by temporarily breaking the `onChange` wiring; ran 3x for stability.
- `npm run typecheck` and `npm run lint` clean throughout.
- CI (this PR's checks) runs the unit, UI, and Linux Electron E2E tiers.

Generated with [Claude Code](https://claude.com/claude-code)
