### PR TITLE
fix(terminal): open OSC 8 links in the default browser, no confirm dialog

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -295,7 +295,7 @@ Machine-global (like Config), not project-scoped - backs the Mobile Devices sett
 | `shell:getAvailable` | invoke | List available shells |
 | `shell:getDefault` | invoke | Get default shell |
 | `shell:openPath` | invoke | Open directory in file explorer |
-| `shell:openExternal` | invoke | Open URL in default browser |
+| `shell:openExternal` | invoke | Open URL in default browser (http/https/mailto only; other schemes are rejected) |
 | `shell:showItemInFolder` | invoke | Reveal a file or directory in the native file manager (Explorer on Windows, Finder on macOS); the path is normalized to platform separators before dispatch |
 | `shell:exec` | invoke | Execute shell command |
 

--- a/docs/embedded-browser.md
+++ b/docs/embedded-browser.md
@@ -23,6 +23,11 @@ The webview is hardened in `src/main/index.ts`:
   - `setWindowOpenHandler` denies all `window.open` and `target=_blank`.
   - `will-navigate` rejects non-`http(s):` schemes.
   - `before-input-event` binds F5 / Ctrl+R / Cmd+R to `webContents.reload`.
+- Non-webview contents (the main window, and any pop-out window) get a `setWindowOpenHandler`
+  too: always deny the popup, and route an allowed URL (`src/shared/external-url.ts`'s
+  `EXTERNAL_OPEN_SCHEMES`) out to the OS default browser instead. This is what stops a
+  `window.open()` call - including the one xterm's OSC-8 link fallback used to trigger - from
+  spawning a bare, chrome-less `BrowserWindow`.
 
 The webview runs in its own renderer process. The host renderer cannot reach into it; the only channel is `webview.executeJavaScript()` (used by the inspector) and the navigation/capture APIs.
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -418,6 +418,21 @@ when a TUI app emits its copy sequence. The copy paths are:
   the replay path strips them so restoring a session (dialog reopen, resize, respawn) never
   clobbers the user's current clipboard.
 
