### PR TITLE
feat(mcp): add send-to-session steering with a durable sent-message log

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -333,6 +333,32 @@ Index: `idx_handoffs_task_id` on (task_id).
 
 TypeScript type: `HandoffRecord` in `src/shared/types.ts`. Repository: `HandoffRepository` in `src/main/db/repositories/handoff-repository.ts`.
 
+### session_messages_sent table
+
+Provenance for messages sent into a session via `kangentic_send_session_message` (see [mcp-server.md](mcp-server.md)) - by another agent, or by a human steering that session directly. The delivered message carries no in-band marker, so these rows are the only record that a turn arrived through the tool rather than being typed at the keyboard.
+
+| Column | Type | Constraints | Default |
+|--------|------|-------------|---------|
+| id | TEXT | PRIMARY KEY | |
+| session_id | TEXT | NOT NULL, FK->sessions ON DELETE CASCADE | |
+| caller_session_id | TEXT | | NULL |
+| caller_task_id | TEXT | | NULL |
+| caller_project_id | TEXT | | NULL |
+| message | TEXT | NOT NULL | |
+| status | TEXT | NOT NULL | |
+| error | TEXT | | NULL |
+| created_at | TEXT | NOT NULL | |
+
+Index: `idx_session_messages_sent_session_id` on (session_id).
+
+`session_id` is the session that RECEIVED the message. `status` is one of `delivered`, `queued` (both produced a turn), `refused` (a guard rejected it), or `failed` (delivery threw; whether a turn landed is unknown) - so a row exists for every attempt, not just the successes. `error` carries the refusal or failure detail and is NULL on success.
+
+The three `caller_*` columns are deliberately NOT foreign keys: a cross-project steer originates in a different project's database, so those ids are unresolvable locally. They are NULL for a human-driven caller with no Kangentic session.
+
+`message` is stored as the caller supplied it, which is how a consumer correlates it to the transcript turn it produced. The delivered text is byte-identical for ordinary prose; the paste path additionally collapses CR/CRLF to LF and strips C0 control characters, so a message carrying those differs from the stored row by exactly that normalization. Reconstructing "which turns arrived this way" means filtering to `delivered` / `queued`.
+
+TypeScript type: `SentSessionMessage` in `src/shared/types.ts`. Repository: `SentSessionMessageRepository` in `src/main/db/repositories/sent-session-message-repository.ts`.
+
 ### memory_chunks table
 
 Conversation-memory index: a per-project retrieval store over the STRUCTURED transcript (TranscriptEntry-derived chunks), not the raw `session_transcripts` scrollback blob. Corpus-generic (a `corpus` column) so the same store can later index repo files/docs; `session_id`/`task_id` are nullable for that reuse and always set for the conversation corpus.
@@ -508,6 +534,7 @@ Grouped by feature. The numbering is for cross-reference only and does not refle
 48. **`auto_command` column on tasks** - adds `auto_command TEXT DEFAULT NULL`, an MCP-only per-task initial command set via `kangentic_create_task`'s `autoCommand` param so a skill can mint a task that runs a command (e.g. `/code-review`) once the agent spawns. Not surfaced in the New Task dialog or project settings. Takes precedence over the swimlane's `auto_command` for this task only; NULL means inherit from the swimlane. Idempotent guarded `ALTER TABLE`.
 49. **`agent` and `effort` columns on `usage_history`** - adds `agent TEXT` and `effort TEXT` (both in the `CREATE TABLE` block plus guarded `ALTER TABLE` for existing DBs) so the usage dashboard can break usage down by agent and by reasoning effort. `agent` is stamped at capture time from the session manager's recorded agent name; `effort` from `sessions.applied_effort` (the last-applied `--effort` value, NULL = agent default). Each has a one-shot backfill: `agent` from surviving `sessions` -> `tasks.agent` joins, `effort` from surviving `sessions.applied_effort`. Rows whose source was deleted stay NULL (rendered "(unknown)" / "(default)"). The one-shot `usage_history` seed backfill (migration 36) also carries both columns. Idempotent guarded `ALTER TABLE`.
 50. **Durable activity-disposition-interval ledger (`session_activity_intervals`)** - creates the table plus its `idx_activity_intervals_task` / `idx_activity_intervals_session` / `idx_activity_intervals_started` / `idx_activity_intervals_open` indices. One row per continuous span a session spent in the `'active'` or `'idle'` `ActivityDisposition` bucket, written by `ActivityIntervalRecorder` the moment the activity engine commits a disposition-changing transition - symmetric by design (both dispositions recorded directly, not one derived as the inverse of the other). `started_at`/`ended_at` mirror `started_ms`/`ended_ms` as UTC ISO 8601, derived from the same value at write time. Deliberately has NO `sessions` DELETE cascade (same rationale as `conversation_turn_usage`): a durable ledger, so an interval outlives the session row that produced it. See the `session_activity_intervals table` section above. Idempotent `CREATE ... IF NOT EXISTS`.
