### PR TITLE
feat(preview): notify the launching session when a preview exits

### DIFF
--- a/.claude/skills/preview/SKILL.md
+++ b/.claude/skills/preview/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Open dev server for previewing live code changes
 allowed-tools: Bash(node:*), Bash(npm:*)
-argument-hint: [--fresh]
+argument-hint: [--fresh] [--no-watch]
 ---
 
 # Preview
@@ -11,8 +11,14 @@ Open a new terminal window running a Kangentic dev server for previewing live co
 ## Instructions
 
 1. If the user passed `--fresh` (e.g. `/preview --fresh`), run `node scripts/worktree-preview.js --fresh`. Otherwise run `node scripts/worktree-preview.js`.
-2. Report the output — it will show the assigned port and directory.
-3. If the command fails, report the error message.
+2. Report the output - it will show the assigned port, PID, and a `Watch:` command.
+3. If the command fails, report the error message and stop.
+4. Unless the user passed `--no-watch`, or the launcher reported `PID: unknown` (the watcher cannot attach without a live PID file and would exit `1` immediately), run the printed `Watch:` command (`node scripts/worktree-preview.js --wait --port=<port>`) as a **separate Bash call with `run_in_background: true`**. Do not poll it, do not wrap it in a `Monitor`, and do not schedule a `ScheduleWakeup` fallback - it blocks until the preview exits, and the harness delivers a `<task-notification>` with its exit code on its own.
+5. When that notification arrives, tell the user what happened and stop offering a `--stop` command for that port:
+   - exit `0` - exited cleanly (user closed the terminal, or a `--stop` you or the user ran)
+   - exit `2` - crashed; point the user at the preview terminal's scrollback
+   - exit `3` - force-killed or the terminal was hard-closed
+   - exit `1` - the watcher couldn't attach (unlikely right after a successful launch)
 
 ## Notes
 
@@ -21,9 +27,13 @@ Open a new terminal window running a Kangentic dev server for previewing live co
 - The preview instance runs on a dynamically assigned port (starting from 5174) so it does not conflict with the root dev server on 5173.
 - Each preview instance has its own empty board — board state does NOT sync between instances. Use the root instance for task management.
 - When the preview terminal is closed, the worktree's `.kangentic/` and `.vite/` directories are automatically cleaned up (ephemeral mode). The node_modules junction is left in place for instant restarts.
-- Multiple `/preview` invocations can run simultaneously — each gets its own port.
+- Multiple `/preview` invocations can run simultaneously - each gets its own port, and each gets its own watcher.
 - Pass `--fresh` to launch without auto-opening a project (shows the Welcome Screen). Useful for testing the first-launch experience. Example: `/preview --fresh`
 - **Stopping a preview (restarts):** run `node scripts/worktree-preview.js --stop --port=<port>` instead of `taskkill`. It writes a stop file that dev.js watches, so the server cleans up and exits 0 and its terminal tab closes itself; a `taskkill /F` exits non-zero and leaves a dead "[process exited with code 1]" tab behind on every restart. `--stop` falls back to a force kill automatically if the server does not exit within 10s (e.g. an instance launched from a checkout predating the stop-file watcher). Omitting `--port` stops every preview this worktree is running.
+- **Watching only observes.** It never stops or restarts the preview - do not run `/preview` again automatically just because a watcher fired.
+- A notification arriving immediately after you ran `--stop` yourself is the expected confirmation of that stop, not a new event to alarm the user about.
+- The watcher holds a background task slot for the preview's whole lifetime, which can be hours. Pass `--no-watch` to skip it and launch fire-and-forget as before.
+- If the Claude Code session restarts, a pending watch notification is lost - the preview keeps running regardless. Re-attach with `node scripts/worktree-preview.js --wait --port=<port>` if you need to know when it later exits.
 
 ## Allowed Tools
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -188,6 +188,8 @@ In worktrees, `dev.js` bypasses `vite.config.mts` and creates an inline Vite con
 
 `scripts/worktree-preview.js` creates a `node_modules` junction/symlink from the worktree to the repo root, then opens a native terminal running the dev server.
 
+`node scripts/worktree-preview.js --wait --port=<port>` blocks until that preview exits, then exits with a code that says why: `0` clean (terminal closed or `--stop`), `1` watcher usage/setup error, `2` crashed (dev server exited non-zero), `3` vanished (force-killed with no recorded exit). `dev.js`'s `cleanup()` writes a small `{ pid, exitCode }` record under `os.tmpdir()` (see `scripts/preview-exit-record.js`) as its first statement, since ephemeral mode removes the whole worktree `.kangentic/` directory on exit and nothing under the worktree would otherwise survive to tell the watcher how the server exited. The `/preview` skill runs this backgrounded by default so the harness delivers a task-notification when the preview exits.
+
 ## Testing
 
 Three tiers. Use the right one for the job.

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const esbuild = require('esbuild');
 const rendererOptimizeDeps = require('./renderer-optimize-deps.json');
 const { copyExternalScripts } = require('./copy-external-scripts');
