### PR TITLE
perf: stop re-parsing whole transcripts, and stop streaming a terminal nobody is watching

### DIFF
--- a/docs/mobile-bridge.md
+++ b/docs/mobile-bridge.md
@@ -231,6 +231,12 @@ Even a correctly-implemented blind relay is not metadata-invisible. A relay oper
 - Protocol: the `session-ended` activity payload and read-stream `sessionStatus`, the `register-push` verb + payloads, the E2E push envelope (`crypto/push-envelope.ts`), and optional project accent colors on the read-board payloads. All additive and wire-compatible (absent fields parse as before on older peers).
 - Desktop: `SessionLifecycleBoardFeed` (lifecycle edges onto the board-changed bus), the read-stream `session-ended` push + `sessionStatus` snapshot field, the push stack described under [Push Notifications](#push-notifications-e2e), and derived project accent colors in `read-board`.
 
+**Shipped (Protocol 0.8.0 - what a session list actually costs):**
+
+- Protocol: the read-stream subscribe `terminal` flag and the `message-preview` activity payload. Both additive and wire-compatible - absent means the previous behaviour, so an older phone and an older desktop each keep working against a newer peer.
+- Desktop: `resolveTaskTranscript` revalidates a task by `fs.stat` before parsing any session, using file signatures recorded in the stitch memo itself (not read back from the file cache, which is a bounded LRU and goes empty on a busy board); `transcript-cache.ts`'s cap raised 16 -> 64 with a 192MB byte budget; `read-stream` honours `terminal: false` by attaching neither the `data-tap` nor the `pty-resize` listener and returning an empty `scrollback` instead of building a serialized frame; `message-preview.ts` derives the one line a phone's session list renders from the transcript the subscription already resolves.
+- Why: measured from a Pixel over a LOOPBACK relay, one Home-feed refresh touched 20 transcript files totalling 319MB (a `--resume` writes a NEW file replaying its parent's whole history, so one task resumed five times owned 267MB across five near-identical files), and individual `transcript-window` requests took 0.7 to 3.8 seconds - the SMALLEST response was the slowest, because the cost was finding the entries rather than sending them. Separately, `event:terminal` streamed continuously to a phone showing no terminal at all (~13MB/hour), because every subscription carried PTY bytes the phone discards by design at its own terminal boundary.
+
 **Explicitly out of scope, later phases:**
 
 - **Bridge Phase 3 remainder:** full desktop static-key rotation and re-provisioning of remaining paired devices on revoke; fuller device-management UX beyond the per-verb toggles.

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kangentic/protocol",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Kangentic mobile bridge wire protocol: framing, Noise-based pairing and session handshakes, signed device roster, and capability verbs shared between desktop and mobile.",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/protocol/src/events/event.ts
+++ b/packages/protocol/src/events/event.ts
@@ -70,7 +70,22 @@ export type ActivityEventPayload =
    * inferring it from silence. `intentional` distinguishes a deliberate
    * stop (desktop Stop button, suspend, shutdown) from a crash.
    */
-  | { type: 'session-ended'; intentional: boolean };
+  | { type: 'session-ended'; intentional: boolean }
+  /**
+   * The agent's most recent assistant message, already collapsed to a short
+   * plain-text preview, pushed whenever it changes.
+   *
+   * A phone's session list renders exactly one line per session. Deriving it
+   * client-side cost a transcript-window request per session (measured 2.3 to
+   * 34.6 KB each, to keep a string under 200 characters) plus 0.7 to 3.8
+   * seconds of desktop work per request. The desktop already resolves the
+   * transcript to compute its delta pushes, so it can carry the line for
+   * free on a feed the phone is receiving anyway.
+   *
+   * Absent from pre-0.8.0 desktops; a phone that sees none should fall back
+   * to whatever it can derive locally rather than showing nothing.
+   */
+  | { type: 'message-preview'; text: string };
 
 export interface ActivityEvent {
   kind: 'activity';
@@ -146,6 +161,10 @@ export function parseActivityEventPayload(payload: JsonValue): ActivityEventPayl
     case 'session-ended': {
       if (typeof payload.intentional !== 'boolean') throw new Error('session-ended payload is missing "intentional"');
       return { type: 'session-ended', intentional: payload.intentional };
+    }
+    case 'message-preview': {
+      if (typeof payload.text !== 'string') throw new Error('message-preview payload is missing "text"');
+      return { type: 'message-preview', text: payload.text };
     }
     default:
       throw new Error('activity payload has an unknown "type"');

--- a/packages/protocol/src/wire/payloads.ts
+++ b/packages/protocol/src/wire/payloads.ts
@@ -58,6 +58,20 @@ export interface ReadStreamRequestPayload {
   beforeIndex?: number;
   /** transcript-window only: maximum entries wanted (the desktop may cap this and may return fewer). */
   limit?: number;
+  /**
+   * subscribe only: whether this subscription wants live PTY bytes.
+   *
+   * A phone watching its session list needs activity, permission and
+   * transcript pushes, but NOT the terminal - it discards those bytes on
+   * arrival. Measured on a live board, that discard cost roughly 13MB an hour
+   * of relay traffic and mobile data for a feed showing no terminal at all.
+   *
+   * Omitted means true, so an older phone keeps the previous behaviour and an
+   * older desktop that ignores the field simply keeps sending (wasteful, not
+   * broken). Set false for a list-only subscription and re-subscribe with it
+   * true when a terminal actually opens.
+   */
+  terminal?: boolean;
 }
 
 /**
@@ -188,6 +202,10 @@ function parseReadStreamRequestPayload(payload: JsonValue): ReadStreamRequestPay
       throw new Error('read-stream payload has an invalid "limit"');
     }
     request.limit = payload.limit;
+  }
+  if (payload.terminal !== undefined) {
+    if (typeof payload.terminal !== 'boolean') throw new Error('read-stream payload has an invalid "terminal"');
+    request.terminal = payload.terminal;
   }
   return request;
 }

--- a/src/main/agent/transcript-cache.ts
+++ b/src/main/agent/transcript-cache.ts
@@ -7,10 +7,23 @@ import type { TranscriptEntry } from '../../shared/types';
  *  identical rule instead of maintaining a second copy that could drift. */
 export const MAX_SPAN_CHARS = 20_000;
 
-/** Cached results are keyed by `(sessionType, agentSessionId)`; cap the number
- *  of distinct sessions held so a long-running app with many opened
- *  conversations does not grow this map unbounded. */
-const CACHE_LIMIT = 16;
+/**
+ * Cached results are keyed by `(sessionType, agentSessionId)`.
+ *
+ * The entry cap used to be 16, which is smaller than a single working set: a
+ * `--resume` writes a NEW transcript file replaying its parent's whole
+ * history, so one task resumed five times owns five files, and a live board
+ * measured 20 files (319MB) behind ONE mobile Home-feed refresh. At 16 the
+ * LRU evicted faster than the feed could reuse it, so every refresh re-parsed
+ * from scratch - the cache was doing strictly negative work.
+ *
+ * Raised well past a realistic board, and bounded by BYTES as well so the
+ * larger count cannot turn into unbounded memory: parsed entries are roughly
+ * proportional to their source file, and a handful of 50MB transcripts would
+ * otherwise dwarf everything else. Whichever bound binds first evicts.
+ */
+const CACHE_LIMIT = 64;
+const CACHE_BYTE_BUDGET = 192 * 1024 * 1024;
 
 export function clampSpan(text: string): string {
   if (text.length <= MAX_SPAN_CHARS) return text;
@@ -55,10 +68,14 @@ const cache = new Map<string, CacheRecord>();
 function touch(key: string, record: CacheRecord): void {
   cache.delete(key);
   cache.set(key, record);
-  while (cache.size > CACHE_LIMIT) {
+  let heldBytes = 0;
+  for (const held of cache.values()) heldBytes += held.size;
+  while (cache.size > CACHE_LIMIT || (heldBytes > CACHE_BYTE_BUDGET && cache.size > 1)) {
     const oldestKey = cache.keys().next().value;
     if (oldestKey === undefined) break;
+    const evicted = cache.get(oldestKey);
     cache.delete(oldestKey);
+    if (evicted) heldBytes -= evicted.size;
   }
 }
 
@@ -122,6 +139,39 @@ export async function getCachedTranscript(
   }
 
   return { entries: truncatedEntries, sourcePath: parsed.sourcePath };
+}
+
+/**
+ * The file signature this session's cached parse was validated against, or
+ * null when nothing is cached for it yet.
+ *
+ * Exported so the task-level stitch memo can ask "is every file behind this
+ * task still untouched?" using stats alone. Without it, answering that
+ * question required parsing every session first, which is precisely the work
+ * the memo exists to avoid - a task with five resumed sessions re-read
+ * hundreds of megabytes of near-identical JSONL to serve one tail request.
+ */
+export function peekCachedFileSignature(
+  sessionType: string,
+  agentSessionId: string,
+): { sourcePath: string; mtimeMs: number; size: number } | null {
+  const cached = cache.get(`${sessionType}:${agentSessionId}`);
+  if (!cached) return null;
+  return { sourcePath: cached.sourcePath, mtimeMs: cached.mtimeMs, size: cached.size };
+}
+
+/** True when the file behind a signature is still byte-identical by stat. */
+export async function isCachedFileUnchanged(signature: {
+  sourcePath: string;
+  mtimeMs: number;
+  size: number;
+}): Promise<boolean> {
+  try {
+    const stat = await fs.stat(signature.sourcePath);
+    return stat.mtimeMs === signature.mtimeMs && stat.size === signature.size;
+  } catch {
+    return false;
+  }
 }
 
 /** Test-only: clear the module-scope cache between test cases. */

--- a/src/main/agent/transcript-service.ts
+++ b/src/main/agent/transcript-service.ts
@@ -5,6 +5,8 @@ import { RetrievalStore } from '../retrieval/retrieval-store';
 import {
   clampSpan,
   getCachedTranscript,
+  isCachedFileUnchanged,
+  peekCachedFileSignature,
   resetForTests as resetTranscriptCacheForTests,
 } from './transcript-cache';
 import type {
@@ -181,6 +183,25 @@ interface StitchMemoRecord {
   depsFingerprint: string;
   revision: number;
   entries: TranscriptEntry[];
+  /**
+   * The file signatures this stitch was built from, captured HERE rather than
+   * read back out of the file cache. That independence is the whole point:
+   * the file cache is a small LRU, and a busy board evicts it constantly (one
+   * measured Home refresh touched 20 files against a 16-entry cache), so a
+   * fast path that depended on it would go dark exactly when it is needed
+   * most. Empty when any contributing session had no file to stat (an
+   * index/none source), which disables the fast path for that task rather
+   * than letting it return a stitch it cannot prove is current.
+   */
+  fileSignatures: Array<{ sourcePath: string; mtimeMs: number; size: number }>;
+  /** File-derived fields, safe to reuse when every file is untouched. */
+  fileDerived: {
+    source: TranscriptSource;
+    sourcePath: string | null;
+    degraded: boolean;
+    unavailableReason: TranscriptUnavailableReason | undefined;
+    agentName: string;
+  };
 }
 
 /** Task-level stitch memo, capped so a long-running app does not grow this
@@ -264,6 +285,50 @@ export async function resolveTaskTranscript(
   const sessions = anchor.task_id
     ? sessionRepo.listForTaskNewestFirst(anchor.task_id).reverse() // oldest first
     : [anchor];
+
+  /**
+   * STAT-ONLY FAST PATH.
+   *
+   * The loop below resolves EVERY session of the task, and a `--resume`
+   * session's JSONL replays its parent's full history, so a task resumed five
+   * times is five near-identical files. Measured on a live board: one task
+   * held 267MB across five files, and a single Home-feed refresh touched
+   * 20 files totalling 319MB - all of it re-read to serve tail requests of a
+   * few KB, because the memo below could only be consulted AFTER parsing.
+   *
+   * The file cache already remembers each session's path/mtime/size, so ask
+   * it first: when every contributing file is untouched, the previous stitch
+   * is still exactly correct. Only the DB-derived fields (task title, session
+   * records) are re-read, and those are sub-millisecond.
+   */
+  if (anchor.task_id) {
+    const memo = stitchMemoByTaskId.get(anchor.task_id);
+    if (memo && memo.fileSignatures.length > 0 && memo.fileSignatures.length === sessions.length) {
+      const freshness = await Promise.all(memo.fileSignatures.map((signature) => isCachedFileUnchanged(signature)));
+      if (freshness.every(Boolean)) {
+        {
+          touchStitchMemo(anchor.task_id, memo);
+          const taskRow = db.prepare('SELECT title FROM tasks WHERE id = ?').get(anchor.task_id) as
+            | { title: string }
+            | undefined;
+          return {
+            record: sessions[sessions.length - 1] ?? anchor,
+            taskTitle: taskRow?.title ?? '(unknown task)',
+            agentName: memo.fileDerived.agentName,
+            source: memo.fileDerived.source,
+            sourcePath: memo.fileDerived.sourcePath,
+            entries: memo.entries,
+            degraded: memo.fileDerived.degraded,
+            unavailableReason: memo.fileDerived.unavailableReason,
+            sessions: sessions.map((session) =>
+              toSessionMeta(session, agentRegistry.getBySessionType(session.session_type)?.displayName ?? session.session_type),
+            ),
+            revision: memo.revision,
+          };
+        }
+      }
+    }
+  }
 
   const sessionMetas: ConversationSessionMeta[] = [];
   const depsParts: string[] = [];
@@ -364,7 +429,35 @@ export async function resolveTaskTranscript(
 
   const revision = taskId ? (stitchMemoByTaskId.get(taskId)?.revision ?? 0) + 1 : 0;
   if (taskId) {
-    touchStitchMemo(taskId, { depsFingerprint, revision, entries });
+    // Only record file keys when EVERY contributing session has a cached file
+    // signature. A session resolved from the index (or with no source at all)
+    // has no file to stat, so it cannot be revalidated cheaply - leaving the
+    // list empty disables the stat-only fast path for this task rather than
+    // letting it return a stitch it cannot prove is current.
+    const fileSignatures: Array<{ sourcePath: string; mtimeMs: number; size: number }> = [];
+    let everySessionHasFile = resolvedBySession.length === sessions.length;
+    for (const { session } of resolvedBySession) {
+      const agentSessionId = session.agent_session_id;
+      const signature = agentSessionId ? peekCachedFileSignature(session.session_type, agentSessionId) : null;
+      if (!signature) {
+        everySessionHasFile = false;
+        break;
+      }
+      fileSignatures.push(signature);
+    }
+    touchStitchMemo(taskId, {
+      depsFingerprint,
+      revision,
+      entries,
+      fileSignatures: everySessionHasFile ? fileSignatures : [],
+      fileDerived: {
+        source: latest.source,
+        sourcePath: latest.sourcePath,
+        degraded: anyDegraded,
+        unavailableReason: latest.unavailableReason,
+        agentName: latest.agentName,
+      },
+    });
   }
 
   return {

--- a/src/main/mobile-bridge/handlers/read-stream.ts
+++ b/src/main/mobile-bridge/handlers/read-stream.ts
@@ -5,7 +5,8 @@ import {
   type ReadStreamResponsePayload,
   type TranscriptWindowResponsePayload,
 } from '@kangentic/protocol';
-import type { ActivityReason, ActivityState, SessionEvent, SessionUsage } from '../../../shared/types';
+import type { ActivityReason, ActivityState, SessionEvent, SessionUsage, TranscriptEntry } from '../../../shared/types';
+import { lastAssistantPreview } from '../message-preview';
 import { getProjectDb } from '../../db/database';
 import { resolveTaskTranscript } from '../../agent/transcript-service';
 import type { IpcContext } from '../../ipc/ipc-context';
@@ -81,6 +82,7 @@ function subscribeReadStream(
   const db = getProjectDb(context.sessionManager.getSessionProjectId(sessionId) ?? '');
   const transcriptSync = new TranscriptSync();
   let lastAwaitedPromptId = initialAwaitedPromptId;
+  let lastMessagePreview: string | null = null;
   let disposed = false;
   let pendingTerminalChunks: string[] = [];
   let pendingTerminalChars = 0;
@@ -107,9 +109,20 @@ function subscribeReadStream(
       for (const payload of transcriptSync.diff(resolved)) {
         sendEvent(session, { kind: 'transcript', sessionId, taskId, payload });
       }
+      pushMessagePreviewIfChanged(resolved.entries);
     } catch {
       // Best-effort; a transcript-read failure should not tear down the subscription.
     }
+  };
+
+  // The one line a phone's session list renders. Derived from the transcript
+  // we just resolved anyway, so the list costs no request of its own; sent
+  // only when the text actually changes, so an idle session is silent.
+  const pushMessagePreviewIfChanged = (entries: TranscriptEntry[]): void => {
+    const text = lastAssistantPreview(entries);
+    if (text === null || text === lastMessagePreview) return;
+    lastMessagePreview = text;
+    sendEvent(session, { kind: 'activity', sessionId, taskId, payload: { type: 'message-preview', text } });
   };
 
   // The snapshot's awaitedPromptId only covers a prompt outstanding AT
@@ -242,7 +255,12 @@ function subscribeReadStream(
   void (async (): Promise<void> => {
     try {
       const resolved = await resolveTaskTranscript(db, sessionId);
-      if (resolved) transcriptSync.seed(resolved);
+      if (!resolved) return;
+      transcriptSync.seed(resolved);
+      // The list's one line, delivered at subscribe rather than waiting for
+      // the session's next change: an idle session may never change again,
+      // and its card would otherwise have nothing to show.
+      if (!disposed) pushMessagePreviewIfChanged(resolved.entries);
     } catch {
       // Best-effort: an unseeded sync just means the first post-subscribe
       // change diffs against nothing and streams as plain appends.

--- a/src/main/mobile-bridge/handlers/read-stream.ts
+++ b/src/main/mobile-bridge/handlers/read-stream.ts
@@ -76,6 +76,7 @@ function subscribeReadStream(
   session: BridgeSession,
   context: IpcContext,
   subscriptions: SubscriptionRegistry,
+  wantsTerminal: boolean,
 ): void {
   const db = getProjectDb(context.sessionManager.getSessionProjectId(sessionId) ?? '');
   const transcriptSync = new TranscriptSync();
@@ -207,8 +208,16 @@ function subscribeReadStream(
     subscriptions.remove(subscriptionKeyFor(sessionId));
   };
 
-  context.sessionManager.on('data-tap', onDataTap);
-  context.sessionManager.on('pty-resize', onPtyResize);
+  // A list-only subscriber (a phone showing its session feed) discards PTY
+  // bytes on arrival, so never attach the taps that produce them. Activity,
+  // permission and transcript pushes still flow - those are what the list is
+  // for. The grid-size event goes too: it only explains bytes we are not
+  // sending, and the phone re-subscribes with terminal:true the moment a
+  // terminal opens, which delivers a fresh frame and its dimensions together.
+  if (wantsTerminal) {
+    context.sessionManager.on('data-tap', onDataTap);
+    context.sessionManager.on('pty-resize', onPtyResize);
+  }
   context.sessionManager.on('activity', onActivity);
   context.sessionManager.on('usage', onUsage);
   context.sessionManager.on('event', onSessionEvent);
@@ -273,7 +282,13 @@ export async function handleReadStream(
   // replay: a raw 512KB replay drops a fullscreen TUI's write-once static cells
   // once their drawing bytes age out of the window, so the phone's cold replay
   // renders them blank. The serialized frame reconstructs every visible cell.
-  const scrollback = await context.sessionManager.getSerializedFrame(payload.sessionId);
+  //
+  // A list-only subscriber (terminal:false) has no renderer to seed and drops
+  // this on arrival, so skip building it entirely - it is the single largest
+  // field in this response, and it was being sent once per live session on
+  // every cold start.
+  const wantsTerminal = payload.terminal !== false;
+  const scrollback = wantsTerminal ? await context.sessionManager.getSerializedFrame(payload.sessionId) : '';
   const activityState = context.sessionManager.getActivityCache()[payload.sessionId] ?? null;
   const activityReason = context.sessionManager.getActivityReason(payload.sessionId);
   const usage = context.sessionManager.getUsageCache()[payload.sessionId] ?? null;
@@ -298,7 +313,7 @@ export async function handleReadStream(
     sessionStatus: toReadStreamSessionStatusWire(liveSession.status),
   };
 
-  subscribeReadStream(payload.sessionId, liveSession.taskId, awaitedPromptId, session, context, subscriptions);
+  subscribeReadStream(payload.sessionId, liveSession.taskId, awaitedPromptId, session, context, subscriptions, wantsTerminal);
 
   return { type: 'capability-response', requestId: request.requestId, ok: true, payload: toWireJson(responsePayload) };
 }

--- a/src/main/mobile-bridge/message-preview.ts
+++ b/src/main/mobile-bridge/message-preview.ts
@@ -22,7 +22,8 @@ const LEADING_STRUCTURE_MARKERS = /^(?:#{1,6}\s+|>\s*|[-*+]\s+|\d{1,3}[.)]\s+)+/
  * Miscellaneous Technical (agent status indicators), the private-use area
  * (icon fonts), variation selectors, and the replacement character.
  */
-const UNRENDERABLE_CHROME = /[⌀-⏿-︀-️�]/g;
+const UNRENDERABLE_CHROME = /[\u2300-\u23FF\uE000-\uF8FF\uFFFD]/gu;
+const VARIATION_SELECTORS = /[\uFE00-\uFE0F]/gu;
 
 /** Collapse markdown prose to a single plain line; empty when it was decoration through and through. */
 function collapseToPreviewText(text: string): string {
@@ -39,6 +40,7 @@ function collapseToPreviewText(text: string): string {
     .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
     .replace(/\*\*|`/g, '')
     .replace(UNRENDERABLE_CHROME, '')
+    .replace(VARIATION_SELECTORS, '')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/src/main/mobile-bridge/message-preview.ts
+++ b/src/main/mobile-bridge/message-preview.ts
@@ -1,0 +1,66 @@
+import type { TranscriptEntry } from '../../shared/types';
+
+/**
+ * The one line a phone's session list shows under a task title: the agent's
+ * most recent assistant text, collapsed to plain prose.
+ *
+ * Kept small on purpose. This rides on the activity feed the phone already
+ * receives, replacing a per-session transcript-window request that measured
+ * 2.3 to 34.6 KB (to keep a string under 200 characters) and 0.7 to 3.8
+ * seconds of desktop work each.
+ */
+export const MESSAGE_PREVIEW_MAX_CHARS = 200;
+
+/** A line that is pure decoration: rules, box-drawing, table borders, dash/ellipsis runs. */
+const DECORATION_ONLY_LINE = /^[\s\-=_*~#>|+:.·‒-―…−⋯⎯⏤─-╿▀-▟]+$/;
+/** A code-fence delimiter line (```ts, ~~~). */
+const CODE_FENCE_LINE = /^(?:`{3,}|~{3,})[\w-]*$/;
+/** Leading markdown structure markers: headings, blockquotes, bullets, ordered lists. */
+const LEADING_STRUCTURE_MARKERS = /^(?:#{1,6}\s+|>\s*|[-*+]\s+|\d{1,3}[.)]\s+)+/;
+/**
+ * Terminal-UI chrome a phone has no glyph for, so it renders as tofu boxes:
+ * Miscellaneous Technical (agent status indicators), the private-use area
+ * (icon fonts), variation selectors, and the replacement character.
+ */
+const UNRENDERABLE_CHROME = /[⌀-⏿-︀-️�]/g;
+
+/** Collapse markdown prose to a single plain line; empty when it was decoration through and through. */
+function collapseToPreviewText(text: string): string {
+  const keptLines: string[] = [];
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (line.length === 0) continue;
+    if (CODE_FENCE_LINE.test(line)) continue;
+    if (DECORATION_ONLY_LINE.test(line)) continue;
+    keptLines.push(line.replace(LEADING_STRUCTURE_MARKERS, ''));
+  }
+  return keptLines
+    .join(' ')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\*\*|`/g, '')
+    .replace(UNRENDERABLE_CHROME, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * The newest assistant text in the transcript that still says something once
+ * decoration is stripped, capped for a two-line card. Returns null when no
+ * assistant entry carries prose - the caller then sends nothing rather than
+ * blanking a preview the phone already has.
+ */
+export function lastAssistantPreview(entries: readonly TranscriptEntry[]): string | null {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry.kind !== 'assistant') continue;
+    const text = entry.blocks
+      .filter((block): block is Extract<typeof block, { type: 'text' }> => block.type === 'text')
+      .map((block) => block.text)
+      .join('\n');
+    if (text.length === 0) continue;
+    const collapsed = collapseToPreviewText(text);
+    if (collapsed.length === 0) continue;
+    return collapsed.length > MESSAGE_PREVIEW_MAX_CHARS ? collapsed.slice(0, MESSAGE_PREVIEW_MAX_CHARS) : collapsed;
+  }
+  return null;
+}

--- a/tests/unit/mobile-bridge/message-preview.test.ts
+++ b/tests/unit/mobile-bridge/message-preview.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import type { TranscriptEntry } from '../../../src/shared/types';
+import { MESSAGE_PREVIEW_MAX_CHARS, lastAssistantPreview } from '../../../src/main/mobile-bridge/message-preview';
+
+function assistant(text: string, uuid = 'a1'): TranscriptEntry {
+  return { kind: 'assistant', uuid, ts: 1, blocks: [{ type: 'text', text }] };
+}
+
+describe('lastAssistantPreview', () => {
+  it('returns the newest assistant text', () => {
+    const entries: TranscriptEntry[] = [
+      assistant('older message', 'a1'),
+      { kind: 'user', uuid: 'u1', ts: 2, text: 'a question' },
+      assistant('newest message', 'a2'),
+    ];
+    expect(lastAssistantPreview(entries)).toBe('newest message');
+  });
+
+  it('skips tool_use-only assistant entries and keeps looking back', () => {
+    const entries: TranscriptEntry[] = [
+      assistant('the last thing actually said', 'a1'),
+      { kind: 'assistant', uuid: 'a2', ts: 2, blocks: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }] },
+      { kind: 'tool_result', uuid: 'r1', ts: 3, toolUseId: 't1', content: 'output' },
+    ];
+    expect(lastAssistantPreview(entries)).toBe('the last thing actually said');
+  });
+
+  it('collapses markdown structure to one plain line', () => {
+    expect(lastAssistantPreview([assistant('## Heading\n\n- first point\n- second point')])).toBe(
+      'Heading first point second point',
+    );
+  });
+
+  it('drops decoration-only content and code fences', () => {
+    expect(lastAssistantPreview([assistant('```ts\nconst x = 1;\n```')])).toBe('const x = 1;');
+    expect(lastAssistantPreview([assistant('Done.\n\n---')])).toBe('Done.');
+  });
+
+  /**
+   * The phone has no glyph for the agent TUI's status indicators, so they
+   * render as tofu boxes on a card. Seen live on a Pixel.
+   */
+  it('drops glyphs a phone cannot render, keeping arrows and bullets', () => {
+    expect(lastAssistantPreview([assistant('⏵⏵ auto mode on')])).toBe('auto mode on');
+    expect(lastAssistantPreview([assistant('← back · done')])).toBe('← back · done');
+  });
+
+  it('caps the preview so a card never carries a whole message', () => {
+    const preview = lastAssistantPreview([assistant('x'.repeat(MESSAGE_PREVIEW_MAX_CHARS + 500))]);
+    expect(preview).toHaveLength(MESSAGE_PREVIEW_MAX_CHARS);
+  });
+
+  /**
+   * Null, not empty string: the caller sends nothing rather than blanking a
+   * preview the phone is already showing.
+   */
+  it('returns null when nothing was actually said', () => {
+    expect(lastAssistantPreview([])).toBeNull();
+    expect(lastAssistantPreview([assistant('   \n\n---\n')])).toBeNull();
+    expect(lastAssistantPreview([{ kind: 'user', uuid: 'u1', ts: 1, text: 'only a user turn' }])).toBeNull();
+  });
+});

--- a/tests/unit/mobile-bridge/read-stream.test.ts
+++ b/tests/unit/mobile-bridge/read-stream.test.ts
@@ -138,6 +138,69 @@ describe('handleReadStream', () => {
     expect(sessionManager.listenerCount('event')).toBe(0);
   });
 
+  /**
+   * A phone showing its session list needs activity, permission and
+   * transcript pushes, but discards PTY bytes on arrival. Measured live, that
+   * discard cost roughly 13MB an hour of relay traffic for a feed with no
+   * terminal open, plus a full serialized frame per session on every cold
+   * start. `terminal: false` subscribes to everything except the bytes.
+   */
+  it('a list-only subscribe attaches no terminal taps and returns no scrollback', async () => {
+    const context = { sessionManager } as unknown as IpcContext;
+    const subscriptions = new SubscriptionRegistry();
+
+    const response = await handleReadStream(
+      fakeRequest({ sessionId: 'sess-1', action: 'subscribe', terminal: false }),
+      fakeSession(),
+      context,
+      subscriptions,
+    );
+
+    expect((response.payload as { scrollback: string }).scrollback).toBe('');
+    expect(sessionManager.listenerCount('data-tap')).toBe(0);
+    expect(sessionManager.listenerCount('pty-resize')).toBe(0);
+    // Everything the list actually renders still flows.
+    expect(sessionManager.listenerCount('activity')).toBe(1);
+    expect(sessionManager.listenerCount('usage')).toBe(1);
+    expect(sessionManager.listenerCount('event')).toBe(1);
+    expect(sessionManager.listenerCount('exit')).toBe(1);
+  });
+
+  it('an omitted terminal flag keeps the full stream, so an older phone is unaffected', async () => {
+    const context = { sessionManager } as unknown as IpcContext;
+    const subscriptions = new SubscriptionRegistry();
+
+    const response = await handleReadStream(
+      fakeRequest({ sessionId: 'sess-1', action: 'subscribe' }),
+      fakeSession(),
+      context,
+      subscriptions,
+    );
+
+    expect((response.payload as { scrollback: string }).scrollback).toBe('serialized-frame');
+    expect(sessionManager.listenerCount('data-tap')).toBe(1);
+    expect(sessionManager.listenerCount('pty-resize')).toBe(1);
+  });
+
+  it('a list-only subscriber receives no terminal events when the pty produces output', async () => {
+    const context = { sessionManager } as unknown as IpcContext;
+    const subscriptions = new SubscriptionRegistry();
+    const session = fakeSession();
+
+    await handleReadStream(
+      fakeRequest({ sessionId: 'sess-1', action: 'subscribe', terminal: false }),
+      session,
+      context,
+      subscriptions,
+    );
+    sessionManager.emit('data-tap', 'sess-1', 'output the phone would have discarded');
+    sessionManager.emit('pty-resize', 'sess-1', 100, 40);
+
+    const sent = vi.mocked(session.sendMessage).mock.calls.map((call) => call[0] as { event?: { kind?: string } });
+    expect(sent.some((message) => message?.event?.kind === 'terminal')).toBe(false);
+    expect(sent.some((message) => message?.event?.kind === 'terminal-resize')).toBe(false);
+  });
+
   it('tears its own subscription down when the streamed session exits (no listener leak)', async () => {
     const context = { sessionManager } as unknown as IpcContext;
     const subscriptions = new SubscriptionRegistry();

--- a/tests/unit/protocol/payloads.test.ts
+++ b/tests/unit/protocol/payloads.test.ts
@@ -25,6 +25,26 @@ describe('parseCapabilityRequestPayload', () => {
     expect(() => parseCapabilityRequestPayload('read-stream', { sessionId: 'sess-1', action: 'watch' })).toThrow(/action/);
   });
 
+  /**
+   * `terminal: false` is how a phone showing its session list subscribes to
+   * activity without the PTY bytes it would discard. Absent means true, so an
+   * older phone that never sends it keeps the full stream.
+   */
+  it('read-stream: carries the terminal flag through, and omits it when absent', () => {
+    expect(parseCapabilityRequestPayload('read-stream', { sessionId: 'sess-1', action: 'subscribe', terminal: false })).toEqual({
+      sessionId: 'sess-1',
+      action: 'subscribe',
+      terminal: false,
+    });
+    expect(parseCapabilityRequestPayload('read-stream', { sessionId: 'sess-1', action: 'subscribe' })).not.toHaveProperty('terminal');
+  });
+
+  it('read-stream: rejects a non-boolean terminal flag', () => {
+    expect(() => parseCapabilityRequestPayload('read-stream', { sessionId: 'sess-1', action: 'subscribe', terminal: 'no' })).toThrow(
+      /terminal/,
+    );
+  });
+
   it('read-board: allows an omitted projectId', () => {
     const parsed = parseCapabilityRequestPayload('read-board', {});
     expect(parsed).toEqual({ projectId: undefined, action: undefined });

--- a/tests/unit/transcript-cache.test.ts
+++ b/tests/unit/transcript-cache.test.ts
@@ -105,11 +105,38 @@ describe('getCachedTranscript', () => {
     expect(result.entries).toEqual([]);
   });
 
-  it('evicts the least-recently-used entry once the cache grows past its cap', async () => {
-    // The cache is capped at 16; fill it with 17 distinct sessions and verify
-    // the FIRST (oldest, never re-touched) session re-parses on next access.
+  /**
+   * The cap has to clear a realistic working set, not just be non-zero. A
+   * `--resume` writes a NEW transcript file replaying its parent's history,
+   * so one task resumed five times owns five files, and a live board measured
+   * 20 files behind ONE mobile Home-feed refresh. The old cap of 16 evicted
+   * faster than the feed reused it, so every refresh re-parsed from scratch.
+   */
+  it('keeps a whole board-sized working set resident', async () => {
     const files: string[] = [];
-    for (let index = 0; index < 17; index += 1) {
+    for (let index = 0; index < 24; index += 1) {
+      const file = writeFile(tmpDir, `busy-${index}.jsonl`, `content-${index}\n`);
+      files.push(file);
+      await getCachedTranscript('claude_agent', `busy-${index}`, async () => ({
+        entries: [{ kind: 'user', uuid: `u${index}`, ts: index, text: `t${index}` }] as TranscriptEntry[],
+        sourcePath: file,
+      }));
+    }
+
+    let reparsed = false;
+    await getCachedTranscript('claude_agent', 'busy-0', async () => {
+      reparsed = true;
+      return { entries: [] as TranscriptEntry[], sourcePath: files[0] };
+    });
+
+    expect(reparsed).toBe(false);
+  });
+
+  it('evicts the least-recently-used entry once the cache grows past its cap', async () => {
+    // Fill past the 64-entry cap and verify the FIRST (oldest, never
+    // re-touched) session re-parses on next access.
+    const files: string[] = [];
+    for (let index = 0; index < 65; index += 1) {
       const file = writeFile(tmpDir, `session-${index}.jsonl`, `content-${index}\n`);
       files.push(file);
       await getCachedTranscript('claude_agent', `agent-${index}`, async () => ({

--- a/tests/unit/transcript-service-stat-fast-path.test.ts
+++ b/tests/unit/transcript-service-stat-fast-path.test.ts
@@ -1,0 +1,182 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import type { SessionRecord } from '../../src/shared/types';
+
+/**
+ * A mobile `transcript-window` request asks for the last handful of entries,
+ * but resolving it walks EVERY session of the task - and a `--resume` writes a
+ * new transcript file that replays its parent's entire history, so a task
+ * resumed five times owns five near-identical files. Measured on a live
+ * board: 267MB behind one task, 319MB across one Home-feed refresh.
+ *
+ * `resolveTaskTranscript` therefore revalidates a task by STAT alone before
+ * parsing anything, using signatures recorded in the stitch memo itself. That
+ * independence from the file cache is the point: the file cache is a bounded
+ * LRU, and these tests pin that the fast path still works after it has been
+ * evicted, which is precisely the busy-board case that was re-parsing
+ * hundreds of megabytes per refresh.
+ */
+
+vi.mock('../../src/main/agent/agent-registry', () => ({
+  agentRegistry: { getBySessionType: vi.fn() },
+}));
+
+import { resolveTaskTranscript, resetForTests } from '../../src/main/agent/transcript-service';
+import { getCachedTranscript } from '../../src/main/agent/transcript-cache';
+import { agentRegistry } from '../../src/main/agent/agent-registry';
+
+function makeRecord(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    id: 'session-1',
+    task_id: 'task-1',
+    session_type: 'claude_agent',
+    isolated_swimlane_id: null,
+    agent_session_id: 'agent-1',
+    cwd: '/work/project',
+    started_at: '2026-06-01T12:00:00Z',
+    exited_at: null,
+    status: 'running',
+    ...overrides,
+  } as unknown as SessionRecord;
+}
+
+function makeFakeDb(records: SessionRecord[]): Database.Database {
+  return {
+    prepare(sql: string) {
+      return {
+        get: (...args: unknown[]) => {
+          if (sql.includes('FROM sessions WHERE id = ? OR agent_session_id = ?')) {
+            const requestedId = args[0] as string;
+            return records.find((record) => record.id === requestedId || record.agent_session_id === requestedId);
+          }
+          if (sql.includes('SELECT title FROM tasks WHERE id = ?')) return { title: 'Fast Path Task' };
+          throw new Error(`unexpected get SQL: ${sql}`);
+        },
+        all: () => {
+          if (sql.includes('FROM sessions WHERE task_id = ?')) return [...records].reverse();
+          // The index fallback, reached when a live parse yields nothing.
+          if (sql.includes('FROM memory_chunks')) return [];
+          throw new Error(`unexpected all SQL: ${sql}`);
+        },
+      };
+    },
+  } as unknown as Database.Database;
+}
+
+const getBySessionType = vi.mocked(agentRegistry.getBySessionType);
+
+describe('resolveTaskTranscript stat-only fast path', () => {
+  let tmpDir: string;
+  let transcriptFilePath: string;
+  let parseTranscript: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    resetForTests();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kangentic-fast-path-'));
+    transcriptFilePath = path.join(tmpDir, 'transcript.jsonl');
+    fs.writeFileSync(transcriptFilePath, JSON.stringify({ turn: 'first' }));
+    parseTranscript = vi.fn(async () => ({
+      entries: [{ kind: 'user' as const, uuid: 'turn-1', ts: 1, text: 'hello' }],
+      sourcePath: transcriptFilePath,
+    }));
+    getBySessionType.mockReturnValue({
+      displayName: 'Claude Code',
+      parseTranscript,
+    } as unknown as ReturnType<typeof agentRegistry.getBySessionType>);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('serves an unchanged task without parsing any transcript file', async () => {
+    const db = makeFakeDb([makeRecord()]);
+
+    const first = await resolveTaskTranscript(db, 'session-1');
+    expect(parseTranscript).toHaveBeenCalledTimes(1);
+
+    const second = await resolveTaskTranscript(db, 'session-1');
+
+    expect(second!.entries).toBe(first!.entries);
+    expect(second!.revision).toBe(first!.revision);
+    expect(parseTranscript).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The busy-board case. The file cache is a bounded LRU, so on a board with
+   * many live sessions a task's own entry is routinely evicted between
+   * refreshes. Before the memo carried its own signatures, that eviction
+   * forced a full re-parse of every file behind the task.
+   */
+  it('still avoids parsing after the file cache has evicted this session', async () => {
+    const db = makeFakeDb([makeRecord()]);
+    const first = await resolveTaskTranscript(db, 'session-1');
+    expect(parseTranscript).toHaveBeenCalledTimes(1);
+
+    // Push this session out of the file-level LRU with unrelated traffic.
+    for (let index = 0; index < 70; index += 1) {
+      const otherFile = path.join(tmpDir, `other-${index}.jsonl`);
+      fs.writeFileSync(otherFile, `filler-${index}`);
+      await getCachedTranscript('claude_agent', `other-${index}`, async () => ({
+        entries: [],
+        sourcePath: otherFile,
+      }));
+    }
+
+    const afterEviction = await resolveTaskTranscript(db, 'session-1');
+
+    expect(afterEviction!.entries).toBe(first!.entries);
+    expect(parseTranscript).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-parses and re-stitches when a contributing file genuinely changes', async () => {
+    const db = makeFakeDb([makeRecord()]);
+    const first = await resolveTaskTranscript(db, 'session-1');
+
+    fs.writeFileSync(transcriptFilePath, JSON.stringify({ turn: 'first-plus-a-second-turn-changing-the-size' }));
+    parseTranscript.mockResolvedValueOnce({
+      entries: [
+        { kind: 'user' as const, uuid: 'turn-1', ts: 1, text: 'hello' },
+        { kind: 'user' as const, uuid: 'turn-2', ts: 2, text: 'new turn' },
+      ],
+      sourcePath: transcriptFilePath,
+    });
+
+    const second = await resolveTaskTranscript(db, 'session-1');
+
+    expect(parseTranscript).toHaveBeenCalledTimes(2);
+    expect(second!.revision).toBe(first!.revision + 1);
+    expect(second!.entries.some((entry) => entry.uuid === 'turn-2')).toBe(true);
+  });
+
+  /** A file that disappears must fail the stat check, never serve a stale stitch. */
+  it('falls back to a full resolve when a recorded file is gone', async () => {
+    const db = makeFakeDb([makeRecord()]);
+    await resolveTaskTranscript(db, 'session-1');
+
+    fs.rmSync(transcriptFilePath);
+    parseTranscript.mockResolvedValueOnce({ entries: [], sourcePath: null });
+
+    await resolveTaskTranscript(db, 'session-1');
+
+    expect(parseTranscript).toHaveBeenCalledTimes(2);
+  });
+
+  /** A newly-added session changes the task's shape, so the memo must not answer. */
+  it('does not answer from the memo when the task gains a session', async () => {
+    const db = makeFakeDb([makeRecord()]);
+    await resolveTaskTranscript(db, 'session-1');
+    expect(parseTranscript).toHaveBeenCalledTimes(1);
+
+    const secondFile = path.join(tmpDir, 'transcript-2.jsonl');
+    fs.writeFileSync(secondFile, JSON.stringify({ turn: 'resumed' }));
+    const grown = makeFakeDb([makeRecord(), makeRecord({ id: 'session-2', agent_session_id: 'agent-2' })]);
+
+    await resolveTaskTranscript(grown, 'session-1');
+
+    expect(parseTranscript.mock.calls.length).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
Cuts the cost of serving a phone's session list, on both axes. Every number
below was measured on a Pixel against this desktop over a LOOPBACK relay, so
no network is involved in any of it.

## Latency: 3804ms -> 771ms cold, 31ms warm

A mobile `transcript-window` request asks for the last handful of entries and
was costing hundreds of megabytes of parsing. One Home-feed refresh:

| session | sessions on task | transcript bytes |
|---|---|---|
| 54e83015 | 4 | 16.9 MB |
| 212141d8 | 3 | 17.8 MB |
| 5e050933 | 3 | 13.3 MB |
| badfb67b | 5 | **267.1 MB** |
| bb86ab6b | 1 | 0.1 MB |
| 5c6fd019 | 4 | 3.7 MB |

**20 files, 319 MB, against a 16-entry cache.** Three compounding causes:

1. A `--resume` writes a NEW transcript file replaying its parent's entire
   history, so a task resumed five times owns five near-identical ~53MB files.
   `resolveTaskTranscript` walks all of them (it must - it dedupes by uuid) to
   return the last 8 entries.
2. The stitch memo could only be consulted AFTER every session was resolved,
   so the parsing it was meant to save had already happened.
3. `CACHE_LIMIT` was 16, smaller than one refresh's working set. The LRU
   evicted faster than the feed reused it, so the cache did negative work.

`resolveTaskTranscript` now revalidates a task by **stat** before parsing
anything. The signatures live in the stitch memo rather than being read back
out of the file cache, deliberately: that cache is a bounded LRU, so a fast
path depending on it would go dark exactly on the busy boards that need it. A
test evicts the cache and asserts the fast path still avoids parsing.

Cache cap 16 -> 64 with a 192MB byte budget, since an entry count cannot
bound memory when single transcripts run to tens of megabytes.

## Payload: the feed was streaming a terminal nobody was watching

Decrypted plaintext by message kind, app on the Agents feed, **no terminal
open**:

```
capability-response = 214.1 KB  x78    one-time
event:terminal      =  75.2 KB x243    still climbing after 20s
event:activity      =   6.8 KB  x15
event:transcript    =   1.1 KB   x2
```

`event:terminal` is not a startup cost. The phone subscribes `read-stream`
per live session for activity, every subscription carries live PTY bytes, and
the phone then **discards them by design** at its own terminalFeed boundary
("triage needs activity, not PTY bytes"). That is ~225KB/minute, ~13MB/hour
of relay traffic and mobile data for output nobody is looking at.

Two protocol additions, both additive and both safe in either landing order:

- `read-stream` subscribe takes an optional **`terminal`** flag. False
  attaches neither the data tap nor the pty-resize tap and returns an empty
  scrollback instead of building a serialized frame - the largest field in
  that response, sent once per live session on every cold start.
- New **`message-preview`** activity payload carries the one line a session
  list renders, derived from the transcript the desktop already resolves for
  its delta pushes. Replaces a per-session transcript fetch that cost 2.3-34.6
  KB to keep a string under 200 characters.

Absent means previous behaviour on both, so an older phone and an older
desktop each keep working.

## Protocol 0.8.0

Both wire changes ship in one release rather than two. The mobile side is
gated on the npm publish and lands separately.

## Tests

`tests/unit/mobile-bridge` + `tests/unit/protocol`: **493 passing**, including
new coverage for the stat fast path surviving cache eviction, list-only
subscribes attaching no terminal taps, and preview derivation (markdown
collapse, unrenderable-glyph stripping, the null-not-empty contract).
