### PR TITLE
fix(footer): derive agent-not-found status from agentList, not a Claude-only probe

### DIFF
--- a/.claude/agents/marketing-captures.md
+++ b/.claude/agents/marketing-captures.md
@@ -115,13 +115,18 @@ window.__mockConfigOverrides = {
 
 **IMPORTANT:** `Object.assign` is shallow — the `terminal` object must include ALL defaults, not just overrides.
 
-### Agent Detection Override
+### Agent Version Override
 
-The context bar version comes from `window.electronAPI.agent.detect()`. Override it in the fixture:
+The context bar version pill reads the agent's own entry in `agentList` (returned by
+`window.electronAPI.agents.list()`), not a separate detection probe. Override it in the fixture:
 
 ```javascript
-window.electronAPI.agent.detect = async function () {
-  return { found: true, path: '/usr/bin/claude', version: '2.1.104 (Claude Code)' };
+var origAgentsList = window.electronAPI.agents.list;
+window.electronAPI.agents.list = async function (forceRefresh) {
+  var list = await origAgentsList(forceRefresh);
+  return list.map(function (agent) {
+    return agent.name === 'claude' ? Object.assign({}, agent, { version: '2.1.104' }) : agent;
+  });
 };
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -271,10 +271,9 @@ Machine-global (like Config), not project-scoped - backs the Mobile Devices sett
 | `notification:show` | send | Show native OS notification (task name + project name) |
 | `notification:clicked` | on | User clicked a notification (includes projectId, taskId) |
 
-### Agent (3 channels)
+### Agent (2 channels)
 | Channel | Pattern | Purpose |
 |---------|---------|---------|
-| `agent:detect` | invoke | Detect agent CLI (path, version) |
 | `agent:listCommands` | invoke | List available agent commands and skills |
 | `agent:summarize` | invoke | Summarize a free-form prompt into a short task title via the active project's default agent (or `input.agentName`). Returns `{ ok, title } \| { ok: false, reason }`. Sliding-window rate limit per `AppConfig.autoNameRateLimitPerHour`. |
 
@@ -601,11 +600,11 @@ State: `sessions`, `activeSessionId`, `openTaskId`, `dialogSessionIds`, `session
 
 ### ConfigStore (`config-store.ts`)
 
-State: `config` (AppConfig), `globalConfig`, `appVersion`, `agentInfo`, `agentVersionNumber`, `gitInfo`, `settingsOpen`, `projectOverrides`
+State: `config` (AppConfig), `globalConfig`, `appVersion`, `agentList`, `gitInfo`, `settingsOpen`, `projectOverrides`
 
 - **Theme subscription** -- watches theme changes, updates `<html>` class for CSS variables.
 - **App version** -- `loadAppVersion()` fetches the Electron app version via IPC.
-- **Agent detection** -- `detectAgent()` finds CLI path and parses version string.
+- **Agent inventory** - `loadAgentList()` probes every registered agent adapter and returns per-agent found/path/version/displayName (`AgentDetectionInfo[]`); consumers look up their own agent's entry rather than reading a single Claude-only detection result.
 - **Git detection** -- `detectGit()` checks for git installation, version, and minimum version requirement.
 - **Project overrides** -- `loadProjectOverrides()`, `updateProjectOverride()`, `removeProjectOverride()` manage per-project config overrides by filesystem path.
 

--- a/src/main/diagnostics/ipc-recorder.ts
+++ b/src/main/diagnostics/ipc-recorder.ts
@@ -49,7 +49,6 @@ const SAFE_CHANNELS = new Set<string>([
   'backlog:list',
   'search:everything',
   'system:getAppVersion',
-  'system:detectAgent',
   'diagnostics:logAppend',
 ]);
 

--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -263,15 +263,6 @@ export function registerSystemHandlers(context: IpcContext): void {
     },
   );
 