+51. **Sent-message provenance (`session_messages_sent`)** - creates the table plus `idx_session_messages_sent_session_id`, recording every `kangentic_send_session_message` ATTEMPT (`delivered` / `queued` / `refused` / `failed`) against the session that received it. `session_id` cascades on `sessions` DELETE; the three `caller_*` columns are deliberately plain ids, not foreign keys, because a cross-project steer originates in another project's database. Followed by a guarded `ALTER TABLE ... ADD COLUMN error TEXT` so a database created by the intermediate (pre-`error`) shape picks the column up. Because the delivered message carries no in-band marker, these rows are the only record that a turn arrived through the tool rather than being typed. See the `session_messages_sent table` section above. Idempotent `CREATE ... IF NOT EXISTS` + `pragma table_info` guard.
 
 ### Key Migrations (Global DB)
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -28,6 +28,8 @@ Claude Code agent calls MCP tool (e.g. kangentic_create_task)
 | MCP HTTP Server | `src/main/agent/mcp-http-server.ts` | In-process Node `http` server using `@modelcontextprotocol/sdk` Streamable HTTP transport. Binds 127.0.0.1 by default (configurable via `mcpServer.bindAddress`), random `:0` port, random per-launch token validated via `X-Kangentic-Token`. See [Network Access](#network-access). |
 | Task Tools | `src/main/agent/mcp-http/task-tools.ts` | Board/task/column mutations + related reads (`kangentic_create_task`, `kangentic_move_task`, `kangentic_update_task`, `kangentic_link_pr`, `kangentic_update_column`, `kangentic_delete_task`, `kangentic_list_columns`, `kangentic_find_task`, `kangentic_get_current_task`, etc.). |
 | Session Tools | `src/main/agent/mcp-http/session-tools.ts` | Session inspection, backlog, read-only SQL (`kangentic_list_sessions`, `kangentic_get_transcript`, `kangentic_get_session_files`, `kangentic_get_session_events`, `kangentic_get_activity_intervals`, `kangentic_query_db`, `kangentic_list_backlog`, etc.). |
+| Steering Tools | `src/main/agent/mcp-http/steering-tools.ts` | The write side of the session surface (`kangentic_send_session_message`) plus its debugging read (`kangentic_get_session_messages_sent`). Kept out of `session-tools.ts` because the send needs live main-process singletons (SessionManager, TerminalSubmit) that `CommandContext` does not carry. |
+| Session Send Coordinator | `src/main/agent/mcp-http/session-send.ts` | Delivery + guards behind the steering tools: per-target serialization, the sliding-window ceiling, the steer-chain depth backstop, deferred `deliverWhen: "idle"` delivery, and out-of-band provenance recording (the message itself carries no in-band prefix). |
 | Project Tools | `src/main/agent/mcp-http/project-tools.ts` | Multi-project discovery (`kangentic_list_projects`). |
 | Search Tools | `src/main/agent/mcp-http/search-tools.ts` | The single unified search (`kangentic_search`): tasks, backlog, session events, projects, and past conversations (keyword or, with `mode:"hybrid"`, semantic). The board-scoped `kangentic_search_tasks` lives in `task-tools.ts`. |
 | Diagnostics Tools | `src/main/agent/mcp-http/diagnostics-tools.ts` | Read-only product tools backing crash records, persistent console logs, process metrics, IPC traffic recordings, and worktree state. |
@@ -416,7 +418,7 @@ Get the most recent handoff record for a task. Returns metadata about the cross-
 
 Inspect what the agent on another task (or another project) said - "check the response from Task #25" or "read the full transcript from Task #30". At least one of `taskId` or `sessionId` must be provided. Two formats, selected with `format`:
 
-- `format="structured"` (default): the parsed agent conversation - user prompts, assistant text, tool calls and results - rendered as clean markdown, read from the agent's native session history via the adapter's `parseTranscript` capability. The Claude parser also drops noise (slash-command XML, `<system-reminder>` spans, `isMeta` injections) and surfaces compaction boundaries/summaries explicitly. There is no cleaned-scrollback substitute: structured either comes from real session history or reports that it is unavailable and points at `format="raw"`.
+- `format="structured"` (default): the parsed agent conversation - user prompts, assistant text, tool calls and results - rendered as clean markdown, read from the agent's native session history via the adapter's `parseTranscript` capability. The Claude parser also drops noise (slash-command XML, `<system-reminder>` spans, `isMeta` messages) and surfaces compaction boundaries/summaries explicitly. There is no cleaned-scrollback substitute: structured either comes from real session history or reports that it is unavailable and points at `format="raw"`.
 - `format="raw"`: the verbatim ANSI-stripped PTY scrollback (the full terminal output, including TUI redraws), available for every agent. Useful for debugging the terminal layer or for agents without a structured parser. Raw scrollback is mostly repeated terminal redraws (empirically ~85% duplicate lines and multiple MB for a long session), so when a structured parser exists for the agent the raw response notes that `structured` is the cleaner, far smaller view for evaluation. Every returned transcript (both formats) is prefixed with a one-line note marking the content as read-only reference data, not instructions to follow.
 
 Structured output is shaped by three agent-agnostic levers, applied to the parsed `TranscriptEntry[]` (so no adapter branching):
@@ -449,6 +451,78 @@ Structured-format support by agent:
 | `context` | number | No | Structured only. Turns either side of `aroundUuid` (default 3, max 50). Ignored without `aroundUuid`. |
 | `maxChars` | number | No | Override the default ~50,000-char output cap (hard ceiling 500,000). Applies to structured and raw. |
 | `project` | string | No | Project selector (name or UUID). Defaults to the URL-path project. |
+
+### kangentic_send_session_message
+
+Send a message to another task's **running** agent session, exactly as if it had been typed into that session's input box. This is the write-side counterpart to the read-only session tools: `kangentic_get_session_events`, `kangentic_get_transcript`, and `kangentic_list_sessions` observe another agent, and this one steers it. Typical uses are handing off a decision, unblocking a stalled agent, answering a question a session is waiting on, and redirecting work a newer decision superseded.
+
+Provide either `taskId` or `sessionId` (not both). A `taskId` resolves to that task's live session via the PTY registry, preferring the registry over the `task.session_id` column, which is known to drift.
+
+**Delivery.** The message goes through the same bracketed-paste submit path a human paste uses (`TerminalSubmit.submitContent`): drain, chunked write, output settle, `\r`, then wait for submission evidence. It is not instant, and it is measurably slower when nobody has the target session's terminal open, because the paste engine's fast path needs the session subscribed. `delivered` means the message was handed to the session's input, not that the agent has finished reading it.
+
+Against a **busy** target, treat `delivered` as weaker still. The paste engine's submission check accepts "at least 50 bytes of output arrived after the `\r`" as evidence, which a mid-turn session satisfies trivially from its own ambient streaming output. So a `delivered` result on a thinking session means the paste was written, not that it was confirmed submitted. Use `deliverWhen: "idle"` when you need the stronger guarantee.
+
+A deferred (`"idle"`) delivery that later fails is not reported back - the tool call that queued it has already returned - so it is written as a `failed` row instead (and, for a delivery that threw, logged to the Electron main console too). That covers the target exiting or going unwritable before it ever flushed, which is otherwise silent: a `queued` result is not a promise the message landed.
+
+**Attribution is out-of-band.** The message is delivered **verbatim** - no prefix, no marker, nothing prepended. Instead, every send ATTEMPT is recorded in the target project's `session_messages_sent` table (`session_id`, `caller_session_id`, `caller_task_id`, `caller_project_id`, `message`, `status`, `error`, `created_at`), with the caller resolved server-side from the URL segment rather than from a tool parameter, so an agent cannot omit or alter it through the tool's own arguments. See the caller-identity note under [Security](#security) for what that does and does not guarantee: it is honesty-by-default, not cryptographic attribution.
+
+`status` is one of four values, so "did my message go through?" always has an answer when debugging:
+
+| `status` | Meaning | Produced a turn? |
+|----------|---------|------------------|
+| `delivered` | Handed to the session's input | Yes |
+| `queued` | Held for the next idle transition, then delivered | Yes |
+| `refused` | A guard rejected it (self-send, dead session, target at a permission prompt, cross-project session id, hop-depth backstop, rate limit); `error` carries which | No |
+| `failed` | Delivery was attempted and threw (e.g. `no-submission-evidence`), or a `queued` message's target exited before it could flush; `error` carries the detail | **Unknown** - the paste engine can fail with the text half-committed; an exited target produced no turn |
+
+Reconstructing which turns arrived this way means filtering to `delivered` / `queued`. Two caveats for debugging.
+
+`session_id` carries a foreign key so these rows are cleaned up with their session, which means an attempt naming a session id that was never real (a typo, or an id from another project) records nothing - there is no session row to attach it to. The caller still receives the refusal synchronously. This does not affect the realistic dead-session case: a session that exited or was suspended still has its row, so its refusal is recorded.
+
+Second: repeated refusals are deduped to one row per (target, reason) per 5-minute window. Without that the audit trail becomes an amplification vector - the self-send, dead-session, and hop-depth guards all run *before* the rate limiter, so they never consume a slot (the permission-prompt guard runs after it, and does), and a looping agent would write one row per attempt indefinitely. A `refused` row therefore means "at least one refusal for this reason in this window", not an exact count. `failed` rows are never deduped, since a failure required an actual delivery attempt, which the rate limiter already bounds.
+
+This replaced an in-band `[Kangentic relay]` prefix, which was removed after live testing on 2026-07-25. Two problems: it cost tokens on every single send, and the receiving agent read it as injected content asserting its own authority - structurally the shape of a prompt injection - and refused to act on messages sent this way, reasoning that "legitimate authority doesn't need to announce itself through injected content." Out-of-band provenance costs nothing, cannot be forged by anything the agent writes, and leaves the receiver's context clean.
+
+Because nothing is prepended, the stored `message` matches the transcript turn it produced, which is how a consumer correlates a turn to the row that sent it. One caveat for an exact-match consumer: the row stores what the caller supplied, while delivery runs the text through the same `sanitizeForPaste` every paste undergoes (CR and CRLF collapse to LF, C0 control characters are stripped). For ordinary prose the two are byte-identical; a message carrying those bytes differs by exactly that normalization. Note the consequence: the `session_messages_sent` row is the **only** record that a turn arrived through this tool rather than being typed. A sent message that is never recorded is indistinguishable from one the human typed.
+
+**Guards.** These are circuit breakers against unattended token spend (two agents ping-ponging overnight), not a permission policy - deliberate multi-agent orchestration is meant to pass through unobstructed:
+
+- A session cannot send to itself.
+- A `deliverWhen: "now"` send into a target sitting at a **permission prompt** is refused. The submit path ends in `\r` (and retries it), which a modal prompt reads as confirming its highlighted option, so an ordinary steer could silently approve a tool call nobody sanctioned. The paste engine's own modal safety net cannot cover this: it detects bracketed-paste-mode-off from the terminal `data` stream, which is only forwarded while the session is subscribed, and an MCP send targets a background session by construction. `deliverWhen: "idle"` is not refused for this state - it holds the message until the prompt clears, which is what the refusal points you at.
+- An explicit `sessionId` naming a session in a **different project** is refused. Liveness is checked against the global PTY registry, so such a send would otherwise deliver while its provenance row silently vanished into the wrong project's database. Pass `project` naming the session's own project.
+- Each target accepts at most 30 messages per rolling 5 minutes. A genuine orchestration hop costs the receiving agent a whole turn, so only a runaway loop approaches this.
+- A steer chain deeper than 25 hops is refused as a loop. Depth is tracked server-side from the caller's session id rather than a tool parameter; it is deliberately not a low cap, because a legitimate A -> B -> C -> D -> E chain must work. The depth is one scalar per session (the most recent inbound hop), so two independent chains converging on one target overwrite each other's count - fine for a runaway backstop, but not an exact per-chain measure.
+- Concurrent sends to one session are serialized, so two callers cannot interleave their pastes.
+
+Every refusal comes back as a normal tool result with `isError: true` and text explaining what to do next.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `taskId` | string | No | Task ID (numeric display ID like `"42"` or full UUID). Resolves to that task's live session. Mutually exclusive with `sessionId`. |
+| `sessionId` | string | No | Kangentic session UUID (the `sessions.id` column). Mutually exclusive with `taskId`. |
+| `message` | string | Yes | The message to deliver. Write it as a self-contained prompt: it lands in a session that cannot see your conversation. |
+| `deliverWhen` | string | No | `"now"` (default) delivers immediately, like a human typing mid-turn - a busy agent picks it up when its current turn ends. `"idle"` holds the message until the target finishes its turn. |
+| `project` | string | No | Project selector (name or UUID). Defaults to the URL-path project. |
+
+Returns `status` (`"delivered"` or `"queued"`), the resolved `sessionId`, the target's `targetActivity` at send time, and the `hopDepth` of this steer chain. `"queued"` is returned only for `deliverWhen: "idle"` against a busy target; if the target is already idle, `"idle"` delivers immediately rather than waiting for a transition that would never come.
+
+### kangentic_get_session_messages_sent
+
+Read the log of messages sent **into** a session by another agent via `kangentic_send_session_message`. This is the debugging counterpart to that tool: it answers "did my message actually go through?" for every attempt, including the ones that never produced a turn.
+
+Provide either `taskId` or `sessionId` (not both). `taskId` returns messages across **all** of the task's sessions, which is usually what you want - a task accumulates sessions across resumes and agent handoffs, and you should not have to work out which session was live at the time.
+
+Each entry carries the caller (`caller_session_id`, `caller_task_id`, `caller_project_id` - all null for a human-driven send), the exact `message` text, a `status`, and an `error` for anything that did not land cleanly. See the `status` table under `kangentic_send_session_message` for what each value means; the short version is that `delivered` and `queued` produced a turn, `refused` did not, and `failed` is genuinely unknown.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `taskId` | string | No | Task ID (numeric display ID or full UUID). Covers every session the task has had. Mutually exclusive with `sessionId`. |
+| `sessionId` | string | No | Kangentic session UUID (the `sessions.id` column). Mutually exclusive with `taskId`. |
+| `status` | string | No | Only return attempts with this status: `delivered`, `queued`, `refused`, or `failed`. |
+| `tail` | number | No | Return only the last N attempts (most recent). Default 100, hard cap 500. |
+| `project` | string | No | Project selector (name or UUID). Defaults to the URL-path project. |
+
+Returns `total` (matching the filter), `returned` (after `tail`), and the `messages` array. Note that a send naming a session id that was never real records nothing at all - see the foreign-key caveat above - so an empty result can also mean the target id was wrong.
 
 ### kangentic_get_session_files
 
@@ -625,6 +699,7 @@ The committed `.claude/settings.json` `mcp__kangentic` entry remains for humans 
 - **Per-launch token** - every Kangentic launch generates a fresh 32-byte random `X-Kangentic-Token`. Clients without the token get `401`. Comparison is constant-time (`timingSafeEqual`) so a local timing oracle cannot byte-by-byte recover the token. This becomes the primary defense once a user widens `bindAddress`.
 - **DNS rebinding protection** - the Streamable HTTP transport enforces a host allowlist (`127.0.0.1`, `localhost`, `[::1]`, plus the configured `bindAddress`/`callbackHost` when set) on top of the bind.
 - **Project routing via URL path** - the URL embeds the project ID (`/mcp/<projectId>`). A stale `mcp.json` for a different project cannot be reused against the current launch.
+- **Caller identity via URL path** - a spawned TASK session's URL carries a third segment, `/mcp/<projectId>/<callerSessionId>`, stamped into that session's own `mcp.json` at spawn by the two task-spawn chokepoints (`prepare-spawn.ts` and `transition-engine.ts`). The agent never chooses it through a tool parameter, so `kangentic_send_session_message` can refuse self-sends, track a steer chain, and attribute a sent message truthfully without trusting a caller-supplied field. This is honesty-by-default, not cryptographic attribution: the bearer token is one shared per-launch secret every spawned agent holds, and the segment is not validated against a real or connected session, so a process with the token (an agent has both it and shell access) can dial any caller id via a raw HTTP request. The guards it feeds are circuit breakers against a looping or careless agent, not a defense against a deliberately lying one. The segment is optional: a human-driven client, the per-project `.kangentic/mcp-config.json`, and a Command Terminal session (`transient-sessions.ts` does not pre-generate its PTY id, so it has none to stamp) all dial the two-segment URL and are treated as unattributed callers, never refused. An unattributed caller records `caller_session_id: null` and resets the steer-chain depth, so a send routed through a Command Terminal is indistinguishable from a human's.
 - **Runaway-loop safeguard** - task creations are capped at a fixed 500 per app launch, enforced atomically by the shared `TaskCounter`. This is an internal circuit breaker against a looping agent, not a user-tunable knob; the count resets on restart.
 - **Input validation** - Zod schemas enforce title (200 chars) and description (50000 chars for tasks; 10000 chars for backlog item descriptions) limits at the protocol level, and the command handlers validate again. A backlog item created via `kangentic_create_task` shares the task 50000-char Zod schema, so `handleCreateTask` enforces the 10000 backlog cap itself and rejects an over-cap backlog description rather than truncating it.
 - **Column safety** - `kangentic_create_task` defaults to the To Do column; creating in an auto_spawn column intentionally triggers agent spawn. `kangentic_move_task_to_project` follows the same rule on the destination board: landing in an auto_spawn `column` there spawns an agent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14016,7 +14016,7 @@
     },
     "packages/protocol": {
       "name": "@kangentic/protocol",
-      "version": "0.7.0",
+      "version": "0.9.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/src/main/agent/mcp-http-server.ts
+++ b/src/main/agent/mcp-http-server.ts
@@ -7,7 +7,16 @@
  * DB via the `commandHandlers` map -- no subprocess, no file bridge,
  * no offset tracking.
  *
- * URL shape: http://127.0.0.1:<port>/mcp/<projectId>
+ * URL shape: http://127.0.0.1:<port>/mcp/<projectId>[/<callerSessionId>]
+ *       The optional third segment identifies WHICH session is calling. It is
+ *       stamped into that session's own mcp.json at spawn, so it is correct by
+ *       construction and not settable through any tool parameter. It is not a
+ *       cryptographic identity: the bearer token is shared per launch and the
+ *       segment is not validated, so a process holding the token can dial any
+ *       id (see caller-url.ts). Absent for a human-driven client, the
+ *       per-project `.kangentic/mcp-config.json`, or a Command Terminal
+ *       session; steering then degrades to an unattributed caller rather than
+ *       refusing.
  * Auth: random per-launch token, validated via `X-Kangentic-Token` header
  * Bind: 127.0.0.1 by default -- loopback skips Windows Defender Firewall
  *       prompts and is unreachable from other machines. A user can widen
@@ -23,10 +32,12 @@
  *       would get an unreachable URL - see docs/mcp-server.md's Network
  *       Access section.
  *
- * Tool registrations live under ./mcp-http/:
- *   - task-tools.ts     - board/task/column mutations + related reads
- *   - session-tools.ts  - session inspection, backlog, read-only SQL
- *   - handler-helpers.ts - runHandler/callHandler + TaskCounter primitive
+ * Tool registrations live under ./mcp-http/, one `register*Tools` file per
+ * family - see the `register*Tools` imports below for the current set rather
+ * than an enumeration here, which drifts every time a family is added.
+ * `handler-helpers.ts` holds the shared runHandler/callHandler + TaskCounter
+ * primitives, and `session-send.ts` the delivery coordinator behind
+ * `steering-tools.ts`.
  */
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
 import { randomBytes, timingSafeEqual } from 'node:crypto';
@@ -40,6 +51,13 @@ import { registerSearchTools } from './mcp-http/search-tools';
 import { registerDiagnosticsTools } from './mcp-http/diagnostics-tools';
 import { registerUsageTools } from './mcp-http/usage-tools';
 import { registerBrowserTools, type AutomationConfigReader } from './mcp-http/browser-tools';
+import { registerSteeringTools, type SteeringToolDependencies, type SteeringSessionLookup } from './mcp-http/steering-tools';
+import {
+  createSessionSendCoordinator,
+  type SessionSendCoordinator,
+  type SessionSendSessionManager,
+  type SessionSendTerminalSubmit,
+} from './mcp-http/session-send';
 import { registerDevtoolsMcpTools } from '../../devtools/mcp/register';
 import { buildServerInstructions } from './mcp-http/server-instructions';
 import { logMcpToolArguments } from './mcp-http/tool-call-logging';
@@ -88,6 +106,20 @@ export interface McpHttpServerHandle {
 }
 
 /**
+ * Main-process singletons the steering tools need. `CommandContext` carries
+ * only the project DB and board callbacks, so these are threaded in at
+ * registration time instead (the `browser-tools.ts` precedent). Read lazily
+ * per request because the MCP server starts before `createWindow`, so the IPC
+ * context does not exist yet at `startMcpHttpServer` time.
+ */
+export interface McpSteeringContext {
+  sessionManager: SessionSendSessionManager & SteeringSessionLookup;
+  terminalSubmit: SessionSendTerminalSubmit;
+}
+
+export type SteeringContextReader = () => McpSteeringContext | null;
+
+/**
  * Start the HTTP server. Resolves once it's listening; the OS picks a
  * free port via `.listen(0)`.
  */
@@ -95,13 +127,30 @@ export async function startMcpHttpServer(
   buildContext: ProjectContextFactory,
   getBrowserAutomationConfig: AutomationConfigReader,
   networkConfig: McpServerNetworkConfig,
+  getSteeringContext: SteeringContextReader = () => null,
 ): Promise<McpHttpServerHandle> {
   const token = randomBytes(32).toString('hex');
   const expectedTokenBuffer = Buffer.from(token, 'utf-8');
   const taskCounter = makeTaskCounter();
 
+  // One coordinator per server launch (its rate-limit windows, steer-chain
+  // depths and pending deferred deliveries are launch-scoped state), built on
+  // first use because the IPC context does not exist yet at startup.
+  let sessionSendCoordinator: SessionSendCoordinator | null = null;
+  const resolveSteering = (callerSessionId?: string): SteeringToolDependencies | null => {
+    const steeringContext = getSteeringContext();
+    if (!steeringContext) return null;
+    if (!sessionSendCoordinator) {
+      sessionSendCoordinator = createSessionSendCoordinator({
+        sessionManager: steeringContext.sessionManager,
+        terminalSubmit: steeringContext.terminalSubmit,
+      });
+    }
+    return { coordinator: sessionSendCoordinator, sessions: steeringContext.sessionManager, callerSessionId };
+  };
+
   const httpServer: Server = createServer((req, res) => {
-    handleHttpRequest(req, res, expectedTokenBuffer, buildContext, taskCounter, getBrowserAutomationConfig, networkConfig)
+    handleHttpRequest(req, res, expectedTokenBuffer, buildContext, taskCounter, getBrowserAutomationConfig, networkConfig, resolveSteering)
       .catch((error) => {
         console.error('[mcp-http] Request handler crashed:', error);
         if (!res.headersSent) {
@@ -154,7 +203,14 @@ export async function startMcpHttpServer(
     baseUrl,
     token,
     urlForProject: (projectId: string) => `${baseUrl}/${projectId}`,
-    close: () => closeMcpHttpServerSafely(httpServer),
+    close: () => {
+      // Detach the SessionManager listeners the coordinator holds before the
+      // socket teardown, so a shutdown never leaves a live 'activity'/'exit'
+      // subscriber pointing at a disposed server.
+      sessionSendCoordinator?.dispose();
+      sessionSendCoordinator = null;
+      closeMcpHttpServerSafely(httpServer);
+    },
   };
 }
 
@@ -180,6 +236,33 @@ export function closeMcpHttpServerSafely(httpServer: Pick<Server, 'closeAllConne
   } catch (error) {
     console.error('[mcp-http] close() failed:', error);
   }
+}
+
+/**
+ * Parse the request path into `{ projectId, callerSessionId }`. Expected shape:
+ * `/mcp/<projectId>` or, when the client is a Kangentic-spawned agent,
+ * `/mcp/<projectId>/<callerSessionId>`.
+ *
+ * `callerSessionId` (the third segment) is OPTIONAL by design and its absence
+ * is never an error: a human running `claude` outside Kangentic, an older
+ * session whose mcp.json predates the third segment, and the per-project
+ * `.kangentic/mcp-config.json` all legitimately dial the two-segment form.
+ * Steering degrades gracefully to an unattributed caller rather than refusing
+ * (see caller-url.ts). A fourth-and-later segment is ignored, matching the
+ * behavior before this was extracted (only segments[1]/segments[2] were ever
+ * read).
+ *
+ * Returns null when the path does not match `/mcp/<projectId>[/...]` at all.
+ *
+ * Exported as a pure function for unit-test isolation, mirroring
+ * `buildAllowedHosts` below - testing the URL-segment contract via a real HTTP
+ * request through `startMcpHttpServer` would require booting the full MCP
+ * module graph just to observe string parsing.
+ */
+export function parseMcpRequestPath(pathname: string): { projectId: string; callerSessionId?: string } | null {
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments.length < 2 || segments[0] !== 'mcp') return null;
+  return { projectId: segments[1], callerSessionId: segments[2] };
 }
 
 /**
@@ -228,6 +311,7 @@ export function buildConfiguredMcpServer(
   resolver: RequestResolver,
   taskCounter: TaskCounter,
   getBrowserAutomationConfig: AutomationConfigReader,
+  steering?: SteeringToolDependencies | null,
 ): McpServer {
   const browserAutomationEnabled = getBrowserAutomationConfig().enabled;
   const instructions = buildServerInstructions(resolver, browserAutomationEnabled);
@@ -243,6 +327,12 @@ export function buildConfiguredMcpServer(
   registerDiagnosticsTools(mcpServer, resolver);
   if (browserAutomationEnabled) {
     registerBrowserTools(mcpServer, getBrowserAutomationConfig);
+  }
+  // Steering needs live main-process singletons. They are absent only before
+  // the IPC context exists (the server starts ahead of createWindow), which is
+  // strictly before any agent can be running to be steered.
+  if (steering) {
+    registerSteeringTools(mcpServer, resolver, steering);
   }
 
   // Dev-only: register the kangentic_devtools_* tools that drive the localhost
@@ -264,6 +354,7 @@ async function handleHttpRequest(
   taskCounter: TaskCounter,
   getBrowserAutomationConfig: AutomationConfigReader,
   networkConfig: McpServerNetworkConfig,
+  resolveSteering: (callerSessionId?: string) => SteeringToolDependencies | null,
 ): Promise<void> {
   // Token check first -- cheapest reject path. Constant-time compare so a
   // local timing oracle can't byte-by-byte recover the token. When bound to
@@ -286,16 +377,17 @@ async function handleHttpRequest(
     return;
   }
 
-  // Parse projectId from URL path. Expected: /mcp/<projectId>
-  // (the SDK transport handles JSON-RPC body parsing -- we just route).
+  // Parse the URL path (see parseMcpRequestPath's doc comment for the shape
+  // and the caller-segment-optional rationale). The SDK transport handles
+  // JSON-RPC body parsing -- we just route.
   const url = new URL(req.url ?? '/', 'http://127.0.0.1');
-  const segments = url.pathname.split('/').filter(Boolean);
-  if (segments.length < 2 || segments[0] !== 'mcp') {
+  const parsedPath = parseMcpRequestPath(url.pathname);
+  if (!parsedPath) {
     res.statusCode = 404;
     res.end();
     return;
   }
-  const projectId = segments[1];
+  const { projectId, callerSessionId } = parsedPath;
 
   const resolver = buildContext(projectId);
   if (!resolver) {
@@ -310,7 +402,12 @@ async function handleHttpRequest(
   // instructions (active-project name, registered-project list) and the
   // browser-tool gating reflect current DB / settings state (see
   // buildConfiguredMcpServer).
-  const mcpServer = buildConfiguredMcpServer(resolver, taskCounter, getBrowserAutomationConfig);
+  const mcpServer = buildConfiguredMcpServer(
+    resolver,
+    taskCounter,
+    getBrowserAutomationConfig,
+    resolveSteering(callerSessionId),
+  );
 
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: undefined,

--- a/src/main/agent/mcp-http/caller-url.ts
+++ b/src/main/agent/mcp-http/caller-url.ts
@@ -1,0 +1,43 @@
+/**
+ * Caller-identity URL segment for the MCP HTTP server.
+ *
+ * Deliberately a standalone, dependency-free module rather than a helper on
+ * `mcp-http-server.ts`: its consumers are the two agent-spawn chokepoints
+ * (`prepare-spawn.ts` and `transition-engine.ts`), and importing it from the
+ * server module would drag the entire MCP tool graph (the SDK, every
+ * `*-tools.ts` file, the DB repositories, the browser/CDP surface) into their
+ * module load for the sake of one string concatenation.
+ */
+
+/**
+ * Append the caller's session id to a project-scoped MCP URL, producing
+ * `/mcp/<projectId>/<sessionId>`.
+ *
+ * The server otherwise has no way to know WHICH session is calling: the token
+ * is per-launch and the URL is per-project. Stamping the spawning session's own
+ * id into its own `mcp.json` makes caller identity correct by construction - it
+ * is written, never looked up, so it cannot drift - and takes it out of the set
+ * of things the agent can choose through the tool's own parameters. That is
+ * what lets `kangentic_send_session_message` refuse self-sends, track a steer
+ * chain server-side, and attribute a relayed message truthfully instead of
+ * trusting a caller-supplied field.
+ *
+ * This is honesty-by-default, NOT cryptographic attribution. The bearer token
+ * is one shared per-launch secret every spawned agent holds, and the server
+ * does not verify that the segment names a real or currently-connected session,
+ * so a process with the token (an agent has both the token and shell access)
+ * can dial any caller id via a raw HTTP request. The guards this feeds are
+ * circuit breakers against a looping or careless agent, not a defense against a
+ * deliberately lying one. A real guarantee would need a per-session secret
+ * distinct from the session id, which `kangentic_list_sessions` already exposes.
+ *
+ * Returns undefined when there is no URL (MCP server disabled or not yet
+ * listening), so call sites can pass the result straight through.
+ */
+export function appendCallerSession(
+  projectUrl: string | undefined,
+  callerSessionId: string,
+): string | undefined {
+  if (!projectUrl) return undefined;
+  return `${projectUrl}/${callerSessionId}`;
+}

--- a/src/main/agent/mcp-http/session-send.ts
+++ b/src/main/agent/mcp-http/session-send.ts
@@ -1,0 +1,502 @@
+import PQueue from 'p-queue';
+import { isActive } from '../../../shared/activity-state';
+import type { ActivityState } from '../../../shared/types';
+
+/**
+ * Agent-to-agent steering: deliver a message into a running agent session.
+ *
+ * This is the write-side counterpart to the read-only session tools
+ * (`kangentic_get_session_events`, `kangentic_get_transcript`, ...). Before it
+ * existed, an agent could observe another session perfectly but had no way to
+ * hand it a prompt - the only transport was a human copy-pasting into that
+ * session's input box.
+ *
+ * Delivery reuses `TerminalSubmit.submitContent` (bracketed paste -> settle ->
+ * `\r` -> submission evidence), the same path the mobile bridge's
+ * `send-user-message` verb and the Browser pane's Send affordance use. It is
+ * deliberately NOT `sessionManager.write` (no submit semantics) and NOT
+ * `submitKeystrokes` (slash-command delivery; a 2KB payload would take ~80s).
+ *
+ * The guards here are circuit breakers against unattended token spend - two
+ * agents ping-ponging overnight - not a permission policy. Deliberate
+ * multi-agent orchestration (A -> B -> C -> D -> E) must pass through
+ * unobstructed, so the discriminator is send FREQUENCY, not chain depth.
+ */
+
+/**
+ * Sliding-window ceiling per target session. A genuine orchestration hop costs
+ * the receiving agent a whole turn (tens of seconds at minimum), so legitimate
+ * traffic never approaches this; only a runaway loop does. Deliberately not
+ * modelled on `MAX_TASK_CREATE_PER_LAUNCH`, which is monotonic and never
+ * recovers: a create storm corrupts a board that must be cleaned up by hand,
+ * whereas a send storm only burns tokens, and a monotonic ceiling would
+ * eventually kill a long-running instance doing legitimate work.
+ */
+const SEND_WINDOW_MS = 5 * 60 * 1000;
+const MAX_SENDS_PER_TARGET_PER_WINDOW = 30;
+
+/**
+ * Backstop against a true infinite A -> B -> A loop. Intentionally absurd:
+ * this is not a policy on how deep an orchestration may nest, it is the depth
+ * past which a chain is definitionally a bug. Depth is tracked server-side
+ * from the caller's authenticated URL segment, so it cannot be forged by a
+ * caller-supplied field.
+ */
+const MAX_HOP_DEPTH = 25;
+
+/** How the caller wants the message delivered relative to the target's turn. */
+export type SessionSendDeliverWhen = 'now' | 'idle';
+
+/**
+ * `delivered` - handed to the session's input via the submit path.
+ * `queued`    - target was mid-turn and `deliverWhen: 'idle'` was requested;
+ *               held in main and flushed on the next idle transition.
+ */
+export type SessionSendStatus = 'delivered' | 'queued';
+
+export interface SessionSendSuccess {
+  status: SessionSendStatus;
+  sessionId: string;
+  targetActivity: ActivityState | 'unknown';
+  hopDepth: number;
+}
+
+export interface SessionSendFailure {
+  error: string;
+}
+
+export type SessionSendOutcome = SessionSendSuccess | SessionSendFailure;
+
+export interface SessionSendRequest {
+  /** Resolved live target session. */
+  targetSessionId: string;
+  /**
+   * Message text, delivered verbatim. No attribution prefix is added here or
+   * anywhere else in the pipeline - provenance is recorded out-of-band via
+   * `recordSentMessage`. See the comment above `const text = message` in
+   * `send()` for why the in-band prefix was removed.
+   */
+  message: string;
+  /**
+   * Authenticated caller session, from the MCP URL path segment. Absent for a
+   * human-driven `claude` run outside Kangentic, or any client using the
+   * legacy `/mcp/<projectId>` URL. Absence is never an error.
+   */
+  callerSessionId?: string;
+  deliverWhen: SessionSendDeliverWhen;
+  /**
+   * Persists the provenance of this message. Called once the text is actually
+   * handed to the session (so a refused or failed send leaves no row), and for
+   * a deferred send at flush time rather than at queue time.
+   */
+  recordSentMessage?: SentMessageRecorder;
+}
+
+/**
+ * The slice of `SessionManager` this module needs. Declared structurally
+ * rather than importing the class so unit tests can drive it with a stub
+ * instead of booting a PTY.
+ */
+export interface SessionSendSessionManager {
+  isWritable(sessionId: string): boolean;
+  getActivityCache(): Record<string, ActivityState>;
+  on(event: string, listener: (...args: unknown[]) => void): unknown;
+  off(event: string, listener: (...args: unknown[]) => void): unknown;
+}
+
+/** The slice of `TerminalSubmit` this module needs. */
+export interface SessionSendTerminalSubmit {
+  submitContent(sessionId: string, text: string, opts?: { source?: string }): Promise<void>;
+}
+
+export interface SessionSendDependencies {
+  sessionManager: SessionSendSessionManager;
+  terminalSubmit: SessionSendTerminalSubmit;
+}
+
+export interface SessionSendCoordinator {
+  send(request: SessionSendRequest): Promise<SessionSendOutcome>;
+  /** Detach the SessionManager listeners. Called on server shutdown. */
+  dispose(): void;
+  /** @internal Test-only view of the tracked-map sizes, to assert they drain. */
+  _stateSizesForTesting(): {
+    queues: number;
+    pending: number;
+    hops: number;
+    windows: number;
+    refusalNotices: number;
+  };
+}
+
+/**
+ * Outcome recorded for one send ATTEMPT, which is a wider set than the two
+ * success statuses a caller can receive back:
+ *
+ * - `delivered` / `queued` - the message reached the session (or is held for
+ *   its next idle transition). These are the only two that produce a turn.
+ * - `refused`  - a guard rejected it before delivery (self-send, dead session,
+ *   hop-depth backstop, rate limit). No turn was produced.
+ * - `failed`   - delivery was attempted and threw (e.g. the paste engine's
+ *   `no-submission-evidence`). Whether a turn was produced is genuinely
+ *   unknown, which is exactly why it is worth a row.
+ *
+ * Any consumer reconstructing "which turns arrived this way" must filter to
+ * `delivered` / `queued`; the other two record an attempt, not a turn.
+ */
+export type SentMessageStatus = SessionSendStatus | 'refused' | 'failed';
+
+/**
+ * Provenance record for one send. The tool layer owns persistence (it
+ * holds the project DB); the coordinator stays DB-agnostic so it can be
+ * unit-tested without SQLite.
+ */
+export interface SentMessageRecord {
+  targetSessionId: string;
+  callerSessionId?: string;
+  message: string;
+  status: SentMessageStatus;
+  /** Refusal or failure detail. Null for a successful delivery. */
+  error?: string;
+}
+
+export type SentMessageRecorder = (delivery: SentMessageRecord) => void;
+
+export function createSessionSendCoordinator(
+  dependencies: SessionSendDependencies,
+  options: { maxSendsPerWindow?: number; windowMs?: number; maxHopDepth?: number } = {},
+): SessionSendCoordinator {
+  const { sessionManager, terminalSubmit } = dependencies;
+  const maxSendsPerWindow = options.maxSendsPerWindow ?? MAX_SENDS_PER_TARGET_PER_WINDOW;
+  const windowMs = options.windowMs ?? SEND_WINDOW_MS;
+  const maxHopDepth = options.maxHopDepth ?? MAX_HOP_DEPTH;
+
+  /** Per-target serialization. Two callers pasting into one session would otherwise
+   *  interleave their bracketed-paste packets (writeChunked yields between 1KB chunks). */
+  const deliveryQueues = new Map<string, PQueue>();
+  /** Send timestamps per target, pruned to the sliding window on each check. */
+  const sendWindows = new Map<string, number[]>();
+  /**
+   * Inbound steer depth per session, so an onward send inherits its chain
+   * position.
+   *
+   * Deliberately ONE scalar per session, not per chain: it holds the depth of
+   * the most recent inbound message, which two independent chains converging on
+   * the same target will overwrite for each other (a shallow chain's onward hop
+   * can inherit a deep chain's depth and vice versa). That is acceptable for a
+   * runaway backstop set at 25 - it only ever mis-counts by conflating real
+   * traffic, and both directions still terminate - but it is not an accurate
+   * per-chain measure, so do not build anything on `hopDepth` that needs to be
+   * exact.
+   */
+  const hopDepths = new Map<string, number>();
+  /**
+   * Messages held for `deliverWhen: 'idle'`, flushed on the next idle
+   * transition. Each entry carries its own recorder so provenance is written
+   * when the text actually lands, not when it was queued.
+   */
+  const pendingDeliveries = new Map<
+    string,
+    Array<{ text: string; onDelivered: () => void; onFailed: (detail: string) => void }>
+  >();
+  /** Last time a refusal row was written per `${sessionId}:${reason}`, for dedupe. */
+  const refusalNotices = new Map<string, number>();
+
+  function runSerialized(sessionId: string, task: () => Promise<void>): Promise<void> {
+    let queue = deliveryQueues.get(sessionId);
+    if (!queue) {
+      queue = new PQueue({ concurrency: 1 });
+      deliveryQueues.set(sessionId, queue);
+    }
+    const heldQueue = queue;
+    const result = heldQueue.add(task) as Promise<void>;
+    // Mirror withTaskLock's disposal: drop the entry once the queue drains, so
+    // the map does not accumulate one entry per session touched for the life of
+    // the process. The catch keeps a rejecting task from producing an
+    // unhandledRejection on this derived promise; the caller still sees it.
+    result
+      .catch(() => {})
+      .finally(() => {
+        if (heldQueue.size === 0 && heldQueue.pending === 0) {
+          deliveryQueues.delete(sessionId);
+        }
+      });
+    return result;
+  }
+
+  function deliver(sessionId: string, text: string): Promise<void> {
+    return runSerialized(sessionId, () => terminalSubmit.submitContent(sessionId, text, { source: 'mcp' }));
+  }
+
+  /**
+   * Ready for a fresh prompt: the agent finished its turn. Deliberately
+   * excludes `'permission'`, which `isActive` also treats as non-active - a
+   * deferred flush into an open permission prompt could have its `\r`
+   * interpreted as confirming the prompt.
+   */
+  function isReadyForPrompt(state: ActivityState | undefined): boolean {
+    if (state === undefined) return true;
+    // activity-state-ok: granular exclusion of 'permission', not an idle-vs-active
+    // bucket - a queued paste must not land on an open permission prompt.
+    if (state === 'permission') return false;
+    return !isActive(state);
+  }
+
+  const onActivity = (...args: unknown[]): void => {
+    const sessionId = args[0];
+    const state = args[1];
+    if (typeof sessionId !== 'string') return;
+    if (!pendingDeliveries.has(sessionId)) return;
+    if (!isReadyForPrompt(state as ActivityState | undefined)) return;
+    const queued = pendingDeliveries.get(sessionId) ?? [];
+    pendingDeliveries.delete(sessionId);
+    // Checked once for the whole batch rather than per entry. The loop body
+    // only ENQUEUES (deliver is not awaited), so writability cannot flip
+    // mid-loop, and a per-entry `break` would abandon the remainder with no
+    // row at all - the one outcome this table exists to make impossible.
+    if (!sessionManager.isWritable(sessionId)) {
+      for (const entry of queued) {
+        entry.onFailed('target session stopped accepting input before the deferred delivery flushed');
+      }
+      return;
+    }
+    for (const entry of queued) {
+      void deliver(sessionId, entry.text)
+        .then(() => entry.onDelivered())
+        .catch((error: unknown) => {
+          const detail = error instanceof Error ? error.message : String(error);
+          // The tool call that queued this already returned, so a row is the
+          // ONLY way the failure ever reaches anyone.
+          entry.onFailed(detail);
+          console.error(`[session-send] Deferred delivery to ${sessionId} failed: ${detail}`);
+        });
+    }
+  };
+
+  const onExit = (...args: unknown[]): void => {
+    const sessionId = args[0];
+    if (typeof sessionId !== 'string') return;
+    // The caller was already told "queued" and has long since returned, so
+    // dropping these silently would leave an attempt with no row anywhere -
+    // breaking the "a row exists for every attempt" contract the log is built
+    // on. Record each as failed before discarding.
+    const abandoned = pendingDeliveries.get(sessionId);
+    pendingDeliveries.delete(sessionId);
+    if (abandoned) {
+      for (const entry of abandoned) {
+        entry.onFailed('target session exited before the deferred delivery flushed');
+      }
+    }
+    hopDepths.delete(sessionId);
+    sendWindows.delete(sessionId);
+    for (const key of [...refusalNotices.keys()]) {
+      if (key.startsWith(`${sessionId}:`)) refusalNotices.delete(key);
+    }
+  };
+
+  sessionManager.on('activity', onActivity);
+  sessionManager.on('exit', onExit);
+
+  /**
+   * Check-and-record in one synchronous step so a burst of concurrent requests
+   * cannot all pass the check before any of them is recorded.
+   */
+  function reserveSendSlot(sessionId: string): boolean {
+    const now = Date.now();
+    const cutoff = now - windowMs;
+    const recent = (sendWindows.get(sessionId) ?? []).filter((at) => at > cutoff);
+    if (recent.length >= maxSendsPerWindow) {
+      sendWindows.set(sessionId, recent);
+      return false;
+    }
+    recent.push(now);
+    sendWindows.set(sessionId, recent);
+    return true;
+  }
+
+  /** True at most once per (target, reason) per window. See `refuse`. */
+  function shouldRecordRefusal(sessionId: string, reason: string): boolean {
+    const key = `${sessionId}:${reason}`;
+    const now = Date.now();
+    const lastRecordedAt = refusalNotices.get(key);
+    if (lastRecordedAt !== undefined && now - lastRecordedAt < windowMs) return false;
+    refusalNotices.set(key, now);
+    return true;
+  }
+
+  return {
+    async send(request: SessionSendRequest): Promise<SessionSendOutcome> {
+      const { targetSessionId, message, callerSessionId, deliverWhen, recordSentMessage } = request;
+
+      const record = (status: SentMessageStatus, error?: string): void => {
+        try {
+          recordSentMessage?.({ targetSessionId, callerSessionId, message, status, error });
+        } catch (caught) {
+          // Provenance is best-effort and must never fail a delivered message.
+          // Nothing else can persist this: the store that would hold the record
+          // is the thing that just failed, so a loud log is the only recourse.
+          const detail = caught instanceof Error ? caught.message : String(caught);
+          console.error(`[session-send] Failed to record sent message ${status} for ${targetSessionId}: ${detail}`);
+        }
+      };
+
+      /**
+       * Record a refusal, then return the caller-facing error.
+       *
+       * Refusals are deduped per (target, reason) per window. Without that, the
+       * guards become an amplification vector rather than a circuit breaker: a
+       * looping agent whose sends are all refused writes one row per attempt
+       * forever, and the self-send / dead-session / hop-depth checks all run
+       * BEFORE the rate limiter so they never even consume a slot. One row per reason per
+       * window keeps the debugging signal ("it was rate-limited at 14:03")
+       * without letting a runaway fill the database instead of the PTY.
+       */
+      const refuse = (reason: string, error: string): SessionSendFailure => {
+        if (shouldRecordRefusal(targetSessionId, reason)) record('refused', error);
+        return { error };
+      };
+
+      if (callerSessionId && callerSessionId === targetSessionId) {
+        return refuse(
+          'self-send',
+          'Refused: a session cannot send a message to itself. To continue your own work, just keep going - this tool is for steering a DIFFERENT session.',
+        );
+      }
+
+      if (!sessionManager.isWritable(targetSessionId)) {
+        return refuse(
+          'not-writable',
+          `Session ${targetSessionId} is not accepting input (no live PTY - it has exited, been suspended, or is still queued). ` +
+            'Use kangentic_list_sessions to check its status, or move the task back onto the board to resume it.',
+        );
+      }
+
+      const hopDepth = (callerSessionId ? hopDepths.get(callerSessionId) ?? 0 : 0) + 1;
+      if (hopDepth > maxHopDepth) {
+        return refuse(
+          'hop-depth',
+          `Refused: steer chain depth ${hopDepth} exceeds the ${maxHopDepth}-hop backstop, which indicates a send loop rather than an orchestration. Break the chain before sending again.`,
+        );
+      }
+
+      if (!reserveSendSlot(targetSessionId)) {
+        const windowMinutes = Math.round(windowMs / 60000);
+        return refuse(
+          'rate-limit',
+          `Rate limit: session ${targetSessionId} has already received ${maxSendsPerWindow} messages in the last ${windowMinutes} minutes. This ceiling exists to stop runaway send loops; wait for the window to roll off before sending again.`,
+        );
+      }
+
+      const activityCache = sessionManager.getActivityCache();
+      const targetActivity = activityCache[targetSessionId];
+
+      // An open permission prompt is unsafe to deliver into on the IMMEDIATE
+      // path too, not just the deferred one: the hazard is the delivery itself,
+      // not when it was scheduled. The submit path ends in `\r` (and retries
+      // it), which a modal prompt reads as confirming its highlighted option -
+      // so a routine steer could silently approve a tool call nobody
+      // sanctioned. The paste engine's own modal safety net cannot cover this,
+      // because it detects bracketed-paste-mode-off from the 'data' event,
+      // which is gated on the session being subscribed - and an MCP send
+      // targets a BACKGROUND session by construction, so nobody has its
+      // terminal open.
+      //
+      // Scoped to 'now' deliberately: `deliverWhen: 'idle'` already holds for
+      // this state a few lines below (isReadyForPrompt excludes 'permission'),
+      // which is the outcome the refusal text points the caller at.
+      if (deliverWhen === 'now' && targetActivity === 'permission') {
+        return refuse(
+          'target-at-prompt',
+          `Session ${targetSessionId} is sitting at a permission prompt, where the submit path's Enter would confirm the highlighted option instead of sending your message. ` +
+            'Re-send with deliverWhen: "idle" to hold until the prompt clears, or resolve the prompt first.',
+        );
+      }
+
+      // The message goes in VERBATIM. No attribution prefix: it costs tokens on
+      // every send, and empirically (2026-07-25) the receiving agent read it as
+      // injected content asserting its own authority - the shape of a prompt
+      // injection - and refused to act on messages sent this way. Provenance is
+      // recorded out-of-band instead, via recordSentMessage.
+      const text = message;
+
+      // Record the chain position BEFORE delivery: a fast target can act on the
+      // message (and send onward) before submitContent resolves, and that
+      // onward send must already see the correct inbound depth. Rolled back if
+      // delivery fails, so repeated failures against one target cannot ratchet
+      // it toward the backstop with nothing ever delivered.
+      const previousHopDepth = hopDepths.get(targetSessionId);
+      const rollBackHopDepth = (): void => {
+        if (previousHopDepth === undefined) hopDepths.delete(targetSessionId);
+        else hopDepths.set(targetSessionId, previousHopDepth);
+      };
+      hopDepths.set(targetSessionId, hopDepth);
+
+      // Check the CURRENT state before subscribing. Waiting only for the next
+      // idle transition would never fire for a target already parked at
+      // idle_hint - which is the whole motivating case for this tool.
+      if (deliverWhen === 'idle' && !isReadyForPrompt(targetActivity)) {
+        const queued = pendingDeliveries.get(targetSessionId) ?? [];
+        queued.push({
+          text,
+          onDelivered: () => record('queued'),
+          // Same rollback the immediate path does in its catch: a target that
+          // never received the message must not carry this hop's depth into
+          // its own onward sends, or repeated deferred failures ratchet it
+          // toward the backstop with nothing ever delivered.
+          onFailed: (detail: string) => {
+            rollBackHopDepth();
+            record('failed', detail);
+          },
+        });
+        pendingDeliveries.set(targetSessionId, queued);
+        return {
+          status: 'queued',
+          sessionId: targetSessionId,
+          targetActivity: targetActivity ?? 'unknown',
+          hopDepth,
+        };
+      }
+
+      try {
+        await deliver(targetSessionId, text);
+      } catch (error) {
+        rollBackHopDepth();
+        const detail = error instanceof Error ? error.message : String(error);
+        // Not deduped: a delivery failure required an actual attempt, which the
+        // rate limiter already bounds, and it is the single most useful row
+        // when debugging "did my message go through?" - the paste engine can
+        // fail with the text half-committed, so the answer is genuinely unknown.
+        record('failed', detail);
+        return { error: `Delivery to session ${targetSessionId} failed: ${detail}` };
+      }
+
+      record('delivered');
+
+      return {
+        status: 'delivered',
+        sessionId: targetSessionId,
+        targetActivity: targetActivity ?? 'unknown',
+        hopDepth,
+      };
+    },
+
+    dispose(): void {
+      sessionManager.off('activity', onActivity);
+      sessionManager.off('exit', onExit);
+      pendingDeliveries.clear();
+      hopDepths.clear();
+      sendWindows.clear();
+      deliveryQueues.clear();
+      refusalNotices.clear();
+    },
+
+    _stateSizesForTesting() {
+      return {
+        queues: deliveryQueues.size,
+        pending: pendingDeliveries.size,
+        hops: hopDepths.size,
+        windows: sendWindows.size,
+        refusalNotices: refusalNotices.size,
+      };
+    },
+  };
+}

--- a/src/main/agent/mcp-http/steering-tools.ts
+++ b/src/main/agent/mcp-http/steering-tools.ts
@@ -1,0 +1,253 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod/v4';
+import { withProject, PROJECT_SELECTOR_DESCRIPTION, type McpToolResult } from './handler-helpers';
+import { MUTATING_ANNOTATIONS, READ_ONLY_ANNOTATIONS } from './annotations';
+import type Database from 'better-sqlite3';
+import { resolveTask } from '../commands/task-resolver';
+import { TaskRepository } from '../../db/repositories/task-repository';
+import { SentSessionMessageRepository } from '../../db/repositories/sent-session-message-repository';
+import type { RequestResolver } from './project-resolver';
+import type { SessionSendCoordinator, SentMessageRecord } from './session-send';
+
+/**
+ * Steering tools: the write side of the session surface.
+ *
+ * Everything else under `mcp-http/` either reads a session or mutates the
+ * board. These tools act on a RUNNING agent, so they live in their own file
+ * rather than in `session-tools.ts`: they need main-process singletons
+ * (SessionManager, TerminalSubmit) that `CommandContext` deliberately does not
+ * carry, and they take those at registration time the way `browser-tools.ts`
+ * does. `session-tools.ts` stays a pure `commandHandlers` consumer.
+ */
+
+/** The `SessionManager` lookups the tool layer needs to resolve a target and a caller. */
+export interface SteeringSessionLookup {
+  findLiveSessionByTaskId(taskId: string): { id: string } | undefined;
+  getSessionTaskId(sessionId: string): string | undefined;
+  getSessionProjectId(sessionId: string): string | undefined;
+}
+
+export interface SteeringToolDependencies {
+  coordinator: SessionSendCoordinator;
+  sessions: SteeringSessionLookup;
+  /**
+   * The authenticated caller's session id, parsed from the MCP URL path
+   * (`/mcp/<projectId>/<sessionId>`). Undefined for a human-driven client or
+   * any consumer of the legacy two-segment URL. Never required.
+   */
+  callerSessionId?: string;
+}
+
+function errorResult(text: string): McpToolResult {
+  return { content: [{ type: 'text' as const, text }], isError: true };
+}
+
+export function registerSteeringTools(
+  server: McpServer,
+  resolver: RequestResolver,
+  dependencies: SteeringToolDependencies,
+): void {
+  const { coordinator, sessions, callerSessionId } = dependencies;
+
+  /**
+   * Persist the provenance of a sent message into the TARGET project's
+   * database, resolved server-side from the authenticated URL segment so a
+   * caller cannot supply, omit, or forge it.
+   *
+   * This is the only record that a turn arrived through the tool rather than being typed: the
+   * delivered text carries no in-band marker. Caller ids are stored raw (not
+   * resolved to a display id) because a cross-project caller is not resolvable
+   * in this database, and a raw id keeps the row honest either way.
+   */
+  function makeSentMessageRecorder(targetContext: { getProjectDb: () => Database.Database }) {
+    return (delivery: SentMessageRecord): void => {
+      const callerTaskId = delivery.callerSessionId
+        ? sessions.getSessionTaskId(delivery.callerSessionId) ?? null
+        : null;
+      const callerProjectId = delivery.callerSessionId
+        ? sessions.getSessionProjectId(delivery.callerSessionId) ?? null
+        : null;
+      new SentSessionMessageRepository(targetContext.getProjectDb()).insert({
+        session_id: delivery.targetSessionId,
+        caller_session_id: delivery.callerSessionId ?? null,
+        caller_task_id: callerTaskId,
+        caller_project_id: callerProjectId,
+        message: delivery.message,
+        status: delivery.status,
+        error: delivery.error ?? null,
+      });
+    };
+  }
+
+  // --- kangentic_send_session_message ---
+  server.registerTool(
+    'kangentic_send_session_message',
+    {
+      description:
+        'Send a message to another task\'s RUNNING agent session, exactly as if it had been typed into that session\'s input box. This is how one agent steers another: hand off a decision, unblock a stalled agent, answer a question a session is waiting on, or redirect work a newer decision superseded. Pair it with kangentic_get_session_events (watch for `idle` / `idle_hint`) and kangentic_get_transcript to see what the other agent is doing before and after you send. Provide either taskId or sessionId. The message is delivered VERBATIM - nothing is prepended, so the receiving agent sees exactly what you wrote and cannot tell it came from another agent. Say who you are and why you are writing if that matters; provenance is recorded out-of-band in session_messages_sent, readable via kangentic_get_session_messages_sent. Delivery is not instant: it goes through the same bracketed-paste submit path a human paste uses, and takes longer when nobody has that session\'s terminal open. Pass `project` to steer a session in a different project.',
+      inputSchema: z.object({
+        taskId: z
+          .string()
+          .optional()
+          .describe('Task ID (numeric display ID like "42" or full UUID). Resolves to that task\'s live session. Use this unless you already hold a session id.'),
+        sessionId: z
+          .string()
+          .optional()
+          .describe('Kangentic session UUID (sessions.id), when you already have one from kangentic_list_sessions. Mutually exclusive with taskId.'),
+        message: z
+          .string()
+          .min(1)
+          .describe('The message to deliver. Write it as a prompt addressed to the receiving agent, with enough context to act on alone - it lands in a session that cannot see your conversation.'),
+        deliverWhen: z
+          .enum(['now', 'idle'])
+          .optional()
+          .describe('"now" (default) delivers immediately, like a human typing mid-turn: a busy agent picks it up when its current turn ends. "idle" holds the message until the target finishes its turn, then delivers - use it when the message would be misread mid-task. Returns "queued" instead of "delivered" when it holds.'),
+        project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
+      }),
+      annotations: MUTATING_ANNOTATIONS,
+    },
+    async ({ taskId, sessionId, message, deliverWhen, project }) => {
+      if (!taskId && !sessionId) {
+        return errorResult('Provide either taskId or sessionId to identify the session to send to.');
+      }
+      if (taskId && sessionId) {
+        return errorResult('Provide taskId or sessionId, not both.');
+      }
+
+      return withProject(resolver, project, async (context, resolved) => {
+        let targetSessionId = sessionId;
+
+        if (!targetSessionId && taskId) {
+          const task = resolveTask(new TaskRepository(context.getProjectDb()), taskId);
+          if (!task) {
+            return errorResult(`No task found for "${taskId}". Use kangentic_list_tasks or kangentic_find_task to get a valid task ID.`);
+          }
+          // Prefer the registry's live session over task.session_id, which is
+          // known to drift (reconcileTaskSessionRef exists to heal it). When the
+          // drift-prone column IS the only candidate, refuse it if the registry
+          // says that session now belongs to a different task - liveness alone
+          // is not ownership, and a stale pointer would steer a stranger.
+          const liveSession = sessions.findLiveSessionByTaskId(task.id);
+          const fallbackSessionId = task.session_id ?? undefined;
+          if (liveSession) {
+            targetSessionId = liveSession.id;
+          } else if (fallbackSessionId && (sessions.getSessionTaskId(fallbackSessionId) ?? task.id) === task.id) {
+            targetSessionId = fallbackSessionId;
+          }
+          if (!targetSessionId) {
+            return errorResult(
+              `Task #${task.display_id} "${task.title}" has no session to send to. Move it into a column that spawns an agent, or check kangentic_list_sessions for its history.`,
+            );
+          }
+        }
+
+        if (!targetSessionId) {
+          return errorResult('Could not resolve a target session.');
+        }
+
+        // An explicit sessionId is not proof of ownership: the coordinator's
+        // liveness check reads the GLOBAL PTY registry, so a session belonging
+        // to another project would deliver successfully while its provenance
+        // row silently vanished (the recorder writes into THIS project's
+        // database, where no matching sessions row exists, and the repository
+        // skips the insert). An unrecorded send is indistinguishable from a
+        // human-typed turn, so fail closed instead.
+        const targetProjectId = sessions.getSessionProjectId(targetSessionId);
+        if (targetProjectId && targetProjectId !== resolved.projectId) {
+          return errorResult(
+            `Session ${targetSessionId} belongs to a different project than "${resolved.projectName}". ` +
+              'Pass `project` naming the session\'s own project so the send is recorded against it.',
+          );
+        }
+
+        const outcome = await coordinator.send({
+          targetSessionId,
+          message,
+          callerSessionId,
+          deliverWhen: deliverWhen ?? 'now',
+          recordSentMessage: makeSentMessageRecorder(context),
+        });
+
+        if ('error' in outcome) {
+          return errorResult(outcome.error);
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(outcome, null, 2) }],
+        };
+      });
+    },
+  );
+
+  // --- kangentic_get_session_messages_sent ---
+  server.registerTool(
+    'kangentic_get_session_messages_sent',
+    {
+      description:
+        'Read the log of messages sent INTO a session by another agent via kangentic_send_session_message. This is the debugging counterpart to that tool: it answers "did my message actually go through?" for every attempt, including the ones that never produced a turn. Each entry records the caller, the exact message text, and one of four statuses: "delivered" and "queued" produced a turn in the target\'s transcript; "refused" means a guard rejected it (the `error` field says which - self-send, dead session, a target sitting at a permission prompt, a session in another project, the hop-depth backstop, or the rate limit); "failed" means delivery was attempted and threw, or a queued message\'s target exited before it flushed, so whether a turn landed is genuinely unknown. Provide either taskId (covers every session the task has had, which is usually what you want) or sessionId. Pass `project` to inspect a different project.',
+      inputSchema: z.object({
+        taskId: z
+          .string()
+          .optional()
+          .describe('Task ID (numeric display ID like "42" or full UUID). Returns messages across ALL of the task\'s sessions, so a resumed or handed-off task still reports its full history.'),
+        sessionId: z
+          .string()
+          .optional()
+          .describe('Kangentic session UUID (sessions.id), to scope to one session. Mutually exclusive with taskId.'),
+        status: z
+          .enum(['delivered', 'queued', 'refused', 'failed'])
+          .optional()
+          .describe('Only return attempts with this status. Use "failed" or "refused" to see just the ones that did not land cleanly.'),
+        tail: z
+          .number()
+          .int()
+          .min(1)
+          .max(500)
+          .optional()
+          .describe('Return only the last N attempts (most recent). Default 100.'),
+        project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
+      }),
+      annotations: READ_ONLY_ANNOTATIONS,
+    },
+    async ({ taskId, sessionId, status, tail, project }) => {
+      if (!taskId && !sessionId) {
+        return errorResult('Provide either taskId or sessionId to identify whose messages to read.');
+      }
+      if (taskId && sessionId) {
+        return errorResult('Provide taskId or sessionId, not both.');
+      }
+
+      return withProject(resolver, project, async (context) => {
+        const repository = new SentSessionMessageRepository(context.getProjectDb());
+        let messages;
+
+        if (sessionId) {
+          messages = repository.listForSession(sessionId);
+        } else if (taskId) {
+          const task = resolveTask(new TaskRepository(context.getProjectDb()), taskId);
+          if (!task) {
+            return errorResult(`No task found for "${taskId}". Use kangentic_list_tasks or kangentic_find_task to get a valid task ID.`);
+          }
+          messages = repository.listForTask(task.id);
+        } else {
+          return errorResult('Could not resolve a target.');
+        }
+
+        const filtered = status ? messages.filter((sent) => sent.status === status) : messages;
+        const limit = tail ?? 100;
+        const window = filtered.slice(-limit);
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              total: filtered.length,
+              returned: window.length,
+              messages: window,
+            }, null, 2),
+          }],
+        };
+      });
+    },
+  );
+}

