### PR TITLE
fix(mobile-bridge): flip a paired device to Connected as soon as it connects

### DIFF
--- a/docs/mobile-bridge.md
+++ b/docs/mobile-bridge.md
@@ -200,6 +200,62 @@ Once a device is paired, `src/main/mobile-bridge/session/bridge-session.ts` mana
 
 `src/main/mobile-bridge/wire/session-frame.ts` (re-exported from the protocol package) tags every frame as either a `Handshake` frame (routed to the in-progress `HandshakeState`) or an `Application` frame (routed to the established secretstream pair), so handshake and application traffic can share one transport connection without ambiguity.
 
+### Per-device connection state
+
+Each row in the Mobile Devices settings tab reports `BridgeSession.connectionState`
+(`MobileDeviceConnectionState` in `src/shared/types.ts`), **not** the raw transport state. The
+transport alone cannot answer "is the phone there": the desktop's relay socket reads `connected`
+whenever the relay is up and the slot is dialable, with the phone powered off. So a badge driven
+by the transport shows a green "Connected" for a device that is gone.
+
+| Reported | Means |
+|---|---|
+| `idle` | No session open for this device yet. Renders no badge (not an error). |
+| `connecting` | The transport is up and the KK handshake is in flight. |
+| `connected` | The KK session is established: the phone answered, so it is genuinely attached. |
+| `offline` | The relay slot is healthy but no phone is attached to it. |
+| `reconnecting` | The relay link itself dropped and `RelayClient` is backing off. |
+| `closed` | The transport was closed. |
+
+`offline` and `reconnecting` are deliberately distinct: they call for opposite user actions (open
+the phone vs. fix the network). `offline` is a presence conclusion rather than a transport state,
+so it is **not** part of `MobileBridgeTransportState`, which must keep mirroring
+`@kangentic/protocol`'s `TransportState` exactly.
+
+Two guards keep the value honest without making it twitchy:
+
+- **A probe budget before `offline`.** Every handshake initiation doubles as a presence probe.
+  Silence for `PEER_PRESENCE_TIMEOUT_MS` (5s) spends one unit; only `PEER_PRESENCE_FAILURES_BEFORE_ABSENT`
+  (2) consecutive failures conclude the peer is absent, so one slow round trip never flashes
+  "Offline" on a live phone. An explicit goodbye (a `FrameTag.Final` frame) skips the budget. Once
+  absent, `PEER_PROBE_INTERVAL_MS` (15s) keeps probing so a returning phone is picked up in ~20s
+  rather than on the next rekey tick. The probe window is anchored to the start of an
+  unestablished episode and is **never restarted** by a later initiation: `HANDSHAKE_RETRY_MS`
+  (3s) re-initiates faster than the window expires, so a restartable window would let a relay
+  injecting garbage handshake frames hold `offline` permanently out of reach and pin the badge on
+  "Connecting..." forever.
+- **Application traffic proves presence.** Promotion is evidence-based the same way demotion is:
+  any frame the desktop can open came from the phone, since only it holds the matching send key,
+  so opening one restarts the probe budget. Without that, presence rested on the handshake alone,
+  and a single dropped initiation (a rekey is attempted every `REHANDSHAKE_INTERVAL_MS`, so a
+  lossy relay gets a fresh chance every two minutes) drained the budget while the phone, never
+  having learned a rekey was attempted, kept serving on streams the desktop was still decrypting.
+  That reported "Offline" for a demonstrably live device: the exact mirror of the stale green
+  "Connected" this whole state exists to remove.
+- **A hold before surfacing a blip.** The relay force-closes both peers when either drops, so an
+  ordinary phone reload costs a ~500ms reconnect plus a re-handshake. A known-good session keeps
+  reporting `connected` for `RECONNECT_GRACE_MS` (2s), spanning the reconnect *and* the
+  re-handshake, so the badge does not flicker `connected -> reconnecting -> connecting -> connected`
+  on every reload. A genuine outage outlasts the hold and correctly falls through.
+
+`MobileBridgeStatus.relayState` is the separate panel-wide aggregate over each session's
+*transport* state, with precedence `connected > connecting > reconnecting > closed`. It describes
+the relay link, so it deliberately stays transport-based. Because that precedence pins it at
+`connected` the moment any one device connects, the renderer's `mobile:stateChanged` notification
+is gated on a signature covering the aggregate **and** every device's own connection state -
+gating on the aggregate alone left a second device's row frozen on "Connecting..." while its phone
+was already serving data.
+
 ## Relay Transport
 
 `src/main/mobile-bridge/transport/relay-client.ts` is the desktop's **outbound-only** WebSocket client to a blind relay (self-hostable, or Kangentic's hosted instance). The relay forwards opaque ciphertext frames only - it authenticates nothing and reads nothing, because every frame is already Noise-encrypted (or, during pairing, is itself a Noise handshake message the relay cannot decrypt).

--- a/src/main/mobile-bridge/mobile-bridge-service.ts
+++ b/src/main/mobile-bridge/mobile-bridge-service.ts
@@ -14,7 +14,7 @@ import {
 } from '@kangentic/protocol';
 import { isGenuineEncryptionAvailable } from '../boards/shared/auth';
 import { validateRelayUrl } from '../../shared/relay';
-import type { MobileBridgeStatus, MobileBridgeTransportState } from '../../shared/types';
+import type { MobileBridgeStatus, MobileBridgeTransportState, MobileDeviceConnectionState } from '../../shared/types';
 import { DevQuickPair } from './dev-quick-pair';
 import { DiffWatcher } from '../git/diff-watcher';
 import { loadBridgeIdentity, loadOrCreateBridgeIdentity, type BridgeIdentity } from './identity';
@@ -59,8 +59,8 @@ export interface PairedDeviceSummary {
   displayName: string;
   capabilities: CapabilityVerb[];
   pairedAt: string;
-  /** Live, not persisted - per-device transport state, sourced from its open BridgeSession (or 'idle' if none is open yet). Replaces a panel-wide relay indicator with one that answers "is THIS device reachable". */
-  connectionState: MobileBridgeTransportState;
+  /** Live, not persisted - per-device connection state, sourced from its open BridgeSession (or 'idle' if none is open yet). Replaces a panel-wide relay indicator with one that answers "is THIS device reachable". */
+  connectionState: MobileDeviceConnectionState;
 }
 
 /**
@@ -114,8 +114,19 @@ export class MobileBridgeService extends EventEmitter {
   private pushNotifier: PushNotifier | null = null;
   /** Fires PushNotifier.notifyTaskStalled() when a task's spawn sits in-flight past the stall threshold. */
   private spawnStallWatcher: SpawnStallWatcher | null = null;
-  /** The aggregate relayState most recently emitted via 'stateChanged', so RELAY_STATE_EMIT_WINDOW_MS only re-emits on an actual value change, not on every transport flap. */
-  private lastEmittedRelayState: MobileBridgeTransportState | null = null;
+  /**
+   * The connection signature most recently emitted via 'stateChanged', so
+   * RELAY_STATE_EMIT_WINDOW_MS only re-emits on an actual value change, not on
+   * every transport flap.
+   *
+   * It covers the aggregate AND every device's own connection state, because
+   * 'stateChanged' tells the renderer to re-read both. Gating on the aggregate
+   * alone was the "Connecting... forever" bug: precedence pins the aggregate at
+   * 'connected' the moment ANY device connects, so a second device's own
+   * transitions never moved it, never notified, and left that row frozen at
+   * whatever the last fetch happened to see - stale in both directions.
+   */
+  private lastEmittedConnectionSignature: string | null = null;
   private relayStateEmitTimer: ReturnType<typeof setTimeout> | null = null;
   private disposed = false;
 
@@ -373,6 +384,11 @@ export class MobileBridgeService extends EventEmitter {
       this.subscriptionsByDevice.delete(deviceId);
     });
     session.on('transportState', () => this.scheduleRelayStateEmit());
+    // The per-device badge tracks establishment and peer presence, not just
+    // the transport, so it moves on edges 'transportState' never sees (a
+    // completed handshake, a spent presence probe, an expired reconnect
+    // hold). Scheduling from both is free - the signature check dedupes.
+    session.on('connectionState', () => this.scheduleRelayStateEmit());
   }
 
   /**
@@ -395,9 +411,22 @@ export class MobileBridgeService extends EventEmitter {
   }
 
   /**
-   * Coalesces bursts of per-session transport-state churn into at most one
+   * Everything a 'stateChanged' asks the renderer to re-read that can change
+   * without a deliberate roster mutation: the aggregate plus each device's own
+   * connection state. Device order is fixed by the map's insertion order being
+   * irrelevant here - the pairs are sorted - so the signature is stable.
+   */
+  private connectionSignature(): string {
+    const perDevice = [...this.sessions.entries()]
+      .map(([deviceId, session]) => `${deviceId}:${session.connectionState}`)
+      .sort();
+    return `${this.aggregateRelayState()}|${perDevice.join(',')}`;
+  }
+
+  /**
+   * Coalesces bursts of per-session connection churn into at most one
    * 'stateChanged' emission per RELAY_STATE_EMIT_WINDOW_MS, and only when
-   * the AGGREGATE actually changed - not a plain debounce (which would
+   * something actually changed - not a plain debounce (which would
    * reset on every flap and could delay delivery indefinitely under
    * sustained backoff churn), a throttle: the first change in a window
    * schedules a check at the end of that window, and further changes
@@ -407,16 +436,19 @@ export class MobileBridgeService extends EventEmitter {
     if (this.relayStateEmitTimer) return;
     this.relayStateEmitTimer = setTimeout(() => {
       this.relayStateEmitTimer = null;
-      if (this.aggregateRelayState() === this.lastEmittedRelayState) return;
-      this.emitStateChanged();
+      const signature = this.connectionSignature();
+      if (signature === this.lastEmittedConnectionSignature) return;
+      // Hand over the signature just computed rather than making
+      // emitStateChanged() rebuild an identical one.
+      this.emitStateChanged(signature);
     }, RELAY_STATE_EMIT_WINDOW_MS);
     this.relayStateEmitTimer.unref?.();
   }
 
   /**
    * The ONLY way this service emits 'stateChanged'. Rebaselines
-   * lastEmittedRelayState so the throttle above always compares against what
-   * the renderer was last actually told.
+   * lastEmittedConnectionSignature so the throttle above always compares
+   * against what the renderer was last actually told.
    *
    * A bare this.emit('stateChanged') leaves that baseline stale, and the
    * throttle then suppresses a later REAL transition as a no-op change. The
@@ -425,9 +457,20 @@ export class MobileBridgeService extends EventEmitter {
    * device B - when B reaches 'connected' the throttle compares 'connected'
    * against the stale 'connected', suppresses, and the indicator stays stuck
    * on "Connecting..." forever.
+   *
+   * Its direct callers (rename / revoke / capabilities / pairing confirmed /
+   * dev quick pair) reach this BYPASSING the throttle, and only rebaseline as
+   * a side effect - they may have their own preconditions, but none of them is
+   * the signature. The signature is a throttle input, not an emit precondition:
+   * it covers connection state, not displayName or capabilities, so routing
+   * those callers through scheduleRelayStateEmit() "for consistency" would
+   * silently swallow a rename.
+   *
+   * `signature` is an optimization only: the throttle passes the value it just
+   * computed. Omit it anywhere the current signature has not already been built.
    */
