### PR TITLE
feat(mobile-bridge): send project groups to the phone

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kangentic/protocol",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Kangentic mobile bridge wire protocol: framing, Noise-based pairing and session handshakes, signed device roster, and capability verbs shared between desktop and mobile.",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -55,6 +55,7 @@ export {
   type ReadBoardRequestPayload,
   type ReadBoardView,
   type ReadBoardProjectSummary,
+  type ReadBoardProjectGroup,
   type ReadBoardProjectListResponsePayload,
   type ReadBoardSnapshotResponsePayload,
   type ReadBoardArchivedResponsePayload,

--- a/packages/protocol/src/wire/payloads.ts
+++ b/packages/protocol/src/wire/payloads.ts
@@ -268,9 +268,29 @@ export interface ReadBoardRequestPayload {
   view?: ReadBoardView;
 }
 
+/**
+ * A desktop project group ("KANGENTIC", "TROY WEB"), for a phone rendering
+ * its project list with the same structure the desktop sidebar shows
+ * (protocol 0.11.0).
+ */
+export interface ReadBoardProjectGroup {
+  id: string;
+  name: string;
+  /** Display order among groups. */
+  position: number;
+}
+
 export interface ReadBoardProjectSummary {
   id: string;
   name: string;
+  /**
+   * The group this project belongs to, or null/absent for an ungrouped one
+   * (protocol 0.11.0). Absent from an older desktop, which is indistinguishable
+   * from ungrouped and renders the same flat list as before.
+   */
+  groupId?: string | null;
+  /** Display order within the group, mirroring the desktop's own ordering (protocol 0.11.0). */
+  position?: number;
   /**
    * Accent color for this project ("#rrggbb"). Today the desktop derives
    * it deterministically from the project id; a user-set project color
@@ -283,6 +303,12 @@ export interface ReadBoardProjectSummary {
 /** Returned when the request omits projectId - the phone's project-bootstrap listing. */
 export interface ReadBoardProjectListResponsePayload {
   projects: ReadBoardProjectSummary[];
+  /**
+   * The desktop's project groups, in display order (protocol 0.11.0). Absent
+   * from an older desktop; a phone that gets none renders one flat list, which
+   * is exactly the pre-0.11.0 behaviour.
+   */
+  groups?: ReadBoardProjectGroup[];
 }
 
 /** Returned when the request carries a projectId - a snapshot of that project's board. */
@@ -384,9 +410,21 @@ export function parseReadBoardResponsePayload(payload: JsonValue): ReadBoardResp
         id: project.id,
         name: project.name,
         ...(project.color !== undefined ? { color: parseAccentColor(project.color, `read-board project ${index}`) } : {}),
+        ...(typeof project.groupId === 'string' ? { groupId: project.groupId } : {}),
+        ...(typeof project.position === 'number' ? { position: project.position } : {}),
       };
     });
-    return { projects };
+    // A malformed group is dropped rather than failing the whole listing: the
+    // projects are what the phone cannot work without, and grouping degrades
+    // to the flat list it rendered before 0.11.0.
+    const groups = Array.isArray(payload.groups)
+      ? payload.groups.flatMap((group): ReadBoardProjectGroup[] =>
+          isRecord(group) && typeof group.id === 'string' && typeof group.name === 'string' && typeof group.position === 'number'
+            ? [{ id: group.id, name: group.name, position: group.position }]
+            : [],
+        )
+      : undefined;
+    return { projects, ...(groups !== undefined ? { groups } : {}) };
   }
 
   if (typeof payload.projectId !== 'string') throw new Error('read-board response is missing "projectId"');

