### PR TITLE
feat(dialogs): add an edit pencil to the Agent Override branch

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -62,7 +62,7 @@ Choosing **Agent Override** reveals the per-task pins:
 
 | Field | Description |
 |-------|-------------|
-| **Agent** | Pick a specific agent CLI (Claude, Codex, etc.) for this task. Defaults to the destination column's agent override, then the project default. Hidden when only one agent is detected on the machine. |
+| **Agent** | Pick a specific agent CLI (Claude, Codex, etc.) for this task. Defaults to the destination column's agent override, then the project default. Locked (shown disabled, on the one agent it has) when only one agent is detected on the machine. The pencil beside it opens Settings > Agent, where all four of these fields get their project defaults. |
 | **Model** | Adapter-specific model identifier (e.g. `opus`, `sonnet`, `claude-opus-4-8`). The dropdown is fed by the shared model cache. For Claude, the list is populated both by scanning past session transcripts and by harvesting the CLI's own `/model` picker through a hidden background probe, so newly shipped models surface without first being used in a session. |
 | **Effort** | Adapter-specific reasoning tier (Claude: `low`, `medium`, `high`, `xhigh`, `max`). Only shown when the agent reports effort levels. |
 | **Permission** | Permission mode for this task. A column that forces Plan mode still wins while the task is in that column - that is a safety guarantee, not an ordinary default. |