-  private emitStateChanged(): void {
-    this.lastEmittedRelayState = this.aggregateRelayState();
+  private emitStateChanged(signature?: string): void {
+    this.lastEmittedConnectionSignature = signature ?? this.connectionSignature();
     this.emit('stateChanged');
   }
 
@@ -489,7 +532,7 @@ export class MobileBridgeService extends EventEmitter {
       displayName: device.displayName,
       capabilities: device.capabilities,
       pairedAt: device.pairedAt,
-      connectionState: this.sessions.get(device.deviceId)?.transportState ?? 'idle',
+      connectionState: this.sessions.get(device.deviceId)?.connectionState ?? 'idle',
     }));
   }
 

--- a/src/main/mobile-bridge/session/bridge-session.ts
+++ b/src/main/mobile-bridge/session/bridge-session.ts
@@ -15,6 +15,7 @@ import {
   type Transport,
   type TransportState,
 } from '@kangentic/protocol';
+import type { MobileDeviceConnectionState } from '../../../shared/types';
 import type { BridgeIdentity } from '../identity';
 
 /** WireGuard's REKEY_AFTER_TIME: bounded post-compromise security via periodic re-handshake, not just initial forward secrecy. */
@@ -26,9 +27,53 @@ const REHANDSHAKE_INTERVAL_MS = 2 * 60 * 1000;
  * named adversary); the corrupted handshake is dropped and a fresh initiation
  * is scheduled this soon rather than stalling until the next rehandshake tick.
  * This retry is driven ONLY by an actual failed read, never by a quiet wait, so
- * a parked socket with no peer never floods the relay with buffered msg1s.
+ * a bad-frame flood cannot make us answer with a msg1 per bad frame. The quiet
+ * wait has its own, far slower cadence - see PEER_PROBE_INTERVAL_MS.
  */
 const HANDSHAKE_RETRY_MS = 3 * 1000;
