### PR TITLE
fix(command-terminal): remount xterm host on branch switch instead of swapping session id

### DIFF
--- a/src/main/ipc/handlers/transient-sessions.ts
+++ b/src/main/ipc/handlers/transient-sessions.ts
@@ -118,6 +118,8 @@ export function registerTransientSessionHandlers(context: IpcContext): void {
       agentParser: adapter,
       agentName: adapter.name,
       exitSequence: adapter.getExitSequence?.() ?? ['\x03'],
+      cols: input.cols,
+      rows: input.rows,
     });
 
     trackEvent('transient_session_spawn', { agent: adapter.name });

--- a/src/main/pty/lifecycle/session-spawn-flow.ts
+++ b/src/main/pty/lifecycle/session-spawn-flow.ts
@@ -165,14 +165,30 @@ export async function performSpawn(
   });
 
   // Spawn at the real fitted dimensions if a resize arrived before the PTY
-  // existed (auto-resume / queued / suspended-resume race). Otherwise the
+  // existed (auto-resume / queued / suspended-resume race) - takePendingResize
+  // wins even when the caller also passed input.cols/rows, since it reflects a
+  // resize that happened AFTER the caller computed its own grid. Next,
+  // input.cols/rows: a caller-known grid (e.g. a Command Terminal branch
+  // respawn reusing its still-mounted xterm's current size). Otherwise the
   // default: a background session that is never opened keeps this size, and an
   // opened one is resized to its container on mount. Spawning at the fitted
   // size means that mount-time resize is a no-op, avoiding the stale-width
-  // repaint window entirely.
+  // repaint window entirely. takePendingResize is called unconditionally so
+  // its entry is always consumed, even when input.cols/rows also apply.
   const pendingResize = context.takePendingResize(id);
