### PR TITLE
fix(protocol): reject userinfo that disguises a relay host as loopback

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kangentic/protocol",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Kangentic mobile bridge wire protocol: framing, Noise-based pairing and session handshakes, signed device roster, and capability verbs shared between desktop and mobile.",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/protocol/src/pairing/relay-address.ts
+++ b/packages/protocol/src/pairing/relay-address.ts
@@ -1,6 +1,7 @@
 /**
- * Relay address rules shared, byte-for-byte, with the mobile app's
- * src/pairing/qr.ts. This module imports nothing on purpose: it is
+ * Relay address rules, mirrored by the mobile app's src/pairing/qr.ts (which
+ * hardened these rules first; this module now matches it). This module
+ * imports nothing on purpose: it is
  * deep-imported by the desktop's src/shared/relay.ts, which the RENDERER
  * bundles, and pulling in the rest of this package (crypto/primitives ->
  * @noble/*) would drag Noise crypto into that bundle for no reason. Keep it
@@ -9,21 +10,70 @@
 
 export const MAX_RELAY_ADDRESS_LENGTH = 512;
 
-const LOOPBACK_WS_PREFIXES = ['ws://localhost', 'ws://127.0.0.1', 'ws://[::1]'];
+const LOOPBACK_WS_HOSTS = ['localhost', '127.0.0.1', '[::1]'];
+const PLAINTEXT_SCHEME = 'ws://';
+
+/**
+ * Strips a `:port` suffix, leaving an IPv6 literal's bracketed colons alone.
+ * Null when the authority is malformed.
+ *
+ * The bracketed branch REJECTS rather than truncates: trimming at the ']'
+ * would read `[::1]evil.com` as the host `[::1]`, handing the loopback
+ * carve-out to an attacker-controlled name. After the literal, only a port
+ * may follow.
+ */
+function hostWithoutPort(authority: string): string | null {
+  if (authority.startsWith('[')) {
+    const closingBracket = authority.indexOf(']');
+    if (closingBracket === -1) return null;
+    const afterLiteral = authority.slice(closingBracket + 1);
+    if (afterLiteral !== '' && !/^:[0-9]+$/.test(afterLiteral)) return null;
+    return authority.slice(0, closingBracket + 1);
+  }
+  const portSeparator = authority.lastIndexOf(':');
+  if (portSeparator === -1) return authority;
+  const port = authority.slice(portSeparator + 1);
+  // A non-numeric "port" is not a port, so the whole string is the host - and
+  // will simply fail the loopback check.
+  return /^[0-9]+$/.test(port) ? authority.slice(0, portSeparator) : authority;
+}
+
+/**
+ * The host a `ws://` address actually dials, or null when it is not plaintext
+ * or cannot be read as a bare authority.
+ *
+ * Hand-rolled rather than `new URL()` because this module is deliberately
+ * dependency-free AND because the mobile app runs the same rules on Hermes,
+ * whose URL implementation is partial.
+ */
+function plaintextRelayHost(relayAddress: string): string | null {
+  if (!relayAddress.startsWith(PLAINTEXT_SCHEME)) return null;
+  const afterScheme = relayAddress.slice(PLAINTEXT_SCHEME.length);
+  const authorityEnd = afterScheme.search(/[/?#]/);
+  const authority = authorityEnd === -1 ? afterScheme : afterScheme.slice(0, authorityEnd);
+  // Userinfo present: everything before the '@' is credentials, so the real
+  // host is whatever follows. Rejected outright rather than parsed - a
+  // loopback carve-out has no reason to carry credentials.
+  if (authority.includes('@')) return null;
+  const host = hostWithoutPort(authority);
+  return host === null ? null : host.toLowerCase();
+}
 
 /**
  * True if the phone's pairing QR scanner will accept this relay address.
  * wss:// is always secure; ws:// is accepted only for loopback, since the
- * pairing token doubles as the Noise PSK and is dialed verbatim as
- * `?slot=`. Prefix-based (not hostname-based) with an explicit boundary
- * check, so `ws://localhost.evil.com` - a hostname that merely starts with
- * the string "localhost" - is rejected rather than treated as loopback.
+ * pairing token doubles as the Noise PSK and is dialed verbatim as `?slot=`.
+ *
+ * Parses the AUTHORITY rather than prefix-matching. Prefix matching accepted
+ * `ws://127.0.0.1:8080@evil.test`: everything before an '@' is userinfo, so
+ * that address dials evil.test while looking like loopback, putting the PSK
+ * on the wire in cleartext to an attacker-chosen host - and the pairing then
+ * persists that host to the trust anchor for every later session. Authority
+ * parsing also subsumes the old boundary check, since `localhost.evil.com`
+ * is simply a different host.
  */
 export function isSecureRelayAddress(relayAddress: string): boolean {
   if (relayAddress.startsWith('wss://')) return true;
-  return LOOPBACK_WS_PREFIXES.some((prefix) => {
-    if (!relayAddress.startsWith(prefix)) return false;
-    const boundaryChar = relayAddress.charAt(prefix.length);
-    return boundaryChar === '' || boundaryChar === ':' || boundaryChar === '/' || boundaryChar === '?' || boundaryChar === '#';
-  });
+  const host = plaintextRelayHost(relayAddress);
+  return host !== null && LOOPBACK_WS_HOSTS.includes(host);
 }

--- a/tests/unit/protocol/relay-address.test.ts
+++ b/tests/unit/protocol/relay-address.test.ts
@@ -44,6 +44,18 @@ describe('isSecureRelayAddress', () => {
     expect(isSecureRelayAddress('ws://[::1]evil.com')).toBe(false);
   });
 
+  it('rejects userinfo that disguises the real host as loopback', () => {
+    // Everything before an '@' in an authority is credentials, so each of
+    // these dials evil.test. The pairing token IS the Noise PSK and is dialed
+    // verbatim as ?slot=, so accepting one would hand the PSK to an
+    // attacker-chosen host in cleartext, and the pairing would then persist
+    // that host to the trust anchor for every later session.
+    expect(isSecureRelayAddress('ws://127.0.0.1:8080@evil.test')).toBe(false);
+    expect(isSecureRelayAddress('ws://localhost@evil.test')).toBe(false);
+    expect(isSecureRelayAddress('ws://[::1]:8080@evil.test')).toBe(false);
+    expect(isSecureRelayAddress('ws://user:pass@127.0.0.1')).toBe(false);
+  });
+
   it('rejects a plain non-loopback ws:// address', () => {
     expect(isSecureRelayAddress('ws://relay.kangentic.com')).toBe(false);
     expect(isSecureRelayAddress('ws://my-server.example.com')).toBe(false);


### PR DESCRIPTION
fix(protocol): reject userinfo that disguises a relay host as loopback

`isSecureRelayAddress('ws://127.0.0.1:8080@evil.test')` returned true.
Everything before an '@' in a URL authority is credentials, so that address
dials evil.test - and the pairing token IS the Noise PSK, dialed verbatim as
the relay's `?slot=`. One crafted QR field therefore put the PSK on the wire
in cleartext to an attacker-chosen host, and `activePairing` then persisted
that host to the trust anchor for every later session. The loopback carve-out
is not behind a dev gate, so this applied to production builds.

Prefix matching was the flaw: it can only ask what an address STARTS with,
which says nothing about the host it resolves to. Now parses the authority,
which also subsumes the old boundary check - `localhost.evil.com` is simply a
different host rather than a prefix that needs a special case.

Hand-rolled rather than `new URL()`, deliberately: this module is dependency-
free by contract (the renderer deep-imports it, and pulling in the rest of
the package would drag Noise crypto into that bundle), and the mobile app runs
the same rules on Hermes, whose URL implementation is partial.

One subtlety worth naming, because the first attempt got it wrong and this
suite caught it: the IPv6 branch must REJECT trailing garbage after the
closing bracket, not trim to it. Truncating read `ws://[::1]evil.com` as the
host `[::1]`, which hands the carve-out to an attacker-controlled name - a
narrower hole than the original but the same kind.

The mobile app hardened its mirror of these rules first (its
src/pairing/qr.ts); this brings the shared module back in line, so the
desktop - which reaches this through src/shared/relay.ts - is covered too.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