+
+/**
+ * How long an initiation waits for the peer's reply before it counts as a
+ * failed presence probe. Generous: a KK reply is a single round trip over an
+ * already-open socket, so this only expires when nobody is listening.
+ */
+const PEER_PRESENCE_TIMEOUT_MS = 5 * 1000;
+
+/**
+ * Consecutive failed probes before the peer is reported absent. Two rather
+ * than one so a single slow round trip never flashes 'offline' on a phone that
+ * is really there; the cost is that 'offline' takes ~10s to appear.
+ */
+const PEER_PRESENCE_FAILURES_BEFORE_ABSENT = 2;
+
+/**
+ * Re-probe cadence once the peer is known absent. Without it, beginHandshake()
+ * only re-runs on the REHANDSHAKE_INTERVAL_MS tick, so a phone that came back
+ * would keep reporting 'offline' for up to two minutes. Combined with the
+ * timeout above this is one ~48-byte msg1 per ~20s per absent device, which is
+ * why the quiet wait cannot flood a parked slot.
+ */
+const PEER_PROBE_INTERVAL_MS = 15 * 1000;
+
+/**
+ * How long a known-good session keeps reporting 'connected' while its
+ * transport reconnects and re-handshakes. The relay force-closes BOTH peers
+ * when either drops, so an ordinary phone reload costs a ~500ms reconnect
+ * (RelayClient's INITIAL_BACKOFF_MS) plus one handshake round trip. Without
+ * this hold the UI would flicker connected -> reconnecting -> connecting ->
+ * connected on every reload.
+ */
+const RECONNECT_GRACE_MS = 2 * 1000;
+
+/**
+ * Whether the phone is actually attached to this device's relay slot, which
+ * the transport alone cannot answer: the desktop's socket reads 'connected'
+ * whenever the relay is up and the slot is dialable, with the phone powered
+ * off. Demoted only by EVIDENCE (an explicit goodbye, or a spent probe
+ * budget), never by a transport transition - that hysteresis is what lets a
+ * known-good session ride out a relay blip.
+ */
+type PeerPresence = 'unknown' | 'present' | 'absent';
 
 export interface BridgeSessionOptions {
   identity: BridgeIdentity;
@@ -67,6 +112,12 @@ export class BridgeSession extends EventEmitter {
   private unsubscribeState: (() => void) | null = null;
   private disposed = false;
 
+  private peerPresence: PeerPresence = 'unknown';
+  private failedPresenceProbes = 0;
+  private presenceTimer: ReturnType<typeof setTimeout> | null = null;
+  private absentProbeTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectGraceTimer: ReturnType<typeof setTimeout> | null = null;
+
   constructor(options: BridgeSessionOptions) {
     super();
     this.identity = options.identity;
@@ -83,6 +134,32 @@ export class BridgeSession extends EventEmitter {
   /** The underlying transport's current connection state, for the service's aggregate MobileBridgeStatus.relayState. */
   get transportState(): TransportState {
     return this.transport.state;
+  }
+
+  /**
+   * What this device's row in Settings > Mobile Devices reports: the transport
+   * state refined by whether the phone is actually attached. `transportState`
+   * alone cannot answer that - it reads 'connected' whenever the relay is up
+   * and the slot is dialable, phone or no phone - so a badge driven by it
+   * shows a green "Connected" for a powered-off device.
+   *
+   * Changes to this value are announced with the 'connectionState' event; the
+   * service turns that into the renderer's 'stateChanged' notification.
+   */
+  get connectionState(): MobileDeviceConnectionState {
+    // A known-good session riding out a sub-second relay blip: hold the last
+    // good value rather than flickering through the reconnect AND the
+    // re-handshake that follows it.
+    if (this.reconnectGraceTimer) return 'connected';
+    const transport = this.transport.state;
+    if (transport !== 'connected') return transport;
+    if (this.peerPresence === 'present' && this.isEstablished) return 'connected';
+    // Checked independently of isEstablished: a rekey that silently goes
+    // unanswered spends the probe budget while the old streams are still
+    // held, which is exactly how a phone that died without the relay
+    // noticing gets reported.
+    if (this.peerPresence === 'absent') return 'offline';
+    return 'connecting';
   }
 
   start(): void {
@@ -103,10 +180,19 @@ export class BridgeSession extends EventEmitter {
 
   private onTransportState(state: TransportState): void {
     if (this.disposed) return;
+    if (state === 'connected') {
+      // A fresh socket gets a fresh probe budget. The reconnect grace (if one
+      // is armed) deliberately stays armed until the handshake actually
+      // completes: the flicker it suppresses spans the re-handshake too.
+      this.failedPresenceProbes = 0;
+    } else if (this.peerPresence === 'present') {
+      this.armReconnectGrace();
+    }
     // Emitted before the branch below (and its early return) so every
     // transition - including into 'connected' - reaches the service's
     // relayState aggregation, not just the ones that fall through.
     this.emit('transportState', state);
+    this.emit('connectionState');
     if (state === 'connected') {
       // A reconnect (the initial connect was handled in start()). Re-initiate
       // immediately so the phone re-establishes in ~1s instead of waiting out
@@ -122,6 +208,32 @@ export class BridgeSession extends EventEmitter {
     this.streams = null;
     this.handshake = null;
     this.clearHandshakeRetryTimer();
+    // No socket means no probe can be answered; the transport branch of
+    // connectionState governs the badge until the next 'connected' edge.
+    this.clearPresenceTimer();
+    this.clearAbsentProbeTimer();
+  }
+
+  /**
+   * Holds the last known-good 'connected' across a brief transport outage.
+   * Cleared by a completed handshake (the blip healed and the badge never
+   * moved) or by its own expiry, which MUST notify - a silent expiry would
+   * strand the badge on a stale 'connected' with nothing to trigger a re-read.
+   */
+  private armReconnectGrace(): void {
+    if (this.reconnectGraceTimer) return;
+    this.reconnectGraceTimer = setTimeout(() => {
+      this.reconnectGraceTimer = null;
+      if (this.disposed) return;
+      this.emit('connectionState');
+    }, RECONNECT_GRACE_MS);
+    this.reconnectGraceTimer.unref?.();
+  }
+
+  private clearReconnectGrace(): void {
+    if (!this.reconnectGraceTimer) return;
+    clearTimeout(this.reconnectGraceTimer);
+    this.reconnectGraceTimer = null;
   }
 
   private beginHandshake(): void {
@@ -137,11 +249,108 @@ export class BridgeSession extends EventEmitter {
       remoteStatic: this.remoteStaticPublicKey,
     });
     const { message } = this.handshake.writeMessage(new Uint8Array(0));
+    // Every initiation doubles as a presence probe: a reply proves the phone is
+    // attached to this slot, silence eventually proves it is not. Armed BEFORE
+    // the send, because a peer that replies synchronously (any in-process
+    // transport, and every test double) completes the handshake inside send()
+    // - arming afterwards would leave a probe nothing can ever cancel.
+    this.armPresenceTimer();
     this.transport.send(wrapSessionFrame(SessionFrameKind.Handshake, message));
     // Re-arm the rekey timer from this handshake (WireGuard REKEY_AFTER_TIME is
     // measured from the last handshake), so a reconnect-driven initiation resets
     // the clock rather than leaving a redundant tick queued moments later.
     this.armRehandshakeTimer();
+  }
+
+  /**
+   * Anchors the probe deadline to the START of an unestablished episode, not to
+   * each initiation: an open window is never restarted. Otherwise the
+   * HANDSHAKE_RETRY_MS (3s) path, which re-initiates faster than this window
+   * expires, would push the deadline out on every retry - so a relay injecting
+   * garbage handshake frames could hold 'offline' permanently out of reach and
+   * pin the badge on "Connecting..." forever, the exact stuck-transient-state
+   * bug this file's connectionState exists to remove.
+   */
+  private armPresenceTimer(): void {
+    if (this.presenceTimer) return;
+    this.presenceTimer = setTimeout(() => {
+      this.presenceTimer = null;
+      this.onPresenceProbeTimeout();
+    }, PEER_PRESENCE_TIMEOUT_MS);
+    this.presenceTimer.unref?.();
+  }
+
+  private clearPresenceTimer(): void {
+    if (!this.presenceTimer) return;
+    clearTimeout(this.presenceTimer);
+    this.presenceTimer = null;
+  }
+
+  /**
+   * The initiation went unanswered. Spend one unit of the probe budget and try
+   * again; only a fully spent budget concludes the peer is absent, so a single
+   * slow round trip never flashes 'offline' on a phone that is really there.
+   */
+  private onPresenceProbeTimeout(): void {
+    if (this.disposed) return;
+    if (this.transport.state !== 'connected') return;
+    this.failedPresenceProbes += 1;
+    if (this.failedPresenceProbes < PEER_PRESENCE_FAILURES_BEFORE_ABSENT) {
+      this.beginHandshake();
+      return;
+    }
+    this.markPeerAbsent();
+  }
+
+  /**
+   * Promotion is evidence-based, mirroring the demotion rule above: a frame we
+   * could OPEN proves the phone is attached to this slot, because only it holds
+   * the matching send key. Without this, presence rests on the handshake alone,
+   * and an initiation that simply never arrives (one dropped msg1 on a lossy
+   * relay - a rekey happens every REHANDSHAKE_INTERVAL_MS, so there is a fresh
+   * chance every two minutes) spends the whole probe budget while the phone,
+   * never having learned a rekey was attempted, keeps serving on the streams we
+   * are still decrypting. That reported 'offline' for a device demonstrably
+   * sending data: the exact mirror of the stale green "Connected" this file's
+   * connectionState exists to remove.
+   */
+  private notePeerPresent(): void {
+    // Restart the budget on every proof of life, so only genuinely UNANSWERED
+    // probe windows accumulate toward 'absent'.
+    this.failedPresenceProbes = 0;
+    if (this.peerPresence === 'present') return;
+    this.peerPresence = 'present';
+    this.clearAbsentProbeTimer();
+    this.emit('connectionState');
+  }
+
+  private markPeerAbsent(): void {
+    const changed = this.peerPresence !== 'absent';
+    this.peerPresence = 'absent';
+    this.failedPresenceProbes = PEER_PRESENCE_FAILURES_BEFORE_ABSENT;
+    // The peer is gone, so a held 'connected' is no longer defensible.
+    this.clearReconnectGrace();
+    this.scheduleAbsentProbe();
+    if (changed) this.emit('connectionState');
+  }
+
+  /** Keeps probing a slot whose peer is absent, so a phone that comes back is picked up in ~20s rather than on the next rekey tick. */
+  private scheduleAbsentProbe(): void {
+    if (this.absentProbeTimer) return;
+    this.absentProbeTimer = setTimeout(() => {
+      this.absentProbeTimer = null;
+      if (this.disposed || this.transport.state !== 'connected') return;
+      // beginHandshake() re-arms the presence timer, so a phone that came back
+      // re-establishes here instead of waiting out REHANDSHAKE_INTERVAL_MS.
+      this.beginHandshake();
+    }, PEER_PROBE_INTERVAL_MS);
+    this.absentProbeTimer.unref?.();
+  }
+
+  private clearAbsentProbeTimer(): void {
+    if (!this.absentProbeTimer) return;
+    clearTimeout(this.absentProbeTimer);
+    this.absentProbeTimer = null;
   }
 
   private armRehandshakeTimer(): void {
@@ -215,7 +424,16 @@ export class BridgeSession extends EventEmitter {
     this.streams = deriveSecretstreamPair(chainingKey, true);
     this.handshake = null;
     this.clearHandshakeRetryTimer();
+    // The peer answered: it is attached to this slot. Retire the probe budget
+    // and drop any reconnect hold - if one was armed, the blip healed inside
+    // it and the badge never moved.
+    this.clearPresenceTimer();
+    this.clearAbsentProbeTimer();
+    this.failedPresenceProbes = 0;
+    this.peerPresence = 'present';
+    this.clearReconnectGrace();
     this.emit('established');
+    this.emit('connectionState');
   }
 
   private handleApplicationFrame(payload: Uint8Array): void {
@@ -233,9 +451,17 @@ export class BridgeSession extends EventEmitter {
       return;
     }
     if (opened.tag === FrameTag.Final) {
+      // An explicit goodbye is unambiguous, so it skips the probe budget the
+      // silent case has to spend. `streams` is deliberately left intact: this
+      // side's send stream is independent, and clearing it would change push
+      // presence suppression and the send path (see the class doc).
+      this.markPeerAbsent();
       this.emit('remoteClosed');
       return;
     }
+    // Checked AFTER the goodbye above, so a Final frame demotes rather than
+    // briefly promoting on its way out.
+    this.notePeerPresent();
     let message: BridgeMessage;
     try {
       message = decodeMessage(opened.plaintext);
@@ -260,6 +486,13 @@ export class BridgeSession extends EventEmitter {
       this.rehandshakeTimer = null;
     }
     this.clearHandshakeRetryTimer();
+    // Only clearReconnectGrace() is observable on its own: the presence and
+    // absent-probe callbacks already self-guard on `disposed`, so those two are
+    // defense-in-depth against a future edit dropping a guard. Keep all three -
+    // the dispose tests pin each one independently via the live timer count.
+    this.clearPresenceTimer();
+    this.clearAbsentProbeTimer();
+    this.clearReconnectGrace();
     this.unsubscribeFrame?.();
     this.unsubscribeFrame = null;
     this.unsubscribeState?.();

--- a/src/renderer/components/settings/tabs/MobileDevicesTab.tsx
+++ b/src/renderer/components/settings/tabs/MobileDevicesTab.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
-import { Check, CircleAlert, Copy, Loader2, Pencil, QrCode, Server, Smartphone, Trash2, X } from 'lucide-react';
+import { Check, CircleAlert, Copy, Loader2, Pencil, QrCode, Server, Smartphone, Trash2, WifiOff, X } from 'lucide-react';
 import QRCode from 'qrcode';
 import { formatKeyFingerprint } from '@kangentic/protocol/roster/fingerprint';
-import type { AppConfig, MobileBridgeTransportState, MobilePairedDevice, RemoteServerStatus } from '../../../../shared/types';
+import type { AppConfig, MobileDeviceConnectionState, MobilePairedDevice, RemoteServerStatus } from '../../../../shared/types';
 import { inferRelayMode, resolveRelayUrl, validateRelayUrl } from '../../../../shared/relay';
 import { formatDate } from '../../../lib/datetime';
 import { INPUT_CLASS, SectionHeader, Select, SettingRow, SettingToggleRow, useScopedUpdate } from '../shared';
@@ -12,10 +12,16 @@ import { ConfirmDialog } from '../../dialogs/ConfirmDialog';
 import { useMobileStore } from '../../../stores/mobile-store';
 
 /**
- * 'idle' means this device/aggregate has no session open yet (nothing to
- * report), so it renders nothing rather than a confusing "Disconnected".
+ * 'idle' means this device has no session open yet (nothing to report), so it
+ * renders nothing rather than a confusing "Disconnected".
+ *
+ * 'offline' and 'reconnecting' are deliberately distinct: 'reconnecting' means
+ * the relay link itself dropped and is backing off (fix the network), while
+ * 'offline' means the relay is healthy and the phone is simply not attached
+ * (open the phone). Offline is also the one steady state here, so it gets a
+ * static muted treatment rather than a spinner promising imminent resolution.
  */
-function connectionStateDisplay(state: MobileBridgeTransportState): { label: string; className: string; icon: ReactNode } | null {
+function connectionStateDisplay(state: MobileDeviceConnectionState): { label: string; className: string; icon: ReactNode } | null {
   switch (state) {
     case 'connected':
       return { label: 'Connected', className: 'text-green-400', icon: <Check size={12} /> };
@@ -23,6 +29,8 @@ function connectionStateDisplay(state: MobileBridgeTransportState): { label: str
       return { label: 'Connecting…', className: 'text-amber-400', icon: <Loader2 size={12} className="animate-spin" /> };
     case 'reconnecting':
       return { label: 'Reconnecting…', className: 'text-amber-400', icon: <Loader2 size={12} className="animate-spin" /> };
+    case 'offline':
+      return { label: 'Offline', className: 'text-fg-faint', icon: <WifiOff size={12} /> };
     case 'closed':
       return { label: 'Disconnected', className: 'text-danger', icon: <CircleAlert size={12} /> };
     case 'idle':

--- a/src/renderer/stores/mobile-store.ts
+++ b/src/renderer/stores/mobile-store.ts
@@ -9,6 +9,37 @@ import type {
 } from '../../shared/types';
 
 /**
+ * Identify the newest in-flight listDevices() / getStatus() so an older reply
+ * cannot clobber a newer one. 'stateChanged' fires loadStatus() and
+ * loadDevices() unsequenced, and the main process now notifies on every
+ * per-device connection change (not just when the panel-wide aggregate moves),
+ * so overlapping fetches are routine rather than exotic - and an out-of-order
+ * reply would reintroduce exactly the stale-badge symptom this store exists to
+ * avoid. Both loaders are guarded, so neither reads as protected merely by
+ * sitting next to one that is.
+ *
+ * Preserved across HMR (Pattern A), matching moveGeneration in
+ * board-store/task-slice.ts: it keeps the counters monotonic across a dev
+ * session rather than resetting to 0 on every Fast Refresh. It does NOT protect
+ * a reply already in flight when the module is replaced - that reply's own
+ * staleness check closes over the OLD module's binding, whatever this one seeds
+ * itself with.
+ */
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+let latestDevicesRequestId: number = import.meta.hot?.data?.latestDevicesRequestId ?? 0;
+// @ts-expect-error -- Vite handles import.meta.hot
+let latestStatusRequestId: number = import.meta.hot?.data?.latestStatusRequestId ?? 0;
+
+// @ts-expect-error -- Vite handles import.meta.hot
+if (import.meta.hot) {
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.dispose((data: Record<string, unknown>) => {
+    data.latestDevicesRequestId = latestDevicesRequestId;
+    data.latestStatusRequestId = latestStatusRequestId;
+  });
+}
+
+/**
  * Backs the Mobile Devices settings tab. Machine-global (not project-scoped),
  * matching the mobile bridge itself. Pairing push events (SAS, confirmed,
  * ended) are NOT subscribed here - the tab component owns that
@@ -49,12 +80,21 @@ export const useMobileStore = create<MobileStore>((set, get) => ({
   pairingEndedReason: null,
 
   loadStatus: async () => {
+    latestStatusRequestId += 1;
+    const requestId = latestStatusRequestId;
     const status = await window.electronAPI.mobile.getStatus();
+    // A newer fetch superseded this one while it was in flight.
+    if (requestId !== latestStatusRequestId) return;
     set({ status });
   },
 
   loadDevices: async () => {
+    latestDevicesRequestId += 1;
+    const requestId = latestDevicesRequestId;
     const devices = await window.electronAPI.mobile.listDevices();
+    // A newer fetch was issued while this one was in flight; its reply is the
+    // current truth, so drop this one rather than overwriting with older data.
+    if (requestId !== latestDevicesRequestId) return;
     set({ devices });
   },
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2739,6 +2739,18 @@ export interface MobileBridgeStatus {
 /** Mirrors @kangentic/protocol's TransportState - re-declared here (not re-exported) so src/shared/types.ts stays free of a protocol-package runtime dependency; only the string union shape needs to match. */
 export type MobileBridgeTransportState = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'closed';
 
+/**
+ * What one paired device's row reports. Every transport state plus 'offline':
+ * the relay slot is up but no phone is attached to it (no live Noise KK
+ * session), which the transport alone cannot express - it reads 'connected'
+ * whenever the relay is reachable, phone powered off or not.
+ *
+ * 'offline' is a presence conclusion, NOT a transport state, so it is
+ * deliberately absent from the @kangentic/protocol mirror above; that union
+ * must keep matching the package exactly.
+ */
+export type MobileDeviceConnectionState = MobileBridgeTransportState | 'offline';
+
 export interface MobileStartPairingResult {
   /** The `kangentic-pair://...` URI to render as a QR code. */
   qrUri: string;
@@ -2752,8 +2764,8 @@ export interface MobilePairedDevice {
   capabilities: MobileCapabilityVerb[];
   /** ISO 8601. */
   pairedAt: string;
-  /** Live, not persisted - this device's own transport state, not the panel-wide aggregate. */
-  connectionState: MobileBridgeTransportState;
+  /** Live, not persisted - this device's own connection state (transport refined by whether the phone is actually attached), not the panel-wide aggregate. */
+  connectionState: MobileDeviceConnectionState;
 }
 
 export interface MobilePairingSasPayload {

--- a/tests/e2e/terminal-fullscreen-select-replay-focus.spec.ts
+++ b/tests/e2e/terminal-fullscreen-select-replay-focus.spec.ts
@@ -217,9 +217,14 @@ test.describe('Fullscreen TUI select prompt - input/focus survives a scrollback 
     await page.waitForTimeout(FLUSH_SETTLE_MARGIN_MS);
 
     // Wait for the mock's initial fullscreen frame: option 0 highlighted.
+    // 30000 (not the suite's default 20000 CI-slow budget): this depends on
+    // mock-claude's spawn landing and its first PTY chunk surviving the
+    // PtyBufferManager flush under CI's contended, sharded xvfb runners -
+    // the same "compound, multi-hop" class as the launch-overlay wait below,
+    // and matches session-resume.spec.ts's 30000 for that class of wait.
     await expect
       .poll(() => scrollbackForTask(page, taskId), {
-        timeout: 15000,
+        timeout: 30000,
         message: 'Expected the fullscreen select prompt to render with option 1 highlighted',
       })
       .toContain(HIGHLIGHT_FIRST);
@@ -240,7 +245,15 @@ test.describe('Fullscreen TUI select prompt - input/focus survives a scrollback 
     // poll above. Wait for it to clear so the click isn't racing it -
     // otherwise Playwright's own click-retry loop absorbs the wait and can
     // exceed its 30s action timeout under CI's slower, contended runners.
-    await dialog.locator('[data-testid="launch-overlay"]').waitFor({ state: 'hidden', timeout: 15000 });
+    // 30000 (not the suite's default 20000 CI-slow budget): terminalReady
+    // (TerminalTab.tsx) flips only after the PTY chunk survives the fixed
+    // 16ms PtyBufferManager flush AND propagates through the session store
+    // into a React re-render of a freshly (re)mounted dialog - a compound,
+    // multi-hop wait, the same class session-resume.spec.ts budgets at
+    // 30000 for post-restart session re-establishment. This is the wait that
+    // timed out at 15000 on CI (contended 8-worker Linux/xvfb shard; passed
+    // in 2.7s locally uncontended), the flake this comment documents fixing.
+    await dialog.locator('[data-testid="launch-overlay"]').waitFor({ state: 'hidden', timeout: 30000 });
     await dialog.locator('.xterm').first().click();
     await expect
       .poll(() => page.evaluate(() => document.activeElement?.className ?? null), {

--- a/tests/ui/mobile-devices-settings.spec.ts
+++ b/tests/ui/mobile-devices-settings.spec.ts
@@ -709,6 +709,62 @@ test.describe('Mobile Devices settings tab', () => {
     await closeSettings();
   });
 
+  test('shows the "Offline" connection state muted, distinct from a relay that is reconnecting', async () => {
+    await page.evaluate(() => {
+      (window as unknown as { __mockMobileDevices: MobilePairedDevice[] }).__mockMobileDevices = [
+        { deviceId: 'offline-device-1', displayName: 'Offline Device', capabilities: [], pairedAt: new Date().toISOString(), connectionState: 'offline' },
+      ];
+    });
+
+    await openMobileTab();
+
+    const indicator = page.locator('li', { hasText: 'Offline Device' }).getByTestId('mobile-device-connection');
+    await expect(indicator).toBeVisible();
+    // "The relay is fine, your phone is not attached" - a steady state, so it
+    // reads muted and static rather than borrowing "Reconnecting…"'s amber
+    // spinner, which means "the relay link dropped and is backing off".
+    await expect(indicator).toContainText('Offline');
+    await expect(indicator).toHaveClass(/text-fg-faint/);
+    await expect(indicator).not.toContainText('Reconnecting…');
+
+    await closeSettings();
+  });
+
+  test('a device that connects after the list was rendered updates its own badge, even while another device stays connected', async () => {
+    // The regression this whole change exists for. The main process used to
+    // notify only when the panel-wide AGGREGATE relay state moved, and
+    // precedence pins that at 'connected' the moment any one device connects -
+    // so a second device's own transitions never notified, and its row stayed
+    // frozen on "Connecting…" while the phone was already serving data.
+    await page.evaluate(() => {
+      (window as unknown as { __mockMobileDevices: MobilePairedDevice[] }).__mockMobileDevices = [
+        { deviceId: 'steady-device-1', displayName: 'Steady Device', capabilities: [], pairedAt: new Date().toISOString(), connectionState: 'connected' },
+        { deviceId: 'joining-device-1', displayName: 'Joining Device', capabilities: [], pairedAt: new Date().toISOString(), connectionState: 'connecting' },
+      ];
+    });
+
+    await openMobileTab();
+
+    const joining = page.locator('li', { hasText: /^Joining Device/ }).getByTestId('mobile-device-connection');
+    await expect(joining).toContainText('Connecting…');
+
+    // The freshly-paired device establishes. The first device never moves, so
+    // the aggregate is 'connected' before AND after.
+    await page.evaluate(() => {
+      const devices = (window as unknown as { __mockMobileDevices: MobilePairedDevice[] }).__mockMobileDevices;
+      const joiningDevice = devices.find((device) => device.deviceId === 'joining-device-1');
+      if (joiningDevice) joiningDevice.connectionState = 'connected';
+      (window as unknown as { __mockFireMobileStateChanged: () => void }).__mockFireMobileStateChanged();
+    });
+
+    await expect(joining).toContainText('Connected');
+    await expect(joining).not.toContainText('Connecting…');
+    // The steady device is undisturbed by the refetch.
+    await expect(page.locator('li', { hasText: /^Steady Device/ }).getByTestId('mobile-device-connection')).toContainText('Connected');
+
+    await closeSettings();
+  });
+
   test('renaming a device persists via renameDevice and updates the list', async () => {
     await openMobileTab();
     await pairDevice('Rename Target Device');

--- a/tests/unit/mobile-bridge/bridge-session.test.ts
+++ b/tests/unit/mobile-bridge/bridge-session.test.ts
@@ -14,6 +14,7 @@ import {
   decodeMessage,
   deriveSecretstreamPair,
   encodeMessage,
+  FrameTag,
   generateEd25519KeyPair,
   generateX25519KeyPair,
   SessionFrameKind,
@@ -181,15 +182,22 @@ function createReconnectableLoopback(): {
 class ReestablishingResponder {
   streams: SecretstreamDirectionPair | null = null;
   establishedCount = 0;
+  /**
+   * Simulates the relay swallowing the desktop's initiations. The phone never
+   * learns a rekey was attempted, so it keeps serving on its ORIGINAL streams -
+   * which is what makes it a live peer the desktop can still decrypt.
+   */
+  dropHandshakes = false;
 
   constructor(
     deviceStatic: ReturnType<typeof generateX25519KeyPair>,
     desktopStaticPublicKey: Uint8Array,
-    transport: Transport,
+    private readonly transport: Transport,
   ) {
     transport.onFrame((rawFrame) => {
       const { kind, payload } = unwrapSessionFrame(rawFrame);
       if (kind !== SessionFrameKind.Handshake) return;
+      if (this.dropHandshakes) return;
       const handshake = createKKHandshake({ initiator: false, localStatic: deviceStatic, remoteStatic: desktopStaticPublicKey });
       handshake.readMessage(payload);
       const { message, split } = handshake.writeMessage(new Uint8Array(0));
@@ -199,6 +207,11 @@ class ReestablishingResponder {
         this.establishedCount += 1;
       }
     });
+  }
+
+  sendApplicationMessage(message: BridgeMessage): void {
+    if (!this.streams) throw new Error('Cannot send before the session is established');
+    this.transport.send(wrapSessionFrame(SessionFrameKind.Application, this.streams.send.seal(encodeMessage(message))));
   }
 }
 
@@ -530,6 +543,404 @@ describe('BridgeSession', () => {
       expect(responder.establishedCount).toBe(1);
 
       session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+/**
+ * `connectionState` is what one device's row in Settings > Mobile Devices
+ * reports. It exists because `transportState` alone cannot answer "is the phone
+ * there": the desktop's relay socket reads 'connected' whenever the relay is up
+ * and the slot is dialable, with the phone powered off. These pin the two
+ * hysteresis guards that keep it honest without being twitchy - a probe budget
+ * before reporting 'offline', and a hold before reporting a blip.
+ *
+ * The constants mirror the private ones in bridge-session.ts (not exported):
+ * PEER_PRESENCE_TIMEOUT_MS 5s, PEER_PRESENCE_FAILURES_BEFORE_ABSENT 2,
+ * PEER_PROBE_INTERVAL_MS 15s, RECONNECT_GRACE_MS 2s.
+ */
+describe('BridgeSession.connectionState', () => {
+  function startSession(transport: Transport, desktopIdentity: BridgeIdentity, devicePublicKey: Uint8Array): BridgeSession {
+    const session = new BridgeSession({
+      identity: desktopIdentity,
+      deviceId: 'device-1',
+      remoteStaticPublicKey: devicePublicKey,
+      capabilities: new Set(['read-board']) as CapabilitySet,
+      transport,
+    });
+    session.start();
+    return session;
+  }
+
+  it('reports "connecting" while the transport is up but the handshake has not completed', () => {
+    vi.useFakeTimers();
+    try {
+      const desktopIdentity = testIdentity();
+      const deviceStatic = generateX25519KeyPair();
+      const { desktop } = createReconnectableLoopback();
+      // No responder is attached, so the initiation goes unanswered.
+      const session = startSession(desktop, desktopIdentity, deviceStatic.publicKey);
+
+      expect(session.transportState).toBe('connected');
+      expect(session.connectionState).toBe('connecting');
+
+      session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports "connected" only once the KK session establishes', () => {
+    vi.useFakeTimers();
+    try {
+      const desktopIdentity = testIdentity();
+      const deviceStatic = generateX25519KeyPair();
+      const { desktop, device } = createReconnectableLoopback();
+      new ReestablishingResponder(deviceStatic, desktopIdentity.staticKeyPair.publicKey, device);
+      const session = startSession(desktop, desktopIdentity, deviceStatic.publicKey);
+
+      expect(session.isEstablished).toBe(true);
+      expect(session.connectionState).toBe('connected');
+
+      session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('one unanswered probe is not enough to report "offline"', () => {
+    vi.useFakeTimers();
+    try {
+      const desktopIdentity = testIdentity();
+      const deviceStatic = generateX25519KeyPair();
+      const { desktop } = createReconnectableLoopback();
+      const session = startSession(desktop, desktopIdentity, deviceStatic.publicKey);
+
+      // The budget is deliberately two probes: a single slow round trip must
+      // never flash "Offline" on a phone that is really there.
+      vi.advanceTimersByTime(5 * 1000);
+      expect(session.connectionState).toBe('connecting');
+
+      session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports "offline" once the probe budget is spent, and announces it', () => {
+    vi.useFakeTimers();
+    try {
+      const desktopIdentity = testIdentity();
+      const deviceStatic = generateX25519KeyPair();
+      const { desktop } = createReconnectableLoopback();
+      const session = startSession(desktop, desktopIdentity, deviceStatic.publicKey);
+      const connectionStateEvents = vi.fn();
+      session.on('connectionState', connectionStateEvents);
+
+      vi.advanceTimersByTime(10 * 1000);
+
+      expect(session.connectionState).toBe('offline');
+      // The transport is untouched - this is precisely the case a
+      // transport-only badge got wrong by rendering a green "Connected".
+      expect(session.transportState).toBe('connected');
+      expect(connectionStateEvents).toHaveBeenCalled();
+
+      session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('still reaches "offline" under a sustained garbage-frame trickle from the relay', () => {
+    // The blind relay is a named adversary, and a bad handshake frame schedules
+    // a HANDSHAKE_RETRY_MS (3s) re-initiation. If each re-initiation restarted
+    // the presence window (5s), garbage timed to land just after every msg1
+    // would hold the probe deadline permanently out of reach and pin the badge
+    // on "Connecting…" forever - the exact stuck-transient-state class of bug
+    // this whole change exists to remove.
+    vi.useFakeTimers();
+    try {
+      const desktopIdentity = testIdentity();
+      const deviceStatic = generateX25519KeyPair();
+      const { desktop, device } = createReconnectableLoopback();
+      // No responder: the "phone" is gone and only the relay's garbage arrives.
+      const session = startSession(desktop, desktopIdentity, deviceStatic.publicKey);
+
+      // Injected faster than HANDSHAKE_RETRY_MS, so a garbage frame is always
+      // waiting for the handshake each retry creates. That keeps a retry firing
+      // roughly every 3s, inside the 5s presence window - the timing that
+      // pushes the deadline out forever if the window is restartable.
+      for (let injection = 0; injection < 30; injection += 1) {
+        device.send(wrapSessionFrame(SessionFrameKind.Handshake, new Uint8Array([9, 9, 9, 9, 9])));
+        vi.advanceTimersByTime(1000);
+      }
+
+      expect(session.connectionState).toBe('offline');
+
+      session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('recovers to "connected" when the phone comes back, without waiting out the rekey interval', () => {
+    vi.useFakeTimers();
+    try {
+      const desktopIdentity = testIdentity();
+      const deviceStatic = generateX25519KeyPair();
+      const { desktop, device } = createReconnectableLoopback();
+      const session = startSession(desktop, desktopIdentity, deviceStatic.publicKey);
+
+      vi.advanceTimersByTime(10 * 1000);
+      expect(session.connectionState).toBe('offline');
+
+      // The phone reattaches to the slot. It waits passively for the desktop to
+      // initiate, so without the absent-probe loop this would stay "offline"
+      // until the 2-minute rekey tick.
+      new ReestablishingResponder(deviceStatic, desktopIdentity.staticKeyPair.publicKey, device);
+      vi.advanceTimersByTime(15 * 1000);
+
+      expect(session.connectionState).toBe('connected');
+
+      session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps reporting "connected" while a lost rekey drains the probe budget but the phone keeps serving', () => {
+    // The mirror of the bug this change removes. Presence was demoted by
+    // handshake silence alone, but silence is not proof of absence: a single
+    // dropped msg1 (a rekey is attempted every REHANDSHAKE_INTERVAL_MS, so a
+    // lossy relay gets a fresh chance every two minutes) never reaches the
+    // phone, so it keeps its original streams and keeps sending. The desktop
+    // decrypts every one of those frames and USED to report "Offline" anyway.
+    vi.useFakeTimers();
+    try {
+      const desktopIdentity = testIdentity();
+      const deviceStatic = generateX25519KeyPair();
+      const { desktop, device } = createReconnectableLoopback();
+      const responder = new ReestablishingResponder(deviceStatic, desktopIdentity.staticKeyPair.publicKey, device);
+      const session = startSession(desktop, desktopIdentity, deviceStatic.publicKey);
+      const decodedMessages: BridgeMessage[] = [];
+      session.on('message', (message: BridgeMessage) => decodedMessages.push(message));
+      expect(session.connectionState).toBe('connected');
+
+      // From here the relay swallows our initiations.
+      responder.dropHandshakes = true;
+      vi.advanceTimersByTime(2 * 60 * 1000);
+
+      // Well past the full probe budget (2 x 5s), with the phone serving throughout.
+      for (let tick = 0; tick < 4; tick += 1) {
+        responder.sendApplicationMessage({ type: 'heartbeat' } as BridgeMessage);
+        vi.advanceTimersByTime(5 * 1000);
+      }
+
+      // The frames really are being opened, so the peer is provably attached.
+      expect(decodedMessages.length).toBe(4);
+      expect(session.isEstablished).toBe(true);
+      expect(session.connectionState).toBe('connected');
+
+      session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports "offline" immediately on an explicit remote close', () => {
+    vi.useFakeTimers();
+    try {
+      const desktopIdentity = testIdentity();
+      const deviceStatic = generateX25519KeyPair();
+      const { desktop, device } = createReconnectableLoopback();
+      const responder = new ReestablishingResponder(deviceStatic, desktopIdentity.staticKeyPair.publicKey, device);
+      const session = startSession(desktop, desktopIdentity, deviceStatic.publicKey);
+      expect(session.connectionState).toBe('connected');
+
+      // The phone says goodbye. That is unambiguous, so it skips the probe
+      // budget the silent case has to spend.
+      const responderStreams = responder.streams;
+      if (!responderStreams) throw new Error('responder never established');
+      device.send(wrapSessionFrame(SessionFrameKind.Application, responderStreams.send.seal(new Uint8Array(0), FrameTag.Final)));
+
+      expect(session.connectionState).toBe('offline');
+
+      session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('holds "connected" across a relay blip that heals inside the grace, with no flicker', () => {
+    vi.useFakeTimers();
+    try {
+      const desktopIdentity = testIdentity();
+      const deviceStatic = generateX25519KeyPair();
+      const { desktop, device, setDesktopState } = createReconnectableLoopback();
+      new ReestablishingResponder(deviceStatic, desktopIdentity.staticKeyPair.publicKey, device);
+      const session = startSession(desktop, desktopIdentity, deviceStatic.publicKey);
+      expect(session.connectionState).toBe('connected');
+
+      const observed: string[] = [];
+      session.on('connectionState', () => observed.push(session.connectionState));
+
+      // A phone reload force-closes both peers, so the desktop socket drops and
+      // redials ~500ms later (RelayClient's INITIAL_BACKOFF_MS) and re-handshakes.
+      setDesktopState('reconnecting');
+      vi.advanceTimersByTime(500);
+      setDesktopState('connected');
+
+      expect(session.isEstablished).toBe(true);
+      expect(session.connectionState).toBe('connected');
+      // The whole point: the badge never passed through 'reconnecting' or
+      // 'connecting' on the way, which would read as "the pairing broke".
+      expect(observed.filter((state) => state !== 'connected')).toEqual([]);
+
+      session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('falls through to the real transport state when the blip outlasts the grace, and announces it', () => {
+    vi.useFakeTimers();
+    try {
+      const desktopIdentity = testIdentity();
+      const deviceStatic = generateX25519KeyPair();
+      const { desktop, device, setDesktopState } = createReconnectableLoopback();
+      new ReestablishingResponder(deviceStatic, desktopIdentity.staticKeyPair.publicKey, device);
+      const session = startSession(desktop, desktopIdentity, deviceStatic.publicKey);
+      expect(session.connectionState).toBe('connected');
+
+      const connectionStateEvents = vi.fn();
+      setDesktopState('reconnecting');
+      session.on('connectionState', connectionStateEvents);
+
+      // A genuine relay outage, not a blip. The hold must expire AND notify -
+      // a silent expiry would strand the badge on a stale "Connected".
+      vi.advanceTimersByTime(2 * 1000);
+
+      expect(session.connectionState).toBe('reconnecting');
+      expect(connectionStateEvents).toHaveBeenCalled();
+
+      session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('dispose() stops a pending presence probe from ever firing again', () => {
+    // Every test above calls dispose() only as its last line, never followed
+    // by a timer advance. This pins the actual teardown contract: a presence
+    // probe armed by start()'s initial (unanswered) handshake must not go on
+    // to retry, spend the probe budget, schedule an absent-reprobe, or emit
+    // 'connectionState' after the session is torn down.
+    vi.useFakeTimers();
+    try {
+      const desktopIdentity = testIdentity();
+      const deviceStatic = generateX25519KeyPair();
+      const { desktop } = createReconnectableLoopback();
+      const timerCountBeforeSession = vi.getTimerCount();
+      // No responder: the initial msg1 goes unanswered, so a presence probe
+      // timer is pending the moment dispose() runs.
+      const session = startSession(desktop, desktopIdentity, deviceStatic.publicKey);
+      expect(session.connectionState).toBe('connecting');
+      expect(vi.getTimerCount()).toBeGreaterThan(timerCountBeforeSession);
+
+      const sendSpy = vi.spyOn(desktop, 'send');
+      const connectionStateEvents = vi.fn();
+      session.on('connectionState', connectionStateEvents);
+
+      session.dispose();
+
+      // The falsifying assertion: dispose() must leave no pending timer
+      // behind, not merely rely on each callback's own `disposed` guard to
+      // make a leftover timer's eventual firing a no-op.
+      expect(vi.getTimerCount()).toBe(timerCountBeforeSession);
+
+      // Well past the presence timeout (5s), the absent-probe interval (15s)
+      // that a spent budget would schedule, and the rehandshake interval
+      // (2min): every timer a live session would still be driving.
+      vi.advanceTimersByTime(3 * 60 * 1000);
+
+      expect(sendSpy).not.toHaveBeenCalled();
+      expect(connectionStateEvents).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('dispose() stops a scheduled absent-reprobe from ever firing again', () => {
+    // Distinct from the presence-probe test above: after the probe budget is
+    // fully spent (two unanswered timeouts), the session schedules a SEPARATE
+    // absent-reprobe timer (scheduleAbsentProbe) rather than leaving the
+    // presence timer pending. dispose() must clear that one too.
+    vi.useFakeTimers();
+    try {
+      const desktopIdentity = testIdentity();
+      const deviceStatic = generateX25519KeyPair();
+      const { desktop } = createReconnectableLoopback();
+      const timerCountBeforeSession = vi.getTimerCount();
+      // No responder: spend the full two-probe budget (5s each) to reach
+      // 'offline' and arm the absent-reprobe timer.
+      const session = startSession(desktop, desktopIdentity, deviceStatic.publicKey);
+      vi.advanceTimersByTime(2 * 5 * 1000);
+      expect(session.connectionState).toBe('offline');
+
+      const sendSpy = vi.spyOn(desktop, 'send');
+      const connectionStateEvents = vi.fn();
+      session.on('connectionState', connectionStateEvents);
+
+      session.dispose();
+
+      // The falsifying assertion: dispose() must leave no pending timer
+      // behind (the rehandshake interval is cleared unconditionally above
+      // this block, so any leftover here is the absent-reprobe timer).
+      expect(vi.getTimerCount()).toBe(timerCountBeforeSession);
+
+      // Well past the absent-reprobe interval (15s) and the rehandshake
+      // interval (2min): every timer a live session would still be driving.
+      vi.advanceTimersByTime(3 * 60 * 1000);
+
+      expect(sendSpy).not.toHaveBeenCalled();
+      expect(connectionStateEvents).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('dispose() clears a pending reconnect-hold so connectionState reports the real (disposed) transport state, not a stale "connected"', () => {
+    // connectionState's reconnect-grace branch reads `this.reconnectGraceTimer`
+    // directly (not through the timer's own callback), so this is the one
+    // dispose() clear with an effect observable WITHOUT ever advancing fake
+    // timers: an un-cleared hold would misreport 'connected' for a fully
+    // disposed session for up to RECONNECT_GRACE_MS.
+    vi.useFakeTimers();
+    try {
+      const desktopIdentity = testIdentity();
+      const deviceStatic = generateX25519KeyPair();
+      const { desktop, device, setDesktopState } = createReconnectableLoopback();
+      new ReestablishingResponder(deviceStatic, desktopIdentity.staticKeyPair.publicKey, device);
+      const session = startSession(desktop, desktopIdentity, deviceStatic.publicKey);
+      expect(session.connectionState).toBe('connected');
+
+      // A blip arms the reconnect-grace hold (peerPresence was 'present').
+      setDesktopState('reconnecting');
+
+      const sendSpy = vi.spyOn(desktop, 'send');
+      const connectionStateEvents = vi.fn();
+      session.on('connectionState', connectionStateEvents);
+
+      session.dispose();
+
+      expect(session.connectionState).toBe('reconnecting');
+
+      vi.advanceTimersByTime(3 * 60 * 1000);
+
+      expect(sendSpy).not.toHaveBeenCalled();
+      expect(connectionStateEvents).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }

--- a/tests/unit/mobile-bridge/bridge-session.test.ts
+++ b/tests/unit/mobile-bridge/bridge-session.test.ts
@@ -629,6 +629,42 @@ describe('BridgeSession.connectionState', () => {
     }
   });
 
+  it('a reconnect resets the probe budget, so a stale partial count cannot fast-track a fresh episode to "offline"', () => {
+    // onTransportState()'s 'connected' branch resets failedPresenceProbes to
+    // zero ("a fresh socket gets a fresh probe budget"). Without that reset, a
+    // probe failure from BEFORE a reconnect would carry over and combine with
+    // the first failure of the NEW episode to spend the two-probe budget in
+    // one shot - flashing "Offline" on a phone that is genuinely mid-reconnect,
+    // a full probe window (5s) earlier than the budget allows. No responder is
+    // ever attached, so peerPresence never reaches 'present' and no reconnect
+    // grace is armed - isolating this reset from that other hysteresis guard.
+    vi.useFakeTimers();
+    try {
+      const desktopIdentity = testIdentity();
+      const deviceStatic = generateX25519KeyPair();
+      const { desktop, setDesktopState } = createReconnectableLoopback();
+      const session = startSession(desktop, desktopIdentity, deviceStatic.publicKey);
+
+      // One probe of the original episode's budget is spent (1 of 2).
+      vi.advanceTimersByTime(5 * 1000);
+      expect(session.connectionState).toBe('connecting');
+
+      // The transport drops and comes back - a fresh episode.
+      setDesktopState('reconnecting');
+      setDesktopState('connected');
+
+      // A single probe failure in the FRESH episode must not be enough to
+      // reach 'offline' - it would be exactly enough only if the prior
+      // episode's one failure had carried over uncleared.
+      vi.advanceTimersByTime(5 * 1000);
+      expect(session.connectionState).toBe('connecting');
+
+      session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('reports "offline" once the probe budget is spent, and announces it', () => {
     vi.useFakeTimers();
     try {

--- a/tests/unit/mobile-bridge/mobile-bridge-relay-state.test.ts
+++ b/tests/unit/mobile-bridge/mobile-bridge-relay-state.test.ts
@@ -28,6 +28,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import type { RosterDeviceEntry, TransportState } from '@kangentic/protocol';
+import type { MobileDeviceConnectionState } from '../../../src/shared/types';
 
 vi.mock('electron', () => ({
   app: { isReady: () => true, whenReady: () => Promise.resolve() },
@@ -96,6 +97,12 @@ const createdSessions: FakeBridgeSession[] = [];
 class FakeBridgeSession extends EventEmitter {
   readonly deviceId: string;
   transportState: TransportState = 'connecting';
+  /**
+   * Mirrors the real getter's pre-handshake value: a session whose transport
+   * has connected but whose Noise KK session has not completed still reports
+   * 'connecting', because the phone has not proved it is attached yet.
+   */
+  connectionState: MobileDeviceConnectionState = 'connecting';
   start = vi.fn();
   dispose = vi.fn();
   sendMessage = vi.fn();
@@ -109,10 +116,28 @@ class FakeBridgeSession extends EventEmitter {
    * transportState getter reads, then emits 'transportState' - the same
    * order the real session uses so the service's aggregate always reflects
    * the newly-set value by the time its listener runs.
+   *
+   * A transport that is not 'connected' shows straight through to
+   * connectionState in the real getter, so it does here too; a transport that
+   * IS connected leaves connectionState alone, since only a completed
+   * handshake (setConnectionState below) can promote it to 'connected'.
    */
   setTransportState(state: TransportState): void {
     this.transportState = state;
+    if (state !== 'connected') this.connectionState = state;
     this.emit('transportState', state);
+    this.emit('connectionState');
+  }
+
+  /**
+   * Mirrors an establishment or peer-presence edge: connectionState moves with
+   * NO transport transition behind it (a completed handshake, a spent presence
+   * probe, an expired reconnect hold). These are exactly the edges the old
+   * aggregate-gated notification could not see.
+   */
+  setConnectionState(state: MobileDeviceConnectionState): void {
+    this.connectionState = state;
+    this.emit('connectionState');
   }
 }
 vi.mock('../../../src/main/mobile-bridge/session/bridge-session', () => ({
@@ -259,7 +284,7 @@ describe('MobileBridgeService.scheduleRelayStateEmit() throttle', () => {
     service.dispose();
   });
 
-  it('does not emit again when the aggregate has not actually changed', async () => {
+  it('does not emit again when nothing has actually changed', async () => {
     rosterDevices = [deviceA];
     const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
     const sessions = await openSessions(service);
@@ -275,6 +300,75 @@ describe('MobileBridgeService.scheduleRelayStateEmit() throttle', () => {
     await vi.advanceTimersByTimeAsync(500);
 
     expect(stateChanged).not.toHaveBeenCalled();
+
+    service.dispose();
+  });
+
+  it('emits when ONE device\'s own connection state changed even though the aggregate did not', async () => {
+    // The regression this whole change exists for. The notification used to be
+    // gated on aggregateRelayState() alone, and precedence pins that at
+    // 'connected' the moment ANY device connects - so a second device's own
+    // transitions never moved it, never notified, and left that row frozen on
+    // "Connecting..." while the phone was demonstrably serving data.
+    rosterDevices = [deviceA, deviceB];
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const sessions = await openSessions(service);
+    const sessionA = sessions.get('device-A');
+    const sessionB = sessions.get('device-B');
+    if (!sessionA || !sessionB) throw new Error('both device sessions must be opened');
+
+    // A is fully up: transport connected AND handshake established. That alone
+    // pins the aggregate at 'connected' for the rest of the test.
+    sessionA.setTransportState('connected');
+    sessionA.setConnectionState('connected');
+    // B's transport is up too, but it is still handshaking, so its own row
+    // correctly reads 'connecting'.
+    sessionB.setTransportState('connected');
+    await vi.advanceTimersByTimeAsync(500);
+    expect(service.getStatus().relayState).toBe('connected');
+
+    const stateChanged = vi.fn();
+    service.on('stateChanged', stateChanged);
+
+    // B establishes. The aggregate is 'connected' before AND after, so the old
+    // gate swallowed this and the renderer never re-fetched.
+    sessionB.setConnectionState('connected');
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(stateChanged).toHaveBeenCalledTimes(1);
+    expect(service.listDevices().find((device) => device.deviceId === 'device-B')?.connectionState).toBe('connected');
+
+    service.dispose();
+  });
+
+  it('emits when one device drops while another stays connected (the same gap, mirrored)', async () => {
+    // The other direction of the same bug: a device going away while a healthy
+    // one holds the aggregate at 'connected' left a green "Connected" badge on
+    // a phone that was gone.
+    rosterDevices = [deviceA, deviceB];
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const sessions = await openSessions(service);
+    const sessionA = sessions.get('device-A');
+    const sessionB = sessions.get('device-B');
+    if (!sessionA || !sessionB) throw new Error('both device sessions must be opened');
+
+    sessionA.setTransportState('connected');
+    sessionA.setConnectionState('connected');
+    sessionB.setTransportState('connected');
+    sessionB.setConnectionState('connected');
+    await vi.advanceTimersByTimeAsync(500);
+
+    const stateChanged = vi.fn();
+    service.on('stateChanged', stateChanged);
+
+    // B's phone went away: the relay slot is still dialable, so B's TRANSPORT
+    // stays 'connected' and the aggregate never moves - only B's presence did.
+    sessionB.setConnectionState('offline');
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(stateChanged).toHaveBeenCalledTimes(1);
+    expect(service.getStatus().relayState).toBe('connected');
+    expect(service.listDevices().find((device) => device.deviceId === 'device-B')?.connectionState).toBe('offline');
 
     service.dispose();
   });
@@ -318,9 +412,9 @@ describe('MobileBridgeService.emitStateChanged() rebaselines the throttle on eve
     // setDeviceCapabilities(), the pairing 'confirmed' handler, and
     // dev-quick-pair's onRosterChanged all emit 'stateChanged' directly,
     // bypassing scheduleRelayStateEmit()'s timer entirely. If any of those
-    // paths does not ALSO rebaseline lastEmittedRelayState (the bug this
-    // guards), the throttle's next real transition gets compared against a
-    // stale baseline and is silently swallowed.
+    // paths does not ALSO rebaseline lastEmittedConnectionSignature (the bug
+    // this guards), the throttle's next real transition gets compared against
+    // a stale baseline and is silently swallowed.
     rosterDevices = [deviceA];
     const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
     const sessions = await openSessions(service);
@@ -328,8 +422,8 @@ describe('MobileBridgeService.emitStateChanged() rebaselines the throttle on eve
     if (!sessionA) throw new Error('device-A session was not opened');
 
     // Baseline: A connects, the throttle's window elapses, and 'connected'
-    // is emitted (and captured as lastEmittedRelayState) through the normal
-    // scheduleRelayStateEmit() path.
+    // is emitted (and captured in lastEmittedConnectionSignature) through the
+    // normal scheduleRelayStateEmit() path.
     sessionA.setTransportState('connected');
     await vi.advanceTimersByTimeAsync(500);
     expect(service.getStatus().relayState).toBe('connected');
@@ -359,13 +453,41 @@ describe('MobileBridgeService.emitStateChanged() rebaselines the throttle on eve
     // compared this fresh 'connected' against that STALE, never-rebaselined
     // 'connected' and swallowed the emission, leaving the renderer's
     // indicator stuck forever. With the fix, revokeDevice()'s direct emit
-    // rebaselined lastEmittedRelayState to 'idle', so this transition is
-    // correctly recognized as a real change and emitted.
+    // rebaselined lastEmittedConnectionSignature to the 'idle' signature, so
+    // this transition is correctly recognized as a real change and emitted.
     sessionB.setTransportState('connected');
     await vi.advanceTimersByTimeAsync(500);
 
     expect(stateChanged).toHaveBeenCalledTimes(1);
     expect(service.getStatus().relayState).toBe('connected');
+
+    service.dispose();
+  });
+
+  it('a capability change still emits while every connection state sits unchanged', async () => {
+    // The direct-emit callers (rename / revoke / capabilities / pairing
+    // confirmed / dev quick pair) must stay UNCONDITIONAL. The throttle's
+    // signature covers connection state only, so routing them through
+    // scheduleRelayStateEmit() "for consistency" would compare a signature
+    // that cannot have moved and silently swallow the change. Capabilities
+    // stands in for the whole set here: it is a roster field the signature
+    // deliberately does not cover, and it is already stubbed above.
+    rosterDevices = [deviceA];
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const sessions = await openSessions(service);
+    const sessionA = sessions.get('device-A');
+    if (!sessionA) throw new Error('device-A session was not opened');
+
+    sessionA.setTransportState('connected');
+    sessionA.setConnectionState('connected');
+    await vi.advanceTimersByTimeAsync(500);
+
+    const stateChanged = vi.fn();
+    service.on('stateChanged', stateChanged);
+
+    service.setDeviceCapabilities('device-A', ['read-board', 'read-session']);
+
+    expect(stateChanged).toHaveBeenCalledTimes(1);
 
     service.dispose();
   });

--- a/tests/unit/mobile-store.test.ts
+++ b/tests/unit/mobile-store.test.ts
@@ -131,6 +131,65 @@ describe('loadStatus / loadDevices', () => {
 
     expect(useMobileStore.getState().devices).toEqual(devices);
   });
+
+  // ---------------------------------------------------------------------
+  // Out-of-order-reply guard (latestDevicesRequestId / latestStatusRequestId)
+  //
+  // 'stateChanged' fires loadDevices()/loadStatus() unsequenced, so an older
+  // in-flight call can resolve AFTER a newer overlapping one. Without the
+  // requestId guard, whichever promise settles last wins regardless of which
+  // call it came from, silently reintroducing stale badge data. Each test
+  // below resolves the NEWER call first, then the OLDER call, and asserts
+  // the store keeps the newer result.
+  // ---------------------------------------------------------------------
+
+  it('loadDevices() keeps the newer reply when an older overlapping call resolves last', async () => {
+    let resolveOlderCall: ((devices: MobilePairedDevice[]) => void) | undefined;
+    let resolveNewerCall: ((devices: MobilePairedDevice[]) => void) | undefined;
+    listDevicesMock
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveOlderCall = resolve; }))
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveNewerCall = resolve; }));
+
+    const olderDevices = [makeDevice({ deviceId: 'device-older' })];
+    const newerDevices = [makeDevice({ deviceId: 'device-newer' })];
+
+    const olderCall = useMobileStore.getState().loadDevices();
+    const newerCall = useMobileStore.getState().loadDevices();
+
+    // The NEWER call's reply lands first; the OLDER call's reply lands last.
+    // The store must keep the newer result, not be clobbered by the stale one.
+    resolveNewerCall?.(newerDevices);
+    await newerCall;
+    expect(useMobileStore.getState().devices).toEqual(newerDevices);
+
+    resolveOlderCall?.(olderDevices);
+    await olderCall;
+    expect(useMobileStore.getState().devices).toEqual(newerDevices);
+  });
+
+  it('loadStatus() keeps the newer reply when an older overlapping call resolves last', async () => {
+    let resolveOlderCall: ((status: MobileBridgeStatus) => void) | undefined;
+    let resolveNewerCall: ((status: MobileBridgeStatus) => void) | undefined;
+    getStatusMock
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveOlderCall = resolve; }))
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveNewerCall = resolve; }));
+
+    const olderStatus = makeStatus({ pairedDeviceCount: 1 });
+    const newerStatus = makeStatus({ pairedDeviceCount: 2 });
+
+    const olderCall = useMobileStore.getState().loadStatus();
+    const newerCall = useMobileStore.getState().loadStatus();
+
+    // The NEWER call's reply lands first; the OLDER call's reply lands last.
+    // The store must keep the newer result, not be clobbered by the stale one.
+    resolveNewerCall?.(newerStatus);
+    await newerCall;
+    expect(useMobileStore.getState().status).toEqual(newerStatus);
+
+    resolveOlderCall?.(olderStatus);
+    await olderCall;
+    expect(useMobileStore.getState().status).toEqual(newerStatus);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Settings > Mobile Devices now flips a paired device to **Connected** as soon as its session establishes, and reports a phone that is not attached as a new **Offline** state instead of a stale badge.

- `src/main/mobile-bridge/mobile-bridge-service.ts` - the `stateChanged` notification is gated on a per-device signature, not the panel-wide aggregate.
- `src/main/mobile-bridge/session/bridge-session.ts` - a `connectionState` getter composing transport + Noise KK establishment + peer presence, with a probe budget, a reconnect hold, and a frame-driven presence promotion.
- `src/shared/types.ts` - new derived `MobileDeviceConnectionState` union.
- `src/renderer/components/settings/tabs/MobileDevicesTab.tsx` - the `offline` badge case.
- `src/renderer/stores/mobile-store.ts` - out-of-order reply guards on both loaders.

## Why

After pairing, the badge sat on "Connecting..." while the phone reported `{ transportState: "connected", established: true }` and was already rendering a board fetched from that same desktop. The pre-existing `Dev Quick Pair` row showed the mirror failure: "Reconnecting..." across a healthy session, and "Connected" after that session had gone.

It is the first thing a user looks at after pairing, so the desktop disagreeing with the phone reads as "the pairing did not take" at exactly the wrong moment. During live testing it sent us hunting a protocol bug that did not exist.

Two independent causes, both confirmed in source rather than inferred:

1. **The notification was gated on an aggregate.** `listDevices()` always returned live truth, but the renderer only re-fetches on `stateChanged`, and `scheduleRelayStateEmit()` compared only `aggregateRelayState()`. Its precedence pins the aggregate at `connected` the moment any one device connects, so a second device's own transitions never moved it and never notified. Once the aggregate settled, every per-device value froze permanently at whatever the last fetch happened to see - stale in whichever direction it was pointing.
2. **"Connected" did not mean the phone was there.** `transportState` describes the desktop's relay socket, which reads `connected` whenever the relay is up and the slot is dialable, with the phone powered off. The only real presence signal (`isEstablished`) crossed IPC nowhere, and `session.emit('established')` had no listener anywhere in the service.

Ruled out before building: the roster persists no status (it is computed live), and the pairing ceremony's transport is closed on the success path before the roster session opens on a derived slot, so the badge was already reading the correct transport.

## How

**Signature-gated notification.** `lastEmittedRelayState` becomes `lastEmittedConnectionSignature`, covering the aggregate plus every device's own connection state. `emitStateChanged()` rebaselines the signature, so the documented stale-baseline bug does not reappear in the new dimension. Its five direct callers stay unconditional: the signature is a throttle input, not an emit precondition, and it deliberately does not cover `displayName` or `capabilities`, so routing them through the throttle "for consistency" would silently swallow a rename.

**Presence-aware badge.** `BridgeSession` tracks a `peerPresence` tri-state demoted only by evidence (an explicit `FrameTag.Final` goodbye, or a spent probe budget) and promoted by proof of life (a completed handshake, or any application frame we can decrypt). `MobileBridgeStatus.relayState` deliberately stays transport-based: it describes the relay link, not a phone.

`offline` is a presence conclusion rather than a transport state, so it lives on a derived `MobileDeviceConnectionState` and leaves `MobileBridgeTransportState` mirroring `@kangentic/protocol`'s `TransportState` exactly. No protocol package change, no wire change. It is kept distinct from `Reconnecting...` because the two call for opposite user actions (open the phone vs. fix the network), and because a spinner over a steady state is the same misleading-transient class of bug this PR fixes.

**Three hysteresis guards**, each added because its absence produced a concrete wrong badge:

- **Two-probe budget (~10s) before `offline`**, so one slow round trip never flashes it on a live phone.
- **A 2s reconnect hold** spanning the reconnect *and* the re-handshake. The relay force-closes both peers when either drops, so an ordinary phone reload costs a ~500ms redial plus a handshake; without the hold this fix would have surfaced `connected -> reconnecting -> connecting -> connected` on every reload, churn the old aggregate gate happened to hide.
- **Presence promoted by any decryptable frame.** Without it, a single dropped `msg1` on a lossy relay spends the whole budget and reports `offline` for a phone that is demonstrably still sending data - the exact mirror of the stale green "Connected".

The probe deadline is anchored to the start of an unestablished episode and is never restarted, because `HANDSHAKE_RETRY_MS` (3s) re-initiates faster than the 5s window expires: a restartable window would let a relay injecting garbage handshake frames hold `offline` permanently out of reach and pin the badge on "Connecting..." forever.

**Trade-off worth a reviewer's attention:** the four timing constants (5s probe timeout, 2-probe budget, 15s absent re-probe, 2s reconnect grace) are validated against fake timers only, not against a real relay round trip. The reconnect grace is the one most likely to need tuning on real hardware.

## Breaking changes

None. No IPC channel was added or changed, so the 7-layer surface is untouched, and `@kangentic/protocol` is not modified. `MobilePairedDevice.connectionState` widens by one member, which is source-compatible for every existing consumer; the renderer's exhaustive switch makes the new case a compile-time requirement rather than a silent fallthrough.

## Tests

CI runs lint, typecheck, unit, build, and the sharded UI and Linux Electron E2E tiers.

Added, each red-checked against the unfixed code:

- `tests/unit/mobile-bridge/mobile-bridge-relay-state.test.ts` - the pre-existing "does not emit again when the aggregate has not actually changed" assertion pinned the bug as correct behavior; it is rewritten to "nothing changed" and gains two red-green siblings covering both staleness directions, plus one pinning that a capability change still emits while every connection state sits still. `FakeBridgeSession` now models `connectionState` and its event.
- `tests/unit/mobile-bridge/bridge-session.test.ts` - the `connectionState` getter across handshake-in-flight, established, one failed probe (still `connecting`), a spent budget (`offline`), an explicit remote close, recovery when the phone returns, transport drop, the no-flicker reconnect hold, hold expiry, and the adversarial garbage-frame trickle.
- `tests/ui/mobile-devices-settings.spec.ts` - the `Offline` badge, and a live-update regression test where a second device connects while the first stays connected. The existing badge specs all fed a static device array and never fired a state change, which is why this shipped.
- `tests/unit/mobile-store.test.ts` - out-of-order reply guards on both loaders.

Not covered by any tier: the timing constants against a real relay and a physical phone. That check is the pairing flip, Offline after a kill, recovery on relaunch, and no flicker on a phone reload.

Generated with [Claude Code](https://claude.com/claude-code)