--- a/src/main/mobile-bridge/handlers/read-board.ts
+++ b/src/main/mobile-bridge/handlers/read-board.ts
@@ -42,10 +42,19 @@ export async function handleReadBoard(
   const payload = parseCapabilityRequestPayload('read-board', request.payload);
 
   if (!payload.projectId) {
-    const projects = context.projectRepo
+    const projects = context.projectRepo.list().map((project) => ({
+      id: project.id,
+      name: project.name,
+      color: deriveProjectAccentColor(project.id),
+      // Structure the desktop sidebar already shows, so the phone's picker can
+      // render the same grouping instead of one flat list (protocol 0.11.0).
+      groupId: project.group_id,
+      position: project.position,
+    }));
+    const groups = context.projectGroupRepo
       .list()
-      .map((project) => ({ id: project.id, name: project.name, color: deriveProjectAccentColor(project.id) }));
-    const responsePayload: ReadBoardResponsePayload = { projects };
+      .map((group) => ({ id: group.id, name: group.name, position: group.position }));
+    const responsePayload: ReadBoardResponsePayload = { projects, groups };
     return { type: 'capability-response', requestId: request.requestId, ok: true, payload: toWireJson(responsePayload) };
   }
 

--- a/tests/unit/mobile-bridge/read-board.test.ts
+++ b/tests/unit/mobile-bridge/read-board.test.ts
@@ -42,15 +42,26 @@ describe('handleReadBoard', () => {
     backlogList.mockReset().mockReturnValue([{ id: 'b-1', external_metadata: { secret: true } }]);
   });
 
-  it('with no projectId, returns the project bootstrap list (with derived accent colors) and never touches repos', async () => {
-    const projectRepoList = vi.fn(() => [{ id: 'proj-1', name: 'Alpha' }]);
-    const context = { projectRepo: { list: projectRepoList, getById: vi.fn() } } as unknown as IpcContext;
+  it('with no projectId, returns the project bootstrap list (with derived accent colors, group and position) and never touches task repos', async () => {
+    const projectRepoList = vi.fn(() => [{ id: 'proj-1', name: 'Alpha', group_id: 'grp-1', position: 0 }]);
+    const projectGroupList = vi.fn(() => [{ id: 'grp-1', name: 'Kangentic', position: 0, is_collapsed: false }]);
+    const context = {
+      projectRepo: { list: projectRepoList, getById: vi.fn() },
+      projectGroupRepo: { list: projectGroupList },
+    } as unknown as IpcContext;
     const subscriptions = new SubscriptionRegistry();
 
     const response = await handleReadBoard(fakeRequest({}), fakeSession(), context, subscriptions);
 
     expect(response.ok).toBe(true);
-    expect(response.payload).toEqual({ projects: [{ id: 'proj-1', name: 'Alpha', color: deriveProjectAccentColor('proj-1') }] });
+    expect(response.payload).toEqual({
+      projects: [
+        { id: 'proj-1', name: 'Alpha', color: deriveProjectAccentColor('proj-1'), groupId: 'grp-1', position: 0 },
+      ],
+      // is_collapsed stays desktop-internal: the phone's sheet is scrolled,
+      // not collapsed, so a collapse flag would describe nothing it renders.
+      groups: [{ id: 'grp-1', name: 'Kangentic', position: 0 }],
+    });
     const listed = (response.payload as { projects: Array<{ color: string }> }).projects[0];
     expect(PROJECT_ACCENT_PALETTE).toContain(listed.color);
     expect(tasksList).not.toHaveBeenCalled();
@@ -59,7 +70,10 @@ describe('handleReadBoard', () => {
   it('rejects an unsubscribe with no projectId as a no-op success (nothing to tear down)', async () => {
     // action alone with no projectId falls through to the project-list branch
     // since there is no per-project subscription to identify.
-    const context = { projectRepo: { list: vi.fn(() => []), getById: vi.fn() } } as unknown as IpcContext;
+    const context = {
+      projectRepo: { list: vi.fn(() => []), getById: vi.fn() },
+      projectGroupRepo: { list: vi.fn(() => []) },
+    } as unknown as IpcContext;
     const response = await handleReadBoard(fakeRequest({ action: 'unsubscribe' }), fakeSession(), context, new SubscriptionRegistry());
     expect(response.ok).toBe(true);
   });


### PR DESCRIPTION
feat(mobile-bridge): send project groups to the phone

The phone's project listing carried only id, name and colour, so its
switcher was a flat list of every project on the machine - 15 of them here,
in no order the user recognises. The desktop sidebar has grouped them for
some time, and that structure is exactly what a small screen needs most.

read-board's project-list branch now includes each project's group_id and
position, plus the group list itself. The data needs no new plumbing:
ProjectGroupRepository is already on IpcContext, and the fields are already
columns on projects.

Protocol 0.11.0, additive. PROTOCOL_VERSION stays at 2 and no handshake
changes. An older phone ignores the new fields; a newer phone talking to an
older desktop receives no groups, puts every project in the ungrouped
bucket, and renders the same flat list it always did - verified on device
against a pre-0.11.0 desktop before this shipped.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