+### Terminal hyperlinks (OSC 8)
+
+A TUI app can emit `ESC]8;;<url>ESC\` to mark text as a clickable hyperlink. Like OSC 52, these
+are agent-controlled bytes with no user intent behind them - anything a session prints, `cat`s, or
+echoes can carry one - so activation is gated rather than handed to the OS directly. `useTerminal`
+installs a `linkHandler` (`src/renderer/utils/terminal-link-handler.ts`) that checks the URL
+against `TERMINAL_LINK_SCHEMES` (`http:` / `https:` only, no `mailto:`) from
+`src/shared/external-url.ts` and routes an allowed URL to the OS default browser via
+`shell:openExternal`; anything else is dropped with a warning. Supplying this handler also replaces
+xterm's built-in fallback, which would otherwise show a native `confirm()` dialog and then open the
+URL in a bare, chrome-less `window.open()` window. The handler deliberately leaves
+`allowNonHttpProtocols` unset so xterm's own http(s)-only filter stays live as an independent
+second check; `tests/unit/terminal-link-handler.test.ts` statically scans `src/renderer` to keep it
+that way.
+
 ## See Also
 
 - [Configuration](configuration.md) -- permission modes and session limits

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 const PROCESS_START = performance.now();
 
-import { app, BrowserWindow, clipboard, Menu, nativeImage, powerMonitor, session } from 'electron';
+import { app, BrowserWindow, clipboard, Menu, nativeImage, powerMonitor, session, shell } from 'electron';
 import path from 'node:path';
 import { registerAllIpc, getSessionManager, getTerminalSubmitScheduler, getBoardConfigManager, getCurrentProjectId, getOptionalIpcContext, openProjectByPath, deleteProjectFromIndex, pruneStaleWorktreeProjects, activateAllProjects, getLastOpenedProject } from './ipc/register-all';
 import { installDiagnostics } from './diagnostics/install';
@@ -39,6 +39,7 @@ import { restoreShellEnv } from './shell-env';
 import { isFirstPartyPermissionAllowed } from './permission-policy';
 import { MIN_ZOOM, MAX_ZOOM } from '../shared/zoom-steps';
 import { defaultDeveloperFlag, type DeveloperFlagKey } from '../shared/developer-flag-defaults';
+import { createExternalWindowOpenHandler } from './window-open-policy';
 
 initStartupTimer(PROCESS_START);
 mark('process_start');
@@ -246,8 +247,13 @@ app.on('web-contents-created', (_event, contents) => {
     }
   });
 
-  // The remaining handlers apply only to webview contents themselves.
-  if (contents.getType() !== 'webview') return;
+  // Non-webview contents (the main window, and any pop-out window - both fire
+  // web-contents-created) get the shared external-window-open policy (see
+  // createExternalWindowOpenHandler for the full rationale).
+  if (contents.getType() !== 'webview') {
+    contents.setWindowOpenHandler(createExternalWindowOpenHandler((url) => shell.openExternal(url)));
+    return;
+  }
 
   contents.setWindowOpenHandler(() => ({ action: 'deny' }));
 

--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -16,6 +16,7 @@ import { listAgents, invalidateAgentListCache } from '../../agent/agent-list';
 import { agentRegistry } from '../../agent/agent-registry';
 import { broadcast } from '../../pop-out/window-broadcast';
 import { resolveRelayUrl } from '../../../shared/relay';
+import { EXTERNAL_OPEN_SCHEMES, isAllowedExternalUrl } from '../../../shared/external-url';
 import type {
   NotificationInput,
   AgentCommand,
@@ -531,7 +532,19 @@ export function registerSystemHandlers(context: IpcContext): void {
   // '/') opens correctly on Windows, which needs native backslash separators -
   // matching the SHELL_SHOW_ITEM_IN_FOLDER handler below.
   ipcMain.handle(IPC.SHELL_OPEN_PATH, (_, dirPath: string) => shell.openPath(path.normalize(dirPath)));
-  ipcMain.handle(IPC.SHELL_OPEN_EXTERNAL, (_, url: string) => shell.openExternal(url));
+  // shell.openExternal is ShellExecute on Windows and will launch any
+  // registered protocol handler, so this is a process trust boundary -
+  // reject anything outside the allowlist instead of passing it straight to
+  // the OS. A rejected URL is silently inert (warn + no-op) rather than
+  // thrown, because several callers invoke this as a bare `void` with no
+  // .catch (e.g. MarkdownRenderer's link handler on agent-authored markdown).
+  ipcMain.handle(IPC.SHELL_OPEN_EXTERNAL, (_, url: string) => {
+    if (!isAllowedExternalUrl(url, EXTERNAL_OPEN_SCHEMES)) {
+      console.warn(`[SHELL_OPEN_EXTERNAL] Blocked disallowed URL: ${url}`);
+      return;
+    }
+    return shell.openExternal(url);
+  });
   // Normalize so a worktree-relative path joined with forward slashes in the
   // renderer (git paths use '/') resolves correctly on Windows, where
   // showItemInFolder needs native backslash separators.

--- a/src/main/window-open-policy.ts
+++ b/src/main/window-open-policy.ts
@@ -1,0 +1,48 @@
+import { EXTERNAL_OPEN_SCHEMES, isAllowedExternalUrl } from '../shared/external-url';
+
+/**
+ * Builds the `setWindowOpenHandler` callback for non-webview WebContents (the
+ * main window, and any pop-out window - both fire `web-contents-created`).
+ * Those contents get no window-open policy by default, so a renderer
+ * `window.open()` falls through to Electron's default: spawning a bare,
+ * chrome-less BrowserWindow. This handler denies that always, routing an
+ * allowed URL out to the OS default browser instead.
+ *
+ * This is defense in depth, not the primary path for any one feature. xterm
+ * OSC 8 links are claimed by `createTerminalLinkHandler` before they can reach
+ * here (and gated more tightly, on TERMINAL_LINK_SCHEMES, since terminal bytes
+ * are agent-controlled). What DOES still land here is any other
+ * renderer-originated window.open - the realistic one being a middle-click or
+ * Ctrl+click on an agent-authored markdown link, which Chromium turns into a
+ * new-window request rather than the `onClick` that MarkdownRenderer
+ * intercepts. That is why the allowlist here matches the shell:openExternal
+ * IPC channel's (EXTERNAL_OPEN_SCHEMES, mailto: included): it is the same link,
+ * and a middle-click should not resolve differently from a left-click.
+ *
+ * `openExternal` is injected so this stays unit-testable without importing
+ * Electron's `shell` module.
+ */
+export function createExternalWindowOpenHandler(
+  openExternal: (url: string) => Promise<void>,
+): (details: { url: string }) => { action: 'deny' } {
+  return ({ url }) => {
+    if (!isAllowedExternalUrl(url, EXTERNAL_OPEN_SCHEMES)) {
+      console.warn(`[WINDOW_OPEN] Denied window.open for disallowed URL: ${url}`);
+      return { action: 'deny' };
+    }
+    // Deferred to the next tick so this callback stays synchronous and
+    // returns its deny verdict before ShellExecute runs - Electron reads the
+    // return value inline, and openExternal is not required to be cheap.
+    // .catch, not a bare `void`: openExternal REJECTS when the OS has no
+    // registered handler (a stock Windows box with no mail client, for
+    // mailto:), and an unhandled rejection here would be picked up by the
+    // process-level handler above and reported as an `app_error` telemetry
+    // event - turning an expected, non-actionable outcome into crash signal.
+    setImmediate(() => {
+      openExternal(url).catch((openError) => {
+        console.warn(`[WINDOW_OPEN] shell.openExternal failed for ${url}`, openError);
+      });
+    });
+    return { action: 'deny' };
+  };
+}

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -3,6 +3,7 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '../addons/fit-addon';
 import { attachWebglRenderer, notifyFontChanged } from '../utils/terminal-webgl';
 import { copySelectionToClipboard, enableTerminalClipboard, stripOsc52Sequences } from '../utils/terminal-clipboard';
+import { createTerminalLinkHandler } from '../utils/terminal-link-handler';
 import { createWriteBatcher, type WriteBatcher } from '../utils/write-batcher';
 import { createIncomingWriteQueue, writeChunkedToTerminal } from '../utils/incoming-write-queue';
 import { isBoardDragActive, onBoardDragEnd } from '../lib/session-update-coalescer';
@@ -293,6 +294,7 @@ export function useTerminal(options: UseTerminalOptions) {
       // the "which window is selected" cue for the unfocused panes.
       cursorInactiveStyle: 'none',
       allowProposedApi: true,
+      linkHandler: createTerminalLinkHandler((url) => window.electronAPI.shell.openExternal(url)),
     });
 
     const fitAddon = new FitAddon();

--- a/src/renderer/utils/ansi-filter.ts
+++ b/src/renderer/utils/ansi-filter.ts
@@ -42,6 +42,11 @@ export function createAnsiFilter(): {
   el.style.cssText = 'width:800px;height:400px';
   container.appendChild(el);
 
+  // No `linkHandler` here, unlike useTerminal's real terminal: this instance is
+  // a headless serializer sink parked off-screen with pointer-events:none, so an
+  // OSC 8 hyperlink can never be activated in it. If this terminal ever becomes
+  // user-visible or interactive, wire createTerminalLinkHandler in - otherwise a
+  // link activation would fall through to xterm's built-in window.open fallback.
   const term = new Terminal({
     cols: 120,
     rows: 40,

--- a/src/renderer/utils/terminal-link-handler.ts
+++ b/src/renderer/utils/terminal-link-handler.ts
@@ -1,0 +1,26 @@
+import type { ILinkHandler } from '@xterm/xterm';
+import { TERMINAL_LINK_SCHEMES, isAllowedExternalUrl } from '../../shared/external-url';
+
+/**
+ * Routes OSC 8 hyperlink activation to the OS default browser instead of
+ * xterm's built-in fallback, which shows a native confirm() dialog and then
+ * opens the URL in a bare chrome-less window.open() BrowserWindow.
+ *
+ * `allowNonHttpProtocols` is deliberately left unset on the returned handler:
+ * xterm's own OscLinkProvider only applies its http(s)-only filter while that
+ * flag is falsy, so leaving it unset keeps that filter live as an independent
+ * check alongside the one below. Do not set it without adding equivalent
+ * protection here first - see the enforcement scan in
+ * tests/unit/terminal-link-handler.test.ts.
+ */
+export function createTerminalLinkHandler(openExternal: (url: string) => void): ILinkHandler {
+  return {
+    activate: (_event, uri) => {
+      if (!isAllowedExternalUrl(uri, TERMINAL_LINK_SCHEMES)) {
+        console.warn(`[terminal-link-handler] Blocked link with disallowed scheme: ${uri}`);
+        return;
+      }
+      openExternal(uri);
+    },
+  };
+}

--- a/src/shared/external-url.ts
+++ b/src/shared/external-url.ts
@@ -1,0 +1,27 @@
+/**
+ * Scheme allowlist for URLs handed to the OS (shell.openExternal, a denied
+ * window.open, a terminal OSC 8 hyperlink). shell.openExternal is
+ * ShellExecute on Windows and will launch any registered protocol handler,
+ * so every caller of this module is a process trust boundary.
+ *
+ * Two allowed sets, not one, because the callers have different threat
+ * models: terminal OSC 8 sequences are agent-controlled bytes with zero user
+ * intent (anything a session prints, cats, or echoes can carry one), while
+ * the shell:openExternal IPC channel is invoked only by deliberate UI
+ * affordances (markdown links, PR pills, docs pills) that legitimately need
+ * mailto:.
+ */
+
+export const TERMINAL_LINK_SCHEMES = ['http:', 'https:'] as const;
+export const EXTERNAL_OPEN_SCHEMES = ['http:', 'https:', 'mailto:'] as const;
+
+export function isAllowedExternalUrl(rawUrl: string, allowedSchemes: readonly string[]): boolean {
+  if (!rawUrl) return false;
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  return allowedSchemes.includes(url.protocol);
+}

--- a/tests/unit/external-url.test.ts
+++ b/tests/unit/external-url.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { EXTERNAL_OPEN_SCHEMES, TERMINAL_LINK_SCHEMES, isAllowedExternalUrl } from '../../src/shared/external-url';
+
+describe('isAllowedExternalUrl', () => {
+  describe('TERMINAL_LINK_SCHEMES (http/https only)', () => {
+    it.each([
+      ['http', 'http://localhost:3000'],
+      ['https', 'https://kangentic.com/docs'],
+    ])('accepts %s URLs', (_label, url) => {
+      expect(isAllowedExternalUrl(url, TERMINAL_LINK_SCHEMES)).toBe(true);
+    });
+
+    it.each([
+      ['mailto', 'mailto:someone@example.com'],
+      ['javascript', 'javascript:alert(1)'],
+      ['file', 'file:///etc/passwd'],
+      ['data', 'data:text/html,<script>alert(1)</script>'],
+      ['a windows protocol handler', 'ms-msdt:/id PCWDiagnostic'],
+      ['empty string', ''],
+      ['a relative path', './foo.md'],
+      ['an unparseable string', 'not a url'],
+    ])('rejects %s', (_label, url) => {
+      expect(isAllowedExternalUrl(url, TERMINAL_LINK_SCHEMES)).toBe(false);
+    });
+  });
+
+  // The allowlist compares against `URL.protocol`, which the WHATWG spec
+  // lowercases and which is only reached after the parser strips leading and
+  // trailing whitespace plus embedded TAB/CR/LF. Both behaviors are load-bearing
+  // for the scheme check, so pin them rather than rely on recalled spec
+  // semantics surviving a future Node/ada-url change.
+  describe('scheme normalization boundary', () => {
+    it.each([
+      ['an uppercase scheme', 'HTTPS://kangentic.com/docs'],
+      ['a mixed-case scheme', 'HtTp://localhost:3000'],
+      ['a whitespace-padded URL', '  https://kangentic.com/docs  '],
+    ])('still accepts %s', (_label, url) => {
+      expect(isAllowedExternalUrl(url, TERMINAL_LINK_SCHEMES)).toBe(true);
+    });
+
+    it.each([
+      ['a mixed-case javascript scheme', 'JavaScript:alert(1)'],
+      ['a TAB-obfuscated javascript scheme', 'java\tscript:alert(1)'],
+      ['a newline-obfuscated javascript scheme', 'java\nscript:alert(1)'],
+    ])('still rejects %s', (_label, url) => {
+      expect(isAllowedExternalUrl(url, TERMINAL_LINK_SCHEMES)).toBe(false);
+      expect(isAllowedExternalUrl(url, EXTERNAL_OPEN_SCHEMES)).toBe(false);
+    });
+  });
+
+  describe('EXTERNAL_OPEN_SCHEMES (http/https/mailto)', () => {
+    it.each([
+      ['http', 'http://localhost:3000'],
+      ['https', 'https://kangentic.com/docs'],
+      ['mailto', 'mailto:someone@example.com'],
+    ])('accepts %s URLs', (_label, url) => {
+      expect(isAllowedExternalUrl(url, EXTERNAL_OPEN_SCHEMES)).toBe(true);
+    });
+
+    it.each([
+      ['javascript', 'javascript:alert(1)'],
+      ['file', 'file:///etc/passwd'],
+      ['data', 'data:text/html,<script>alert(1)</script>'],
+      ['a windows protocol handler', 'ms-msdt:/id PCWDiagnostic'],
+      ['empty string', ''],
+      ['an unparseable string', 'not a url'],
+    ])('rejects %s', (_label, url) => {
+      expect(isAllowedExternalUrl(url, EXTERNAL_OPEN_SCHEMES)).toBe(false);
+    });
+  });
+});

--- a/tests/unit/shell-open-external-handler.test.ts
+++ b/tests/unit/shell-open-external-handler.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for the SHELL_OPEN_EXTERNAL IPC handler in
+ * src/main/ipc/handlers/system.ts.
+ *
+ * shell.openExternal is ShellExecute on Windows and will launch any
+ * registered protocol handler, so the handler gates the URL against
+ * EXTERNAL_OPEN_SCHEMES (http/https/mailto) before calling out. A rejected
+ * URL warns and returns without throwing - several renderer call sites
+ * invoke shell:openExternal as a bare `void` with no .catch (e.g.
+ * MarkdownRenderer's link handler on agent-authored markdown), so a thrown
+ * rejection would surface as an unhandled promise rejection.
+ *
+ * Strategy mirrors clipboard-write-text-handler.test.ts: mock electron's
+ * ipcMain to capture registered handlers, then invoke the SHELL_OPEN_EXTERNAL
+ * handler directly and assert against a mocked `shell.openExternal`.
+ *
+ * Tier: Unit (vitest, no browser, no Electron).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { IPC } from '../../src/shared/ipc-channels';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks - must be declared before any imports that trigger them.
+// ---------------------------------------------------------------------------
+
+const { capturedHandlers, mockShell } = vi.hoisted(() => {
+  const capturedHandlers = new Map<string, (...args: unknown[]) => unknown>();
+  const mockShell = { openPath: vi.fn(), openExternal: vi.fn(), showItemInFolder: vi.fn() };
+  return { capturedHandlers, mockShell };
+});
+
+vi.mock('electron', () => ({
+  app: { getVersion: vi.fn(() => '0.0.0'), getPath: vi.fn(() => '/tmp') },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      capturedHandlers.set(channel, handler);
+    }),
+    on: vi.fn(),
+  },
+  Notification: { isSupported: vi.fn(() => false) },
+  dialog: { showOpenDialog: vi.fn() },
+  shell: mockShell,
+  globalShortcut: { isRegistered: vi.fn(() => false), register: vi.fn(() => true), unregister: vi.fn() },
+  clipboard: { writeText: vi.fn(), readImage: vi.fn() },
+}));
+
+vi.mock('../../src/main/agent/agent-registry', () => ({
+  agentRegistry: {
+    list: vi.fn(() => []),
+    get: vi.fn(() => null),
+    getOrThrow: vi.fn(),
+    has: vi.fn(() => false),
+  },
+}));
+
+vi.mock('../../src/main/git/worktree-manager', () => ({ WorktreeManager: class {} }));
+vi.mock('../../src/main/git/git-checks', () => ({ isGitRepo: vi.fn(() => false) }));
+vi.mock('../../src/main/db/database', () => ({ getProjectDb: vi.fn() }));
+vi.mock('../../src/main/db/repositories/handoff-repository', () => ({
+  HandoffRepository: class { listByTaskId = vi.fn(() => []); },
+}));
+vi.mock('../../src/shared/object-utils', () => ({
+  deepMergeConfig: vi.fn((a: unknown, b: unknown) => ({ ...(a as object), ...(b as object) })),
+}));
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => ({ pid: 1234, unref: vi.fn() })),
+  exec: vi.fn(),
+  execFile: vi.fn(),
+}));
+vi.mock('../../src/main/config/apply-runtime-config', () => ({
+  applyRuntimeConfig: vi.fn(),
+}));
+vi.mock('../../src/main/ipc/handlers/projects', () => ({
+  syncProjectMcpConfig: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after all mocks are registered).
+// ---------------------------------------------------------------------------
+
+import { registerSystemHandlers } from '../../src/main/ipc/handlers/system';
+
+// ---------------------------------------------------------------------------
+// Test context factory (minimal - the shell handler needs no project state).
+// ---------------------------------------------------------------------------
+
+function makeContext() {
+  return {
+    configManager: {
+      load: vi.fn(() => ({
+        agent: { cliPaths: {}, maxConcurrentSessions: 5, idleTimeoutMinutes: 30 },
+        terminal: { shell: null },
+        mcpServer: { enabled: false },
+        autoNameRateLimitPerHour: 60,
+      })),
+      getEffectiveConfig: vi.fn(() => ({
+        agent: { maxConcurrentSessions: 5, idleTimeoutMinutes: 30 },
+        terminal: { shell: null },
+      })),
+      save: vi.fn(),
+      saveProjectOverrides: vi.fn(),
+      loadProjectOverrides: vi.fn(() => null),
+    },
+    sessionManager: {
+      setMaxConcurrent: vi.fn(),
+      setShell: vi.fn(),
+      setIdleTimeout: vi.fn(),
+    },
+    boardConfigManager: { getDefaultBaseBranch: vi.fn(() => null) },
+    projectRepo: { list: vi.fn(() => []) },
+    shellResolver: { getAvailableShells: vi.fn(() => []), getDefaultShell: vi.fn(() => 'bash') },
+    gitDetector: { detect: vi.fn(() => ({ found: false })) },
+    mainWindow: {
+      minimize: vi.fn(), maximize: vi.fn(), unmaximize: vi.fn(),
+      isMaximized: vi.fn(() => false), close: vi.fn(), isFocused: vi.fn(() => true),
+      flashFrame: vi.fn(), isDestroyed: vi.fn(() => false),
+      isMinimized: vi.fn(() => false), restore: vi.fn(), show: vi.fn(),
+      focus: vi.fn(), once: vi.fn(), webContents: { send: vi.fn() },
+    },
+    currentProjectPath: null,
+    currentProjectId: null,
+    mcpServerHandle: null,
+  };
+}
+
+function invokeShellOpenExternalHandler(url: unknown): unknown {
+  const handler = capturedHandlers.get(IPC.SHELL_OPEN_EXTERNAL);
+  if (!handler) throw new Error(`Handler not registered for ${IPC.SHELL_OPEN_EXTERNAL}`);
+  return handler(undefined, url);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SHELL_OPEN_EXTERNAL IPC handler', () => {
+  beforeEach(() => {
+    capturedHandlers.clear();
+    mockShell.openExternal.mockReset();
+    registerSystemHandlers(makeContext() as Parameters<typeof registerSystemHandlers>[0]);
+  });
+
+  it.each([
+    ['http', 'http://localhost:3000'],
+    ['https', 'https://kangentic.com/docs'],
+    ['mailto', 'mailto:someone@example.com'],
+  ])('opens %s URLs', (_label, url) => {
+    invokeShellOpenExternalHandler(url);
+
+    expect(mockShell.openExternal).toHaveBeenCalledWith(url);
+  });
+
+  it.each([
+    ['javascript', 'javascript:alert(1)'],
+    ['file', 'file:///etc/passwd'],
+    ['a windows protocol handler', 'ms-msdt:/id PCWDiagnostic'],
+    ['empty string', ''],
+    ['an unparseable string', 'not a url'],
+  ])('does not open %s and does not throw', (_label, url) => {
+    expect(() => invokeShellOpenExternalHandler(url)).not.toThrow();
+    expect(mockShell.openExternal).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/shell-open-external-handler.test.ts
+++ b/tests/unit/shell-open-external-handler.test.ts
@@ -160,4 +160,16 @@ describe('SHELL_OPEN_EXTERNAL IPC handler', () => {
     expect(() => invokeShellOpenExternalHandler(url)).not.toThrow();
     expect(mockShell.openExternal).not.toHaveBeenCalled();
   });
+
+  it('warns with the [SHELL_OPEN_EXTERNAL] prefix for a blocked URL', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    invokeShellOpenExternalHandler('file:///etc/passwd');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[SHELL_OPEN_EXTERNAL] Blocked disallowed URL: file:///etc/passwd'),
+    );
+
+    warnSpy.mockRestore();
+  });
 });

--- a/tests/unit/terminal-link-handler.test.ts
+++ b/tests/unit/terminal-link-handler.test.ts
@@ -34,6 +34,20 @@ describe('createTerminalLinkHandler', () => {
     const handler = createTerminalLinkHandler(vi.fn());
     expect(handler.allowNonHttpProtocols).toBeUndefined();
   });
+
+  it('warns with the [terminal-link-handler] prefix for a blocked link', () => {
+    const openExternal = vi.fn();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handler = createTerminalLinkHandler(openExternal);
+
+    handler.activate(fakeEvent, 'javascript:alert(1)', fakeRange);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[terminal-link-handler] Blocked link with disallowed scheme: javascript:alert(1)'),
+    );
+
+    warnSpy.mockRestore();
+  });
 });
 
 // allowNonHttpProtocols disables xterm's own http(s)-only OSC 8 filter (see

--- a/tests/unit/terminal-link-handler.test.ts
+++ b/tests/unit/terminal-link-handler.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createTerminalLinkHandler } from '../../src/renderer/utils/terminal-link-handler';
+
+const fakeEvent = {} as MouseEvent;
+const fakeRange = {} as never;
+
+describe('createTerminalLinkHandler', () => {
+  it.each([
+    ['http', 'http://localhost:3000'],
+    ['https', 'https://kangentic.com/docs'],
+  ])('opens %s links via the injected openExternal', (_label, url) => {
+    const openExternal = vi.fn();
+    const handler = createTerminalLinkHandler(openExternal);
+    handler.activate(fakeEvent, url, fakeRange);
+    expect(openExternal).toHaveBeenCalledWith(url);
+  });
+
+  it.each([
+    ['javascript', 'javascript:alert(1)'],
+    ['file', 'file:///etc/passwd'],
+    ['data', 'data:text/html,<script>alert(1)</script>'],
+    ['mailto', 'mailto:someone@example.com'],
+    ['unparseable', 'not a url'],
+  ])('does not open %s links', (_label, url) => {
+    const openExternal = vi.fn();
+    const handler = createTerminalLinkHandler(openExternal);
+    handler.activate(fakeEvent, url, fakeRange);
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('does not set allowNonHttpProtocols', () => {
+    const handler = createTerminalLinkHandler(vi.fn());
+    expect(handler.allowNonHttpProtocols).toBeUndefined();
+  });
+});
+
+// allowNonHttpProtocols disables xterm's own http(s)-only OSC 8 filter (see
+// OscLinkProvider in @xterm/xterm). It is one word away from being flipped by
+// a future "why isn't my file:// link clickable" fix, which would remove an
+// independent layer of the scheme check this handler relies on. Guard it
+// with a static scan rather than trusting review alone.
+describe('allowNonHttpProtocols is never set under src/renderer', () => {
+  it('scans for the flag', () => {
+    const REPO_ROOT = path.resolve(__dirname, '../..');
+    const scanDir = path.join(REPO_ROOT, 'src/renderer');
+    const offenders: string[] = [];
+
+    // Matches the flag being SET (`allowNonHttpProtocols: true`, `.allowNonHttpProtocols =`), not a
+    // prose mention in a comment explaining why it must stay unset.
+    const ALLOW_NON_HTTP_ASSIGNMENT = /allowNonHttpProtocols\s*[:=]/;
+
+    function isCommentLine(line: string): boolean {
+      const trimmed = line.trim();
+      return trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*');
+    }
+
+    function walk(directory: string): void {
+      for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        const fullPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+          walk(fullPath);
+        } else if (entry.name.endsWith('.ts') || entry.name.endsWith('.tsx')) {
+          const lines = fs.readFileSync(fullPath, 'utf-8').split('\n');
+          lines.forEach((line, index) => {
+            if (isCommentLine(line)) return;
+            if (ALLOW_NON_HTTP_ASSIGNMENT.test(line)) {
+              offenders.push(`${path.relative(REPO_ROOT, fullPath).replace(/\\/g, '/')}:${index + 1}`);
+            }
+          });
+        }
+      }
+    }
+    walk(scanDir);
+
+    expect(
+      offenders,
+      `allowNonHttpProtocols must never be set on a terminal linkHandler - it disables xterm's own scheme filter.\nOffenders:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+});
+
+// createTerminalLinkHandler is fully covered above in isolation, but nothing
+// asserted it is actually WIRED into the constructed Terminal. Without this
+// scan, deleting the `linkHandler: createTerminalLinkHandler(...)` line from
+// useTerminal.ts silently restores xterm's built-in OSC 8 fallback (a native
+// confirm() dialog plus a bare chrome-less window.open()) while every other
+// test stays green.
+describe('useTerminal wires createTerminalLinkHandler into the xterm Terminal constructor', () => {
+  it('passes linkHandler: createTerminalLinkHandler(...) in the `new Terminal({` options', () => {
+    const REPO_ROOT = path.resolve(__dirname, '../..');
+    const useTerminalPath = path.join(REPO_ROOT, 'src/renderer/hooks/useTerminal.ts');
+    const source = fs.readFileSync(useTerminalPath, 'utf-8');
+
+    const constructorStart = source.indexOf('new Terminal({');
+    expect(constructorStart, 'expected to find `new Terminal({` in useTerminal.ts').toBeGreaterThanOrEqual(0);
+
+    const constructorEnd = source.indexOf('});', constructorStart);
+    expect(constructorEnd, 'expected a closing `});` after `new Terminal({`').toBeGreaterThan(constructorStart);
+
+    const constructorOptions = source.slice(constructorStart, constructorEnd);
+
+    expect(
+      constructorOptions,
+      "useTerminal.ts must pass linkHandler: createTerminalLinkHandler(...) into the Terminal constructor options, otherwise OSC 8 link clicks fall back to xterm's built-in confirm() dialog plus a bare chrome-less window.open()",
+    ).toMatch(/linkHandler:\s*createTerminalLinkHandler\(/);
+  });
+});

--- a/tests/unit/window-open-policy.test.ts
+++ b/tests/unit/window-open-policy.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for createExternalWindowOpenHandler in
+ * src/main/window-open-policy.ts.
+ *
+ * This is the setWindowOpenHandler installed on non-webview WebContents (the
+ * main window, and any pop-out window) in src/main/index.ts's
+ * `web-contents-created` handler. It is the widest trust boundary added by
+ * the terminal-links-open change: a renderer window.open() must never spawn
+ * a bare, chrome-less BrowserWindow, an allowed URL must still reach the OS
+ * default browser, and a disallowed URL must never reach openExternal.
+ *
+ * Tier: Unit (vitest, no browser, no Electron - openExternal is injected).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createExternalWindowOpenHandler } from '../../src/main/window-open-policy';
+
+// Flushes the setImmediate the handler defers openExternal into.
+function flushImmediate(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('createExternalWindowOpenHandler', () => {
+  it.each([
+    ['http', 'http://localhost:3000'],
+    ['https', 'https://kangentic.com/docs'],
+    ['mailto', 'mailto:someone@example.com'],
+  ])('always returns deny for an allowed %s URL (never spawns the popup)', (_label, url) => {
+    const openExternal = vi.fn(() => Promise.resolve());
+    const handler = createExternalWindowOpenHandler(openExternal);
+
+    const result = handler({ url });
+
+    expect(result).toEqual({ action: 'deny' });
+  });
+
+  it.each([
+    ['javascript', 'javascript:alert(1)'],
+    ['file', 'file:///etc/passwd'],
+    ['a windows protocol handler', 'ms-msdt:/id PCWDiagnostic'],
+    ['empty string', ''],
+    ['an unparseable string', 'not a url'],
+  ])('returns deny for a disallowed %s URL', (_label, url) => {
+    const openExternal = vi.fn(() => Promise.resolve());
+    const handler = createExternalWindowOpenHandler(openExternal);
+
+    const result = handler({ url });
+
+    expect(result).toEqual({ action: 'deny' });
+  });
+
+  it.each([
+    ['http', 'http://localhost:3000'],
+    ['https', 'https://kangentic.com/docs'],
+    ['mailto', 'mailto:someone@example.com'],
+  ])('routes an allowed %s URL out to openExternal, deferred past the synchronous return', async (_label, url) => {
+    const openExternal = vi.fn(() => Promise.resolve());
+    const handler = createExternalWindowOpenHandler(openExternal);
+
+    handler({ url });
+
+    // Must not have been called synchronously - the callback has to return
+    // its deny verdict before ShellExecute runs.
+    expect(openExternal).not.toHaveBeenCalled();
+
+    await flushImmediate();
+
+    expect(openExternal).toHaveBeenCalledWith(url);
+  });
+
+  it.each([
+    ['javascript', 'javascript:alert(1)'],
+    ['file', 'file:///etc/passwd'],
+    ['a windows protocol handler', 'ms-msdt:/id PCWDiagnostic'],
+    ['empty string', ''],
+    ['an unparseable string', 'not a url'],
+  ])('never calls openExternal for a disallowed %s URL', async (_label, url) => {
+    const openExternal = vi.fn(() => Promise.resolve());
+    const handler = createExternalWindowOpenHandler(openExternal);
+
+    handler({ url });
+    await flushImmediate();
+
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('warns with the [WINDOW_OPEN] prefix and does not throw when openExternal rejects', async () => {
+    const rejection = new Error('no registered handler');
+    const openExternal = vi.fn(() => Promise.reject(rejection));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handler = createExternalWindowOpenHandler(openExternal);
+
+    handler({ url: 'mailto:someone@example.com' });
+    await flushImmediate();
+    // Let the rejected promise's .catch handler run.
+    await flushImmediate();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[WINDOW_OPEN] shell.openExternal failed for mailto:someone@example.com'),
+      rejection,
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('warns with the [WINDOW_OPEN] prefix for a denied URL', () => {
+    const openExternal = vi.fn(() => Promise.resolve());
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handler = createExternalWindowOpenHandler(openExternal);
+
+    handler({ url: 'file:///etc/passwd' });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[WINDOW_OPEN] Denied window.open for disallowed URL: file:///etc/passwd'),
+    );
+
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/unit/window-open-policy.test.ts
+++ b/tests/unit/window-open-policy.test.ts
@@ -12,6 +12,8 @@
  * Tier: Unit (vitest, no browser, no Electron - openExternal is injected).
  */
 import { describe, it, expect, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
 import { createExternalWindowOpenHandler } from '../../src/main/window-open-policy';
 
 // Flushes the setImmediate the handler defers openExternal into.
@@ -114,5 +116,28 @@ describe('createExternalWindowOpenHandler', () => {
     );
 
     warnSpy.mockRestore();
+  });
+});
+
+// createExternalWindowOpenHandler is fully covered above in isolation, but
+// nothing asserted it is actually WIRED into the main window's
+// web-contents-created handler in src/main/index.ts. Without this scan,
+// deleting the setWindowOpenHandler(createExternalWindowOpenHandler(...))
+// call silently restores Electron's default: a renderer window.open() spawns
+// a bare, chrome-less BrowserWindow with no policy at all. This mirrors the
+// same-PR precedent in tests/unit/terminal-link-handler.test.ts (which scans
+// useTerminal.ts for its linkHandler wiring) applied to the other wiring site
+// this change touches, and the existing src/main/index.ts static-scan
+// precedent in tests/unit/pop-out-surface-registry.test.ts.
+describe('createExternalWindowOpenHandler is wired into src/main/index.ts', () => {
+  it('calls setWindowOpenHandler(createExternalWindowOpenHandler(...)) for non-webview contents', () => {
+    const REPO_ROOT = path.resolve(__dirname, '../..');
+    const indexPath = path.join(REPO_ROOT, 'src/main/index.ts');
+    const source = fs.readFileSync(indexPath, 'utf-8');
+
+    expect(
+      source,
+      "src/main/index.ts must call contents.setWindowOpenHandler(createExternalWindowOpenHandler(...)) for non-webview contents, otherwise a renderer window.open() falls through to Electron's default: a bare, chrome-less BrowserWindow with no policy at all",
+    ).toMatch(/setWindowOpenHandler\(\s*createExternalWindowOpenHandler\(/);
   });
 });


### PR DESCRIPTION
## What

Terminal hyperlinks (OSC 8, emitted by Claude Code and other TUI apps) now open in the OS default
browser directly, with no confirmation dialog and no intermediate popup window. Two adjacent trust
boundaries are also hardened as part of the same fix, since this change is what makes them
reachable from agent-controlled bytes: the `shell:openExternal` IPC channel now rejects
disallowed URL schemes, and the main/pop-out windows now get an explicit `setWindowOpenHandler`
policy where none existed before.

- `src/shared/external-url.ts` (new): a shared scheme allowlist, `isAllowedExternalUrl(url,
  allowedSchemes)`, with two sets - `TERMINAL_LINK_SCHEMES` (http/https) and
  `EXTERNAL_OPEN_SCHEMES` (http/https/mailto).
- `src/renderer/utils/terminal-link-handler.ts` (new): builds an xterm `ILinkHandler` that routes
  an allowed OSC 8 link to `shell:openExternal` and drops anything else with a console warning.
- `src/renderer/hooks/useTerminal.ts`: wires that handler into the `Terminal` constructor's
  `linkHandler` option.
- `src/main/ipc/handlers/system.ts`: `SHELL_OPEN_EXTERNAL` now gates the URL against
  `EXTERNAL_OPEN_SCHEMES` before calling `shell.openExternal` (which is `ShellExecute` on
  Windows and will launch any registered protocol handler).
- `src/main/window-open-policy.ts` (new) + `src/main/index.ts`: non-webview `WebContents` (the
  main window and pop-out windows) now get a `setWindowOpenHandler` that always denies the popup
  and forwards an allowed URL to the OS browser instead.
- Docs updated: `docs/architecture.md` (the `shell:openExternal` row), `docs/embedded-browser.md`
  (the non-webview window-open policy), `docs/session-lifecycle.md` (new "Terminal hyperlinks
  (OSC 8)" section).

## Why

Clicking a link in a terminal pane popped a native `confirm()` dialog ("Do you want to navigate
to `<url>`? WARNING: This link could potentially be dangerous"), and clicking OK opened the URL in
a bare, chrome-less Electron `BrowserWindow` instead of the user's default browser. Ctrl+click
triggered both that popup and the default browser.

Root cause: xterm.js linkifies OSC 8 hyperlinks itself, but `useTerminal.ts` constructed the
`Terminal` with no `linkHandler`, so xterm's `OscLinkProvider` fell back to its own
`defaultActivate` (the `confirm()` + `window.open()` behavior). The resulting `window.open()` had
nowhere to go: `src/main/index.ts` only installed a `setWindowOpenHandler` on `<webview>` contents,
so the main window fell through to Electron's default of spawning a real `BrowserWindow`.

A terminal link should behave like every other link in the app - `MarkdownRenderer`, `PrLink`, the
settings docs pills, and the backlog external-URL items all already route through
`window.electronAPI.shell.openExternal(url)`. No setting was added; a choice between "default
browser" and "the popup nobody asked for" isn't a real choice.

## How

Two allowed-scheme sets, not one, because the two callers have different threat models: terminal
OSC 8 bytes are agent-controlled with zero user intent (anything a session prints, cats, or
echoes can carry one), so they're capped to http/https, matching xterm's own filter. The
`shell:openExternal` IPC channel is invoked by seven deliberate UI affordances that legitimately
need `mailto:` (e.g. `MarkdownRenderer` forwards any `href` from task descriptions and agent
markdown), so it keeps that scheme.

`allowNonHttpProtocols` is deliberately left unset on the terminal `linkHandler` - xterm's own
http(s)-only OSC 8 filter is only active while that flag is falsy, so leaving it unset keeps that
filter live as an independent second check alongside the explicit one in `terminal-link-handler.ts`.
A static scan in `tests/unit/terminal-link-handler.test.ts` guards against a future change
flipping it.

A rejected URL is silently inert (`console.warn` + no-op) rather than thrown, both in the IPC
handler and the terminal link handler - several renderer callers invoke `shell:openExternal` as a
bare `void` with no `.catch`, so a throw would surface as an unhandled promise rejection.

Plain-text URLs in scrollback are out of scope: `@xterm/addon-web-links` isn't a dependency, so
bare `http://...` text stays non-clickable, unchanged by this PR.

## Breaking changes

None. `shell:openExternal` behavior narrows (rejects schemes outside http/https/mailto instead of
passing anything through), which is a security hardening, not an API shape change - the channel,
its argument, and its return type are unchanged.

## Tests

- `tests/unit/external-url.test.ts`: the shared scheme allowlist, including case/whitespace/
  control-character normalization edge cases.
- `tests/unit/terminal-link-handler.test.ts`: the terminal `linkHandler`'s activate behavior, a
  static scan that `allowNonHttpProtocols` is never set under `src/renderer`, and a static scan
  that `useTerminal.ts` actually wires the handler into the `Terminal` constructor.
- `tests/unit/shell-open-external-handler.test.ts`: the `SHELL_OPEN_EXTERNAL` IPC handler's
  allow/reject behavior and its warn-not-throw contract.
- `tests/unit/window-open-policy.test.ts`: `createExternalWindowOpenHandler`'s deny-always /
  deferred-openExternal / warn behavior, and a static scan that `index.ts` actually wires it into
  the non-webview `setWindowOpenHandler`.

Verified locally: `npm run typecheck`, `npm run lint`, and all four test files pass. CI runs the
full unit/UI/E2E tiers.

Generated with [Claude Code](https://claude.com/claude-code)