-  // === Agent ===
-  ipcMain.handle(IPC.AGENT_DETECT, async () => {
-    const { agentRegistry } = await import('../../agent/agent-registry');
-    const config = context.configManager.load();
-    const claudeAdapter = agentRegistry.get('claude');
-    if (!claudeAdapter) return { found: false, path: null, version: null };
-    return claudeAdapter.detect(config.agent.cliPaths.claude ?? null);
-  });
-
   // === Agents ===
   // The inventory is cached across calls (bootstrap, welcome screen, Settings,
   // and the column manager all request it) and rebuilt only on agent-config

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -299,7 +299,6 @@ const api: ElectronAPI = {
   },
 
   agent: {
-    detect: () => ipcRenderer.invoke(IPC.AGENT_DETECT),
     listCommands: (cwd?) => ipcRenderer.invoke(IPC.AGENT_LIST_COMMANDS, cwd),
     summarize: (input) => ipcRenderer.invoke(IPC.AGENT_SUMMARIZE, input),
   },

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -40,7 +40,6 @@ export function App() {
   const currentProject = useProjectStore((s) => s.currentProject);
   const loadConfig = useConfigStore((s) => s.loadConfig);
   const loadAppVersion = useConfigStore((s) => s.loadAppVersion);
-  const detectAgent = useConfigStore((s) => s.detectAgent);
   const loadAgentList = useConfigStore((s) => s.loadAgentList);
   const detectGit = useConfigStore((s) => s.detectGit);
   const upsertSession = useSessionStore((s) => s.upsertSession);
@@ -53,7 +52,6 @@ export function App() {
     }
     loadConfig();
     loadAppVersion();
-    detectAgent();
     loadAgentList();
     detectGit();
     loadProjects();

--- a/src/renderer/components/layout/StatusBar.tsx
+++ b/src/renderer/components/layout/StatusBar.tsx
@@ -3,7 +3,6 @@ import { useSessionStore } from '../../stores/session-store';
 import { useConfigStore } from '../../stores/config-store';
 import { useBoardStore } from '../../stores/board-store';
 import { useProjectStore } from '../../stores/project-store';
-import { agentDisplayName } from '../../utils/agent-display-name';
 import { DEFAULT_AGENT } from '../../../shared/types';
 import { Pill } from '../Pill';
 
@@ -15,11 +14,12 @@ import { Pill } from '../Pill';
  */
 export function StatusBar() {
   const allSessions = useSessionStore((s) => s.sessions);
-  const agentInfo = useConfigStore((s) => s.agentInfo);
   const appVersion = useConfigStore((s) => s.appVersion);
   const tasks = useBoardStore((s) => s.tasks);
   const swimlanes = useBoardStore((s) => s.swimlanes);
   const currentProject = useProjectStore((s) => s.currentProject);
+  const agentEntry = useConfigStore((s) =>
+    s.agentList.find((agent) => agent.name === (currentProject?.default_agent ?? DEFAULT_AGENT)));
 
   const projectSessions = allSessions.filter((s) => s.projectId === currentProject?.id);
   const activeSessions = projectSessions.filter((s) => s.status === 'running').length;
@@ -55,8 +55,8 @@ export function StatusBar() {
       <div className="flex-1" />
 
       <div className="flex items-center gap-4">
-        {agentInfo && !agentInfo.found && (
-          <span className="text-red-400">{agentDisplayName(currentProject?.default_agent ?? DEFAULT_AGENT)} not found</span>
+        {agentEntry && !agentEntry.found && (
+          <span className="text-red-400" data-testid="agent-not-found">{agentEntry.displayName} not found</span>
         )}
         {appVersion && (
           <Pill size="sm" className="border border-edge text-fg-muted">v{appVersion}</Pill>

--- a/src/renderer/components/settings/AppSettingsPanel.tsx
+++ b/src/renderer/components/settings/AppSettingsPanel.tsx
@@ -89,7 +89,6 @@ export function SettingsContent({ activeTab, isSearching, searchQuery, matchingT
   const projectOverrides = useConfigStore((state) => state.projectOverrides);
   const updateConfig = useConfigStore((state) => state.updateConfig);
   const updateProjectOverride = useConfigStore((state) => state.updateProjectOverride);
-  const agentInfo = useConfigStore((state) => state.agentInfo);
   const agentList = useConfigStore((state) => state.agentList);
 
   // Effective config for per-project tabs: global merged with project overrides
@@ -112,7 +111,7 @@ export function SettingsContent({ activeTab, isSearching, searchQuery, matchingT
       case 'general': return <GeneralTab />;
       case 'theme': return <ThemeTab config={effectiveConfig} />;
       case 'terminal': return <TerminalTab config={effectiveConfig} globalConfig={globalConfig} shells={shells} fonts={fonts} />;
-      case 'agent': return <AgentTab config={effectiveConfig} globalConfig={globalConfig} agentInfo={agentInfo} agentList={agentList} />;
+      case 'agent': return <AgentTab config={effectiveConfig} globalConfig={globalConfig} agentList={agentList} />;
       case 'git': return <GitTab config={effectiveConfig} />;
       case 'browser': return <BrowserTab config={effectiveConfig} />;
       case 'shortcuts': return <ShortcutsTab />;

--- a/src/renderer/components/settings/SettingsPanel.tsx
+++ b/src/renderer/components/settings/SettingsPanel.tsx
@@ -20,7 +20,6 @@ export function SettingsPanel() {
   const openProjectSettings = useConfigStore((state) => state.openProjectSettings);
   const currentProject = useProjectStore((state) => state.currentProject);
   const projects = useProjectStore((state) => state.projects);
-  const detectAgent = useConfigStore((state) => state.detectAgent);
   const loadAgentList = useConfigStore((state) => state.loadAgentList);
 
   // Determine if we have a project context (either from sidebar gear icon or current project)
@@ -57,14 +56,13 @@ export function SettingsPanel() {
   useEffect(() => {
     window.electronAPI.shell.getAvailable().then(setShells).catch(() => {});
     window.electronAPI.font.getAvailable().then(setFonts).catch(() => {});
-    // The store already holds the agent inventory and detected-agent info from
-    // app bootstrap (App.tsx), so opening Settings does not need to re-probe -
-    // only fetch when the store is empty (e.g. opened before bootstrap settled).
-    // The Agent tab's re-detect button is the explicit fresh path.
-    const { agentList, agentInfo } = useConfigStore.getState();
-    if (!agentInfo) detectAgent();
+    // The store already holds the agent inventory from app bootstrap (App.tsx),
+    // so opening Settings does not need to re-probe - only fetch when the store
+    // is empty (e.g. opened before bootstrap settled). The Agent tab's re-detect
+    // button is the explicit fresh path.
+    const { agentList } = useConfigStore.getState();
     if (agentList.length === 0) loadAgentList();
-  }, [detectAgent, loadAgentList]);
+  }, [loadAgentList]);
 
   // When opening settings for a different project via sidebar gear icon,
   // pick up the initial tab if set.

--- a/src/renderer/components/settings/tabs/AgentTab.tsx
+++ b/src/renderer/components/settings/tabs/AgentTab.tsx
@@ -14,16 +14,11 @@ import { settingProps } from '../settings-registry';
 import { AgentExecutionFields } from './agent-execution-fields';
 import { AgentLaunchOptionFields } from './agent-launch-option-fields';
 
-export function AgentTab({ config, globalConfig, agentInfo, agentList }: {
+export function AgentTab({ config, globalConfig, agentList }: {
   config: AppConfig;
   globalConfig: AppConfig;
-  agentInfo: { found: boolean; path: string | null; version: string | null } | null;
   agentList: AgentDetectionInfo[];
 }) {
-  // agentInfo is kept in the signature for future use (e.g. surfacing the currently-detected
-  // Claude CLI details even when another agent is the project default).
-  void agentInfo;
-
   const updateGlobal = useScopedUpdate('global');
   const updateProject = useScopedUpdate('project');
   const currentProject = useProjectStore((state) => state.currentProject);

--- a/src/renderer/components/terminal/ContextBar.tsx
+++ b/src/renderer/components/terminal/ContextBar.tsx
@@ -23,6 +23,11 @@ interface ContextBarProps {
   agentFallback?: string | null;
 }
 
+/** Extract the version number from the raw string (e.g. "2.1.50 (Claude Code)" -> "2.1.50"). */
+function parseAgentVersion(version: string | null | undefined): string | null {
+  return version?.replace(/\s*\(.*\)/, '') || null;
+}
+
 const pill = 'px-2 py-0.5 rounded bg-surface-raised whitespace-nowrap select-none';
 // `[transform:translateZ(0)]` promotes the footer to its own compositing layer.
 // Without it, a freshly-spawned tiled window's frame composites such that the bar's
@@ -150,7 +155,14 @@ export function ContextBar({ sessionId, agentFallback = null }: ContextBarProps)
   const sourceAgent = useBoardStore((s) =>
     latestRateLimits ? s.tasks.find((t) => t.session_id === latestRateLimits.sourceSessionId)?.agent : undefined,
   );
-  const agentVersionNumber = useConfigStore((s) => s.agentVersionNumber);
+  // The agent's own list entry - not agentDisplayName's separate hardcoded map - so the
+  // version pill can never name one agent while showing another's version number.
+  const taskAgentDisplayName = useConfigStore(
+    (s) => s.agentList.find((a) => a.name === taskAgent)?.displayName
+  );
+  const taskAgentVersion = useConfigStore(
+    (s) => s.agentList.find((a) => a.name === taskAgent)?.version
+  );
   const contextBarConfig = useConfigStore((s) => s.config.contextBar);
   // Adapter-declared affordance for agents whose CLI exposes no live-telemetry
   // channel. Label and tooltip live with the adapter (see AgentAdapter.liveTelemetryUnsupported);
@@ -312,6 +324,7 @@ export function ContextBar({ sessionId, agentFallback = null }: ContextBarProps)
   const showRateLimits = agentReportsRateLimits
     && !!latestRateLimits && latestRateLimits.rateLimits.length > 0
     && contextBarConfig.showRateLimits;
+  const taskAgentVersionNumber = parseAgentVersion(taskAgentVersion);
 
   // No empty-state early-return: model pill is permanent (it doubles as
   // the picker trigger), so the bar always has at least one cell of content
@@ -329,9 +342,9 @@ export function ContextBar({ sessionId, agentFallback = null }: ContextBarProps)
       )}
       {showVersion && (
         <span className={`${pill} text-fg-muted`}>
-          {agentDisplayName(taskAgent)}
-          {agentVersionNumber && (
-            <span className="text-fg-faint ml-1.5">v{agentVersionNumber}</span>
+          {taskAgentDisplayName ?? agentDisplayName(taskAgent)}
+          {taskAgentVersionNumber && (
+            <span className="text-fg-faint ml-1.5">v{taskAgentVersionNumber}</span>
           )}
         </span>
       )}

--- a/src/renderer/stores/config-store.ts
+++ b/src/renderer/stores/config-store.ts
@@ -19,11 +19,6 @@ if (import.meta.hot) {
   });
 }
 
-/** Extract the version number from the raw string (e.g. "2.1.50 (Claude Code)" -> "2.1.50"). */
-function parseAgentVersion(version: string | null): string | null {
-  return version?.replace(/\s*\(.*\)/, '') || null;
-}
-
 /** Throttle for the on-demand model rescan a Model dropdown fires when it opens
  *  (`rescanModels`). Models ship rarely and each forced rescan spawns a fresh
  *  hidden /model PTY probe, so re-opening a dropdown within this window is a
@@ -64,11 +59,6 @@ interface ConfigStore {
   // -- App version --
   appVersion: string | null;
   loadAppVersion: () => Promise<void>;
-
-  // -- Agent CLI detection --
-  agentInfo: { found: boolean; path: string | null; version: string | null } | null;
-  agentVersionNumber: string | null;
-  detectAgent: () => Promise<void>;
 
   // -- Git detection --
   gitInfo: { found: boolean; path: string | null; version: string | null; meetsMinimum: boolean } | null;
@@ -187,8 +177,6 @@ export const useConfigStore = create<ConfigStore>((set, get) => {
     globalConfig: DEFAULT_CONFIG,
     appVersion: null,
     agentList: [],
-    agentInfo: null,
-    agentVersionNumber: null,
     gitInfo: null,
     loading: true,
     workspaceSeeded: false,
@@ -214,9 +202,11 @@ export const useConfigStore = create<ConfigStore>((set, get) => {
       // need to be invalidated so a future switch refetches.
       invalidateAllProjects();
       // Re-detect agents when CLI path settings change so the UI
-      // updates immediately instead of requiring an app restart.
+      // updates immediately instead of requiring an app restart. CONFIG_SET
+      // already invalidated the detection + list caches server-side, so a
+      // plain (non-forced) reload is enough to pick up the new cliPaths.
       if (partial.agent) {
-        get().detectAgent();
+        get().loadAgentList();
       }
     },
 
@@ -244,15 +234,6 @@ export const useConfigStore = create<ConfigStore>((set, get) => {
     loadAppVersion: async () => {
       const appVersion = await window.electronAPI.app.getVersion();
       set({ appVersion });
-    },
-
-    detectAgent: async () => {
-      const agentInfo = await window.electronAPI.agent.detect();
-      const version = parseAgentVersion(agentInfo?.version ?? null);
-      set({
-        agentInfo,
-        agentVersionNumber: version,
-      });
     },
 
     detectGit: async () => {

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -143,7 +143,6 @@ export const IPC = {
   KEYBINDINGS_PROBE_GLOBAL: 'keybindings:probeGlobal',
 
   // Agent
-  AGENT_DETECT: 'agent:detect',
   AGENT_LIST_COMMANDS: 'agent:listCommands',
   AGENT_SUMMARIZE: 'agent:summarize',
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3844,9 +3844,8 @@ export interface ElectronAPI {
     probeGlobal: (combos: string[]) => Promise<Record<string, 'available' | 'taken' | 'unsupported'>>;
   };
 
-  // Agent detection & commands
+  // Agent commands
   agent: {
-    detect: () => Promise<{ found: boolean; path: string | null; version: string | null }>;
     listCommands: (cwd?: string) => Promise<AgentCommand[]>;
     summarize: (input: AgentSummarizeInput) => Promise<AgentSummarizeResult>;
   };

--- a/tests/captures/helpers/marketing-fixture.ts
+++ b/tests/captures/helpers/marketing-fixture.ts
@@ -543,9 +543,15 @@ export function buildMarketingPreConfig(): string {
       return function () { clearInterval(interval); };
     };
 
-    // Override agent.detect to show correct version in context bar
-    window.electronAPI.agent.detect = async function () {
-      return { found: true, path: '/usr/bin/claude', version: '2.1.104 (Claude Code)' };
+    // Override agents.list so the context bar shows a nicer marketing
+    // version number for Claude (the ContextBar version pill reads the
+    // agent's own agentList entry, not a separate detection probe).
+    var origAgentsList = window.electronAPI.agents.list;
+    window.electronAPI.agents.list = async function (forceRefresh) {
+      var list = await origAgentsList(forceRefresh);
+      return list.map(function (agent) {
+        return agent.name === 'claude' ? Object.assign({}, agent, { version: '2.1.104' }) : agent;
+      });
     };
 
     // Override getUsage to return realistic model/cost data

--- a/tests/ui/agent-tab-force-refresh.spec.ts
+++ b/tests/ui/agent-tab-force-refresh.spec.ts
@@ -173,15 +173,14 @@ test.describe('AgentTab - re-detect button wires forceRefresh=true', () => {
     await waitForBootstrapComplete(page);
 
     // Clear the agentList so Settings open DOES trigger a loadAgentList() call
-    // (giving us a call to observe the argument on). agentInfo is also cleared
-    // so detectAgent() runs too, but we only track agents.list() (loadAgentList).
+    // (giving us a call to observe the argument on).
     await page.evaluate(() => {
       const configStore = (window as unknown as {
         __zustandStores?: {
-          config?: { setState: (partial: { agentList: unknown[]; agentInfo: null }) => void };
+          config?: { setState: (partial: { agentList: unknown[] }) => void };
         };
       }).__zustandStores?.config;
-      configStore?.setState({ agentList: [], agentInfo: null });
+      configStore?.setState({ agentList: [] });
     });
 
     // Install the call interceptor AFTER clearing the store.
@@ -205,5 +204,41 @@ test.describe('AgentTab - re-detect button wires forceRefresh=true', () => {
     expect(finalCalls.wasCalledWithTrue).toBe(false);
 
     await closeSettings(page);
+  });
+
+  test('updateConfig with a cliPaths change refreshes the agent inventory', async () => {
+    // config-store's updateConfig() calls get().loadAgentList() (a plain,
+    // non-forced reload) whenever partial.agent is present, so a CLI-path
+    // save picks up the new binary immediately instead of requiring a
+    // restart. Drive updateConfig directly against the store (no Settings UI
+    // involved) so this test pins the store-level wiring in isolation from
+    // the AgentTab input form.
+    ({ browser, page } = await launchFreshPage());
+    await createProjectAndWaitForBoard(page, 'agent-tab-cli-path-refresh');
+
+    await waitForBootstrapComplete(page);
+
+    // Install the call interceptor AFTER bootstrap so bootstrap's own
+    // agents.list() call does not contaminate the recorded state.
+    await instrumentAgentListCalls(page);
+
+    await page.evaluate(async () => {
+      const configStore = (window as unknown as {
+        __zustandStores?: {
+          config?: { getState: () => { updateConfig: (partial: unknown) => Promise<void> } };
+        };
+      }).__zustandStores?.config;
+      await configStore?.getState().updateConfig({ agent: { cliPaths: { claude: '/mock/bin/claude' } } });
+    });
+
+    // A cliPaths change must trigger at least one agents.list() call so the
+    // UI reflects the new path without a restart.
+    await expect.poll(
+      async () => {
+        const calls = await readAgentListCalls(page);
+        return calls.callCount;
+      },
+      { timeout: 3000, intervals: [200, 200, 300, 300] },
+    ).toBeGreaterThanOrEqual(1);
   });
 });

--- a/tests/ui/board-manager-agent-gate.spec.ts
+++ b/tests/ui/board-manager-agent-gate.spec.ts
@@ -137,7 +137,7 @@ test.describe('BoardManagerDialog - agents.list() load gate', () => {
 
     await waitForBootstrapComplete(page);
 
-    // Clear only agentList (BoardManagerDialog gates on agentList, not agentInfo).
+    // Clear the agentList so the gate condition triggers on next open.
     await page.evaluate(() => {
       const configStore = (window as unknown as {
         __zustandStores?: {

--- a/tests/ui/context-bar-version-pill.spec.ts
+++ b/tests/ui/context-bar-version-pill.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * UI tests for the ContextBar version pill resolving from the TASK's own
+ * agent, not a global Claude-only version number (GitHub issue #199 follow-up).
+ *
+ * Before the fix, the pill's name came from the task's agent
+ * (`agentDisplayName(taskAgent)`) but its version number came from a global,
+ * Claude-only `agentVersionNumber` field on the config store. A non-Claude
+ * task's pill could show that task's agent name paired with Claude's version
+ * number. The fix resolves BOTH the display name and the version from the
+ * same `agentList` entry keyed by the task's own agent
+ * (`s.agentList.find((a) => a.name === taskAgent)`), so they can never
+ * disagree - mirroring the same-entry-for-both-fields fix pattern used for
+ * the footer warning in `tests/ui/status-bar-agent-not-found.spec.ts`.
+ *
+ * Pattern-matched off `tests/ui/cursor-context-bar.spec.ts`: a task+session
+ * pre-seeded via `__mockPreConfigure`, with usage pushed through
+ * `session-store.updateUsage` (the same store update the real `usage` IPC
+ * event triggers) so the ContextBar renders past its "Starting agent..."
+ * spinner. `__mockAgentListOverrides` (see `tests/ui/agent-auth-warning.spec.ts`)
+ * seeds distinct claude/codex versions so a version mix-up is observable.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-context-bar-version';
+const TASK_ID = 'task-context-bar-version';
+const SESSION_ID = 'sess-context-bar-version';
+const SWIMLANE_ID = 'lane-context-bar-version-todo';
+
+// Distinct, easily-distinguishable version strings for claude vs codex so a
+// pill that accidentally showed the wrong agent's version is unmistakable.
+const CLAUDE_VERSION = '2.1.72';
+const CODEX_VERSION = '9.9.9';
+
+async function launchWithCodexTask(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  // __mockAgentListOverrides must be set before the mock script installs
+  // window.electronAPI, so agents.list() returns distinct claude/codex
+  // versions from the very first bootstrap call.
+  await page.addInitScript((overrides) => {
+    (window as unknown as { __mockAgentListOverrides?: unknown }).__mockAgentListOverrides = overrides;
+  }, {
+    claude: { found: true, path: '/usr/bin/claude', version: CLAUDE_VERSION },
+    codex: { found: true, path: '/usr/bin/codex', version: CODEX_VERSION },
+  });
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(`
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+
+      state.projects.push({
+        id: '${PROJECT_ID}',
+        name: 'Context Bar Version Test',
+        path: '/mock/context-bar-version',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        var id = i === 0 ? '${SWIMLANE_ID}' : state.uuid();
+        state.swimlanes.push({
+          id: id,
+          name: s.name,
+          role: s.role,
+          color: s.color,
+          icon: s.icon,
+          is_archived: s.is_archived,
+          permission_strategy: s.permission_strategy ?? null,
+          auto_spawn: s.auto_spawn ?? false,
+          position: i,
+          created_at: ts,
+        });
+      });
+
+      state.sessions.push({
+        id: '${SESSION_ID}',
+        taskId: '${TASK_ID}',
+        projectId: '${PROJECT_ID}',
+        pid: 9999,
+        status: 'running',
+        shell: 'bash',
+        cwd: '/mock/context-bar-version',
+        startedAt: ts,
+        exitCode: null,
+        resuming: false,
+      });
+
+      // The task's own agent is codex, distinct from the project default
+      // (claude), so a pill that fell back to a global Claude-only version
+      // would show the wrong number.
+      state.tasks.push({
+        id: '${TASK_ID}',
+        title: 'Codex Version Pill Task',
+        description: '',
+        swimlane_id: '${SWIMLANE_ID}',
+        position: 0,
+        agent: 'codex',
+        session_id: '${SESSION_ID}',
+        worktree_path: null,
+        branch_name: null,
+        pr_number: null,
+        pr_url: null,
+        base_branch: null,
+        archived_at: null,
+        created_at: ts,
+        updated_at: ts,
+      });
+
+      return { currentProjectId: '${PROJECT_ID}' };
+    });
+  `);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+  return { browser, page };
+}
+
+test.describe('ContextBar version pill resolves from the task\'s own agent', () => {
+  test('a codex task shows codex\'s own version, never claude\'s global version', async () => {
+    const { browser, page } = await launchWithCodexTask();
+    try {
+      await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+      // Bottom-panel ContextBar (disambiguated via `.min-h-8`, same pattern as
+      // tests/ui/cursor-context-bar.spec.ts and tests/ui/context-bar-popover.spec.ts).
+      const contextBar = page.locator('[data-testid="usage-bar"].min-h-8');
+      await expect(contextBar).toBeVisible({ timeout: 10000 });
+      await expect(contextBar).toContainText('Starting agent...');
+
+      // Push usage so the ContextBar renders past its spinner. Mirrors the
+      // real applyUsage -> usageTracker -> IPC 'usage' -> session-store.updateUsage
+      // path (see cursor-context-bar.spec.ts for the full rationale).
+      await page.evaluate(
+        (sessionId: string) => {
+          const stores = (window as unknown as {
+            __zustandStores?: {
+              session: { getState: () => { updateUsage: (id: string, data: unknown) => void } };
+            };
+          }).__zustandStores;
+          stores?.session.getState().updateUsage(sessionId, {
+            model: { id: 'gpt-5-codex', displayName: 'GPT-5 Codex' },
+            contextWindow: {
+              usedPercentage: 5,
+              usedTokens: 200,
+              cacheTokens: 0,
+              totalInputTokens: 150,
+              totalOutputTokens: 50,
+              contextWindowSize: 200000,
+            },
+            cost: { totalCostUsd: 0.001, totalDurationMs: 500 },
+          });
+        },
+        SESSION_ID,
+      );
+
+      await expect.poll(async () => contextBar.textContent(), { timeout: 5000 }).toMatch(/GPT-5 Codex/);
+
+      // The version pill must show codex's own version and name, never
+      // claude's. This is the regression: before the fix, the version number
+      // came from a global Claude-only field regardless of the task's agent.
+      await expect(contextBar).toContainText(`v${CODEX_VERSION}`);
+      await expect(contextBar).toContainText('Codex CLI');
+      await expect(contextBar).not.toContainText(`v${CLAUDE_VERSION}`);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -1893,9 +1893,6 @@
     },
 
     agent: {
-      detect: async function () {
-        return { found: true, path: '/usr/bin/claude', version: '2.1.72 (Claude Code)' };
-      },
       listCommands: async function (/* cwd */) {
         return [
           { name: 'code-review', displayName: '/code-review', description: 'Review code for quality and conventions', argumentHint: '', source: 'command' },

--- a/tests/ui/settings-panel-agent-gate.spec.ts
+++ b/tests/ui/settings-panel-agent-gate.spec.ts
@@ -150,10 +150,10 @@ test.describe('SettingsPanel - agents.list() load gate', () => {
     await page.evaluate(() => {
       const configStore = (window as unknown as {
         __zustandStores?: {
-          config?: { setState: (partial: { agentList: unknown[]; agentInfo: null }) => void };
+          config?: { setState: (partial: { agentList: unknown[] }) => void };
         };
       }).__zustandStores?.config;
-      configStore?.setState({ agentList: [], agentInfo: null });
+      configStore?.setState({ agentList: [] });
     });
 
     // Install the call counter AFTER clearing the store.

--- a/tests/ui/status-bar-agent-not-found.spec.ts
+++ b/tests/ui/status-bar-agent-not-found.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * UI tests for the footer's agent-not-found warning (GitHub issue #199).
+ *
+ * The footer used to build its warning from two values keyed to different
+ * agents: the condition came from a Claude-only detection probe while the
+ * noun came from the project's `default_agent`. A project defaulted to a
+ * non-Claude agent could show "<that agent> not found" even when the agent
+ * was installed and working, as long as Claude itself was missing.
+ *
+ * The fix derives both the condition and the noun from the same
+ * `agentList` entry (`s.agentList.find((a) => a.name === project.default_agent)`),
+ * so they can no longer disagree. `window.__mockAgentListOverrides` lets a
+ * test control per-agent `found` state; it must be injected before the app
+ * boots (see `tests/ui/agent-tab-auth-warning.spec.ts`).
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-status-bar-agent';
+
+async function launchWithCodexProject(agentListOverrides: Record<string, unknown>): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  // __mockAgentListOverrides must be set before the mock script installs
+  // window.electronAPI, so the renderer's bootstrap agents.list() call sees it.
+  await page.addInitScript((overrides) => {
+    (window as unknown as { __mockAgentListOverrides?: unknown }).__mockAgentListOverrides = overrides;
+  }, agentListOverrides);
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(`
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+      state.projects.push({
+        id: '${PROJECT_ID}',
+        name: 'Codex Project',
+        path: '/mock/status-bar-agent',
+        github_url: null,
+        default_agent: 'codex',
+        last_opened: ts,
+        created_at: ts,
+      });
+      return { currentProjectId: '${PROJECT_ID}' };
+    });
+  `);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+  return { browser, page };
+}
+
+/**
+ * Poll until the config store's agentList is non-empty (bootstrap agents.list()
+ * has resolved). `toBeHidden` passes immediately when an element is absent, so
+ * without this positive precondition a `toBeHidden` assertion on
+ * `[data-testid="agent-not-found"]` would pass vacuously if it ran before the
+ * bootstrap fetch resolved, proving nothing about the fix.
+ */
+async function waitForAgentListLoaded(page: Page): Promise<void> {
+  await expect.poll(
+    async () => page.evaluate(() => {
+      const configStore = (window as unknown as {
+        __zustandStores?: { config?: { getState: () => { agentList: unknown[] } } };
+      }).__zustandStores?.config;
+      return configStore?.getState().agentList.length ?? 0;
+    }),
+    { timeout: 10000, intervals: [200, 200, 200, 500] },
+  ).toBeGreaterThan(0);
+}
+
+test.describe('StatusBar agent-not-found warning', () => {
+  test('does not warn when the project default agent is found, even though Claude itself is not', async () => {
+    const { browser, page } = await launchWithCodexProject({
+      claude: { found: false, path: null, version: null },
+      codex: { found: true, path: '/usr/bin/codex', version: '1.0.0' },
+    });
+    try {
+      await page.locator('[data-testid="task-count"]').waitFor({ state: 'visible', timeout: 15000 });
+
+      // Positive precondition: prove the bootstrap agents.list() call actually
+      // resolved and populated agentList before asserting the warning is
+      // hidden, so the hidden check below cannot pass vacuously.
+      await waitForAgentListLoaded(page);
+
+      // The regression: a Claude-only detection probe fed a project-agent-labelled
+      // warning, so "Codex CLI not found" rendered even though Codex was installed.
+      await expect(page.locator('[data-testid="agent-not-found"]')).toBeHidden({ timeout: 5000 });
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('warns with the project default agent name when that agent is genuinely not found', async () => {
+    const { browser, page } = await launchWithCodexProject({
+      claude: { found: true, path: '/usr/bin/claude', version: '2.1.72' },
+      codex: { found: false, path: null, version: null },
+    });
+    try {
+      await page.locator('[data-testid="task-count"]').waitFor({ state: 'visible', timeout: 15000 });
+
+      const warning = page.locator('[data-testid="agent-not-found"]');
+      await expect(warning).toBeVisible({ timeout: 5000 });
+      await expect(warning).toHaveText('Codex CLI not found');
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/unit/hmr-resync.test.ts
+++ b/tests/unit/hmr-resync.test.ts
@@ -21,8 +21,6 @@ const APP_TSX = path.resolve(__dirname, '../../src/renderer/App.tsx');
 const EXCLUDED_METHODS = new Set([
   'loadArchivedTasks', // only loaded when archive panel is opened
   'loadAppVersion',    // static, doesn't change during a session
-  'detectAgent',       // static CLI detection, doesn't change during a session
-  'loadAgentList',     // static agent detection, doesn't change during a session
   'loadProjectOverrides', // called internally by loadConfig
   'loadShortcuts',     // called internally by loadBoard
 ]);


### PR DESCRIPTION
## What

The bottom status bar's "`<agent>` not found" warning, and the ContextBar's version pill, both used to build one displayed value out of two facts keyed to different agents. This fixes both:

- **`StatusBar`**: the footer's condition and label now both come from the same `agentList` entry (`s.agentList.find((a) => a.name === project.default_agent)`), so they can no longer disagree.
- **`ContextBar`**: the version pill's name and version number now both come from the task's own `agentList` entry, instead of the name coming from the task's agent while the version came from a separate global field.
- **Deleted `AGENT_DETECT`**: the handler was hardcoded to probe Claude only (`agentRegistry.get('claude')`), which was the root cause. It duplicated the already-correct, per-agent `AGENT_LIST` path (`agentList: AgentDetectionInfo[]`), which probes every registered adapter and already drives this same messaging in the Agent settings tab and Welcome screen. Removed across all 7 IPC layers (channel, type, preload, handler, store, mock, diagnostics allowlist) along with the renderer state it backed (`agentInfo`, `agentVersionNumber`, `detectAgent`).

## Why

GitHub issue #199: a Codex project showed a red "Codex CLI not found" in the footer while Codex was installed and running fine. Root cause: `AGENT_DETECT` always probed Claude, so on a machine without Claude but with the project's actual agent installed, the probe returned `found: false` while the label rendered the project's real (working) agent name.

Closes #199.

## How

Rather than making `AGENT_DETECT` project-aware (the task's original suggested direction), the repo already had the correct per-agent detection path (`AGENT_LIST`/`agentList`), so the fix derives both the footer's condition and its label from one `agentList` record instead of two independently-sourced values. This is structurally safer than fixing the label alone: condition and noun can never skew again, no project-switch re-detect effect is needed (the list already covers every agent), and it removes an `agent-adapters-boundary.md` violation (the hardcoded `'claude'` in a shared handler).

Along the way, caught two related mislabeling sites that would otherwise have gone stale silently:
- `AGENT_META` (the renderer's separate hardcoded display-name map) is missing `cursor`, so it rendered "Cursor" where every `agentList`-driven surface says "Cursor CLI" - `StatusBar` now sources the name from `agentList` instead, closing that gap.
- `tests/captures/helpers/marketing-fixture.ts` had a live `window.electronAPI.agent.detect` override for marketing screenshots that would have silently gone dead; updated it (and the corresponding doc in `.claude/agents/marketing-captures.md`) to patch `agents.list()` instead.

## Breaking changes

None. `window.electronAPI.agent.detect` is removed, but it had exactly one real consumer (the footer) plus a copy in the marketing-captures test fixture, both updated in this PR.

## Tests

- `tests/ui/status-bar-agent-not-found.spec.ts` (new): footer stays clean when the project's own agent is found even though Claude is not; footer warns with the correct agent name when that agent is genuinely not found. Verified red-to-green by stashing this fix and confirming the second case fails against the pre-fix code.
- `tests/ui/context-bar-version-pill.spec.ts` (new): a codex task's version pill shows codex's own version, never claude's.
- `tests/ui/agent-tab-force-refresh.spec.ts`: added a case pinning that a `cliPaths` config change triggers `loadAgentList()`.
- `tests/ui/settings-panel-agent-gate.spec.ts`, `tests/ui/board-manager-agent-gate.spec.ts`, `tests/unit/hmr-resync.test.ts`: updated for the deleted `agentInfo`/`detectAgent` state.
- Manually verified end-to-end in a running `/preview` instance (real IPC, real DB write, all 12 real agent CLIs on the dev machine) by switching a project's default agent to an uninstalled CLI and confirming the footer correctly showed "Aider not found", then reverted.
- `npm run typecheck` and `npm run lint` both clean.

Generated with [Claude Code](https://claude.com/claude-code)