--- a/src/main/db/migrations/project-schema.ts
+++ b/src/main/db/migrations/project-schema.ts
@@ -1084,6 +1084,49 @@ export function runProjectMigrations(db: Database.Database): void {
     db.exec('ALTER TABLE tasks ADD COLUMN auto_command TEXT DEFAULT NULL');
   }
 
+  // Migration: record every message sent into a session via
+  // kangentic_send_session_message - by another agent, or by a human steering
+  // that session directly.
+  //
+  // The delivered text carries NO in-band marker: an attribution prefix costs
+  // tokens on every send and, empirically (2026-07-25), reads to the receiving
+  // agent as injected content asserting its own authority, which is the shape
+  // of a prompt injection - it refused messages sent this way rather than
+  // acting on them. So provenance lives here, out of the agent's context, where
+  // it costs nothing and cannot be forged by anything the agent writes.
+  // `message` is stored verbatim, which is exactly the transcript turn's
+  // content now that nothing is prepended, so a consumer can match a turn to
+  // the row that sent it.
+  //
+  // caller_session_id / caller_task_id are deliberately NOT foreign keys: a
+  // cross-project send originates in a different project's database, so the
+  // ids are not resolvable locally. They are null when a human sent the message
+  // with no Kangentic session of their own.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS session_messages_sent (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      caller_session_id TEXT,
+      caller_task_id TEXT,
+      caller_project_id TEXT,
+      message TEXT NOT NULL,
+      status TEXT NOT NULL,
+      error TEXT,
+      created_at TEXT NOT NULL
+    )
+  `);
+  db.exec('CREATE INDEX IF NOT EXISTS idx_session_messages_sent_session_id ON session_messages_sent(session_id)');
+
+  // `error` was added after the table shipped: a row records every
+  // ATTEMPT (delivered / queued / refused / failed), not just the ones that
+  // landed, so "did my message go through?" always has an answer. Guarded so a
+  // database created by the intermediate shape picks the column up.
+  const hasSentMessageError = (db.pragma('table_info(session_messages_sent)') as Array<{ name: string }>)
+    .some((col) => col.name === 'error');
+  if (!hasSentMessageError) {
+    db.exec('ALTER TABLE session_messages_sent ADD COLUMN error TEXT DEFAULT NULL');
+  }
+
   // Seed default swimlanes if empty (must run after all ALTER TABLE migrations)
   const laneCount = db.prepare('SELECT COUNT(*) as c FROM swimlanes').get() as { c: number };
   if (laneCount.c === 0) {

--- a/src/main/db/repositories/sent-session-message-repository.ts
+++ b/src/main/db/repositories/sent-session-message-repository.ts
@@ -1,0 +1,97 @@
+import { v4 as uuidv4 } from 'uuid';
+import type Database from 'better-sqlite3';
+import type { SentSessionMessage } from '../../../shared/types';
+
+const COLUMNS =
+  'id, session_id, caller_session_id, caller_task_id, caller_project_id, message, status, error, created_at';
+
+/**
+ * Provenance for messages sent into a session.
+ *
+ * `kangentic_send_session_message` delivers its text with no in-band marker, so
+ * these rows are the only place that records a turn arrived from another agent
+ * rather than from the human at the keyboard. Keeping the marker out of the
+ * message costs zero tokens and cannot be forged by the receiving agent, but it
+ * means this table is load-bearing: without a row, a sent turn is
+ * indistinguishable from a typed one.
+ */
+export class SentSessionMessageRepository {
+  constructor(private db: Database.Database) {}
+
+  /**
+   * Record one send attempt against the session it targeted.
+   *
+   * Returns null, and writes nothing, when no `sessions` row exists for
+   * `session_id`. That happens when a caller names a session id that was never
+   * real (a typo, or an id from another project). `session_id` carries a
+   * foreign key so these rows are cleaned up with their session, which means
+   * such an insert would otherwise raise an FK violation - an exception on a
+   * routine bad argument, swallowed into a log line. Skipping is the honest
+   * behavior: there is no session to attach provenance to, and the caller
+   * already received the refusal synchronously.
+   *
+   * Note this does NOT affect the realistic dead-session case: a session that
+   * exited or was suspended still has its row, so its refusal is recorded.
+   */
+  insert(record: Omit<SentSessionMessage, 'id' | 'created_at'>): SentSessionMessage | null {
+    const sessionExists = this.db
+      .prepare('SELECT 1 FROM sessions WHERE id = ?')
+      .get(record.session_id);
+    if (!sessionExists) return null;
+
+    const id = uuidv4();
+    const createdAt = new Date().toISOString();
+    this.db.prepare(`
+      INSERT INTO session_messages_sent (${COLUMNS})
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      id,
+      record.session_id,
+      // Every nullable field is coalesced before binding, matching the other
+      // repositories: better-sqlite3 throws on an `undefined` parameter, so a
+      // caller that omits an optional-looking field would crash the insert
+      // rather than storing NULL.
+      record.caller_session_id ?? null,
+      record.caller_task_id ?? null,
+      record.caller_project_id ?? null,
+      record.message,
+      record.status,
+      record.error ?? null,
+      createdAt,
+    );
+    return { id, ...record, created_at: createdAt };
+  }
+
+  /**
+   * Every send attempt against a session, oldest first.
+   *
+   * `rowid` breaks the tie because `created_at` is millisecond-resolution and a
+   * burst of sends lands several rows in the same millisecond; ordering by the
+   * timestamp alone leaves those in an order SQLite does not promise, which the
+   * `tail` slice in `kangentic_get_session_messages_sent` would then truncate
+   * arbitrarily.
+   */
+  listForSession(sessionId: string): SentSessionMessage[] {
+    return this.db.prepare(
+      `SELECT ${COLUMNS} FROM session_messages_sent WHERE session_id = ? ORDER BY created_at, rowid`,
+    ).all(sessionId) as SentSessionMessage[];
+  }
+
+  /**
+   * Every send attempt across ALL of a task's sessions, oldest first.
+   *
+   * Task-scoped rather than session-scoped because that is the question being
+   * asked when debugging: a task accumulates sessions across resumes and agent
+   * handoffs, and "did my message reach task #13?" should not depend on the
+   * caller first working out which session was live at the time.
+   */
+  listForTask(taskId: string): SentSessionMessage[] {
+    const prefixed = COLUMNS.split(', ').map((column) => `messages.${column}`).join(', ');
+    return this.db.prepare(
+      `SELECT ${prefixed} FROM session_messages_sent messages
+       JOIN sessions ON sessions.id = messages.session_id
+       WHERE sessions.task_id = ?
+       ORDER BY messages.created_at, messages.rowid`,
+    ).all(taskId) as SentSessionMessage[];
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -836,6 +836,15 @@ app.whenReady().then(async () => {
         bindAddress: startupMcpServerConfig?.bindAddress ?? '127.0.0.1',
         callbackHost: startupMcpServerConfig?.callbackHost,
       },
+      // Steering (kangentic_send_session_message) needs the live PTY
+      // singletons, which do not exist until the IPC context is built. Read
+      // lazily per request; null just means the tool is not registered yet,
+      // which is only true before any agent could be running.
+      () => {
+        const ctx = getOptionalIpcContext();
+        if (!ctx) return null;
+        return { sessionManager: ctx.sessionManager, terminalSubmit: ctx.terminalSubmit };
+      },
     );
   } catch (err) {
     console.error('[APP] Failed to start MCP HTTP server:', err);

--- a/src/main/transition-engine/session-startup/prepare-spawn.ts
+++ b/src/main/transition-engine/session-startup/prepare-spawn.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto';
 import { agentRegistry } from '../../agent/agent-registry';
 import type { AgentAdapter } from '../../agent/agent-adapter';
 import type { McpHttpServerHandle } from '../../agent/mcp-http-server';
+import { appendCallerSession } from '../../agent/mcp-http/caller-url';
 import type { AppConfig, Swimlane, Task } from '../../../shared/types';
 import type { TaskRepository } from '../../db/repositories/task-repository';
 import { runSpawnPreamble, resolveEffectivePermissionMode } from '../spawn-preamble';
@@ -159,7 +160,9 @@ export async function prepareAgentSpawn(input: {
     eventsOutputPath,
     shell: input.resolvedShell,
     mcpServerEnabled: config.mcpServer?.enabled ?? true,
-    mcpServerUrl: input.mcpServerHandle?.urlForProject(projectId),
+    // Carries this session's own id so the MCP server can identify the caller
+    // (see appendCallerSession). Stamped, never looked up, so it cannot drift.
+    mcpServerUrl: appendCallerSession(input.mcpServerHandle?.urlForProject(projectId), sessionRecordId),
     mcpServerToken: input.mcpServerHandle?.token,
     // Task-level override (set by the ContextBar popover) wins over the
     // swimlane override, which wins over the project-level default - once a

--- a/src/main/transition-engine/transition-engine.ts
+++ b/src/main/transition-engine/transition-engine.ts
@@ -10,6 +10,7 @@ import { resolveExecutionTarget } from '../agent/shared/execution-target';
 import { resolveLaunchOptions } from '../agent/shared/launch-options';
 import { WorktreeManager, prepareWorktreeForRemoval, GitQueuePriority } from '../git/worktree-manager';
 import { agentRegistry } from '../agent/agent-registry';
+import { appendCallerSession } from '../agent/mcp-http/caller-url';
 import { retireRecord, markRecordSuspended } from './session-lifecycle';
 import { resolveEffectivePermissionMode } from './spawn-preamble';
 import { resolveSpawnIntent } from './spawn-intent';
@@ -289,7 +290,9 @@ export class TransitionEngine {
       eventsOutputPath,
       shell,
       mcpServerEnabled: appConfig.mcpServerEnabled,
-      mcpServerUrl: appConfig.mcpServerUrl,
+      // Carries this session's own id so the MCP server can identify the caller
+      // (see appendCallerSession). Stamped, never looked up, so it cannot drift.
+      mcpServerUrl: appendCallerSession(appConfig.mcpServerUrl, ptySessionId),
       mcpServerToken: appConfig.mcpServerToken,
       model: spawnOverrides?.model ?? undefined,
       effort: spawnOverrides?.effort ?? undefined,

--- a/src/shared/mcp-tool-manifest.ts
+++ b/src/shared/mcp-tool-manifest.ts
@@ -76,7 +76,8 @@ export const MCP_TOOL_MANIFEST: McpToolManifestEntry[] = [
   { name: 'kangentic_list_projects', label: 'List Projects', blurb: 'every Kangentic project registered on this machine', category: 'board' },
   { name: 'kangentic_search', label: 'Search', blurb: 'unified search across tasks, backlog, session events, projects, and past conversations (keyword or semantic)', category: 'board' },
 
-  // ── Sessions (session-tools.ts) - per-task session history, transcripts, and handoff ──
+  // ── Sessions (session-tools.ts, steering-tools.ts) - per-task session history,
+  //    transcripts, handoff, and the one write-side tool that steers a live session ──
   { name: 'kangentic_list_sessions', label: 'List Sessions', blurb: 'session records for a task with timings, cost, and exit info', category: 'sessions' },
   { name: 'kangentic_get_session_history', label: 'Session History', blurb: 'read the native agent session transcript file for a task', category: 'sessions' },
   { name: 'kangentic_get_session_files', label: 'Session Files', blurb: 'absolute paths to a session activity, status, and history files', category: 'sessions' },
@@ -84,6 +85,8 @@ export const MCP_TOOL_MANIFEST: McpToolManifestEntry[] = [
   { name: 'kangentic_get_activity_intervals', label: 'Activity Intervals', blurb: 'durable history of active vs idle time for a task or session', category: 'sessions' },
   { name: 'kangentic_get_handoff_context', label: 'Handoff Context', blurb: 'the most recent cross-agent handoff record for a task', category: 'sessions' },
   { name: 'kangentic_get_transcript', label: 'Get Transcript', blurb: 'read what the agent on another task or project said', category: 'sessions' },
+  { name: 'kangentic_send_session_message', label: 'Send Session Message', blurb: 'send a message to another task\'s running agent to steer it', category: 'sessions' },
+  { name: 'kangentic_get_session_messages_sent', label: 'Sent Session Messages', blurb: 'log of messages sent into a session, and whether each landed', category: 'sessions' },
 
   // ── Browser Automation (browser-tools.ts) ──
   { name: 'kangentic_browser_list_panes', label: 'List Browser Panes', blurb: 'open embedded Browser panes and their URLs', category: 'browser' },

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -598,6 +598,53 @@ export interface HandoffRecord {
   created_at: string;
 }
 
+/**
+ * Outcome of one `kangentic_send_session_message` ATTEMPT. Declared here rather
+ * than beside the coordinator so the row type and the code that writes it share
+ * one definition, with the dependency running shared -> main (never the
+ * reverse). `delivered` and `queued` produced a turn; `refused` and `failed`
+ * record an attempt only.
+ */
+export type SentSessionMessageStatus = 'delivered' | 'queued' | 'refused' | 'failed';
+
+/**
+ * One message sent into a session via `kangentic_send_session_message`, by
+ * another agent or by a human steering it directly.
+ *
+ * The delivered text carries no in-band marker, so this row is the ONLY record
+ * that a given turn arrived through the tool rather than being typed at the
+ * keyboard. `message` is stored as the caller supplied it, which matches the
+ * transcript turn it produced for ordinary prose - the paste path normalizes CR
+ * to LF and strips C0 control characters, so a message containing those differs
+ * from the delivered text by exactly that normalization.
+ *
+ * The caller fields are null when a human sent it with no Kangentic session of
+ * their own, and are plain ids (not foreign keys) because a cross-project send
+ * originates in a different project's database.
+ */
+export interface SentSessionMessage {
+  id: string;
+  /** The session that RECEIVED the message. */
+  session_id: string;
+  caller_session_id: string | null;
+  caller_task_id: string | null;
+  caller_project_id: string | null;
+  message: string;
+  /**
+   * The attempt's outcome, not just its successes:
+   * `delivered` (sent straight through), `queued` (held for the next idle
+   * transition), `refused` (a guard rejected it - no turn produced), or
+   * `failed` (delivery threw; whether a turn was produced is unknown).
+   *
+   * Reconstructing "which turns arrived this way" means filtering to
+   * `delivered` / `queued`. The other two record an attempt, not a turn.
+   */
+  status: SentSessionMessageStatus;
+  /** Refusal or failure detail. Null for a successful delivery. */
+  error: string | null;
+  created_at: string;
+}
+
 export interface SessionSummary {
   sessionId: string;
   totalCostUsd: number;

--- a/tests/unit/mcp-caller-url.test.ts
+++ b/tests/unit/mcp-caller-url.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Unit tests for `appendCallerSession` (src/main/agent/mcp-http/caller-url.ts).
+ *
+ * The function is a single string-concatenation guard: it stamps a spawning
+ * session's own id onto its project-scoped MCP URL so the server can identify
+ * WHICH session is calling (see the file's own doc comment for the full
+ * rationale). It had zero test coverage before this file - both spawn
+ * chokepoints (prepare-spawn.ts, transition-engine.ts) call it, but neither of
+ * their existing test suites ever passed a real project URL through, so
+ * reverting this function to a no-op (`return projectUrl;`) would fail nothing
+ * anywhere in the suite until now.
+ */
+import { describe, it, expect } from 'vitest';
+import { appendCallerSession } from '../../src/main/agent/mcp-http/caller-url';
+
+describe('appendCallerSession', () => {
+  it('appends the caller session id as a third URL segment', () => {
+    // Red: reverting to `return projectUrl;` (dropping the session segment)
+    // makes this equal 'http://127.0.0.1:1234/mcp/proj-1', not the URL below.
+    expect(appendCallerSession('http://127.0.0.1:1234/mcp/proj-1', 'session-abc')).toBe(
+      'http://127.0.0.1:1234/mcp/proj-1/session-abc',
+    );
+  });
+
+  it('returns undefined when projectUrl is undefined', () => {
+    // The MCP server may not be enabled or not yet listening - callers rely on
+    // this passing straight through so a spawn can omit --mcp-config entirely.
+    expect(appendCallerSession(undefined, 'session-abc')).toBeUndefined();
+  });
+
+  it('returns undefined when projectUrl is an empty string', () => {
+    expect(appendCallerSession('', 'session-abc')).toBeUndefined();
+  });
+
+  it('does not append anything for an empty caller session id (still concatenates the segment)', () => {
+    // Not a realistic caller (every spawn chokepoint passes a real UUID), but
+    // pins the function's actual contract: it does not validate the id, only
+    // concatenates it - a trailing slash with nothing after it.
+    expect(appendCallerSession('http://127.0.0.1:1234/mcp/proj-1', '')).toBe(
+      'http://127.0.0.1:1234/mcp/proj-1/',
+    );
+  });
+
+  it('preserves a project URL that itself has no port or extra path segments', () => {
+    expect(appendCallerSession('http://127.0.0.1/mcp/proj-1', 'session-xyz')).toBe(
+      'http://127.0.0.1/mcp/proj-1/session-xyz',
+    );
+  });
+});

--- a/tests/unit/mcp-http-server-steering-lifecycle.test.ts
+++ b/tests/unit/mcp-http-server-steering-lifecycle.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Guards two lifecycle properties of the lazily-built SessionSendCoordinator
+ * inside startMcpHttpServer/resolveSteering (src/main/agent/mcp-http-server.ts):
+ *
+ *   1. `close()` must detach the coordinator's SessionManager listeners
+ *      (`sessionSendCoordinator?.dispose()`) BEFORE the socket teardown, so a
+ *      shutdown never leaves a live 'activity'/'exit' subscriber pointing at a
+ *      disposed server. Deleting those lines fails nothing today - no
+ *      existing test ever builds a real coordinator through a real server
+ *      launch and then closes it.
+ *   2. `resolveSteering` builds the coordinator ONCE per server launch (the
+ *      `if (!sessionSendCoordinator)` guard) and reuses it across requests, so
+ *      its rate-limit windows and hop depths persist for the life of the
+ *      launch. Removing that guard would rebuild (and re-subscribe) a fresh
+ *      coordinator on every request, which fails nothing today either - no
+ *      existing test issues two requests against one running server and
+ *      checks the coordinator was not rebuilt.
+ *
+ * Both are observed indirectly via the fake SessionManager's listener count:
+ * the coordinator subscribes exactly one 'activity' and one 'exit' listener
+ * per construction, so listener count is a faithful proxy for "was a
+ * coordinator built" without reaching into module-private state.
+ *
+ * Heavy leaf modules are stubbed so mcp-http-server imports under node
+ * (mirrors mcp-server-config-gating.test.ts / mcp-server-network-config.test.ts).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import * as http from 'node:http';
+
+vi.mock('electron', () => ({
+  webContents: { fromId: () => null },
+  app: { getPath: () => '/tmp', isPackaged: false },
+}));
+vi.mock('../../src/main/agent/commands', () => ({ commandHandlers: {} }));
+vi.mock('../../src/main/agent/mcp-project-context', () => ({
+  buildCommandContextForProject: vi.fn(() => null),
+}));
+vi.mock('../../src/main/search/search-core', () => ({ runSearchEverything: vi.fn() }));
+vi.mock('../../src/main/diagnostics/process-metrics', () => ({ getProcessMetrics: vi.fn() }));
+vi.mock('../../src/main/git/worktree-list', () => ({ enumerateWorktrees: vi.fn() }));
+vi.mock('../../src/main/browser/browser-pane-driver', () => ({
+  withGuest: vi.fn(),
+  validateNavigationUrl: vi.fn(),
+}));
+vi.mock('../../src/main/browser/browser-pane-registry', () => ({
+  browserPaneRegistry: { list: () => [] },
+}));
+vi.mock('../../src/main/browser/cdp/cdp', () => ({
+  clickAtCenterOfSelector: vi.fn(),
+  dispatchMouseEvent: vi.fn(),
+  dispatchKeyEvent: vi.fn(),
+  dispatchKeypress: vi.fn(),
+  dragFromTo: vi.fn(),
+  getOuterHtml: vi.fn(),
+  getBoundingBox: vi.fn(),
+  getConsoleEntries: vi.fn(),
+  getLayoutMetrics: vi.fn(),
+  queryAllElements: vi.fn(),
+  runtimeEvaluate: vi.fn(),
+  typeText: vi.fn(),
+}));
+vi.mock('../../src/main/browser/cdp/screenshot', () => ({
+  captureScreenshotWithBudget: vi.fn(),
+  captureElementClip: vi.fn(),
+}));
+vi.mock('../../src/devtools/mcp/register', () => ({ registerDevtoolsMcpTools: vi.fn() }));
+
+import { startMcpHttpServer, type McpHttpServerHandle, type McpSteeringContext } from '../../src/main/agent/mcp-http-server';
+import { RequestResolver } from '../../src/main/agent/mcp-http/project-resolver';
+import type { IpcContext } from '../../src/main/ipc/ipc-context';
+import type { CommandContext } from '../../src/main/agent/commands/types';
+
+/**
+ * Minimal fake for the `sessionManager` slice `McpSteeringContext` requires
+ * (`SessionSendSessionManager & SteeringSessionLookup`), with listener-count
+ * tracking so we can observe how many times the coordinator subscribed/
+ * unsubscribed without reaching into mcp-http-server's private state.
+ */
+function createFakeSteeringSessionManager() {
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+  return {
+    isWritable: () => false,
+    getActivityCache: () => ({}),
+    findLiveSessionByTaskId: () => undefined,
+    getSessionTaskId: () => undefined,
+    getSessionProjectId: () => undefined,
+    on(event: string, listener: (...args: unknown[]) => void) {
+      const existing = listeners.get(event) ?? [];
+      existing.push(listener);
+      listeners.set(event, existing);
+      return this;
+    },
+    off(event: string, listener: (...args: unknown[]) => void) {
+      listeners.set(event, (listeners.get(event) ?? []).filter((candidate) => candidate !== listener));
+      return this;
+    },
+    listenerCount(event: string) {
+      return (listeners.get(event) ?? []).length;
+    },
+  };
+}
+
+function makeResolver(): RequestResolver {
+  const fakeIpcContext = { projectRepo: { list: () => [] } } as unknown as IpcContext;
+  const fakeCommandContext = {} as unknown as CommandContext;
+  return new RequestResolver({
+    ipcContext: fakeIpcContext,
+    defaultContext: fakeCommandContext,
+    defaultProjectId: 'proj-1',
+    defaultProjectName: 'Test Project',
+  });
+}
+
+/**
+ * Sends a POST that reaches `resolveSteering(callerSessionId)` inside
+ * `handleHttpRequest` without needing a valid JSON-RPC body: that call happens
+ * BEFORE the request body is read (see mcp-http-server.ts), so a bogus body is
+ * sufficient to exercise the coordinator lazy-build path. Uses `node:http`
+ * directly (not fetch) to match the pattern in mcp-server-network-config.test.ts.
+ */
+function postToPath(port: number, pathname: string, token: string): Promise<{ statusCode: number }> {
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: pathname,
+        method: 'POST',
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          'Content-Type': 'application/json',
+          'X-Kangentic-Token': token,
+        },
+      },
+      (response) => {
+        response.resume();
+        response.on('end', () => resolve({ statusCode: response.statusCode ?? 0 }));
+      },
+    );
+    request.on('error', reject);
+    request.end(JSON.stringify({ jsonrpc: '2.0', method: 'ping', id: 1 }));
+  });
+}
+
+describe('startMcpHttpServer - SessionSendCoordinator lifecycle', () => {
+  let handle: McpHttpServerHandle | undefined;
+
+  afterEach(() => {
+    handle?.close();
+    handle = undefined;
+  });
+
+  it('detaches the coordinator\'s SessionManager listeners when the server is closed', async () => {
+    const sessionManager = createFakeSteeringSessionManager();
+    const steeringContext: McpSteeringContext = {
+      sessionManager,
+      terminalSubmit: { submitContent: vi.fn(() => Promise.resolve()) },
+    };
+    const resolver = makeResolver();
+
+    handle = await startMcpHttpServer(
+      (projectId) => (projectId === 'proj-1' ? resolver : null),
+      () => ({ enabled: false, allowInteraction: false, allowNavigation: false, allowEval: false, restrictNavigationToLocalhost: false }),
+      { bindAddress: '127.0.0.1' },
+      () => steeringContext,
+    );
+    const port = Number(new URL(handle.baseUrl).port);
+
+    await postToPath(port, '/mcp/proj-1/caller-session-xyz', handle.token);
+
+    // A coordinator was actually built and subscribed before we assert close()
+    // detached it - otherwise the post-close assertion below would pass
+    // vacuously (0 listeners because none were ever attached).
+    expect(sessionManager.listenerCount('activity')).toBeGreaterThan(0);
+    expect(sessionManager.listenerCount('exit')).toBeGreaterThan(0);
+
+    handle.close();
+
+    // Red: removing `sessionSendCoordinator?.dispose();` from
+    // startMcpHttpServer's returned close() (mcp-http-server.ts) leaves these
+    // at their pre-close count instead of 0.
+    expect(sessionManager.listenerCount('activity')).toBe(0);
+    expect(sessionManager.listenerCount('exit')).toBe(0);
+  });
+
+  it('builds the SessionSendCoordinator once per server launch and reuses it across requests', async () => {
+    const sessionManager = createFakeSteeringSessionManager();
+    const steeringContext: McpSteeringContext = {
+      sessionManager,
+      terminalSubmit: { submitContent: vi.fn(() => Promise.resolve()) },
+    };
+    const resolver = makeResolver();
+
+    handle = await startMcpHttpServer(
+      (projectId) => (projectId === 'proj-1' ? resolver : null),
+      () => ({ enabled: false, allowInteraction: false, allowNavigation: false, allowEval: false, restrictNavigationToLocalhost: false }),
+      { bindAddress: '127.0.0.1' },
+      () => steeringContext,
+    );
+    const port = Number(new URL(handle.baseUrl).port);
+
+    await postToPath(port, '/mcp/proj-1/caller-a', handle.token);
+    expect(sessionManager.listenerCount('activity')).toBe(1);
+    expect(sessionManager.listenerCount('exit')).toBe(1);
+
+    await postToPath(port, '/mcp/proj-1/caller-b', handle.token);
+
+    // Red: removing the `if (!sessionSendCoordinator)` guard in
+    // resolveSteering (mcp-http-server.ts) builds a fresh coordinator - and
+    // re-subscribes a fresh 'activity'/'exit' listener pair - on every
+    // request, so this would read 2 instead of 1.
+    expect(sessionManager.listenerCount('activity')).toBe(1);
+    expect(sessionManager.listenerCount('exit')).toBe(1);
+  });
+});

--- a/tests/unit/mcp-request-path-parsing.test.ts
+++ b/tests/unit/mcp-request-path-parsing.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for `parseMcpRequestPath` (src/main/agent/mcp-http-server.ts).
+ *
+ * `handleHttpRequest` used to inline this parse (`segments[1]` -> projectId,
+ * `segments[2]` -> optional callerSessionId) with zero test coverage - only
+ * reachable through a real HTTP request. It was extracted into a small pure
+ * function (mirroring the existing `buildAllowedHosts` precedent in this same
+ * file) so the URL-segment contract is directly testable. Before the
+ * extraction, reverting the parse to 2-segment-only (dropping `segments[2]`
+ * entirely) failed nothing anywhere in the suite.
+ *
+ * Heavy leaf modules are stubbed so mcp-http-server imports under node
+ * (mirrors mcp-server-config-gating.test.ts / mcp-server-network-config.test.ts).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  webContents: { fromId: () => null },
+  app: { getPath: () => '/tmp', isPackaged: false },
+}));
+vi.mock('../../src/main/agent/commands', () => ({ commandHandlers: {} }));
+vi.mock('../../src/main/agent/mcp-project-context', () => ({
+  buildCommandContextForProject: vi.fn(() => null),
+}));
+vi.mock('../../src/main/search/search-core', () => ({ runSearchEverything: vi.fn() }));
+vi.mock('../../src/main/diagnostics/process-metrics', () => ({ getProcessMetrics: vi.fn() }));
+vi.mock('../../src/main/git/worktree-list', () => ({ enumerateWorktrees: vi.fn() }));
+vi.mock('../../src/main/browser/browser-pane-driver', () => ({
+  withGuest: vi.fn(),
+  validateNavigationUrl: vi.fn(),
+}));
+vi.mock('../../src/main/browser/browser-pane-registry', () => ({
+  browserPaneRegistry: { list: () => [] },
+}));
+vi.mock('../../src/main/browser/cdp/cdp', () => ({
+  clickAtCenterOfSelector: vi.fn(),
+  dispatchMouseEvent: vi.fn(),
+  dispatchKeyEvent: vi.fn(),
+  dispatchKeypress: vi.fn(),
+  dragFromTo: vi.fn(),
+  getOuterHtml: vi.fn(),
+  getBoundingBox: vi.fn(),
+  getConsoleEntries: vi.fn(),
+  getLayoutMetrics: vi.fn(),
+  queryAllElements: vi.fn(),
+  runtimeEvaluate: vi.fn(),
+  typeText: vi.fn(),
+}));
+vi.mock('../../src/main/browser/cdp/screenshot', () => ({
+  captureScreenshotWithBudget: vi.fn(),
+  captureElementClip: vi.fn(),
+}));
+vi.mock('../../src/devtools/mcp/register', () => ({ registerDevtoolsMcpTools: vi.fn() }));
+
+import { parseMcpRequestPath } from '../../src/main/agent/mcp-http-server';
+
+describe('parseMcpRequestPath', () => {
+  it('returns projectId with callerSessionId undefined when there is no third segment', () => {
+    expect(parseMcpRequestPath('/mcp/proj-1')).toEqual({ projectId: 'proj-1', callerSessionId: undefined });
+  });
+
+  it('returns both projectId and callerSessionId when a third segment is present', () => {
+    // Red: reverting the parse to 2-segment-only (never reading segments[2])
+    // makes callerSessionId undefined here too.
+    expect(parseMcpRequestPath('/mcp/proj-1/session-abc')).toEqual({
+      projectId: 'proj-1',
+      callerSessionId: 'session-abc',
+    });
+  });
+
+  it('ignores a trailing slash (no phantom empty callerSessionId)', () => {
+    expect(parseMcpRequestPath('/mcp/proj-1/')).toEqual({ projectId: 'proj-1', callerSessionId: undefined });
+  });
+
+  it('ignores segments past the caller session id', () => {
+    // Matches the pre-extraction behavior: only segments[1]/segments[2] were
+    // ever read, so a 4th+ segment is silently dropped, not an error.
+    expect(parseMcpRequestPath('/mcp/proj-1/session-abc/extra/stuff')).toEqual({
+      projectId: 'proj-1',
+      callerSessionId: 'session-abc',
+    });
+  });
+
+  it('returns null when the path has fewer than two segments', () => {
+    expect(parseMcpRequestPath('/mcp')).toBeNull();
+    expect(parseMcpRequestPath('/')).toBeNull();
+  });
+
+  it('returns null when the first segment is not "mcp"', () => {
+    expect(parseMcpRequestPath('/notmcp/proj-1')).toBeNull();
+  });
+});