-  const spawnCols = pendingResize?.cols ?? DEFAULT_PTY_COLS;
-  const spawnRows = pendingResize?.rows ?? DEFAULT_PTY_ROWS;
+  // A caller-supplied grid is clamped here exactly the way SessionManager.resize
+  // clamps before it stashes a pendingResize: node-pty throws on 0 or negative,
+  // and a non-finite value (a layout edge case yielding parseInt -> NaN) must
+  // never reach pty.spawn. pendingResize is already clamped at its source;
+  // input.cols/rows arrives straight off the IPC boundary, so it is clamped here.
+  const requestedCols = input.cols !== undefined && Number.isFinite(input.cols)
+    ? Math.max(2, Math.floor(input.cols))
+    : undefined;
+  const requestedRows = input.rows !== undefined && Number.isFinite(input.rows)
+    ? Math.max(1, Math.floor(input.rows))
+    : undefined;
+  const spawnCols = pendingResize?.cols ?? requestedCols ?? DEFAULT_PTY_COLS;
+  const spawnRows = pendingResize?.rows ?? requestedRows ?? DEFAULT_PTY_ROWS;
 
   let ptyProcess: pty.IPty;
   try {

--- a/src/renderer/addons/fit-addon.ts
+++ b/src/renderer/addons/fit-addon.ts
@@ -78,6 +78,17 @@ export class FitAddon implements ITerminalAddon {
     const parentHeight = parseInt(parentStyle.getPropertyValue('height'));
     const parentWidth = Math.max(0, parseInt(parentStyle.getPropertyValue('width')));
 
+    // A collapsed or hidden container (a visibility toggle mid-transition, a
+    // tile/untile or reflow race) reports a 0 (or NaN) box. Clamping to
+    // MINIMUM_COLS/MINIMUM_ROWS below would still produce a valid-looking 2x1
+    // grid that flows all the way to sessions.resize, corrupting the PTY's
+    // real width instead of leaving it alone. Bail here instead - the next
+    // real resize/refit (once the container has real dimensions again)
+    // supplies the true grid. `> 0` also rejects NaN.
+    if (!(parentWidth > 0) || !(parentHeight > 0)) {
+      return undefined;
+    }
+
     const elementStyle = window.getComputedStyle(this._terminal.element);
     const paddingVertical = parseInt(elementStyle.getPropertyValue('padding-top'))
       + parseInt(elementStyle.getPropertyValue('padding-bottom'));

--- a/src/renderer/components/command-bar/CommandTerminalPane.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalPane.tsx
@@ -1,0 +1,149 @@
+/**
+ * The Command Terminal's xterm host, extracted from `CommandTerminalWindow` so
+ * it can be mounted with `key={sessionId}`. `useTerminal` is unmount-only
+ * teardown (see its dispose effect) - a host MUST remount per session, which
+ * both task-detail terminal hosts already do (`TerminalTab` via
+ * `key={sessionId}` / `key={session.id}` at their mount sites). The Command
+ * Terminal used to swap `sessionId` in place on a branch switch instead,
+ * leaving the old xterm's onData/onResize/clipboard/WebGL permanently bound to
+ * the killed session (initTerminal's `if (xtermRef.current) return` guard
+ * never lets a second session take over an existing instance).
+ *
+ * `CommandTerminalWindow` renders this GATED on `effectiveSessionId` (not just
+ * keyed): `effectiveSessionId` goes `null` mid-switch, and keying a
+ * still-mounted subtree on `null` would mount a throwaway Terminal with no
+ * onData/onResize and a wasted WebGL attach, then immediately tear it down.
+ * Gating means the pane only ever exists with a real session id, so
+ * `sessionId` here is non-nullable.
+ */
+import { useEffect, useRef, type RefObject } from 'react';
+import { useTerminal } from '../../hooks/useTerminal';
+import { useTerminalRefit } from '../../hooks/useTerminalRefit';
+import { useTerminalFileDrop } from '../../hooks/useTerminalFileDrop';
+import { FileDropOverlay } from '../terminal/FileDropOverlay';
+import { useConfigStore } from '../../stores/config-store';
+import { useSessionStore } from '../../stores/session-store';
+import { useProjectStore } from '../../stores/project-store';
+
+/** The terminal's current grid, published by the pane so a caller (a branch
+ *  respawn) can seed the new PTY at the size the user is already looking at
+ *  instead of the spawn defaults. Null before the terminal has initialized. */
+export type TerminalGridGetter = () => { cols: number; rows: number } | null;
+
+interface CommandTerminalPaneProps {
+  sessionId: string;
+  isMaximized: boolean;
+  /** Parent-owned ref this pane publishes its live `getDimensions` into on
+   *  mount, and clears on unmount. See `TerminalGridGetter`. */
+  gridGetterRef: RefObject<TerminalGridGetter | null>;
+}
+
+export function CommandTerminalPane({ sessionId, isMaximized, gridGetterRef }: CommandTerminalPaneProps) {
+  const config = useConfigStore((s) => s.config);
+  const projectAgent = useProjectStore((s) => s.currentProject?.default_agent ?? null);
+  // Adapter-declared: this agent needs an explicit reference (not a bare path) to
+  // reliably read a pasted/dropped image. Never branch on agent name - see
+  // .claude/rules/agent-adapters-boundary.md.
+  const pasteImageTemplate = useConfigStore(
+    (s) => s.agentList.find((a) => a.name === projectAgent)?.pastedImageReferenceTemplate,
+  );
+  const commandTerminalShell = useSessionStore(
+    (s) => s.sessions.find((session) => session.id === sessionId)?.shell,
+  );
+
+  const { terminalRef, initTerminal, fit, flushResize, focus, getDimensions } = useTerminal({
+    sessionId,
+    fontFamily: config.terminal.fontFamily,
+    fontSize: config.terminal.fontSize,
+    cursorStyle: config.terminal.cursorStyle,
+    colors: config.terminal.colors,
+    shellName: commandTerminalShell ?? undefined,
+    pasteImageTemplate,
+    backspaceSendsCtrlH: config.terminal.backspaceSendsCtrlH,
+  });
+
+  const fileDrop = useTerminalFileDrop(sessionId, focus, commandTerminalShell ?? undefined, pasteImageTemplate);
+
+  // Publish the live grid getter for the parent to read before a branch
+  // respawn. Cleared on unmount so a stale getter from a disposed session is
+  // never read.
+  useEffect(() => {
+    gridGetterRef.current = getDimensions;
+    return () => {
+      gridGetterRef.current = null;
+    };
+  }, [gridGetterRef, getDimensions]);
+
+  // Init the terminal once the container has dimensions.
+  const initialized = useRef(false);
+  useEffect(() => {
+    const element = terminalRef.current;
+    if (!element) return;
+
+    const tryInit = () => {
+      if (initialized.current) return;
+      if (element.offsetWidth > 0 && element.offsetHeight > 0) {
+        initTerminal();
+        initialized.current = true;
+        fit();
+        focus();
+      }
+    };
+
+    tryInit();
+
+    let observer: ResizeObserver | null = null;
+    if (!initialized.current) {
+      observer = new ResizeObserver(() => {
+        tryInit();
+        if (initialized.current) observer?.disconnect();
+      });
+      observer.observe(element);
+    }
+
+    return () => {
+      observer?.disconnect();
+      initialized.current = false;
+    };
+  }, [initTerminal, terminalRef, fit, focus]);
+
+  // Refit on any size change, shared with TerminalTab via useTerminalRefit so
+  // the two hosts cannot drift:
+  // - Engine commits (drag/resize/maximize/snap/tile) dispatch one coalesced
+  //   `terminal-panel-resize`, handled synchronously (fit + immediate SIGWINCH).
+  // - Container-only changes (the footer ContextBar growing as pills populate or
+  //   wrap, the Changes panel toggling the column width) are caught by the hook's
+  //   persistent ResizeObserver, which the old hand-rolled paths missed - that
+  //   gap clipped the fullscreen TUI's bottom rows under the pane edge.
+  useTerminalRefit({
+    terminalRef,
+    initializedRef: initialized,
+    fit,
+    flushResize,
+    immediatePanelResize: true,
+  });
+
+  // Restore terminal focus after a maximize/restore toggle (the button, Ctrl+Shift+M,
+  // and the header double-click all flip `isMaximized`), so the next keystroke lands
+  // in the terminal instead of the maximize button. The command terminal OWNS the
+  // xterm focus, so call `focus()` directly. Mirrors TaskDetailWindow's re-homing of
+  // the PR #33 fix; keys on the maximize toggle (not `terminal-panel-resize`, which
+  // also fires on drag/resize) and skips the initial mount.
+  const wasMaximizedRef = useRef(isMaximized);
+  useEffect(() => {
+    if (wasMaximizedRef.current === isMaximized) return;
+    wasMaximizedRef.current = isMaximized;
+    if (initialized.current) focus();
+  }, [isMaximized, focus]);
+
+  return (
+    <div className="h-full" data-testid="command-bar-terminal-pane" data-session-id={sessionId}>
+      <FileDropOverlay {...fileDrop} />
+      <div
+        ref={terminalRef}
+        className="h-full"
+        data-testid="command-bar-terminal"
+      />
+    </div>
+  );
+}

--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -27,12 +27,10 @@ import { KebabMenu, KebabMenuItem, KebabMenuDivider } from '../KebabMenu';
 import { CommandPalettePopover } from '../dialogs/task-detail/CommandPalettePopover';
 import { useHeaderPillOverflow, type HeaderPillSpec } from '../dialogs/task-detail/useHeaderPillOverflow';
 import { WindowLayoutMenu } from '../dialogs/WindowLayoutMenu';
-import { resolveTerminalBackground, useTerminal } from '../../hooks/useTerminal';
-import { useTerminalRefit } from '../../hooks/useTerminalRefit';
+import { resolveTerminalBackground } from '../../hooks/useTerminal';
 import { useKeybinding, useFormattedCombo } from '../../hooks/useKeybinding';
-import { useTerminalFileDrop } from '../../hooks/useTerminalFileDrop';
-import { FileDropOverlay } from '../terminal/FileDropOverlay';
 import { ContextBar } from '../terminal/ContextBar';
+import { CommandTerminalPane, type TerminalGridGetter } from './CommandTerminalPane';
 import { useSessionStore } from '../../stores/session-store';
 import { transientKey } from '../../stores/session-store/transient-session-slice';
 import { commandTerminalChangesEntityId } from '../../stores/session-store/task-changes-panel-slice';
@@ -129,15 +127,10 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
   const [showCommandPalette, setShowCommandPalette] = useState(false);
   const config = useConfigStore((s) => s.config);
   const rawProjectPath = useProjectStore((s) => s.currentProject?.path ?? null);
+  // Also the source for CommandTerminalPane's own pasteImageTemplate lookup
+  // (SESSION_INJECT_SETTINGS uses the same signal) - kept here too since
+  // ContextBar's agentFallback below needs it regardless of the pane.
   const projectAgent = useProjectStore((s) => s.currentProject?.default_agent ?? null);
-  // Adapter-declared: this agent needs an explicit reference (not a bare path) to
-  // reliably read a pasted/dropped image. A transient Command Terminal spawns the
-  // project's default agent (see transient-sessions.ts), so resolve the template by
-  // projectAgent - the same signal ContextBar's agentFallback and SESSION_INJECT_SETTINGS
-  // use here. Never branch on agent name - see .claude/rules/agent-adapters-boundary.md.
-  const pasteImageTemplate = useConfigStore(
-    (s) => s.agentList.find((a) => a.name === projectAgent)?.pastedImageReferenceTemplate,
-  );
   // Resolve to the main repo root if the current project is a worktree.
   const projectPath = useMemo(() => (rawProjectPath ? resolveProjectRoot(rawProjectPath) : null), [rawProjectPath]);
   const shortcuts = useBoardStore((s) => s.shortcuts);
@@ -301,99 +294,10 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
   const isIdle = sessionRunning && requiresUserInteraction(activity);
   const showActivityRing = isThinking || isIdle;
 
-  const commandTerminalShell = useSessionStore(
-    useCallback(
-      (s: ReturnType<typeof useSessionStore.getState>) =>
-        sessionId ? s.sessions.find((session) => session.id === sessionId)?.shell : undefined,
-      [sessionId],
-    ),
-  );
-
-  const { terminalRef, initTerminal, fit, flushResize, focus } = useTerminal({
-    sessionId: effectiveSessionId,
-    fontFamily: config.terminal.fontFamily,
-    fontSize: config.terminal.fontSize,
-    cursorStyle: config.terminal.cursorStyle,
-    colors: config.terminal.colors,
-    shellName: commandTerminalShell ?? undefined,
-    pasteImageTemplate,
-    backspaceSendsCtrlH: config.terminal.backspaceSendsCtrlH,
-  });
-
-  const fileDrop = useTerminalFileDrop(effectiveSessionId, focus, commandTerminalShell ?? undefined, pasteImageTemplate);
-
-  // Init the terminal once the session is ready AND the container has dimensions.
-  const initialized = useRef(false);
-  useEffect(() => {
-    if (!effectiveSessionId) return;
-    const element = terminalRef.current;
-    if (!element) return;
-
-    const tryInit = () => {
-      if (initialized.current) return;
-      if (element.offsetWidth > 0 && element.offsetHeight > 0) {
-        initTerminal();
-        initialized.current = true;
-        fit();
-        focus();
-      }
-    };
-
-    tryInit();
-
-    let observer: ResizeObserver | null = null;
-    if (!initialized.current) {
-      observer = new ResizeObserver(() => {
-        tryInit();
-        if (initialized.current) observer?.disconnect();
-      });
-      observer.observe(element);
-    }
-
-    return () => {
-      observer?.disconnect();
-      initialized.current = false;
-    };
-  }, [effectiveSessionId, initTerminal, terminalRef, fit, focus]);
-
-  // Refit on any size change, shared with TerminalTab via useTerminalRefit so
-  // the two hosts cannot drift:
-  // - Engine commits (drag/resize/maximize/snap/tile) dispatch one coalesced
-  //   `terminal-panel-resize`, handled synchronously (fit + immediate SIGWINCH).
-  // - Container-only changes (the footer ContextBar growing as pills populate or
-  //   wrap, the Changes panel toggling the column width) are caught by the hook's
-  //   persistent ResizeObserver, which the old hand-rolled paths missed - that
-  //   gap clipped the fullscreen TUI's bottom rows under the pane edge.
-  useTerminalRefit({
-    terminalRef,
-    initializedRef: initialized,
-    fit,
-    flushResize,
-    immediatePanelResize: true,
-  });
-
-  // Restore terminal focus after a maximize/restore toggle (the button, Ctrl+Shift+M,
-  // and the header double-click all flip `isMaximized`), so the next keystroke lands
-  // in the terminal instead of the maximize button. The command terminal OWNS the
-  // xterm focus, so call `focus()` directly. Mirrors TaskDetailWindow's re-homing of
-  // the PR #33 fix; keys on the maximize toggle (not `terminal-panel-resize`, which
-  // also fires on drag/resize) and skips the initial mount.
-  const wasMaximizedRef = useRef(isMaximized);
-  useEffect(() => {
-    if (wasMaximizedRef.current === isMaximized) return;
-    wasMaximizedRef.current = isMaximized;
-    if (initialized.current) focus();
-  }, [isMaximized, focus]);
-
-  // Restore keyboard focus to the terminal after a maximize/restore toggle, so the
-  // next keystroke lands in the terminal instead of the maximize button (the button
-  // takes DOM focus when clicked; the panel.maximize keybinding and the header
-  // double-click also flip `isMaximized`). Keyed on `isMaximized`, deliberately NOT
-  // on `terminal-panel-resize` (which also fires on drag/snap/tile and would steal
-  // focus then).
-  useEffect(() => {
-    if (initialized.current) focus();
-  }, [isMaximized, focus]);
+  // Published by the mounted CommandTerminalPane; read by handleBranchChange
+  // before killing the old session so the respawn can seed the new PTY at the
+  // grid the user is already looking at (see spawnTransientSession's cols/rows).
+  const gridGetterRef = useRef<TerminalGridGetter | null>(null);
 
   const defaultBranch = config.git.defaultBaseBranch || 'main';
 
@@ -402,12 +306,15 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
     const resolvedBranch = newBranch || defaultBranch;
     const currentProjectId = useProjectStore.getState().currentProject?.id ?? null;
     if (!currentProjectId) return;
+    // Read BEFORE the kill: the pane unmounts (and clears this ref) once
+    // sessionId flips to null below, and the awaited spawn IPC is not
+    // guaranteed to happen after that unmount commits.
+    const grid = gridGetterRef.current?.() ?? undefined;
     try {
       await useSessionStore.getState().killTransientSessionBySlot(currentProjectId, slot);
       setSessionId(null);
       setTerminalReady(false);
-      initialized.current = false;
-      const result = await useSessionStore.getState().spawnTransientSession(slot, resolvedBranch);
+      const result = await useSessionStore.getState().spawnTransientSession(slot, resolvedBranch, grid);
       setSessionId(result.session.id);
       setBranch(result.branch);
       if (result.checkoutError) {
@@ -691,12 +598,22 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
             the brief pre-fit overflow. Mirrors the Changes panel sibling. */}
         <div className={`${changesOpen ? 'w-1/2' : 'flex-1'} relative min-w-0 overflow-hidden`} style={{ backgroundColor: resolveTerminalBackground(config.terminal.colors) }}>
           {!terminalReady && <LaunchOverlay label="Starting Command Terminal..." variant="terminal" />}
-          <FileDropOverlay {...fileDrop} />
-          <div
-            ref={terminalRef}
-            className="h-full"
-            data-testid="command-bar-terminal"
-          />
+          {/* Keyed (and gated, not just keyed) by session id: useTerminal is
+              unmount-only teardown, so a session swap on a live instance would
+              leave onData/onResize/clipboard/WebGL bound to the dead session.
+              Gating on effectiveSessionId (rather than keying an always-mounted
+              subtree) matters because effectiveSessionId goes null mid-switch
+              (see handleBranchChange) - a null key would mount a throwaway
+              Terminal with no onData/onResize, then tear it down. See
+              CommandTerminalPane.tsx. */}
+          {effectiveSessionId && (
+            <CommandTerminalPane
+              key={effectiveSessionId}
+              sessionId={effectiveSessionId}
+              isMaximized={isMaximized}
+              gridGetterRef={gridGetterRef}
+            />
+          )}
         </div>
 
         {/* Changes panel */}

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -155,6 +155,27 @@ function restoreScrollPosition(terminal: Terminal, sessionId: string | null): bo
   return true;
 }
 
+/** Pure predicate for the hook's host contract (see the unmount-only dispose
+ *  effect's eslint-disable below): a host must remount (key={sessionId})
+ *  rather than swap `options.sessionId` to a different live session on the
+ *  same instance. Swapping in place leaves `initTerminal`'s
+ *  `if (xtermRef.current) return` guard permanently short-circuited, so
+ *  onData/onResize/clipboard/WebGL stay bound to the dead session - the exact
+ *  bug a Command Terminal branch switch shipped. Exported so the contract is
+ *  unit-testable without mounting a real Terminal. */
+export function isSessionSwapWithoutRemount(
+  previousSessionId: string | null,
+  nextSessionId: string | null,
+  hasLiveTerminal: boolean,
+): boolean {
+  return (
+    hasLiveTerminal
+    && previousSessionId !== null
+    && nextSessionId !== null
+    && previousSessionId !== nextSessionId
+  );
+}
+
 export function useTerminal(options: UseTerminalOptions) {
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<Terminal | null>(null);
@@ -218,6 +239,25 @@ export function useTerminal(options: UseTerminalOptions) {
     if (shouldKickIncomingQueue) incomingResumeRef.current?.();
     onScrollbackSettledRef.current?.();
   }, []);
+
+  // Dev-only host-contract tripwire (compiled out of production, where
+  // import.meta.env.DEV is statically false). Registered before any effect the
+  // host itself declares (useTerminal()'s own hooks always run first within a
+  // render, since the host calls useTerminal() before its own useEffect
+  // calls), so it observes xtermRef.current from the PRIOR commit - still the
+  // old session's terminal - the same instant the host's init effect would.
+  // Never fires for a correctly-keyed host (see isSessionSwapWithoutRemount).
+  const lastNonNullSessionIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    // @ts-expect-error -- Vite defines import.meta.env; tsc's "module": "commonjs" doesn't support it
+    if (import.meta.env?.DEV && isSessionSwapWithoutRemount(lastNonNullSessionIdRef.current, options.sessionId, xtermRef.current !== null)) {
+      console.error(
+        `[useTerminal] sessionId changed from ${lastNonNullSessionIdRef.current} to ${options.sessionId} on a live terminal instance. `
+        + 'A host must remount (key={sessionId}) instead of swapping sessionId in place - see the unmount-only dispose effect below.',
+      );
+    }
+    if (options.sessionId !== null) lastNonNullSessionIdRef.current = options.sessionId;
+  }, [options.sessionId]);
 
   // Destructured to PRIMITIVES, deliberately: `config.terminal.colors` is a
   // fresh object on every config refetch (updateConfig -> refreshConfigs