+const { writeExitRecord } = require('./preview-exit-record');
 
 const projectDir = path.resolve(__dirname, '..');
 
@@ -289,7 +290,25 @@ async function start() {
   });
 }
 
+let cleaningUp = false;
+
 function cleanup(exitCode) {
+  // Re-entrancy guard. Today the process.exit() at the end wins the race
+  // against any second trigger, but only incidentally: adding a single await
+  // above it would let the electronProc 'close' event (or an exception raised
+  // while cleaning up) re-enter and write a SECOND, contradictory exit record.
+  if (cleaningUp) return;
+  cleaningUp = true;
+
+  // FIRST action, with nothing but the re-entrancy guard above it: the
+  // ephemeral cleanup below removes the worktree's entire .kangentic/
+  // directory (including the PID file), so a --wait watcher polling for
+  // "PID file gone" must already find this record on disk by the time that
+  // happens, or it misclassifies a clean exit as vanished. See
+  // scripts/preview-exit-record.js and the --wait loop in
+  // scripts/worktree-preview.js.
+  writeExitRecord(projectDir, port, { pid: process.pid, exitCode });
+
   if (viteServer) {
     viteServer.close().catch(() => {});
     viteServer = null;
@@ -339,6 +358,23 @@ process.on('SIGTERM', () => cleanup(0));
 // for the next launch to misreport. cleanup() is comfortably faster than the
 // grace window (sync kills + fs removals).
 process.on('SIGHUP', () => cleanup(0));
+
+// A post-start crash (a rejected promise in a Vite callback, a throw from an
+// event listener registered during start()) otherwise takes Node's default
+// fatal path, which never runs cleanup() and so never writes an exit record.
+// A --wait watcher would then read the absence of a record as 'vanished'
+// (force-killed) instead of 'crashed', pointing the user at the wrong cause.
+function exitOnFatal(label, fatalError) {
+  console.error(`[dev] ${label}:`, fatalError);
+  cleanup(1);
+  // cleanup() short-circuits when it is already running, and its own
+  // process.exit() then never fires. Exit here too, so a throw raised from
+  // inside cleanup (the case these handlers exist to catch) cannot leave a
+  // half-cleaned dev server alive still holding the port.
+  process.exit(1);
+}
+process.on('uncaughtException', (uncaughtError) => exitOnFatal('Uncaught exception', uncaughtError));
+process.on('unhandledRejection', (rejectionReason) => exitOnFatal('Unhandled rejection', rejectionReason));
 
 start().catch((err) => {
   console.error('[dev] Fatal error:', err);

--- a/scripts/preview-exit-record.js
+++ b/scripts/preview-exit-record.js
@@ -1,0 +1,101 @@
+/**
+ * preview-exit-record.js - Shared exit-record contract between scripts/dev.js
+ * (the preview dev server) and scripts/worktree-preview.js (the launcher's
+ * --wait watcher).
+ *
+ * dev.js's ephemeral cleanup() removes the whole worktree .kangentic/
+ * directory on exit, so nothing under the worktree survives to tell a
+ * watcher HOW the server exited. This module keys a tiny JSON record under
+ * os.tmpdir() by (worktree, port) so it survives that cleanup: dev.js writes
+ * { pid, exitCode } as the first statement of cleanup(), and the watcher
+ * reads it to distinguish a clean exit from a crash.
+ *
+ * Both callers pass their raw worktree directory string and never normalize
+ * it themselves. normalizeWorktreeKey is the single implementation, so the
+ * two sides (process.cwd() in worktree-preview.js, path.resolve(__dirname,
+ * '..') in dev.js) cannot drift into different keys for the same directory.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+
+function normalizeWorktreeKey(worktreeDir) {
+  let normalized = path.resolve(worktreeDir).replace(/\\/g, '/');
+  if (process.platform === 'win32') {
+    normalized = normalized.toLowerCase();
+  }
+  return normalized;
+}
+
+function exitRecordPath(worktreeDir, port) {
+  const key = normalizeWorktreeKey(worktreeDir);
+  const hash = crypto.createHash('sha1').update(key).digest('hex').slice(0, 12);
+  return path.join(os.tmpdir(), 'kangentic-preview', `${hash}-${port}.json`);
+}
+
+function writeExitRecord(worktreeDir, port, { pid, exitCode }) {
+  const recordPath = exitRecordPath(worktreeDir, port);
+  try {
+    fs.mkdirSync(path.dirname(recordPath), { recursive: true });
+    fs.writeFileSync(recordPath, JSON.stringify({ pid, exitCode }));
+  } catch {
+    // best-effort: a failed write just means the watcher falls back to the
+    // PID-liveness classification (status 'vanished') instead of 'crashed'.
+  }
+}
+
+function readExitRecord(worktreeDir, port) {
+  try {
+    const raw = fs.readFileSync(exitRecordPath(worktreeDir, port), 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (typeof parsed.pid === 'number' && typeof parsed.exitCode === 'number') {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function clearExitRecord(worktreeDir, port) {
+  try {
+    fs.rmSync(exitRecordPath(worktreeDir, port), { force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Pure classification, no I/O. `processAlive` must already be the caller's
+ * AND of "PID file still names this PID" and "process responds to signal 0"
+ * (see worktree-preview.js's --wait loop), so a hard-killed PID that the
+ * OS later recycles for an unrelated process cannot read back as alive here.
+ *
+ * Returns null when the caller should keep polling (still running, or a
+ * stale record from an earlier instance on this port that hasn't been
+ * superseded yet).
+ */
+function classifyPreviewExit({ record, watchedPid, processAlive, stopRequested }) {
+  if (record && record.pid === watchedPid) {
+    return record.exitCode === 0
+      ? { status: 'clean', code: 0 }
+      : { status: 'crashed', code: 2 };
+  }
+  if (processAlive) {
+    return null;
+  }
+  return stopRequested
+    ? { status: 'clean', code: 0 }
+    : { status: 'vanished', code: 3 };
+}
+
+module.exports = {
+  normalizeWorktreeKey,
+  exitRecordPath,
+  writeExitRecord,
+  readExitRecord,
+  clearExitRecord,
+  classifyPreviewExit,
+};

--- a/scripts/worktree-preview.js
+++ b/scripts/worktree-preview.js
@@ -17,6 +17,7 @@ const { spawn, execSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const net = require('net');
+const { readExitRecord, clearExitRecord, classifyPreviewExit, exitRecordPath } = require('./preview-exit-record');
 
 // ---------------------------------------------------------------------------
 // Worktree / root detection
@@ -357,6 +358,103 @@ function waitForPidFile(worktreeDir, port, timeoutMs = 30000) {
 }
 
 // ---------------------------------------------------------------------------
+// Blocking watch (--wait --port=N)
+// ---------------------------------------------------------------------------
+
+// How recent an exit record must be for --wait to adopt it when no live PID
+// file exists. Comfortably wider than waitForPidFile's 5s attach timeout, and
+// far narrower than the "leftover from an earlier session" case it rules out.
+const STALE_ATTACH_WINDOW_MS = 60000;
+
+const EXIT_MESSAGES = {
+  clean: (port) => `[preview] Port ${port}: exited cleanly.`,
+  crashed: (port) => `[preview] Port ${port}: crashed (non-zero exit). Check the preview terminal for details.`,
+  vanished: (port) => `[preview] Port ${port}: vanished (force-killed or the terminal was hard-closed) with no recorded exit.`,
+};
+
+/**
+ * Blocks until the preview on `port` exits, then exits this process with a
+ * reason-carrying code: 0 clean, 2 crashed, 3 vanished (see EXIT_MESSAGES).
+ * Companion to writeExitRecord in scripts/dev.js's cleanup(); that record
+ * is the only way to distinguish a crash from a clean exit once ephemeral
+ * cleanup has already removed the worktree's .kangentic/ directory.
+ *
+ * NOTE: a hard-killed PID can in principle be recycled by the OS for an
+ * unrelated process before this watcher notices; that would read back as
+ * "still running" indefinitely. Not mitigated: narrow and not worth the
+ * complexity of a start-time / argv fingerprint check here.
+ */
+async function waitForPreviewExit(worktreeDir, port) {
+  const pidFilePath = pidFilePathFor(worktreeDir, port);
+  const stopFilePath = stopFilePathFor(worktreeDir, port);
+
+  let watchedPid = await waitForPidFile(worktreeDir, port, 5000);
+  if (!watchedPid) {
+    // No live PID file. The ONLY legitimate reason to still proceed is that
+    // the preview exited during the few seconds between its launch and this
+    // watcher attaching, so its record is seconds old. An older record is a
+    // leftover from a previous session that nothing has cleared (only a
+    // launch or a watcher clears one), and adopting its pid as watchedPid
+    // would make the very next loop iteration match record.pid === watchedPid
+    // and report that ancient verdict instantly, instead of blocking as
+    // documented. Age-gate it rather than trusting any record we find.
+    const record = readExitRecord(worktreeDir, port);
+    let recordAgeMs = Infinity;
+    try {
+      recordAgeMs = Date.now() - fs.statSync(exitRecordPath(worktreeDir, port)).mtimeMs;
+    } catch {
+      // no record file: recordAgeMs stays Infinity and the guard below fires
+    }
+    if (!record || recordAgeMs > STALE_ATTACH_WINDOW_MS) {
+      console.error(`[preview] No preview running on port ${port} in this worktree.`);
+      process.exit(1);
+    }
+    watchedPid = record.pid;
+  }
+
+  console.log(`[preview] Watching port ${port} (PID ${watchedPid})...`);
+
+  let stopRequested = false;
+  let vanishedSince = null;
+
+  for (;;) {
+    const record = readExitRecord(worktreeDir, port);
+    if (fs.existsSync(stopFilePath)) stopRequested = true;
+
+    let pidFileMatches = false;
+    try {
+      pidFileMatches = parseInt(fs.readFileSync(pidFilePath, 'utf-8').trim(), 10) === watchedPid;
+    } catch {
+      pidFileMatches = false;
+    }
+    const processAlive = pidFileMatches && isProcessAlive(watchedPid);
+
+    const verdict = classifyPreviewExit({ record, watchedPid, processAlive, stopRequested });
+
+    if (verdict && verdict.status === 'vanished') {
+      // Give a late-arriving exit record (Windows fs-write latency) a ~1s
+      // grace window to turn this into 'clean' or 'crashed' before we
+      // commit. Classification runs fresh every iteration of this loop.
+      if (vanishedSince === null) {
+        vanishedSince = Date.now();
+      } else if (Date.now() - vanishedSince >= 1000) {
+        clearExitRecord(worktreeDir, port);
+        console.log(EXIT_MESSAGES.vanished(port));
+        process.exit(verdict.code);
+      }
+    } else if (verdict) {
+      clearExitRecord(worktreeDir, port);
+      console.log(EXIT_MESSAGES[verdict.status](port));
+      process.exit(verdict.code);
+    } else {
+      vanishedSince = null;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -364,6 +462,7 @@ async function main() {
   const worktreeDir = process.cwd();
   const isFresh = process.argv.includes('--fresh');
   const isStop = process.argv.includes('--stop');
+  const isWait = process.argv.includes('--wait');
   const portFlag = process.argv.find((arg) => arg.startsWith('--port='));
   const requestedPort = portFlag ? parseInt(portFlag.split('=')[1], 10) : null;
 
@@ -381,6 +480,21 @@ async function main() {
     return;
   }
 
+  if (isWait) {
+    if (!requestedPort) {
+      const ports = listRunningPreviewPorts(worktreeDir);
+      console.error(
+        '[preview] --wait requires --port=<port>.' +
+        (ports.length
+          ? ` Running previews in this worktree: ${ports.join(', ')}`
+          : ' No previews are currently running in this worktree.')
+      );
+      process.exit(1);
+    }
+    await waitForPreviewExit(worktreeDir, requestedPort);
+    return;
+  }
+
   console.log(`[preview] Root project: ${rootDir}`);
   console.log(`[preview] Worktree:     ${worktreeDir}`);
   if (isFresh) console.log('[preview] Fresh mode: launching without --cwd (Welcome Screen)');
@@ -389,6 +503,7 @@ async function main() {
 
   const port = await findAvailablePort(5174);
   removeStalePidFile(worktreeDir, port);
+  clearExitRecord(worktreeDir, port);
   const command = buildCommand(worktreeDir, port, { fresh: isFresh });
 
   console.log(`[preview] Opening preview terminal...`);
@@ -409,6 +524,7 @@ async function main() {
   } else {
     console.log('[preview]   PID:     unknown (dev server did not report one within 30s - check the terminal window)');
   }
+  console.log(`[preview]   Watch:   node scripts/worktree-preview.js --wait --port=${port}`);
 }
 
 main().catch((err) => {

--- a/tests/unit/preview-exit-classification.test.ts
+++ b/tests/unit/preview-exit-classification.test.ts
@@ -168,6 +168,31 @@ describe('classifyPreviewExit', () => {
     });
     expect(verdict).toEqual({ status: 'clean', code: 0 });
   });
+
+  // A matching record is terminal and takes priority over BOTH processAlive
+  // and stopRequested - the function checks the record branch first and
+  // returns unconditionally from it. This matters beyond the ordinary
+  // wind-down race (dev.js writes the record, then exits, so processAlive
+  // usually catches up a poll later anyway): the module's own doc comment
+  // calls out that a hard-killed PID can be recycled by the OS for an
+  // unrelated process, which would read back as "still alive" indefinitely.
+  // Once a definitive record exists, the watcher must trust it rather than
+  // stall on that recycled PID's liveness.
+  it.each([
+    { exitCode: 0, expectedStatus: 'clean', expectedCode: 0 },
+    { exitCode: 1, expectedStatus: 'crashed', expectedCode: 2 },
+  ])(
+    'treats a matching record as authoritative even while liveness still reads alive (exitCode $exitCode)',
+    ({ exitCode, expectedStatus, expectedCode }) => {
+      const verdict = classifyPreviewExit({
+        record: { pid: 100, exitCode },
+        watchedPid: 100,
+        processAlive: true,
+        stopRequested: false,
+      });
+      expect(verdict).toEqual({ status: expectedStatus, code: expectedCode });
+    },
+  );
 });
 
 describe('writeExitRecord / readExitRecord / clearExitRecord (filesystem round trip)', () => {

--- a/tests/unit/preview-exit-classification.test.ts
+++ b/tests/unit/preview-exit-classification.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Unit coverage for scripts/preview-exit-record.js - the shared contract
+ * between scripts/dev.js (writes { pid, exitCode } as the first statement of
+ * cleanup(), before ephemeral mode removes the worktree's .kangentic/
+ * directory) and scripts/worktree-preview.js's --wait watcher (classifies
+ * why a preview exited from that record plus PID liveness).
+ *
+ * Three concerns, three describe groups:
+ *  - normalizeWorktreeKey/exitRecordPath: pure path functions, no filesystem
+ *    writes, plain object fixtures.
+ *  - classifyPreviewExit: pure logic, plain object fixtures.
+ *  - writeExitRecord/readExitRecord/clearExitRecord: real filesystem I/O
+ *    under a per-test fs.mkdtempSync(os.tmpdir()) directory, because
+ *    classifyPreviewExit passing proves nothing about whether a record is
+ *    ever actually written to or parsed back from disk.
+ *  - scripts/dev.js cleanup() ordering: a static source-order check (no
+ *    filesystem writes, just fs.readFileSync) pinning that writeExitRecord()
+ *    runs before the ephemeral .kangentic/ removal - see that describe
+ *    block's comment for why the order is load-bearing.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+// scripts/preview-exit-record.js is CJS (a build/dev script, not bundled
+// src - the esbuild-cjs-imports rule scopes to src/, not scripts/);
+// vite-node's require/import interop lets these named exports come through
+// a plain ES import, mirroring tests/unit/assert-vendor-chunks-lazy.test.ts
+// importing scripts/build.js the same way.
+import {
+  normalizeWorktreeKey,
+  exitRecordPath,
+  writeExitRecord,
+  readExitRecord,
+  clearExitRecord,
+  classifyPreviewExit,
+} from '../../scripts/preview-exit-record.js';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+const isWindows = process.platform === 'win32';
+const WORKTREE_A = isWindows ? 'C:\\Users\\dev\\kangentic\\.kangentic\\worktrees\\task-a' : '/Users/dev/kangentic/.kangentic/worktrees/task-a';
+const WORKTREE_B = isWindows ? 'C:\\Users\\dev\\kangentic\\.kangentic\\worktrees\\task-b' : '/Users/dev/kangentic/.kangentic/worktrees/task-b';
+
+// A Windows-shaped literal, asserted on EVERY platform. Off win32 the
+// backslash-normalization tests would otherwise be tautologies: WORKTREE_A is
+// a POSIX path there, so "contains no backslash" is trivially true and the
+// branch that actually does the replacing never gets exercised on Linux CI.
+// normalizeWorktreeKey is a pure string/path function, so feeding it a
+// foreign-shaped path is safe on any host.
+const WINDOWS_SHAPED_PATH = 'C:\\Users\\dev\\kangentic\\worktrees\\task-a';
+
+describe('normalizeWorktreeKey', () => {
+  it('normalizes backslashes to forward slashes on every platform', () => {
+    expect(normalizeWorktreeKey(WINDOWS_SHAPED_PATH)).not.toContain('\\');
+  });
+
+  it('is stable under trailing-slash and relative-vs-resolved differences', () => {
+    expect(normalizeWorktreeKey(`${WORKTREE_A}${isWindows ? '\\' : '/'}.`)).toBe(
+      normalizeWorktreeKey(WORKTREE_A)
+    );
+  });
+
+  (isWindows ? it : it.skip)('is case-insensitive on win32', () => {
+    expect(normalizeWorktreeKey(WORKTREE_A.toUpperCase())).toBe(normalizeWorktreeKey(WORKTREE_A.toLowerCase()));
+  });
+
+  (isWindows ? it.skip : it)('is case-sensitive off win32', () => {
+    expect(normalizeWorktreeKey(WORKTREE_A.toUpperCase())).not.toBe(normalizeWorktreeKey(WORKTREE_A.toLowerCase()));
+  });
+});
+
+describe('exitRecordPath', () => {
+  it('resolves under the OS temp directory', () => {
+    expect(exitRecordPath(WORKTREE_A, 5174).startsWith(os.tmpdir())).toBe(true);
+  });
+
+  // Asserted unconditionally: on Linux CI the old form compared WORKTREE_A to
+  // itself, so it proved nothing. Backslash-vs-forward-slash spellings of one
+  // path must collapse to one key on every platform, or dev.js and the --wait
+  // watcher could key the same worktree to two different record files.
+  it('is identical for separator-only spelling differences of the same worktree', () => {
+    expect(exitRecordPath(WINDOWS_SHAPED_PATH, 5174)).toBe(
+      exitRecordPath(WINDOWS_SHAPED_PATH.replace(/\\/g, '/'), 5174)
+    );
+  });
+
+  (isWindows ? it : it.skip)('is identical for casing-only differences on win32', () => {
+    expect(exitRecordPath(WORKTREE_A.toUpperCase(), 5174)).toBe(exitRecordPath(WORKTREE_A, 5174));
+  });
+
+  it('differs for different ports on the same worktree', () => {
+    expect(exitRecordPath(WORKTREE_A, 5174)).not.toBe(exitRecordPath(WORKTREE_A, 5175));
+  });
+
+  it('differs for different worktrees on the same port', () => {
+    expect(exitRecordPath(WORKTREE_A, 5174)).not.toBe(exitRecordPath(WORKTREE_B, 5174));
+  });
+});
+
+describe('classifyPreviewExit', () => {
+  it('reports clean when the matching record has exitCode 0', () => {
+    const verdict = classifyPreviewExit({
+      record: { pid: 100, exitCode: 0 },
+      watchedPid: 100,
+      processAlive: false,
+      stopRequested: false,
+    });
+    expect(verdict).toEqual({ status: 'clean', code: 0 });
+  });
+
+  it('reports crashed when the matching record has a non-zero exitCode', () => {
+    const verdict = classifyPreviewExit({
+      record: { pid: 100, exitCode: 1 },
+      watchedPid: 100,
+      processAlive: false,
+      stopRequested: false,
+    });
+    expect(verdict).toEqual({ status: 'crashed', code: 2 });
+  });
+
+  it('reports clean when the process is gone with no record but a stop was requested', () => {
+    const verdict = classifyPreviewExit({
+      record: null,
+      watchedPid: 100,
+      processAlive: false,
+      stopRequested: true,
+    });
+    expect(verdict).toEqual({ status: 'clean', code: 0 });
+  });
+
+  it('reports vanished when the process is gone with no record and no stop was requested', () => {
+    const verdict = classifyPreviewExit({
+      record: null,
+      watchedPid: 100,
+      processAlive: false,
+      stopRequested: false,
+    });
+    expect(verdict).toEqual({ status: 'vanished', code: 3 });
+  });
+
+  it('keeps polling (null) while the process is alive and there is no record', () => {
+    const verdict = classifyPreviewExit({
+      record: null,
+      watchedPid: 100,
+      processAlive: true,
+      stopRequested: false,
+    });
+    expect(verdict).toBeNull();
+  });
+
+  it('ignores a stale record from a different PID while the current process is alive', () => {
+    const verdict = classifyPreviewExit({
+      record: { pid: 99, exitCode: 0 },
+      watchedPid: 100,
+      processAlive: true,
+      stopRequested: false,
+    });
+    expect(verdict).toBeNull();
+  });
+
+  it('falls back to the liveness-based verdict when the record belongs to a different PID and the process is gone', () => {
+    const verdict = classifyPreviewExit({
+      record: { pid: 99, exitCode: 0 },
+      watchedPid: 100,
+      processAlive: false,
+      stopRequested: true,
+    });
+    expect(verdict).toEqual({ status: 'clean', code: 0 });
+  });
+});
+
+describe('writeExitRecord / readExitRecord / clearExitRecord (filesystem round trip)', () => {
+  // A fresh mkdtemp'd worktree directory and a unique port per test: the
+  // record path is a hash of (normalized worktree dir, port), so distinct
+  // directories and ports guarantee distinct record files even when tests
+  // run with repeat-each or across parallel worker processes.
+  let nextPort = 45000;
+  let temporaryWorktreeDirectory: string;
+  let port: number;
+
+  beforeEach(() => {
+    temporaryWorktreeDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kangentic-preview-record-test-'),
+    );
+    port = nextPort;
+    nextPort += 1;
+  });
+
+  afterEach(() => {
+    clearExitRecord(temporaryWorktreeDirectory, port);
+    fs.rmSync(temporaryWorktreeDirectory, { recursive: true, force: true });
+  });
+
+  it('round trips a written record back through readExitRecord', () => {
+    writeExitRecord(temporaryWorktreeDirectory, port, { pid: 4242, exitCode: 0 });
+    const record = readExitRecord(temporaryWorktreeDirectory, port);
+    expect(record).toEqual({ pid: 4242, exitCode: 0 });
+  });
+
+  it('returns null when no record has ever been written for this worktree/port', () => {
+    const record = readExitRecord(temporaryWorktreeDirectory, port);
+    expect(record).toBeNull();
+  });
+
+  it('returns null on malformed/truncated JSON', () => {
+    const recordPath = exitRecordPath(temporaryWorktreeDirectory, port);
+    fs.mkdirSync(path.dirname(recordPath), { recursive: true });
+    fs.writeFileSync(recordPath, '{ "pid": 100, "exitCode": ');
+    const record = readExitRecord(temporaryWorktreeDirectory, port);
+    expect(record).toBeNull();
+  });
+
+  // The guard is a conjunction (typeof pid === 'number' && typeof exitCode
+  // === 'number'). A single wrong-typed field pins only half of it - a
+  // revert of just the exitCode half of the conjunction would stay green
+  // against a pid-only case. Cover both halves independently.
+  it.each([
+    { pid: '100', exitCode: 0 },
+    { pid: 100, exitCode: '0' },
+  ])('returns null when fields are wrong-typed: %j', (malformedFields) => {
+    const recordPath = exitRecordPath(temporaryWorktreeDirectory, port);
+    fs.mkdirSync(path.dirname(recordPath), { recursive: true });
+    fs.writeFileSync(recordPath, JSON.stringify(malformedFields));
+    const record = readExitRecord(temporaryWorktreeDirectory, port);
+    expect(record).toBeNull();
+  });
+
+  it('clearExitRecord removes the file, and a second clear on an already-gone record does not throw', () => {
+    writeExitRecord(temporaryWorktreeDirectory, port, { pid: 4242, exitCode: 0 });
+    clearExitRecord(temporaryWorktreeDirectory, port);
+    expect(readExitRecord(temporaryWorktreeDirectory, port)).toBeNull();
+    expect(() => clearExitRecord(temporaryWorktreeDirectory, port)).not.toThrow();
+  });
+});
+
+describe('scripts/dev.js cleanup(): writeExitRecord runs before the ephemeral .kangentic/ removal', () => {
+  // Ephemeral mode's cleanup() deletes the worktree's entire .kangentic/
+  // directory, including the PID file the --wait watcher polls for. If
+  // writeExitRecord() ran AFTER that removal instead of before it, a crash
+  // (or even a clean exit) could hit the removal, delete the PID file, and
+  // let the watcher observe "PID file gone, no record on disk" - which
+  // classifyPreviewExit reads as 'vanished' rather than the record-backed
+  // 'clean'/'crashed' verdict. The inline comment at the top of cleanup()
+  // names this by design; this test makes the ordering unmergeable instead
+  // of just documented.
+  function isCommentLine(line: string): boolean {
+    const trimmed = line.trim();
+    return trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*');
+  }
+
+  function extractFunctionBody(source: string, functionName: string): string {
+    const declarationPattern = new RegExp(`function\\s+${functionName}\\s*\\(`, 'g');
+    const declarationMatches = [...source.matchAll(declarationPattern)];
+    expect(
+      declarationMatches.length,
+      `Expected exactly one 'function ${functionName}(' declaration in the source so the `
+        + `extraction target is unambiguous; found ${declarationMatches.length}.`,
+    ).toBe(1);
+    const declarationIndex = declarationMatches[0].index;
+    const openBraceIndex = source.indexOf('{', declarationIndex);
+    expect(openBraceIndex, `No opening brace found after 'function ${functionName}(' declaration.`).toBeGreaterThan(-1);
+    let braceDepth = 0;
+    for (let sourceIndex = openBraceIndex; sourceIndex < source.length; sourceIndex++) {
+      const character = source[sourceIndex];
+      if (character === '{') braceDepth += 1;
+      else if (character === '}') {
+        braceDepth -= 1;
+        if (braceDepth === 0) {
+          return source.slice(openBraceIndex, sourceIndex + 1);
+        }
+      }
+    }
+    throw new Error(`Unbalanced braces while extracting function '${functionName}' body.`);
+  }
+
+  it('writeExitRecord( precedes the ephemeral block\'s .kangentic-removing rmSync(', () => {
+    const devJsSource = fs.readFileSync(path.join(REPO_ROOT, 'scripts/dev.js'), 'utf-8');
+    const cleanupBodyRaw = extractFunctionBody(devJsSource, 'cleanup');
+    // Strip comment-only lines before locating anchors: cleanup()'s own
+    // comments reference '.kangentic' and 'ephemeral' in prose, so indexOf
+    // against the raw body could match a comment instead of the code it
+    // describes and silently pass regardless of the real statement order.
+    const cleanupBodyCode = cleanupBodyRaw
+      .split('\n')
+      .filter((line) => !isCommentLine(line))
+      .join('\n');
+
+    const writeExitRecordIndex = cleanupBodyCode.indexOf('writeExitRecord(');
+    const ephemeralBlockIndex = cleanupBodyCode.indexOf('if (ephemeral)');
+    expect(writeExitRecordIndex, 'cleanup() must call writeExitRecord(...).').toBeGreaterThan(-1);
+    expect(ephemeralBlockIndex, "cleanup() must have an 'if (ephemeral)' block.").toBeGreaterThan(-1);
+
+    const ephemeralRemovalIndex = cleanupBodyCode.indexOf('rmSync(dir', ephemeralBlockIndex);
+    expect(
+      ephemeralRemovalIndex,
+      "Expected the ephemeral block to remove '.kangentic'/'.vite' via fs.rmSync(dir, ...).",
+    ).toBeGreaterThan(-1);
+
+    expect(
+      writeExitRecordIndex,
+      'writeExitRecord(...) must run BEFORE the ephemeral .kangentic/ removal in cleanup(): '
+        + 'ephemeral mode deletes the worktree\'s entire .kangentic/ directory (including the PID '
+        + 'file) on exit, so a --wait watcher polling for "the PID file is gone" has no way to '
+        + 'distinguish a clean exit from a crash unless the { pid, exitCode } record already '
+        + 'exists on disk (under os.tmpdir(), outside .kangentic/) by the time that directory '
+        + 'disappears. If this ordering is reversed, a crash can delete the record\'s only source '
+        + 'before it is ever written, and the watcher misclassifies every ephemeral crash as '
+        + "'vanished' instead of 'crashed'. See scripts/preview-exit-record.js.",
+    ).toBeLessThan(ephemeralRemovalIndex);
+  });
+});


### PR DESCRIPTION
## What

Adds a blocking `--wait --port=<port>` watch mode to `scripts/worktree-preview.js`, and has the `/preview` skill run it backgrounded by default so the launching Claude Code session gets a task-notification the moment a preview dev server exits, carrying a reason code.

## Why

`worktree-preview.js` opens a detached OS terminal and returns immediately, so the agent's Bash call exits 0 at launch time and never holds a handle to the dev server. When the user closed the preview terminal, the session that launched it had no way to know. Observed failure: an agent reported "preview is still running on http://localhost:5176" and handed back a `--stop` command for a process that no longer existed, well after the user had already closed it.

## How

Three cooperating pieces, keyed by `(worktree, port)`:

- **`scripts/preview-exit-record.js`** (new) - shared module holding path derivation (`normalizeWorktreeKey` / `exitRecordPath`, keyed under `os.tmpdir()` since ephemeral mode wipes the worktree's whole `.kangentic/` directory on exit), record read/write/clear helpers, and the pure `classifyPreviewExit` decision function.
- **`scripts/dev.js`** - `cleanup(exitCode)` now writes `{ pid, exitCode }` via `writeExitRecord` as its *first* statement, before the PID file and ephemeral directory are removed. This ordering is load-bearing: writing it later would leave a window where the PID file is gone, the record isn't written yet, and a watcher would misclassify a clean exit as vanished.
- **`scripts/worktree-preview.js`** - new `--wait --port=<port>` mode. Polls every second, resolves `processAlive` as the AND of "PID file still names this PID" and "process responds to signal 0" (guards against OS PID reuse after a hard kill), and classifies via `classifyPreviewExit`. Exit codes: `0` clean, `1` usage/setup error, `2` crashed, `3` vanished (with a ~1s grace re-check before committing to "vanished," in case the exit record is about to land). `--port` is required for `--wait` (unlike `--stop`, which defaults to "every preview in this worktree"). `clearExitRecord` runs only at the launch site, never inside `stopPreview`, to avoid a race where stopping one preview clears a record another watcher hasn't consumed yet.

The `/preview` skill now runs the printed `Watch:` command as a separate backgrounded Bash call by default (`--no-watch` to opt out), never polling or scheduling a wakeup fallback - the harness delivers the `<task-notification>` on its own when the blocking watcher resolves.

Trade-off: the watcher holds a background task slot for the preview's whole lifetime (potentially hours), and a pending notification is lost if the Claude Code session restarts (the preview itself keeps running regardless; `--wait` can be re-attached).

## Breaking changes

None.

## Tests

- `tests/unit/preview-exit-classification.test.ts` (new): `classifyPreviewExit`'s full decision table including the record-priority-over-liveness case (PID-recycling scenario), `exitRecordPath`/`normalizeWorktreeKey` path stability across separators/casing/uniqueness, a real `fs.mkdtempSync`-sandboxed round trip for `writeExitRecord`/`readExitRecord`/`clearExitRecord` (including malformed-JSON and ENOENT handling), and a static source-order check pinning `dev.js`'s write-before-cleanup ordering.
- Manually verified end-to-end against synthetic PID/record files: clean exit (0), crash (2), vanished/force-kill (3), the two watcher error paths, and port-scoped concurrency (two watchers, stopping one leaves the other running). Also verified against a real `/preview` launch and a real terminal close, confirming the actual `dev.js` SIGHUP -> `cleanup()` -> exit-record path.
- `npm run typecheck` and `npm run lint` both clean.

Generated with [Claude Code](https://claude.com/claude-code)