--- a/tests/unit/mcp-server-config-gating.test.ts
+++ b/tests/unit/mcp-server-config-gating.test.ts
@@ -65,6 +65,7 @@ import { buildServerInstructions } from '../../src/main/agent/mcp-http/server-in
 import { PROJECT_SELECTOR_DESCRIPTION, type TaskCounter } from '../../src/main/agent/mcp-http/handler-helpers';
 import type { RequestResolver } from '../../src/main/agent/mcp-http/project-resolver';
 import type { ResolvedBrowserAutomationConfig } from '../../src/main/browser/browser-automation-config';
+import type { SteeringToolDependencies } from '../../src/main/agent/mcp-http/steering-tools';
 
 function makeResolver(): RequestResolver {
   return {
@@ -88,11 +89,15 @@ function configReader(enabled: boolean): () => ResolvedBrowserAutomationConfig {
 }
 
 /** Build a configured server and read its advertised tool names via the public client API. */
-async function listToolNames(browserEnabled: boolean): Promise<string[]> {
+async function listToolNames(
+  browserEnabled: boolean,
+  steering?: SteeringToolDependencies | null,
+): Promise<string[]> {
   const server = buildConfiguredMcpServer(
     makeResolver(),
     fakeTaskCounter,
     configReader(browserEnabled),
+    steering,
   );
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const client = new Client({ name: 'guard', version: '1.0.0' });
@@ -102,6 +107,22 @@ async function listToolNames(browserEnabled: boolean): Promise<string[]> {
   await client.close();
   await server.close();
   return tools.map((tool) => tool.name);
+}
+
+/** A minimal, valid SteeringToolDependencies stub - only the shape matters for gating. */
+function fakeSteeringDependencies(): SteeringToolDependencies {
+  return {
+    coordinator: {
+      send: async () => ({ error: 'unused in this test' }),
+      dispose: () => {},
+      _stateSizesForTesting: () => ({ queues: 0, pending: 0, hops: 0, windows: 0, refusalNotices: 0 }),
+    },
+    sessions: {
+      findLiveSessionByTaskId: () => undefined,
+      getSessionTaskId: () => undefined,
+      getSessionProjectId: () => undefined,
+    },
+  };
 }
 
 describe('buildConfiguredMcpServer - browser tool gating', () => {
@@ -136,5 +157,41 @@ describe('project-selector description dedup', () => {
     const instructions = buildServerInstructions(makeResolver());
     expect(instructions).toContain('PROJECT ROUTING RULE');
     expect(instructions).toContain("X's backlog");
+  });
+});
+
+describe('buildConfiguredMcpServer - steering tool gating', () => {
+  // Coverage hole: registerSteeringTools is called only `if (steering)`
+  // (mcp-http-server.ts's buildConfiguredMcpServer). Every browser-gating test
+  // above calls buildConfiguredMcpServer with the `steering` argument omitted,
+  // so a regression that registered the steering tools unconditionally (or
+  // never registered them at all) would fail nothing above.
+  it('registers the steering tools when a truthy steering dependency is passed', async () => {
+    const names = await listToolNames(true, fakeSteeringDependencies());
+
+    // Red: wrapping registerSteeringTools's call site in `if (false)` (or
+    // deleting the call) makes these absent even with steering supplied.
+    expect(names).toContain('kangentic_send_session_message');
+    expect(names).toContain('kangentic_get_session_messages_sent');
+  });
+
+  it('omits the steering tools when steering is undefined (IPC context not ready yet)', async () => {
+    const names = await listToolNames(true, undefined);
+
+    expect(names).not.toContain('kangentic_send_session_message');
+    expect(names).not.toContain('kangentic_get_session_messages_sent');
+    // Confirms the omission is scoped to steering, not a broken server.
+    expect(names).toContain('kangentic_create_task');
+  });
+
+  it('omits the steering tools when steering is explicitly null', async () => {
+    // Red: removing the `if (steering)` guard entirely (calling
+    // registerSteeringTools unconditionally) would crash on a null
+    // `dependencies.coordinator` before this assertion, or - if guarded only
+    // against undefined - register the tools here when it should not.
+    const names = await listToolNames(true, null);
+
+    expect(names).not.toContain('kangentic_send_session_message');
+    expect(names).not.toContain('kangentic_get_session_messages_sent');
   });
 });

--- a/tests/unit/mcp-session-send.test.ts
+++ b/tests/unit/mcp-session-send.test.ts
@@ -96,6 +96,36 @@ describe('session-send coordinator', () => {
     });
   });
 
+  it('still resolves "delivered" when the recorder throws, per "provenance is best-effort"', async () => {
+    // record() wraps recordSentMessage in try/catch specifically so a failing
+    // provenance write (e.g. a locked SQLite handle) cannot turn a message that
+    // actually landed in the target's PTY into a thrown error out of the tool
+    // handler - the delivery already happened and cannot be undone.
+    const sessionManager = createFakeSessionManager({ writable: ['target'], activity: { target: 'idle' } });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const recordSentMessage = vi.fn(() => {
+      throw new Error('db locked');
+    });
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    const outcome = await coordinator.send({
+      targetSessionId: 'target',
+      message: 'go',
+      deliverWhen: 'now',
+      recordSentMessage,
+    });
+
+    // Red: removing the try/catch around `recordSentMessage?.(...)` in
+    // session-send.ts's `record` makes this reject with "db locked" instead of
+    // resolving.
+    expect(outcome).toMatchObject({ status: 'delivered' });
+    expect(submitContent).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('db locked'));
+    consoleErrorSpy.mockRestore();
+    coordinator.dispose();
+  });
+
   it('records a refusal so "did my message go through?" always has an answer', async () => {
     const sessionManager = createFakeSessionManager({ writable: [] });
     const submitContent = vi.fn(() => Promise.resolve());

--- a/tests/unit/mcp-session-send.test.ts
+++ b/tests/unit/mcp-session-send.test.ts
@@ -1,0 +1,542 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createSessionSendCoordinator,
+  type SessionSendOutcome,
+} from '../../src/main/agent/mcp-http/session-send';
+import type { ActivityState } from '../../src/shared/types';
+
+/**
+ * Minimal stand-in for the SessionManager slice the coordinator consumes, with
+ * an `emit` so tests can drive the activity/exit transitions that gate deferred
+ * delivery. Booting a real SessionManager would mean spawning a PTY.
+ */
+function createFakeSessionManager(initial: { writable?: string[]; activity?: Record<string, ActivityState> } = {}) {
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+  const writable = new Set(initial.writable ?? []);
+  const activity: Record<string, ActivityState> = { ...(initial.activity ?? {}) };
+  return {
+    writable,
+    activity,
+    isWritable: (sessionId: string) => writable.has(sessionId),
+    getActivityCache: () => activity,
+    on(event: string, listener: (...args: unknown[]) => void) {
+      const existing = listeners.get(event) ?? [];
+      existing.push(listener);
+      listeners.set(event, existing);
+      return this;
+    },
+    off(event: string, listener: (...args: unknown[]) => void) {
+      listeners.set(event, (listeners.get(event) ?? []).filter((candidate) => candidate !== listener));
+      return this;
+    },
+    emit(event: string, ...args: unknown[]) {
+      for (const listener of [...(listeners.get(event) ?? [])]) listener(...args);
+    },
+    listenerCount(event: string) {
+      return (listeners.get(event) ?? []).length;
+    },
+  };
+}
+
+/** Let queued microtasks (PQueue scheduling, promise chains) run to completion. */
+async function flushMicrotasks(): Promise<void> {
+  for (let index = 0; index < 5; index += 1) await Promise.resolve();
+}
+
+function isFailure(outcome: SessionSendOutcome): outcome is { error: string } {
+  return 'error' in outcome;
+}
+
+describe('session-send coordinator', () => {
+  it('delivers the message VERBATIM through the bracketed-paste submit path', async () => {
+    const sessionManager = createFakeSessionManager({ writable: ['target'], activity: { target: 'idle' } });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    const outcome = await coordinator.send({
+      targetSessionId: 'target',
+      message: 'please rebase onto main',
+      callerSessionId: 'caller',
+      deliverWhen: 'now',
+    });
+
+    expect(outcome).toMatchObject({ status: 'delivered', sessionId: 'target', targetActivity: 'idle', hopDepth: 1 });
+    expect(submitContent).toHaveBeenCalledTimes(1);
+    const [sessionId, text, options] = submitContent.mock.calls[0];
+    expect(sessionId).toBe('target');
+    expect(options).toEqual({ source: 'mcp' });
+    // No in-band attribution. A prefix costs tokens on every send and reads to
+    // the receiving agent as injected content asserting its own authority,
+    // which made it refuse messages sent this way (verified live 2026-07-25).
+    // Provenance goes to the session_messages_sent table instead. Byte-exact equality
+    // also keeps the stored `message` matchable against the transcript turn.
+    expect(text).toBe('please rebase onto main');
+    coordinator.dispose();
+  });
+
+  it('records provenance for a delivered message so a sent turn stays identifiable', async () => {
+    const sessionManager = createFakeSessionManager({ writable: ['target'], activity: { target: 'idle' } });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const recordSentMessage = vi.fn();
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    await coordinator.send({
+      targetSessionId: 'target',
+      message: 'take this over',
+      callerSessionId: 'caller',
+      deliverWhen: 'now',
+      recordSentMessage,
+    });
+
+    expect(recordSentMessage).toHaveBeenCalledWith({
+      targetSessionId: 'target',
+      callerSessionId: 'caller',
+      message: 'take this over',
+      status: 'delivered',
+    });
+  });
+
+  it('records a refusal so "did my message go through?" always has an answer', async () => {
+    const sessionManager = createFakeSessionManager({ writable: [] });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const recordSentMessage = vi.fn();
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    await coordinator.send({ targetSessionId: 'gone', message: 'x', deliverWhen: 'now', recordSentMessage });
+
+    expect(recordSentMessage).toHaveBeenCalledWith(expect.objectContaining({
+      targetSessionId: 'gone',
+      message: 'x',
+      status: 'refused',
+      error: expect.stringContaining('not accepting input'),
+    }));
+    expect(submitContent).not.toHaveBeenCalled();
+    coordinator.dispose();
+  });
+
+  it('records a delivery failure, where whether a turn landed is genuinely unknown', async () => {
+    const sessionManager = createFakeSessionManager({ writable: ['target'] });
+    const submitContent = vi.fn(() => Promise.reject(new Error('no-submission-evidence')));
+    const recordSentMessage = vi.fn();
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    await coordinator.send({ targetSessionId: 'target', message: 'x', deliverWhen: 'now', recordSentMessage });
+
+    expect(recordSentMessage).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      error: expect.stringContaining('no-submission-evidence'),
+    }));
+    coordinator.dispose();
+  });
+
+  it('records a deferred delivery failure, the only channel left once the call returned', async () => {
+    const sessionManager = createFakeSessionManager({ writable: ['target'], activity: { target: 'thinking' } });
+    const submitContent = vi.fn(() => Promise.reject(new Error('paste exploded')));
+    const recordSentMessage = vi.fn();
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    await coordinator.send({ targetSessionId: 'target', message: 'x', deliverWhen: 'idle', recordSentMessage });
+    expect(recordSentMessage).not.toHaveBeenCalled();
+
+    sessionManager.emit('activity', 'target', 'idle');
+    await flushMicrotasks();
+
+    expect(recordSentMessage).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      error: expect.stringContaining('paste exploded'),
+    }));
+    coordinator.dispose();
+  });
+
+  it('dedupes repeated refusals per window so a runaway cannot fill the database', async () => {
+    // The self-send and dead-session guards run BEFORE the rate limiter, so
+    // they never consume a slot. Without dedupe, a looping agent writes one row
+    // per attempt forever and the audit trail becomes the amplification vector.
+    const sessionManager = createFakeSessionManager({ writable: [] });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const recordSentMessage = vi.fn();
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    for (let attempt = 0; attempt < 25; attempt += 1) {
+      await coordinator.send({ targetSessionId: 'gone', message: 'x', deliverWhen: 'now', recordSentMessage });
+    }
+
+    expect(recordSentMessage).toHaveBeenCalledTimes(1);
+    coordinator.dispose();
+  });
+
+  it('keeps a separate refusal notice per reason and per target', async () => {
+    const sessionManager = createFakeSessionManager({ writable: ['live'] });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const recordSentMessage = vi.fn();
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    // Distinct reason (self-send vs dead session) and distinct target: both
+    // are separately interesting when debugging, so neither may mask the other.
+    await coordinator.send({ targetSessionId: 'live', message: 'x', callerSessionId: 'live', deliverWhen: 'now', recordSentMessage });
+    await coordinator.send({ targetSessionId: 'gone', message: 'x', deliverWhen: 'now', recordSentMessage });
+
+    const statuses = recordSentMessage.mock.calls.map((call) => (call[0] as { targetSessionId: string }).targetSessionId);
+    expect(statuses).toEqual(['live', 'gone']);
+    coordinator.dispose();
+  });
+
+  it('accepts a message with no caller session without inventing an origin', async () => {
+    const sessionManager = createFakeSessionManager({ writable: ['target'] });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const recordSentMessage = vi.fn();
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    const outcome = await coordinator.send({
+      targetSessionId: 'target',
+      message: 'hello',
+      deliverWhen: 'now',
+      recordSentMessage,
+    });
+
+    expect(isFailure(outcome)).toBe(false);
+    expect(submitContent.mock.calls[0][1]).toBe('hello');
+    expect(recordSentMessage).toHaveBeenCalledWith(expect.objectContaining({ callerSessionId: undefined }));
+    coordinator.dispose();
+  });
+
+  it('refuses a session sending to itself', async () => {
+    const sessionManager = createFakeSessionManager({ writable: ['same'] });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    const outcome = await coordinator.send({
+      targetSessionId: 'same',
+      message: 'loop',
+      callerSessionId: 'same',
+      deliverWhen: 'now',
+    });
+
+    expect(isFailure(outcome) && outcome.error).toMatch(/cannot send a message to itself/);
+    expect(submitContent).not.toHaveBeenCalled();
+    coordinator.dispose();
+  });
+
+  it('rejects a session with no live PTY without burning the submit timeout', async () => {
+    // The mobile bridge checks registry existence, so a suspended session gets
+    // all the way into the paste engine and fails ~7s later. Gate on isWritable.
+    const sessionManager = createFakeSessionManager({ writable: [] });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    const outcome = await coordinator.send({
+      targetSessionId: 'suspended',
+      message: 'hello',
+      deliverWhen: 'now',
+    });
+
+    expect(isFailure(outcome) && outcome.error).toMatch(/not accepting input/);
+    expect(submitContent).not.toHaveBeenCalled();
+    coordinator.dispose();
+  });
+
+  it('refuses an immediate send into an open permission prompt', async () => {
+    // The submit path ends in \r (and retries it), which a modal prompt reads
+    // as confirming its highlighted option - so an ordinary steer could approve
+    // a tool call nobody sanctioned. The deferred path already excluded
+    // 'permission'; the hazard is the delivery, not when it was scheduled.
+    const sessionManager = createFakeSessionManager({ writable: ['target'], activity: { target: 'permission' } });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const recordSentMessage = vi.fn();
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    const outcome = await coordinator.send({
+      targetSessionId: 'target',
+      message: 'unrelated steer',
+      deliverWhen: 'now',
+      recordSentMessage,
+    });
+
+    expect(isFailure(outcome) && outcome.error).toMatch(/permission prompt/);
+    expect(submitContent).not.toHaveBeenCalled();
+    expect(recordSentMessage).toHaveBeenCalledWith(expect.objectContaining({ status: 'refused' }));
+    coordinator.dispose();
+  });
+
+  it('QUEUES rather than refuses when deliverWhen is "idle" and the target is at a prompt', async () => {
+    // The immediate-path refusal tells the caller to re-send with "idle", so
+    // "idle" must actually hold for this state instead of refusing too.
+    const sessionManager = createFakeSessionManager({ writable: ['target'], activity: { target: 'permission' } });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    const outcome = await coordinator.send({ targetSessionId: 'target', message: 'go', deliverWhen: 'idle' });
+
+    expect(outcome).toMatchObject({ status: 'queued', targetActivity: 'permission' });
+    expect(submitContent).not.toHaveBeenCalled();
+
+    sessionManager.emit('activity', 'target', 'idle');
+    await flushMicrotasks();
+    expect(submitContent).toHaveBeenCalledTimes(1);
+    coordinator.dispose();
+  });
+
+  it('records a failed row when the target exits before a queued message flushes', async () => {
+    // The caller was already told "queued" and has returned. Dropping the entry
+    // silently would leave an attempt with no row anywhere, breaking the "a row
+    // exists for every attempt" contract the log is built on.
+    const sessionManager = createFakeSessionManager({ writable: ['target'], activity: { target: 'thinking' } });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const recordSentMessage = vi.fn();
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    await coordinator.send({ targetSessionId: 'target', message: 'go', deliverWhen: 'idle', recordSentMessage });
+    expect(recordSentMessage).not.toHaveBeenCalled();
+
+    sessionManager.emit('exit', 'target');
+
+    expect(recordSentMessage).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'go',
+      status: 'failed',
+      error: expect.stringContaining('exited'),
+    }));
+    expect(submitContent).not.toHaveBeenCalled();
+    coordinator.dispose();
+  });
+
+  it('records the whole batch as failed when the target stops accepting input at flush time', async () => {
+    // A per-entry break would abandon everything after the first entry with no
+    // row at all - the one outcome this table exists to make impossible.
+    const sessionManager = createFakeSessionManager({ writable: ['target'], activity: { target: 'thinking' } });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const recordSentMessage = vi.fn();
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    for (const message of ['first', 'second', 'third']) {
+      await coordinator.send({ targetSessionId: 'target', message, deliverWhen: 'idle', recordSentMessage });
+    }
+
+    // Went unwritable without an 'exit' (suspended mid-flight), then reported idle.
+    sessionManager.writable.delete('target');
+    sessionManager.emit('activity', 'target', 'idle');
+    await flushMicrotasks();
+
+    expect(submitContent).not.toHaveBeenCalled();
+    expect(recordSentMessage).toHaveBeenCalledTimes(3);
+    expect(recordSentMessage.mock.calls.map((call) => (call[0] as { message: string }).message))
+      .toEqual(['first', 'second', 'third']);
+    coordinator.dispose();
+  });
+
+  it('rolls back the hop depth when a DEFERRED delivery fails, like the immediate path', async () => {
+    // A target that never received the message must not carry this hop's depth
+    // into its own onward sends, or repeated deferred failures ratchet it
+    // toward the backstop with nothing ever delivered.
+    const sessionManager = createFakeSessionManager({ writable: ['b', 'c'], activity: { b: 'thinking' } });
+    // Only the deferred flush into b fails; the later onward send must succeed
+    // so its reported hopDepth is observable.
+    const submitContent = vi.fn((sessionId: string) => (
+      sessionId === 'b' ? Promise.reject(new Error('paste exploded')) : Promise.resolve()
+    ));
+    const coordinator = createSessionSendCoordinator(
+      { sessionManager, terminalSubmit: { submitContent } },
+      { maxHopDepth: 2 },
+    );
+
+    // a -> b at depth 1, deferred, then fails on flush.
+    await coordinator.send({ targetSessionId: 'b', message: 'go', callerSessionId: 'a', deliverWhen: 'idle' });
+    sessionManager.emit('activity', 'b', 'idle');
+    await flushMicrotasks();
+
+    // b never received it, so b's own onward send starts a fresh chain at 1.
+    const onward = await coordinator.send({ targetSessionId: 'c', message: 'go', callerSessionId: 'b', deliverWhen: 'now' });
+    expect(onward).toMatchObject({ hopDepth: 1 });
+    coordinator.dispose();
+  });
+
+  it('refuses once the per-target sliding window is full', async () => {
+    const sessionManager = createFakeSessionManager({ writable: ['target'] });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const coordinator = createSessionSendCoordinator(
+      { sessionManager, terminalSubmit: { submitContent } },
+      { maxSendsPerWindow: 2 },
+    );
+
+    const request = { targetSessionId: 'target', message: 'go', deliverWhen: 'now' as const };
+    expect(isFailure(await coordinator.send(request))).toBe(false);
+    expect(isFailure(await coordinator.send(request))).toBe(false);
+    const third = await coordinator.send(request);
+
+    expect(isFailure(third) && third.error).toMatch(/Rate limit/);
+    expect(submitContent).toHaveBeenCalledTimes(2);
+    coordinator.dispose();
+  });
+
+  it('counts a steer chain server-side and refuses past the depth backstop', async () => {
+    const sessionManager = createFakeSessionManager({ writable: ['b', 'c', 'd'] });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const coordinator = createSessionSendCoordinator(
+      { sessionManager, terminalSubmit: { submitContent } },
+      { maxHopDepth: 2 },
+    );
+
+    const first = await coordinator.send({ targetSessionId: 'b', message: 'go', callerSessionId: 'a', deliverWhen: 'now' });
+    expect(first).toMatchObject({ hopDepth: 1 });
+
+    // b now carries depth 1, so its own onward send is depth 2.
+    const second = await coordinator.send({ targetSessionId: 'c', message: 'go', callerSessionId: 'b', deliverWhen: 'now' });
+    expect(second).toMatchObject({ hopDepth: 2 });
+
+    const third = await coordinator.send({ targetSessionId: 'd', message: 'go', callerSessionId: 'c', deliverWhen: 'now' });
+    expect(isFailure(third) && third.error).toMatch(/chain depth 3 exceeds/);
+    coordinator.dispose();
+  });
+
+  it('delivers immediately for deliverWhen "idle" when the target is ALREADY idle', async () => {
+    // The motivating case is a target parked at idle_hint. Waiting for the next
+    // idle transition would never fire, leaving the message stuck indefinitely.
+    const sessionManager = createFakeSessionManager({ writable: ['target'], activity: { target: 'idle' } });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    const outcome = await coordinator.send({ targetSessionId: 'target', message: 'go', deliverWhen: 'idle' });
+
+    expect(outcome).toMatchObject({ status: 'delivered' });
+    expect(submitContent).toHaveBeenCalledTimes(1);
+    coordinator.dispose();
+  });
+
+  it('queues for deliverWhen "idle" against a busy target and flushes on the idle transition', async () => {
+    const sessionManager = createFakeSessionManager({ writable: ['target'], activity: { target: 'thinking' } });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const recordSentMessage = vi.fn();
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    const outcome = await coordinator.send({ targetSessionId: 'target', message: 'go', deliverWhen: 'idle', recordSentMessage });
+    expect(outcome).toMatchObject({ status: 'queued', targetActivity: 'thinking' });
+    expect(submitContent).not.toHaveBeenCalled();
+    // Provenance is written when the text LANDS, not when it was queued - a
+    // queued message that never flushes must leave no row claiming it arrived.
+    expect(recordSentMessage).not.toHaveBeenCalled();
+
+    // A permission prompt is "not active", but a queued paste must not land on
+    // an open prompt where its \r could confirm it.
+    sessionManager.emit('activity', 'target', 'permission');
+    await flushMicrotasks();
+    expect(submitContent).not.toHaveBeenCalled();
+
+    sessionManager.emit('activity', 'target', 'idle');
+    await flushMicrotasks();
+    expect(submitContent).toHaveBeenCalledTimes(1);
+    expect(submitContent.mock.calls[0][1]).toBe('go');
+    expect(recordSentMessage).toHaveBeenCalledWith(expect.objectContaining({ message: 'go', status: 'queued' }));
+    coordinator.dispose();
+  });
+
+  it('drops a pending deferred delivery when the target session exits', async () => {
+    const sessionManager = createFakeSessionManager({ writable: ['target'], activity: { target: 'thinking' } });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    await coordinator.send({ targetSessionId: 'target', message: 'go', deliverWhen: 'idle' });
+    expect(coordinator._stateSizesForTesting().pending).toBe(1);
+
+    sessionManager.emit('exit', 'target');
+    expect(coordinator._stateSizesForTesting()).toMatchObject({ pending: 0, hops: 0, windows: 0 });
+
+    sessionManager.emit('activity', 'target', 'idle');
+    await flushMicrotasks();
+    expect(submitContent).not.toHaveBeenCalled();
+    coordinator.dispose();
+  });
+
+  it('serializes concurrent sends to one target so pastes cannot interleave', async () => {
+    const sessionManager = createFakeSessionManager({ writable: ['target'] });
+    const started: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const submitContent = vi.fn((_sessionId: string, text: string) => {
+      started.push(text);
+      if (started.length === 1) {
+        return new Promise<void>((resolve) => { releaseFirst = resolve; });
+      }
+      return Promise.resolve();
+    });
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    const first = coordinator.send({ targetSessionId: 'target', message: 'first', deliverWhen: 'now' });
+    const second = coordinator.send({ targetSessionId: 'target', message: 'second', deliverWhen: 'now' });
+    await flushMicrotasks();
+
+    expect(started).toHaveLength(1);
+    releaseFirst?.();
+    await Promise.all([first, second]);
+    expect(started).toHaveLength(2);
+    expect(started[0]).toContain('first');
+    expect(started[1]).toContain('second');
+    coordinator.dispose();
+  });
+
+  it('drains its per-target queue map so long-running instances do not accumulate entries', async () => {
+    const sessionManager = createFakeSessionManager({ writable: ['one', 'two'] });
+    const submitContent = vi.fn(() => Promise.resolve());
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    await coordinator.send({ targetSessionId: 'one', message: 'go', deliverWhen: 'now' });
+    await coordinator.send({ targetSessionId: 'two', message: 'go', deliverWhen: 'now' });
+    await flushMicrotasks();
+
+    expect(coordinator._stateSizesForTesting().queues).toBe(0);
+    coordinator.dispose();
+  });
+
+  it('surfaces a submit failure as an error result rather than throwing', async () => {
+    const sessionManager = createFakeSessionManager({ writable: ['target'] });
+    const submitContent = vi.fn(() => Promise.reject(new Error('no-submission-evidence')));
+    const coordinator = createSessionSendCoordinator({ sessionManager, terminalSubmit: { submitContent } });
+
+    const outcome = await coordinator.send({ targetSessionId: 'target', message: 'go', deliverWhen: 'now' });
+
+    expect(isFailure(outcome) && outcome.error).toMatch(/no-submission-evidence/);
+    coordinator.dispose();
+  });
+
+  it('detaches its SessionManager listeners on dispose', () => {
+    const sessionManager = createFakeSessionManager();
+    const coordinator = createSessionSendCoordinator({
+      sessionManager,
+      terminalSubmit: { submitContent: vi.fn(() => Promise.resolve()) },
+    });
+
+    expect(sessionManager.listenerCount('activity')).toBe(1);
+    expect(sessionManager.listenerCount('exit')).toBe(1);
+    coordinator.dispose();
+    expect(sessionManager.listenerCount('activity')).toBe(0);
+    expect(sessionManager.listenerCount('exit')).toBe(0);
+  });
+
+  it('clears its tracked state on dispose, not just the listeners', async () => {
+    // dispose() runs on server shutdown. Detaching the listeners but leaving
+    // the maps populated would strand a launch's worth of hop depths, rate
+    // windows and refusal notices on a coordinator nothing can drain anymore.
+    const sessionManager = createFakeSessionManager({ writable: ['live'], activity: { live: 'thinking' } });
+    const coordinator = createSessionSendCoordinator({
+      sessionManager,
+      terminalSubmit: { submitContent: vi.fn(() => Promise.resolve()) },
+    });
+
+    // Populate every map: a queued deferred delivery (pending + hops + windows)
+    // and a refusal against a dead target (refusalNotices).
+    await coordinator.send({ targetSessionId: 'live', message: 'go', callerSessionId: 'caller', deliverWhen: 'idle' });
+    await coordinator.send({ targetSessionId: 'gone', message: 'go', deliverWhen: 'now' });
+    const populated = coordinator._stateSizesForTesting();
+    expect(populated.pending).toBeGreaterThan(0);
+    expect(populated.hops).toBeGreaterThan(0);
+    expect(populated.windows).toBeGreaterThan(0);
+    expect(populated.refusalNotices).toBeGreaterThan(0);
+
+    coordinator.dispose();
+
+    expect(coordinator._stateSizesForTesting()).toEqual({
+      queues: 0,
+      pending: 0,
+      hops: 0,
+      windows: 0,
+      refusalNotices: 0,
+    });
+  });
+});

