### PR TITLE
fix: loosen the cramped padding on the task run-mode cards

### DIFF
--- a/src/renderer/components/dialogs/AdvancedOverridesSection.tsx
+++ b/src/renderer/components/dialogs/AdvancedOverridesSection.tsx
@@ -217,7 +217,7 @@ export function AdvancedOverridesSection({
           aria-checked={selected}
           onClick={mode === 'profile' ? selectProfileMode : selectOverrideMode}
           data-testid={testId}
-          className="w-full flex items-start gap-2.5 px-3 py-2 text-left cursor-pointer"
+          className="w-full flex items-start gap-2.5 px-4 py-2.5 text-left cursor-pointer"
         >
           <span
             className={`mt-px h-3.5 w-3.5 shrink-0 rounded-full border flex items-center justify-center transition-colors ${
@@ -231,9 +231,19 @@ export function AdvancedOverridesSection({
             <span className="block text-xs text-fg-faint mt-0.5">{description}</span>
           </span>
         </button>
-        {/* pl-9 aligns the body with the card's LABEL, not its dot: px-3 (12) +
-            dot (14) + gap-2.5 (10). */}
-        {selected && <div className="px-3 pb-2.5 pl-9">{body}</div>}
+        {/* pl-10 aligns the body with the card's LABEL, not its dot: the header's
+            px-4 (16) + dot (14) + gap-2.5 (10).
+            The other three sides are the card's frame, and it is deliberately
+            looser than the form's own space-y-3 (12) rhythm: a bordered card
+            holding bordered controls needs more clearance than a bare labelled
+            field does. pt-1.5 (6) against the header's py-2.5 (10) bottom padding
+            puts 16px between the description and the first label, so the body
+            reads as the branch's contents rather than as part of the header
+            block. pr-4 and pb-4 keep the fields off the card's edge - at the
+            previous 12px the bottom-right corner was the tightest point on the
+            whole card, with the body indented 36px on the left but running to
+            within 12px of the border on the right. */}
+        {selected && <div className="pl-10 pr-4 pt-1.5 pb-4">{body}</div>}
       </div>
     );
   };
@@ -317,7 +327,13 @@ export function AdvancedOverridesSection({
             // "for the whole task".
             'Pinned for the whole task, ignoring column settings.',
             'task-advanced-toggle',
-            <div className="space-y-2" data-testid="task-advanced-section">
+            // space-y-3 matches the form these cards sit in (NewTaskDialog /
+            // TaskDetailEditForm). On space-y-2 the override fields stacked
+            // tighter than the plain labelled fields above them, so the card
+            // read as denser than the dialog even though it holds more. The
+            // radiogroup's own space-y-2 stays tighter on purpose: that gap is
+            // what makes the two cards read as one either/or.
+            <div className="space-y-3" data-testid="task-advanced-section">
             {showAgentPicker && (
               <div>
                 <label className="text-xs text-fg-muted mb-1 block">Agent</label>


### PR DESCRIPTION
## What

Spacing polish on the "how this task runs" cards (Column Settings / Agent Override) in
`AdvancedOverridesSection`, the section shared by the New Task dialog and the task-detail edit
form. Three class changes, no structural or behavioral edits:

- card header `px-3 py-2` to `px-4 py-2.5`
- selected card body `px-3 pb-2.5 pl-9` to `pl-10 pr-4 pt-1.5 pb-4`
- Agent Override field stack `space-y-2` to `space-y-3`

## Why

The cards ran their contents into their own border. The selected body carried no top padding at
all, so the branch's first field sat 8px under the description and read as part of the header
block rather than as the branch's contents, and only 10px sat below the last control. The
override fields also stacked on `space-y-2` while every plain labelled field above them in the
same form uses `space-y-3`, so the cards read denser than the dialog despite holding more.

The most visible pinch was horizontal. The body is indented so it aligns under the card's label
rather than its dot, which is deliberate, but it then ran out to the card's ordinary 12px right
padding. That left the fields starting 36px from the left border and ending 12px from the right
one, with the bottom-right corner as the tightest point on the card.

Measured gutters, before and after:

| | before | after |
|---|---|---|
| left (border to fields) | 36px | 41px |
| right (fields to border) | 12px | 17px |
| bottom (last field to border) | 11px | 17px |
| header to body | 8px | 16px |
| between fields | 8px | 12px |

## How

The card's frame grows rather than the indent shrinking, so the body keeps its alignment under
the card label. `pl-10` is that alignment recomputed against the header's new padding
(`px-4` 16 + dot 14 + `gap-2.5` 10 = 40).

The frame is deliberately looser than the form's own 12px rhythm: a bordered card holding
bordered controls needs more clearance than a bare labelled field does. The interior, by
contrast, is put ON that rhythm (`space-y-3`), matching the fields above it.

Two things stay tight on purpose and are called out in the code comments so they are not
"fixed" later: the radiogroup's own `space-y-2` between the two cards, which is what makes them
read as one either/or rather than two independent settings, and the `mb-1` label gaps, which
already match the dialog's Priority and Branch labels.

Out of scope and unchanged: the two-card either/or structure, the neutral selection treatment,
the copy, and the body's alignment under the card label. All three are deliberate and documented
in the component's header comment.

## Breaking changes

None. Padding and gap classes only. No props, state, DOM structure, or `data-testid` changed.

## Tests

No new tests. The change is Tailwind spacing classes, and both `.claude/rules/cross-platform-parity.md`
(no pixel-exact layout assertions, because font metrics differ between local Windows and CI's
headless Linux) and `.claude/rules/ui-conventions.md` (spacing is not mechanized) argue against
asserting these values.

`tests/ui/task-level-overrides.spec.ts` (38 tests) exercises both run-mode branches, the profile
picker, all four override comboboxes, persistence, and the edit-mode path. It passes unchanged.

One thing worth knowing rather than having to find. That suite's height guard, "a To Do task
opens with its run-mode controls reachable without scrolling", reopens its task on the default
Column Settings branch and never clicks `task-advanced-toggle`, so it covers the collapsed case
only, where this branch measures 0px of scroll overflow. Measuring the expanded Agent Override
branch in the task-detail edit pane directly: it overflows that pane by 38px on `main` today and
by 62px here. The pane is `overflow-y-auto` and has always scrolled in that state, so this is not
a new failure mode, but this change does add roughly 24px to it (header padding on both cards,
the selected body's padding, and one extra `space-y` gap). Left as-is deliberately: a guard on
that branch would have to either commit red or pin a value that is already over the threshold
before this PR, and the cards' own reachability on open is what the existing guard protects.

Verified locally: `npm run typecheck`, `npm run lint`, and
`npx playwright test tests/ui/task-level-overrides.spec.ts` (38 passed). Visually confirmed by
rendering this branch's own code through the UI test harness and measuring the live
`getBoundingClientRect()` gutters, which is where the numbers in the table above come from.

Generated with [Claude Code](https://claude.com/claude-code)