@@ -400,7 +440,16 @@ export function useTerminal(options: UseTerminalOptions) {
           if (scrollback && xtermRef.current) {
             // Chunked so a 512KB replay doesn't parse in one synchronous write.
             // Strip OSC 52 so replaying recorded output never clobbers the live clipboard.
-            writeChunkedToTerminal(xtermRef.current, stripOsc52Sequences(scrollback), afterWrite);
+            // shouldAbort: a newer replay (reveal catch-up, reloadScrollback) may
+            // start and bump the generation while this chunked write is still
+            // draining; abandon rather than write a stale frame over the new one.
+            writeChunkedToTerminal(
+              xtermRef.current,
+              stripOsc52Sequences(scrollback),
+              afterWrite,
+              undefined,
+              () => scrollbackGenerationRef.current !== scrollbackGeneration,
+            );
           } else {
             afterWrite();
           }
@@ -771,7 +820,14 @@ export function useTerminal(options: UseTerminalOptions) {
           // Chunked so a 512KB replay (tab/window switch, resize) doesn't parse
           // in one synchronous write that stalls the renderer mid-drag.
           // Strip OSC 52 so replaying recorded output never clobbers the live clipboard.
-          writeChunkedToTerminal(xtermRef.current, stripOsc52Sequences(scrollback), afterWrite);
+          // shouldAbort: see the matching call in initTerminal above.
+          writeChunkedToTerminal(
+            xtermRef.current,
+            stripOsc52Sequences(scrollback),
+            afterWrite,
+            undefined,
+            () => scrollbackGenerationRef.current !== scrollbackGeneration,
+          );
         } else {
           afterWrite();
         }
@@ -808,6 +864,15 @@ export function useTerminal(options: UseTerminalOptions) {
     xtermRef.current?.focus();
   }, []);
 