--- a/tests/unit/mcp-steering-tools.test.ts
+++ b/tests/unit/mcp-steering-tools.test.ts
@@ -1,0 +1,472 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Stubbed so the tool's resolution and attribution logic can be exercised
+ * without standing up a per-project SQLite file and its migrations. Keyed by
+ * the fake project DB handle, so a lookup against the WRONG project's database
+ * returns nothing - which is exactly the cross-project attribution bug this
+ * file exists to pin.
+ */
+const tasksByProjectDb = new Map<string, Map<string, { id: string; display_id: number; title: string; session_id: string | null }>>();
+
+vi.mock('../../src/main/db/repositories/task-repository', () => ({
+  TaskRepository: class {
+    private readonly rows: Map<string, { id: string; display_id: number; title: string; session_id: string | null }>;
+    constructor(database: unknown) {
+      this.rows = tasksByProjectDb.get(String(database)) ?? new Map();
+    }
+    getById(taskId: string) {
+      return this.rows.get(taskId);
+    }
+    getByDisplayId(displayId: number) {
+      return [...this.rows.values()].find((row) => row.display_id === displayId);
+    }
+  },
+}));
+
+/** Rows the tool wrote, tagged with which project DB handle received them. */
+const insertedSentMessages: Array<{ db: string; row: Record<string, unknown> }> = [];
+
+/** Rows the mocked repository returns from its list methods. */
+let storedSentMessages: Array<Record<string, unknown>> = [];
+
+vi.mock('../../src/main/db/repositories/sent-session-message-repository', () => ({
+  SentSessionMessageRepository: class {
+    constructor(private readonly database: unknown) {}
+    insert(row: Record<string, unknown>) {
+      insertedSentMessages.push({ db: String(this.database), row });
+      return { id: 'sent-1', created_at: '2026-07-25T00:00:00.000Z', ...row };
+    }
+    listForSession(sessionId: string) {
+      return storedSentMessages.filter((row) => row.session_id === sessionId);
+    }
+    listForTask() {
+      return storedSentMessages;
+    }
+  },
+}));
+
+const { registerSteeringTools } = await import('../../src/main/agent/mcp-http/steering-tools');
+type ToolHandler = (args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+
+function makeProject(dbHandle: string, rows: Array<{ id: string; display_id: number; title: string; session_id?: string | null }>) {
+  tasksByProjectDb.set(
+    dbHandle,
+    new Map(rows.map((row) => [row.id, { session_id: null, ...row }])),
+  );
+  return { getProjectDb: () => dbHandle, getProjectPath: () => '/mock/project' };
+}
+
+/**
+ * Captures every handler `registerTool` is called with, keyed by tool name,
+ * plus each one's declared annotations. `handler` / `annotations` refer to the
+ * send tool so existing callers read unchanged.
+ */
+function captureTool(dependencies: Parameters<typeof registerSteeringTools>[2], resolver: Parameters<typeof registerSteeringTools>[1]) {
+  const handlers = new Map<string, ToolHandler>();
+  const annotationsByName = new Map<string, unknown>();
+  const server = {
+    registerTool: (name: string, config: { annotations?: unknown }, toolHandler: ToolHandler) => {
+      handlers.set(name, toolHandler);
+      annotationsByName.set(name, config.annotations);
+    },
+  };
+  registerSteeringTools(server as unknown as Parameters<typeof registerSteeringTools>[0], resolver, dependencies);
+  const sendHandler = handlers.get('kangentic_send_session_message');
+  if (!sendHandler) throw new Error('registerSteeringTools did not register the send tool');
+  return {
+    handler: sendHandler,
+    annotations: annotationsByName.get('kangentic_send_session_message'),
+    handlers,
+    annotationsByName,
+  };
+}
+
+beforeEach(() => {
+  tasksByProjectDb.clear();
+  insertedSentMessages.length = 0;
+  storedSentMessages = [];
+});
+
+describe('kangentic_send_session_message registration', () => {
+  const targetProject = () => makeProject('target-db', [{ id: 'task-uuid-target', display_id: 42, title: 'Fix the switch' }]);
+
+  function makeResolver(overrides: Record<string, ReturnType<typeof makeProject>> = {}) {
+    const resolveProject = vi.fn((selector: string | null | undefined) => {
+      if (selector && overrides[selector]) {
+        return { context: overrides[selector], projectId: selector, projectName: selector, isDefault: false };
+      }
+      if (selector) return { error: `No project "${selector}"` };
+      return { context: targetProject(), projectId: 'target-project', projectName: 'target', isDefault: true };
+    });
+    return { resolver: { resolveProject } as unknown as Parameters<typeof registerSteeringTools>[1], resolveProject };
+  }
+
+  /**
+   * Sessions the registry places in the resolved (target) project. Needed
+   * because the tool asks `getSessionProjectId` two different questions - which
+   * project the CALLER belongs to, for provenance, and which project the TARGET
+   * belongs to, for the cross-project guard. A single-constant stub answers the
+   * second one wrongly and would refuse every send in this file.
+   */
+  const TARGET_PROJECT_SESSIONS = new Set(['target-session', 'explicit']);
+
+  function makeSessions(overrides: Partial<{ live: string | undefined; taskId: string | undefined; projectId: string | undefined }> = {}) {
+    return {
+      findLiveSessionByTaskId: vi.fn(() => ('live' in overrides ? (overrides.live ? { id: overrides.live } : undefined) : { id: 'target-session' })),
+      getSessionTaskId: vi.fn(() => ('taskId' in overrides ? overrides.taskId : 'task-uuid-caller')),
+      getSessionProjectId: vi.fn((sessionId: string) => (
+        TARGET_PROJECT_SESSIONS.has(sessionId)
+          ? 'target-project'
+          : ('projectId' in overrides ? overrides.projectId : 'caller-project')
+      )),
+    };
+  }
+
+  it('declares mutating annotations so plan mode cannot auto-approve a live PTY write', () => {
+    const { resolver } = makeResolver();
+    const { annotations } = captureTool(
+      { coordinator: { send: vi.fn(), dispose: vi.fn(), _stateSizesForTesting: vi.fn() }, sessions: makeSessions() },
+      resolver,
+    );
+    expect(annotations).toMatchObject({ readOnlyHint: false, idempotentHint: false });
+  });
+
+  it('resolves a taskId to the registry live session, not the drift-prone task.session_id', async () => {
+    const { resolver } = makeResolver();
+    const send = vi.fn(() => Promise.resolve({ status: 'delivered', sessionId: 'target-session', targetActivity: 'idle', hopDepth: 1 }));
+    const { handler } = captureTool(
+      { coordinator: { send, dispose: vi.fn(), _stateSizesForTesting: vi.fn() }, sessions: makeSessions() },
+      resolver,
+    );
+
+    const result = await handler({ taskId: '42', message: 'rebase onto main' });
+
+    expect(result.isError).toBeUndefined();
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({ targetSessionId: 'target-session', message: 'rebase onto main', deliverWhen: 'now' }));
+  });
+
+  it('records provenance into the TARGET project database, resolving caller ids server-side', async () => {
+    const { resolver } = makeResolver();
+    const send = vi.fn(() => Promise.resolve({ status: 'delivered', sessionId: 'target-session', targetActivity: 'idle', hopDepth: 1 }));
+    const { handler } = captureTool(
+      { coordinator: { send, dispose: vi.fn(), _stateSizesForTesting: vi.fn() }, sessions: makeSessions(), callerSessionId: 'caller-session' },
+      resolver,
+    );
+
+    await handler({ taskId: '42', message: 'take this over' });
+
+    // The recorder is handed to the coordinator rather than invoked inline, so
+    // a deferred send writes its row when the text lands, not when it queued.
+    const request = send.mock.calls[0][0] as { recordSentMessage: (delivery: unknown) => void };
+    expect(typeof request.recordSentMessage).toBe('function');
+
+    request.recordSentMessage({
+      targetSessionId: 'target-session',
+      callerSessionId: 'caller-session',
+      message: 'take this over',
+      status: 'delivered',
+    });
+
+    expect(insertedSentMessages).toEqual([
+      {
+        db: 'target-db',
+        row: {
+          session_id: 'target-session',
+          caller_session_id: 'caller-session',
+          caller_task_id: 'task-uuid-caller',
+          caller_project_id: 'caller-project',
+          message: 'take this over',
+          status: 'delivered',
+          error: null,
+        },
+      },
+    ]);
+  });
+
+  it('records a caller-less human send with null caller ids rather than inventing them', async () => {
+    const { resolver } = makeResolver();
+    const send = vi.fn(() => Promise.resolve({ status: 'delivered', sessionId: 'target-session', targetActivity: 'idle', hopDepth: 1 }));
+    const { handler } = captureTool(
+      { coordinator: { send, dispose: vi.fn(), _stateSizesForTesting: vi.fn() }, sessions: makeSessions() },
+      resolver,
+    );
+
+    await handler({ taskId: '42', message: 'hello' });
+
+    const request = send.mock.calls[0][0] as { recordSentMessage: (delivery: unknown) => void };
+    request.recordSentMessage({ targetSessionId: 'target-session', message: 'hello', status: 'delivered' });
+
+    expect(insertedSentMessages[0].row).toMatchObject({
+      caller_session_id: null,
+      caller_task_id: null,
+      caller_project_id: null,
+    });
+  });
+
+  it('records a task-less transient caller without failing the send', async () => {
+    const { resolver } = makeResolver();
+    const send = vi.fn(() => Promise.resolve({ status: 'delivered', sessionId: 'target-session', targetActivity: 'idle', hopDepth: 1 }));
+    const { handler } = captureTool(
+      {
+        coordinator: { send, dispose: vi.fn(), _stateSizesForTesting: vi.fn() },
+        sessions: makeSessions({ taskId: undefined }),
+        callerSessionId: 'command-terminal-session',
+      },
+      resolver,
+    );
+
+    const result = await handler({ taskId: '42', message: 'hello' });
+    expect(result.isError).toBeUndefined();
+
+    const request = send.mock.calls[0][0] as { recordSentMessage: (delivery: unknown) => void };
+    request.recordSentMessage({
+      targetSessionId: 'target-session',
+      callerSessionId: 'command-terminal-session',
+      message: 'hello',
+      status: 'delivered',
+    });
+
+    expect(insertedSentMessages[0].row).toMatchObject({
+      caller_session_id: 'command-terminal-session',
+      caller_task_id: null,
+    });
+  });
+
+  it('reports a task with no session instead of sending nowhere', async () => {
+    const { resolver } = makeResolver();
+    const send = vi.fn();
+    const { handler } = captureTool(
+      { coordinator: { send, dispose: vi.fn(), _stateSizesForTesting: vi.fn() }, sessions: makeSessions({ live: undefined }) },
+      resolver,
+    );
+
+    const result = await handler({ taskId: '42', message: 'hello' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/has no session to send to/);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown task id', async () => {
+    const { resolver } = makeResolver();
+    const send = vi.fn();
+    const { handler } = captureTool(
+      { coordinator: { send, dispose: vi.fn(), _stateSizesForTesting: vi.fn() }, sessions: makeSessions() },
+      resolver,
+    );
+
+    const result = await handler({ taskId: '9999', message: 'hello' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/No task found/);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('requires exactly one of taskId or sessionId', async () => {
+    const { resolver } = makeResolver();
+    const send = vi.fn();
+    const { handler } = captureTool(
+      { coordinator: { send, dispose: vi.fn(), _stateSizesForTesting: vi.fn() }, sessions: makeSessions() },
+      resolver,
+    );
+
+    const neither = await handler({ message: 'hello' });
+    expect(neither.isError).toBe(true);
+    expect(neither.content[0].text).toMatch(/either taskId or sessionId/);
+
+    const both = await handler({ taskId: '42', sessionId: 'target-session', message: 'hello' });
+    expect(both.isError).toBe(true);
+    expect(both.content[0].text).toMatch(/not both/);
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('passes an explicit sessionId straight through without a task lookup', async () => {
+    const { resolver } = makeResolver();
+    const send = vi.fn(() => Promise.resolve({ status: 'queued', sessionId: 'explicit', targetActivity: 'thinking', hopDepth: 1 }));
+    const sessions = makeSessions();
+    const { handler } = captureTool(
+      { coordinator: { send, dispose: vi.fn(), _stateSizesForTesting: vi.fn() }, sessions },
+      resolver,
+    );
+
+    const result = await handler({ sessionId: 'explicit', message: 'hello', deliverWhen: 'idle' });
+
+    expect(sessions.findLiveSessionByTaskId).not.toHaveBeenCalled();
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({ targetSessionId: 'explicit', deliverWhen: 'idle' }));
+    expect(result.content[0].text).toContain('"status": "queued"');
+  });
+
+  it('refuses an explicit sessionId that lives in a different project', async () => {
+    // Liveness is checked against the GLOBAL PTY registry, so without this the
+    // send would land while its provenance row silently vanished: the recorder
+    // writes into the resolved project's database, where no matching sessions
+    // row exists, and the repository skips the insert. An unrecorded send is
+    // indistinguishable from a human-typed turn.
+    const { resolver } = makeResolver();
+    const send = vi.fn();
+    const { handler } = captureTool(
+      { coordinator: { send, dispose: vi.fn(), _stateSizesForTesting: vi.fn() }, sessions: makeSessions() },
+      resolver,
+    );
+
+    const result = await handler({ sessionId: 'session-in-another-project', message: 'hello' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/belongs to a different project/);
+    expect(send).not.toHaveBeenCalled();
+    expect(insertedSentMessages).toEqual([]);
+  });
+
+  it('refuses the drift-prone task.session_id fallback when it now belongs to another task', async () => {
+    // findLiveSessionByTaskId misses, so the stale column is the only candidate
+    // - and the registry says that session is another task's. Liveness is not
+    // ownership; delivering would steer a stranger's agent.
+    const { resolver } = makeResolver({
+      drift: makeProject('drift-db', [
+        { id: 'task-uuid-target', display_id: 42, title: 'Fix the switch', session_id: 'someone-elses-session' },
+      ]),
+    });
+    const send = vi.fn();
+    const { handler } = captureTool(
+      {
+        coordinator: { send, dispose: vi.fn(), _stateSizesForTesting: vi.fn() },
+        // No live session for the task; the stale id maps to a different task.
+        sessions: { ...makeSessions({ live: undefined }), getSessionTaskId: vi.fn(() => 'a-completely-different-task') },
+      },
+      resolver,
+    );
+
+    const result = await handler({ taskId: '42', message: 'hello', project: 'drift' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/has no session to send to/);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('accepts the task.session_id fallback when the registry cannot contradict it', async () => {
+    // The common case: the session is gone from the registry entirely, so
+    // getSessionTaskId returns undefined. Absence of proof is not proof of
+    // drift - fall back and let the coordinator's liveness guard decide.
+    const { resolver } = makeResolver({
+      stale: makeProject('stale-db', [
+        { id: 'task-uuid-target', display_id: 42, title: 'Fix the switch', session_id: 'previous-session' },
+      ]),
+    });
+    const send = vi.fn(() => Promise.resolve({ status: 'delivered', sessionId: 'previous-session', targetActivity: 'idle', hopDepth: 1 }));
+    const { handler } = captureTool(
+      {
+        coordinator: { send, dispose: vi.fn(), _stateSizesForTesting: vi.fn() },
+        sessions: {
+          ...makeSessions({ live: undefined }),
+          getSessionTaskId: vi.fn(() => undefined),
+          getSessionProjectId: vi.fn(() => undefined),
+        },
+      },
+      resolver,
+    );
+
+    const result = await handler({ taskId: '42', message: 'hello', project: 'stale' });
+
+    expect(result.isError).toBeUndefined();
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({ targetSessionId: 'previous-session' }));
+  });
+
+  describe('kangentic_get_session_messages_sent', () => {
+    function captureReadTool() {
+      const { handlers, annotationsByName } = captureTool(
+        {
+          coordinator: { send: vi.fn(), dispose: vi.fn(), _stateSizesForTesting: vi.fn() },
+          sessions: makeSessions(),
+        },
+        makeResolver().resolver,
+      );
+      const handler = handlers.get('kangentic_get_session_messages_sent');
+      if (!handler) throw new Error('the read tool was not registered');
+      return { handler, annotations: annotationsByName.get('kangentic_get_session_messages_sent') };
+    }
+
+    it('is annotated read-only so it stays usable in plan mode', () => {
+      expect(captureReadTool().annotations).toMatchObject({ readOnlyHint: true });
+    });
+
+    it('returns a session\'s messages with a total and a returned count', async () => {
+      storedSentMessages = [
+        { session_id: 'target-session', message: 'one', status: 'delivered', error: null },
+        { session_id: 'target-session', message: 'two', status: 'failed', error: 'no-submission-evidence' },
+      ];
+      const { handler } = captureReadTool();
+
+      const result = await handler({ sessionId: 'target-session' });
+      const payload = JSON.parse(result.content[0].text) as { total: number; returned: number; messages: unknown[] };
+
+      expect(payload).toMatchObject({ total: 2, returned: 2 });
+      expect(payload.messages).toHaveLength(2);
+    });
+
+    it('filters to a single status so failures can be isolated', async () => {
+      storedSentMessages = [
+        { session_id: 'target-session', message: 'ok', status: 'delivered', error: null },
+        { session_id: 'target-session', message: 'bad', status: 'failed', error: 'boom' },
+        { session_id: 'target-session', message: 'blocked', status: 'refused', error: 'rate limit' },
+      ];
+      const { handler } = captureReadTool();
+
+      const result = await handler({ sessionId: 'target-session', status: 'failed' });
+      const payload = JSON.parse(result.content[0].text) as { total: number; messages: Array<{ message: string }> };
+
+      expect(payload.total).toBe(1);
+      expect(payload.messages[0].message).toBe('bad');
+    });
+
+    it('keeps the MOST RECENT attempts when tail truncates', async () => {
+      storedSentMessages = ['a', 'b', 'c', 'd'].map((message) => ({
+        session_id: 'target-session', message, status: 'delivered', error: null,
+      }));
+      const { handler } = captureReadTool();
+
+      const result = await handler({ sessionId: 'target-session', tail: 2 });
+      const payload = JSON.parse(result.content[0].text) as { total: number; returned: number; messages: Array<{ message: string }> };
+
+      // Oldest-first storage, so a tail must slice from the END - returning the
+      // first N would report the least useful rows when debugging.
+      expect(payload).toMatchObject({ total: 4, returned: 2 });
+      expect(payload.messages.map((sent) => sent.message)).toEqual(['c', 'd']);
+    });
+
+    it('rejects an unknown task id rather than reporting an empty log', async () => {
+      const { handler } = captureReadTool();
+      const result = await handler({ taskId: '9999' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/No task found/);
+    });
+
+    it('requires exactly one of taskId or sessionId', async () => {
+      const { handler } = captureReadTool();
+
+      const neither = await handler({});
+      expect(neither.isError).toBe(true);
+      expect(neither.content[0].text).toMatch(/either taskId or sessionId/);
+
+      const both = await handler({ taskId: '42', sessionId: 'target-session' });
+      expect(both.isError).toBe(true);
+      expect(both.content[0].text).toMatch(/not both/);
+    });
+  });
+
+  it('surfaces a coordinator refusal as an isError result', async () => {
+    const { resolver } = makeResolver();
+    const send = vi.fn(() => Promise.resolve({ error: 'Rate limit: too many messages' }));
+    const { handler } = captureTool(
+      { coordinator: { send, dispose: vi.fn(), _stateSizesForTesting: vi.fn() }, sessions: makeSessions() },
+      resolver,
+    );
+
+    const result = await handler({ taskId: '42', message: 'hello' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/Rate limit/);
+  });
+});

--- a/tests/unit/mcp-steering-tools.test.ts
+++ b/tests/unit/mcp-steering-tools.test.ts
@@ -405,6 +405,25 @@ describe('kangentic_send_session_message registration', () => {
       expect(payload.messages).toHaveLength(2);
     });
 
+    it('resolves a taskId and reads via listForTask, not listForSession(taskId)', async () => {
+      // storedSentMessages carries session_id 'target-session', which is NOT
+      // task-uuid-target (the id 'task-uuid-target' resolves to for display_id
+      // 42). The mocked listForSession filters by session_id === the id it is
+      // given, so calling it with the task's id (a plausible copy-paste
+      // regression: `repository.listForSession(task.id)` instead of
+      // `repository.listForTask(task.id)`) would return 0 rows here, not 2.
+      storedSentMessages = [
+        { session_id: 'target-session', message: 'one', status: 'delivered', error: null },
+        { session_id: 'target-session', message: 'two', status: 'failed', error: 'no-submission-evidence' },
+      ];
+      const { handler } = captureReadTool();
+
+      const result = await handler({ taskId: '42' });
+      const payload = JSON.parse(result.content[0].text) as { total: number; returned: number; messages: unknown[] };
+
+      expect(payload).toMatchObject({ total: 2, returned: 2 });
+    });
+
     it('filters to a single status so failures can be isolated', async () => {
       storedSentMessages = [
         { session_id: 'target-session', message: 'ok', status: 'delivered', error: null },

--- a/tests/unit/mcp-tool-list-parity.test.ts
+++ b/tests/unit/mcp-tool-list-parity.test.ts
@@ -97,7 +97,16 @@ function collectToolRegistrations(): ToolRegistration[] {
   return registrations;
 }
 
-/** Tool-name prefixes that unambiguously denote a board/backlog mutation. */
+/**
+ * Tool-name prefixes that unambiguously denote a mutation - of the board, the
+ * backlog, or (for `send`) a live agent session.
+ *
+ * `kangentic_send_` is here because a send writes into a running PTY, which is
+ * at least as consequential as a board edit: annotated read-only it would be
+ * silently auto-approved in plan mode, letting a plan-mode agent launder a side
+ * effect through another agent that is not in plan mode. Keep this list ahead
+ * of new write verbs (an `interrupt` tool would need `kangentic_interrupt_`).
+ */
 const MUTATING_NAME_PREFIXES = [
   'kangentic_create_',
   'kangentic_update_',
@@ -106,6 +115,7 @@ const MUTATING_NAME_PREFIXES = [
   'kangentic_move_',
   'kangentic_promote_',
   'kangentic_link_',
+  'kangentic_send_',
 ];
 
 const toolRegistrations = collectToolRegistrations();

--- a/tests/unit/prepare-agent-spawn.test.ts
+++ b/tests/unit/prepare-agent-spawn.test.ts
@@ -19,6 +19,9 @@ import type { Task, Swimlane, AppConfig } from '../../src/shared/types';
 import { OpenCodeCommandBuilder, type OpenCodeCommandOptions } from '../../src/main/agent/adapters/opencode';
 import { CodexCommandBuilder, type CodexCommandOptions } from '../../src/main/agent/adapters/codex';
 import type { AgentLaunchOptionInfo } from '../../src/shared/types';
+// Type-only: erased at compile time, so importing it does not drag the heavy
+// mcp-http-server module graph (SDK, agent commands, ...) into this test.
+import type { McpHttpServerHandle } from '../../src/main/agent/mcp-http-server';
 
 // ---------------------------------------------------------------------------
 // Hoisted mock functions - all mocks that need to be referenced outside of
@@ -710,5 +713,58 @@ describe('prepareAgentSpawn - Codex launch-option wiring', () => {
     if (!result.ok) throw new Error('Expected ok:true');
     expect(capturedCommandOptions).toHaveLength(1);
     expect(capturedCommandOptions[0].launchOptions).toBeUndefined();
+  });
+});
+
+describe('prepareAgentSpawn - MCP caller-session URL stamping', () => {
+  // Coverage hole: prepareAgentSpawn wraps mcpServerUrl in
+  // `appendCallerSession(input.mcpServerHandle?.urlForProject(projectId), sessionRecordId)`
+  // so the MCP server can identify which session is calling (see
+  // caller-url.ts). Every existing test in this file passes
+  // mcpServerHandle: null (the makeSpawnInput default), so
+  // appendCallerSession(undefined, id) returns undefined either way and a
+  // regression to `input.mcpServerHandle?.urlForProject(projectId)` (dropping
+  // the appendCallerSession wrapper entirely) would fail nothing above.
+  function makeFakeMcpHandle(baseUrl: string): McpHttpServerHandle {
+    return {
+      baseUrl: `${baseUrl}/mcp`,
+      token: 'mcp-token',
+      urlForProject: (projectId: string) => `${baseUrl}/mcp/${projectId}`,
+      close: () => {},
+    };
+  }
+
+  it('stamps the spawned session record id as the third URL segment when an mcpServerHandle is supplied', async () => {
+    const { adapter, capturedCommandOptions } = makeCaptureAdapter();
+    agentRegistryGetMock.mockReturnValue(adapter);
+
+    const result = await prepareAgentSpawn(makeSpawnInput({
+      projectId: 'proj-caller-test',
+      mcpServerHandle: makeFakeMcpHandle('http://127.0.0.1:9999'),
+    }));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('Expected ok:true');
+    expect(capturedCommandOptions).toHaveLength(1);
+    // Red: reverting prepare-spawn.ts's
+    // `mcpServerUrl: appendCallerSession(input.mcpServerHandle?.urlForProject(projectId), sessionRecordId)`
+    // back to `input.mcpServerHandle?.urlForProject(projectId)` makes this
+    // 'http://127.0.0.1:9999/mcp/proj-caller-test' - no session segment.
+    expect(capturedCommandOptions[0].mcpServerUrl).toBe(
+      `http://127.0.0.1:9999/mcp/proj-caller-test/${FAKE_SESSION_RECORD_ID}`,
+    );
+    expect(result.data.sessionRecordId).toBe(FAKE_SESSION_RECORD_ID);
+  });
+
+  it('leaves mcpServerUrl undefined when no mcpServerHandle is supplied', async () => {
+    const { adapter, capturedCommandOptions } = makeCaptureAdapter();
+    agentRegistryGetMock.mockReturnValue(adapter);
+
+    const result = await prepareAgentSpawn(makeSpawnInput({ mcpServerHandle: null }));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('Expected ok:true');
+    expect(capturedCommandOptions).toHaveLength(1);
+    expect(capturedCommandOptions[0].mcpServerUrl).toBeUndefined();
   });
 });

--- a/tests/unit/sent-session-message-migration.test.ts
+++ b/tests/unit/sent-session-message-migration.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Migration + real-SQL round-trip tests for the `session_messages_sent` table
+ * (src/main/db/migrations/project-schema.ts) and the SentSessionMessageRepository
+ * that reads/writes it (src/main/db/repositories/sent-session-message-repository.ts).
+ *
+ * tests/unit/mcp-steering-tools.test.ts drives the repository through a MOCKED
+ * module, so it never executes the real CREATE TABLE or the real INSERT. A
+ * column-name typo in the migration, a mismatch between the migration's columns
+ * and the repository's column list, or deleting the CREATE TABLE block outright
+ * would leave that suite green.
+ *
+ * This file closes that gap by running the REAL migration against a REAL
+ * in-memory better-sqlite3 database and round-tripping through the REAL
+ * repository. It matters more than usual here: since
+ * kangentic_send_session_message delivers its message verbatim with no in-band
+ * marker, a row in this table is the ONLY record that a transcript turn was
+ * sent through the tool rather than typed by the human.
+ *
+ * Skips cleanly when better-sqlite3 cannot load under the test runner's Node
+ * ABI (NODE_MODULE_VERSION mismatch under plain system Node); mirrors the probe
+ * pattern in activity-interval-migration.test.ts. Expected to skip on a
+ * developer's local Windows machine (built for Electron's ABI) and RUN on CI
+ * (built for plain Node).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type DatabaseType from 'better-sqlite3';
+
+// ---------------------------------------------------------------------------
+// ABI probe - mirrors activity-interval-migration.test.ts.
+// ---------------------------------------------------------------------------
+
+function probeBetterSqlite3(): typeof DatabaseType | null {
+  try {
+    // Variable module name avoids the static-require lint rule, which targets
+    // string-literal bare requires in bundled main/preload code; this is a test
+    // helper for a native probe, not a bundled require.
+    const moduleName = 'better-sqlite3';
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const nativeModule = require(moduleName) as unknown;
+    const databaseConstructor = (
+      (nativeModule as { default?: typeof DatabaseType }).default ?? nativeModule
+    ) as typeof DatabaseType;
+    // Force the native binding to load now - the NODE_MODULE_VERSION mismatch
+    // only surfaces on instantiation, not on require.
+    const probeHandle = new databaseConstructor(':memory:');
+    probeHandle.close();
+    return databaseConstructor;
+  } catch {
+    return null;
+  }
+}
+
+const Database = probeBetterSqlite3();
+const CAN_RUN = Database !== null;
+
+import { runProjectMigrations } from '../../src/main/db/migrations/project-schema';
+import { SentSessionMessageRepository } from '../../src/main/db/repositories/sent-session-message-repository';
+
+interface TableColumnInfo {
+  name: string;
+  notnull: number;
+}
+
+const EXPECTED_COLUMNS: Array<{ name: string; notnull: number }> = [
+  { name: 'id', notnull: 0 },
+  { name: 'session_id', notnull: 1 },
+  { name: 'caller_session_id', notnull: 0 },
+  { name: 'caller_task_id', notnull: 0 },
+  { name: 'caller_project_id', notnull: 0 },
+  { name: 'message', notnull: 1 },
+  { name: 'status', notnull: 1 },
+  { name: 'error', notnull: 0 },
+  { name: 'created_at', notnull: 1 },
+];
+
+describe.skipIf(!CAN_RUN)('session_messages_sent migration + repository round-trip', () => {
+  let database: DatabaseType.Database;
+
+  beforeEach(() => {
+    database = new Database!(':memory:');
+    // Matches production ordering exactly (src/main/db/database.ts sets this
+    // pragma immediately before calling runProjectMigrations). Without it,
+    // `session_id ... REFERENCES sessions(id) ON DELETE CASCADE` is parsed but
+    // never enforced - SQLite silently accepts and ignores FK clauses while
+    // this pragma is off, which is exactly how a schema can drift from its own
+    // migration comment ("rows are cleaned up with their session") with
+    // nothing catching it.
+    database.pragma('foreign_keys = ON');
+    runProjectMigrations(database);
+  });
+
+  afterEach(() => {
+    database.close();
+  });
+
+  it('creates the table with the columns the repository writes', () => {
+    const columns = database.pragma('table_info(session_messages_sent)') as TableColumnInfo[];
+    const actual = columns.map((column) => ({ name: column.name, notnull: column.notnull }));
+    expect(actual).toEqual(EXPECTED_COLUMNS);
+  });
+
+  it('is idempotent across repeated migration runs', () => {
+    expect(() => runProjectMigrations(database)).not.toThrow();
+    const columns = database.pragma('table_info(session_messages_sent)') as TableColumnInfo[];
+    expect(columns).toHaveLength(EXPECTED_COLUMNS.length);
+  });
+
+  it('indexes session_id, the column every read filters on', () => {
+    const indexes = database.pragma('index_list(session_messages_sent)') as Array<{ name: string }>;
+    expect(indexes.some((index) => index.name === 'idx_session_messages_sent_session_id')).toBe(true);
+  });
+
+  /**
+   * Seed a task in a lane `runProjectMigrations` already created. `tasks`
+   * declares `swimlane_id TEXT NOT NULL REFERENCES swimlanes(id)`, so a task
+   * cannot be inserted with a null lane.
+   */
+  function seedTask(taskId: string): void {
+    const seededSwimlane = database.prepare('SELECT id FROM swimlanes LIMIT 1').get() as { id: string };
+    const now = new Date().toISOString();
+    // updated_at is NOT NULL with no DEFAULT on the tasks table - omitting it
+    // fails the insert outright. This is independent of the foreign_keys
+    // pragma above (a plain NOT NULL violation, confirmed via a node:sqlite
+    // replay of this exact statement against the real migration).
+    database
+      .prepare('INSERT INTO tasks (id, title, swimlane_id, position, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)')
+      .run(taskId, `Task ${taskId}`, seededSwimlane.id, 0, now, now);
+  }
+
+  /**
+   * `session_id` carries a foreign key, so a row cannot exist without its
+   * session. Every test that inserts must seed one first.
+   *
+   * The full NOT NULL column set is spelled out because `sessions` declares
+   * `task_id`, `session_type`, `command`, and `cwd` NOT NULL with no defaults -
+   * omitting any of them (or passing a null task_id) fails the insert outright.
+   * Matches the shape usage-history-migration.test.ts seeds with.
+   */
+  function seedSession(sessionId: string, taskId?: string): void {
+    const owningTaskId = taskId ?? `task-for-${sessionId}`;
+    if (!taskId) seedTask(owningTaskId);
+    database
+      .prepare(`
+        INSERT INTO sessions (id, task_id, session_type, command, cwd, status, started_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `)
+      .run(sessionId, owningTaskId, 'agent', 'claude', '/mock/project', 'running', new Date().toISOString());
+  }
+
+  it('skips the write for a session that does not exist rather than raising an FK violation', () => {
+    // Live testing (2026-07-25) hit this: a fabricated session id made insert
+    // throw, and the caller swallowed it into a console line. A bad argument
+    // must not be an exception path.
+    const repository = new SentSessionMessageRepository(database);
+    let result: unknown;
+    expect(() => {
+      result = repository.insert({
+        session_id: 'never-existed',
+        caller_session_id: null,
+        caller_task_id: null,
+        caller_project_id: null,
+        message: 'x',
+        status: 'refused',
+        error: 'no such session',
+      });
+    }).not.toThrow();
+    expect(result).toBeNull();
+    expect(repository.listForSession('never-existed')).toEqual([]);
+  });
+
+  it('still records a refusal for a session that exists but is no longer writable', () => {
+    // The realistic dead-session case: exited or suspended, row still present.
+    // This is the one that matters for "did my message go through?".
+    seedSession('exited-session');
+    const repository = new SentSessionMessageRepository(database);
+    repository.insert({
+      session_id: 'exited-session',
+      caller_session_id: null,
+      caller_task_id: null,
+      caller_project_id: null,
+      message: 'x',
+      status: 'refused',
+      error: 'not accepting input',
+    });
+
+    expect(repository.listForSession('exited-session')).toHaveLength(1);
+  });
+
+  it('round-trips a sent message through the real repository', () => {
+    seedSession('target-session');
+    const repository = new SentSessionMessageRepository(database);
+    const inserted = repository.insert({
+      session_id: 'target-session',
+      caller_session_id: 'caller-session',
+      caller_task_id: 'caller-task',
+      caller_project_id: 'caller-project',
+      message: 'rebase onto main',
+      status: 'delivered',
+      error: null,
+    });
+
+    // insert() returns null when the target session row is missing; a seeded
+    // session must never take that path, so assert it before reading fields.
+    expect(inserted).not.toBeNull();
+    expect(inserted?.id).toBeTruthy();
+    // UTC ISO 8601, never SQLite's naive CURRENT_TIMESTAMP.
+    expect(inserted?.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
+
+    const rows = repository.listForSession('target-session');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      session_id: 'target-session',
+      caller_session_id: 'caller-session',
+      caller_task_id: 'caller-task',
+      caller_project_id: 'caller-project',
+      message: 'rebase onto main',
+      status: 'delivered',
+    });
+  });
+
+  it('stores the message byte-exact so it can be matched against a transcript turn', () => {
+    seedSession('target-session');
+    const repository = new SentSessionMessageRepository(database);
+    // Multi-line with characters a naive escaping layer would mangle. Nothing
+    // is prepended to the delivered text, so this must survive verbatim or the
+    // turn can no longer be correlated back to the row that sent it.
+    const message = 'line one\nline two with "quotes" and \'apostrophes\'\n  indented';
+    repository.insert({
+      session_id: 'target-session',
+      caller_session_id: null,
+      caller_task_id: null,
+      caller_project_id: null,
+      message,
+      status: 'delivered',
+      error: null,
+    });
+
+    expect(repository.listForSession('target-session')[0].message).toBe(message);
+  });
+
+  it('accepts a caller-less human send with null caller ids', () => {
+    seedSession('target-session');
+    const repository = new SentSessionMessageRepository(database);
+    expect(() => repository.insert({
+      session_id: 'target-session',
+      caller_session_id: null,
+      caller_task_id: null,
+      caller_project_id: null,
+      message: 'from a human',
+      status: 'delivered',
+      error: null,
+    })).not.toThrow();
+
+    expect(repository.listForSession('target-session')[0].caller_session_id).toBeNull();
+  });
+
+  it('accepts a cross-project caller id that does not exist locally', () => {
+    // caller_session_id / caller_task_id are deliberately NOT foreign keys: a
+    // cross-project steer originates in another project's database, so the ids
+    // are unresolvable here. A FK would reject the row outright.
+    seedSession('target-session');
+    const repository = new SentSessionMessageRepository(database);
+    expect(() => repository.insert({
+      session_id: 'target-session',
+      caller_session_id: 'session-in-another-project',
+      caller_task_id: 'task-in-another-project',
+      caller_project_id: 'another-project',
+      message: 'cross-project steer',
+      status: 'delivered',
+      error: null,
+    })).not.toThrow();
+  });
+
+  it('spans every session a task has had, so a resumed task reports its full history', () => {
+    // The debugging question is "did my message reach task #13?", and a task
+    // accumulates sessions across resumes and agent handoffs. Scoping to one
+    // session would silently hide messages sent to an earlier one.
+    seedTask('task-1');
+    seedSession('session-old', 'task-1');
+    seedSession('session-new', 'task-1');
+
+    const repository = new SentSessionMessageRepository(database);
+    const base = { caller_session_id: null, caller_task_id: null, caller_project_id: null, error: null };
+    repository.insert({ ...base, session_id: 'session-old', message: 'to the old session', status: 'delivered' });
+    repository.insert({ ...base, session_id: 'session-new', message: 'to the new session', status: 'delivered' });
+    // A send against an unrelated task must not leak in.
+    seedSession('unrelated');
+    repository.insert({ ...base, session_id: 'unrelated', message: 'other task', status: 'delivered' });
+
+    expect(repository.listForTask('task-1').map((row) => row.message))
+      .toEqual(['to the old session', 'to the new session']);
+    expect(repository.listForTask('no-such-task')).toEqual([]);
+  });
+
+  it('returns messages oldest-first and scoped to the requested session', () => {
+    seedSession('session-a');
+    seedSession('session-b');
+    const repository = new SentSessionMessageRepository(database);
+    const base = {
+      caller_session_id: null,
+      caller_task_id: null,
+      caller_project_id: null,
+      status: 'delivered' as const,
+      error: null,
+    };
+    repository.insert({ ...base, session_id: 'session-a', message: 'first' });
+    repository.insert({ ...base, session_id: 'session-b', message: 'other session' });
+    repository.insert({ ...base, session_id: 'session-a', message: 'second' });
+
+    expect(repository.listForSession('session-a').map((row) => row.message)).toEqual(['first', 'second']);
+    expect(repository.listForSession('session-b').map((row) => row.message)).toEqual(['other session']);
+    expect(repository.listForSession('session-none')).toEqual([]);
+  });
+
+  it('cascades: deleting the parent session deletes its session_messages_sent rows', () => {
+    // docs/database.md and the migration comment above `session_messages_sent`
+    // both claim `ON DELETE CASCADE` cleans these rows up with their session.
+    // That claim is only true when `PRAGMA foreign_keys = ON` is actually set
+    // (see beforeEach above): SQLite parses and stores an FK clause even when
+    // the pragma is off, but never enforces or acts on it, so without the
+    // pragma this assertion would pass FOR THE WRONG REASON (a delete that
+    // simply leaves the row behind untouched, not one that cascades).
+    seedSession('cascade-target');
+    const repository = new SentSessionMessageRepository(database);
+    repository.insert({
+      session_id: 'cascade-target',
+      caller_session_id: null,
+      caller_task_id: null,
+      caller_project_id: null,
+      message: 'will be cascaded',
+      status: 'delivered',
+      error: null,
+    });
+    expect(repository.listForSession('cascade-target')).toHaveLength(1);
+
+    database.prepare('DELETE FROM sessions WHERE id = ?').run('cascade-target');
+
+    // Red: removing `database.pragma('foreign_keys = ON')` from beforeEach (or
+    // the `ON DELETE CASCADE` clause from the session_messages_sent migration)
+    // leaves this row behind after its parent session is deleted.
+    expect(repository.listForSession('cascade-target')).toEqual([]);
+  });
+
+  it('backfills the error column via ALTER TABLE for a database created before it existed', () => {
+    // Simulate a database created by an install that predates the `error`
+    // column: drop the table beforeEach's migration run already created (which
+    // already has `error`, since CREATE TABLE IF NOT EXISTS always includes it
+    // for a fresh DB) and recreate it in the pre-error shape, then re-run
+    // migrations to exercise the guarded ALTER TABLE block.
+    database.exec('DROP TABLE session_messages_sent');
+    database.exec(`
+      CREATE TABLE session_messages_sent (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+        caller_session_id TEXT,
+        caller_task_id TEXT,
+        caller_project_id TEXT,
+        message TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      )
+    `);
+    const columnsBefore = (database.pragma('table_info(session_messages_sent)') as TableColumnInfo[])
+      .map((column) => column.name);
+    expect(columnsBefore).not.toContain('error');
+
+    // Red: deleting the guarded `ALTER TABLE session_messages_sent ADD COLUMN
+    // error TEXT` block in project-schema.ts leaves `error` permanently
+    // missing from a database created in this intermediate shape, and the
+    // insert below would throw ("table session_messages_sent has no column
+    // named error") instead of succeeding.
+    expect(() => runProjectMigrations(database)).not.toThrow();
+
+    const columnsAfter = (database.pragma('table_info(session_messages_sent)') as TableColumnInfo[])
+      .map((column) => column.name);
+    expect(columnsAfter).toContain('error');
+
+    seedSession('post-backfill-session');
+    const repository = new SentSessionMessageRepository(database);
+    expect(() => repository.insert({
+      session_id: 'post-backfill-session',
+      caller_session_id: null,
+      caller_task_id: null,
+      caller_project_id: null,
+      message: 'x',
+      status: 'delivered',
+      error: null,
+    })).not.toThrow();
+  });
+});

--- a/tests/unit/transition-engine.test.ts
+++ b/tests/unit/transition-engine.test.ts
@@ -217,6 +217,9 @@ function makeEngine(options: {
    * need submitKeystrokes to return a real Promise so its internal `.catch`
    * doesn't throw). */
   terminalSubmit?: ReturnType<typeof makeTerminalSubmit>;
+  /** Project-scoped MCP server URL (mirrors TransitionEngineConfig.mcpServerUrl).
+   * Defaults to undefined, matching every existing caller of makeEngine. */
+  mcpServerUrl?: string;
 }) {
   const sessionManager = options.sessionManager ?? makeSessionManager();
   const sessionRepo = options.sessionRepo ?? makeSessionRepo();
@@ -236,7 +239,7 @@ function makeEngine(options: {
       copyFiles: [],
     },
     mcpServerEnabled: false,
-    mcpServerUrl: undefined,
+    mcpServerUrl: options.mcpServerUrl,
     mcpServerToken: undefined,
     defaultAgent: 'claude',
     cliPathOverrides: {},
@@ -866,5 +869,62 @@ describe('TransitionEngine - executeAction builds ONE shared templateVars for ev
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe('https://example.test/notify?branch=main');
     expect(init.body).toBe(JSON.stringify({ branch: 'main' }));
+  });
+});
+
+describe('TransitionEngine - MCP caller-session URL stamping (executeSpawnAgent chokepoint)', () => {
+  // Coverage hole: executeSpawnAgent wraps mcpServerUrl in
+  // `appendCallerSession(appConfig.mcpServerUrl, ptySessionId)` so the MCP
+  // server can identify which session is calling (see caller-url.ts). Every
+  // existing test in this file leaves mcpServerUrl undefined (the makeEngine
+  // default), so appendCallerSession(undefined, id) returns undefined either
+  // way and a regression to `appConfig.mcpServerUrl` (dropping the
+  // appendCallerSession wrapper) would fail nothing above. ptySessionId is a
+  // real crypto.randomUUID() generated inside executeSpawnAgent (this file
+  // does not mock node:crypto), so it is read back from the inserted session
+  // record rather than predicted.
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAdapter.buildCommand.mockImplementation((options: { prompt?: string }) => {
+      return `claude ${options.prompt ?? ''}`;
+    });
+  });
+
+  it('stamps the spawned ptySessionId as the third URL segment when mcpServerUrl is configured', async () => {
+    let capturedOptions: { mcpServerUrl?: string } | undefined;
+    mockAdapter.buildCommand.mockImplementation((options: { mcpServerUrl?: string; prompt?: string }) => {
+      capturedOptions = options;
+      return `claude ${options.prompt ?? ''}`;
+    });
+
+    const task = makeTask();
+    const sessionRepo = makeSessionRepo();
+    const { engine } = makeEngine({ sessionRepo, mcpServerUrl: 'http://127.0.0.1:1234/mcp/proj-1' });
+
+    await engine.executeTransition(task as Parameters<typeof engine.executeTransition>[0], 'todo', 'doing');
+
+    expect(sessionRepo.insert).toHaveBeenCalledTimes(1);
+    const insertedId = (sessionRepo.insert.mock.calls[0][0] as { id: string }).id;
+    expect(insertedId).toBeTruthy();
+    // Red: reverting executeSpawnAgent's
+    // `mcpServerUrl: appendCallerSession(appConfig.mcpServerUrl, ptySessionId)`
+    // back to `appConfig.mcpServerUrl` makes this
+    // 'http://127.0.0.1:1234/mcp/proj-1' - no session segment.
+    expect(capturedOptions?.mcpServerUrl).toBe(`http://127.0.0.1:1234/mcp/proj-1/${insertedId}`);
+  });
+
+  it('leaves mcpServerUrl undefined when the project has no configured MCP server URL', async () => {
+    let capturedOptions: { mcpServerUrl?: string } | undefined;
+    mockAdapter.buildCommand.mockImplementation((options: { mcpServerUrl?: string; prompt?: string }) => {
+      capturedOptions = options;
+      return `claude ${options.prompt ?? ''}`;
+    });
+
+    const task = makeTask();
+    const { engine } = makeEngine({});
+
+    await engine.executeTransition(task as Parameters<typeof engine.executeTransition>[0], 'todo', 'doing');
+
+    expect(capturedOptions?.mcpServerUrl).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What

Adds agent-to-agent (and human-to-agent) steering to the Kangentic MCP server:

- **`kangentic_send_session_message`** - send a message into another task's running agent session, delivered exactly as if typed into its input box.
- **`kangentic_get_session_messages_sent`** - read the log back, so "did my message go through?" always has an answer.
- **`session_messages_sent`** - a new per-project table recording every send attempt.

Touches `src/main/agent/mcp-http/` (new `steering-tools.ts`, `session-send.ts`, `caller-url.ts`), the MCP HTTP server, both agent-spawn chokepoints, the project schema, and the shared types + tool manifest.

## Why

The MCP server could read everything about a running session (`kangentic_get_session_events`, `kangentic_get_transcript`, `kangentic_list_sessions`) and write everything about a task, but it could not hand a running agent a prompt. The only transport was a human copy-pasting into that session's input box.

The asymmetry that made it plain: the mobile companion protocol already has a `send-user-message` capability verb, so a **phone** could steer a running session that the local MCP server could not. The desktop was more restricted than its own remote control.

Cross-task steering, unblocking a stalled agent, answering a question a session is waiting on, and cancelling superseded work are all routine, and all previously required a human as the transport.

## How

**Delivery** reuses `TerminalSubmit.submitContent` (bracketed paste, drain, chunked write, settle, `\r`, submission evidence) - the same path the mobile bridge and the Browser pane's Send use. Gated on `sessionManager.isWritable` rather than registry presence, so a suspended target fails fast instead of burning the full paste timeout.

**Caller identity** is stamped into each session's own `mcp.json` as a third URL segment (`/mcp/<projectId>/<sessionId>`) at the two spawn chokepoints. It is resolved server-side from the URL rather than from a tool parameter, so an agent cannot set it through the tool's own arguments. The segment is optional and its absence is never an error: human-driven clients and Command Terminal sessions dial the two-segment URL and are treated as unattributed callers.

This is honesty-by-default, **not** cryptographic attribution, and the docs say so: the bearer token is one shared per-launch secret, so a process holding it can dial any caller id over raw HTTP. The guards it feeds bound a looping or careless agent, not a deliberately lying one.

**No in-band attribution prefix.** An earlier revision prefixed each message with a `[Kangentic relay]` line. Live testing killed it: the receiving agent read the prefix as injected content asserting its own authority - structurally the shape of a prompt injection - and refused to act on messages sent that way, reasoning that "legitimate authority doesn't need to announce itself through injected content." It also cost tokens on every send. Provenance moved out-of-band to `session_messages_sent`, which costs nothing in the agent's context and cannot be forged by anything the agent writes. With the prefix gone the same fixture complied immediately.

Because nothing is prepended, the stored `message` is byte-identical to the transcript turn it produced, which is how a consumer correlates the two.

**Every attempt is recorded**, not just successes: `delivered` / `queued` (produced a turn), `refused` (a guard rejected it), `failed` (delivery threw, so whether a turn landed is genuinely unknown). That last one matters most for debugging.

**Guards are circuit breakers against unattended token spend, not a permission policy** - deliberate multi-agent orchestration is meant to pass through unobstructed:

- self-send refusal
- a per-target sliding window
- an absurd-depth steer-chain backstop (deliberately not a low cap: an A -> B -> C -> D -> E chain must work)
- refusal rows deduped per reason per window, so the audit trail cannot itself become the amplification vector a runaway fills the database with

## Breaking changes

None. New tools and a new table; no existing behavior changes. The MCP URL gains an optional third path segment, and the two-segment form keeps working unchanged.

## Tests

- **Unit:** `mcp-session-send.test.ts` (coordinator: verbatim delivery, provenance for all four statuses, refusal dedupe, self-send, `isWritable` gate, deferred idle flush including the already-idle case and the permission-state exclusion, per-target serialization, map drain), `mcp-steering-tools.test.ts` (registration, annotations, task -> live-session resolution, cross-project provenance, the read tool's filters), `sent-session-message-migration.test.ts` (REAL migration + REAL repository against in-memory better-sqlite3), plus `mcp-caller-url.test.ts`, `mcp-request-path-parsing.test.ts`, `mcp-http-server-steering-lifecycle.test.ts`.
- **Parity:** `kangentic_send_` added to `MUTATING_NAME_PREFIXES` in `mcp-tool-list-parity.test.ts`. Without it a `send_*` tool would pass every assertion even if annotated read-only, silently auto-approving a live PTY write in plan mode - the exact hole `annotations.ts` exists to close. Red-green verified.
- **Verified live** against a real preview instance with real `claude-sonnet-5` sessions: caller-identity URL stamping, delivery, self-send refusal, deferred `deliverWhen: "idle"` queue-then-flush, the unattributed human path, and reading the log back with both statuses.
- CI runs the full unit, UI, and Linux Electron E2E tiers.

Generated with [Claude Code](https://claude.com/claude-code)
