### PR TITLE
feat: show release notes in a modal before restarting to update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,30 +209,15 @@ jobs:
   # Only publish the draft release when ALL platform builds succeed.
   # This prevents partial releases (e.g. missing macOS artifacts) from
   # reaching users. If any platform fails, the release stays as a draft.
+  #
+  # Publishing (--draft=false) and setting the notes body happen in the SAME
+  # `gh release edit` call so the release is never live with an empty body:
+  # two separate calls (draft=false, then --notes-file) left a window where
+  # the release was published and discoverable with no body for the
+  # duration of a whole job.
   publish-release:
     needs: [release]
     if: ${{ !cancelled() && needs.release.result == 'success' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Determine version tag
-        id: version
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=v${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Publish release (remove draft status)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${{ steps.version.outputs.tag }}" --draft=false --repo ${{ github.repository }}
-
-  publish-notes:
-    needs: [publish-release]
-    if: ${{ !cancelled() && needs.publish-release.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -250,10 +235,10 @@ jobs:
             echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Set release body from RELEASE_NOTES.md
+      - name: Publish release with notes (remove draft status)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${{ steps.version.outputs.tag }}" --notes-file RELEASE_NOTES.md
+        run: gh release edit "${{ steps.version.outputs.tag }}" --draft=false --notes-file RELEASE_NOTES.md --repo ${{ github.repository }}
 
   publish-npm:
     needs: [publish-release]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,6 +86,7 @@ These settings appear in both App Settings (as defaults) and Project Settings (a
 | `windowLightDismiss` | `'off'` \| `'single'` \| `'focused'` \| `'all'` | `'single'` | Click-outside (light-dismiss) policy for modeless task-detail windows. `off` disables; `single` closes the lone window (any state); `focused` closes the focused window (any state); `all` closes every window. Closing a window does not kill its session. Global-only. |
 | `restoreWindowPosition` | boolean | `true` | Remember window size and position between launches. Global-only. |
 | `hasCompletedFirstRun` | boolean | `false` | Whether the user has completed first-run onboarding. Auto-set, not shown in UI. |
+| `lastSeenReleaseNotesVersion` | string | `''` | The version whose release-notes modal has already been auto-shown (see [Auto-Update Behavior](deployment.md#auto-update-behavior)), so it does not reopen on every relaunch after "Later". Auto-set, not shown in UI. |
 | `windowBounds` | object \| null | `null` | Persisted window bounds `{x, y, width, height}`. Auto-saved, not shown in UI. |
 | `windowMaximized` | boolean | `false` | Whether the window was maximized at last close. Auto-saved, not shown in UI. |
 | `popOutBounds` | object | `{}` | Persisted bounds + last target display id for each detached pop-out surface (usage stats, git changes, the Browser pane), keyed by `PopOutKind` so a surface reopens on the monitor it was last placed on. Auto-saved, not shown in UI. |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -16,11 +16,11 @@ This downloads the pre-built binary for your platform, installs it, and launches
 
 | Platform | Update mechanism | User action |
 |----------|-----------------|-------------|
-| Windows | `electron-updater` (NSIS) | Click "Restart to update" toast, or quit normally -- installs silently on next launch. |
-| macOS | `electron-updater` | Click "Restart to update" when prompted. Requires code signing -- see [macOS signing note](#macos-auto-update-requires-signing). |
+| Windows | `electron-updater` (NSIS) | Review the release notes in the modal and click "Restart to update", or quit normally - installs silently on next launch. |
+| macOS | `electron-updater` | Review the release notes in the modal and click "Restart to update". Requires code signing - see [macOS signing note](#macos-auto-update-requires-signing). |
 | Linux | None | Re-run `npx kangentic` or download from [GitHub Releases](https://github.com/Kangentic/kangentic/releases). |
 
-Auto-update is implemented in `src/main/updater.ts`. It checks for updates 5 seconds after launch, then every 4 hours. Updates download in the background; a persistent toast notifies the user when ready. v0.1.0 users must manually update to v0.2.0 -- auto-update kicks in from v0.2.0 onward.
+Auto-update is implemented in `src/main/updater.ts`. It checks for updates 5 seconds after launch, then every 4 hours. Updates download in the background; when ready, a centered modal shows the new version's release notes (rendered markdown, sourced from `RELEASE_NOTES.md` baked into the update manifest at build time - see [Release Sequencing](#release-sequencing)) with "Restart to update" and "Later". The modal auto-opens once per version; "Later" dismisses it in favor of a persistent title-bar indicator that reopens it. A version whose release carried no notes falls back to the legacy persistent toast. v0.1.0 users must manually update to v0.2.0 - auto-update kicks in from v0.2.0 onward.
 
 ### Install a Specific Version
 
@@ -38,12 +38,13 @@ To roll back to a previous version, run `npx kangentic@X.Y.Z` with the desired v
 
 ### Release Sequencing
 
-1. **`/release patch`** (or `minor`/`major`) -- analyzes conventional commits, bumps version in root `package.json` + `packages/launcher/package.json`, generates CHANGELOG entry + user-friendly release notes, commits, tags, pushes.
-2. **Tag push triggers `release.yml`** -- requires approval from the `release` environment (Settings > Environments). Builds all platforms (Linux x64, Windows x64, macOS arm64), signs binaries (when signing secrets are configured), creates a **draft** GitHub Release with artifacts attached.
-3. **Run the [release smoke checklist](release-checklist.md)** against the draft build before publishing. Automated tests use mock CLI fixtures, so this manual gate is the only place real model latency, real tool calls, and conversation continuity across resume get exercised. Failure here blocks publish.
-4. **Review and publish the draft release** at [github.com/Kangentic/kangentic/releases](https://github.com/Kangentic/kangentic/releases). Paste the release notes from `/release` output. Publishing is a manual gate.
-5. **The `publish-npm` job in `release.yml`** publishes the launcher package to npm after `publish-release` succeeds, using Trusted Publishing (OIDC) -- no token required.
-6. **`npx kangentic`** now downloads the new version's signed binaries.
+1. **`/release patch`** (or `minor`/`major`) - analyzes conventional commits, bumps version in root `package.json` + `packages/launcher/package.json`, generates CHANGELOG entry + user-friendly release notes written to `RELEASE_NOTES.md` at the repo root, commits, tags, pushes.
+2. **`electron-builder.yml`'s `releaseInfo.releaseNotesFile: RELEASE_NOTES.md`** bakes that file's contents into every generated `latest*.yml` update manifest at build time. `electron-updater`'s GitHub provider prefers a populated `releaseNotes` key over its Atom-feed fallback, so this is also the source for the in-app release-notes modal (see [Auto-Update Behavior](#auto-update-behavior)), with no separate fetch and no new IPC channel.
+3. **Tag push triggers `release.yml`** - requires approval from the `release` environment (Settings > Environments). Builds all platforms (Linux x64, Windows x64, macOS arm64), signs binaries (when signing secrets are configured), creates a **draft** GitHub Release with artifacts attached.
+4. **Run the [release smoke checklist](release-checklist.md)** against the built artifacts. Automated tests use mock CLI fixtures, so this is the only place real model latency, real tool calls, and conversation continuity across resume get exercised. It does not gate publishing: `publish-release` fires as soon as the builds succeed (step 5), so the lever for a failure here is [Rollback](#rollback), not withholding the release. To gate on the checklist instead, the approval in step 3 has to be the decision point.
+5. **The `publish-release` job publishes the draft automatically** once every platform build succeeds: it clears draft status (`--draft=false`) and sets the body from `RELEASE_NOTES.md` in the same `gh release edit` call, so the release is never live with an empty body. The human gate sits earlier, on the `release` environment approval in step 3 - `publish-release` declares no `environment:` of its own, so nothing blocks between the builds finishing and the release going live. Watch the run at [github.com/Kangentic/kangentic/releases](https://github.com/Kangentic/kangentic/releases).
+6. **The `publish-npm` job in `release.yml`** publishes the launcher package to npm after `publish-release` succeeds, using Trusted Publishing (OIDC) - no token required.
+7. **`npx kangentic`** now downloads the new version's signed binaries.
 
 ### Commit Conventions
 
@@ -98,7 +99,7 @@ Electron's `autoUpdater` on macOS only works with signed apps (Electron docs: "m
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | `ci.yml` | Push to main, PRs | Typecheck, unit tests, UI tests |
-| `release.yml` | Tag push (`v*`) or `workflow_dispatch` | Build + sign + draft GitHub Release, then publish + set notes + publish launcher to npm (via OIDC trusted publishing) |
+| `release.yml` | Tag push (`v*`) or `workflow_dispatch` | Build + sign + draft GitHub Release, then publish with notes (one atomic `gh release edit`) + publish launcher to npm (via OIDC trusted publishing) |
 
 ### CI Build Matrix
 
@@ -129,7 +130,7 @@ The installed app and `npm run dev` share the same data directory. Set `KANGENTI
 ### Update not appearing
 
 - Verify the release is **published** (not draft) on GitHub
-- The app checks hourly -- restart the app to trigger an immediate check
+- The app checks every 4 hours - restart the app to trigger an immediate check
 - On macOS, auto-update requires code signing. Without it, updates won't be detected.
 
 ### Rollback

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -144,3 +144,9 @@ publish:
   owner: Kangentic
   repo: kangentic
   releaseType: draft
+
+# Bakes RELEASE_NOTES.md into every generated latest*.yml at build time, so
+# electron-updater's GitHubProvider finds releaseNotes already populated and
+# never falls back to the (HTML, unsanitized) Atom feed content.
+releaseInfo:
+  releaseNotesFile: RELEASE_NOTES.md

--- a/src/devtools/renderer/DevToolsSections.tsx
+++ b/src/devtools/renderer/DevToolsSections.tsx
@@ -1,12 +1,24 @@
-import { Network, Code2 } from 'lucide-react';
+import { Network, Code2, Sparkles } from 'lucide-react';
 import type { AppConfig } from '../../shared/types';
 import { useScopedUpdate } from '../../renderer/components/settings/shared';
+import { useUpdaterStore } from '../../renderer/stores/updater-store';
 import {
   Code,
   Description,
   GroupHeading,
   ToggleRow,
 } from '../../renderer/components/settings/tabs/dev-tab-primitives';
+
+const FIXTURE_RELEASE_NOTES = `## What's New
+
+- **Release notes modal** - see what changed before you restart to update.
+- **Faster board load** - the initial swimlane render is now [twice as fast](https://github.com/Kangentic/kangentic).
+
+## Bug Fixes
+
+- Fixed a crash when opening an empty board.
+- \`Escape\` now closes the release-notes modal like every other dialog.
+`;
 
 /**
  * Dev-only sections appended to the bottom of the product Developer
@@ -72,6 +84,36 @@ export function DevToolsSections({ globalConfig }: { globalConfig: AppConfig }) 
           including control codes that bypass the click/type input path). Flip on for stress-testing
           and hard-to-reach UI paths; leave off otherwise.
         </Description>
+      </section>
+
+      {/* initUpdater() early-returns on !app.isPackaged and on Linux (see
+          src/main/updater.ts), so the release-notes modal is unreachable while
+          dogfooding from `npm start`. This trigger fires it directly with
+          fixture notes so the modal stays visible to whoever is working on it. */}
+      <section className="space-y-2">
+        <div className="flex items-center justify-between gap-3 rounded-lg bg-surface-hover px-4 py-3">
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-fg-primary">Release Notes Modal</div>
+            <div className="text-xs text-fg-muted">
+              Fire an update-downloaded push with fixture markdown notes. The real trigger is
+              unreachable in dev (the updater only runs on a packaged Windows/macOS build).
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              useUpdaterStore.getState().receiveUpdate({
+                version: '99.0.0',
+                releaseNotes: FIXTURE_RELEASE_NOTES,
+              });
+            }}
+            data-testid="dev-trigger-release-notes-modal"
+            className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-md border border-edge/60 bg-surface-inset/40 px-2.5 py-1 text-xs font-medium text-fg-secondary transition-colors hover:border-accent/50 hover:bg-accent/10 hover:text-fg"
+          >
+            <Sparkles size={13} />
+            Show modal
+          </button>
+        </div>
       </section>
     </div>
   );

--- a/src/devtools/renderer/state-mirror.ts
+++ b/src/devtools/renderer/state-mirror.ts
@@ -7,6 +7,7 @@ import { usePopOutStore } from '../../renderer/stores/pop-out-store';
 import { useProjectStore } from '../../renderer/stores/project-store';
 import { useSessionStore } from '../../renderer/stores/session-store';
 import { useToastStore } from '../../renderer/stores/toast-store';
+import { useUpdaterStore } from '../../renderer/stores/updater-store';
 import { useUsageDashboardStore } from '../../renderer/stores/usage-dashboard-store';
 import type { RendererStateSnapshot, StoreStateResult } from '../shared/types';
 import { readStoreStateFrom, type ReadableStore } from './store-state';
@@ -76,6 +77,7 @@ const PREVIEW_STORES: Record<string, ReadableStore> = {
   project: useProjectStore,
   session: useSessionStore,
   toast: useToastStore,
+  updater: useUpdaterStore,
   // Quoted because the file stem is kebab-case (usage-dashboard-store.ts);
   // the completeness test matches the key to the filename stem.
   'usage-dashboard': useUsageDashboardStore,

--- a/src/main/updater-release-notes.ts
+++ b/src/main/updater-release-notes.ts
@@ -1,0 +1,31 @@
+// Normalizes electron-updater's release-notes union into the flat string the
+// renderer's release-notes modal expects. Kept standalone (no `electron` /
+// `electron-updater` imports) so it is reachable from the node-env unit
+// tier without dragging in the updater.ts mock bag.
+
+/** Structurally matches builder-util-runtime's ReleaseNoteInfo. */
+export interface ReleaseNoteEntry {
+  version: string;
+  note: string | null;
+}
+
+export type RawReleaseNotes = string | ReleaseNoteEntry[] | null | undefined;
+
+/**
+ * `fullChangelog` is left at its `false` default (see AppUpdater.js), so
+ * electron-updater's `releaseNotes` is a plain string in practice. The array
+ * form only appears with `fullChangelog: true`; handled here for type safety
+ * even though we do not enable it.
+ *
+ * GitHubProvider reports GitHub's empty-body sentinel ("No content.") as an
+ * empty string, not null, so empty string is the real "nothing to show"
+ * signal the caller must check for.
+ */
+export function normalizeReleaseNotes(input: RawReleaseNotes): string {
+  if (input == null) return '';
+  if (typeof input === 'string') return input;
+  return input
+    .map((entry) => entry.note)
+    .filter((note): note is string => note != null && note.length > 0)
+    .join('\n\n');
+}

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -4,6 +4,7 @@ import { app, BrowserWindow, ipcMain } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import { IPC } from '../shared/ipc-channels';
 import { trackEvent, sanitizeErrorMessage } from './analytics/analytics';
+import { normalizeReleaseNotes } from './updater-release-notes';
 
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const INITIAL_DELAY_MS = 5000; // 5 seconds after launch
@@ -98,11 +99,29 @@ export async function downloadWithRetry(): Promise<void> {
 }
 
 /**
+ * Registered on every path that bails out of updater init (dev, Linux, and a
+ * build with no update manifest). The renderer's updater surfaces still exist
+ * on those paths, so without these `ipcRenderer.invoke` rejects with
+ * `No handler registered` and surfaces as an unhandled rejection.
+ */
+function registerNoOpUpdaterHandlers(): void {
+  ipcMain.handle(IPC.UPDATE_CHECK, () => {});
+  ipcMain.handle(IPC.UPDATE_INSTALL, () => {});
+}
+
+/**
  * Initialize the auto-updater for packaged builds (Windows and macOS only).
  * Linux users update via the launcher package (`npx kangentic`).
  */
 export function initUpdater(mainWindow: BrowserWindow): void {
-  if (!app.isPackaged || process.platform === 'linux') return;
+  if (!app.isPackaged || process.platform === 'linux') {
+    // The renderer's release-notes modal reaches `installUpdate()` from its
+    // primary button, and the Developer tab can open that modal with fixture
+    // notes in dev. Register no-ops so the invoke resolves instead of
+    // rejecting with `No handler registered` (an unhandled rejection).
+    registerNoOpUpdaterHandlers();
+    return;
+  }
 
   updaterWindow = mainWindow;
 
@@ -115,11 +134,7 @@ export function initUpdater(mainWindow: BrowserWindow): void {
   // catch a recurrence in production, and bail before scheduling.
   if (!manifestExists()) {
     console.warn(`[UPDATER] Skipping init: ${manifestPath()} not found.`);
-    // Defense-in-depth: no current renderer surface invokes these, but
-    // registering no-ops keeps any future "Check for updates" UI from
-    // throwing `No handler registered` on a manifest-less build.
-    ipcMain.handle(IPC.UPDATE_CHECK, () => {});
-    ipcMain.handle(IPC.UPDATE_INSTALL, () => {});
+    registerNoOpUpdaterHandlers();
     trackEvent('app_error', {
       source: 'updater',
       message: 'missing_manifest',
@@ -160,7 +175,10 @@ export function initUpdater(mainWindow: BrowserWindow): void {
   autoUpdater.on('update-downloaded', (info) => {
     console.log('[UPDATER] Update downloaded:', info.version);
     if (updaterWindow && !updaterWindow.isDestroyed()) {
-      updaterWindow.webContents.send(IPC.UPDATE_DOWNLOADED, { version: info.version });
+      updaterWindow.webContents.send(IPC.UPDATE_DOWNLOADED, {
+        version: info.version,
+        releaseNotes: normalizeReleaseNotes(info.releaseNotes),
+      });
     }
   });
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -10,6 +10,7 @@ import { useMobileStore } from './stores/mobile-store';
 import { useSessionStore } from './stores/session-store';
 import { useBacklogStore } from './stores/backlog-store';
 import { useToastStore } from './stores/toast-store';
+import { useUpdaterStore } from './stores/updater-store';
 import { useUsageDashboardStore } from './stores/usage-dashboard-store';
 import { usePopOutStore } from './stores/pop-out-store';
 import { useProjectSwitchEffect } from './hooks/useProjectSwitchEffect';
@@ -94,15 +95,7 @@ export function App() {
 
     // Listen for auto-update downloaded notification
     const cleanupUpdateListener = window.electronAPI.updater?.onUpdateDownloaded((info) => {
-      useToastStore.getState().addToast({
-        message: `Version ${info.version} is ready to install`,
-        variant: 'info',
-        duration: 0, // persistent -- user must act or dismiss
-        action: {
-          label: 'Restart to update',
-          onClick: () => window.electronAPI.updater.installUpdate(),
-        },
-      });
+      useUpdaterStore.getState().receiveUpdate(info);
     });
 
     return () => {

--- a/src/renderer/components/dialogs/ReleaseNotesDialog.tsx
+++ b/src/renderer/components/dialogs/ReleaseNotesDialog.tsx
@@ -1,0 +1,74 @@
+import { CloudDownload, ExternalLink } from 'lucide-react';
+import { BaseDialog } from './BaseDialog';
+import { MarkdownRenderer } from '../MarkdownRenderer';
+import { useUpdaterStore } from '../../stores/updater-store';
+
+/** Matches electron-builder.yml's `publish` block (owner: Kangentic, repo: kangentic)
+ *  and the `vX.Y.Z` tag format `/release` creates. */
+function githubReleaseUrl(version: string): string {
+  return `https://github.com/Kangentic/kangentic/releases/tag/v${version}`;
+}
+
+/**
+ * Shown when a downloaded update's release notes should be reviewed before
+ * restarting. Replaces the old persistent "Restart to update" toast: the
+ * toast is now the fallback for a version with no notes (see
+ * updater-store.ts's receiveUpdate), and the title-bar indicator is the
+ * always-available way back in after "Later".
+ *
+ * Auto-opened for a version not yet seen; `autoOpened` gates focus trapping
+ * so an unbidden modal never steals focus from a PTY mid-keystroke, while a
+ * user-initiated reopen (the title-bar indicator) traps normally.
+ *
+ * Mounted in AppLayout so it appears regardless of sidebar state.
+ */
+export function ReleaseNotesDialog() {
+  const pendingUpdate = useUpdaterStore((state) => state.pendingUpdate);
+  const isModalOpen = useUpdaterStore((state) => state.isModalOpen);
+  const autoOpened = useUpdaterStore((state) => state.autoOpened);
+  const dismiss = useUpdaterStore((state) => state.dismiss);
+
+  if (!pendingUpdate || !isModalOpen) return null;
+
+  return (
+    <BaseDialog
+      onClose={dismiss}
+      title={`Version ${pendingUpdate.version} is ready to install`}
+      icon={<CloudDownload size={16} className="text-attention" />}
+      trapFocus={!autoOpened}
+      backdropClassName="backdrop-blur-xs"
+      className="w-[560px] max-h-[80vh]"
+      testId="release-notes-dialog"
+      footer={
+        <div className="flex items-center justify-between gap-3">
+          <button
+            onClick={() => window.electronAPI.shell.openExternal(githubReleaseUrl(pendingUpdate.version))}
+            className="flex items-center gap-1.5 px-1 py-1.5 text-xs text-fg-faint hover:text-fg-secondary transition-colors"
+            data-testid="release-notes-github-link"
+          >
+            <ExternalLink size={12} />
+            GitHub Release
+          </button>
+          <div className="flex gap-3">
+            <button
+              onClick={dismiss}
+              className="px-4 py-1.5 text-xs text-fg-muted hover:text-fg-secondary border border-edge-input hover:border-fg-faint rounded transition-colors"
+            >
+              Later
+            </button>
+            <button
+              onClick={() => window.electronAPI.updater.installUpdate()}
+              className="px-4 py-1.5 text-xs rounded transition-colors bg-accent-emphasis hover:bg-accent text-accent-on"
+            >
+              Restart to update
+            </button>
+          </div>
+        </div>
+      }
+    >
+      <div className="overflow-y-auto max-h-[55vh]">
+        <MarkdownRenderer content={pendingUpdate.releaseNotes} />
+      </div>
+    </BaseDialog>
+  );
+}

--- a/src/renderer/components/layout/AppLayout.tsx
+++ b/src/renderer/components/layout/AppLayout.tsx
@@ -14,6 +14,7 @@ import { commandWindowManager } from '../../window-manager';
 import { SearchPalette } from '../search/SearchPalette';
 import { WelcomeScreen } from './WelcomeScreen';
 import { ProjectPathMissingDialog } from '../dialogs/ProjectPathMissingDialog';
+import { ReleaseNotesDialog } from '../dialogs/ReleaseNotesDialog';
 import { useConfigStore } from '../../stores/config-store';
 import { useProjectStore } from '../../stores/project-store';
 import { useBoardStore } from '../../stores/board-store';
@@ -249,6 +250,7 @@ export function AppLayout() {
       {commandBar.isOpen && <CommandTerminalLayer onHide={commandBar.close} />}
       {searchPalette.isOpen && <SearchPalette onClose={searchPalette.close} />}
       <ProjectPathMissingDialog />
+      <ReleaseNotesDialog />
       <ToastContainer />
       <DictationSurface />
       <WindowLayer />

--- a/src/renderer/components/layout/TitleBar.tsx
+++ b/src/renderer/components/layout/TitleBar.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { ChartColumn, Command, Mic, Minus, Settings, Square, X } from 'lucide-react';
+import { ChartColumn, CloudDownload, Command, Mic, Minus, Settings, Square, X } from 'lucide-react';
 import { useProjectStore } from '../../stores/project-store';
 import { useConfigStore } from '../../stores/config-store';
 import { useDictationStore } from '../../stores/dictation-store';
 import { useSessionStore } from '../../stores/session-store';
+import { useUpdaterStore } from '../../stores/updater-store';
 import { useUsageDashboardStore } from '../../stores/usage-dashboard-store';
 import { warmStatsDashboard } from '../stats/LazyStatsDashboard';
 import { usePopOut } from '../../pop-out/usePopOut';
@@ -110,6 +111,9 @@ export function TitleBar({
   const setSettingsOpen = useConfigStore((s) => s.setSettingsOpen);
   const openProjectSettings = useConfigStore((s) => s.openProjectSettings);
   const openSettingsToTab = useConfigStore((s) => s.openSettingsToTab);
+
+  const pendingUpdate = useUpdaterStore((s) => s.pendingUpdate);
+  const openUpdateModal = useUpdaterStore((s) => s.openModal);
 
   // Voice dictation mic button: shown only when dictation is enabled; its color
   // reflects whether a push-to-talk session is live (active token), matching the
@@ -224,6 +228,24 @@ export function TitleBar({
       <div className="flex-1" />
 
       <div className="flex items-center gap-1" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
+        {/* Update-available indicator: LEFT-MOST of all conditionally-mounted
+            controls in this row, for the same reason "New terminal" is (see
+            the comment on that pair below) - this row is right-anchored, so
+            an element's on-screen position is fixed by what comes AFTER it.
+            Placing this first means it appearing/disappearing (when an
+            update lands / is installed) never shifts the "New terminal" /
+            Command Terminal pair or anything to their right. */}
+        {pendingUpdate && (
+          <button
+            onClick={openUpdateModal}
+            className="p-1.5 hover:bg-surface-hover rounded text-attention transition-colors"
+            title={`Version ${pendingUpdate.version} is ready to install`}
+            aria-label="Update available"
+            data-testid="update-available-button"
+          >
+            <CloudDownload size={20} />
+          </button>
+        )}
         {/* "New terminal" + the Command Terminal toggle are the LEFT-MOST icons
             in this row on purpose: this row is right-anchored (the flex-1
             spacer eats the space to its left), so an element's on-screen

--- a/src/renderer/stores/updater-store.ts
+++ b/src/renderer/stores/updater-store.ts
@@ -1,0 +1,102 @@
+import { create } from 'zustand';
+import type { UpdateDownloadedInfo } from '../../shared/types';
+import { useConfigStore } from './config-store';
+import { useToastStore } from './toast-store';
+
+interface UpdaterState {
+  pendingUpdate: UpdateDownloadedInfo | null;
+  isModalOpen: boolean;
+  /** True when the modal opened itself (a fresh version landed) rather than
+   *  from the user clicking the title-bar indicator. Drives whether the
+   *  dialog traps focus - an unbidden modal must not steal focus from a PTY
+   *  mid-keystroke. */
+  autoOpened: boolean;
+
+  /** Called from the update-downloaded IPC push. Auto-opens the modal once
+   *  per version; a version already seen (or a relaunch after "Later") does
+   *  not reopen it. Falls back to the legacy persistent toast when there are
+   *  no notes to show. */
+  receiveUpdate: (info: UpdateDownloadedInfo) => void;
+  /** Opens the modal for the pending update. Used by the title-bar indicator
+   *  to reopen a dismissed modal. */
+  openModal: () => void;
+  /** Closes the modal and records the version as seen. The title-bar
+   *  indicator stays available for the rest of the session, and after a
+   *  relaunch the re-delivered update re-shows the indicator without
+   *  auto-opening the modal again. */
+  dismiss: () => void;
+}
+
+const createUpdaterStore = () => create<UpdaterState>((set, get) => ({
+  pendingUpdate: null,
+  isModalOpen: false,
+  autoOpened: false,
+
+  receiveUpdate: (info) => {
+    if (!info.releaseNotes?.trim()) {
+      // No notes to show: keep today's toast behavior verbatim rather than
+      // opening an empty modal. Clear any pending update first - a SECOND
+      // update can land in a long-lived session (the updater re-checks every
+      // 4 hours), and leaving an earlier version's `pendingUpdate` in place
+      // would keep the title-bar indicator offering notes for a version that
+      // is no longer the one `installUpdate()` would install.
+      set({ pendingUpdate: null, isModalOpen: false, autoOpened: false });
+      useToastStore.getState().addToast({
+        message: `Version ${info.version} is ready to install`,
+        variant: 'info',
+        duration: 0, // persistent - user must act or dismiss
+        action: {
+          label: 'Restart to update',
+          onClick: () => window.electronAPI.updater.installUpdate(),
+        },
+      });
+      return;
+    }
+
+    const alreadySeen = useConfigStore.getState().config.lastSeenReleaseNotesVersion === info.version;
+    set({
+      pendingUpdate: info,
+      isModalOpen: !alreadySeen,
+      autoOpened: !alreadySeen,
+    });
+  },
+
+  openModal: () => {
+    if (!get().pendingUpdate) return;
+    set({ isModalOpen: true, autoOpened: false });
+  },
+
+  dismiss: () => {
+    const { pendingUpdate } = get();
+    set({ isModalOpen: false });
+    if (pendingUpdate) {
+      // Fire-and-forget, matching the other incidental config writes in
+      // config-store.ts: failing to record "seen" must not break dismissal.
+      void useConfigStore
+        .getState()
+        .updateConfig({ lastSeenReleaseNotesVersion: pendingUpdate.version })
+        .catch(() => undefined);
+    }
+  },
+}));
+
+// HMR instance pinning (Pattern E, see .claude/rules/hmr-patterns.md): this
+// module's only runtime export is the non-component `useUpdaterStore`, so it
+// is not a React Fast Refresh boundary. Pin the instance in
+// `import.meta.hot.data` so a Fast Refresh cannot hand a second store to the
+// title bar while the release-notes modal stays subscribed to the first.
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+const preservedUpdaterStore: ReturnType<typeof createUpdaterStore> | undefined = import.meta.hot?.data?.updaterStore;
+
+export const useUpdaterStore = preservedUpdaterStore ?? createUpdaterStore();
+
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+if (import.meta.hot) {
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.data.updaterStore = useUpdaterStore;
+  // Editing this module's OWN code would leave the pinned instance running
+  // stale closures; force a clean full reload instead. Rare; prod is
+  // unaffected (import.meta.hot is undefined there, so this block is dropped).
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.accept(() => import.meta.hot.invalidate());
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2214,6 +2214,9 @@ export interface AppConfig {
   };
 
   hasCompletedFirstRun: boolean;
+  /** The version whose release-notes modal has already been auto-shown, so it does
+   *  not reopen on every relaunch. Empty string until the first update lands. */
+  lastSeenReleaseNotesVersion: string;
   skipDeleteConfirm: boolean;
   skipBoardConfigConfirm: boolean;
   autoFocusIdleSession: boolean;
@@ -2426,6 +2429,7 @@ export const DEFAULT_CONFIG: AppConfig = {
     enabled: true,
   },
   hasCompletedFirstRun: false,
+  lastSeenReleaseNotesVersion: '',
   skipDeleteConfirm: false,
   skipBoardConfigConfirm: false,
   autoFocusIdleSession: false,
@@ -2493,6 +2497,8 @@ export interface AgentCommand {
 
 export interface UpdateDownloadedInfo {
   version: string;
+  /** Markdown release notes for this version, normalized to a flat string. Empty if none. */
+  releaseNotes: string;
 }
 
 // === Backlog ===

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -160,6 +160,7 @@
     workspaceByProject: {},
     commandTerminalWorkspace: null,
     hasCompletedFirstRun: true,
+    lastSeenReleaseNotesVersion: '',
     skipDeleteConfirm: false,
     skipBoardConfigConfirm: false,
     autoFocusIdleSession: false,
@@ -334,6 +335,17 @@
   //   - window.__mockDefaultAgentOverride: default_agent for the next project created
   //     via projects.create() or projects.openByPath(); cleared after first use
   //     (used by agent-tab-auth-warning.spec.ts to seed projects with kimi/opencode/etc.)
+  // Release-notes modal test hooks: installed eagerly here (not lazily inside
+  // updater.onUpdateDownloaded) so `__mockFireUpdateDownloaded` exists even
+  // before any renderer subscriber has registered. A spec that calls it too
+  // early throws loudly instead of silently no-op'ing into a confusing
+  // "dialog never appeared" failure.
+  window.__mockUpdateDownloadedListeners = [];
+  window.__mockFireUpdateDownloaded = function (info) {
+    var listeners = window.__mockUpdateDownloadedListeners.slice();
+    listeners.forEach(function (fn) { fn(info); });
+  };
+
   window.electronAPI = {
     projects: {
       list: async function () {
@@ -2142,6 +2154,15 @@
         return '';
       },
       openExternal: async function () {
+        // Test hook: record external-open calls so a test can assert the URL.
+        // Shares window.__openedExternalUrls with the ad-hoc openExternal
+        // patches in pr-link-badge.spec.ts / settings-panel.spec.ts (both
+        // replace this function wholesale before use, so there is no
+        // double-recording risk).
+        if (typeof window !== 'undefined') {
+          window.__openedExternalUrls = window.__openedExternalUrls || [];
+          window.__openedExternalUrls.push(arguments[0]);
+        }
         return;
       },
       showItemInFolder: async function () {
@@ -2896,8 +2917,24 @@
 
     updater: {
       checkForUpdate: async function () {},
-      installUpdate: async function () {},
-      onUpdateDownloaded: function () { return noop; },
+      installUpdate: async function () {
+        // Record calls so UI tests can assert "Restart to update" wired
+        // through to the IPC layer.
+        if (!window.__mockInstallUpdateCalls) window.__mockInstallUpdateCalls = [];
+        window.__mockInstallUpdateCalls.push(true);
+      },
+      onUpdateDownloaded: function (callback) {
+        // Tests can fire the update-downloaded push via
+        // `window.__mockFireUpdateDownloaded({ version, releaseNotes })`. The
+        // listener array and the fire hook itself are installed eagerly at
+        // mock-bootstrap time (see top of file), not lazily here.
+        window.__mockUpdateDownloadedListeners.push(callback);
+        return function () {
+          var listeners = window.__mockUpdateDownloadedListeners || [];
+          var idx = listeners.indexOf(callback);
+          if (idx >= 0) listeners.splice(idx, 1);
+        };
+      },
     },
 
     notifications: {

--- a/tests/ui/release-notes-modal.spec.ts
+++ b/tests/ui/release-notes-modal.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect, type Page } from '@playwright/test';
+import { launchPage, createProject } from './helpers';
+
+// Each describe is isolated per worker (separate process; per-test page launch / goto reset),
+// so the file's tests can fan out across the UI workers safely.
+test.describe.configure({ mode: 'parallel' });
+
+let page: Page;
+
+test.beforeEach(async () => {
+  const launched = await launchPage();
+  page = launched.page;
+  await createProject(page, 'TestProject');
+});
+
+test.afterEach(async () => {
+  await page.context().browser()?.close();
+});
+
+async function fireUpdateDownloaded(target: Page, info: { version: string; releaseNotes: string }) {
+  await target.evaluate((payload) => {
+    // Installed unconditionally at mock-bootstrap time (mock-electron-api.js);
+    // a missing hook here is a real test-infra bug, not a state a test
+    // should silently tolerate.
+    if (!window.__mockFireUpdateDownloaded) {
+      throw new Error('window.__mockFireUpdateDownloaded is not installed by the mock');
+    }
+    window.__mockFireUpdateDownloaded(payload);
+  }, info);
+}
+
+/** Reads the config store's persisted `lastSeenReleaseNotesVersion`, exposed
+ *  dev-only via `window.__zustandStores` (see App.tsx). */
+async function readLastSeenReleaseNotesVersion(target: Page): Promise<string> {
+  return target.evaluate(() => {
+    const stores = (window as unknown as {
+      __zustandStores?: { config: { getState: () => { config: { lastSeenReleaseNotesVersion: string } } } };
+    }).__zustandStores;
+    if (!stores) throw new Error('window.__zustandStores not exposed');
+    return stores.config.getState().config.lastSeenReleaseNotesVersion;
+  });
+}
+
+test.describe('Release notes modal', () => {
+  test('update-downloaded with notes opens the modal with rendered markdown', async () => {
+    await fireUpdateDownloaded(page, {
+      version: '9.9.9',
+      releaseNotes: '## What\'s New\n\n- A brand new thing',
+    });
+
+    const dialog = page.getByTestId('release-notes-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Version 9.9.9 is ready to install' })).toBeVisible();
+    await expect(dialog.getByRole('heading', { name: "What's New" })).toBeVisible();
+    await expect(dialog.getByText('A brand new thing')).toBeVisible();
+  });
+
+  test('Restart to update calls installUpdate', async () => {
+    await fireUpdateDownloaded(page, { version: '9.9.9', releaseNotes: 'Some notes' });
+    await page.getByTestId('release-notes-dialog').getByRole('button', { name: 'Restart to update' }).click();
+
+    const calls = await page.evaluate(() => window.__mockInstallUpdateCalls ?? []);
+    expect(calls).toHaveLength(1);
+  });
+
+  test('Later dismisses the modal and leaves a reopenable title-bar indicator', async () => {
+    await fireUpdateDownloaded(page, { version: '9.9.9', releaseNotes: 'Some notes' });
+    const dialog = page.getByTestId('release-notes-dialog');
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Later' }).click();
+    await expect(dialog).toBeHidden();
+
+    const indicator = page.getByTestId('update-available-button');
+    await expect(indicator).toBeVisible();
+
+    await indicator.click();
+    await expect(page.getByTestId('release-notes-dialog')).toBeVisible();
+  });
+
+  test('GitHub Release link opens the release page for this version', async () => {
+    await fireUpdateDownloaded(page, { version: '9.9.9', releaseNotes: 'Some notes' });
+    await page.getByTestId('release-notes-github-link').click();
+
+    const calls = await page.evaluate(() => window.__openedExternalUrls ?? []);
+    expect(calls).toEqual(['https://github.com/Kangentic/kangentic/releases/tag/v9.9.9']);
+  });
+
+  test('update-downloaded with no notes falls back to the persistent toast, no modal', async () => {
+    await fireUpdateDownloaded(page, { version: '9.9.9', releaseNotes: '' });
+
+    await expect(page.getByTestId('release-notes-dialog')).toHaveCount(0);
+    const toast = page.getByTestId('toast');
+    await expect(toast).toBeVisible();
+    await expect(toast).toContainText('Version 9.9.9 is ready to install');
+    await expect(page.getByTestId('update-available-button')).toHaveCount(0);
+  });
+
+  test('a second update-downloaded push for an already-seen version keeps the indicator but does not reopen the modal', async () => {
+    await fireUpdateDownloaded(page, { version: '9.9.9', releaseNotes: 'Some notes' });
+    const dialog = page.getByTestId('release-notes-dialog');
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Later' }).click();
+    await expect(dialog).toHaveCount(0);
+
+    // dismiss() persists lastSeenReleaseNotesVersion via a fire-and-forget
+    // updateConfig call (not synchronously with the click), so poll for the
+    // write to land before re-firing the same version - otherwise the
+    // second push could race ahead of the persisted "already seen" state.
+    await expect.poll(() => readLastSeenReleaseNotesVersion(page)).toBe('9.9.9');
+
+    await fireUpdateDownloaded(page, { version: '9.9.9', releaseNotes: 'Some notes' });
+
+    await expect(dialog).toHaveCount(0);
+    await expect(page.getByTestId('update-available-button')).toBeVisible();
+  });
+
+  test('an auto-opened modal does not steal focus; reopening via the title-bar indicator traps it', async () => {
+    // Anchor a known focus target before the update lands, so we can prove
+    // the auto-opened modal never pulls focus away from it.
+    const searchButton = page.locator('[data-testid="open-search-button"]');
+    await searchButton.focus();
+    await expect(searchButton).toBeFocused();
+
+    await fireUpdateDownloaded(page, { version: '9.9.9', releaseNotes: 'Some notes' });
+    const dialog = page.getByTestId('release-notes-dialog');
+    await expect(dialog).toBeVisible();
+
+    // Auto-opened: focus must stay put and the content wrapper must not be a
+    // focus trap (no tabindex="-1"), so an unbidden modal never interrupts a
+    // PTY mid-keystroke.
+    await expect(searchButton).toBeFocused();
+    await expect(dialog).not.toHaveAttribute('tabindex');
+
+    await dialog.getByRole('button', { name: 'Later' }).click();
+    const indicator = page.getByTestId('update-available-button');
+    await expect(indicator).toBeVisible();
+    await indicator.click();
+    await expect(dialog).toBeVisible();
+
+    // Reopened via the title-bar indicator: this is a user-initiated reopen,
+    // so it traps focus normally, pulling it into the dialog.
+    await expect.poll(async () => dialog.evaluate((element) => element.contains(document.activeElement))).toBe(true);
+    await expect(dialog).toHaveAttribute('tabindex', '-1');
+  });
+});

--- a/tests/ui/release-notes-modal.spec.ts
+++ b/tests/ui/release-notes-modal.spec.ts
@@ -116,6 +116,34 @@ test.describe('Release notes modal', () => {
     await expect(page.getByTestId('update-available-button')).toBeVisible();
   });
 
+  test('Escape dismisses the modal (BaseDialog\'s shared Escape handler) and leaves the reopenable indicator', async () => {
+    await fireUpdateDownloaded(page, { version: '9.9.9', releaseNotes: 'Some notes' });
+    const dialog = page.getByTestId('release-notes-dialog');
+    await expect(dialog).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden();
+
+    await expect(page.getByTestId('update-available-button')).toBeVisible();
+  });
+
+  test('a markdown link in the notes body opens externally instead of navigating the window', async () => {
+    await fireUpdateDownloaded(page, {
+      version: '9.9.9',
+      releaseNotes: 'See the [full changelog](https://github.com/Kangentic/kangentic/compare/v9.9.8...v9.9.9) for details.',
+    });
+    const dialog = page.getByTestId('release-notes-dialog');
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole('link', { name: 'full changelog' }).click();
+
+    const calls = await page.evaluate(() => window.__openedExternalUrls ?? []);
+    expect(calls).toEqual(['https://github.com/Kangentic/kangentic/compare/v9.9.8...v9.9.9']);
+    // preventDefault() in MarkdownRenderer's <a onClick> must stop the click from
+    // navigating the renderer window; the dialog staying open is proof it didn't.
+    await expect(dialog).toBeVisible();
+  });
+
   test('an auto-opened modal does not steal focus; reopening via the title-bar indicator traps it', async () => {
     // Anchor a known focus target before the update lands, so we can prove
     // the auto-opened modal never pulls focus away from it.

--- a/tests/ui/test-globals.d.ts
+++ b/tests/ui/test-globals.d.ts
@@ -26,6 +26,14 @@ declare global {
 
     /** Records URLs passed to a spec-patched `shell.openExternal`. */
     __openedExternalUrls?: string[];
+
+    /** Release-notes modal mock hooks. See mock-electron-api.js. */
+    /** Records `installUpdate()` calls (Restart to update button). */
+    __mockInstallUpdateCalls?: unknown[];
+    /** Subscribers registered via `updater.onUpdateDownloaded`; fired by `__mockFireUpdateDownloaded`. */
+    __mockUpdateDownloadedListeners?: Array<(info: { version: string; releaseNotes: string }) => void>;
+    /** Fires the update-downloaded push to every registered subscriber. Installed eagerly at mock-bootstrap time. */
+    __mockFireUpdateDownloaded?: (info: { version: string; releaseNotes: string }) => void;
   }
 }
 

--- a/tests/unit/hmr-resync.test.ts
+++ b/tests/unit/hmr-resync.test.ts
@@ -247,7 +247,7 @@ describe('HMR store re-sync', () => {
   // back, and self-accept so editing the store's own code forces a clean reload
   // instead of running stale closures. See .claude/rules/hmr-patterns.md.
   it('instance-pinned stores read, write, and self-accept across HMR (Pattern E)', () => {
-    const PATTERN_E_STORES = ['board-store.ts', 'backlog-store.ts', 'project-store.ts', 'dictation-store.ts', 'usage-dashboard-store.ts', 'pop-out-store.ts'];
+    const PATTERN_E_STORES = ['board-store.ts', 'backlog-store.ts', 'project-store.ts', 'dictation-store.ts', 'usage-dashboard-store.ts', 'pop-out-store.ts', 'updater-store.ts'];
     const violations: string[] = [];
     for (const fileName of PATTERN_E_STORES) {
       const source = fs.readFileSync(path.join(STORES_DIR, fileName), 'utf-8');

--- a/tests/unit/updater-init-guard.test.ts
+++ b/tests/unit/updater-init-guard.test.ts
@@ -33,7 +33,14 @@ vi.mock('fs', async () => {
 import { initUpdater } from '../../src/main/updater';
 import { IPC } from '../../src/shared/ipc-channels';
 
-const fakeWindow = {} as Electron.BrowserWindow;
+// Only populated on the full-wiring path (packaged + manifest present), where
+// initUpdater assigns this window as `updaterWindow` and later sends the
+// normalized update-downloaded payload through it.
+const fakeWindowSend = vi.fn();
+const fakeWindow = {
+  isDestroyed: () => false,
+  webContents: { send: fakeWindowSend },
+} as unknown as Electron.BrowserWindow;
 
 describe('initUpdater manifest guard', () => {
   const originalResourcesPath = process.resourcesPath;
@@ -60,6 +67,7 @@ describe('initUpdater manifest guard', () => {
     mocks.autoUpdaterMock.disableDifferentialDownload = false;
     mocks.trackEventMock.mockReset();
     mocks.existsSyncMock.mockReset();
+    fakeWindowSend.mockReset();
   });
 
   afterEach(() => {
@@ -113,13 +121,47 @@ describe('initUpdater manifest guard', () => {
     expect(mocks.trackEventMock).not.toHaveBeenCalled();
   });
 
-  it('does not consult the manifest or fire telemetry on unpackaged builds', () => {
+  it('normalizes array-form release notes before sending update-downloaded to the renderer', () => {
+    mocks.existsSyncMock.mockReturnValue(true);
+
+    initUpdater(fakeWindow);
+
+    const updateDownloadedCall = mocks.autoUpdaterMock.on.mock.calls.find(
+      (call) => call[0] === 'update-downloaded',
+    );
+    if (!updateDownloadedCall) throw new Error('update-downloaded handler was not registered');
+    const updateDownloadedHandler = updateDownloadedCall[1] as (info: {
+      version: string;
+      releaseNotes: unknown;
+    }) => void;
+
+    // Array form (builder-util-runtime's ReleaseNoteInfo[]) proves
+    // normalizeReleaseNotes actually runs rather than a raw passthrough -
+    // a passthrough would forward the array itself, not the joined string.
+    updateDownloadedHandler({
+      version: '9.9.9',
+      releaseNotes: [{ version: '9.9.9', note: 'x' }],
+    });
+
+    expect(fakeWindowSend).toHaveBeenCalledWith(IPC.UPDATE_DOWNLOADED, {
+      version: '9.9.9',
+      releaseNotes: 'x',
+    });
+  });
+
+  it('registers no-op IPC handlers and skips wiring on unpackaged builds', () => {
     mocks.electronMock.app.isPackaged = false;
 
     initUpdater(fakeWindow);
 
+    const handlerCalls = mocks.electronMock.ipcMain.handle.mock.calls;
+    const channels = handlerCalls.map((call) => call[0]);
+    expect(channels).toEqual([IPC.UPDATE_CHECK, IPC.UPDATE_INSTALL]);
+    for (const [, fn] of handlerCalls) {
+      expect((fn as () => unknown)()).toBeUndefined();
+    }
+
     expect(mocks.existsSyncMock).not.toHaveBeenCalled();
-    expect(mocks.electronMock.ipcMain.handle).not.toHaveBeenCalled();
     expect(mocks.autoUpdaterMock.on).not.toHaveBeenCalled();
     expect(mocks.trackEventMock).not.toHaveBeenCalled();
   });

--- a/tests/unit/updater-release-notes.test.ts
+++ b/tests/unit/updater-release-notes.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for the updater release-notes normalizer.
+ *
+ * normalizeReleaseNotes is pure - no browser globals, no Electron, no async.
+ *
+ * Coverage:
+ *   - Plain string passthrough (the real-world shape: fullChangelog is false).
+ *   - null / undefined -> ''.
+ *   - '' (GitHub's "No content." sentinel, per GitHubProvider.js) -> ''.
+ *   - The ReleaseNoteInfo[] branch: joins notes, tolerates a null note, and
+ *     drops empty-string notes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normalizeReleaseNotes } from '../../src/main/updater-release-notes';
+
+describe('normalizeReleaseNotes', () => {
+  it('passes a plain string through unchanged', () => {
+    expect(normalizeReleaseNotes('## What\'s New\n- Dark mode')).toBe('## What\'s New\n- Dark mode');
+  });
+
+  it('returns empty string for null', () => {
+    expect(normalizeReleaseNotes(null)).toBe('');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(normalizeReleaseNotes(undefined)).toBe('');
+  });
+
+  it('returns empty string for the GitHub "No content." sentinel (already empty string)', () => {
+    expect(normalizeReleaseNotes('')).toBe('');
+  });
+
+  it('joins ReleaseNoteInfo[] notes with a blank line between entries', () => {
+    const result = normalizeReleaseNotes([
+      { version: '1.1.0', note: 'Second release notes' },
+      { version: '1.0.0', note: 'First release notes' },
+    ]);
+    expect(result).toBe('Second release notes\n\nFirst release notes');
+  });
+
+  it('tolerates a null note inside the array', () => {
+    const result = normalizeReleaseNotes([
+      { version: '1.1.0', note: null },
+      { version: '1.0.0', note: 'Only real notes' },
+    ]);
+    expect(result).toBe('Only real notes');
+  });
+
+  it('drops empty-string notes inside the array', () => {
+    const result = normalizeReleaseNotes([
+      { version: '1.1.0', note: '' },
+      { version: '1.0.0', note: 'Only real notes' },
+    ]);
+    expect(result).toBe('Only real notes');
+  });
+
+  it('returns empty string for an empty array', () => {
+    expect(normalizeReleaseNotes([])).toBe('');
+  });
+});

--- a/tests/unit/updater-store.test.ts
+++ b/tests/unit/updater-store.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit tests for the updater store (`src/renderer/stores/updater-store.ts`).
+ *
+ * tests/ui/release-notes-modal.spec.ts already exercises this store end to
+ * end through the real ReleaseNotesDialog + TitleBar and a headless
+ * mock-electron-api, but only through the branches those components render a
+ * clickable path for. Two branches are unreachable from the UI entirely:
+ *   - `openModal()` when `pendingUpdate` is null - the title-bar indicator
+ *     button that calls it only renders when `pendingUpdate` is truthy, so
+ *     the early-return guard has no UI path to exercise it.
+ *   - `dismiss()` when `pendingUpdate` is null - "Later" only renders inside
+ *     the modal, which only opens when `pendingUpdate` is set.
+ * This file drives the store directly to pin those guards, plus the
+ * `receiveUpdate()` state-machine branches (fresh version / already-seen
+ * version / no-notes fallback / a second no-notes push clearing a PRIOR
+ * notes-bearing pendingUpdate - the exact staleness hazard called out in the
+ * store's own comment) and the fire-and-forget persistence + toast action
+ * wiring, mirroring the direct-store-drive pattern in mobile-store.test.ts
+ * and the vi.mock cross-store pattern in auto-name-scheduler.test.ts.
+ *
+ * window.electronAPI.updater.installUpdate is stubbed globally before
+ * importing the store (Node, non-jsdom unit tier); useConfigStore and
+ * useToastStore are vi.mock'd so this file asserts on the exact calls the
+ * updater store makes into them without depending on either store's own
+ * internals.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DEFAULT_CONFIG, type UpdateDownloadedInfo } from '../../src/shared/types';
+
+// ---------------------------------------------------------------------------
+// Hoisted store mocks - declared via vi.hoisted so the vi.mock factories
+// below (which run before this file's top-level body) can see them.
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  useConfigStore: { getState: vi.fn() },
+  useToastStore: { getState: vi.fn() },
+}));
+
+vi.mock('../../src/renderer/stores/config-store', () => ({ useConfigStore: mocks.useConfigStore }));
+vi.mock('../../src/renderer/stores/toast-store', () => ({ useToastStore: mocks.useToastStore }));
+
+const { useConfigStore, useToastStore } = mocks;
+
+const installUpdateMock = vi.fn();
+(globalThis as Record<string, unknown>).window = {
+  electronAPI: {
+    updater: {
+      installUpdate: installUpdateMock,
+    },
+  },
+};
+
+// Imported after the mocks/stub so the store module sees them.
+import { useUpdaterStore } from '../../src/renderer/stores/updater-store';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeUpdateInfo(overrides: Partial<UpdateDownloadedInfo> = {}): UpdateDownloadedInfo {
+  return {
+    version: '9.9.9',
+    releaseNotes: '## What\'s New\n\n- A brand new thing',
+    ...overrides,
+  };
+}
+
+function resetStore(): void {
+  useUpdaterStore.setState({ pendingUpdate: null, isModalOpen: false, autoOpened: false });
+}
+
+let addToastMock: ReturnType<typeof vi.fn>;
+let updateConfigMock: ReturnType<typeof vi.fn>;
+let lastSeenReleaseNotesVersion: string;
+
+beforeEach(() => {
+  resetStore();
+  installUpdateMock.mockReset();
+
+  lastSeenReleaseNotesVersion = '';
+  addToastMock = vi.fn();
+  updateConfigMock = vi.fn().mockResolvedValue(undefined);
+
+  useConfigStore.getState.mockReset().mockImplementation(() => ({
+    config: { ...DEFAULT_CONFIG, lastSeenReleaseNotesVersion },
+    updateConfig: updateConfigMock,
+  }));
+  useToastStore.getState.mockReset().mockImplementation(() => ({
+    addToast: addToastMock,
+  }));
+});
+
+// ---------------------------------------------------------------------------
+// receiveUpdate()
+// ---------------------------------------------------------------------------
+
+describe('receiveUpdate()', () => {
+  it('a fresh version with notes auto-opens the modal', () => {
+    const info = makeUpdateInfo({ version: '1.2.3' });
+
+    useUpdaterStore.getState().receiveUpdate(info);
+
+    expect(useUpdaterStore.getState().pendingUpdate).toEqual(info);
+    expect(useUpdaterStore.getState().isModalOpen).toBe(true);
+    expect(useUpdaterStore.getState().autoOpened).toBe(true);
+    expect(addToastMock).not.toHaveBeenCalled();
+  });
+
+  it('an already-seen version (matches config.lastSeenReleaseNotesVersion) stores the update but does not auto-open', () => {
+    lastSeenReleaseNotesVersion = '1.2.3';
+    const info = makeUpdateInfo({ version: '1.2.3' });
+
+    useUpdaterStore.getState().receiveUpdate(info);
+
+    expect(useUpdaterStore.getState().pendingUpdate).toEqual(info);
+    expect(useUpdaterStore.getState().isModalOpen).toBe(false);
+    expect(useUpdaterStore.getState().autoOpened).toBe(false);
+  });
+
+  it('empty release notes falls back to the persistent toast instead of the modal', () => {
+    const info = makeUpdateInfo({ version: '1.2.3', releaseNotes: '' });
+
+    useUpdaterStore.getState().receiveUpdate(info);
+
+    expect(useUpdaterStore.getState().pendingUpdate).toBeNull();
+    expect(useUpdaterStore.getState().isModalOpen).toBe(false);
+    expect(useUpdaterStore.getState().autoOpened).toBe(false);
+    expect(addToastMock).toHaveBeenCalledTimes(1);
+    expect(addToastMock).toHaveBeenCalledWith({
+      message: 'Version 1.2.3 is ready to install',
+      variant: 'info',
+      duration: 0,
+      action: {
+        label: 'Restart to update',
+        onClick: expect.any(Function),
+      },
+    });
+  });
+
+  it('whitespace-only release notes also falls back to the toast (notes are trimmed before the check)', () => {
+    const info = makeUpdateInfo({ version: '1.2.3', releaseNotes: '   \n  ' });
+
+    useUpdaterStore.getState().receiveUpdate(info);
+
+    expect(useUpdaterStore.getState().pendingUpdate).toBeNull();
+    expect(addToastMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('the toast action calls window.electronAPI.updater.installUpdate()', () => {
+    useUpdaterStore.getState().receiveUpdate(makeUpdateInfo({ releaseNotes: '' }));
+
+    const call = addToastMock.mock.calls[0][0] as { action: { onClick: () => void } };
+    call.action.onClick();
+
+    expect(installUpdateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('a second no-notes push clears a PRIOR notes-bearing pendingUpdate, so the indicator does not offer a stale version', () => {
+    // First update has real notes: pendingUpdate is set and the modal auto-opens.
+    useUpdaterStore.getState().receiveUpdate(makeUpdateInfo({ version: '1.0.0' }));
+    expect(useUpdaterStore.getState().pendingUpdate?.version).toBe('1.0.0');
+
+    // A second, newer update lands with no notes (e.g. a patch release).
+    useUpdaterStore.getState().receiveUpdate(makeUpdateInfo({ version: '1.0.1', releaseNotes: '' }));
+
+    expect(useUpdaterStore.getState().pendingUpdate).toBeNull();
+    expect(useUpdaterStore.getState().isModalOpen).toBe(false);
+    expect(useUpdaterStore.getState().autoOpened).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openModal()
+// ---------------------------------------------------------------------------
+
+describe('openModal()', () => {
+  it('is a no-op when there is no pendingUpdate (unreachable from the UI, but must stay safe)', () => {
+    expect(useUpdaterStore.getState().pendingUpdate).toBeNull();
+
+    useUpdaterStore.getState().openModal();
+
+    expect(useUpdaterStore.getState().isModalOpen).toBe(false);
+  });
+
+  it('opens the modal for the pending update without re-marking it as auto-opened', () => {
+    useUpdaterStore.setState({ pendingUpdate: makeUpdateInfo(), isModalOpen: false, autoOpened: true });
+
+    useUpdaterStore.getState().openModal();
+
+    expect(useUpdaterStore.getState().isModalOpen).toBe(true);
+    expect(useUpdaterStore.getState().autoOpened).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dismiss()
+// ---------------------------------------------------------------------------
+
+describe('dismiss()', () => {
+  it('closes the modal and persists the pending update version as seen', async () => {
+    const info = makeUpdateInfo({ version: '1.2.3' });
+    useUpdaterStore.setState({ pendingUpdate: info, isModalOpen: true, autoOpened: true });
+
+    useUpdaterStore.getState().dismiss();
+
+    expect(useUpdaterStore.getState().isModalOpen).toBe(false);
+    // updateConfig is fired-and-forgotten (not awaited by dismiss()); flush
+    // the microtask queue before asserting the call landed.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(updateConfigMock).toHaveBeenCalledWith({ lastSeenReleaseNotesVersion: '1.2.3' });
+  });
+
+  it('does not call updateConfig when there is no pendingUpdate (unreachable from the UI, but must stay safe)', async () => {
+    expect(useUpdaterStore.getState().pendingUpdate).toBeNull();
+    useUpdaterStore.setState({ isModalOpen: true });
+
+    useUpdaterStore.getState().dismiss();
+
+    expect(useUpdaterStore.getState().isModalOpen).toBe(false);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(updateConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows a rejected updateConfig instead of throwing (dismissal must not fail on a persistence error)', async () => {
+    // A vi.fn() built via mockRejectedValue has its returned promise
+    // instrumented internally (for mock.results tracking), which itself
+    // attaches a handler and would mask a missing `.catch()` in the store -
+    // the assertion below would stay green either way. Use a PLAIN rejecting
+    // function instead so the only thing that can attach a handler to its
+    // promise is the store's own `dismiss()` implementation.
+    const rejectingUpdateConfig = () => Promise.reject(new Error('disk full'));
+    useConfigStore.getState.mockReturnValue({
+      config: { ...DEFAULT_CONFIG, lastSeenReleaseNotesVersion: '' },
+      updateConfig: rejectingUpdateConfig,
+    });
+    useUpdaterStore.setState({ pendingUpdate: makeUpdateInfo({ version: '1.2.3' }), isModalOpen: true });
+
+    // dismiss() does not await updateConfig(), so a synchronous throw/not-throw
+    // assertion here would pass whether or not the rejection is actually
+    // caught. Listen for Node's 'unhandledRejection' instead: it only fires if
+    // dismiss()'s `.catch(() => undefined)` is missing or broken, which is the
+    // real thing this test guards.
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason);
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      useUpdaterStore.getState().dismiss();
+      expect(useUpdaterStore.getState().isModalOpen).toBe(false);
+
+      // Cross a macrotask boundary so Node's unhandled-rejection check (which
+      // runs after the microtask queue drains) has a chance to fire before we
+      // assert on it.
+      await new Promise((resolve) => setImmediate(resolve));
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+
+    expect(unhandledRejections).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Replaces the persistent "Restart to update" toast (`App.tsx`) with a centered modal, shown over a blurred backdrop, displaying the new version's release notes as rendered markdown. The modal has "Restart to update", "Later", and a link to the GitHub release for the version.

Affected components:
- `src/main/updater.ts` / `src/main/updater-release-notes.ts` - widens the existing `update-downloaded` payload with normalized release notes (no new IPC channel).
- `src/renderer/stores/updater-store.ts` (new) - the auto-show/dismiss/reopen state machine.
- `src/renderer/components/dialogs/ReleaseNotesDialog.tsx` (new) - the modal itself.
- `src/renderer/components/layout/TitleBar.tsx` - a persistent reopen indicator.
- `src/devtools/renderer/DevToolsSections.tsx` - a dev-only trigger, since the real updater never initializes outside a packaged build.
- `electron-builder.yml`, `.github/workflows/release.yml` - bakes `RELEASE_NOTES.md` into the update manifest at build time and fixes a release-publish/notes race.

## Why

The old toast gave no context on what changed before asking the user to restart, and the release workflow published a version live with an empty body for the duration of a whole CI job (notes were set in a separate, later step).

## How

**Sourcing the notes:** confirmed against the installed `electron-updater` / `app-builder-lib` source that `releaseInfo.releaseNotesFile` gets baked into every generated `latest*.yml` at build time, and that `GitHubProvider` only falls back to its (unsanitized HTML) Atom feed when `releaseNotes` is `null` - so a populated key wins outright with no new network call and no new IPC channel.

**Auto-show, once per version:** the modal opens itself the first time a version's notes are seen (persisted `lastSeenReleaseNotesVersion` in global config) and does **not** trap focus on that auto-open path, so it can't steal keyboard focus from a running PTY session mid-keystroke. "Later" dismisses it and leaves a reopenable title-bar indicator (`CloudDownload` icon) instead of a dead end; reopening via that indicator is a deliberate click, so it traps focus normally.

**Fallback:** a release that ships with no notes falls back to the original persistent toast unchanged.

**Trade-off:** the modal's markdown renderer (`MarkdownRenderer`) does not render raw HTML and already routes links through `shell.openExternal`, so untrusted release-note content (GitHub release bodies) is handled the same way as everywhere else it's used (task descriptions, PR descriptions).

## Breaking changes

None.

## Tests

- `tests/unit/updater-release-notes.test.ts` - the release-notes normalizer (string passthrough, null/undefined, GitHub's empty-string sentinel, the `ReleaseNoteInfo[]` array form).
- `tests/unit/updater-init-guard.test.ts` - extended: no-op IPC handlers now register on every early-return path (dev/Linux and manifest-missing, not just manifest-missing), and the registered `update-downloaded` handler normalizes array-form notes before sending.
- `tests/unit/updater-store.test.ts` - the store's full state machine (notes vs. no-notes fallback, already-seen version, staleness, unreachable-via-UI null guards).
- `tests/unit/hmr-resync.test.ts` - the new store's Pattern E instance pinning.
- `tests/ui/release-notes-modal.spec.ts` - 9 end-to-end UI tests: modal open + rendered markdown, "Restart to update", "Later" + reopen via the title-bar indicator, the GitHub release link, the no-notes toast fallback, already-seen-version suppression, Escape dismissal, an in-body markdown link opening externally, and focus-trap behavior (auto-open vs. deliberate reopen).
- All new/modified tests are scoped and passing locally; CI runs the full suite.

Generated with [Claude Code](https://claude.com/claude-code)