+  // The terminal's current grid, read live off the xterm instance (the same
+  // read flushResize already does). Used to seed a respawned PTY's dimensions
+  // (e.g. a Command Terminal branch switch) so the new session starts at the
+  // grid the user is already looking at instead of the spawn defaults.
+  const getDimensions = useCallback((): { cols: number; rows: number } | null => {
+    if (!xtermRef.current) return null;
+    return { cols: xtermRef.current.cols, rows: xtermRef.current.rows };
+  }, []);
+
   return {
     terminalRef,
     initTerminal,
@@ -817,5 +882,6 @@ export function useTerminal(options: UseTerminalOptions) {
     reloadScrollback,
     scrollbackPending: scrollbackPendingRef,
     suppressDataRef,
+    getDimensions,
   };
 }

--- a/src/renderer/hooks/useTerminalRefit.ts
+++ b/src/renderer/hooks/useTerminalRefit.ts
@@ -124,7 +124,11 @@ export function useTerminalRefit(options: TerminalRefitOptions): void {
       if (resizeTimer) clearTimeout(resizeTimer);
       resizeTimer = setTimeout(() => {
         resizeTimer = null;
-        fit();
+        // Re-check size at fire time, not just at schedule time: a container
+        // can collapse to 0 during the debounce (a tile/untile or visibility
+        // transition), and FitAddon's own zero-size guard already no-ops in
+        // that case - this just skips the wasted fit() call.
+        if (element.offsetWidth > 0 && element.offsetHeight > 0) fit();
       }, delayMs);
     };
 

--- a/src/renderer/stores/session-store/transient-session-slice.ts
+++ b/src/renderer/stores/session-store/transient-session-slice.ts
@@ -82,8 +82,14 @@ export interface TransientSessionSlice {
   transientSessions: Record<string, TransientSessionEntry>;
 
   /** Spawn a transient session for `slot` in the current project (optionally on a
-   *  branch). Records it in the map under `transientKey(projectId, slot)`. */
-  spawnTransientSession: (slot: string, branch?: string) => Promise<{ session: Session; branch: string; checkoutError?: string }>;
+   *  branch). Records it in the map under `transientKey(projectId, slot)`. `grid`
+   *  seeds the new PTY's dimensions (e.g. a branch respawn reusing the still-mounted
+   *  xterm's current size); omit to spawn at the defaults. */
+  spawnTransientSession: (
+    slot: string,
+    branch?: string,
+    grid?: { cols: number; rows: number },
+  ) => Promise<{ session: Session; branch: string; checkoutError?: string }>;
   /** Kill one slot's transient PTY (IPC) and scrub its renderer state. */
   killTransientSessionBySlot: (projectId: string, slot: string) => Promise<void>;
   /** Remove a transient session's renderer state by session id, no IPC (the PTY
@@ -123,12 +129,14 @@ export function createTransientSessionSlice(preserved: {
 
     transientSessions: preserved?.transientSessions ?? {},
 
-    spawnTransientSession: async (slot, branch?) => {
+    spawnTransientSession: async (slot, branch?, grid?) => {
       const currentProject = useProjectStore.getState().currentProject;
       if (!currentProject) throw new Error('No project is currently open');
       const result = await window.electronAPI.sessions.spawnTransient({
         projectId: currentProject.id,
         branch,
+        cols: grid?.cols,
+        rows: grid?.rows,
       });
       // Insert the session synchronously so anything that filters
       // state.sessions for `projectId === current && status === 'running'`

--- a/src/renderer/utils/incoming-write-queue.ts
+++ b/src/renderer/utils/incoming-write-queue.ts
@@ -149,19 +149,34 @@ export function createIncomingWriteQueue(
  * surrogate-safe slices, calling `onDone` after the last slice is processed.
  * Avoids one giant synchronous parse on a tab/window switch or resize.
  * Not backpressure-counted: scrollback is pulled, not pushed, so no acking.
+ *
+ * `shouldAbort`, when provided, is checked before writing each slice AND
+ * before firing `onDone` off a slice's write callback: two chunked replays
+ * can race into the same Terminal (a reveal catch-up or overlay-lift reload
+ * starting while a mount-time replay is still draining its writes). On abort
+ * this returns WITHOUT calling `onDone` - the newer replay owns
+ * scrollbackPendingRef and the incoming-queue kick, so firing the aborted
+ * write's onDone would open the drop/hold gate early and race the newer
+ * replay's own settle. Callers pass a generation check (see useTerminal.ts).
  */
 export function writeChunkedToTerminal(
   term: Terminal,
   data: string,
   onDone: () => void,
   chunkSize: number = DEFAULT_INCOMING_CHUNK,
+  shouldAbort?: () => boolean,
 ): void {
+  if (shouldAbort?.()) return;
   if (data.length <= chunkSize) {
-    term.write(data, onDone);
+    term.write(data, () => {
+      if (shouldAbort?.()) return;
+      onDone();
+    });
     return;
   }
   let offset = 0;
   const writeNext = (): void => {
+    if (shouldAbort?.()) return;
     if (offset >= data.length) {
       onDone();
       return;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3378,12 +3378,23 @@ export interface SpawnSessionInput {
    * Isolated. Defaults to null when omitted.
    */
   isolatedSwimlaneId?: string | null;
+  /**
+   * Caller-known PTY grid to spawn at, when available (e.g. a Command
+   * Terminal branch respawn reusing the still-mounted xterm's current size).
+   * Falls back to `takePendingResize` (a resize that beat the spawn), then to
+   * DEFAULT_PTY_COLS/ROWS - see session-spawn-flow.ts.
+   */
+  cols?: number;
+  rows?: number;
 }
 
 export interface SpawnTransientSessionInput {
   projectId: string;
   /** Branch to checkout before spawning. If omitted, uses the project's default base branch. */
   branch?: string;
+  /** See `SpawnSessionInput.cols`/`rows` - the same seed-the-real-grid escape hatch. */
+  cols?: number;
+  rows?: number;
 }
 
 export interface NotificationInput {

--- a/tests/ui/command-terminal.spec.ts
+++ b/tests/ui/command-terminal.spec.ts
@@ -2862,5 +2862,54 @@ test.describe('Command Terminal', () => {
         await browser.close();
       }
     });
+
+    test('a branch switch never fires the dev-only session-swap-without-remount tripwire', async () => {
+      // useTerminal's dev-only tripwire (isSessionSwapWithoutRemount,
+      // useTerminal.ts) console.errors if a host's sessionId changes to a
+      // different LIVE session without remounting. UI specs run against the
+      // real Vite dev server, so import.meta.env.DEV is true here - the
+      // tripwire is live in this test the same way it is in `npm start`
+      // dogfooding. This is the wiring the pure-predicate unit test
+      // (terminal-session-swap-contract.test.ts) cannot reach: it exercises
+      // real refs across real re-renders, not a copy of the effect's logic.
+      const { browser, page } = await launchWithState(branchSwitchPreConfig());
+      const consoleErrors: string[] = [];
+      page.on('console', (message) => {
+        if (message.type() === 'error') consoleErrors.push(message.text());
+      });
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+        await page.keyboard.press('Control+Shift+P');
+        await expect(page.getByTestId('command-terminal-window')).toBeVisible();
+        await markFirstOutput(page, 'branch-switch-session-1');
+        await expect(page.getByTestId('command-terminal-window').locator('.xterm-helper-textarea').first())
+          .toBeAttached({ timeout: 8000 });
+
+        await page.getByTestId('branch-picker-chip').click();
+        const developButton = page.locator('button:has-text("develop")');
+        await developButton.waitFor({ state: 'visible' });
+        await developButton.click();
+
+        await expect.poll(async () => {
+          const entries = await transientEntriesFor(page, BRANCH_SWITCH_PROJECT_ID);
+          return entries[0]?.sessionId;
+        }, { timeout: 8000, intervals: [50, 100, 200, 500] }).toBe('branch-switch-session-2');
+
+        await markFirstOutput(page, 'branch-switch-session-2');
+        await expect(page.getByTestId('command-terminal-window').locator('.xterm-helper-textarea').first())
+          .toBeAttached({ timeout: 8000 });
+
+        // Negative assertion, so a fixed budget rather than a poll: give the
+        // tripwire's effect (and any deferred console output) time to have
+        // fired by now if it was going to.
+        await page.waitForTimeout(500);
+
+        const tripwireErrors = consoleErrors.filter((text) => text.includes('[useTerminal] sessionId changed'));
+        expect(tripwireErrors).toEqual([]);
+      } finally {
+        await browser.close();
+      }
+    });
   });
 });

