### PR TITLE
fix(usage): clamp context bar to 100% instead of hiding it near auto-compaction

### DIFF
--- a/src/main/activity-engine/usage-accumulator.ts
+++ b/src/main/activity-engine/usage-accumulator.ts
@@ -210,8 +210,26 @@ export class UsageAccumulator {
    * Replace the cached usage for a session outright (no merge). Used
    * by Claude's status.json reader where each parse already carries the
    * complete usage payload.
+   *
+   * Fills a zero/missing window from the account's known window for this
+   * model, mirroring setSessionUsage's merge-path fill: a status.json can
+   * omit `context_window_size` (or report 0) while still carrying real usage,
+   * which would otherwise blank the bar with no recovery until a later
+   * nonzero status. Reads the map as it stood BEFORE this call, since the
+   * caller (SessionTelemetry.processStatusUpdate) teaches the map from this
+   * same usage AFTER replacing. Unlike the merge path, an over-budget pairing
+   * (usedTokens > window) is left as-is: this snapshot is authoritative, so
+   * usedTokens > window is a legitimate critical state, not a stale seed.
    */
   replaceSessionUsage(sessionId: string, usage: SessionUsage): void {
+    const context = usage.contextWindow;
+    if (context.contextWindowSize <= 0 && context.usedTokens > 0) {
+      const knownWindow = this.getKnownWindow(usage.model.id);
+      if (knownWindow && knownWindow > 0) {
+        context.contextWindowSize = knownWindow;
+        context.usedPercentage = (context.usedTokens / knownWindow) * 100;
+      }
+    }
     // Recording the authoritative window for this model (and re-emitting any
     // sibling background sessions it back-fills) is done by the caller
     // (SessionTelemetry.processStatusUpdate) so it can push the re-emits.

--- a/src/renderer/components/board/TaskCard.tsx
+++ b/src/renderer/components/board/TaskCard.tsx
@@ -14,7 +14,7 @@ import { useBacklogStore } from '../../stores/backlog-store';
 import { useConfigStore } from '../../stores/config-store';
 import { useToastStore } from '../../stores/toast-store';
 import { useTaskProgress } from '../../utils/task-progress';
-import { isContextWindowTrusted } from '../../utils/format-tokens';
+import { isContextWindowKnown, contextWindowDisplayPercent } from '../../utils/format-tokens';
 import { requiresUserInteraction, isActive } from '../../../shared/activity-state';
 import { getProgressColor } from '../../utils/color-lerp';
 import { LabelPills } from '../Pill';
@@ -350,22 +350,29 @@ const TaskCardInner = function TaskCard({ task, isDragOverlay, compact, onDelete
               // Always render the full bar layout (model + percent + track) once
               // the model name is known, so the card height is STABLE - the bar
               // does not mount in later and shove the card taller (the boot-window
-              // jank). The bar sits at 0% until a TRUSTWORTHY window exists: a
-              // positive contextWindowSize (0 is the "unknown size" sentinel) AND
-              // usedTokens within it (usedTokens > window is impossible, so the
-              // window is wrong - never divide by a bad denominator). It animates
-              // to the real value when telemetry fills in. Gating pct on
-              // windowTrusted also guarantees the label is never > 100%.
+              // jank). The bar sits at 0% until a KNOWN window exists: a positive
+              // contextWindowSize (0 is the "unknown size" sentinel). It animates
+              // to the real value when telemetry fills in. An over-budget window
+              // (usedTokens > window, only reachable via Claude's authoritative
+              // status.json replace path) forces the percent to a full 100 rather
+              // than hiding the bar - a near-full/auto-compacting session still
+              // shows a full critical bar. The label is never > 100% because of
+              // this clamp, not because of the render gate.
               const usage = displayState.usage;
-              const windowTrusted = !!usage
-                && isContextWindowTrusted(usage.contextWindow.contextWindowSize, usage.contextWindow.usedTokens);
-              const pct = windowTrusted ? Math.round(usage?.contextWindow.usedPercentage ?? 0) : 0;
+              const windowKnown = !!usage && isContextWindowKnown(usage.contextWindow.contextWindowSize);
+              const pct = usage
+                ? contextWindowDisplayPercent(
+                    usage.contextWindow.contextWindowSize,
+                    usage.contextWindow.usedTokens,
+                    usage.contextWindow.usedPercentage ?? 0,
+                  )
+                : 0;
               const progressColor = getProgressColor(pct);
               return (
                 <div
                   className="mt-2 pt-2 border-t border-edge"
                   data-testid="usage-bar"
-                  data-context-window={windowTrusted ? undefined : 'unknown'}
+                  data-context-window={windowKnown ? undefined : 'unknown'}
                 >
                   <div className="flex items-center justify-between mb-1.5">
                     <span className="text-xs text-fg-faint truncate">

--- a/src/renderer/components/terminal/ContextBar.tsx
+++ b/src/renderer/components/terminal/ContextBar.tsx
@@ -7,7 +7,7 @@ import { useSessionStore } from '../../stores/session-store';
 import { useConfigStore } from '../../stores/config-store';
 import { getProgressColor } from '../../utils/color-lerp';
 import { windowElapsedPercentage } from '../../utils/rate-limit-window';
-import { formatTokenCount, isContextWindowTrusted } from '../../utils/format-tokens';
+import { formatTokenCount, isContextWindowKnown, contextWindowDisplayPercent } from '../../utils/format-tokens';
 import { formatCost, formatDuration } from '../../utils/format-session';
 import { formatDateTime, formatTime } from '../../lib/datetime';
 import { agentDisplayName } from '../../utils/agent-display-name';
@@ -177,7 +177,20 @@ export function ContextBar({ sessionId, agentFallback = null }: ContextBarProps)
   const outputTokens = usage?.contextWindow.totalOutputTokens;
   const tokenKey = `${inputTokens}-${outputTokens}`;
   const tokenRef = useValuePulse(tokenKey, { resetKey: sessionId });
-  const pctRef = useValuePulse(usage ? Math.round(usage.contextWindow.usedPercentage) : 0, { resetKey: sessionId });
+  // Pulse on the CLAMPED display percent, not the raw usedPercentage: an
+  // over-budget window paints a fixed "100%" while the raw value keeps climbing
+  // (105 -> 110 ...), and pulsing on the raw value would flash the pill on every
+  // status update even though the visible text never changes.
+  const pctRef = useValuePulse(
+    usage
+      ? contextWindowDisplayPercent(
+          usage.contextWindow.contextWindowSize,
+          usage.contextWindow.usedTokens ?? 0,
+          usage.contextWindow.usedPercentage,
+        )
+      : 0,
+    { resetKey: sessionId },
+  );
   const fractionRef = useValuePulse(usage?.contextWindow.usedTokens, { resetKey: sessionId });
   const rateLimitsKey = latestRateLimits
     ? latestRateLimits.rateLimits.map((limitWindow) => `${limitWindow.id}:${Math.round(limitWindow.usedPercentage)}`).join('|')
@@ -230,9 +243,6 @@ export function ContextBar({ sessionId, agentFallback = null }: ContextBarProps)
     );
   }
 
-  const pct = Math.round(usage.contextWindow.usedPercentage);
-  const progressColor = getProgressColor(pct);
-
   const modelName = resolvedModelName;
 
   // Transient (command-terminal) sessions have no task row, so the task-keyed
@@ -262,13 +272,17 @@ export function ContextBar({ sessionId, agentFallback = null }: ContextBarProps)
   const cacheTokens = usage.contextWindow.cacheTokens ?? 0;
   const { contextWindowSize } = usage.contextWindow;
 
-  // Render the context fraction/bar/percent ONLY when the window is trustworthy:
-  // a positive size (0 is the "unknown size" sentinel) AND usedTokens within it
-  // (usedTokens > window is physically impossible, so the window is wrong).
-  // Numerator and denominator both come from this one `usage.contextWindow`, so
-  // a trustworthy pairing renders and an untrustworthy one degrades to the model
-  // name only - we never render a percentage whose parts disagree.
-  const windowTrusted = isContextWindowTrusted(contextWindowSize, usedTokens);
+  // Render the context fraction/bar/percent whenever the window is KNOWN (a
+  // positive size - 0 is the "unknown size" sentinel before any window has
+  // been learned for this session's model). `pct` is the shared clamped
+  // display percentage: an over-budget pairing (usedTokens > window) is a
+  // legitimate critical state on this authoritative status.json snapshot, not a
+  // broken denominator, so contextWindowDisplayPercent forces a full 100%
+  // critical bar rather than hiding it - a near-full/auto-compacting session
+  // still shows a full bar instead of vanishing.
+  const windowKnown = isContextWindowKnown(contextWindowSize);
+  const pct = contextWindowDisplayPercent(contextWindowSize, usedTokens, usage.contextWindow.usedPercentage);
+  const progressColor = getProgressColor(pct);
 
   const barTooltip = `${formatTokenCount(cacheTokens)} cached (system) \u00b7 ${formatTokenCount(Math.max(0, usedTokens - cacheTokens))} conversation`;
 
@@ -432,11 +446,12 @@ export function ContextBar({ sessionId, agentFallback = null }: ContextBarProps)
           When only the fraction is enabled (bar off), it renders as a minimal
           pill so the toggle stays meaningful. */}
       {(() => {
-        // No bar/fraction/percent when the window is untrusted (unknown size, or
-        // an impossible usedTokens > window): show the model name only, never a
-        // bar against a bad denominator. The hidden sentinel keeps the state
-        // queryable for tests without adding a visible element.
-        if (!windowTrusted) {
+        // No bar/fraction/percent when the window is unknown (size 0, no
+        // denominator to draw a bar against): show the model name only. An
+        // over-budget window (usedTokens > size) still renders below, clamped
+        // to a full 100% critical bar rather than hidden. The hidden sentinel
+        // keeps the state queryable for tests without adding a visible element.
+        if (!windowKnown) {
           return <span data-context-window="unknown" className="hidden" />;
         }
         // Shared so the bar-embedded fraction and the bare-fraction pill render

--- a/src/renderer/utils/format-tokens.ts
+++ b/src/renderer/utils/format-tokens.ts
@@ -78,15 +78,60 @@ export function modelRowLabel(id: string, displayNames: Record<string, string>):
 }
 
 /**
- * A context-window pairing is trustworthy only when the reported window size is
- * positive (0 is the "unknown size" sentinel) AND the used-token count fits
- * within it (usedTokens > window is physically impossible, so the window is
- * wrong, never the tokens). TaskCard and ContextBar both gate their
- * fraction/bar/percent on this single predicate so the two board surfaces
- * cannot drift apart on what counts as trustworthy. The main-process
- * UsageAccumulator.setSessionUsage enforces the same invariant on the merge
- * path, where the 0 sentinel originates.
+ * A context window is known (has a real denominator to draw a bar against)
+ * only when the reported size is positive - 0 is the "unknown size" sentinel
+ * used before any window has been learned for a session's model. TaskCard and
+ * ContextBar both gate their fraction/bar/percent render on this predicate so
+ * the two board surfaces cannot drift on what counts as renderable.
  */
-export function isContextWindowTrusted(contextWindowSize: number, usedTokens: number): boolean {
-  return contextWindowSize > 0 && usedTokens <= contextWindowSize;
+export function isContextWindowKnown(contextWindowSize: number): boolean {
+  return contextWindowSize > 0;
+}
+
+/**
+ * True when usedTokens exceeds a known window - occupancy at or past
+ * auto-compaction. This is a legitimate critical state, not a broken
+ * denominator: it only ever reaches the renderer from the Claude status.json
+ * replace path (UsageAccumulator.replaceSessionUsage), where window and tokens
+ * come from one authoritative snapshot. TaskCard and ContextBar both force the
+ * displayed percent to 100 on this predicate instead of hiding the bar, so a
+ * near-full/auto-compacting session still shows a full critical bar rather
+ * than vanishing. (The merge path, UsageAccumulator.setSessionUsage, degrades
+ * an over-budget pairing to the 0 sentinel before it reaches the renderer -
+ * that protects against a stale/mismatched window seed paired with fresh
+ * transcript-fallback tokens, and is unaffected by this predicate.)
+ */
+export function isContextWindowOverBudget(contextWindowSize: number, usedTokens: number): boolean {
+  return contextWindowSize > 0 && usedTokens > contextWindowSize;
+}
+
+/**
+ * The clamped context-window percentage to DISPLAY, shared by TaskCard and
+ * ContextBar so the two board surfaces cannot drift on the number they paint
+ * (the same reason the predicates above are shared). Returns:
+ *   - 0 for an unknown window (size 0, no denominator - callers render a
+ *     reserved 0% bar or hide the segment entirely via isContextWindowKnown),
+ *   - 100 for an over-budget window (the near-full/auto-compaction critical
+ *     state - a full bar rather than a hidden one),
+ *   - otherwise the reported percentage rounded and capped at 100. Claude's
+ *     authoritative used_percentage can exceed 100 against an
+ *     auto-compact-adjusted denominator even while usedTokens still fits the
+ *     window, so the cap is load-bearing, not decorative.
+ * This computes the NUMBER only; callers still gate the render on
+ * isContextWindowKnown. Feeding both the value-pulse baseline and the rendered
+ * label through this one function keeps the pulse inert while the displayed
+ * percent holds at a clamped 100 during sustained over-budget growth.
+ */
+export function contextWindowDisplayPercent(
+  contextWindowSize: number,
+  usedTokens: number,
+  usedPercentage: number,
+): number {
+  if (!isContextWindowKnown(contextWindowSize)) {
+    return 0;
+  }
+  if (isContextWindowOverBudget(contextWindowSize, usedTokens)) {
+    return 100;
+  }
+  return Math.min(100, Math.round(usedPercentage));
 }

--- a/tests/ui/context-bar-unknown-window.spec.ts
+++ b/tests/ui/context-bar-unknown-window.spec.ts
@@ -1,16 +1,19 @@
 /**
- * UI tests for ContextBar's context-window trust gate.
+ * UI tests for ContextBar's context-window render gate.
  *
  * ContextBar (src/renderer/components/terminal/ContextBar.tsx) reads
  * `usage.contextWindow` and computes:
  *
- *   windowTrusted = contextWindowSize > 0 && usedTokens <= contextWindowSize
+ *   windowKnown = contextWindowSize > 0
+ *   overBudget = contextWindowSize > 0 && usedTokens > contextWindowSize
  *
- * When the window is untrusted (unknown size, or an impossible pairing where
- * usedTokens exceeds the reported window), the context-usage section renders
- * nothing but a hidden sentinel (`<span data-context-window="unknown"
- * className="hidden" />`) - no fraction, no bar, no percent. The model/effort
- * pills render regardless (separate cells). When the window is trusted, the
+ * When the window is unknown (size 0, no denominator to draw a bar against),
+ * the context-usage section renders nothing but a hidden sentinel (`<span
+ * data-context-window="unknown" className="hidden" />`) - no fraction, no
+ * bar, no percent. The model/effort pills render regardless (separate
+ * cells). When the window is known but over budget (usedTokens exceeds it -
+ * the near-full/auto-compaction state), the bar still renders, clamped to a
+ * full 100% critical bar instead of hiding. When usage fits comfortably, the
  * fraction pill + bar + `{pct}%` render as usual.
  *
  * Setup mirrors context-bar-popover.spec.ts's CLAUDE_RUNNING_PRECONFIG and
@@ -154,8 +157,8 @@ async function applyUsage(
   );
 }
 
-test.describe('ContextBar context-window trust gate', () => {
-  test('impossible usage (usedTokens > contextWindowSize) hides percent/fraction/bar', async () => {
+test.describe('ContextBar context-window render gate', () => {
+  test('over-budget usage (usedTokens > contextWindowSize) clamps to a full 100% critical bar', async () => {
     const { browser, page } = await launchWithState(CLAUDE_RUNNING_PRECONFIG);
     try {
       await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
@@ -180,16 +183,18 @@ test.describe('ContextBar context-window trust gate', () => {
       // Model pill renders as usual (separate cell from the context-usage section).
       await expect.poll(async () => contextBar.textContent(), { timeout: 5000 }).toMatch(/Opus 4\.8/);
 
-      // The impossible 325% and the guessed-window fraction/bar are gone: the
-      // context-usage section renders only the hidden sentinel. Assert
-      // structurally (the bar track carries a "cached (system)" title, the
-      // percent label an "N% remaining" title) rather than by raw text, because
-      // the SEPARATE tokens pill legitimately still shows the used-token count
+      // The over-budget pairing is a known window (200k, not the unknown
+      // sentinel), so the segment still renders - clamped to a full 100%
+      // critical bar rather than the impossible 325%. Assert structurally
+      // (the bar track carries a "cached (system)" title, the percent label
+      // an "N% remaining" title) rather than by raw text, because the
+      // SEPARATE tokens pill legitimately still shows the used-token count
       // ("650.4k") - that cell is not the context-window bar.
       await expect(contextBar).not.toContainText('325');
-      await expect(contextBar.locator('[data-context-window="unknown"]')).toHaveCount(1);
-      await expect(contextBar.locator('[title*="cached (system)"]')).toHaveCount(0);
-      await expect(contextBar.locator('[title*="remaining"]')).toHaveCount(0);
+      await expect(contextBar.locator('[data-context-window="unknown"]')).toHaveCount(0);
+      await expect(contextBar.locator('[title*="cached (system)"]')).toHaveCount(1);
+      await expect(contextBar.locator('[title*="remaining"]')).toHaveCount(1);
+      await expect.poll(async () => contextBar.textContent(), { timeout: 5000 }).toMatch(/100%/);
     } finally {
       await browser.close();
     }

--- a/tests/ui/cursor-context-bar.spec.ts
+++ b/tests/ui/cursor-context-bar.spec.ts
@@ -205,7 +205,7 @@ test.describe('Cursor ContextBar model pill', () => {
 
       // Same store-driven update path as the "resolves model pill" test
       // above: contextWindowSize: 0 is the "unknown size" sentinel, so
-      // windowTrusted is false and the fraction/bar/percent must not render.
+      // windowKnown is false and the fraction/bar/percent must not render.
       await page.evaluate(
         (sessionId: string) => {
           const stores = (window as unknown as {

--- a/tests/ui/task-card-context-window.spec.ts
+++ b/tests/ui/task-card-context-window.spec.ts
@@ -1,23 +1,28 @@
 /**
- * UI tests for TaskCard's board-card context-window trust gate.
+ * UI tests for TaskCard's board-card context-window render gate.
  *
  * TaskCard (src/renderer/components/board/TaskCard.tsx), the 'running'
  * bottom-bar case, computes the SAME gate as ContextBar but on its own
  * separate render path:
  *
- *   windowTrusted = contextWindowSize > 0 && usedTokens <= contextWindowSize
+ *   windowKnown = contextWindowSize > 0
+ *   overBudget = contextWindowSize > 0 && usedTokens > contextWindowSize
  *
- * When untrusted, the card footer renders `<div data-testid="usage-bar"
- * data-context-window="unknown"><span>{modelName}</span></div>` - model name
- * only, no "%" text, no bar track div. When trusted, it renders the model
- * name + `{pct}%` label + the bar track (`div.h-full.rounded-full`).
+ * When the window is unknown, the card footer renders `<div
+ * data-testid="usage-bar" data-context-window="unknown"><span>{modelName}
+ * </span></div>` with the bar reserved at 0% (stable card height) - no
+ * denominator to draw a real bar against. When the window is known but
+ * over budget (the near-full/auto-compaction state), the bar still renders,
+ * clamped to a full 100% critical bar. When usage fits comfortably, it
+ * renders the model name + `{pct}%` label + the bar track
+ * (`div.h-full.rounded-full`).
  *
  * The card must have already streamed a model displayName (else it shows the
  * "Starting agent..." spinner), so usage is seeded via a `sessions.getUsage`
  * override BEFORE mount - the same pattern task-activity-indicators.spec.ts
  * uses in its "ContextBar spinner pill" group (e.g. "shows model name with 0%
  * bar when usage exists but no tokens streamed yet"), which this spec's cases
- * extend to the impossible/consistent context-window pairing.
+ * extend to the over-budget/consistent context-window pairing.
  */
 import { test, expect } from '@playwright/test';
 import { chromium, type Browser, type Page } from '@playwright/test';
@@ -146,8 +151,8 @@ function makePreConfig(contextWindow: ContextWindowPatch): string {
   `;
 }
 
-test.describe('TaskCard context-window trust gate', () => {
-  test('impossible usage (usedTokens > contextWindowSize) shows a 0% bar, never the impossible percent', async () => {
+test.describe('TaskCard context-window render gate', () => {
+  test('over-budget usage (usedTokens > contextWindowSize) shows a full 100% critical bar', async () => {
     const { browser, page } = await launchWithState(makePreConfig({
       usedPercentage: 325,
       usedTokens: 650398,
@@ -163,11 +168,12 @@ test.describe('TaskCard context-window trust gate', () => {
       await expect(usageBar).toBeVisible({ timeout: 10000 });
 
       await expect(usageBar).toContainText('Opus 4.8');
-      // The bar layout is reserved (stable card height) at 0%, never the
-      // impossible 325% - the window is untrusted, so we do not divide by it.
-      await expect(usageBar).toContainText('0%');
+      // Over budget on a KNOWN window (200k) clamps to a full 100%, never the
+      // impossible 325% - this is a critical state to show, not a broken
+      // denominator to hide.
+      await expect(usageBar).toContainText('100%');
       await expect(usageBar).not.toContainText('325');
-      await expect(usageBar).toHaveAttribute('data-context-window', 'unknown');
+      await expect(usageBar).not.toHaveAttribute('data-context-window', 'unknown');
       await expect(usageBar.locator('div.h-full.rounded-full')).toHaveCount(1);
     } finally {
       await browser.close();

--- a/tests/unit/format-tokens.test.ts
+++ b/tests/unit/format-tokens.test.ts
@@ -5,7 +5,9 @@ import { describe, it, expect } from 'vitest';
 import {
   formatTokenCount,
   formatContextWindow,
-  isContextWindowTrusted,
+  isContextWindowKnown,
+  isContextWindowOverBudget,
+  contextWindowDisplayPercent,
   modelContextBadgeLabel,
   modelRowLabel,
 } from '../../src/renderer/utils/format-tokens';
@@ -50,14 +52,50 @@ describe('formatContextWindow', () => {
   });
 });
 
-describe('isContextWindowTrusted', () => {
-  it('trusts a positive window that fits the used tokens', () => {
-    expect(isContextWindowTrusted(1_000_000, 85_000)).toBe(true);
+describe('isContextWindowKnown', () => {
+  it('is known for any positive window size, regardless of usage', () => {
+    expect(isContextWindowKnown(1_000_000)).toBe(true);
+    expect(isContextWindowKnown(200_000)).toBe(true);
   });
 
-  it('rejects the 0 sentinel and an impossible over-full window', () => {
-    expect(isContextWindowTrusted(0, 85_000)).toBe(false);
-    expect(isContextWindowTrusted(200_000, 250_000)).toBe(false);
+  it('rejects the 0/negative "unknown size" sentinel', () => {
+    expect(isContextWindowKnown(0)).toBe(false);
+    expect(isContextWindowKnown(-1)).toBe(false);
+  });
+});
+
+describe('isContextWindowOverBudget', () => {
+  it('flags usedTokens exceeding a known window', () => {
+    expect(isContextWindowOverBudget(200_000, 250_000)).toBe(true);
+  });
+
+  it('is not over budget when tokens fit the window, or the window is unknown', () => {
+    expect(isContextWindowOverBudget(1_000_000, 85_000)).toBe(false);
+    expect(isContextWindowOverBudget(0, 85_000)).toBe(false);
+  });
+});
+
+describe('contextWindowDisplayPercent', () => {
+  it('rounds the reported percentage for a known, in-budget window', () => {
+    expect(contextWindowDisplayPercent(1_000_000, 85_000, 8.5)).toBe(9);
+    expect(contextWindowDisplayPercent(200_000, 130_000, 65)).toBe(65);
+  });
+
+  it('returns 0 for an unknown window regardless of the reported percentage', () => {
+    expect(contextWindowDisplayPercent(0, 100_000, 42)).toBe(0);
+    expect(contextWindowDisplayPercent(-1, 100_000, 42)).toBe(0);
+  });
+
+  it('forces 100 when usedTokens exceeds a known window', () => {
+    expect(contextWindowDisplayPercent(200_000, 250_000, 325)).toBe(100);
+  });
+
+  it('caps a known, in-budget window whose reported percentage still exceeds 100', () => {
+    // usedTokens fits the window (not over budget), but Claude's authoritative
+    // used_percentage can exceed 100 against an auto-compact-adjusted
+    // denominator. The cap keeps the label from reading e.g. 105%. Reverting the
+    // Math.min to a plain Math.round turns this case red.
+    expect(contextWindowDisplayPercent(200_000, 190_000, 105)).toBe(100);
   });
 });
 

--- a/tests/unit/format-tokens.test.ts
+++ b/tests/unit/format-tokens.test.ts
@@ -73,6 +73,13 @@ describe('isContextWindowOverBudget', () => {
     expect(isContextWindowOverBudget(1_000_000, 85_000)).toBe(false);
     expect(isContextWindowOverBudget(0, 85_000)).toBe(false);
   });
+
+  it('is not over budget when usedTokens exactly equals the window (strict >, not >=)', () => {
+    // Pins the strict-inequality boundary: a session that has used exactly its
+    // full window has not exceeded it. Flipping the predicate's `>` to `>=`
+    // would turn this red while leaving every other case in this file green.
+    expect(isContextWindowOverBudget(200_000, 200_000)).toBe(false);
+  });
 });
 
 describe('contextWindowDisplayPercent', () => {

--- a/tests/unit/session-telemetry-wiring.test.ts
+++ b/tests/unit/session-telemetry-wiring.test.ts
@@ -839,6 +839,118 @@ describe('SessionTelemetry: processStatusUpdate -> reemitBackfilled wiring', () 
 });
 
 // ---------------------------------------------------------------------------
+// Gap: processStatusUpdate -> replaceSessionUsage's own-session window fill
+// must reach the EMITTED onUsageChange callback, not just the cache
+// ---------------------------------------------------------------------------
+
+describe('SessionTelemetry: processStatusUpdate -> replaceSessionUsage own-session fill wiring', () => {
+  // UsageAccumulator.replaceSessionUsage fills a zero/missing window from the
+  // account's known window for this model (tests/unit/usage-accumulator.test.ts
+  // covers that fill directly against the accumulator). What that test cannot
+  // see is whether the fill reaches the renderer: processStatusUpdate calls
+  // `usage.toolCallCount = ...; this.usage.replaceSessionUsage(sessionId, usage);
+  // this.callbacks.onUsageChange(sessionId, usage);` - the fill only helps if
+  // it lands on the SAME `usage` object before the emit fires.
+  //
+  // Two calls, same session: the first status update establishes the known
+  // window via processStatusUpdate's own recordKnownWindow call (the real
+  // wiring path, not a direct accumulator seed); the second, for the SAME
+  // session, arrives with contextWindowSize 0 (a status.json glitch/model
+  // hiccup) but real tokens. replaceSessionUsage's fill (reading the map as it
+  // stood after call 1) should recover the window on call 2's own emit.
+  //
+  // Red-green: commenting out the fill block in
+  // UsageAccumulator.replaceSessionUsage leaves call 2's emitted usage at
+  // contextWindowSize 0, so the assertion below goes red; restoring it goes
+  // green (verified below).
+
+  let probe: MockProcessTreeProbe;
+  let rootPids: Map<string, number>;
+  let log: CallbackLog;
+  let usageChanges: Array<{ sessionId: string; usage: SessionUsage }>;
+  let telemetry: SessionTelemetry;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    probe = new MockProcessTreeProbe();
+    rootPids = new Map();
+    log = { activityChanges: [], events: [], usageChanges: [] };
+    usageChanges = [];
+    const baseCallbacks = makeCallbacks(log);
+    telemetry = new SessionTelemetry(
+      {
+        ...baseCallbacks,
+        onUsageChange: (sessionId, usage) => {
+          usageChanges.push({ sessionId, usage });
+        },
+        getSessionRootPid: (sessionId) => rootPids.get(sessionId),
+      },
+      {
+        processTreeProbe: probe,
+        disableBgShellWatcher: false,
+        activityEngineOptions: {
+          bgShellEscapeHatchMs: 60_000,
+          staleThinkingTimeoutMs: 60_000,
+          idleStabilityWindowMs: 0,
+        },
+      },
+    );
+  });
+
+  afterEach(() => {
+    telemetry.dispose();
+    vi.useRealTimers();
+  });
+
+  it('recovers a same-session window drop on the very emit that reports it, using the window learned on the prior call', () => {
+    const firstStatus: SessionUsage = {
+      contextWindow: {
+        usedPercentage: 10,
+        usedTokens: 100_000,
+        cacheTokens: 0,
+        totalInputTokens: 100_000,
+        totalOutputTokens: 500,
+        contextWindowSize: 1_000_000,
+      },
+      cost: { totalCostUsd: 0.05, totalDurationMs: 500 },
+      model: { id: 'claude-opus-4-8', displayName: 'Opus 4.8' },
+    };
+    telemetry.processStatusUpdate('session-x', firstStatus);
+
+    const firstEmit = usageChanges.find((entry) => entry.sessionId === 'session-x');
+    expect(firstEmit).toBeDefined();
+    expect(firstEmit!.usage.contextWindow.contextWindowSize).toBe(1_000_000);
+
+    usageChanges.length = 0;
+
+    // Second status.json for the SAME session drops the window to 0 while
+    // still carrying real tokens (200k of the same 1M window - a clean ratio,
+    // matching the hydrate wiring test's proven-float-safe 200k/1M -> 20).
+    const secondStatus: SessionUsage = {
+      contextWindow: {
+        usedPercentage: 0,
+        usedTokens: 200_000,
+        cacheTokens: 0,
+        totalInputTokens: 200_000,
+        totalOutputTokens: 600,
+        contextWindowSize: 0,
+      },
+      cost: { totalCostUsd: 0.06, totalDurationMs: 600 },
+      model: { id: 'claude-opus-4-8', displayName: 'Opus 4.8' },
+    };
+    telemetry.processStatusUpdate('session-x', secondStatus);
+
+    // Exactly one emit for session-x on this call: the fill means
+    // recordKnownWindow finds nothing left to back-fill (session-x's own cache
+    // entry IS the one being replaced), so reemitBackfilled does not also fire.
+    const secondEmits = usageChanges.filter((entry) => entry.sessionId === 'session-x');
+    expect(secondEmits).toHaveLength(1);
+    expect(secondEmits[0].usage.contextWindow.contextWindowSize).toBe(1_000_000);
+    expect(secondEmits[0].usage.contextWindow.usedPercentage).toBe(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Gap: hydrateKnownWindows - boot-time hydration from persisted metrics
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/usage-accumulator.test.ts
+++ b/tests/unit/usage-accumulator.test.ts
@@ -368,6 +368,68 @@ describe('UsageAccumulator.setSessionUsage - merge behavior', () => {
     expect(cached?.contextWindow.contextWindowSize).toBe(200_000);
     expect(cached?.contextWindow.usedPercentage).toBe(92);
   });
+
+  it('replaceSessionUsage fills a zero/missing window from a known window and recomputes the percentage', () => {
+    usage.recordKnownWindow('claude-opus-4-8', 1_000_000);
+    const zeroWindowStatus: SessionUsage = {
+      contextWindow: {
+        usedPercentage: 0,
+        usedTokens: 100_000,
+        cacheTokens: 90_000,
+        totalInputTokens: 100_000,
+        totalOutputTokens: 0,
+        contextWindowSize: 0,
+      },
+      cost: { totalCostUsd: 0, totalDurationMs: 0 },
+      model: { id: 'claude-opus-4-8', displayName: 'Opus 4.8' },
+    };
+    usage.replaceSessionUsage('zero-window-session', zeroWindowStatus);
+    const cached = usage.getSessionUsage('zero-window-session');
+    expect(cached?.contextWindow.contextWindowSize).toBe(1_000_000);
+    expect(cached?.contextWindow.usedPercentage).toBe(10);
+  });
+
+  it('replaceSessionUsage fill can itself land over budget, left for the renderer to clamp', () => {
+    usage.recordKnownWindow('claude-opus-4-8', 200_000);
+    const zeroWindowOverBudget: SessionUsage = {
+      contextWindow: {
+        usedPercentage: 0,
+        usedTokens: 250_000,
+        cacheTokens: 200_000,
+        totalInputTokens: 250_000,
+        totalOutputTokens: 0,
+        contextWindowSize: 0,
+      },
+      cost: { totalCostUsd: 0, totalDurationMs: 0 },
+      model: { id: 'claude-opus-4-8', displayName: 'Opus 4.8' },
+    };
+    usage.replaceSessionUsage('fill-over-budget-session', zeroWindowOverBudget);
+    const cached = usage.getSessionUsage('fill-over-budget-session');
+    // Filled to the known window, not degraded to 0 - the replace path never
+    // second-guesses an over-budget pairing (see the "bypasses the
+    // impossibility guard" test above); the renderer clamps the display.
+    expect(cached?.contextWindow.contextWindowSize).toBe(200_000);
+    expect(cached?.contextWindow.usedPercentage).toBe(125);
+  });
+
+  it('replaceSessionUsage leaves a zero window at 0 when no known window has been learned', () => {
+    const zeroWindowStatus: SessionUsage = {
+      contextWindow: {
+        usedPercentage: 0,
+        usedTokens: 100_000,
+        cacheTokens: 90_000,
+        totalInputTokens: 100_000,
+        totalOutputTokens: 0,
+        contextWindowSize: 0,
+      },
+      cost: { totalCostUsd: 0, totalDurationMs: 0 },
+      model: { id: 'claude-sonnet-5', displayName: 'Sonnet 5' },
+    };
+    usage.replaceSessionUsage('unlearned-session', zeroWindowStatus);
+    const cached = usage.getSessionUsage('unlearned-session');
+    expect(cached?.contextWindow.contextWindowSize).toBe(0);
+    expect(cached?.contextWindow.usedPercentage).toBe(0);
+  });
 });
 
 describe('UsageAccumulator - per-tool aggregation', () => {


### PR DESCRIPTION
## What

The context-usage bar in `ContextBar` (bottom terminal panel) and `TaskCard` (board card footer) vanished entirely - no fraction, no bar, no percent - for a session whose context occupancy exceeded its reported context window. It now renders a full, clamped 100% critical bar instead of hiding.

- `src/renderer/utils/format-tokens.ts`: replaced the single overloaded `isContextWindowTrusted` predicate with three pieces: `isContextWindowKnown` (render gate: window size > 0), `isContextWindowOverBudget` (usedTokens > window), and a new shared `contextWindowDisplayPercent` helper that returns the number to actually paint (0 for unknown, 100 for over-budget, otherwise the reported percentage rounded and capped at 100).
- `src/renderer/components/terminal/ContextBar.tsx` and `src/renderer/components/board/TaskCard.tsx`: both now render the bar whenever the window is known, and use the shared `contextWindowDisplayPercent` for the bar width, color, and label - so the two board surfaces can't drift on the number they paint. `ContextBar`'s value-pulse baseline for the percent pill also switched from the raw `usedPercentage` to the clamped display value, so a sustained over-budget session (raw percentage still climbing) doesn't flash the pill on every update when the visible "100%" text never changes.
- `src/main/activity-engine/usage-accumulator.ts`: `replaceSessionUsage` (the Claude status.json replace path) now fills a zero/missing `contextWindowSize` from the model's learned known-window and recomputes `usedPercentage`, mirroring the existing fill already done on the merge path (`setSessionUsage`).

## Why

Closes #424. Observed live on a task running Sonnet 5 mid auto-compaction (footer showed ~1.3M input tokens against a 1M window) - the indicator disappeared at exactly the moment it's most needed. Root cause: both surfaces gated the whole segment on `contextWindowSize > 0 && usedTokens <= contextWindowSize`, which fails on the `usedTokens <= contextWindowSize` clause whenever occupancy crosses the window on Claude's authoritative status.json snapshot.

An over-budget pairing (`size > 0 && used > size`) only ever reaches the renderer from that authoritative replace path - the merge path (`setSessionUsage`) already degrades an over-budget pairing to the `0` "unknown" sentinel before it reaches the renderer, as a deliberate stale-seed protection that is left untouched here. So relaxing the render gate for over-budget only ever affects internally-consistent, authoritative data.

## How

Forces the displayed percent to 100 (not the raw, possibly-over-100 reported value) when over budget, so the bar, the percent label, and the honest "used / total" fraction all read "critical/maxed" together, and the display never depends on exactly what Claude's `used_percentage` reports near compaction. Also closes a secondary, previously-unobserved branch: a status.json that omits or zeroes `context_window_size` while still carrying real usage now recovers via the same known-window fill the merge path already had.

**Deliberately out of scope:** the merge path's stale-seed degrade-to-0 protection, and whether the bucket-sum `usedTokens` (which includes cumulative `cache_read`) is the ideal numerator against the window denominator - noted as a follow-up candidate, not needed to fix the vanish.

## Breaking changes

None.

## Tests

- `tests/unit/format-tokens.test.ts`: `isContextWindowKnown`, `isContextWindowOverBudget` (including the `usedTokens === contextWindowSize` boundary), and `contextWindowDisplayPercent` (unknown/over-budget/in-budget-but-still->100%-reported cases).
- `tests/unit/usage-accumulator.test.ts`: `replaceSessionUsage` fills a zero window from a learned known-window and recomputes the percentage; leaves it at 0 with no known window; and a case where the fill itself lands over budget (left unclamped for the renderer, per the predicate split above).
- `tests/unit/session-telemetry-wiring.test.ts`: a `SessionTelemetry.processStatusUpdate` wiring test that the new fill reaches the actual emitted `onUsageChange` payload, not just the accumulator's internal cache.
- `tests/ui/context-bar-unknown-window.spec.ts` and `tests/ui/task-card-context-window.spec.ts`: inverted the previous "impossible usage hides the bar" assertions to assert a full 100% critical bar renders instead (both surfaces).
- `tests/ui/cursor-context-bar.spec.ts`: unchanged - still covers the genuine `contextWindowSize: 0` unknown-window case.

CI: typecheck, lint, unit, UI (sharded), and Linux Electron E2E (sharded) checks on this PR.

Generated with [Claude Code](https://claude.com/claude-code)