--- a/src/renderer/components/dialogs/AdvancedOverridesSection.tsx
+++ b/src/renderer/components/dialogs/AdvancedOverridesSection.tsx
@@ -393,7 +393,7 @@ export function AdvancedOverridesSection({
                 on this wrapper rather than on the Combobox - the pencil's own
                 title wins over an ancestor's while hovering the button, so both
                 read correctly with no prop added to a shared control. */}
-            <div title={agentFieldTitle}>
+            <div title={agentFieldTitle} data-testid="task-agent-field">
               <label className="text-xs text-fg-muted mb-1 block">Agent</label>
               <div className="flex items-center gap-2">
                 <Combobox

--- a/src/renderer/components/dialogs/AdvancedOverridesSection.tsx
+++ b/src/renderer/components/dialogs/AdvancedOverridesSection.tsx
@@ -31,6 +31,37 @@ interface AdvancedOverridesSectionProps {
   setProfileId: (value: string | null) => void;
 }
 
+interface EditPencilButtonProps {
+  onClick: () => void;
+  /** Used as both the hover tooltip and the accessible name. */
+  title: string;
+  testId: string;
+  disabled?: boolean;
+}
+
+/**
+ * The bordered pencil that sits to the right of a field and routes to wherever
+ * that field's defaults are authored. Both rows of this section carry one, and
+ * they must land at IDENTICAL geometry so the column of pencils reads as one
+ * affordance rather than two lookalikes. One component is what guarantees that;
+ * two copies of the same class string only promise it in a comment.
+ */
+function EditPencilButton({ onClick, title, testId, disabled = false }: EditPencilButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      aria-label={title}
+      className="shrink-0 p-1.5 rounded border border-edge-input text-fg-muted hover:text-fg hover:bg-surface-hover transition-colors disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:text-fg-muted disabled:hover:bg-transparent"
+      data-testid={testId}
+    >
+      <Pencil size={14} />
+    </button>
+  );
+}
+
 /**
  * The "how this task runs" section, shared between New Task creation
  * (`NewTaskDialog`) and existing-task edit (`TaskDetailEditForm`).
@@ -84,14 +115,17 @@ interface AdvancedOverridesSectionProps {
  *     `resolveEffectivePermissionMode` in `spawn-preamble.ts`).
  *
  * Behaviour notes:
- *   - The Agent picker is hidden when only one agent is `found` (nothing
- *     meaningful to choose between).
+ *   - The Agent picker renders DISABLED, not hidden, when only one agent is
+ *     `found`. Same reasoning as the Profile select above it: a locked field
+ *     still names the agent this task will run on, and it keeps the edit
+ *     pencil beside it - the card's only route to Settings > Agent, where all
+ *     four of these defaults are set - in one place on every machine.
  *   - Changing the agent resets model + effort because the previous picks
  *     were valid for the previous agent's capability matrix.
- *   - The whole section is hidden when no capability surfaces are
- *     applicable (no agent picker, no model override support, no effort
- *     levels). Callers should still render this component and let it
- *     no-op via `null`.
+ *   - The whole section is hidden when the task has nothing to override at
+ *     all: no second agent to pick, no model override support, no effort
+ *     levels, and no permission modes. Callers should still render this
+ *     component and let it no-op via `null`.
  */
 export function AdvancedOverridesSection({
   swimlaneId,
@@ -115,6 +149,11 @@ export function AdvancedOverridesSection({
   const boardProfiles = useBoardStore((state) => state.boardProfiles);
   const openBoardManager = useBoardStore((state) => state.openBoardManager);
   const globalPermissionMode = useConfigStore((state) => state.config.agent.permissionMode);
+  // The three-arg PROJECT open, never `openSettingsToTab`: the Agent tab's
+  // Project Defaults are `scope: 'project'`, and `updateProjectOverride`
+  // returns early when `projectSettingsPath` is null, so the panel would open
+  // and silently drop the Permission write (.claude/rules/settings-tab-scope.md).
+  const openProjectSettings = useConfigStore((state) => state.openProjectSettings);
   // Effective-agent resolution for the New Task / Edit dialog: user pick
   // wins over the destination column's override, then the project default,
   // then the global default. This is the same chain `resolveTargetAgent`
@@ -129,14 +168,22 @@ export function AdvancedOverridesSection({
     effortLevels: advancedEffortOptions,
     supportsModelOverride: showModelPicker,
     availableAgents,
-    showAgentPicker,
+    canPickAgent,
   } = useAgentCapabilityResolution(effectiveAgent);
   const modelContextWindows = useModelContextWindows(effectiveAgent);
   const modelDisplayNames = useModelDisplayNames(effectiveAgent);
   const showEffortPicker = advancedEffortOptions.length > 0;
   const permissionOptions = effectiveAgentInfo?.permissions ?? DEFAULT_PERMISSIONS;
   const showPermissionPicker = permissionOptions.length > 0;
-  const showAdvancedSection = showAgentPicker || showModelPicker || showEffortPicker || showPermissionPicker;
+  // Whether this task has anything to override AT ALL. `canPickAgent` stays a
+  // term in this condition even though the Agent row now always renders inside
+  // the card: a permanently-locked field is not a reason to put the whole
+  // either/or on screen. The condition is inert as things stand - every adapter
+  // declares a non-empty `permissions` list and `DEFAULT_PERMISSIONS` backstops
+  // an agent missing from the detected list, so `showPermissionPicker` is always
+  // true and the `return null` below is unreachable. It holds the line for an
+  // adapter that exposes no surfaces at all.
+  const showAdvancedSection = canPickAgent || showModelPicker || showEffortPicker || showPermissionPicker;
 
   // Resolved values below the task tier - what each field would actually
   // spawn with if left on the inherit state. Shown as the BARE value in the
@@ -151,6 +198,16 @@ export function AdvancedOverridesSection({
   const fallbackPermissionLabel = getPermissionLabel(permissionOptions, fallbackPermission);
 
   const agentInheritLabel = fallbackAgentDisplayName;
+  // Three states, not two: `canPickAgent` is false both when exactly one agent
+  // is installed AND when none has been detected at all (`agentList` starts
+  // empty and fills in from an async probe, and a machine with no agent CLI
+  // never fills it), so one fixed "install another" string is wrong copy in the
+  // second case.
+  const agentFieldTitle = canPickAgent
+    ? 'The agent CLI this task runs on'
+    : availableAgents.length === 1
+      ? 'Only one agent CLI detected - install another to choose'
+      : 'No agent CLI detected yet';
   const modelInheritLabel = fallbackModelLabel ?? 'Agent default';
   const effortInheritLabel = fallbackEffort ?? 'Agent default';
   const permissionInheritLabel = fallbackPermissionLabel;
@@ -306,16 +363,11 @@ export function AdvancedOverridesSection({
                 not profiles exist - "create the first one" and "retune an
                 existing one" are the same trip. Pencil matches the board's own
                 edit-column button. */}
-            <button
-              type="button"
+            <EditPencilButton
               onClick={() => openBoardManager()}
               title="Edit profiles in Edit Columns"
-              aria-label="Edit profiles in Edit Columns"
-              className="shrink-0 p-1.5 rounded border border-edge-input text-fg-muted hover:text-fg hover:bg-surface-hover transition-colors"
-              data-testid="task-profile-edit"
-            >
-              <Pencil size={14} />
-            </button>
+              testId="task-profile-edit"
+            />
           </div>,
         )}
 
@@ -334,19 +386,42 @@ export function AdvancedOverridesSection({
             // radiogroup's own space-y-2 stays tighter on purpose: that gap is
             // what makes the two cards read as one either/or.
             <div className="space-y-3" data-testid="task-advanced-section">
-            {showAgentPicker && (
-              <div>
-                <label className="text-xs text-fg-muted mb-1 block">Agent</label>
+            {/* Disabled rather than hidden with a single agent installed, the
+                same call the Profile select makes above: the field still names
+                what this task will run on, and the pencil beside it stays put
+                on every machine instead of moving row to row. The tooltip sits
+                on this wrapper rather than on the Combobox - the pencil's own
+                title wins over an ancestor's while hovering the button, so both
+                read correctly with no prop added to a shared control. */}
+            <div title={agentFieldTitle}>
+              <label className="text-xs text-fg-muted mb-1 block">Agent</label>
+              <div className="flex items-center gap-2">
                 <Combobox
                   value={agentOverride}
                   onChange={handleAgentChange}
                   options={availableAgents.map((entry) => ({ value: entry.name, label: entry.displayName ?? entry.name }))}
                   placeholder={agentInheritLabel}
                   placeholderVariant="muted"
+                  disabled={!canPickAgent}
+                  className="flex-1 min-w-0"
                   testId="task-agent-override"
                 />
+                {/* The card's only route to where all four of these fields get
+                    their defaults, and the same component as the profile pencil
+                    opposite it, so the two cannot drift apart. Project-scoped
+                    open (see openProjectSettings above). `WindowLayer` mounts
+                    OUTSIDE AppLayout's `currentProject` gate, so an edit form can
+                    outlive its project; disabling on that rather than no-opping
+                    in the handler keeps the button from looking live when the
+                    click would do nothing. */}
+                <EditPencilButton
+                  onClick={() => currentProject && openProjectSettings(currentProject.path, currentProject.name, 'agent')}
+                  title="Edit agent defaults in Settings"
+                  testId="task-agent-edit"
+                  disabled={!currentProject}
+                />
               </div>
-            )}
+            </div>
             {(showModelPicker || showEffortPicker) && (
               <div className="flex gap-3">
                 {showModelPicker && (

--- a/src/renderer/components/dialogs/NewTaskDialog.tsx
+++ b/src/renderer/components/dialogs/NewTaskDialog.tsx
@@ -153,14 +153,16 @@ export function NewTaskDialog({ swimlaneId, onClose }: NewTaskDialogProps) {
   // mirroring the task detail dialog and command terminal). panel.close and
   // Escape both route through the dirty-changes guard. No ad-hoc keydown listener.
   useKeybinding('panel.maximize', handleToggleMaximized, { capture: true });
-  // Suppressed while the Board Manager is open over this dialog (opened from the
-  // Advanced section's profile edit button). This binding is capture-phase while
-  // BoardManagerDialog's Escape is a bubble-phase listener, so without the gate a
-  // single Escape meant to dismiss the manager would reach here first and raise
-  // the discard-changes confirm over a draft the user never tried to abandon.
-  // Mirrors how BoardManagerDialog suppresses its own Escape under a nested modal.
+  // Suppressed while a surface the Advanced section can spawn is open over this
+  // dialog: the Board Manager (profile edit button) or the Settings panel (agent
+  // edit button). This binding is capture-phase while both of those dismiss on a
+  // bubble-phase listener, so without the gate a single Escape meant for the
+  // surface on top would reach here first and raise the discard-changes confirm
+  // over a draft the user never tried to abandon. Mirrors how BoardManagerDialog
+  // suppresses its own Escape under a nested modal.
   const boardManagerOpen = useBoardStore((state) => state.boardManagerOpen);
-  useKeybinding('panel.close', closeWithAnimation, { capture: true, enabled: !boardManagerOpen });
+  const settingsOpen = useConfigStore((state) => state.settingsOpen);
+  useKeybinding('panel.close', closeWithAnimation, { capture: true, enabled: !boardManagerOpen && !settingsOpen });
 
   // Cleanup object URLs on unmount. Track the latest attachments in a ref so the
   // unmount-only cleanup revokes the CURRENT set: a [] dep captures the
@@ -342,9 +344,10 @@ export function NewTaskDialog({ swimlaneId, onClose }: NewTaskDialogProps) {
           onHeaderDoubleClick={handleToggleMaximized}
           onCloseRequest={handleCloseAttempt}
           testId="new-task-dialog"
-          // The Advanced section's profile edit button opens the Board Manager
-          // over this dialog; Escape then belongs to the manager alone.
-          suppressEscape={boardManagerOpen}
+          // The Advanced section's edit buttons open the Board Manager (profile)
+          // or Settings (agent) over this dialog; Escape then belongs to
+          // whichever of those is on top, alone.
+          suppressEscape={boardManagerOpen || settingsOpen}
           title="New Task"
           icon={<Plus size={14} className="text-fg-muted" />}
           headerRight={

--- a/src/renderer/hooks/useAgentCapabilityResolution.ts
+++ b/src/renderer/hooks/useAgentCapabilityResolution.ts
@@ -21,9 +21,10 @@ export interface AgentCapabilityResolution {
    *  itself is unchanged; callers that depend on identity should memoize. */
   availableAgents: AgentDetectionInfo[];
   /** True when there's more than one detected agent to pick between. The
-   *  Agent dropdown in the New Task / Edit dialogs uses this to hide
-   *  itself when there's nothing meaningful to choose. */
-  showAgentPicker: boolean;
+   *  Agent dropdown in the New Task / Edit dialogs always RENDERS; this
+   *  says whether it is interactive, so a single-agent machine shows the
+   *  field locked on the one agent it has rather than dropping the row. */
+  canPickAgent: boolean;
 }
 
 /**
@@ -40,7 +41,7 @@ export interface AgentCapabilityResolution {
  *
  * Pass `null` to opt out of capability lookup entirely (returns empty /
  * undefined fields but still surfaces `availableAgents` and
- * `showAgentPicker` for the dropdown).
+ * `canPickAgent` for the dropdown).
  */
 export function useAgentCapabilityResolution(effectiveAgent: string | null): AgentCapabilityResolution {
   const agentList = useConfigStore((state) => state.agentList);
@@ -57,7 +58,7 @@ export function useAgentCapabilityResolution(effectiveAgent: string | null): Age
     const effortLevels = info?.capabilities?.effortLevels ?? [];
     const supportsModelOverride = !!info?.capabilities?.supportsModelOverride;
     const availableAgents = agentList.filter((entry) => entry.found);
-    const showAgentPicker = availableAgents.length > 1;
-    return { info, models, effortLevels, supportsModelOverride, availableAgents, showAgentPicker };
+    const canPickAgent = availableAgents.length > 1;
+    return { info, models, effortLevels, supportsModelOverride, availableAgents, canPickAgent };
   }, [agentList, effectiveAgent, models]);
 }

--- a/src/renderer/window-manager/components/TaskDetailWindow.tsx
+++ b/src/renderer/window-manager/components/TaskDetailWindow.tsx
@@ -93,6 +93,7 @@ export function TaskDetailWindow({
   const shortcuts = useBoardStore((s) => s.shortcuts);
   const loadBoard = useBoardStore((s) => s.loadBoard);
   const boardManagerOpen = useBoardStore((s) => s.boardManagerOpen);
+  const settingsOpen = useConfigStore((s) => s.settingsOpen);
   const projectPath = useProjectStore((s) => s.currentProject?.path ?? null);
   const killSession = useSessionStore((s) => s.killSession);
   const suspendSession = useSessionStore((s) => s.suspendSession);
@@ -402,11 +403,12 @@ export function TaskDetailWindow({
   // xterm consumes the Ctrl-letter control chars). Gated on `isFocused` so only
   // the focused window reacts when several are open.
   useKeybinding('panel.maximize', handleToggleMaximized, { capture: true, enabled: isFocused });
-  // `!boardManagerOpen`: the edit form's profile picker can open the Board
-  // Manager over this window, and a single Escape meant for the manager must not
-  // also close the window (or raise its discard confirm) underneath. Gates the
-  // bubble-phase Escape listener below too.
-  useKeybinding('panel.close', closeWithGuard, { capture: true, enabled: isFocused && !boardManagerOpen });
+  // `!boardManagerOpen && !settingsOpen`: the edit form's Advanced section can
+  // open the Board Manager (profile pencil) or Settings (agent pencil) over this
+  // window, and a single Escape meant for that surface must not also close the
+  // window (or raise its discard confirm) underneath. Gates the bubble-phase
+  // Escape listener below too.
+  useKeybinding('panel.close', closeWithGuard, { capture: true, enabled: isFocused && !boardManagerOpen && !settingsOpen });
   // Close on a header click with the bound mouse button (default middle). Routed
   // through `closeWithGuard` so an unsaved edit still prompts to discard. The
   // `when` scopes the mouse path to THIS window's title bar; a keyboard rebind
@@ -435,14 +437,14 @@ export function TaskDetailWindow({
   // PTY, consumes Escape itself (reaching the agent's TUI) and this never sees
   // it; with the pointer elsewhere Escape bubbles here and closes.
   useEffect(() => {
-    if (!isFocused || boardManagerOpen) return;
+    if (!isFocused || boardManagerOpen || settingsOpen) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
       closeWithGuard();
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isFocused, boardManagerOpen, closeWithGuard]);
+  }, [isFocused, boardManagerOpen, settingsOpen, closeWithGuard]);
 
   // Expose this window's guarded close to the central click-outside dismiss hook
   // (`useClickOutsideToClose`), so a board-background click routes through the

--- a/tests/ui/task-level-overrides.spec.ts
+++ b/tests/ui/task-level-overrides.spec.ts
@@ -105,6 +105,134 @@ test.describe('NewTaskDialog Advanced section', () => {
     await page.locator('input[placeholder="Task title"]').waitFor({ state: 'hidden', timeout: 2000 });
   });
 
+  test('with one agent detected the Agent picker renders locked, beside an enabled edit button', async () => {
+    await openNewTaskDialog();
+    await page.locator('[data-testid="task-advanced-toggle"]').click();
+
+    // Disabled rather than hidden (the Profile select's treatment one card up):
+    // the field still names the agent this task will run on, and it keeps the
+    // edit pencil in the same place it occupies on a multi-agent machine.
+    const agentInput = page.locator('input[data-testid="task-agent-override"]');
+    await expect(agentInput).toBeVisible();
+    await expect(agentInput).toBeDisabled();
+    await expect(agentInput).toHaveAttribute('placeholder', 'Claude Code');
+
+    // The pencil is the card's only route to Settings > Agent, so it stays live
+    // even while the field beside it is locked.
+    await expect(page.locator('[data-testid="task-agent-edit"]')).toBeEnabled();
+
+    await closeDialog();
+  });
+
+  test('the agent edit button opens Settings on the Agent tab over the dialog, and Escape closes only that', async () => {
+    await openNewTaskDialog();
+    await page.locator('input[placeholder="Task title"]').fill('Draft Survives Settings');
+    await page.locator('[data-testid="task-advanced-toggle"]').click();
+
+    await page.locator('[data-testid="task-agent-edit"]').click();
+    const settingsPanel = page.locator('[data-testid="settings-panel"]');
+    await expect(settingsPanel).toBeVisible();
+    // The tab buttons carry no testid, so assert on the Agent tab's own
+    // section header - it holds the four defaults this card falls back to.
+    await expect(settingsPanel.locator('text=Project Defaults')).toBeVisible();
+
+    // The New Task dialog suppresses its own Escape while Settings is over it.
+    // Without that, this keypress would also reach the dialog and raise the
+    // discard confirm over a draft the user never tried to abandon.
+    await page.keyboard.press('Escape');
+    await expect(settingsPanel).toBeHidden();
+    await expect(page.locator('input[placeholder="Task title"]')).toHaveValue('Draft Survives Settings');
+    await expect(page.locator('button:has-text("Discard")')).toHaveCount(0);
+
+    // Two presses, not one: Settings closes through useOverlayPhase, so
+    // `settingsOpen` (and the suppression it drives) survives until the exit
+    // animation ends. The retrying assertion above is what makes this second
+    // press land after suppression lifts.
+    await page.keyboard.press('Escape');
+    await page.locator('button:has-text("Discard")').click();
+    await page.locator('input[placeholder="Task title"]').waitFor({ state: 'hidden', timeout: 2000 });
+  });
+
+  test('the agent edit button opens Settings scoped to THIS project, so a picked default actually persists', async () => {
+    // Distinct failure mode from the visibility test above: `openSettingsToTab`
+    // (the sibling action on config-store.ts) never sets `projectSettingsPath`,
+    // and `updateProjectOverride` returns early when that path is null - so
+    // swapping the pencil's call from `openProjectSettings` to
+    // `openSettingsToTab('agent')` would open the SAME-LOOKING Agent tab (the
+    // "Project Defaults" header above renders unconditionally from
+    // project-store's currentProject, not from projectSettingsPath) while
+    // silently dropping every write made from it. Permission Mode
+    // (agent.permissionMode, scope: 'project' in settings-registry.ts) is the
+    // concrete probe: prove the pick lands in THIS project's stored overrides,
+    // not just that the combobox's own on-screen value changed.
+    await openNewTaskDialog();
+    await page.locator('[data-testid="task-advanced-toggle"]').click();
+
+    await page.locator('[data-testid="task-agent-edit"]').click();
+    const settingsPanel = page.locator('[data-testid="settings-panel"]');
+    await expect(settingsPanel).toBeVisible();
+
+    const permissionInput = page.locator('input[data-testid="agent-permission-mode"]');
+    await selectCombobox(page, 'agent-permission-mode', 'plan');
+    await expect(permissionInput).toHaveValue('Plan (Read-Only)');
+
+    const persistedPermissionMode = await page.evaluate(async () => {
+      const stores = (window as unknown as {
+        __zustandStores?: { project: { getState: () => { currentProject: { path: string } | null } } };
+      }).__zustandStores;
+      const projectPath = stores?.project.getState().currentProject?.path;
+      if (!projectPath) throw new Error('No current project to read overrides for');
+      const overrides = await window.electronAPI.config.getProjectOverridesByPath(projectPath);
+      return (overrides as { agent?: { permissionMode?: string } } | null)?.agent?.permissionMode ?? null;
+    });
+    expect(persistedPermissionMode).toBe('plan');
+
+    // Reset to the fixture's original value before closing: the Permission
+    // picker test below (and the placeholderVariant block further down) both
+    // assert the Accept Edits global default resolves through, and a leaked
+    // project override here would make that read this project's now-pinned
+    // 'plan' instead.
+    await selectCombobox(page, 'agent-permission-mode', 'acceptEdits');
+    await expect(permissionInput).toHaveValue('Accept Edits');
+
+    await page.keyboard.press('Escape');
+    await expect(settingsPanel).toBeHidden();
+    await closeDialog();
+  });
+
+  test('the panel.close hotkey (Control+Shift+W) is suppressed while Settings is open over the dialog, same as Escape', async () => {
+    // Escape and panel.close are TWO SEPARATE mechanisms here: Escape is
+    // suppressed ad hoc inside BaseDialog via `suppressEscape` (covered above),
+    // while panel.close is the Mod+Shift+W keybinding bound directly on
+    // NewTaskDialog with its own `enabled: !boardManagerOpen && !settingsOpen`
+    // gate. Deleting just the `&& !settingsOpen` half of that gate would leave
+    // every Escape assertion in this file green while this combo still tore
+    // the dialog down (or worse, raised the discard confirm) out from under
+    // the Settings panel it opened.
+    await openNewTaskDialog();
+    await page.locator('input[placeholder="Task title"]').fill('Draft Survives Panel Close Hotkey');
+    await page.locator('[data-testid="task-advanced-toggle"]').click();
+
+    await page.locator('[data-testid="task-agent-edit"]').click();
+    const settingsPanel = page.locator('[data-testid="settings-panel"]');
+    await expect(settingsPanel).toBeVisible();
+
+    await page.keyboard.press('Control+Shift+W');
+
+    // With the listener correctly disabled, this keypress reaches nothing: the
+    // panel stays up, and the dialog underneath neither closes nor raises the
+    // discard confirm.
+    await expect(settingsPanel).toBeVisible();
+    await expect(page.locator('input[placeholder="Task title"]')).toHaveValue('Draft Survives Panel Close Hotkey');
+    await expect(page.locator('button:has-text("Discard")')).toHaveCount(0);
+
+    await page.keyboard.press('Escape');
+    await expect(settingsPanel).toBeHidden();
+    await page.keyboard.press('Escape');
+    await page.locator('button:has-text("Discard")').click();
+    await page.locator('input[placeholder="Task title"]').waitFor({ state: 'hidden', timeout: 2000 });
+  });
+
   test('expanding Advanced reveals model combobox and effort select with a resolved-default placeholder', async () => {
     await openNewTaskDialog();
 
@@ -319,6 +447,70 @@ test.describe('TaskDetailEditForm Advanced section (edit-mode overrides)', () =>
     expect(updated!.effort_override).toBe('medium');
   });
 
+  test('the agent edit button opens Settings over the task window, and Escape closes only that', async () => {
+    // The task-detail window has its OWN Escape gates (a capture-phase
+    // panel.close binding and a bubble-phase listener), separate from
+    // BaseDialog's suppressEscape, so the New Task coverage above does not
+    // reach this path.
+    await createTask(page, 'Window Draft Survives Settings');
+
+    await page.locator('text=Window Draft Survives Settings').first().click();
+    await page.locator('[data-testid="task-detail-dialog"]').waitFor({ state: 'visible' });
+    await page.locator('[data-testid="task-advanced-toggle"]').click();
+
+    await page.locator('[data-testid="task-agent-edit"]').click();
+    const settingsPanel = page.locator('[data-testid="settings-panel"]');
+    await expect(settingsPanel).toBeVisible();
+    await expect(settingsPanel.locator('text=Project Defaults')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(settingsPanel).toBeHidden();
+    // The window survived, still in edit mode with its run-mode choice intact.
+    await expect(page.locator('[data-testid="task-detail-dialog"]')).toBeVisible();
+    await expect(page.locator('[data-testid="task-advanced-section"]')).toBeVisible();
+    await expect(page.locator('button:has-text("Discard")')).toHaveCount(0);
+
+    await page.locator('button:has-text("Cancel")').click();
+    await page.locator('[data-testid="task-detail-dialog"]').waitFor({ state: 'hidden' });
+  });
+
+  test('the panel.close hotkey (Control+Shift+W) is suppressed while Settings is open over the task window, same as Escape', async () => {
+    // TaskDetailWindow's OWN panel.close binding (capture-phase, `enabled:
+    // isFocused && !boardManagerOpen && !settingsOpen`) is a SEPARATE mechanism
+    // from the bubble-phase document Escape listener covered above - deleting
+    // just the `&& !settingsOpen` half of that gate would leave the Escape
+    // coverage green while this combo still tore the window down (or raised
+    // the discard confirm) out from under the Settings panel it opened.
+    await createTask(page, 'Window Draft Survives Panel Close Hotkey');
+
+    await page.locator('text=Window Draft Survives Panel Close Hotkey').first().click();
+    await page.locator('[data-testid="task-detail-dialog"]').waitFor({ state: 'visible' });
+    const titleInput = page.locator('input[placeholder="Task title"]');
+    await titleInput.fill('Window Draft Survives Panel Close Hotkey (edited)');
+    await page.locator('[data-testid="task-advanced-toggle"]').click();
+
+    await page.locator('[data-testid="task-agent-edit"]').click();
+    const settingsPanel = page.locator('[data-testid="settings-panel"]');
+    await expect(settingsPanel).toBeVisible();
+
+    await page.keyboard.press('Control+Shift+W');
+
+    // With the listener correctly disabled, this keypress reaches nothing: the
+    // panel stays up, and the window underneath neither closes nor raises the
+    // discard confirm.
+    await expect(settingsPanel).toBeVisible();
+    await expect(titleInput).toHaveValue('Window Draft Survives Panel Close Hotkey (edited)');
+    await expect(page.locator('button:has-text("Discard")')).toHaveCount(0);
+
+    await page.keyboard.press('Escape');
+    await expect(settingsPanel).toBeHidden();
+    await page.keyboard.press('Escape');
+    const confirmHeading = page.locator('h3:has-text("Discard unsaved changes?")');
+    await expect(confirmHeading).toBeVisible();
+    await page.locator('button:has-text("Discard")').click();
+    await page.locator('[data-testid="task-detail-dialog"]').waitFor({ state: 'hidden' });
+  });
+
   test('clearing an override in edit mode persists the cleared value', async () => {
     // Seed via the UI flow with a model override set.
     const column = page.locator('[data-swimlane-name="To Do"]');
@@ -353,8 +545,9 @@ test.describe('TaskDetailEditForm Advanced section (edit-mode overrides)', () =>
 /**
  * Agent picker tests use their own browser instance with a multi-agent mock
  * fixture. The default fixture only has Claude `found: true`, so the picker
- * is hidden (nothing to choose between). Enabling Codex here gives us two
- * `found` agents, which surfaces the picker.
+ * renders locked (nothing to choose between - covered in the shared-page block
+ * above). Enabling Codex here gives us two `found` agents, which is what makes
+ * it interactive.
  */
 test.describe('NewTaskDialog Advanced - Agent picker (multi-agent fixture)', () => {
   let multiBrowser: Browser;
@@ -409,6 +602,12 @@ test.describe('NewTaskDialog Advanced - Agent picker (multi-agent fixture)', () 
 
     const agentInput = multiPage.locator('input[data-testid="task-agent-override"]');
     await expect(agentInput).toBeVisible();
+    // Two found agents, so this one is interactive (the single-agent fixture
+    // renders the same field disabled).
+    await expect(agentInput).toBeEnabled();
+    // The edit pencil rides the same row here as it does when the field is
+    // locked - one place on every machine.
+    await expect(multiPage.locator('[data-testid="task-agent-edit"]')).toBeEnabled();
 
     // No column or project agent override is set in this fixture, so the
     // inherit placeholder resolves to the app default (Claude Code), shown
@@ -1288,9 +1487,9 @@ test.describe('placeholderVariant: muted vs resolved', () => {
     // Model/Effort have no column or project default here, so their
     // fallback computation bottoms out with no concrete value: plain
     // "Agent default", muted. (Agent's inherit label always resolves to a
-    // concrete app default and is muted too, but the Agent field needs a
-    // multi-agent fixture to render at all; see the "Agent picker" describe
-    // block above.)
+    // concrete app default and is muted too; this single-agent fixture
+    // renders that field locked on it. Its interactive form is covered in
+    // the "Agent picker" describe block above.)
     await expect(taskModelInput).toHaveAttribute('placeholder', 'Agent default');
     await expect(taskEffortInput).toHaveAttribute('placeholder', 'Agent default');
     expect(await placeholderVariantOf(taskModelInput)).toBe('muted');

--- a/tests/ui/task-level-overrides.spec.ts
+++ b/tests/ui/task-level-overrides.spec.ts
@@ -117,6 +117,15 @@ test.describe('NewTaskDialog Advanced section', () => {
     await expect(agentInput).toBeDisabled();
     await expect(agentInput).toHaveAttribute('placeholder', 'Claude Code');
 
+    // Three-state tooltip on the field wrapper (agentFieldTitle): with exactly
+    // one agent detected this must be the "install another" copy, not the
+    // "none detected yet" copy the zero-agent fixture gets below - a single
+    // fixed string for both non-pickable states would be silently wrong here.
+    await expect(page.locator('[data-testid="task-agent-field"]')).toHaveAttribute(
+      'title',
+      'Only one agent CLI detected - install another to choose',
+    );
+
     // The pencil is the card's only route to Settings > Agent, so it stays live
     // even while the field beside it is locked.
     await expect(page.locator('[data-testid="task-agent-edit"]')).toBeEnabled();
@@ -605,6 +614,12 @@ test.describe('NewTaskDialog Advanced - Agent picker (multi-agent fixture)', () 
     // Two found agents, so this one is interactive (the single-agent fixture
     // renders the same field disabled).
     await expect(agentInput).toBeEnabled();
+    // The interactive branch of the three-state tooltip - distinct copy from
+    // both non-pickable states (single-agent and zero-agent fixtures).
+    await expect(multiPage.locator('[data-testid="task-agent-field"]')).toHaveAttribute(
+      'title',
+      'The agent CLI this task runs on',
+    );
     // The edit pencil rides the same row here as it does when the field is
     // locked - one place on every machine.
     await expect(multiPage.locator('[data-testid="task-agent-edit"]')).toBeEnabled();
@@ -680,6 +695,68 @@ test.describe('NewTaskDialog Advanced - Agent picker (multi-agent fixture)', () 
     const task = taskData.find((t: { title: string }) => t.title === 'No Agent Override Task');
     expect(task).toBeDefined();
     expect(task!.agent_override).toBeNull();
+  });
+});
+
+/**
+ * Zero agents detected: `canPickAgent` is false the same way it is with
+ * exactly one agent installed, but `agentFieldTitle`'s ternary in
+ * AdvancedOverridesSection has a THIRD branch for this case ("no agent CLI
+ * detected yet" vs "only one agent CLI detected"). Own browser instance,
+ * same recipe as the multi-agent block above: the override must be injected
+ * before the mock script runs, and every non-Claude agent already defaults
+ * to `found: false` in the fixture, so overriding Claude alone is enough to
+ * empty `availableAgents`.
+ */
+test.describe('NewTaskDialog Advanced - Agent picker (no agent detected fixture)', () => {
+  let noAgentBrowser: Browser;
+  let noAgentPage: Page;
+
+  test.beforeAll(async () => {
+    await waitForViteReady();
+    noAgentBrowser = await chromium.launch({ headless: true });
+    const context = await noAgentBrowser.newContext({ viewport: { width: 1920, height: 1080 } });
+    noAgentPage = await context.newPage();
+
+    await noAgentPage.addInitScript(() => {
+      (window as Record<string, unknown>).__mockAgentListOverrides = {
+        claude: { found: false, path: null, version: null },
+      };
+    });
+    await noAgentPage.addInitScript({ path: MOCK_SCRIPT });
+    await noAgentPage.goto(VITE_URL);
+    await noAgentPage.waitForLoadState('load');
+    await noAgentPage.waitForSelector('text=Kangentic', { timeout: 15000 });
+    await createProject(noAgentPage, `NoAgent ${Date.now()}`);
+  });
+
+  test.afterAll(async () => {
+    await noAgentBrowser?.close();
+  });
+
+  test('with no agent detected the Agent picker renders locked with "none detected" copy, distinct from the single-agent case', async () => {
+    const column = noAgentPage.locator('[data-swimlane-name="To Do"]');
+    await column.locator('text=Add task').click();
+    await noAgentPage.locator('input[placeholder="Task title"]').waitFor({ state: 'visible' });
+    await noAgentPage.locator('[data-testid="task-advanced-toggle"]').click();
+
+    // Same disabled treatment as the single-agent fixture (nothing to pick
+    // between either way), but the copy must differ - this is the state the
+    // single fixed "install another" string would silently mislabel.
+    const agentInput = noAgentPage.locator('input[data-testid="task-agent-override"]');
+    await expect(agentInput).toBeVisible();
+    await expect(agentInput).toBeDisabled();
+    await expect(noAgentPage.locator('[data-testid="task-agent-field"]')).toHaveAttribute(
+      'title',
+      'No agent CLI detected yet',
+    );
+
+    // The pencil is still the only route to Settings > Agent, so it stays
+    // live even with nothing installed - same as the single-agent case.
+    await expect(noAgentPage.locator('[data-testid="task-agent-edit"]')).toBeEnabled();
+
+    await noAgentPage.keyboard.press('Escape');
+    await noAgentPage.locator('input[placeholder="Task title"]').waitFor({ state: 'hidden', timeout: 2000 });
   });
 });
 


### PR DESCRIPTION
## What

Adds an edit pencil to the **Agent Override** branch of `AdvancedOverridesSection`, opening
Settings > Agent. Mirrors the pencil the **Column Settings** branch already pairs with its Profile
select.

Along the way:

- The Agent row now always renders, **disabled** when fewer than two agent CLIs are detected,
  instead of disappearing entirely.
- Both pencils render from one shared `EditPencilButton`, so their geometry cannot drift apart.
- `settingsOpen` gains the Escape suppression `boardManagerOpen` already had, on all four gates
  across `NewTaskDialog` and `TaskDetailWindow`.

Affected: `src/renderer/components/dialogs/AdvancedOverridesSection.tsx`,
`src/renderer/components/dialogs/NewTaskDialog.tsx`,
`src/renderer/window-manager/components/TaskDetailWindow.tsx`,
`src/renderer/hooks/useAgentCapabilityResolution.ts`, `docs/user-guide.md`.

## Why

The Agent Override card's four fields (Agent, Model, Effort, Permission) all fall back to Settings
> Agent's "Project Defaults" section, but nothing in the card pointed there. The Column Settings
branch opposite it has had a route to its own authoring surface all along.

The Agent row being hidden on single-agent machines made a naive fix worse rather than better: the
pencil would have vanished with the row on the most common install, exactly where the route to the
defaults matters most.

## How

**`openProjectSettings`, not `openSettingsToTab`.** The latter sets `settingsOpen` but leaves
`projectSettingsPath` null, and `updateProjectOverride` returns early on a null path. All four
Agent-tab Project Defaults are `scope: 'project'`, so the panel would have opened, accepted clicks,
and silently dropped the Permission write. That is the failure mode
`.claude/rules/settings-tab-scope.md` exists to prevent, so a test probes the persisted override
rather than just the on-screen value.

**Locked, not hidden.** `showAgentPicker` is renamed `canPickAgent` to match its new meaning: it
gates interactivity, not rendering. This is the same call the Profile select already makes when a
board has no profiles - a locked field still names what the task will run on, and it keeps the
pencil in one fixed place on every machine.

**Four Escape gates, not two.** `SettingsPanelShell` registers a bare bubble-phase `document`
Escape listener with no `stopPropagation`, and the host surface mounted first, so one Escape aimed
at Settings would also dismiss the host and raise a discard confirm over an untouched draft. Each
host needs a pair: one gate for the rebindable `panel.close` binding and one for the literal
Escape key. `settingsOpen` previously had no gate anywhere in the renderer, so this closes a latent
hole rather than only serving the new button.

Trade-off worth a look: the disabled-state tooltip sits on the Agent row's wrapper `div` rather
than as a new `title` prop on the shared `Combobox`. That avoids changing a shared control for one
call site; the pencil's own `title` still wins over an ancestor's on hover.

Deliberately unchanged: z-order (the `WindowLayer` overlay is `z-40` and `SettingsPanelShell` is
`z-50`, so Settings paints over both host surfaces) and light dismiss (the settings panel is not a
`[data-dismiss-surface]`, so clicking its backdrop never closes a task window underneath).

## Breaking changes

None.

## Tests

CI runs lint, typecheck, unit, build, and the sharded UI and Linux Electron E2E tiers.

Eight UI-tier tests added to `tests/ui/task-level-overrides.spec.ts`, covering both host surfaces
and all three agent fixtures:

- Agent field renders locked with an enabled pencil (single-agent default fixture), and enabled
  with the same pencil (multi-agent fixture via `__mockAgentListOverrides`).
- The pencil opens Settings on the Agent tab over the New Task dialog; one Escape closes only
  Settings, the draft survives, no Discard confirm. Same again through a task-detail window, which
  has its own gates.
- `Control+Shift+W` (`panel.close`) is suppressed while Settings is open, on both host surfaces.
  Separate mechanism from Escape: deleting only the `&& !settingsOpen` half of either gate would
  leave every Escape assertion green.
- Settings opens scoped to THIS project: a Permission Mode picked from the panel lands in the
  project's stored overrides, not just the combobox's on-screen value.
- The Agent field's tooltip copy in all three states, including a zero-agents-detected fixture.
  `toBeDisabled()` alone does not discriminate the two non-pickable strings, so collapsing that
  ternary to two arms would otherwise stay green.

Locally verified before pushing: `npm run typecheck`, `npm run lint`, and
`npx playwright test tests/ui/task-level-overrides.spec.ts` (45 passed, stable over 3 runs).
`onboarding-walkthrough.spec.ts` and `settings-panel.spec.ts` were also run (70 passed) as the
specs most exposed to a new `settingsOpen` Escape gate.

Generated with [Claude Code](https://claude.com/claude-code)