--- a/tests/ui/command-terminal.spec.ts
+++ b/tests/ui/command-terminal.spec.ts
@@ -2658,4 +2658,209 @@ test.describe('Command Terminal', () => {
       }
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Branch switch (regression lock): CommandTerminalWindow used to swap
+  // sessionId in place on a live useTerminal instance, leaving onData/onResize
+  // permanently bound to the killed session (initTerminal's
+  // `if (xtermRef.current) return` guard). CommandTerminalPane now mounts
+  // keyed-and-gated by session id, so a branch switch remounts the xterm host
+  // instead. See CommandTerminalPane.tsx.
+  // ---------------------------------------------------------------------------
+  test.describe('Branch switch', () => {
+    const BRANCH_SWITCH_PROJECT_ID = 'proj-branch-switch';
+
+    /** One project; a counter-based deterministic spawnTransient that records
+     *  every input (for the cols/rows assertion) and never auto-fires first
+     *  output - the test drives that explicitly via markFirstOutput, mirroring
+     *  openCommandBarWithMountedTerminal above, for both the initial spawn and
+     *  the branch respawn. */
+    function branchSwitchPreConfig(): string {
+      return `
+        window.__mockPreConfigure(function (state) {
+          var ts = new Date().toISOString();
+          state.projects.push({
+            id: '${BRANCH_SWITCH_PROJECT_ID}',
+            name: 'Branch Switch Project',
+            path: '/mock/branch-switch-project',
+            github_url: null,
+            default_agent: 'claude',
+            last_opened: ts,
+            created_at: ts,
+          });
+          state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+            state.swimlanes.push(Object.assign({}, s, {
+              id: 'lane-branch-switch-' + i,
+              position: i,
+              created_at: ts,
+            }));
+          });
+          return { currentProjectId: '${BRANCH_SWITCH_PROJECT_ID}' };
+        });
+
+        var branchSwitchSpawnCounter = 0;
+        window.__branchSwitchSpawnCalls = [];
+        window.electronAPI.sessions.spawnTransient = async function (input) {
+          branchSwitchSpawnCounter += 1;
+          var id = 'branch-switch-session-' + branchSwitchSpawnCounter;
+          window.__branchSwitchSpawnCalls.push(input);
+          var session = {
+            id: id,
+            taskId: id,
+            projectId: input.projectId,
+            pid: null,
+            status: 'running',
+            shell: '/bin/bash',
+            cwd: '/mock/branch-switch-project',
+            startedAt: new Date().toISOString(),
+            exitCode: null,
+            resuming: false,
+            transient: true,
+            isolatedSwimlaneId: null,
+            agentSessionId: null,
+          };
+          return { session: session, branch: input.branch || 'main' };
+        };
+      `;
+    }
+
+    /** Flip sessionFirstOutput for `sessionId` so CommandTerminalPane mounts
+     *  (see CommandTerminalWindow's terminalReady gate). Mirrors
+     *  openCommandBarWithMountedTerminal's injection above. */
+    async function markFirstOutput(page: Page, sessionId: string): Promise<void> {
+      await page.evaluate((id) => {
+        const stores = (window as unknown as {
+          __zustandStores?: { session?: { getState: () => { markFirstOutput: (id: string) => void } } };
+        }).__zustandStores;
+        stores?.session?.getState().markFirstOutput(id);
+      }, sessionId);
+    }
+
+    /** Every input passed to the mock's spawnTransient so far. */
+    async function branchSwitchSpawnCalls(page: Page): Promise<Array<{ branch?: string; cols?: number; rows?: number }>> {
+      return page.evaluate(() => (window as unknown as { __branchSwitchSpawnCalls: Array<{ branch?: string; cols?: number; rows?: number }> }).__branchSwitchSpawnCalls);
+    }
+
+    /** The most recent sessions.resize(sessionId, cols, rows) call recorded by
+     *  the mock for `sessionId`, or undefined if none yet. initTerminal calls
+     *  sessions.resize synchronously (before any await) right after fitting the
+     *  xterm host to its container, so the last entry for a mounted pane's
+     *  session id is that pane's live grid. */
+    async function lastResizeCallFor(
+      page: Page,
+      sessionId: string,
+    ): Promise<{ sessionId: string; cols: number; rows: number } | undefined> {
+      return page.evaluate((id) => {
+        const calls = (window as unknown as {
+          electronAPI: { sessions: { __resizeCalls: Array<{ sessionId: string; cols: number; rows: number }> } };
+        }).electronAPI.sessions.__resizeCalls;
+        return calls.filter((call) => call.sessionId === id).at(-1);
+      }, sessionId);
+    }
+
+    test('typing after a branch switch reaches the NEW session, not the killed one', async () => {
+      const { browser, page } = await launchWithState(branchSwitchPreConfig());
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+        await page.keyboard.press('Control+Shift+P');
+        await expect(page.getByTestId('command-terminal-window')).toBeVisible();
+        await markFirstOutput(page, 'branch-switch-session-1');
+
+        const pane = page.getByTestId('command-bar-terminal-pane');
+        await expect(pane).toBeAttached({ timeout: 8000 });
+        await expect(pane).toHaveAttribute('data-session-id', 'branch-switch-session-1');
+
+        // Switch branch via the header chip.
+        await page.getByTestId('branch-picker-chip').click();
+        const developButton = page.locator('button:has-text("develop")');
+        await developButton.waitFor({ state: 'visible' });
+        await developButton.click();
+
+        // The store's transientSessions entry must carry the NEW session id
+        // before the pane can be expected to have remounted.
+        await expect.poll(async () => {
+          const entries = await transientEntriesFor(page, BRANCH_SWITCH_PROJECT_ID);
+          return entries[0]?.sessionId;
+        }, { timeout: 8000, intervals: [50, 100, 200, 500] }).toBe('branch-switch-session-2');
+
+        await markFirstOutput(page, 'branch-switch-session-2');
+
+        // The pane remounted (React key changed): data-session-id updates, and
+        // there is still exactly one xterm instance (the old one was disposed,
+        // not left running alongside a second one).
+        await expect(pane).toHaveAttribute('data-session-id', 'branch-switch-session-2', { timeout: 8000 });
+        await expect(page.getByTestId('command-terminal-window').locator('.xterm')).toHaveCount(1);
+
+        // Type into the terminal and assert the write landed on the NEW
+        // session id, not the killed one - the positive assertion the vacuous
+        // "no write to the old id" check would miss if the pane never mounted.
+        // .focus() (not a click) is deterministic - xterm's own focus() call
+        // happens inside initTerminal's requestAnimationFrame.
+        const textarea = pane.locator('.xterm-helper-textarea').first();
+        await expect(textarea).toBeAttached({ timeout: 8000 });
+        await page.evaluate(() => { window.electronAPI.sessions.__writeCalls.length = 0; });
+        await textarea.focus();
+        await page.keyboard.type('echo hi');
+
+        await expect.poll(async () => {
+          const calls = await page.evaluate(
+            () => (window as unknown as { electronAPI: { sessions: { __writeCalls: Array<{ sessionId: string; payload: string }> } } })
+              .electronAPI.sessions.__writeCalls,
+          );
+          const last = calls[calls.length - 1];
+          return last?.sessionId;
+        }, { timeout: 8000, intervals: [50, 100, 200, 500] }).toBe('branch-switch-session-2');
+      } finally {
+        await browser.close();
+      }
+    });
+
+    test('branch respawn seeds the new PTY with the pre-switch grid', async () => {
+      const { browser, page } = await launchWithState(branchSwitchPreConfig());
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+        await page.keyboard.press('Control+Shift+P');
+        await expect(page.getByTestId('command-terminal-window')).toBeVisible();
+        await markFirstOutput(page, 'branch-switch-session-1');
+        await expect(page.getByTestId('command-terminal-window').locator('.xterm-helper-textarea').first())
+          .toBeAttached({ timeout: 8000 });
+
+        await page.getByTestId('branch-picker-chip').click();
+        const developButton = page.locator('button:has-text("develop")');
+        await developButton.waitFor({ state: 'visible' });
+
+        // Snapshot the pre-switch pane's live grid via the resize call its
+        // mount-time fit() already sent, immediately before triggering the
+        // switch. This is the SAME grid handleBranchChange reads via
+        // gridGetterRef right before the kill, so equating the two proves the
+        // respawn was seeded from the pane's ACTUAL live grid - not merely
+        // "some positive number" (a regression hardcoding {cols: 80, rows: 24}
+        // in handleBranchChange would pass the old >0 assertions unchanged,
+        // but fails this equality unless it coincidentally matched).
+        await expect.poll(
+          async () => (await lastResizeCallFor(page, 'branch-switch-session-1')) !== undefined,
+          { timeout: 8000, intervals: [50, 100, 200, 500] },
+        ).toBe(true);
+        const preSwitchGrid = await lastResizeCallFor(page, 'branch-switch-session-1');
+
+        await developButton.click();
+
+        await expect.poll(async () => (await branchSwitchSpawnCalls(page)).length, { timeout: 8000 }).toBe(2);
+
+        const calls = await branchSwitchSpawnCalls(page);
+        const respawnCall = calls[1];
+        expect(respawnCall.branch).toBe('develop');
+        // Grid was read from the still-mounted pane before the kill (see
+        // handleBranchChange), so it must equal the pre-switch pane's actual
+        // live grid, not merely be some positive number.
+        expect(preSwitchGrid).toBeDefined();
+        expect(respawnCall.cols).toBe(preSwitchGrid!.cols);
+        expect(respawnCall.rows).toBe(preSwitchGrid!.rows);
+      } finally {
+        await browser.close();
+      }
+    });
+  });
 });

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -1373,7 +1373,14 @@
       write: async function (sessionId, payload) {
         window.electronAPI.sessions.__writeCalls.push({ sessionId: sessionId, payload: payload });
       },
