### PR TITLE
docs(rules): add brief accurate settings/UI copy convention

### DIFF
--- a/.claude/rules/ui-conventions.md
+++ b/.claude/rules/ui-conventions.md
@@ -27,14 +27,31 @@ chrome unless these are stated.
   (`opacity-0 group-hover:opacity-100`) get overlooked and exclude keyboard / touch users.
   Prefer a right-click context menu or an always-visible control; reserve inline visible buttons
   for the single most-used primary action. Default to visual subtraction over addition.
+- **Brief, accurate copy for labels and descriptions.** State what the control does and what
+  distinguishes it - purpose plus distinguishing behavior, the way task and PR descriptions are
+  written. Plain language, no filler. Model: existing registry entries like "Lines kept in the
+  visible scrollback. Full session history is preserved for replay regardless of this value."
+  - No raw hex, byte codes, control-code literals, or escape sequences in a label or description
+    (not "Send Ctrl+H (0x08) instead of Delete (0x7F)"). Describe the behavior a user sees
+    ("Backspace deletes the whole previous word instead of one character").
+  - Do not justify a platform-agnostic (or otherwise universal) default with platform-specific or
+    otherwise scoped language ("...the way Windows terminals behave"). That justification stops
+    holding the moment the default applies everywhere, leaving the copy subtly wrong. Keep the
+    description true regardless of platform or context.
 
 ## Enforcement (self-maintaining)
 
-- **Review:** `/code-review` (Project Conventions list) flags these on renderer changes.
+- **Review:** `/code-review` flags these (Project Conventions list). Renderer changes trigger this
+  rule's `src/renderer/**` auto-load; the copy convention on adapter files
+  (`src/main/agent/adapters/**`) is caught by the always-on conventions finder instead, which runs
+  regardless of which files changed.
 - No dedicated mechanical test yet. Candidate future checks: a scan for raw `<select>` and for
-  `text-[10px]` (or smaller) under `src/renderer/`.
+  `text-[10px]` (or smaller) under `src/renderer/`; a scan of `SETTINGS_REGISTRY` label/description
+  fields for raw hex / byte-code literals (`0x`, `\x`, `\u`, `U+`).
 
 ## Scope
 
 Renderer UI under `src/renderer/`. Does not govern marketing capture fixtures
-(`tests/captures/`), which intentionally use their own font sizing for screenshots.
+(`tests/captures/`), which intentionally use their own font sizing for screenshots. The copy
+convention also applies to adapter-authored setting copy in `src/main/agent/adapters/**`, reviewed
+the same way when adapter files change.

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -121,7 +121,7 @@ These are summarized for review convenience; the authoritative, enforced version
 - Zustand stores with IPC bridge pattern
 - IPC channels defined in `src/shared/ipc-channels.ts`
 - All dialogs use global `useEffect` Escape key listener
-- Shared UI primitives: use `Select` (no raw `<select>`), `CountBadge` for counts, `ConfirmDialog` for confirmations; min font `text-[11px]`; avoid hover-only controls - see `.claude/rules/ui-conventions.md`
+- Shared UI primitives: use `Select` (no raw `<select>`), `CountBadge` for counts, `ConfirmDialog` for confirmations; min font `text-[11px]`; avoid hover-only controls; brief accurate settings/UI copy (purpose + distinguishing behavior, no raw hex/byte literals, no platform-specific justification for a universal default) - see `.claude/rules/ui-conventions.md`
 - No personal info / machine paths in committed code (repo is public) - see `.claude/rules/no-personal-info.md`
 - Dev tooling build-time excluded via `__KANGENTIC_DEV__`, not runtime-toggled - see `.claude/rules/dev-tooling-build-exclusion.md`
 - **No agent-specific code outside `src/main/agent/adapters/`.** Flag any branch on agent name (`agent === 'claude'`, `agent === 'droid'`, `taskAgent === '<x>'`, `switch (adapter.name)`, etc.) found in renderer code, IPC handlers, shared utilities, stores, or tests outside the `adapters/` tree. Adapter-specific copy, tooltips, capability decisions, and behavior must live with the adapter and surface through generic capability fields (e.g. `AgentAdapter.liveTelemetryUnsupported`, `AdapterRuntimeStrategy`, `AgentDetectionInfo` extensions). Suggested grep: `agent === '|taskAgent ===|adapter\.name ===` under `src/renderer/`, `src/shared/`, and `src/main/ipc/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ session; rules with one load when you touch matching files. Each rule names its 
 **Path-scoped rules (load with their subsystem):**
 - `task-lifecycle-lock.md` - wrap per-task async mutation in `withTaskLock` (`src/main/ipc/`).
 - `hmr-patterns.md` - dev-mode HMR parity patterns A through D (`src/renderer/`).
-- `ui-conventions.md` - shared UI primitives, selectors, font floor, no hover-only controls (`src/renderer/`).
+- `ui-conventions.md` - shared UI primitives, selectors, font floor, no hover-only controls, brief accurate copy (`src/renderer/`).
 - `synchronous-shutdown.md` - the `before-quit` path must be synchronous (`src/main/` shutdown).
 - `utc-timestamps.md` - DB writes use `new Date().toISOString()` (`src/main/db/`).
 - `ipc-7-layer-parity.md` - wire an IPC endpoint through all 7 layers.


### PR DESCRIPTION
## What

Adds a convention for brief, accurate settings/UI copy: labels and descriptions must state
purpose plus distinguishing behavior, must not contain raw hex/byte/control-code literals, and
must not justify a platform-agnostic default with platform-specific language.

## Why

Settings labels/descriptions had no stated house style, so copy drifted between two failure
modes: too technical (raw byte codes, hex) or subtly inaccurate (a justification that stops
holding once the underlying behavior changes). The motivating case: a terminal "Backspace"
setting took three rounds to land on accurate, simple copy in a prior session, first shipping
"Send Ctrl+H (0x08) instead of Delete (0x7F)..." (too technical), then keeping a Windows-terminal
justification after the default had flipped to on for every platform (platform-specific language
backing a platform-agnostic default).

## How

Folded three bullets into the existing `.claude/rules/ui-conventions.md` rather than creating a
standalone rule file: it's already a renderer-UX grab-bag where "minimum font size" and "avoid
hover-only controls" are single review-only bullets of the same weight, its `src/renderer/**`
scope already covers `settings-registry.ts` and the settings tabs, and folding respects the
project's anti-sprawl guidance. Considered and rejected an output style (wrong layer, only
changes chat voice), a skill (wrong shape, on-demand workflow), and a dedicated auditor agent
(overkill).

Also extended `.claude/skills/code-review/SKILL.md`'s Project Conventions bullet for
`ui-conventions.md`, since a rule file alone is not auto-picked-up by `/code-review` - the
universal conventions finder is seeded from that hand-maintained list. Updated the `CLAUDE.md`
index line to match.

## Breaking changes

None.

## Tests

Documentation/convention-only change, no product code or new test. Verified:
- `npm run typecheck` and `npm run lint` pass (no source touched).
- The rule bullets, the SKILL.md Project Conventions summary, and the CLAUDE.md index line all
  describe the same convention consistently.
- The new prose itself follows the rules it's adjacent to (single ASCII dashes, no em-dashes).

Generated with [Claude Code](https://claude.com/claude-code)
