### PR TITLE
refactor(dialogs): unify the task dialog field vocabulary and run-mode cards

### DIFF
--- a/src/renderer/components/Field.tsx
+++ b/src/renderer/components/Field.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from 'react';
+import { Info } from 'lucide-react';
+
+/**
+ * The shared shell for a single-line form control inside a dialog: 34px tall
+ * (`py-1.5` + `text-sm` + 1px borders), `rounded`, on the `surface` token.
+ *
+ * 34px is the scale because `Select` (settings/shared.tsx) and `Combobox` are
+ * both already this height and are used across settings, the board manager, and
+ * the task run-mode card - changing THEM ripples app-wide, so everything else
+ * comes up to meet them. Height stays padding-derived rather than a fixed
+ * `h-[34px]` so the box keeps growing with the font if the text scale changes.
+ */
+const FIELD_CONTROL_BASE =
+  'w-full bg-surface border border-edge-input rounded py-1.5 text-sm text-fg placeholder-fg-faint focus:outline-none focus:border-accent';
+
+export const FIELD_CONTROL_CLASS = `${FIELD_CONTROL_BASE} px-3`;
+
+/**
+ * `FIELD_CONTROL_CLASS` for the shared `Select`, whose chevron is overlaid
+ * absolutely and needs the room reserved on the right.
+ *
+ * Spelled `pl-3 pr-10` rather than `px-3 pr-10` on purpose: Tailwind resolves
+ * conflicting utilities by CSS source order, not by the order they appear in the
+ * class attribute, so an override that happens to work is not one you can rely
+ * on when the utility ordering changes.
+ */
+export const FIELD_SELECT_CLASS = `${FIELD_CONTROL_BASE} appearance-none pl-3 pr-10 disabled:cursor-not-allowed`;
+
+interface FieldProps {
+  /** Usually a string; a fragment is allowed for a label that needs an icon. */
+  label: ReactNode;
+  children: ReactNode;
+  /**
+   * Explanatory line under the control, rendered with a leading info icon.
+   * Suppressed while `error` is set - a field cannot be both wrong and merely
+   * informative, and showing two lines there shifts everything below it.
+   */
+  hint?: ReactNode;
+  /** Validation message. Wins over `hint`. */
+  error?: string;
+  /** Applied to the wrapper, e.g. `flex-1` for a field in a row. */
+  className?: string;
+}
+
+/**
+ * Label + control + hint/error, the shape every dialog field already hand-rolled.
+ *
+ * The exact string `text-xs text-fg-muted mb-1 block` appeared ten times across
+ * the five dialog files that consume this, which is what makes one component
+ * worth having rather than a convention nobody can enforce. `font-medium` is
+ * new: at plain weight the labels read as text floating above the controls
+ * rather than as part of them.
+ *
+ * Lives here beside Pill / CountBadge / ToggleCard rather than in
+ * `settings/shared.tsx`. Dialogs already reach into the settings module for
+ * `Select`; a shared form primitive should not widen that dependency.
+ */
+export function Field({ label, children, hint, error, className }: FieldProps) {
+  return (
+    <div className={className}>
+      <label className="mb-1 block text-xs font-medium text-fg-muted">{label}</label>
+      {children}
+      {error ? (
+        <p className="mt-1 text-xs text-danger">{error}</p>
+      ) : hint ? (
+        <p className="mt-1 flex items-center gap-1 text-xs text-fg-disabled">
+          <Info size={12} className="shrink-0" />
+          {hint}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/renderer/components/LabelInput.tsx
+++ b/src/renderer/components/LabelInput.tsx
@@ -95,11 +95,13 @@ export function LabelInput({ labels, setLabels, labelColors, allExistingLabels, 
   };
 
   return (
-    <div className="flex-1 relative">
-      <label className="text-xs text-fg-muted mb-1 block">Labels</label>
+    // No "Labels" <label> of its own: the caller wraps this in `Field`, which
+    // owns the label for every dialog field. Rendering one here too put two
+    // labels side by side in the same row at different font weights.
+    <div className="relative">
       <div
         ref={containerRef}
-        className="flex flex-wrap items-center gap-1 bg-surface border border-edge-input rounded px-2 py-1 min-h-[32px] focus-within:border-accent"
+        className="flex flex-wrap items-center gap-1 bg-surface border border-edge-input rounded px-2 py-1 min-h-[34px] focus-within:border-accent"
       >
         {labels.map((label) => {
           const color = labelColors[label];
@@ -137,7 +139,10 @@ export function LabelInput({ labels, setLabels, labelColors, allExistingLabels, 
           }}
           onKeyDown={handleLabelKeyDown}
           placeholder={labels.length === 0 ? 'Type to add...' : ''}
-          className="flex-1 min-w-[80px] bg-transparent text-xs text-fg placeholder-fg-faint outline-none py-0.5"
+          // text-sm matches the Priority select beside it, so an empty Labels
+          // field reads at the same size as its neighbour. The pills above stay
+          // text-xs - they are pills, sized like every other pill in the app.
+          className="flex-1 min-w-[80px] bg-transparent text-sm text-fg placeholder-fg-faint outline-none py-0.5"
           data-testid={testId}
         />
       </div>

--- a/src/renderer/components/backlog/NewBacklogTaskDialog.tsx
+++ b/src/renderer/components/backlog/NewBacklogTaskDialog.tsx
@@ -3,19 +3,16 @@ import { Plus, X } from 'lucide-react';
 import { BaseDialog } from '../dialogs/BaseDialog';
 import { ConfirmDialog } from '../dialogs/ConfirmDialog';
 import { maximizedDialogLayout, MaximizeToggleButton } from '../dialogs/dialog-maximize';
-import { Select } from '../settings/shared';
-import { LabelInput } from '../LabelInput';
-import { useConfigStore } from '../../stores/config-store';
+import { PriorityLabelsRow } from '../dialogs/PriorityLabelsRow';
+import { DialogFooterActions } from '../dialogs/DialogFooterActions';
 import { useProjectStore } from '../../stores/project-store';
 import { useSessionStore } from '../../stores/session-store';
 import { useToastStore } from '../../stores/toast-store';
-import { useAllExistingLabels } from '../../hooks/useAllExistingLabels';
 import { useKeybinding } from '../../hooks/useKeybinding';
 import { DescriptionEditor } from '../DescriptionEditor';
 import { AttachmentChipStrip } from '../dialogs/AttachmentChipStrip';
 import { MAX_ATTACHMENT_BYTES, MEDIA_TYPE_EXT, resolveMediaType, isImageMediaType, pastedAttachmentPrefix, reserveNextPastedIndex } from '../dialogs/attachment-utils';
 import { compressClipboardImage } from '../dialogs/image-compress';
-import { DEFAULT_PRIORITY_CONFIG } from '../../../shared/types';
 import type { BacklogTask, BacklogTaskCreateInput, BacklogTaskUpdateInput } from '../../../shared/types';
 
 interface PendingAttachment {
@@ -74,13 +71,6 @@ export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: 
   // Ref tracks current attachments for cleanup on unmount (avoids stale closure)
   const attachmentsRef = useRef<DisplayAttachment[]>([]);
   attachmentsRef.current = attachments;
-
-  const labelColors = useConfigStore((state) => state.config.backlog?.labelColors) ?? {};
-
-  // Read priority labels from config
-  const priorities = useConfigStore((state) => state.config.backlog?.priorities) ?? DEFAULT_PRIORITY_CONFIG;
-
-  const allExistingLabels = useAllExistingLabels();
 
   const isDirty = isEditMode
     ? title.trim() !== (editTask?.title ?? '') ||
@@ -332,23 +322,14 @@ export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: 
           closeHotkeyActionId="panel.close"
           testId="new-backlog-task-dialog"
           footer={
-            <div className="flex items-center justify-end gap-3">
-              <button
-                type="button"
-                onClick={onClose}
-                className="px-4 py-1.5 text-xs text-fg-muted hover:text-fg-secondary border border-edge-input hover:border-fg-faint rounded transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={!title.trim() || submitting}
-                className="px-4 py-1.5 text-xs bg-accent-emphasis hover:bg-accent text-accent-on rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                data-testid="create-backlog-task-btn"
-              >
-                {submitting ? (isEditMode ? 'Saving...' : 'Creating...') : (isEditMode ? 'Save' : 'Create')}
-              </button>
-            </div>
+            <DialogFooterActions
+              onCancel={onClose}
+              submitLabel={isEditMode ? 'Save' : 'Create'}
+              busyLabel={isEditMode ? 'Saving...' : 'Creating...'}
+              busy={submitting}
+              disabled={!title.trim()}
+              submitTestId="create-backlog-task-btn"
+            />
           }
         >
           <div
@@ -388,29 +369,13 @@ export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: 
               onRemove={removeAttachment}
             />
 
-            <div className="flex gap-3">
-              <div className="flex-1">
-                <label className="text-xs text-fg-muted mb-1 block">Priority</label>
-                <Select
-                  value={priority}
-                  onChange={(event) => setPriority(Number((event.target as HTMLSelectElement).value))}
-                  className="appearance-none bg-surface border border-edge-input rounded pl-3 pr-10 py-1.5 text-sm text-fg w-full focus:outline-none focus:border-accent"
-                  data-testid="backlog-task-priority"
-                >
-                  {priorities.map((priorityEntry, index) => (
-                    <option key={index} value={index}>{priorityEntry.label}</option>
-                  ))}
-                </Select>
-              </div>
-
-              <LabelInput
-                labels={labels}
-                setLabels={setLabels}
-                labelColors={labelColors}
-                allExistingLabels={allExistingLabels}
-                testId="backlog-task-labels"
-              />
-            </div>
+            <PriorityLabelsRow
+              priority={priority}
+              setPriority={setPriority}
+              labels={labels}
+              setLabels={setLabels}
+              testIdPrefix="backlog-task-"
+            />
 
             {/* Drag overlay */}
             {isDragOver && (

--- a/src/renderer/components/dialogs/AdvancedOverridesSection.tsx
+++ b/src/renderer/components/dialogs/AdvancedOverridesSection.tsx
@@ -10,6 +10,7 @@ import type { TaskRunMode } from '../../../shared/types';
 import { modelRowLabel } from '../../utils/format-tokens';
 import { ModelCombobox } from './ModelCombobox';
 import { Combobox } from './Combobox';
+import { Field, FIELD_SELECT_CLASS } from '../Field';
 import { Select } from '../settings/shared';
 
 interface AdvancedOverridesSectionProps {
@@ -49,6 +50,11 @@ interface EditPencilButtonProps {
  * they must land at IDENTICAL geometry so the column of pencils reads as one
  * affordance rather than two lookalikes. One component is what guarantees that;
  * two copies of the same class string only promise it in a comment.
+ *
+ * Sized to an explicit 34px square rather than padding around the icon: it sits
+ * in an `items-center` row beside a Select and a Combobox, both of which are the
+ * dialog's 34px control height (see FIELD_CONTROL_CLASS), and the previous
+ * `p-1.5` left it 28px - visibly short against its own neighbour.
  */
 function EditPencilButton({ onClick, title, testId, disabled = false }: EditPencilButtonProps) {
   return (
@@ -58,7 +64,7 @@ function EditPencilButton({ onClick, title, testId, disabled = false }: EditPenc
       disabled={disabled}
       title={title}
       aria-label={title}
-      className="shrink-0 p-1.5 rounded border border-edge-input text-fg-muted hover:text-fg hover:bg-surface-hover transition-colors disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:text-fg-muted disabled:hover:bg-transparent"
+      className="inline-flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded border border-edge-input text-fg-muted transition-colors hover:bg-surface-hover hover:text-fg disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
       data-testid={testId}
     >
       <Pencil size={14} />
@@ -259,19 +265,29 @@ export function AdvancedOverridesSection({
   const modeCard = (mode: TaskRunMode, label: string, description: string, testId: string, body: ReactNode) => {
     const selected = runMode === mode;
     return (
-      // Selection is signalled NEUTRALLY - a raised fill and a slightly brighter
-      // edge - with the accent confined to the dot. An accent border round the
-      // whole card made this section shout over the fields above it, which it is
-      // no more important than.
+      // Selection is signalled NEUTRALLY - a fill and a slightly brighter edge -
+      // with the accent confined to the dot. An accent border round the whole
+      // card made this section shout over the fields above it, which it is no
+      // more important than.
       //
-      // The unselected card carries NO fill, only an outline. `bg-surface` is the
-      // token every input above uses (title, priority, branch), so filling it made
-      // an unselected option read as one more field to fill in rather than as the
-      // road not taken. Fill is what marks the live branch here.
+      // Selection is carried by THREE quiet signals stacked, not one loud one:
+      // the accent dot, a brighter border, and the label at full text weight
+      // against a muted one on the road not taken. The fill is only a wash
+      // (`/25`) on top of those.
+      //
+      // A full-strength `bg-surface-hover` was tried and is too much: this
+      // section is no more important than the fields above it, and a solid light
+      // block ran away with the bottom half of the dialog. But the fill cannot go
+      // to zero either - the ORIGINAL bug here was `bg-surface-raised`, which is
+      // the exact colour of the dialog body (BaseDialog), so neither state read
+      // as marked at all. `surface-hover` is the right token for the wash because
+      // its delta against surface-raised survives every one of the 11 themes,
+      // including light, where surface (#f5f5f4) sits only 5/255 from
+      // surface-raised (#fafaf9) and a `bg-surface` fill vanishes.
       <div
         className={`rounded border transition-colors ${selected
-          ? 'border-edge-input bg-surface-raised'
-          : 'border-edge hover:bg-surface-hover/50'}`}
+          ? 'border-edge-input bg-surface-hover/25'
+          : 'border-edge hover:border-edge-input hover:bg-surface-hover/15'}`}
       >
         <button
           type="button"
@@ -279,33 +295,41 @@ export function AdvancedOverridesSection({
           aria-checked={selected}
           onClick={mode === 'column_settings' ? selectProfileMode : selectOverrideMode}
           data-testid={testId}
-          className="w-full flex items-start gap-2.5 px-4 py-2.5 text-left cursor-pointer"
+          // Label and description on ONE line. Stacked, each header was ~56px and
+          // the pair ate as much height as the description editor itself, which
+          // inverted the importance hierarchy of a dialog whose job is writing a
+          // task. Both descriptions still render while unselected - that is what
+          // lets a user tell the branches apart without trying them - they just
+          // sit beside their label instead of under it.
+          className="w-full flex items-center gap-2.5 px-4 py-2 text-left cursor-pointer"
         >
           <span
-            className={`mt-px h-3.5 w-3.5 shrink-0 rounded-full border flex items-center justify-center transition-colors ${
+            className={`h-3.5 w-3.5 shrink-0 rounded-full border flex items-center justify-center transition-colors ${
               selected ? 'border-accent' : 'border-edge-input'
             }`}
           >
             {selected && <span className="h-1.5 w-1.5 rounded-full bg-accent" />}
           </span>
-          <span className="min-w-0">
-            <span className="block text-xs text-fg">{label}</span>
-            <span className="block text-xs text-fg-faint mt-0.5">{description}</span>
-          </span>
+          {/* The label's own weight is part of the selection signal: full text
+              colour on the live branch, muted on the other. That does more work
+              than fill can without adding any visual mass. */}
+          <span className={`text-xs shrink-0 ${selected ? 'text-fg' : 'text-fg-muted'}`}>{label}</span>
+          {/* Both strings fit side by side at the task-detail window's 650px
+              minimum width, so the truncate is a floor, not the normal case. */}
+          <span className={`text-xs min-w-0 truncate ${selected ? 'text-fg-faint' : 'text-fg-disabled'}`}>{description}</span>
         </button>
         {/* pl-10 aligns the body with the card's LABEL, not its dot: the header's
             px-4 (16) + dot (14) + gap-2.5 (10).
             The other three sides are the card's frame, and it is deliberately
             looser than the form's own space-y-3 (12) rhythm: a bordered card
             holding bordered controls needs more clearance than a bare labelled
-            field does. pt-1.5 (6) against the header's py-2.5 (10) bottom padding
-            puts 16px between the description and the first label, so the body
-            reads as the branch's contents rather than as part of the header
-            block. pr-4 and pb-4 keep the fields off the card's edge - at the
-            previous 12px the bottom-right corner was the tightest point on the
-            whole card, with the body indented 36px on the left but running to
-            within 12px of the border on the right. */}
-        {selected && <div className="pl-10 pr-4 pt-1.5 pb-4">{body}</div>}
+            field does. pt-2 (8) against the header's py-2 (8) bottom padding puts
+            16px between the header row and the first control, matching what the
+            two-line header used to leave. pr-4 and pb-4 keep the fields off the
+            card's edge - at the previous 12px the bottom-right corner was the
+            tightest point on the whole card, with the body indented 36px on the
+            left but running to within 12px of the border on the right. */}
+        {selected && <div className="pl-10 pr-4 pt-2 pb-4">{body}</div>}
       </div>
     );
   };
@@ -354,7 +378,7 @@ export function AdvancedOverridesSection({
                 ? 'An alternate set of per-column agent, model, and effort settings'
                 : 'No profiles yet - create one in Edit Columns'}
               onChange={(event) => setProfileId(event.target.value || null)}
-              className="appearance-none bg-surface border border-edge-input rounded pl-3 pr-10 py-1.5 text-sm text-fg w-full focus:outline-none focus:border-accent disabled:cursor-not-allowed"
+              className={FIELD_SELECT_CLASS}
               wrapperClassName="relative flex-1 min-w-0"
               data-testid="task-profile-select"
             >
@@ -399,39 +423,39 @@ export function AdvancedOverridesSection({
                 title wins over an ancestor's while hovering the button, so both
                 read correctly with no prop added to a shared control. */}
             <div title={agentFieldTitle} data-testid="task-agent-field">
-              <label className="text-xs text-fg-muted mb-1 block">Agent</label>
-              <div className="flex items-center gap-2">
-                <Combobox
-                  value={agentOverride}
-                  onChange={handleAgentChange}
-                  options={availableAgents.map((entry) => ({ value: entry.name, label: entry.displayName ?? entry.name }))}
-                  placeholder={agentInheritLabel}
-                  placeholderVariant="muted"
-                  disabled={!canPickAgent}
-                  className="flex-1 min-w-0"
-                  testId="task-agent-override"
-                />
-                {/* The card's only route to where all four of these fields get
-                    their defaults, and the same component as the profile pencil
-                    opposite it, so the two cannot drift apart. Project-scoped
-                    open (see openProjectSettings above). `WindowLayer` mounts
-                    OUTSIDE AppLayout's `currentProject` gate, so an edit form can
-                    outlive its project; disabling on that rather than no-opping
-                    in the handler keeps the button from looking live when the
-                    click would do nothing. */}
-                <EditPencilButton
-                  onClick={() => currentProject && openProjectSettings(currentProject.path, currentProject.name, 'agent')}
-                  title="Edit agent defaults in Settings"
-                  testId="task-agent-edit"
-                  disabled={!currentProject}
-                />
-              </div>
+              <Field label="Agent">
+                <div className="flex items-center gap-2">
+                  <Combobox
+                    value={agentOverride}
+                    onChange={handleAgentChange}
+                    options={availableAgents.map((entry) => ({ value: entry.name, label: entry.displayName ?? entry.name }))}
+                    placeholder={agentInheritLabel}
+                    placeholderVariant="muted"
+                    disabled={!canPickAgent}
+                    className="flex-1 min-w-0"
+                    testId="task-agent-override"
+                  />
+                  {/* The card's only route to where all four of these fields get
+                      their defaults, and the same component as the profile pencil
+                      opposite it, so the two cannot drift apart. Project-scoped
+                      open (see openProjectSettings above). `WindowLayer` mounts
+                      OUTSIDE AppLayout's `currentProject` gate, so an edit form can
+                      outlive its project; disabling on that rather than no-opping
+                      in the handler keeps the button from looking live when the
+                      click would do nothing. */}
+                  <EditPencilButton
+                    onClick={() => currentProject && openProjectSettings(currentProject.path, currentProject.name, 'agent')}
+                    title="Edit agent defaults in Settings"
+                    testId="task-agent-edit"
+                    disabled={!currentProject}
+                  />
+                </div>
+              </Field>
             </div>
             {(showModelPicker || showEffortPicker) && (
               <div className="flex gap-3">
                 {showModelPicker && (
-                  <div className="flex-1">
-                    <label className="text-xs text-fg-muted mb-1 block">Model</label>
+                  <Field label="Model" className="flex-1 min-w-0">
                     <ModelCombobox
                       value={modelOverride}
                       onChange={setModelOverride}
@@ -443,11 +467,10 @@ export function AdvancedOverridesSection({
                       contextWindows={modelContextWindows}
                       modelDisplayNames={modelDisplayNames}
                     />
-                  </div>
+                  </Field>
                 )}
                 {showEffortPicker && (
-                  <div className="flex-1">
-                    <label className="text-xs text-fg-muted mb-1 block">Effort</label>
+                  <Field label="Effort" className="flex-1 min-w-0">
                     <Combobox
                       value={effortOverride}
                       onChange={setEffortOverride}
@@ -456,13 +479,12 @@ export function AdvancedOverridesSection({
                       placeholderVariant="muted"
                       testId="task-effort-override"
                     />
-                  </div>
+                  </Field>
                 )}
               </div>
             )}
             {showPermissionPicker && (
-              <div>
-                <label className="text-xs text-fg-muted mb-1 block">Permission</label>
+              <Field label="Permission">
                 <Combobox
                   value={permissionOverride}
                   onChange={setPermissionOverride}
@@ -471,7 +493,7 @@ export function AdvancedOverridesSection({
                   placeholderVariant="muted"
                   testId="task-permission-override"
                 />
-              </div>
+              </Field>
             )}
           </div>,
         )}

--- a/src/renderer/components/dialogs/BranchPicker.tsx
+++ b/src/renderer/components/dialogs/BranchPicker.tsx
@@ -9,8 +9,12 @@ interface BranchPickerProps {
   value: string;
   defaultBranch: string;
   onChange: (branch: string) => void;
-  /** 'chip' = small pill (dialogs), 'input' = full-width field (settings) */
-  variant?: 'chip' | 'input';
+  /**
+   * 'chip' = small pill (the Command Terminal header's pill row)
+   * 'input' = full-width field (Settings > Git)
+   * 'segment' = flush segment inside a composed field (the task dialogs' Branch row)
+   */
+  variant?: 'chip' | 'input' | 'segment';
   className?: string;
   /** Controlled open state. When provided, the parent owns open/close (e.g. to
    *  re-open the picker from an overflow kebab after the chip has folded). */
@@ -152,6 +156,48 @@ export function BranchPicker({
     </Pill>
   );
 
+  // The base-branch segment of the composed Branch field. Flush (no radius, no
+  // border of its own - the field shell draws the dividers via `divide-x`) so the
+  // field reads as a single control, and width-capped: with no cap a long
+  // base-branch name pushed the branch-name input to its min-w-0 and collapsed
+  // the row. `truncate` keeps the full name in textContent, so assertions on the
+  // branch name still hold.
+  //
+  // Keeps the `branch-picker-chip` test id even though it is no longer a chip:
+  // four specs drive it, and renaming buys nothing.
+  //
+  // Three things carry "this is a button" now that the pill outline is gone, and
+  // all three are needed: a chevron (this opens a picker - the same signal
+  // `Combobox` and this component's own `input` variant use), a tinted
+  // background marking the segment zone as distinct from the text field beside
+  // it, and `cursor-pointer`. The cursor is not optional - Tailwind v4's
+  // preflight gives `button` `cursor: default`, and the `Pill` this replaced was
+  // adding `cursor-pointer` for us.
+  const segmentButton = (
+    <button
+      type="button"
+      onClick={() => setOpen(!open)}
+      // An INSET focus ring, not the default outline: the field shell is
+      // `overflow-hidden` (for its rounded corners) and this button is flush to
+      // its edge, so an outline is clipped on every side. Without the ring the
+      // shell's `focus-within:border-accent` lights up identically for the name
+      // input, this button, and the worktree toggle, so a keyboard user cannot
+      // tell which of the three has focus. Same pattern as `CompactToggleList`.
+      className={`flex w-full max-w-[170px] shrink-0 cursor-pointer items-center gap-1.5 bg-surface-hover/40 px-3 text-xs transition-colors hover:bg-surface-hover focus:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent ${
+        open ? 'text-accent-fg' : 'text-fg-secondary'
+      }`}
+      title={`Base branch: ${displayBranch}`}
+      data-testid="branch-picker-chip"
+    >
+      <GitBranch size={14} className="shrink-0" />
+      <span className="truncate">{displayBranch}</span>
+      <ChevronDown
+        size={12}
+        className={`shrink-0 text-fg-faint transition-transform ${open ? 'rotate-180' : ''}`}
+      />
+    </button>
+  );
+
   const inputButton = (
     <button
       type="button"
@@ -216,9 +262,21 @@ export function BranchPicker({
     </>
   );
 
+  // The segment wrapper is `flex shrink-0`, not `contents`: a display-contents
+  // box has an empty bounding rect, and `containerRef` is what the popover
+  // positions against. As a flex child of the field shell it still stretches to
+  // the shell's full height, which is the point of the segment.
+  const wrapperClass = hideTrigger
+    ? 'contents'
+    : variant === 'segment'
+      ? 'flex shrink-0 min-w-0'
+      : `relative ${variant === 'input' ? 'w-full' : 'inline-block'}`;
+
+  const trigger = variant === 'input' ? inputButton : variant === 'segment' ? segmentButton : chipButton;
+
   return (
-    <div className={hideTrigger ? 'contents' : `relative ${variant === 'input' ? 'w-full' : 'inline-block'}`} ref={containerRef}>
-      {!hideTrigger && (variant === 'input' ? inputButton : chipButton)}
+    <div className={wrapperClass} ref={containerRef}>
+      {!hideTrigger && trigger}
       <OverlayPopover
         open={open}
         popoverRef={dropdownRef}

--- a/src/renderer/components/dialogs/DialogFooterActions.tsx
+++ b/src/renderer/components/dialogs/DialogFooterActions.tsx
@@ -1,0 +1,68 @@
+import type { ReactNode } from 'react';
+
+interface DialogFooterActionsProps {
+  onCancel: () => void;
+  submitLabel: string;
+  /** Replaces `submitLabel` while the submit is in flight. */
+  busyLabel?: string;
+  busy?: boolean;
+  disabled?: boolean;
+  /**
+   * Omit for a submit button inside a `<form>` (NewTaskDialog), which submits
+   * via the form's own onSubmit. Pass a handler for a footer with no form
+   * (the task-detail window).
+   */
+  onSubmit?: () => void;
+  /** Left-aligned slot, e.g. a Delete button. Absent leaves the pair right-aligned. */
+  leading?: ReactNode;
+  /**
+   * Test id for the submit button. Only the backlog dialog needs one - its specs
+   * target the button directly rather than by role and text.
+   */
+  submitTestId?: string;
+}
+
+/**
+ * Cancel + submit for a dialog footer, with an optional leading slot.
+ *
+ * The two hosts had drifted: NewTaskDialog used `px-4` and
+ * `disabled:opacity-50`, the task-detail window used `px-3` and a ternary
+ * producing `bg-accent-emphasis/50` - same two buttons, two different disabled
+ * treatments. They also differ structurally, which is why `onSubmit` is
+ * optional: one is a `type="submit"` inside a `<form>`, the other is a plain
+ * click handler with no form anywhere above it.
+ */
+export function DialogFooterActions({
+  onCancel,
+  submitLabel,
+  busyLabel,
+  busy = false,
+  disabled = false,
+  onSubmit,
+  leading,
+  submitTestId,
+}: DialogFooterActionsProps) {
+  return (
+    <div className={`flex items-center ${leading ? 'justify-between' : 'justify-end'}`}>
+      {leading}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded border border-edge-input px-4 py-1.5 text-xs text-fg-muted transition-colors hover:border-fg-faint hover:text-fg-secondary"
+        >
+          Cancel
+        </button>
+        <button
+          type={onSubmit ? 'button' : 'submit'}
+          onClick={onSubmit}
+          disabled={disabled || busy}
+          className="rounded bg-accent-emphasis px-4 py-1.5 text-xs text-accent-on transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+          data-testid={submitTestId}
+        >
+          {busy && busyLabel ? busyLabel : submitLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/dialogs/NewTaskDialog.tsx
+++ b/src/renderer/components/dialogs/NewTaskDialog.tsx
@@ -1,25 +1,22 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
-import { Plus, X, Info } from 'lucide-react';
+import { Plus, X } from 'lucide-react';
 import { useBoardStore } from '../../stores/board-store';
 import { useConfigStore } from '../../stores/config-store';
 import { useProjectStore } from '../../stores/project-store';
 import { useSessionStore } from '../../stores/session-store';
-import { useAllExistingLabels } from '../../hooks/useAllExistingLabels';
 import { useToastStore } from '../../stores/toast-store';
 import { useKeybinding } from '../../hooks/useKeybinding';
 import { NameFromPromptButton } from '../NameFromPromptButton';
 import { BaseDialog } from './BaseDialog';
 import { ConfirmDialog } from './ConfirmDialog';
 import { maximizedDialogLayout, MaximizeToggleButton } from './dialog-maximize';
-import { BranchPicker } from './BranchPicker';
-import { WorktreeChip } from './WorktreeChip';
+import { TaskBranchRow } from './TaskBranchRow';
+import { PriorityLabelsRow } from './PriorityLabelsRow';
+import { DialogFooterActions } from './DialogFooterActions';
 import { AdvancedOverridesSection } from './AdvancedOverridesSection';
-import { Select } from '../settings/shared';
-import { LabelInput } from '../LabelInput';
 import { fetchGitBranches } from '../../utils/git-branches';
 import { isValidGitBranchName } from '../../../shared/git-utils';
 import { slugify, computeAutoBranchName } from '../../../shared/slugify';
-import { DEFAULT_PRIORITY_CONFIG } from '../../../shared/types';
 import type { PermissionMode, TaskRunMode } from '../../../shared/types';
 import { DescriptionEditor } from '../DescriptionEditor';
 import { AttachmentChipStrip } from './AttachmentChipStrip';
@@ -48,8 +45,6 @@ export function NewTaskDialog({ swimlaneId, onClose }: NewTaskDialogProps) {
   const defaultBaseBranch = useConfigStore((s) => s.config.git.defaultBaseBranch);
   const worktreesEnabled = useConfigStore((s) => s.config.git.worktreesEnabled);
   const currentProject = useProjectStore((s) => s.currentProject);
-  const labelColors = useConfigStore((s) => s.config.backlog?.labelColors) ?? {};
-  const priorities = useConfigStore((s) => s.config.backlog?.priorities) ?? DEFAULT_PRIORITY_CONFIG;
   const isMaximized = useSessionStore((s) => s.maximizedTasks.has(NEW_TASK_ENTITY_ID));
   const toggleMaximized = useSessionStore((s) => s.toggleMaximized);
   const handleToggleMaximized = useCallback(() => toggleMaximized(NEW_TASK_ENTITY_ID), [toggleMaximized]);
@@ -105,7 +100,6 @@ export function NewTaskDialog({ swimlaneId, onClose }: NewTaskDialogProps) {
     }
     return <>Agent will work directly on {pill(effectiveBaseBranch)}</>;
   }, [customBranchName, branchExists, effectiveWorktree, effectiveBaseBranch]);
-  const allExistingLabels = useAllExistingLabels();
 
   const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
   const [previewAttachment, setPreviewAttachment] = useState<PendingAttachment | null>(null);
@@ -372,22 +366,13 @@ export function NewTaskDialog({ swimlaneId, onClose }: NewTaskDialogProps) {
           bodyClassName="flex-1 flex flex-col"
           closeHotkeyActionId="panel.close"
           footer={
-            <div className="flex items-center justify-end gap-3">
-              <button
-                type="button"
-                onClick={closeWithAnimation}
-                className="px-4 py-1.5 text-xs text-fg-muted hover:text-fg-secondary border border-edge-input hover:border-fg-faint rounded transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={!!branchNameError || submitting}
-                className="px-4 py-1.5 text-xs bg-accent-emphasis hover:bg-accent text-accent-on rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {submitting ? 'Creating...' : 'Create'}
-              </button>
-            </div>
+            <DialogFooterActions
+              onCancel={closeWithAnimation}
+              submitLabel="Create"
+              busyLabel="Creating..."
+              busy={submitting}
+              disabled={!!branchNameError}
+            />
           }
         >
           <div
@@ -424,58 +409,26 @@ export function NewTaskDialog({ swimlaneId, onClose }: NewTaskDialogProps) {
               onRemove={removeAttachment}
             />
 
-            <div className="flex gap-3">
-              <div className="flex-1">
-                <label className="text-xs text-fg-muted mb-1 block">Priority</label>
-                <Select
-                  value={priority}
-                  onChange={(event) => setPriority(Number((event.target as HTMLSelectElement).value))}
-                  className="appearance-none bg-surface border border-edge-input rounded pl-3 pr-10 py-1.5 text-sm text-fg w-full focus:outline-none focus:border-accent"
-                  data-testid="task-priority"
-                >
-                  {priorities.map((priorityEntry, index) => (
-                    <option key={index} value={index}>{priorityEntry.label}</option>
-                  ))}
-                </Select>
-              </div>
-              <LabelInput
-                labels={labels}
-                setLabels={setLabels}
-                labelColors={labelColors}
-                allExistingLabels={allExistingLabels}
-                testId="task-labels"
-              />
-            </div>
+            <PriorityLabelsRow
+              priority={priority}
+              setPriority={setPriority}
+              labels={labels}
+              setLabels={setLabels}
+              testIdPrefix="task-"
+            />
 
-            <div>
-              {/* text-xs to match Priority / Labels / Profile. Was text-[10px],
-                  which is below the documented minimum and made this one label
-                  visibly smaller than every other in the dialog. */}
-              <label className="text-xs text-fg-muted mb-1 block">Branch</label>
-              <div className="flex items-center gap-2">
-                <input
-                  data-testid="custom-branch-name-input"
-                  type="text"
-                  placeholder={branchPlaceholder}
-                  value={customBranchName}
-                  onChange={(event) => setCustomBranchName(event.target.value)}
-                  className={`flex-1 min-w-0 bg-surface border rounded px-3 py-1.5 text-xs text-fg placeholder-fg-faint focus:outline-none ${
-                    branchNameError
-                      ? 'border-red-500 focus:border-red-500'
-                      : 'border-edge-input focus:border-accent'
-                  }`}
-                />
-                <span className="text-xs text-fg-disabled shrink-0">from</span>
-                <BranchPicker value={baseBranch} defaultBranch={defaultBaseBranch || 'main'} onChange={setBaseBranch} />
-                <div className="w-px h-5 bg-edge-input shrink-0" />
-                <WorktreeChip enabled={effectiveWorktree} onToggle={() => setUseWorktree(effectiveWorktree ? false : true)} />
-              </div>
-              {branchNameError ? (
-                <p className="text-xs text-red-500 mt-0.5">{branchNameError}</p>
-              ) : (
-                <span className="text-xs text-fg-disabled mt-1 flex items-center gap-1"><Info size={12} className="shrink-0" />{branchHint}</span>
-              )}
-            </div>
+            <TaskBranchRow
+              customBranchName={customBranchName}
+              setCustomBranchName={setCustomBranchName}
+              branchPlaceholder={branchPlaceholder}
+              branchNameError={branchNameError}
+              branchHint={branchHint}
+              baseBranch={baseBranch}
+              setBaseBranch={setBaseBranch}
+              defaultBaseBranch={defaultBaseBranch}
+              effectiveWorktree={effectiveWorktree}
+              setUseWorktree={setUseWorktree}
+            />
 
             <AdvancedOverridesSection
               swimlaneId={swimlaneId}

--- a/src/renderer/components/dialogs/PriorityLabelsRow.tsx
+++ b/src/renderer/components/dialogs/PriorityLabelsRow.tsx
@@ -1,0 +1,68 @@
+import { useConfigStore } from '../../stores/config-store';
+import { useAllExistingLabels } from '../../hooks/useAllExistingLabels';
+import { Field, FIELD_SELECT_CLASS } from '../Field';
+import { LabelInput } from '../LabelInput';
+import { Select } from '../settings/shared';
+import { DEFAULT_PRIORITY_CONFIG } from '../../../shared/types';
+
+interface PriorityLabelsRowProps {
+  priority: number;
+  setPriority: (priority: number) => void;
+  labels: string[];
+  setLabels: (labels: string[]) => void;
+  /**
+   * Prefix for the two test ids, so the board dialogs keep `task-priority` /
+   * `task-labels` while the backlog dialog keeps `backlog-task-priority` /
+   * `backlog-task-labels`.
+   */
+  testIdPrefix: string;
+}
+
+/**
+ * The Priority + Labels pair, side by side.
+ *
+ * Lived as three verbatim copies (NewTaskDialog, TaskDetailEditForm,
+ * NewBacklogTaskDialog), each carrying its own duplicate of the Select's class
+ * string. That is what let the three drift, and what would have made "verify in
+ * both modes" a manual inspection rather than a structural guarantee.
+ *
+ * Both fields read their config from the store directly rather than taking it
+ * as props: every caller was already pulling the same two selectors.
+ */
+export function PriorityLabelsRow({
+  priority,
+  setPriority,
+  labels,
+  setLabels,
+  testIdPrefix,
+}: PriorityLabelsRowProps) {
+  const labelColors = useConfigStore((state) => state.config.backlog?.labelColors) ?? {};
+  const priorities = useConfigStore((state) => state.config.backlog?.priorities) ?? DEFAULT_PRIORITY_CONFIG;
+  const allExistingLabels = useAllExistingLabels();
+
+  return (
+    <div className="flex gap-3">
+      <Field label="Priority" className="flex-1 min-w-0">
+        <Select
+          value={priority}
+          onChange={(event) => setPriority(Number((event.target as HTMLSelectElement).value))}
+          className={FIELD_SELECT_CLASS}
+          data-testid={`${testIdPrefix}priority`}
+        >
+          {priorities.map((priorityEntry, index) => (
+            <option key={index} value={index}>{priorityEntry.label}</option>
+          ))}
+        </Select>
+      </Field>
+      <Field label="Labels" className="flex-1 min-w-0">
+        <LabelInput
+          labels={labels}
+          setLabels={setLabels}
+          labelColors={labelColors}
+          allExistingLabels={allExistingLabels}
+          testId={`${testIdPrefix}labels`}
+        />
+      </Field>
+    </div>
+  );
+}

--- a/src/renderer/components/dialogs/TaskBranchRow.tsx
+++ b/src/renderer/components/dialogs/TaskBranchRow.tsx
@@ -1,0 +1,128 @@
+import type { ReactNode } from 'react';
+import { Field } from '../Field';
+import { BranchPicker } from './BranchPicker';
+import { WorktreeChip } from './WorktreeChip';
+
+interface TaskBranchRowProps {
+  /**
+   * Custom branch name. Omit to render the base-branch + worktree pair alone,
+   * for a task past To Do whose branch name is no longer editable.
+   */
+  customBranchName?: string;
+  setCustomBranchName?: (value: string) => void;
+  /** Resolved auto-generated name, shown as the input's placeholder. */
+  branchPlaceholder?: string;
+  branchNameError?: string;
+  /**
+   * Explains what the branch settings will do. Omitted past To Do, where the
+   * hint's "will be created from ..." phrasing describes a decision the task has
+   * already made.
+   */
+  branchHint?: ReactNode;
+  baseBranch: string;
+  setBaseBranch: (value: string) => void;
+  /** May be empty; the `|| 'main'` fallback is applied here, once, for every caller. */
+  defaultBaseBranch: string;
+  effectiveWorktree: boolean;
+  setUseWorktree: (value: boolean) => void;
+  /** Hide the worktree segment (a task that already has a worktree on disk). */
+  showWorktree?: boolean;
+}
+
+/**
+ * The Branch field, as ONE composed control rather than five loose ones.
+ *
+ * It used to be `[input] from [pill] | [pill]`: a text input, a bare "from", a
+ * rounded-full branch pill, a hand-drawn divider, and a rounded-full worktree
+ * pill, at three radii and two heights. Now it is a single bordered shell with
+ * flush segments and internal dividers, which is the shape `Combobox` already
+ * uses in this same dialog for its chevron button.
+ *
+ * The bare "from" is gone rather than restyled. The hint line underneath already
+ * says "will be created from `main`", so the word was stating the relationship a
+ * second time in the cramped part of the row.
+ *
+ * Shared by NewTaskDialog and TaskDetailEditForm so the two cannot drift; the
+ * second, name-less cluster in TaskDetailEditForm is this component with
+ * `customBranchName` omitted.
+ */
+export function TaskBranchRow({
+  customBranchName,
+  setCustomBranchName,
+  branchPlaceholder,
+  branchNameError,
+  branchHint,
+  baseBranch,
+  setBaseBranch,
+  defaultBaseBranch,
+  effectiveWorktree,
+  setUseWorktree,
+  showWorktree = true,
+}: TaskBranchRowProps) {
+  const editableName = setCustomBranchName !== undefined;
+
+  return (
+    // Past To Do there is no branch name to edit, so the field is only choosing a
+    // base branch - which is what it says. Naming it "Branch" there would promise
+    // an editable branch name that is not on offer.
+    <Field
+      label={editableName ? 'Branch' : 'Base branch'}
+      error={branchNameError}
+      hint={branchHint}
+    >
+      {/* min-h-[34px] rather than letting the input's own padding set the height:
+          the segments carry no vertical padding (items-stretch fills them to the
+          shell), so with the name input absent - the past-To-Do case - the shell
+          collapsed to an 18px sliver. The floor makes the height independent of
+          which children are present, and matches FIELD_CONTROL_CLASS's 34px.
+
+          The internal dividers come from `divide-x` on the shell rather than a
+          `border-l` on each segment, so the leading edge is never doubled up
+          against the shell's own border - which matters because WHICH segment
+          comes first changes with `editableName`.
+
+          Without a name input there is nothing to stretch, so the shell
+          shrink-wraps (inline-flex) instead of running the full width with dead
+          space where the input used to be.
+
+          The shell border does NOT light on focus. Each of the three segments is
+          separately focusable and separately actionable, so a border that lights
+          for all of them says "something in here has focus" without saying what -
+          and it was redundant besides, since the two buttons already draw their
+          own inset ring. Focus is indicated locally, on the segment that has it. */}
+      <div
+        className={`${editableName ? 'flex' : 'inline-flex'} min-h-[34px] items-stretch divide-x divide-edge-input overflow-hidden rounded border bg-surface transition-colors ${
+          branchNameError ? 'border-danger' : 'border-edge-input'
+        }`}
+        data-testid="task-branch-row"
+      >
+        {editableName && (
+          <input
+            data-testid="custom-branch-name-input"
+            type="text"
+            placeholder={branchPlaceholder}
+            value={customBranchName ?? ''}
+            onChange={(event) => setCustomBranchName?.(event.target.value)}
+            // `focus`, not `focus-visible`, unlike the two buttons: clicking into
+            // a text field should show that it took focus, which is how every
+            // other input in this dialog behaves. A button clicked with the mouse
+            // should not keep a ring, which is what focus-visible gets right.
+            className="min-w-0 flex-1 bg-transparent px-3 py-1.5 text-sm text-fg placeholder-fg-faint focus:outline-none focus:ring-1 focus:ring-inset focus:ring-accent"
+          />
+        )}
+        <BranchPicker
+          variant="segment"
+          value={baseBranch}
+          defaultBranch={defaultBaseBranch || 'main'}
+          onChange={setBaseBranch}
+        />
+        {showWorktree && (
+          <WorktreeChip
+            enabled={effectiveWorktree}
+            onToggle={() => setUseWorktree(effectiveWorktree ? false : true)}
+          />
+        )}
+      </div>
+    </Field>
+  );
+}

--- a/src/renderer/components/dialogs/WorktreeChip.tsx
+++ b/src/renderer/components/dialogs/WorktreeChip.tsx
@@ -1,25 +1,58 @@
 import { FolderGit2 } from 'lucide-react';
-import { Pill } from '../Pill';
 
 interface WorktreeChipProps {
   enabled: boolean;
   onToggle: () => void;
 }
 
+/**
+ * The worktree on/off control, rendered as the trailing segment of the composed
+ * Branch field (see `TaskBranchRow`).
+ *
+ * Three deliberate departures from the pill it used to be:
+ *
+ *   - It is flush, not rounded: the Branch field is ONE control whose dividers
+ *     are drawn by the shell's `divide-x`, the same shape `Combobox` uses for its
+ *     chevron button. A `rounded-full` pill inside a `rounded` shell was the
+ *     single loudest source of the row's mixed vocabulary.
+ *   - The off state is muted, not struck through. `line-through` on a toggle
+ *     reads as "deleted" rather than "off", and it was the only strikethrough in
+ *     the app. The state now lives on `aria-pressed` / `data-enabled`, which is
+ *     also what tests should assert on rather than a styling class.
+ *   - On/off is carried by BRIGHTNESS - a fuller fill and full-weight text when
+ *     on, a recessed fill and dimmed text when off. Two louder versions were
+ *     tried and dropped: an explicit checkbox glyph (a tick plus a folder icon
+ *     plus the word "Worktree" is three marks for one boolean, and the tick
+ *     introduced a second "selected" idiom competing with the run-mode radio
+ *     dots just below), then an accent wash borrowed from the Write/Preview
+ *     toggle (hue is too strong a signal for a small boolean sitting inside
+ *     another field - it became the only coloured thing in the row). Neutral
+ *     contrast is the same way the run-mode cards mark their live branch.
+ *
+ * `type="button"` is NOT optional: `NewTaskDialog` wraps its whole body in a
+ * `<form>`, so a bare button here submits the form and creates the task.
+ */
 export function WorktreeChip({ enabled, onToggle }: WorktreeChipProps) {
   return (
-    <Pill
+    <button
+      type="button"
       onClick={onToggle}
-      className={`border transition-colors ${
+      aria-pressed={enabled}
+      data-enabled={enabled}
+      // Inset focus ring for the same reason as the branch segment: the shell is
+      // `overflow-hidden`, so a default outline on a flush segment is clipped.
+      // `cursor-pointer` is explicit because Tailwind v4's preflight gives
+      // `button` `cursor: default`, and the `Pill` this replaced supplied it.
+      className={`flex shrink-0 cursor-pointer items-center gap-1.5 px-3 text-xs transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent ${
         enabled
-          ? 'border-edge-input text-fg-muted hover:text-fg-secondary hover:border-fg-faint'
-          : 'border-edge-input text-fg-disabled hover:border-fg-faint'
+          ? 'bg-surface-hover/70 text-fg-secondary'
+          : 'bg-surface-hover/25 text-fg-disabled hover:bg-surface-hover/50 hover:text-fg-muted'
       }`}
-      title={enabled ? 'Worktree enabled (click to toggle)' : 'Worktree disabled (click to toggle)'}
+      title={enabled ? 'Worktree enabled (click to turn off)' : 'Worktree disabled (click to turn on)'}
       data-testid="worktree-toggle"
     >
-      <FolderGit2 size={16} className={enabled ? '' : 'opacity-40'} />
-      <span className={enabled ? '' : 'line-through opacity-60'}>Worktree</span>
-    </Pill>
+      <FolderGit2 size={14} />
+      <span>Worktree</span>
+    </button>
   );
 }

--- a/src/renderer/components/dialogs/task-detail/TaskDetailEditForm.tsx
+++ b/src/renderer/components/dialogs/task-detail/TaskDetailEditForm.tsx
@@ -1,20 +1,16 @@
 import { useRef, useEffect } from 'react';
-import { Info, GitPullRequest } from 'lucide-react';
-import { BranchPicker } from '../BranchPicker';
-import { WorktreeChip } from '../WorktreeChip';
-import { Select } from '../../settings/shared';
-import { LabelInput } from '../../LabelInput';
+import { GitPullRequest } from 'lucide-react';
+import { Field, FIELD_CONTROL_CLASS } from '../../Field';
+import { TaskBranchRow } from '../TaskBranchRow';
+import { PriorityLabelsRow } from '../PriorityLabelsRow';
 import { DescriptionEditor } from '../../DescriptionEditor';
 import { NameFromPromptButton } from '../../NameFromPromptButton';
 import { AdvancedOverridesSection } from '../AdvancedOverridesSection';
 import { AttachmentChipStrip } from '../AttachmentChipStrip';
 import { isImageMediaType } from '../attachment-utils';
-import { useConfigStore } from '../../../stores/config-store';
 import { useProjectStore } from '../../../stores/project-store';
-import { useAllExistingLabels } from '../../../hooks/useAllExistingLabels';
 import type { AttachmentsState } from './useAttachments';
 import type { BranchConfigState } from './useBranchConfig';
-import { DEFAULT_PRIORITY_CONFIG } from '../../../../shared/types';
 import type { Task, TaskRunMode } from '../../../../shared/types';
 
 interface TaskDetailEditFormProps {
@@ -80,9 +76,6 @@ export function TaskDetailEditForm({
 }: TaskDetailEditFormProps) {
   const titleInputRef = useRef<HTMLInputElement>(null);
 
-  const labelColors = useConfigStore((state) => state.config.backlog?.labelColors) ?? {};
-  const priorities = useConfigStore((state) => state.config.backlog?.priorities) ?? DEFAULT_PRIORITY_CONFIG;
-  const allExistingLabels = useAllExistingLabels();
   const currentProject = useProjectStore((state) => state.currentProject);
 
   // Focus title input on mount
@@ -125,82 +118,53 @@ export function TaskDetailEditForm({
         }
         onRemove={attachments.removeAttachment}
       />
-      <div className="flex gap-3">
-        <div className="flex-1">
-          <label className="text-xs text-fg-muted mb-1 block">Priority</label>
-          <Select
-            value={priority}
-            onChange={(event) => setPriority(Number((event.target as HTMLSelectElement).value))}
-            className="appearance-none bg-surface border border-edge-input rounded pl-3 pr-10 py-1.5 text-sm text-fg w-full focus:outline-none focus:border-accent"
-            data-testid="task-priority"
-          >
-            {priorities.map((priorityEntry, index) => (
-              <option key={index} value={index}>{priorityEntry.label}</option>
-            ))}
-          </Select>
-        </div>
-        <LabelInput
-          labels={labels}
-          setLabels={setLabels}
-          labelColors={labelColors}
-          allExistingLabels={allExistingLabels}
-          testId="task-labels"
-        />
-      </div>
+      <PriorityLabelsRow
+        priority={priority}
+        setPriority={setPriority}
+        labels={labels}
+        setLabels={setLabels}
+        testIdPrefix="task-"
+      />
       {!isInTodo && (
-        <div>
-          <label className="text-xs text-fg-muted mb-1 flex items-center gap-1">
-            <GitPullRequest size={12} />
-            Pull Request
-          </label>
+        <Field label={<span className="flex items-center gap-1"><GitPullRequest size={12} />Pull Request</span>}>
           <input
             type="url"
             placeholder="https://github.com/owner/repo/pull/123"
             value={prUrl}
             onChange={(e) => setPrUrl(e.target.value)}
-            className="w-full bg-surface border border-edge-input rounded px-3 py-1.5 text-xs text-fg placeholder-fg-faint focus:outline-none focus:border-accent"
+            className={FIELD_CONTROL_CLASS}
             data-testid="pr-url-input"
           />
-        </div>
+        </Field>
       )}
       {!isSessionActive && !isArchived && isInTodo && (
-        <div>
-          <label className="text-xs text-fg-muted mb-1 block">Branch</label>
-          <div className="flex items-center gap-2">
-            <input
-              data-testid="custom-branch-name-input"
-              type="text"
-              placeholder={branchConfig.branchPlaceholder}
-              value={branchConfig.customBranchName}
-              onChange={(e) => branchConfig.setCustomBranchName(e.target.value)}
-              className={`flex-1 min-w-0 bg-surface border rounded px-3 py-1.5 text-xs text-fg placeholder-fg-faint focus:outline-none ${
-                branchConfig.branchNameError
-                  ? 'border-red-500 focus:border-red-500'
-                  : 'border-edge-input focus:border-accent'
-              }`}
-            />
-            <span className="text-xs text-fg-disabled shrink-0">from</span>
-            <BranchPicker value={branchConfig.baseBranch} defaultBranch={branchConfig.defaultBaseBranch || 'main'} onChange={branchConfig.setBaseBranch} />
-            <div className="w-px h-5 bg-edge-input shrink-0" />
-            <WorktreeChip enabled={branchConfig.effectiveWorktree} onToggle={() => branchConfig.setUseWorktree(branchConfig.effectiveWorktree ? false : true)} />
-          </div>
-          {branchConfig.branchNameError ? (
-            <p className="text-xs text-red-500 mt-0.5">{branchConfig.branchNameError}</p>
-          ) : (
-            <span className="text-xs text-fg-disabled mt-1 flex items-center gap-1"><Info size={12} className="shrink-0" />{branchConfig.branchHint}</span>
-          )}
-        </div>
+        <TaskBranchRow
+          customBranchName={branchConfig.customBranchName}
+          setCustomBranchName={branchConfig.setCustomBranchName}
+          branchPlaceholder={branchConfig.branchPlaceholder}
+          branchNameError={branchConfig.branchNameError}
+          branchHint={branchConfig.branchHint}
+          baseBranch={branchConfig.baseBranch}
+          setBaseBranch={branchConfig.setBaseBranch}
+          defaultBaseBranch={branchConfig.defaultBaseBranch}
+          effectiveWorktree={branchConfig.effectiveWorktree}
+          setUseWorktree={branchConfig.setUseWorktree}
+        />
       )}
       {!isSessionActive && !isArchived && !isInTodo && (
-        <div className="flex items-center gap-2">
-          <BranchPicker value={branchConfig.baseBranch} defaultBranch={branchConfig.defaultBaseBranch || 'main'} onChange={branchConfig.setBaseBranch} />
-          {!task.worktree_path && (
-            <>
-              <div className="w-px h-5 bg-edge-input" />
-              <WorktreeChip enabled={branchConfig.effectiveWorktree} onToggle={() => branchConfig.setUseWorktree(branchConfig.effectiveWorktree ? false : true)} />
-            </>
-          )}
-        </div>
+        // Past To Do the branch name is fixed, so this is the same field with no
+        // name segment. It used to be a bare, unlabelled pill row - the one
+        // control in the form with nothing naming it. No hint here, matching what
+        // this cluster showed before: the hint reads "will be created from ...",
+        // which describes a decision this task has already made.
+        <TaskBranchRow
+          baseBranch={branchConfig.baseBranch}
+          setBaseBranch={branchConfig.setBaseBranch}
+          defaultBaseBranch={branchConfig.defaultBaseBranch}
+          effectiveWorktree={branchConfig.effectiveWorktree}
+          setUseWorktree={branchConfig.setUseWorktree}
+          showWorktree={!task.worktree_path}
+        />
       )}
       {!isSessionActive && !isArchived && (
         <AdvancedOverridesSection

--- a/src/renderer/window-manager/components/TaskDetailWindow.tsx
+++ b/src/renderer/window-manager/components/TaskDetailWindow.tsx
@@ -30,6 +30,7 @@ import { useKeybinding } from '../../hooks/useKeybinding';
 import { PriorityBadge } from '../../components/backlog/PriorityBadge';
 import { ConfirmDialog } from '../../components/dialogs/ConfirmDialog';
 import { MaximizeToggleButton } from '../../components/dialogs/dialog-maximize';
+import { DialogFooterActions } from '../../components/dialogs/DialogFooterActions';
 import {
   TaskDetailHeader,
   TaskDetailEditForm,
@@ -624,36 +625,24 @@ export function TaskDetailWindow({
                 />
               </div>
               <div className="px-4 py-3 border-t border-edge flex-shrink-0">
-                <div className={`flex ${isInTodo ? 'justify-between' : 'justify-end'} items-center`}>
-                  {isInTodo && (
+                <DialogFooterActions
+                  onCancel={actions.handleCancel}
+                  onSubmit={actions.handleSave}
+                  submitLabel="Save"
+                  busyLabel="Saving..."
+                  busy={actions.saving}
+                  disabled={!!branchConfig.branchNameError}
+                  leading={isInTodo ? (
                     <button
+                      type="button"
                       onClick={() => skipDeleteConfirm ? actions.handleDelete(false) : actions.setConfirmDelete(true)}
-                      className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-fg-faint hover:text-red-400 hover:bg-red-400/10 rounded transition-colors"
+                      className="flex items-center gap-1.5 rounded px-3 py-1.5 text-xs text-fg-faint transition-colors hover:bg-danger/10 hover:text-danger"
                     >
                       <Trash2 size={14} />
                       Delete
                     </button>
-                  )}
-                  <div className="flex items-center gap-2">
-                    <button
-                      onClick={actions.handleCancel}
-                      className="px-3 py-1.5 text-xs text-fg-muted hover:text-fg-secondary border border-edge-input hover:border-fg-faint rounded transition-colors"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      onClick={actions.handleSave}
-                      disabled={!!branchConfig.branchNameError || actions.saving}
-                      className={`px-3 py-1.5 text-xs rounded transition-colors ${
-                        branchConfig.branchNameError || actions.saving
-                          ? 'bg-accent-emphasis/50 text-accent-on/50 cursor-not-allowed'
-                          : 'bg-accent-emphasis hover:bg-accent text-accent-on'
-                      }`}
-                    >
-                      {actions.saving ? 'Saving...' : 'Save'}
-                    </button>
-                  </div>
-                </div>
+                  ) : undefined}
+                />
               </div>
             </>
           ) : (

--- a/tests/ui/new-task-dialog.spec.ts
+++ b/tests/ui/new-task-dialog.spec.ts
@@ -427,12 +427,68 @@ test.describe('To Do Edit Branch Config', () => {
     await expect(page.getByText('Base branch', { exact: true })).toBeVisible();
 
     // The task has no worktree_path yet, so the worktree segment still renders.
-    // NOTE: this pins the toggle's PRESENCE in the fixed-name shape, not the
-    // `showWorktree={!task.worktree_path}` condition itself - the mock never
-    // sets worktree_path, so the hidden arm stays unverified.
+    // The sibling test below covers the opposite arm, once worktree_path is set.
     await expect(page.locator('[data-testid="worktree-toggle"]')).toBeVisible();
 
     await page.keyboard.press('Escape');
+  });
+
+  // Closes the gap the test above leaves open: once the task has a
+  // worktree_path (a worktree already materialized on disk), the worktree
+  // segment must disappear entirely - offering to toggle a worktree that
+  // already exists doesn't make sense. This pins the
+  // `showWorktree={!task.worktree_path}` CALL SITE in TaskDetailEditForm, not
+  // just TaskBranchRow's internal `showWorktree` branch: a unit test that
+  // called `TaskBranchRow({ showWorktree: false })` directly would pass
+  // unchanged even if the call site computed the wrong boolean (e.g. inverted
+  // to `showWorktree={!!task.worktree_path}`).
+  test('non-backlog task edit hides the worktree toggle once the task has a worktree_path', async () => {
+    const uniqueTitle = `Worktree Path Hides Toggle ${Date.now()}`;
+    await createTask(page, uniqueTitle);
+
+    await page.evaluate(async (title) => {
+      const api = (window as any).electronAPI;
+      const stores = (window as any).__zustandStores;
+      const tasks = await api.tasks.list();
+      const task = tasks.find((t: { title: string }) => t.title === title);
+      const swimlanes = await api.swimlanes.list();
+      const planning = swimlanes.find((s: { name: string }) => s.name === 'Planning');
+      if (task && planning) {
+        await api.tasks.move({
+          taskId: task.id,
+          targetSwimlaneId: planning.id,
+          targetPosition: 0,
+        });
+        // Simulate a worktree that has already materialized on disk for this
+        // task (the real main process sets this once the worktree checkout
+        // completes; the mock never sets it on its own).
+        await api.tasks.update({
+          id: task.id,
+          worktree_path: '/mock/worktrees/' + task.id.slice(0, 8),
+        });
+        await stores.board.getState().loadBoard();
+      }
+    }, uniqueTitle);
+
+    const taskCard = page.locator('[data-swimlane-name="Planning"]').locator(`text=${uniqueTitle}`).first();
+    await expect(taskCard).toBeVisible({ timeout: 5000 });
+    await taskCard.click();
+    const detailDialog = page.locator('[data-testid="task-detail-dialog"]');
+    await detailDialog.waitFor({ state: 'visible', timeout: 5000 });
+
+    // Positive anchor: the branch row itself rendered. Without this, the
+    // negative assertion below would pass vacuously if the whole row failed
+    // to render or the form landed in a different mode.
+    await expect(detailDialog.locator('[data-testid="branch-picker-chip"]')).toBeVisible();
+
+    // The assertion this test exists for.
+    await expect(detailDialog.locator('[data-testid="worktree-toggle"]')).not.toBeVisible();
+
+    // No edits were made, so Escape closes directly (no discard confirm).
+    // Wait for the window to fully unmount so it can't leak into a later test
+    // in this shared-page suite (cross-platform-parity.md).
+    await page.keyboard.press('Escape');
+    await detailDialog.waitFor({ state: 'hidden', timeout: 3000 });
   });
 });
 

--- a/tests/ui/new-task-dialog.spec.ts
+++ b/tests/ui/new-task-dialog.spec.ts
@@ -114,13 +114,17 @@ test.describe('Worktree Toggle', () => {
     await closeDialog();
   });
 
+  // The on/off state is read from aria-pressed, not from a styling class. The
+  // control used to signal "off" with `line-through` on an inner span, so these
+  // asserted on that class; a strikethrough reads as "deleted" rather than
+  // "off", so the state now lives on the attribute the control already needs for
+  // accessibility. Asserting programmatic state over pixels is also what
+  // .claude/rules/cross-platform-parity.md asks for.
   test('toggle defaults to enabled when global worktrees setting is ON', async () => {
     await openNewTaskDialog();
 
     const toggle = page.locator('[data-testid="worktree-toggle"]');
-    // Default config has worktreesEnabled: true -- chip should NOT have line-through
-    const span = toggle.locator('span');
-    await expect(span).not.toHaveClass(/line-through/);
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true');
 
     await closeDialog();
   });
@@ -131,9 +135,7 @@ test.describe('Worktree Toggle', () => {
     const toggle = page.locator('[data-testid="worktree-toggle"]');
     await toggle.click();
 
-    // After toggling off, the span should have line-through styling
-    const span = toggle.locator('span');
-    await expect(span).toHaveClass(/line-through/);
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
 
     await closeDialog();
   });
@@ -142,14 +144,11 @@ test.describe('Worktree Toggle', () => {
     await openNewTaskDialog();
 
     const toggle = page.locator('[data-testid="worktree-toggle"]');
-    // Toggle off
     await toggle.click();
-    const span = toggle.locator('span');
-    await expect(span).toHaveClass(/line-through/);
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
 
-    // Toggle back on
     await toggle.click();
-    await expect(span).not.toHaveClass(/line-through/);
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true');
 
     await closeDialog();
   });
@@ -212,6 +211,33 @@ test.describe('Worktree Toggle', () => {
 
     // Close by pressing Escape
     await page.keyboard.press('Escape');
+  });
+
+  // The edit form wires its own `effectiveWorktree` / `setUseWorktree` pair into
+  // TaskBranchRow, separately from the New Task dialog. Visibility alone (the
+  // test above) would still pass if that pair were mis-wired or handed a no-op
+  // handler, so this pins the state readout and the click.
+  test('task detail edit mode toggle reflects and flips worktree state', async () => {
+    const uniqueTitle = `Detail Toggle State ${Date.now()}`;
+    await createTask(page, uniqueTitle);
+
+    const taskCard = page.locator('[data-testid="swimlane"]').locator(`text=${uniqueTitle}`).first();
+    await taskCard.click();
+    const detailDialog = page.locator('[data-testid="task-detail-dialog"]');
+    await detailDialog.waitFor({ state: 'visible', timeout: 5000 });
+
+    // Global worktrees setting is ON in the default config, and the task has no
+    // explicit override, so the effective state starts enabled.
+    const toggle = detailDialog.locator('[data-testid="worktree-toggle"]');
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    // Toggling leaves the form dirty, so Escape raises the discard confirm.
+    await page.keyboard.press('Escape');
+    await page.locator('button:has-text("Discard")').click();
+    await detailDialog.waitFor({ state: 'hidden', timeout: 3000 });
   });
 });
 
@@ -360,6 +386,51 @@ test.describe('To Do Edit Branch Config', () => {
     // But BranchPicker should still be visible (simple chip mode for non-backlog)
     const branchChip = page.locator('[data-testid="branch-picker-chip"]');
     await expect(branchChip).toBeVisible();
+
+    await page.keyboard.press('Escape');
+  });
+
+  // Past To Do the branch NAME is fixed, so TaskBranchRow renders its second
+  // shape: the field is titled "Base branch" rather than "Branch", and the
+  // worktree segment appears only while the task has no worktree on disk. The
+  // sibling test above checks the name input is gone but asserts neither of
+  // those, so both would survive being inverted without it.
+  test('non-backlog task edit labels the field Base branch and keeps the worktree toggle', async () => {
+    const uniqueTitle = `Base Branch Shape ${Date.now()}`;
+    await createTask(page, uniqueTitle);
+
+    await page.evaluate(async (title) => {
+      const api = (window as any).electronAPI;
+      const stores = (window as any).__zustandStores;
+      const tasks = await api.tasks.list();
+      const task = tasks.find((t: { title: string }) => t.title === title);
+      const swimlanes = await api.swimlanes.list();
+      const planning = swimlanes.find((s: { name: string }) => s.name === 'Planning');
+      if (task && planning) {
+        await api.tasks.move({
+          taskId: task.id,
+          targetSwimlaneId: planning.id,
+          targetPosition: 0,
+        });
+        await stores.board.getState().loadBoard();
+      }
+    }, uniqueTitle);
+
+    const taskCard = page.locator('[data-swimlane-name="Planning"]').locator(`text=${uniqueTitle}`).first();
+    await expect(taskCard).toBeVisible({ timeout: 5000 });
+    await taskCard.click();
+    await page.locator('.fixed input[placeholder="Task title"]').waitFor({ state: 'visible' });
+
+    // "Base branch", not "Branch" - there is no editable branch name here. The
+    // exact match is what carries this: it fails if the label reverts to
+    // "Branch", so no page-wide negative assertion is needed alongside it.
+    await expect(page.getByText('Base branch', { exact: true })).toBeVisible();
+
+    // The task has no worktree_path yet, so the worktree segment still renders.
+    // NOTE: this pins the toggle's PRESENCE in the fixed-name shape, not the
+    // `showWorktree={!task.worktree_path}` condition itself - the mock never
+    // sets worktree_path, so the hidden arm stays unverified.
+    await expect(page.locator('[data-testid="worktree-toggle"]')).toBeVisible();
 
     await page.keyboard.press('Escape');
   });

--- a/tests/unit/dialog-form-primitives.test.ts
+++ b/tests/unit/dialog-form-primitives.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit coverage for three of the new shared dialog primitives from the
+ * New/Edit Task dialog presentation refactor: `Field`'s error-wins-over-hint
+ * precedence, `DialogFooterActions`'s submit-vs-button `type` ternary, and
+ * `WorktreeChip`'s `type="button"` guard. All three are hookless function
+ * components, so - following the established pattern in
+ * `panel-error-boundary.test.ts` (this project's vitest config has no jsdom
+ * environment and no @testing-library/react dependency) - they are called
+ * directly as plain functions and their real `React.createElement` output
+ * (`{ type, props }`) is walked without a renderer.
+ *
+ * `TaskBranchRow`'s `showWorktree` prop and `PriorityLabelsRow` are
+ * deliberately NOT covered here: `TaskBranchRow` renders correctly for any
+ * `showWorktree` value passed to it, so a unit test on the component would
+ * pass unchanged even if the call site computed the wrong boolean (e.g.
+ * `showWorktree={!!task.worktree_path}` inverted). That risk lives at the
+ * call site in `TaskDetailEditForm`, and is covered at the UI tier instead
+ * (see the "hides the worktree toggle once the task has a worktree_path" test
+ * in tests/ui/new-task-dialog.spec.ts). `PriorityLabelsRow` reads Zustand
+ * store hooks (`useConfigStore`, `useAllExistingLabels`), so it cannot be
+ * called this way without a reconciler.
+ */
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { Info } from 'lucide-react';
+import { Field } from '../../src/renderer/components/Field';
+import { DialogFooterActions } from '../../src/renderer/components/dialogs/DialogFooterActions';
+import { WorktreeChip } from '../../src/renderer/components/dialogs/WorktreeChip';
+
+interface ElementLike {
+  type: unknown;
+  props: Record<string, unknown>;
+}
+
+function isElementLike(node: unknown): node is ElementLike {
+  return typeof node === 'object' && node !== null && 'props' in node;
+}
+
+function collectText(node: unknown): string {
+  if (node === null || node === undefined || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join('');
+  if (isElementLike(node)) return collectText(node.props.children);
+  return '';
+}
+
+/** Depth-first search for the first element whose className includes `substring`. */
+function findByClassNameIncluding(node: unknown, substring: string): ElementLike | null {
+  if (node === null || node === undefined || typeof node === 'boolean') return null;
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findByClassNameIncluding(child, substring);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (isElementLike(node)) {
+    const className = node.props.className;
+    if (typeof className === 'string' && className.includes(substring)) return node;
+    return findByClassNameIncluding(node.props.children, substring);
+  }
+  return null;
+}
+
+/** Depth-first search for the first element whose `type` is `target` (reference equality). */
+function findByType(node: unknown, target: unknown): ElementLike | null {
+  if (node === null || node === undefined || typeof node === 'boolean') return null;
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findByType(child, target);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (isElementLike(node)) {
+    if (node.type === target) return node;
+    return findByType(node.props.children, target);
+  }
+  return null;
+}
+
+/** Depth-first collection of every native `<button>` element in the tree. */
+function findAllButtons(node: unknown, results: ElementLike[] = []): ElementLike[] {
+  if (node === null || node === undefined || typeof node === 'boolean') return results;
+  if (Array.isArray(node)) {
+    node.forEach((child) => findAllButtons(child, results));
+    return results;
+  }
+  if (isElementLike(node)) {
+    if (node.type === 'button') results.push(node);
+    findAllButtons(node.props.children, results);
+  }
+  return results;
+}
+
+describe('Field', () => {
+  it('renders the error message and suppresses the hint (and its info icon) when both are set', () => {
+    const output = Field({
+      label: 'Branch',
+      children: React.createElement('input'),
+      hint: 'Auto-generated branch will be created from main',
+      error: 'Invalid git branch name',
+    });
+
+    const errorParagraph = findByClassNameIncluding(output, 'text-danger');
+    expect(errorParagraph).not.toBeNull();
+    expect(collectText(errorParagraph)).toBe('Invalid git branch name');
+
+    // The hint paragraph must not render at all while an error is present -
+    // not merely be visually overridden. Both the hint text and its Info icon
+    // must be absent from the output tree.
+    const hintParagraph = findByClassNameIncluding(output, 'text-fg-disabled');
+    expect(hintParagraph).toBeNull();
+    expect(collectText(output)).not.toContain('Auto-generated branch will be created from main');
+    expect(findByType(output, Info)).toBeNull();
+  });
+
+  it('renders the hint (with its info icon) when there is no error', () => {
+    const output = Field({
+      label: 'Branch',
+      children: React.createElement('input'),
+      hint: 'Auto-generated branch will be created from main',
+    });
+
+    const hintParagraph = findByClassNameIncluding(output, 'text-fg-disabled');
+    expect(hintParagraph).not.toBeNull();
+    expect(collectText(hintParagraph)).toBe('Auto-generated branch will be created from main');
+    expect(findByType(output, Info)).not.toBeNull();
+    expect(findByClassNameIncluding(output, 'text-danger')).toBeNull();
+  });
+});
+
+describe('DialogFooterActions', () => {
+  it('renders the submit button as type="submit" when onSubmit is omitted (NewTaskDialog\'s form-submit shape)', () => {
+    const output = DialogFooterActions({
+      onCancel: () => {},
+      submitLabel: 'Create',
+    });
+
+    const buttons = findAllButtons(output);
+    const cancelButton = buttons.find((button) => collectText(button).includes('Cancel'));
+    const submitButton = buttons.find((button) => collectText(button).includes('Create'));
+
+    expect(cancelButton).toBeDefined();
+    expect(cancelButton?.props.type).toBe('button');
+
+    // This is the exact shape NewTaskDialog relies on: it never passes
+    // `onSubmit`, so its <form onSubmit={handleSubmit}> only fires when THIS
+    // button's native type="submit" triggers it.
+    expect(submitButton).toBeDefined();
+    expect(submitButton?.props.type).toBe('submit');
+    expect(submitButton?.props.onClick).toBeUndefined();
+  });
+
+  it('renders the submit button as type="button" when onSubmit is passed (TaskDetailWindow\'s formless footer)', () => {
+    const handleSave = () => {};
+    const output = DialogFooterActions({
+      onCancel: () => {},
+      onSubmit: handleSave,
+      submitLabel: 'Save',
+    });
+
+    const buttons = findAllButtons(output);
+    const cancelButton = buttons.find((button) => collectText(button).includes('Cancel'));
+    const submitButton = buttons.find((button) => collectText(button).includes('Save'));
+
+    expect(cancelButton).toBeDefined();
+    expect(cancelButton?.props.type).toBe('button');
+
+    // TaskDetailWindow has no surrounding <form>, so if this regressed to
+    // type="submit" the click would do nothing (no form to submit) rather
+    // than silently calling handleSave via a native submission.
+    expect(submitButton).toBeDefined();
+    expect(submitButton?.props.type).toBe('button');
+    expect(submitButton?.props.onClick).toBe(handleSave);
+  });
+});
+
+describe('WorktreeChip', () => {
+  it('renders as type="button" so a click inside NewTaskDialog\'s <form> never submits it', () => {
+    // WorktreeChip used to be a `Pill`, which auto-defaults an unset `type` to
+    // "button" for any `as="button"` render (Pill.tsx). Now that it is a raw
+    // <button>, that safety net is gone: a future edit that drops the
+    // explicit type="button" line silently regresses to the browser's
+    // default of type="submit" inside a form, and NewTaskDialog wraps the
+    // whole dialog body (including this control) in exactly such a <form>.
+    const output = WorktreeChip({ enabled: true, onToggle: () => {} });
+
+    expect(output.type).toBe('button');
+    expect(output.props.type).toBe('button');
+  });
+});


### PR DESCRIPTION
## What

A design pass over the lower half of the New/Edit Task dialog: the Priority / Labels / Branch
metadata row, the two run-mode cards, and the dialog footer.

Affected components, all under `src/renderer/`:

- **New** `components/Field.tsx`, `components/dialogs/PriorityLabelsRow.tsx`,
  `components/dialogs/TaskBranchRow.tsx`, `components/dialogs/DialogFooterActions.tsx`
- **Changed** `LabelInput.tsx`, `dialogs/BranchPicker.tsx`, `dialogs/WorktreeChip.tsx`,
  `dialogs/AdvancedOverridesSection.tsx`, `dialogs/NewTaskDialog.tsx`,
  `dialogs/task-detail/TaskDetailEditForm.tsx`, `window-manager/components/TaskDetailWindow.tsx`,
  `backlog/NewBacklogTaskDialog.tsx`

Behavior is unchanged. Every field, override, and the branch/worktree resolution logic work
exactly as before.

## Why

This block was never revisited while the header, title field, and Write/Preview editor were
rebuilt around it, so it read as a different generation of UI. Five controls sat on one strip at
four heights and three corner radii, the word "from" floated as bare text between two pills, and
the two run-mode cards ate as much vertical space as the description editor itself.

Three concrete defects sat underneath the visual complaint, and they are what made this worth
more than a spacing tweak:

1. **The selected run-mode card had no visible fill.** It was painted `bg-surface-raised`, which
   is the exact colour of `BaseDialog`'s own content wrapper, so neither the selected nor the
   unselected state read as marked. The file's own comment said "fill is what marks the live
   branch here"; it was never actually delivered.
2. **The block was duplicated verbatim** across `NewTaskDialog` and `TaskDetailEditForm`, as were
   the two footers, which had already drifted on padding and on their disabled treatment. That
   made "verify in both modes" a manual inspection that could silently fail.
3. **Hardcoded hues** (`red-500`, `red-400`) on the branch error and the footer Delete, in a
   codebase with a `--kng-danger` token and 11 themes.

## How

**A shared field vocabulary.** The exact string `text-xs text-fg-muted mb-1 block` appeared ten
times across five dialog files. `Field` codifies that shape rather than inventing one, and exports
the control shell as `FIELD_CONTROL_CLASS` / `FIELD_SELECT_CLASS`. The scale is 34px because
`Select` and `Combobox` are already that height app-wide; changing *them* would ripple into
settings, so everything else came up to meet them.

**The branch row is one composed control.** A single bordered shell with flush segments and
`divide-x` dividers, reusing the shape `Combobox` already uses for its chevron button in the same
dialog. The bare "from" is deleted rather than restyled: the hint line below already reads "will
be created from `main`". The base-branch segment is width-capped with `truncate`, since without a
cap a long branch name squeezed the name input to its `min-w-0` and collapsed the row.

**Run-mode cards** get one-line headers (~56px to ~34px each). Both descriptions stay visible and
each branch's controls stay inside its own card, per the documented prior decisions in that file.
Selection is carried by four quiet signals stacked rather than one loud one: the accent dot, a
brighter border, the label at full text weight against a muted one, and a `/25` fill wash.

**Token choice is load-bearing on the card fill.** `bg-surface` fixes the invisible-selection bug
in the dark themes but not in light, where surface (`#f5f5f4`) sits 5/255 from surface-raised
(`#fafaf9`) and the fill vanishes again. `surface-hover` holds a 16-24/255 delta in all 11 themes.

**Trade-off worth a reviewer's attention:** the vertical saving is real but modest. The region
below the editor went 324 to 286px and the run-mode card group 176 to 134px (the headers alone
112 to 68px). The group includes the selected branch's body, which is a real control that does not
shrink. Card padding was deliberately not tightened further, because `fd486dee` already tried that
and reverted it.

Two regressions were caught by measuring rather than eyeballing, and are fixed here:

- The composed shell collapsed to an 18px sliver in the past-To-Do shape, where the name input is
  absent and its padding had been the only thing setting the height. Now an explicit `min-h`.
- The shell's `overflow-hidden` clipped the default focus outline on both segments. They now draw
  an inset ring, scoped to the focused segment instead of lighting the whole row.

## Breaking changes

None. Presentation only, and every `data-testid` in the affected surfaces is preserved
(`branch-picker-chip` keeps its name even though the control is no longer a chip, because four
specs drive it).

## Tests

CI: lint, typecheck, unit, build, the UI shards, and the Linux Electron E2E shards.

The three Worktree specs asserted the removed `line-through` class on an inner span. They now
assert `aria-pressed`, which is what `cross-platform-parity.md` asks for (programmatic state over
styling) and is necessary anyway, since `toggle.locator('span')` became strict-mode ambiguous.

Added coverage for the edit-mode worktree toggle's state readout and click (the edit form wires
its own `effectiveWorktree` / `setUseWorktree` pair, which a visibility-only assertion would not
catch if mis-wired) and for `TaskBranchRow`'s fixed-name shape (the "Base branch" label and the
worktree segment's presence).

Verified locally before pushing: typecheck, lint, and the directly affected UI specs
(`new-task-dialog` 20, `task-level-overrides` 54, `backlog` + `backlog-dialog-ux` 29,
`label-input`, `combobox-portal-clipping`, `app`, `task-detail-maximize`). Geometry and computed
colours were measured through the UI harness in both dark and light themes, at the task-detail
window's 650px minimum width, and with a long base-branch name.

Generated with [Claude Code](https://claude.com/claude-code)