-      resize: async function () { return { colsChanged: false }; },
+      // Call log for test assertions. Each entry is { sessionId, cols, rows },
+      // in call order. Mirrors the __writeCalls log above. Reset between tests
+      // via window.electronAPI.sessions.__resizeCalls.length = 0.
+      __resizeCalls: [],
+      resize: async function (sessionId, cols, rows) {
+        window.electronAPI.sessions.__resizeCalls.push({ sessionId: sessionId, cols: cols, rows: rows });
+        return { colsChanged: false };
+      },
       list: async function () {
         return sessions;
       },

--- a/tests/unit/fit-addon.test.ts
+++ b/tests/unit/fit-addon.test.ts
@@ -76,6 +76,47 @@ function makeWindowStub(parentEl: object) {
   };
 }
 
+/** Same shape as makeWindowStub, but the parent box reports a collapsed size
+ *  for one axis - a hidden/mid-transition container. */
+function makeCollapsedWindowStub(parentEl: object, dimension: 'width' | 'height' | 'both'): unknown {
+  const width = dimension === 'width' || dimension === 'both' ? '0' : '800';
+  const height = dimension === 'height' || dimension === 'both' ? '0' : '600';
+  return {
+    getComputedStyle: (element: unknown) => ({
+      getPropertyValue: (prop: string): string => {
+        if (element === parentEl) {
+          if (prop === 'width') return width;
+          if (prop === 'height') return height;
+        }
+        return '0';
+      },
+    }),
+  };
+}
+
+/** Same shape as makeCollapsedWindowStub, but the parent box reports an EMPTY
+ *  string (not '0') for the selected axis - a real-world computed-style value
+ *  ('' or 'auto') that `parseInt` turns into NaN rather than 0. The guard's
+ *  comment claims `> 0` also rejects NaN; this stub is what proves it, since
+ *  an equivalent-looking `=== 0` rewrite would let a NaN box slip past every
+ *  '0'-only case above. The other axis stays a valid '800'/'600' so each
+ *  single-axis case is discriminating. */
+function makeNaNWindowStub(parentEl: object, dimension: 'width' | 'height' | 'both'): unknown {
+  const width = dimension === 'width' || dimension === 'both' ? '' : '800';
+  const height = dimension === 'height' || dimension === 'both' ? '' : '600';
+  return {
+    getComputedStyle: (element: unknown) => ({
+      getPropertyValue: (prop: string): string => {
+        if (element === parentEl) {
+          if (prop === 'width') return width;
+          if (prop === 'height') return height;
+        }
+        return '0';
+      },
+    }),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -124,5 +165,108 @@ describe('FitAddon.proposeDimensions -- alt-buffer scrollbar reclaim', () => {
     const dims = fitAddon.proposeDimensions();
     expect(dims).toBeDefined();
     expect(dims!.cols).toBe(100);
+  });
+});
+
+describe('FitAddon.proposeDimensions -- collapsed container bails instead of clamping', () => {
+  // A hidden/mid-transition container (tile/untile, visibility toggle) can report
+  // a 0 (or NaN) box. Clamping to MINIMUM_COLS/MINIMUM_ROWS would still produce a
+  // valid-looking 2x1 grid that flows all the way to sessions.resize, corrupting
+  // the PTY's real width. proposeDimensions() must return undefined instead, so
+  // fit() no-ops and the real grid survives until the container has real
+  // dimensions again.
+  let fitAddon: FitAddon;
+  const { parentEl, elementEl } = makeElements();
+
+  beforeEach(() => {
+    fitAddon = new FitAddon();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns undefined when the parent width is 0', () => {
+    vi.stubGlobal('window', makeCollapsedWindowStub(parentEl, 'width'));
+    const terminal = makeTerminalStub(elementEl, 'normal', 1000);
+    fitAddon.activate(terminal);
+    expect(fitAddon.proposeDimensions()).toBeUndefined();
+  });
+
+  it('returns undefined when the parent height is 0', () => {
+    vi.stubGlobal('window', makeCollapsedWindowStub(parentEl, 'height'));
+    const terminal = makeTerminalStub(elementEl, 'normal', 1000);
+    fitAddon.activate(terminal);
+    expect(fitAddon.proposeDimensions()).toBeUndefined();
+  });
+
+  it('returns undefined when both dimensions are 0', () => {
+    vi.stubGlobal('window', makeCollapsedWindowStub(parentEl, 'both'));
+    const terminal = makeTerminalStub(elementEl, 'normal', 1000);
+    fitAddon.activate(terminal);
+    expect(fitAddon.proposeDimensions()).toBeUndefined();
+  });
+
+  it('fit() no-ops (never calls terminal.resize) against a collapsed container', () => {
+    vi.stubGlobal('window', makeCollapsedWindowStub(parentEl, 'both'));
+    const terminal = makeTerminalStub(elementEl, 'normal', 1000);
+    const resize = vi.fn();
+    (terminal as unknown as { resize: typeof resize }).resize = resize;
+    fitAddon.activate(terminal);
+    fitAddon.fit();
+    expect(resize).not.toHaveBeenCalled();
+  });
+});
+
+describe('FitAddon.proposeDimensions -- NaN parent box bails instead of clamping', () => {
+  // A real-world collapsed/mid-transition container does not necessarily
+  // report '0' from getComputedStyle - it can report '' or 'auto', which
+  // parseInt turns into NaN, not 0. The guard at fit-addon.ts:88 is written
+  // as `!(parentWidth > 0) || !(parentHeight > 0)` specifically because that
+  // form also rejects NaN (any comparison against NaN is false). An
+  // equivalent-looking `parentWidth === 0 || parentHeight === 0` rewrite
+  // would pass every '0'-only case in the describe block above while letting
+  // a NaN box fall through to the clamp logic below it - the exact
+  // corruption the guard exists to prevent (a valid-looking 2x1 grid flowing
+  // to sessions.resize and corrupting the PTY's real width).
+  //
+  // parentWidth is `Math.max(0, parseInt(...))` and parentHeight is a bare
+  // `parseInt(...)`; Math.max propagates NaN (Math.max(0, NaN) === NaN), so
+  // both axes reach the guard as NaN and both return undefined - there is no
+  // axis-specific carve-out to assert.
+  //
+  // Red-green: reverting the guard to `parentWidth === 0 || parentHeight === 0`
+  // makes all three cases below return a clamped {cols: 2, rows: ...} /
+  // {cols: ..., rows: 1} object instead of undefined.
+  let fitAddon: FitAddon;
+  const { parentEl, elementEl } = makeElements();
+
+  beforeEach(() => {
+    fitAddon = new FitAddon();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns undefined when the parent width computed style is NaN (e.g. \'\')', () => {
+    vi.stubGlobal('window', makeNaNWindowStub(parentEl, 'width'));
+    const terminal = makeTerminalStub(elementEl, 'normal', 1000);
+    fitAddon.activate(terminal);
+    expect(fitAddon.proposeDimensions()).toBeUndefined();
+  });
+
+  it('returns undefined when the parent height computed style is NaN (e.g. \'\')', () => {
+    vi.stubGlobal('window', makeNaNWindowStub(parentEl, 'height'));
+    const terminal = makeTerminalStub(elementEl, 'normal', 1000);
+    fitAddon.activate(terminal);
+    expect(fitAddon.proposeDimensions()).toBeUndefined();
+  });
+
+  it('returns undefined when both parent dimensions are NaN', () => {
+    vi.stubGlobal('window', makeNaNWindowStub(parentEl, 'both'));
+    const terminal = makeTerminalStub(elementEl, 'normal', 1000);
+    fitAddon.activate(terminal);
+    expect(fitAddon.proposeDimensions()).toBeUndefined();
   });
 });

--- a/tests/unit/incoming-write-queue.test.ts
+++ b/tests/unit/incoming-write-queue.test.ts
@@ -295,4 +295,55 @@ describe('writeChunkedToTerminal', () => {
     expect(onDone).toHaveBeenCalledTimes(1);
     expect(writes.join('')).toBe('abcdefghij');
   });
+
+  // shouldAbort: a newer replay (reveal catch-up, reloadScrollback,
+  // overlay-lift reload) can start while an older chunked replay is still
+  // draining into the same Terminal. useTerminal.ts wires this to a
+  // generation check; these tests exercise the abort contract directly.
+  it('never writes when already aborted before the first slice', async () => {
+    const { term, writes } = fakeTerminal();
+    const onDone = vi.fn();
+    writeChunkedToTerminal(term, 'abcdefghij', onDone, 4, () => true);
+    await flush();
+    expect(writes).toEqual([]);
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it('stops writing further slices once shouldAbort flips true mid-replay, and never fires onDone', async () => {
+    const { term, writes } = fakeTerminal();
+    const onDone = vi.fn();
+    let aborted = false;
+    // writeChunkedToTerminal writes its first slice synchronously (only the
+    // continuation to the NEXT slice is deferred via term.write's callback),
+    // so flipping `aborted` right after the call - before yielding at all -
+    // lands strictly between the first and second slice.
+    writeChunkedToTerminal(term, 'abcdefghij', onDone, 4, () => aborted);
+    expect(writes).toEqual(['abcd']);
+    aborted = true;
+    await flush(); // the deferred writeNext for slice 2 now sees aborted=true
+    expect(writes).toEqual(['abcd']);
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it('a short (non-chunked) write checks shouldAbort before firing onDone off the write callback', async () => {
+    const { term, writes } = fakeTerminal();
+    const onDone = vi.fn();
+    let aborted = false;
+    writeChunkedToTerminal(term, 'short', onDone, 64, () => aborted);
+    // The write happens synchronously (before the callback fires); flip abort
+    // before the microtask callback runs.
+    aborted = true;
+    await flush();
+    expect(writes).toEqual(['short']); // the write itself already landed
+    expect(onDone).not.toHaveBeenCalled(); // but settling was suppressed
+  });
+
+  it('a non-aborted replay is unaffected by an always-false shouldAbort', async () => {
+    const { term, writes } = fakeTerminal();
+    const onDone = vi.fn();
+    writeChunkedToTerminal(term, 'abcdefghij', onDone, 4, () => false);
+    await flush();
+    expect(writes).toEqual(['abcd', 'efgh', 'ij']);
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/unit/session-spawn-flow.test.ts
+++ b/tests/unit/session-spawn-flow.test.ts
@@ -84,7 +84,7 @@ vi.mock('../../src/shared/paths', () => ({
 }));
 
 // ---- Import under test (after all vi.mock hoisting) ----
-import { performSpawn } from '../../src/main/pty/lifecycle/session-spawn-flow';
+import { performSpawn, DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS } from '../../src/main/pty/lifecycle/session-spawn-flow';
 import { SessionRegistry } from '../../src/main/pty/session-registry';
 import { resolveSpawnCwd } from '../../src/main/pty/spawn/pty-spawn';
 import { adaptCommandForShell } from '../../src/shared/paths';
@@ -624,5 +624,121 @@ describe('performSpawn - activity engine initialTurnActive seed (thinking vs idl
     expect(context.telemetry.initSession).toHaveBeenCalledOnce();
     const initArgs = (context.telemetry.initSession as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(initArgs[2]).toBe(false);
+  });
+});
+
+describe('performSpawn - cols/rows precedence', () => {
+  // Pins the precedence chain documented at session-spawn-flow.ts lines
+  // 167-192: takePendingResize's stashed grid wins over a caller-supplied
+  // input.cols/rows, which in turn wins over the DEFAULT_PTY_COLS/ROWS
+  // fallback. Also pins the clamp applied to input.cols/rows (mirroring
+  // SessionManager.resize's clamp) before the value can reach pty.spawn.
+  //
+  // Pending grid (200x60) and input grid (100x40) are chosen to be
+  // distinguishable from each other AND from the 120x30 default, so a test
+  // asserting the wrong value in the chain cannot pass by accident.
+  //
+  // Red-green: for each case, the corresponding source line in
+  // session-spawn-flow.ts was temporarily reverted (see the report), the
+  // test observed red, and the source was restored to observe green.
+  //
+  // Tier: Unit - pure mock collaborators, no PTY, no OS, no IPC.
+
+  const ptySpawnMock = ptyModule.spawn as ReturnType<typeof vi.fn>;
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('case (a): uses input.cols/rows when set and no pendingResize is stashed', async () => {
+    const context = makeContext();
+    const input = makeInput({ cols: 100, rows: 40 });
+
+    await performSpawn(input, context);
+
+    expect(ptySpawnMock).toHaveBeenCalledOnce();
+    const spawnOptions = ptySpawnMock.mock.calls[0]?.[2] as { cols: number; rows: number };
+    expect(spawnOptions.cols).toBe(100);
+    expect(spawnOptions.rows).toBe(40);
+  });
+
+  it('case (b): a stashed pendingResize wins over input.cols/rows when both are present', async () => {
+    const context = makeContext();
+    (context.takePendingResize as ReturnType<typeof vi.fn>).mockReturnValue({ cols: 200, rows: 60 });
+    const input = makeInput({ cols: 100, rows: 40 });
+
+    await performSpawn(input, context);
+
+    const spawnOptions = ptySpawnMock.mock.calls[0]?.[2] as { cols: number; rows: number };
+    expect(spawnOptions.cols).toBe(200);
+    expect(spawnOptions.rows).toBe(60);
+  });
+
+  it('case (c): falls back to DEFAULT_PTY_COLS/ROWS when neither pendingResize nor input.cols/rows is set', async () => {
+    const context = makeContext();
+    const input = makeInput();
+
+    await performSpawn(input, context);
+
+    const spawnOptions = ptySpawnMock.mock.calls[0]?.[2] as { cols: number; rows: number };
+    expect(spawnOptions.cols).toBe(DEFAULT_PTY_COLS);
+    expect(spawnOptions.rows).toBe(DEFAULT_PTY_ROWS);
+  });
+
+  it('case (d): takePendingResize is consumed exactly once, unconditionally, keyed on the resolved session id', async () => {
+    // Pins the "called unconditionally" invariant documented at line 176-177:
+    // the pending entry must be consumed even when input.cols/rows also
+    // applies, never gated behind an `if (input.cols === undefined)` check.
+    const context = makeContext();
+    const input = makeInput({ cols: 100, rows: 40 });
+
+    await performSpawn(input, context);
+
+    expect(context.takePendingResize).toHaveBeenCalledTimes(1);
+    expect(context.takePendingResize).toHaveBeenCalledWith(input.id);
+  });
+
+  it('case (e1): clamps input.cols=0 to the minimum of 2', async () => {
+    const context = makeContext();
+    const input = makeInput({ cols: 0, rows: 40 });
+
+    await performSpawn(input, context);
+
+    const spawnOptions = ptySpawnMock.mock.calls[0]?.[2] as { cols: number; rows: number };
+    expect(spawnOptions.cols).toBe(2);
+    expect(spawnOptions.rows).toBe(40);
+  });
+
+  it('case (e2): clamps input.rows=0 to the minimum of 1', async () => {
+    const context = makeContext();
+    const input = makeInput({ cols: 100, rows: 0 });
+
+    await performSpawn(input, context);
+
+    const spawnOptions = ptySpawnMock.mock.calls[0]?.[2] as { cols: number; rows: number };
+    expect(spawnOptions.cols).toBe(100);
+    expect(spawnOptions.rows).toBe(1);
+  });
+
+  it('case (e3): a non-finite input.cols (NaN) is treated as absent and falls through to DEFAULT_PTY_COLS', async () => {
+    const context = makeContext();
+    const input = makeInput({ cols: NaN, rows: 40 });
+
+    await performSpawn(input, context);
+
+    const spawnOptions = ptySpawnMock.mock.calls[0]?.[2] as { cols: number; rows: number };
+    expect(spawnOptions.cols).toBe(DEFAULT_PTY_COLS);
+    expect(spawnOptions.rows).toBe(40);
+  });
+
+  it('case (e4): floors a non-integer input.cols (100.7) to 100', async () => {
+    const context = makeContext();
+    const input = makeInput({ cols: 100.7, rows: 40 });
+
+    await performSpawn(input, context);
+
+    const spawnOptions = ptySpawnMock.mock.calls[0]?.[2] as { cols: number; rows: number };
+    expect(spawnOptions.cols).toBe(100);
+    expect(spawnOptions.rows).toBe(40);
   });
 });

--- a/tests/unit/terminal-session-swap-contract.test.ts
+++ b/tests/unit/terminal-session-swap-contract.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Unit coverage for `isSessionSwapWithoutRemount`, the pure predicate behind
+ * useTerminal's dev-only host-contract tripwire. A host (CommandTerminalWindow,
+ * TerminalTab, ...) must remount (key={sessionId}) rather than swap
+ * `options.sessionId` to a different live session on the same instance -
+ * swapping in place leaves onData/onResize/clipboard/WebGL bound to the dead
+ * session, which is exactly the Command Terminal branch-switch bug this
+ * predicate now catches at dev time.
+ */
+import { describe, it, expect } from 'vitest';
+import { isSessionSwapWithoutRemount } from '../../src/renderer/hooks/useTerminal';
+
+describe('isSessionSwapWithoutRemount', () => {
+  it('flags a live terminal whose sessionId changed to a different session', () => {
+    expect(isSessionSwapWithoutRemount('sess-1', 'sess-2', true)).toBe(true);
+  });
+
+  it('does not flag the first sessionId a fresh instance ever sees (no previous id)', () => {
+    expect(isSessionSwapWithoutRemount(null, 'sess-1', true)).toBe(false);
+  });
+
+  it('does not flag a correctly-keyed remount (no live terminal survives the swap)', () => {
+    expect(isSessionSwapWithoutRemount('sess-1', 'sess-2', false)).toBe(false);
+  });
+
+  it('does not flag the same sessionId repeating (a no-op re-render)', () => {
+    expect(isSessionSwapWithoutRemount('sess-1', 'sess-1', true)).toBe(false);
+  });
+
+  it('does not flag a transition to a null sessionId (a host going session-less)', () => {
+    expect(isSessionSwapWithoutRemount('sess-1', null, true)).toBe(false);
+  });
+
+  it('does not flag two null sessionIds (a session-less pane re-rendering)', () => {
+    expect(isSessionSwapWithoutRemount(null, null, true)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Fixes the Command Terminal so a branch switch remounts its xterm host instead
of swapping the live `sessionId` on a single, never-torn-down instance.

- Extracts the terminal host out of `CommandTerminalWindow` into a new
  `CommandTerminalPane`, mounted `key={sessionId}` and **gated** on a
  non-null session id (not just keyed - `effectiveSessionId` goes `null`
  mid-switch, and keying an always-mounted subtree on `null` would mount a
  throwaway Terminal with no `onData`/`onResize`, then tear it down).
- Seeds a branch respawn's PTY at the still-mounted pane's live grid
  (`cols`/`rows` plumbed end-to-end through the transient-spawn IPC, with
  clamping mirroring `SessionManager.resize`'s), instead of the
  `DEFAULT_PTY_COLS`/`DEFAULT_PTY_ROWS` (120x30) fallback.
- Adds a dev-only tripwire in `useTerminal` (`isSessionSwapWithoutRemount`)
  that flags any future host that violates the "remount per session"
  contract the hook's unmount-only dispose effect depends on.
- Hardens two related paths surfaced while investigating: `writeChunkedToTerminal`
  now takes a `shouldAbort` check so two concurrent scrollback replays can't
  interleave into one xterm, and `FitAddon.proposeDimensions` now returns
  `undefined` for a collapsed/zero-size container instead of clamping to a
  fake 2x1 grid that would otherwise flow through to `sessions.resize`.

## Why

Closes #434.

`useTerminal` disposes its xterm on unmount only - the documented contract
(stated in an eslint-disable comment) is that a host must remount per session.
Both task-detail terminal hosts honor this (`key={sessionId}` /
`key={session.id}`); `CommandTerminalWindow` did not. Its `handleBranchChange`
killed the old PTY and respawned a new one inside the same component
instance, so `initTerminal`'s `if (xtermRef.current) return` guard silently
kept the old `Terminal` alive with `onData`/`onResize`/clipboard/WebGL all
still bound to the killed session: keystrokes went nowhere and the TUI
painted garbled over the previous session's frame. A window resize "fixed"
the display (the data-in path and `flushResize` ARE keyed on session id) but
never the typing.

A second screenshot on the task showed the same symptom class in a
task-detail window, which already keys per session and so is not explained
by this root cause - see Breaking changes / follow-ups below.

## How

`CommandTerminalPane` mirrors the pattern `TerminalTab` already uses (reads
its own config/session-store state rather than taking it as props) and moves
the init effect, refit hook, file-drop overlay, and terminal div verbatim.
The parent gates on `effectiveSessionId` and publishes the pane's live grid
into a parent-owned `gridGetterRef`, read by `handleBranchChange` **before**
the kill (the pane unmounts, clearing the ref, once `sessionId` flips to
`null`).

Trade-off: the dev-only tripwire adds a `console.error` at dev time only
(compiled out via `import.meta.env.DEV`), not a hard runtime assertion - a
loud signal to catch a regression while dogfooding, not a production-blocking
check.

**Verified live** against a real Claude Code session in a `/preview` build:
opened a Command Terminal, switched branches twice in a row, typed into each
new session, and the live agent responded correctly each time reporting the
new branch/cwd - single `.xterm` instance per switch (the old one properly
disposed), zero console errors, tripwire never fired.

## Breaking changes

None.

**Follow-up filed, not fixed here:** the second (task-detail) garbling
screenshot on the task is a different symptom - PTY-wider-than-xterm wrap
bleed, most likely the same 120x30 cold-spawn issue but on the task-agent
spawn path, which can't reuse this fix directly (the session id is minted in
main before the renderer has a live pane to read `cols`/`rows` from). Needs
its own investigation.

## Tests

- `tests/ui/command-terminal.spec.ts` - three new cases under `Branch switch`:
  typing after a switch reaches the new session (not the killed one, exactly
  one `.xterm` instance survives), the respawn's `cols`/`rows` equal the
  pre-switch pane's actual live grid (not just "some positive number"), and
  the dev tripwire never fires during a normal switch (red-green verified
  against a temporarily reverted, unkeyed mount).
- `tests/unit/terminal-session-swap-contract.test.ts` (new) - the tripwire's
  pure predicate.
- `tests/unit/session-spawn-flow.test.ts` - the `cols`/`rows` precedence
  chain (`takePendingResize` > caller input > default) and clamp, 7 cases.
- `tests/unit/incoming-write-queue.test.ts` - 4 new cases for
  `writeChunkedToTerminal`'s `shouldAbort` contract.
- `tests/unit/fit-addon.test.ts` - 4 new cases for the zero-size guard.
- Full `command-terminal.spec.ts` (46 tests), the other terminal-host UI
  specs, and all touched unit tests pass locally; `npm run typecheck` and
  `npm run lint` are clean.

Generated with [Claude Code](https://claude.com/claude-code)
