### PR TITLE
feat(sidebar): surface live Command Terminals per project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,26 @@ won't be found.
   stroke color is the aggregate activity of the project's terminals (active-green working /
   attention-amber needs-you / muted rest, via the central `--kng-active` / `--kng-attention`
   tokens) and the working border MARCHES (`@keyframes march-border` + a `pathLength`-normalized
-  stroke-dash). GEOMETRY is global but POPULATION is per-project: the window layout blob
+  stroke-dash). The toggle reflects only the CURRENT project, so the same glyph is mirrored
+  per project in the sidebar (`SidebarCommandTerminalIndicator` in each `ProjectListItem` row,
+  plus a plain tone dot on `CollapsedRail`'s 28px buttons, where an arc-bearing glyph would read
+  as broken). Both the toggle and the sidebar read one shared selector,
+  `selectCommandTerminalSummary` (`transient-session-slice.ts`), which derives count + tone from
+  the UNSCOPED `sessions` list (`transient && projectId && status === 'running'`) rather than the
+  `transientSessions` map: that map is renderer-owned window pairing whose hard-reload recovery
+  only re-pairs the current project, so a map-based count reads zero for every background project
+  after a reload. The sidebar indicator sits BESIDE the agent thinking/idle counts in the row's
+  right-aligned cluster, never merged into them (a Command Terminal is not a task agent). It always
+  prints its count, even at 1, so it forms an icon+digit pair matching the agent counts and the
+  three indicators stack into one tabular column down the list; a name-adjacent placement was tried
+  and reverted, because project names vary enough that the glyph landed at a different x on every
+  row. Clicking it switches to that project and reopens its layer via the same
+  `setPendingOpenCommandTerminal` flag the notification-click path uses, armed only once the switch
+  is CONFIRMED. Awaiting is not enough: `openProject` also RESOLVES without switching (a moved or
+  renamed folder routes to the "Locate Folder" dialog) and re-throws every other failure, so the
+  sidebar re-reads `currentProject` after the await and leaves the flag disarmed unless it landed.
+  Arming on those paths opens the layer on the OUTGOING project. GEOMETRY is global but
+  POPULATION is per-project: the window layout blob
   is shared, yet WHICH slots get windows is reconciled to the current project's live transient
   sessions on open (`reconcileCommandTerminalWindows` +
   `planCommandWindowReconciliation` in `command-window-reconcile.ts`). Project switching keeps every

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -566,6 +566,10 @@ If a project's folder is moved or renamed while Kangentic is closed, opening it 
 
 When an agent goes idle (waiting for input or stopped) on a non-active project, the sidebar shows a badge. This helps you notice when agents need attention across projects.
 
+### Command Terminal Indicator
+
+Command Terminals keep running when you hide the layer and when you switch projects, so a project you are not looking at can still be holding live terminals. Each project row shows a terminal glyph and a count when it has any, alongside the agent idle/thinking counts, colored the same way as the title-bar toggle: green while a terminal is working, amber when one is waiting on you, muted when it is just sitting there. It sits next to the agent idle/thinking counts rather than merging with them, since a Command Terminal is not a task agent. Click it to switch to that project and reopen its terminals. When the sidebar is collapsed, the rail shows the same state as a small dot on the project's initial.
+
 ### Notifications
 
 Desktop and toast notifications fire when an agent needs attention and the user can't already see it - either the window is minimized/unfocused, or a different project is active. Notification events: agent idle, permission-blocked idle (body shows "Needs permission"), session crash (non-zero exit), and plan-completion auto-moves. The task name is the title and the project name is the body. Clicking a desktop notification brings the window to the foreground, switches to the correct project, and opens the task detail dialog. The taskbar also flashes on Windows. A 10-second per-session cooldown prevents repeated desktop notifications from the same agent.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -487,10 +487,23 @@ export function App() {
         const alreadyActive = useProjectStore.getState().currentProject?.id === projectId;
         const isCommandTerminal = taskId === COMMAND_TERMINAL_NOTIFICATION_TASK_ID;
         if (isCommandTerminal) {
-          useSessionStore.getState().setPendingOpenCommandTerminal(true);
-          if (!alreadyActive) {
-            useProjectStore.getState().openProject(projectId);
+          if (alreadyActive) {
+            useSessionStore.getState().setPendingOpenCommandTerminal(true);
+            return;
           }
+          // Arm the flag only once the switch is CONFIRMED, the same contract the
+          // sidebar indicator follows (`ProjectSidebar.handleOpenCommandTerminals`).
+          // Setting it up front let `useCommandBar`'s effect fire while the OUTGOING
+          // project was still current, opening the layer on the wrong project until
+          // the close-on-project-change effect tore it back down. `openProject` also
+          // RESOLVES without switching (a moved or renamed folder routes to the
+          // "Locate Folder" dialog), so confirm rather than merely sequence.
+          useProjectStore.getState().openProject(projectId)
+            .then(() => {
+              if (useProjectStore.getState().currentProject?.id !== projectId) return;
+              useSessionStore.getState().setPendingOpenCommandTerminal(true);
+            })
+            .catch(() => {});
           return;
         }
         if (taskId && alreadyActive) {

--- a/src/renderer/components/BrandMark.tsx
+++ b/src/renderer/components/BrandMark.tsx
@@ -5,7 +5,7 @@ import brandMarkSvg from '@kangentic/branding/assets/brandmark-mono-amber.svg?ra
  * while the amber slit stays fixed - a themed lockup that reads as one unit with the wordmark
  * on every theme. Deliberate exception to the "use lucide, no inline SVGs" rule: this consumes
  * a shipped brand asset that must theme-tint and cannot be a lucide glyph (precedent:
- * CommandTerminalIcon in TitleBar.tsx). The `?raw` source is a trusted build-time package asset.
+ * command-bar/CommandTerminalIcon.tsx). The `?raw` source is a trusted build-time package asset.
  */
 export function BrandMark({ className = '' }: { className?: string }) {
   return (

--- a/src/renderer/components/command-bar/CommandTerminalIcon.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalIcon.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import type { CommandTerminalTone } from '../../stores/session-store/transient-session-slice';
+
+/**
+ * The Command Terminal glyph: a custom terminal icon whose state lives IN the
+ * glyph rather than in a separate corner badge. The stroke color is the aggregate
+ * activity of a project's terminals (green while working / warm amber when one
+ * needs you / muted rest, via the --kng-active / --kng-attention tokens), and the
+ * working border MARCHES (a dash flows around the perimeter). The center morphs
+ * from the shell prompt to a `+` when rendered for the "New terminal" button, so
+ * that button reads as a terminal glyph (not a bare plus). 24 viewBox at
+ * strokeWidth 2 to match the neighbouring lucide icons.
+ *
+ * A deliberate inline-SVG exception to the lucide-only icon convention
+ * (`ui-conventions.md`): no lucide glyph carries a marching activity border, and
+ * the prompt/plus morph is specific to this control.
+ *
+ * Shared by the title bar (20px, the project-wide toggle) and the project sidebar
+ * (14px, per project row). Callers outside the title bar MUST pass their own
+ * `testId`: the default belongs to the title-bar toggle, and reusing it would make
+ * that button's test locators ambiguous.
+ */
+export function CommandTerminalIcon({
+  tone,
+  showPlus = false,
+  size = 20,
+  testId = 'quick-session-icon',
+}: {
+  tone: CommandTerminalTone;
+  showPlus?: boolean;
+  size?: number;
+  testId?: string;
+}): React.ReactNode {
+  // `tone` is a derived PRESENTATIONAL union (rest | thinking | idle); the idle-vs-active
+  // bucketing already happened upstream via isActive / requiresUserInteraction when this
+  // tone was computed, so these are per-tone affordances, not a hand-rolled ActivityState bucket.
+  const isWorking = tone === 'thinking'; // activity-state-ok: presentational tone, not an ActivityState
+  const needsAttention = tone === 'idle'; // activity-state-ok: presentational tone, not an ActivityState
+  const colorClass = isWorking ? 'text-active' : needsAttention ? 'text-attention' : '';
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={colorClass}
+      data-testid={testId}
+      data-activity={tone}
+      data-plus={showPlus ? 'true' : 'false'}
+      aria-hidden="true"
+    >
+      {/* Terminal screen border. While an agent works it marches (a dash flows
+          around the perimeter); pathLength normalizes the dash math to 100. */}
+      <rect
+        x="3"
+        y="3"
+        width="18"
+        height="18"
+        rx="3"
+        pathLength={100}
+        strokeDasharray={isWorking ? '65 35' : undefined}
+        className={isWorking ? 'animate-march-border' : undefined}
+      />
+      {showPlus ? (
+        // The add affordance, centered in the terminal (replaces the prompt).
+        <>
+          <path d="M12 8.5 V15.5" />
+          <path d="M8.5 12 H15.5" />
+        </>
+      ) : (
+        // The shell prompt: chevron + caret line.
+        <>
+          <path d="M7.5 9.5 L10.5 12 L7.5 14.5" />
+          <path d="M12.5 14.5 H16.5" />
+        </>
+      )}
+    </svg>
+  );
+}

--- a/src/renderer/components/layout/TitleBar.tsx
+++ b/src/renderer/components/layout/TitleBar.tsx
@@ -8,9 +8,9 @@ import { useUpdaterStore } from '../../stores/updater-store';
 import { useUsageDashboardStore } from '../../stores/usage-dashboard-store';
 import { warmStatsDashboard } from '../stats/LazyStatsDashboard';
 import { usePopOut } from '../../pop-out/usePopOut';
-import { selectCurrentProjectTransientSessionIds } from '../../stores/session-store/transient-session-slice';
+import { selectCommandTerminalSummary } from '../../stores/session-store/transient-session-slice';
+import { CommandTerminalIcon } from '../command-bar/CommandTerminalIcon';
 import { isWorktreePath } from '../../../shared/git-utils';
-import { requiresUserInteraction, isActive } from '../../../shared/activity-state';
 import { useFormattedCombo } from '../../hooks/useKeybinding';
 import { BrandMark } from '../BrandMark';
 
@@ -27,76 +27,6 @@ interface TitleBarProps {
   /** Whether another Command Terminal can be opened (below the cap). Disables
    *  the "New terminal" button without unmounting it. */
   canSpawnMoreTerminals?: boolean;
-}
-
-/**
- * The title-bar Command Terminal glyph: a custom terminal icon whose state lives
- * IN the glyph rather than in a separate corner badge. The stroke color is the
- * aggregate activity of the project's terminals (green while working / warm amber
- * when one needs you / muted rest, via the --kng-active / --kng-attention tokens),
- * and the working border MARCHES (a dash flows around the perimeter). The center
- * morphs from the shell prompt to a `+` when rendered for the "New terminal"
- * button, so that button reads as a terminal glyph (not a bare plus). 24 viewBox
- * at strokeWidth 2 to match the neighbouring lucide icons.
- */
-function CommandTerminalIcon({
-  tone,
-  showPlus = false,
-  testId = 'quick-session-icon',
-}: {
-  tone: 'rest' | 'thinking' | 'idle';
-  showPlus?: boolean;
-  testId?: string;
-}): React.ReactNode {
-  // `tone` is a derived PRESENTATIONAL union (rest | thinking | idle); the idle-vs-active
-  // bucketing already happened upstream via isActive / requiresUserInteraction when this
-  // tone was computed, so these are per-tone affordances, not a hand-rolled ActivityState bucket.
-  const isWorking = tone === 'thinking'; // activity-state-ok: presentational tone, not an ActivityState
-  const needsAttention = tone === 'idle'; // activity-state-ok: presentational tone, not an ActivityState
-  const colorClass = isWorking ? 'text-active' : needsAttention ? 'text-attention' : '';
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      width={20}
-      height={20}
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={colorClass}
-      data-testid={testId}
-      data-activity={tone}
-      data-plus={showPlus ? 'true' : 'false'}
-      aria-hidden="true"
-    >
-      {/* Terminal screen border. While an agent works it marches (a dash flows
-          around the perimeter); pathLength normalizes the dash math to 100. */}
-      <rect
-        x="3"
-        y="3"
-        width="18"
-        height="18"
-        rx="3"
-        pathLength={100}
-        strokeDasharray={isWorking ? '65 35' : undefined}
-        className={isWorking ? 'animate-march-border' : undefined}
-      />
-      {showPlus ? (
-        // The add affordance, centered in the terminal (replaces the prompt).
-        <>
-          <path d="M12 8.5 V15.5" />
-          <path d="M8.5 12 H15.5" />
-        </>
-      ) : (
-        // The shell prompt: chevron + caret line.
-        <>
-          <path d="M7.5 9.5 L10.5 12 L7.5 14.5" />
-          <path d="M12.5 14.5 H16.5" />
-        </>
-      )}
-    </svg>
-  );
 }
 
 export function TitleBar({
@@ -126,19 +56,13 @@ export function TitleBar({
 
   // Aggregate activity across THIS project's Command Terminal sessions, surfaced
   // as the title-bar terminal icon's COLOR (the same active/idle language as the
-  // task-detail / per-terminal controls, no separate dot). WORKING (active) wins:
-  // if any terminal is active the icon is active-green, else attention-amber if any needs you,
-  // else rest. Classified only via the shared helpers (activity-state rule).
-  const transientActivityTone = useSessionStore((state) => {
-    const ids = selectCurrentProjectTransientSessionIds(state.transientSessions, currentProject?.id ?? null);
-    let anyIdle = false;
-    for (const sessionId of ids) {
-      const activity = state.sessionActivity[sessionId];
-      if (isActive(activity)) return 'thinking';
-      if (requiresUserInteraction(activity)) anyIdle = true;
-    }
-    return anyIdle ? 'idle' : 'rest';
-  });
+  // task-detail / per-terminal controls, no separate dot). The shared selector is
+  // the same one each project sidebar row uses, so the title bar and the sidebar
+  // can never disagree about a project's terminal activity. Selecting the tone
+  // string (not the summary object) keeps Zustand's default Object.is equality.
+  const transientActivityTone = useSessionStore(
+    (state) => selectCommandTerminalSummary(state.sessions, state.sessionActivity, currentProject?.id ?? null).tone,
+  );
 
   // Tooltips read the live effective combo so they update when the user rebinds.
   const quickFindCombo = useFormattedCombo('search.togglePalette');

--- a/src/renderer/components/sidebar/CollapsedRail.tsx
+++ b/src/renderer/components/sidebar/CollapsedRail.tsx
@@ -1,5 +1,11 @@
 import { PanelLeft, FolderPlus } from 'lucide-react';
+import { useShallow } from 'zustand/react/shallow';
 import { useProjectStore } from '../../stores/project-store';
+import { useSessionStore } from '../../stores/session-store';
+import {
+  selectCommandTerminalSummary,
+  type CommandTerminalTone,
+} from '../../stores/session-store/transient-session-slice';
 import { useFormattedCombo } from '../../hooks/useKeybinding';
 import { useAddProject } from '../../hooks/useAddProject';
 import type { Project } from '../../../shared/types';
@@ -19,12 +25,52 @@ function railLabelFor(project: Project, projects: Project[]): string {
   return project.name.slice(0, 2).toUpperCase();
 }
 
+/**
+ * Tone -> dot color. A LIVE terminal that is merely resting still gets a dot: the
+ * whole point of the rail indicator is that a background project's terminals are
+ * otherwise invisible, so presence is the signal and tone is the detail.
+ */
+const RAIL_DOT_CLASS: Record<CommandTerminalTone, string> = {
+  thinking: 'bg-active',
+  idle: 'bg-attention',
+  rest: 'bg-fg-muted',
+};
+
+/**
+ * Tone -> the spoken half of the rail button's accessible name. The dot carries
+ * tone in COLOR ALONE, so without this a screen-reader user learns a project has
+ * terminals but never that one is waiting on them, while a sighted user reads it
+ * straight off the amber. Reuses the expanded row's parenthetical vocabulary
+ * (`SidebarCommandTerminalIndicator`) so the two views differ in verbosity, not
+ * in meaning. The count is deliberately not spoken: the rail's summary map stores
+ * tone alone so it stays a flat, shallow-comparable record.
+ */
+const RAIL_TERMINAL_LABEL: Record<CommandTerminalTone, string> = {
+  thinking: 'Command Terminals running (working)',
+  idle: 'Command Terminals running (needs you)',
+  rest: 'Command Terminals running (resting)',
+};
+
 export function CollapsedRail({ onExpandSidebar }: CollapsedRailProps) {
   const projects = useProjectStore((s) => s.projects);
   const currentProject = useProjectStore((s) => s.currentProject);
   const openProject = useProjectStore((s) => s.openProject);
   const sidebarCombo = useFormattedCombo('view.toggleSidebar');
   const { startAddProject } = useAddProject();
+
+  // Command Terminal presence per project, for the corner dot below. One
+  // subscription for the whole rail (not one per button), shallow-compared so the
+  // rail re-renders only when some project's terminal state actually changes.
+  const terminalSummaries = useSessionStore(
+    useShallow((store) => {
+      const byProject: Record<string, CommandTerminalTone> = {};
+      for (const project of projects) {
+        const summary = selectCommandTerminalSummary(store.sessions, store.sessionActivity, project.id);
+        if (summary.count > 0) byProject[project.id] = summary.tone;
+      }
+      return byProject;
+    }),
+  );
 
   return (
     <div className="h-full flex flex-col items-center pt-3 pb-2 px-1 bg-surface-raised">
@@ -41,20 +87,39 @@ export function CollapsedRail({ onExpandSidebar }: CollapsedRailProps) {
         {projects.map((project) => {
           const isActive = currentProject?.id === project.id;
           const label = railLabelFor(project, projects);
+          const terminalTone = terminalSummaries[project.id];
 
           return (
             <button
               key={project.id}
               onClick={() => openProject(project.id)}
               title={project.name}
+              // `title` stays the bare project name (a test pins that exactly), so the
+              // terminal state rides on aria-label instead. aria-label REPLACES the
+              // computed accessible name, so it has to restate the project name; when
+              // there are no terminals it is omitted entirely and the name is unchanged.
+              aria-label={terminalTone ? `${project.name}, ${RAIL_TERMINAL_LABEL[terminalTone]}` : undefined}
               data-testid={`rail-project-${project.id}`}
-              className={`w-7 h-7 rounded flex items-center justify-center text-xs font-semibold transition-colors ${
+              className={`relative w-7 h-7 rounded flex items-center justify-center text-xs font-semibold transition-colors ${
                 isActive
                   ? 'bg-accent/20 text-accent-fg'
                   : 'text-fg-muted hover:bg-surface-hover hover:text-fg'
               } ${label.length > 1 ? 'tracking-tight' : ''}`}
             >
               {label}
+              {/* A plain dot, NOT the Command Terminal glyph. At 28px the button is
+                  already full of the project initials; the previous attempt at a rail
+                  activity icon was removed because a partial-arc glyph reads as a broken
+                  icon overflowing the initial. A dot has no arc, so it carries the tone
+                  in the space actually available. */}
+              {terminalTone && (
+                <span
+                  className={`absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full ${RAIL_DOT_CLASS[terminalTone]}`}
+                  data-testid={`rail-project-terminals-${project.id}`}
+                  data-activity={terminalTone}
+                  aria-hidden
+                />
+              )}
             </button>
           );
         })}

--- a/src/renderer/components/sidebar/ProjectSidebar.tsx
+++ b/src/renderer/components/sidebar/ProjectSidebar.tsx
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react';
 import { useProjectStore } from '../../stores/project-store';
 import { useConfigStore } from '../../stores/config-store';
+import { useSessionStore } from '../../stores/session-store';
 import { useToastStore } from '../../stores/toast-store';
 import { useHmrGeneration } from '../../utils/hmr-generation';
 import { useFormattedCombo } from '../../hooks/useKeybinding';
@@ -178,6 +179,37 @@ export function ProjectSidebar({ onToggleSidebar }: ProjectSidebarProps) {
     reorderGroups(reordered.map((g) => g.id));
   }, [sortedGroups, reorderGroups]);
 
+  /**
+   * Jump to a project and reopen its Command Terminal layer, from the row's
+   * terminal indicator. Routes through the same one-shot flag the notification
+   * click path uses; `useCommandBar` consumes it once `currentProjectId` settles.
+   *
+   * The flag is armed only once the switch is CONFIRMED, not merely awaited.
+   * Awaiting alone is not enough: `openProject` also RESOLVES without switching
+   * (a moved or renamed folder is caught internally and routed to the "Locate
+   * Folder" dialog), and it re-throws every other failure. Arming on either path
+   * would let `useCommandBar`'s effect open the layer on the OUTGOING project.
+   * Re-reading the store afterwards covers all of those arms at once.
+   *
+   * Reads the current project from the store instead of closing over it so this
+   * callback stays referentially stable. It is passed to every memoized
+   * `ProjectListItem`, so a new identity on each project switch would defeat
+   * `memo` for the whole list.
+   */
+  const handleOpenCommandTerminals = useCallback(async (projectId: string) => {
+    if (useProjectStore.getState().currentProject?.id !== projectId) {
+      try {
+        await openProject(projectId);
+      } catch {
+        // The store surfaces its own failure (toast / missing-path dialog);
+        // there is nothing to open, so leave the flag disarmed.
+        return;
+      }
+      if (useProjectStore.getState().currentProject?.id !== projectId) return;
+    }
+    useSessionStore.getState().setPendingOpenCommandTerminal(true);
+  }, [openProject]);
+
   const handleContextMenu = useCallback((event: React.MouseEvent, project: Project) => {
     event.preventDefault();
     event.stopPropagation();
@@ -223,6 +255,7 @@ export function ProjectSidebar({ onToggleSidebar }: ProjectSidebarProps) {
         onContextMenu={handleContextMenu}
         onRename={handleRenameProject}
         onCancelRename={handleCancelRename}
+        onOpenCommandTerminals={handleOpenCommandTerminals}
       />
     );
   };

--- a/src/renderer/components/sidebar/project-sidebar/ProjectListItem.tsx
+++ b/src/renderer/components/sidebar/project-sidebar/ProjectListItem.tsx
@@ -4,7 +4,9 @@ import { CSS } from '@dnd-kit/utilities';
 import { useShallow } from 'zustand/react/shallow';
 import { MoreHorizontal } from 'lucide-react';
 import { SidebarActivityCounts } from './SidebarActivityCounts';
+import { SidebarCommandTerminalIndicator } from './SidebarCommandTerminalIndicator';
 import { useSessionStore } from '../../../stores/session-store';
+import { selectCommandTerminalSummary } from '../../../stores/session-store/transient-session-slice';
 import { requiresUserInteraction } from '../../../../shared/activity-state';
 import type { Project } from '../../../../shared/types';
 
@@ -17,6 +19,8 @@ export interface ProjectListItemProps {
   onContextMenu: (e: React.MouseEvent, project: Project) => void;
   onRename: (id: string, name: string) => void;
   onCancelRename: () => void;
+  /** Jump to this project and reopen its Command Terminal layer. */
+  onOpenCommandTerminals: (projectId: string) => void;
 }
 
 function ProjectListItemImpl({
@@ -28,16 +32,22 @@ function ProjectListItemImpl({
   onContextMenu,
   onRename,
   onCancelRename,
+  onOpenCommandTerminals,
 }: ProjectListItemProps) {
-  // Subscribe per-project to thinking/idle counts. Selector body iterates
-  // sessions on every store update, but useShallow on the {thinking, idle}
-  // result means this item only re-renders when ITS counts change - not on
-  // every activity transition for unrelated projects.
-  const { thinkingCount, idleCount } = useSessionStore(
+  // Subscribe per-project to agent thinking/idle counts AND the Command Terminal
+  // aggregate. Selector body iterates sessions on every store update, but useShallow
+  // on the result means this item only re-renders when ITS OWN values change - not on
+  // every activity transition for unrelated projects. Both live in ONE subscription
+  // for that reason; a second useSessionStore call would re-render the row on any
+  // store change the first selector happened to ignore.
+  const { thinkingCount, idleCount, terminalCount, terminalTone } = useSessionStore(
     useShallow((store) => {
       let thinkingSessionsCount = 0;
       let idleSessionsCount = 0;
       for (const session of store.sessions) {
+        // Transient (Command Terminal) sessions are deliberately excluded here and
+        // surfaced by their own indicator instead: a Command Terminal is not a task
+        // agent, and the two must stay readable side by side.
         if (session.status !== 'running' || session.transient) continue;
         if (session.projectId !== project.id) continue;
         if (requiresUserInteraction(store.sessionActivity[session.id])) {
@@ -46,7 +56,13 @@ function ProjectListItemImpl({
           thinkingSessionsCount += 1;
         }
       }
-      return { thinkingCount: thinkingSessionsCount, idleCount: idleSessionsCount };
+      const terminals = selectCommandTerminalSummary(store.sessions, store.sessionActivity, project.id);
+      return {
+        thinkingCount: thinkingSessionsCount,
+        idleCount: idleSessionsCount,
+        terminalCount: terminals.count,
+        terminalTone: terminals.tone,
+      };
     }),
   );
   const {
@@ -136,6 +152,19 @@ function ProjectListItemImpl({
           <span className="truncate font-medium flex-1 min-w-0">{project.name}</span>
         )}
         <SidebarActivityCounts thinkingCount={thinkingCount} idleCount={idleCount} />
+        {/* Stays in the right-aligned cluster rather than riding the project name.
+            Names vary from "kangentic" to "troy-web-operations-dashboard", so a
+            name-adjacent glyph lands at a different x on every row and cuts across
+            the tidy count column; right-aligned, all three indicators stack into one
+            tabular column. It also sits AFTER the counts so the envelope and spinner
+            stay `.first()` for the specs that resolve them positionally. */}
+        <SidebarCommandTerminalIndicator
+          projectId={project.id}
+          projectName={project.name}
+          count={terminalCount}
+          tone={terminalTone}
+          onOpen={onOpenCommandTerminals}
+        />
         <button
           type="button"
           onPointerDown={(e) => e.stopPropagation()}

--- a/src/renderer/components/sidebar/project-sidebar/SidebarActivityCounts.tsx
+++ b/src/renderer/components/sidebar/project-sidebar/SidebarActivityCounts.tsx
@@ -32,6 +32,7 @@ export const SidebarActivityCounts = React.memo(function SidebarActivityCounts({
     <span
       className={`flex-shrink-0 flex items-center gap-2 text-[11px] tabular-nums ${className ?? ''}`}
       aria-label={labelParts.join(', ')}
+      data-testid="sidebar-activity-counts"
     >
       {hasIdle && (
         <span className="flex items-center gap-1" aria-hidden>

--- a/src/renderer/components/sidebar/project-sidebar/SidebarCommandTerminalIndicator.tsx
+++ b/src/renderer/components/sidebar/project-sidebar/SidebarCommandTerminalIndicator.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { CommandTerminalIcon } from '../../command-bar/CommandTerminalIcon';
+import type { CommandTerminalTone } from '../../../stores/session-store/transient-session-slice';
+
+export interface SidebarCommandTerminalIndicatorProps {
+  projectId: string;
+  projectName: string;
+  count: number;
+  tone: CommandTerminalTone;
+  onOpen: (projectId: string) => void;
+}
+
+function labelFor(count: number, tone: CommandTerminalTone): string {
+  const noun = count === 1 ? 'Command Terminal' : 'Command Terminals';
+  // Presentational tone, already bucketed upstream by the shared classifiers.
+  // Mind the last branch: it is reached for `rest`, NOT for the `idle` tone.
+  // "Idle" is this app's word for "needs you" (see `requiresUserInteraction`),
+  // so a merely-resting terminal must not borrow it - saying "(idle)" here would
+  // read, in both the tooltip and the accessible name, as the opposite state.
+  const state = tone === 'thinking' // activity-state-ok: presentational tone, not an ActivityState
+    ? 'working'
+    : tone === 'idle' // activity-state-ok: presentational tone, not an ActivityState
+      ? 'needs you'
+      : 'resting';
+  return `${count} ${noun} running (${state})`;
+}
+
+/**
+ * Per-project Command Terminal presence in the sidebar row. Command Terminal PTYs
+ * survive hiding the layer AND switching projects, so without this the only signal
+ * a background project still has terminals running is the title-bar glyph, which
+ * only ever reflects the project you are currently looking at.
+ *
+ * Reuses the title bar's glyph and tone language rather than inventing a second
+ * vocabulary, so a terminal waiting on input reads the same everywhere. It sits
+ * BESIDE the agent thinking/idle counts (`SidebarActivityCounts`), never merged
+ * into them: a Command Terminal is not a task agent.
+ *
+ * Lives in the row's right-aligned cluster and always prints its count, so it forms
+ * an icon+digit pair matching the agent counts and the three indicators stack into
+ * one tabular column down the list.
+ *
+ * Clicking jumps to that project and reopens its Command Terminal layer.
+ */
+export const SidebarCommandTerminalIndicator = React.memo(function SidebarCommandTerminalIndicator({
+  projectId,
+  projectName,
+  count,
+  tone,
+  onOpen,
+}: SidebarCommandTerminalIndicatorProps) {
+  if (count === 0) return null;
+
+  const label = labelFor(count, tone);
+  // The tone class lives on the button so the digit inherits it via currentColor.
+  // Keeping `text-active` / `text-attention` OFF the digit span matters: the sidebar
+  // specs assert `span.text-active` / `span.text-attention` resolve to the AGENT
+  // counts alone, and a tone-classed digit here would collide with them.
+  const toneClass = tone === 'thinking' // activity-state-ok: presentational tone, not an ActivityState
+    ? 'text-active'
+    : tone === 'idle' // activity-state-ok: presentational tone, not an ActivityState
+      ? 'text-attention'
+      : 'text-fg-muted';
+
+  return (
+    <button
+      type="button"
+      // The row is a dnd-kit sortable with a 5px pointer activation constraint and
+      // its own onClick; both have to be held off so this reads as its own control.
+      onPointerDown={(event) => event.stopPropagation()}
+      onClick={(event) => {
+        event.stopPropagation();
+        onOpen(projectId);
+      }}
+      className={`flex-shrink-0 flex items-center gap-1 rounded px-0.5 text-[11px] tabular-nums outline-none transition-colors hover:bg-surface-hover/60 ${toneClass}`}
+      title={`${label}\nClick to open`}
+      aria-label={`${projectName}: ${label}`}
+      data-testid={`project-terminals-${projectId}`}
+      data-activity={tone}
+      data-count={count}
+    >
+      <CommandTerminalIcon size={14} tone={tone} testId={`project-terminal-icon-${projectId}`} />
+      {/* The count always prints, even at 1. Suppressing it left a lone glyph in a row
+          of icon+digit pairs, where it read as a count that had lost its number. */}
+      <span className="flex items-center justify-center min-w-[1ch] font-semibold" style={{ height: 14 }}>
+        {count}
+      </span>
+    </button>
+  );
+});

--- a/src/renderer/components/sidebar/project-sidebar/index.ts
+++ b/src/renderer/components/sidebar/project-sidebar/index.ts
@@ -3,4 +3,5 @@ export { GroupHeader } from './GroupHeader';
 export { ProjectContextMenu } from './ProjectContextMenu';
 export { GroupContextMenu } from './GroupContextMenu';
 export { SidebarActivityCounts } from './SidebarActivityCounts';
+export { SidebarCommandTerminalIndicator } from './SidebarCommandTerminalIndicator';
 export { useSidebarDragDrop } from './useSidebarDragDrop';

--- a/src/renderer/stores/session-store.ts
+++ b/src/renderer/stores/session-store.ts
@@ -243,6 +243,9 @@ export const useSessionStore = create<SessionStore>((set, get, api) => ({
   pendingCommandLabel: preservedPendingCommandLabel,
   spawnProgress: preservedSpawnProgress,
   _pendingOpenTaskId: null,
+  // hmr-safe: one-shot handoff, armed only across an async project switch; dropping
+  // it on a coincident HMR just skips an auto-open (re-click the indicator), no
+  // visible corruption. Same call as `_pendingOpenConversation` above.
   _pendingOpenCommandTerminal: false,
   setPendingOpenCommandTerminal: (value) => set({ _pendingOpenCommandTerminal: value }),
 

--- a/src/renderer/stores/session-store/transient-session-slice.ts
+++ b/src/renderer/stores/session-store/transient-session-slice.ts
@@ -1,5 +1,6 @@
 import { type StateCreator } from 'zustand';
-import type { Session, SessionInjectSettingsInput } from '../../../shared/types';
+import type { ActivityState, Session, SessionInjectSettingsInput } from '../../../shared/types';
+import { isActive, requiresUserInteraction } from '../../../shared/activity-state';
 import { useProjectStore } from '../project-store';
 import { useToastStore } from '../toast-store';
 import type { SessionStore } from './types';
@@ -30,8 +31,9 @@ export function transientKey(projectId: string, slot: string): string {
 }
 
 /** Every transient session id for a project, in map order. Drives the focused-set
- *  push (each visible terminal must be focused) and the title-bar activity color
- *  aggregate. */
+ *  push (each visible terminal must be focused). Activity aggregates do NOT use
+ *  this: they go through `selectCommandTerminalSummary` below, which reads the
+ *  sessions list so it stays correct for background projects after a reload. */
 export function selectCurrentProjectTransientSessionIds(
   transientSessions: Record<string, TransientSessionEntry>,
   projectId: string | null,
@@ -40,6 +42,58 @@ export function selectCurrentProjectTransientSessionIds(
   return Object.values(transientSessions)
     .filter((entry) => entry.projectId === projectId)
     .map((entry) => entry.sessionId);
+}
+
+/**
+ * Presentational tone for a project's Command Terminal aggregate. Derived, not an
+ * `ActivityState`: the idle-vs-active bucketing already happened via the shared
+ * classifiers when this was computed, so consumers may branch on it directly.
+ */
+export type CommandTerminalTone = 'rest' | 'thinking' | 'idle';
+
+export interface CommandTerminalSummary {
+  /** Live (running) Command Terminal PTYs the project owns right now. */
+  count: number;
+  tone: CommandTerminalTone;
+}
+
+const EMPTY_COMMAND_TERMINAL_SUMMARY: CommandTerminalSummary = { count: 0, tone: 'rest' };
+
+/**
+ * How many Command Terminals a project has running, and their aggregate activity
+ * tone. Drives the title-bar glyph and the per-project sidebar indicator.
+ *
+ * Reads the SESSIONS list rather than the `transientSessions` map on purpose. That
+ * map is renderer-owned window pairing, and its hard-reload recovery only re-pairs
+ * the CURRENT project's survivors (see `syncSessions`), so a map-based count would
+ * read zero for every background project after a reload. `session:list` is unscoped
+ * and every row carries `projectId` + `transient` stamped by main, so this stays
+ * correct cross-project and across reloads.
+ *
+ * WORKING wins: any active terminal makes the whole project read active, else
+ * attention if any needs you, else rest. Bucketed only through the shared
+ * classifiers (activity-state rule).
+ */
+export function selectCommandTerminalSummary(
+  sessions: readonly Session[],
+  sessionActivity: Record<string, ActivityState>,
+  projectId: string | null,
+): CommandTerminalSummary {
+  if (!projectId) return EMPTY_COMMAND_TERMINAL_SUMMARY;
+  let count = 0;
+  let anyActive = false;
+  let anyNeedsUser = false;
+  for (const session of sessions) {
+    if (!session.transient) continue;
+    if (session.status !== 'running') continue;
+    if (session.projectId !== projectId) continue;
+    count += 1;
+    const activity = sessionActivity[session.id];
+    if (isActive(activity)) anyActive = true;
+    else if (requiresUserInteraction(activity)) anyNeedsUser = true;
+  }
+  if (count === 0) return EMPTY_COMMAND_TERMINAL_SUMMARY;
+  return { count, tone: anyActive ? 'thinking' : anyNeedsUser ? 'idle' : 'rest' };
 }
 
 /** Shallow copy of `record` minus any key in `ids`. */

--- a/tests/ui/collapsed-rail.spec.ts
+++ b/tests/ui/collapsed-rail.spec.ts
@@ -303,10 +303,15 @@ test.describe('CollapsedRail - colliding project initials', () => {
 
 // ─── Group 3: idle session, no activity icon ─────────────────────────────
 
-// Activity indicators are intentionally omitted from the collapsed rail: at the
-// rail's narrow column width the partial-arc Loader2 glyph reads as a broken
+// AGENT activity indicators are intentionally omitted from the collapsed rail: at
+// the rail's narrow column width the partial-arc Loader2 glyph reads as a broken
 // icon overflowing the project initial. The expanded sidebar still surfaces
 // thinking/idle counts via SidebarActivityCounts; the rail just shows initials.
+//
+// The rail DOES carry a Command Terminal presence dot (a plain span, no arc, so
+// the rationale above does not transfer). It is a separate signal with its own
+// testid, covered in sidebar-command-terminals.spec.ts; these assertions stay
+// scoped to `svg.*` so they keep meaning "no agent activity icon".
 
 test.describe('CollapsedRail - idle session, no activity icon', () => {
   let browser: Browser;

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -407,7 +407,11 @@
           attachments = [];
         }
       },
+      // Call log for test assertions (mirrors clipboard.__writeTextCalls). Reset
+      // with window.electronAPI.projects.__openCalls.length = 0.
+      __openCalls: [],
       open: async function (id) {
+        window.electronAPI.projects.__openCalls.push(id);
         currentProjectId = id;
         // Create default swimlanes for this project if none exist
         if (swimlanes.length === 0) {

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -358,6 +358,21 @@
     listeners.forEach(function (fn) { fn(info); });
   };
 
+  // Notification-click test hook (App.tsx's `notifications.onClicked` handler,
+  // including the isCommandTerminal branch). Installed eagerly for the same
+  // reason as the update-downloaded hooks above. Unlike that hook, this one
+  // throws when fired with no listener registered: firing before App.tsx has
+  // mounted and subscribed would otherwise silently no-op into a confusing
+  // "nothing happened" failure downstream.
+  window.__mockNotificationClickListeners = [];
+  window.__mockFireNotificationClicked = function (projectId, taskId) {
+    var listeners = window.__mockNotificationClickListeners.slice();
+    if (listeners.length === 0) {
+      throw new Error('__mockFireNotificationClicked called with no onClicked listener registered');
+    }
+    listeners.forEach(function (fn) { fn(projectId, taskId); });
+  };
+
   window.electronAPI = {
     projects: {
       list: async function () {
@@ -3021,8 +3036,16 @@
 
     notifications: {
       show: noop,
-      onClicked: function () {
-        return noop;
+      onClicked: function (callback) {
+        // Tests fire the click push via `window.__mockFireNotificationClicked(projectId,
+        // taskId)`. The listener array and the fire hook itself are installed eagerly at
+        // mock-bootstrap time (see top of file), not lazily here.
+        window.__mockNotificationClickListeners.push(callback);
+        return function () {
+          var listeners = window.__mockNotificationClickListeners || [];
+          var idx = listeners.indexOf(callback);
+          if (idx >= 0) listeners.splice(idx, 1);
+        };
       },
     },
 

--- a/tests/ui/project-session-scope.spec.ts
+++ b/tests/ui/project-session-scope.spec.ts
@@ -600,8 +600,11 @@ test.describe('Project Session Scope', () => {
       const alphaRow = page.locator('[role="button"]:has-text("Project Alpha")');
 
       // The outer wrapper span with aria-label is NOT aria-hidden (the inner pairs are).
-      // We find it by the aria-label attribute pattern.
-      const countsWrapper = alphaRow.locator('[aria-label]').filter({ hasNotText: '' }).first();
+      // Targeted by its own testid rather than by DOM position: the row carries other
+      // aria-labelled controls (the kebab, the Command Terminal indicator), so a
+      // positional `[aria-label]` lookup silently re-points whenever the row's layout
+      // changes.
+      const countsWrapper = alphaRow.locator('[data-testid="sidebar-activity-counts"]');
       await expect(countsWrapper).toBeVisible();
       await expect(countsWrapper).toHaveAttribute('aria-label', /1 idle.*1 thinking|1 thinking.*1 idle/);
     } finally {

--- a/tests/ui/sidebar-command-terminals.spec.ts
+++ b/tests/ui/sidebar-command-terminals.spec.ts
@@ -16,6 +16,8 @@ import { test, expect } from '@playwright/test';
 import { chromium, type Browser, type Page } from '@playwright/test';
 import path from 'node:path';
 import { waitForViteReady } from './helpers';
+import { PROJECT_PATH_MISSING_PREFIX } from '../../src/shared/ipc-channels';
+import { COMMAND_TERMINAL_NOTIFICATION_TASK_ID } from '../../src/shared/notification-constants';
 
 // Each test launches its own browser/page, so the file can fan out across workers.
 test.describe.configure({ mode: 'parallel' });
@@ -394,6 +396,56 @@ test.describe('Sidebar Command Terminal indicator', () => {
     }
   });
 
+  test('a moved/renamed background project does not open the layer (openProject resolves without switching)', async () => {
+    // `openProject` catches a PROJECT_PATH_MISSING_PREFIX failure internally,
+    // routes to the "Locate Folder" dialog, and RESOLVES (does not re-throw) -
+    // WITHOUT switching currentProject. `handleOpenCommandTerminals` must
+    // re-read the store after the await rather than arm the pending-open flag
+    // on the bare await settling, or the layer opens on the OUTGOING project
+    // (Alpha) and has no project-change event left to close it.
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_B_ID, id: 'ct-b1', activity: 'idle' }],
+    }));
+
+    try {
+      await page.evaluate((prefix) => {
+        window.electronAPI.projects.__openCalls.length = 0;
+        window.electronAPI.projects.open = async function (id: string) {
+          window.electronAPI.projects.__openCalls.push(id);
+          throw new Error(prefix + '/mock/project-beta');
+        };
+      }, PROJECT_PATH_MISSING_PREFIX);
+
+      await page.locator(`[data-testid="project-terminals-${PROJECT_B_ID}"]`).click();
+
+      // Positive signal that the click actually drove the broken path: the
+      // "Locate Folder" dialog is the store's own reaction to the missing-path
+      // error, so waiting for it also gives handleOpenCommandTerminals's
+      // continuation (which resolves on the same promise chain) time to run.
+      await page.locator('[data-testid="project-path-missing-dialog"]').waitFor({ state: 'visible', timeout: 5000 });
+
+      // Proves the click actually exercised the broken-open path, not a no-op
+      // that would pass the assertions below for the wrong reason.
+      const openCalls = await page.evaluate(() => window.electronAPI.projects.__openCalls as string[]);
+      expect(openCalls).toEqual([PROJECT_B_ID]);
+
+      // Still on Alpha - the failed switch must not have moved us to Beta.
+      const currentProjectId = await page.evaluate(async () => {
+        const project = await window.electronAPI.projects.getCurrent();
+        return project?.id ?? null;
+      });
+      expect(currentProjectId).toBe(PROJECT_A_ID);
+
+      // Negative assertion (cannot poll for "never opens"; see anti-pattern 6):
+      // give any latent open() a fixed budget beyond the dialog wait above,
+      // then assert. "New terminal" renders only while the layer is open.
+      await page.waitForTimeout(300);
+      await expect(page.locator('[data-testid="quick-session-new-terminal"]')).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
   test('the sidebar renders the terminal icon at 14px, not the title bar\'s default 20px', async () => {
     // CommandTerminalIcon defaults size to 20 (the title bar toggle); the
     // sidebar passes size={14} explicitly. Pins that the prop is actually
@@ -596,6 +648,59 @@ test.describe('Collapsed rail Command Terminal dot', () => {
       const alphaButton = page.locator(`[data-testid="rail-project-${PROJECT_A_ID}"]`);
       await expect(alphaButton).toHaveAttribute('title', 'Project Alpha');
       await expect(alphaButton).toHaveAttribute('aria-label', /\(working\)/);
+    } finally {
+      await browser.close();
+    }
+  });
+});
+
+test.describe('Notification click reopen (App.tsx sibling of the sidebar indicator)', () => {
+  // App.tsx's `notifications.onClicked` handler follows the exact same
+  // confirm-the-switch contract as ProjectSidebar's `handleOpenCommandTerminals`
+  // (see that describe block above), for the Command Terminal notification's
+  // click target. This is not incidental duplicate coverage: it is a distinct
+  // call site with its own history of this exact bug. Pre-diff, this call site
+  // armed `setPendingOpenCommandTerminal(true)` BEFORE awaiting `openProject`,
+  // so a failed switch (moved/renamed project folder) still opened the layer on
+  // the outgoing project, with no project-change event left to close it again.
+  test('a moved/renamed project\'s Command Terminal notification does not open the layer', async () => {
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_B_ID, id: 'ct-b1', activity: 'idle' }],
+    }));
+
+    try {
+      await page.evaluate((prefix) => {
+        window.electronAPI.projects.__openCalls.length = 0;
+        window.electronAPI.projects.open = async function (id: string) {
+          window.electronAPI.projects.__openCalls.push(id);
+          throw new Error(prefix + '/mock/project-beta');
+        };
+      }, PROJECT_PATH_MISSING_PREFIX);
+
+      await page.evaluate(({ projectId, taskId }) => {
+        if (!window.__mockFireNotificationClicked) {
+          throw new Error('window.__mockFireNotificationClicked is not installed by the mock');
+        }
+        window.__mockFireNotificationClicked(projectId, taskId);
+      }, { projectId: PROJECT_B_ID, taskId: COMMAND_TERMINAL_NOTIFICATION_TASK_ID });
+
+      // Positive signal that the click actually drove the broken path (see the
+      // matching comment in the sidebar-indicator version of this test).
+      await page.locator('[data-testid="project-path-missing-dialog"]').waitFor({ state: 'visible', timeout: 5000 });
+
+      const openCalls = await page.evaluate(() => window.electronAPI.projects.__openCalls as string[]);
+      expect(openCalls).toEqual([PROJECT_B_ID]);
+
+      const currentProjectId = await page.evaluate(async () => {
+        const project = await window.electronAPI.projects.getCurrent();
+        return project?.id ?? null;
+      });
+      expect(currentProjectId).toBe(PROJECT_A_ID);
+
+      // Negative assertion (cannot poll for "never opens"; see anti-pattern 6):
+      // give any latent open() a fixed budget beyond the dialog wait above.
+      await page.waitForTimeout(300);
+      await expect(page.locator('[data-testid="quick-session-new-terminal"]')).toHaveCount(0);
     } finally {
       await browser.close();
     }

--- a/tests/ui/sidebar-command-terminals.spec.ts
+++ b/tests/ui/sidebar-command-terminals.spec.ts
@@ -1,0 +1,603 @@
+/**
+ * UI tests for the per-project Command Terminal indicator in the project sidebar.
+ *
+ * Command Terminal PTYs stay alive when the layer is hidden AND across project
+ * switches, so before this indicator the only signal that a project still had
+ * terminals running was the title-bar glyph, which only ever reflects the project
+ * you are currently looking at. These tests pin the two properties that make the
+ * sidebar version trustworthy:
+ *
+ * - It reads the unscoped session list, so a BACKGROUND project's terminals show
+ *   up without visiting that project's board.
+ * - It sits beside the agent thinking/idle counts without disturbing them: a
+ *   Command Terminal is not a task agent, and the two must read side by side.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+// Each test launches its own browser/page, so the file can fan out across workers.
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_A_ID = 'ct-proj-a';
+const PROJECT_B_ID = 'ct-proj-b';
+
+interface TerminalFixture {
+  /** Project the transient PTY belongs to. */
+  project: string;
+  id: string;
+  activity?: 'idle' | 'thinking' | 'permission';
+  status?: 'running' | 'exited';
+}
+
+/**
+ * Two projects (Alpha active, Beta background) plus whatever transient sessions
+ * the test needs. `agentIdleOnAlpha` adds a NON-transient idle session so a test
+ * can assert the agent counts and the terminal indicator coexist.
+ */
+function preConfig(options?: {
+  terminals?: TerminalFixture[];
+  agentIdleOnAlpha?: boolean;
+}): string {
+  const terminals = options?.terminals ?? [];
+  const agentIdleOnAlpha = options?.agentIdleOnAlpha ?? false;
+  const terminalScript = terminals.map((terminal) => `
+      state.sessions.push({
+        id: '${terminal.id}',
+        taskId: 'task-${terminal.id}',
+        projectId: '${terminal.project}',
+        pid: 2001,
+        status: '${terminal.status ?? 'running'}',
+        shell: 'bash',
+        cwd: '/mock/project',
+        startedAt: ts,
+        exitCode: null,
+        transient: true,
+      });
+      ${terminal.activity ? `state.activityCache['${terminal.id}'] = '${terminal.activity}';` : ''}
+  `).join('\n');
+
+  return `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+
+      state.projects.push({
+        id: '${PROJECT_A_ID}',
+        name: 'Project Alpha',
+        path: '/mock/project-alpha',
+        github_url: null,
+        default_agent: 'claude',
+        group_id: null,
+        position: 0,
+        last_opened: ts,
+        created_at: ts,
+      });
+
+      state.projects.push({
+        id: '${PROJECT_B_ID}',
+        name: 'Project Beta',
+        path: '/mock/project-beta',
+        github_url: null,
+        default_agent: 'claude',
+        group_id: null,
+        position: 1,
+        last_opened: ts,
+        created_at: ts,
+      });
+
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        state.swimlanes.push(Object.assign({}, s, {
+          id: 'ct-lane-' + i,
+          position: i,
+          created_at: ts,
+        }));
+      });
+
+      ${agentIdleOnAlpha ? `
+      state.sessions.push({
+        id: 'ct-agent-a',
+        taskId: 'ct-task-agent-a',
+        projectId: '${PROJECT_A_ID}',
+        pid: 1001,
+        status: 'running',
+        shell: 'bash',
+        cwd: '/mock/project-alpha',
+        startedAt: ts,
+        exitCode: null,
+      });
+      state.activityCache['ct-agent-a'] = 'idle';
+      ` : ''}
+
+      ${terminalScript}
+
+      return { currentProjectId: '${PROJECT_A_ID}' };
+    });
+  `;
+}
+
+async function launchWithState(preConfigScript: string): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(preConfigScript);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+  return { browser, page };
+}
+
+test.describe('Sidebar Command Terminal indicator', () => {
+  test('no indicator for a project with no Command Terminals', async () => {
+    const { browser, page } = await launchWithState(preConfig());
+
+    try {
+      await expect(page.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`)).toHaveCount(0);
+      await expect(page.locator(`[data-testid="project-terminals-${PROJECT_B_ID}"]`)).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('a single terminal renders the glyph with its count', async () => {
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_A_ID, id: 'ct-a1', activity: 'idle' }],
+    }));
+
+    try {
+      const indicator = page.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`);
+      await expect(indicator).toBeVisible();
+      await expect(indicator).toHaveAttribute('data-count', '1');
+      // The digit prints even at 1, so this reads as an icon+digit pair matching the
+      // agent counts beside it rather than a lone glyph missing its number.
+      await expect(indicator).toHaveText('1');
+      await expect(indicator.locator(`[data-testid="project-terminal-icon-${PROJECT_A_ID}"]`)).toBeVisible();
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('two terminals render a count digit', async () => {
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [
+        { project: PROJECT_A_ID, id: 'ct-a1', activity: 'idle' },
+        { project: PROJECT_A_ID, id: 'ct-a2', activity: 'idle' },
+      ],
+    }));
+
+    try {
+      const indicator = page.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`);
+      await expect(indicator).toHaveAttribute('data-count', '2');
+      await expect(indicator).toHaveText('2');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('tone is amber when a terminal needs the user', async () => {
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_A_ID, id: 'ct-a1', activity: 'idle' }],
+    }));
+
+    try {
+      const indicator = page.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`);
+      await expect(indicator).toHaveAttribute('data-activity', 'idle');
+      await expect(indicator.locator('svg.text-attention')).toHaveCount(1);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('a permission-blocked terminal reads as needing the user, not working', async () => {
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_A_ID, id: 'ct-a1', activity: 'permission' }],
+    }));
+
+    try {
+      const indicator = page.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`);
+      await expect(indicator).toHaveAttribute('data-activity', 'idle');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('working wins over needs-you across a project\'s terminals', async () => {
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [
+        { project: PROJECT_A_ID, id: 'ct-a1', activity: 'idle' },
+        { project: PROJECT_A_ID, id: 'ct-a2', activity: 'thinking' },
+      ],
+    }));
+
+    try {
+      const indicator = page.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`);
+      await expect(indicator).toHaveAttribute('data-activity', 'thinking');
+      await expect(indicator.locator('svg.text-active')).toHaveCount(1);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('a live terminal with no activity yet still shows, at rest', async () => {
+    // Presence is the point: a resting terminal is exactly the invisible
+    // CPU/memory consumer this indicator exists to surface.
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_A_ID, id: 'ct-a1' }],
+    }));
+
+    try {
+      const indicator = page.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`);
+      await expect(indicator).toBeVisible();
+      await expect(indicator).toHaveAttribute('data-activity', 'rest');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('an exited terminal does not count', async () => {
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_A_ID, id: 'ct-a1', activity: 'idle', status: 'exited' }],
+    }));
+
+    try {
+      await expect(page.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`)).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('a background project\'s terminals are visible without switching to it', async () => {
+    // The whole point of the feature: Alpha is active, Beta's PTYs are running
+    // invisibly, and the sidebar says so.
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [
+        { project: PROJECT_B_ID, id: 'ct-b1', activity: 'thinking' },
+        { project: PROJECT_B_ID, id: 'ct-b2', activity: 'idle' },
+      ],
+    }));
+
+    try {
+      const betaIndicator = page.locator(`[data-testid="project-terminals-${PROJECT_B_ID}"]`);
+      await expect(betaIndicator).toBeVisible();
+      await expect(betaIndicator).toHaveAttribute('data-count', '2');
+      await expect(betaIndicator).toHaveAttribute('data-activity', 'thinking');
+      // Alpha has none of its own.
+      await expect(page.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`)).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('terminal indicator and agent counts read side by side', async () => {
+    const { browser, page } = await launchWithState(preConfig({
+      agentIdleOnAlpha: true,
+      terminals: [{ project: PROJECT_A_ID, id: 'ct-a1', activity: 'thinking' }],
+    }));
+
+    try {
+      const alphaRow = page.locator('[role="button"]:has-text("Project Alpha")');
+
+      // The agent count is unchanged by the presence of a terminal: still one
+      // amber idle agent, and no green agent count.
+      const idleCountSpan = alphaRow.locator('span.text-attention');
+      await expect(idleCountSpan).toBeVisible();
+      await expect(idleCountSpan).toContainText('1');
+      await expect(alphaRow.locator('span.text-active')).toHaveCount(0);
+
+      // ...while the terminal indicator sits beside it with its own tone.
+      const indicator = alphaRow.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`);
+      await expect(indicator).toHaveAttribute('data-activity', 'thinking');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('clicking a background project\'s indicator switches project and opens the layer', async () => {
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_B_ID, id: 'ct-b1', activity: 'idle' }],
+    }));
+
+    try {
+      await page.locator(`[data-testid="project-terminals-${PROJECT_B_ID}"]`).click();
+
+      await expect.poll(async () => {
+        return page.evaluate(async () => {
+          const project = await window.electronAPI.projects.getCurrent();
+          return project?.id ?? null;
+        });
+      }, { timeout: 5000 }).toBe(PROJECT_B_ID);
+
+      // "New terminal" renders only while the Command Terminal layer is open, so
+      // its presence is the cheap signal that the layer reopened on the new project.
+      await expect(page.locator('[data-testid="quick-session-new-terminal"]')).toBeVisible({ timeout: 5000 });
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('clicking the ACTIVE project\'s indicator opens the layer without a project switch', async () => {
+    // The common case: you are already on the project. No openProject call, so the
+    // pending-open flag alone has to reach useCommandBar's effect.
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_A_ID, id: 'ct-a1', activity: 'idle' }],
+    }));
+
+    try {
+      await page.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`).click();
+
+      await expect(page.locator('[data-testid="quick-session-new-terminal"]')).toBeVisible({ timeout: 5000 });
+
+      // Still on the same project - the click must not have re-opened anything.
+      const currentProjectId = await page.evaluate(async () => {
+        const project = await window.electronAPI.projects.getCurrent();
+        return project?.id ?? null;
+      });
+      expect(currentProjectId).toBe(PROJECT_A_ID);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('clicking the indicator does not trigger the row rename or context menu', async () => {
+    // The row is a dnd-kit sortable with its own onClick; the indicator has to
+    // stop propagation or a click would also re-select the row.
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_A_ID, id: 'ct-a1', activity: 'idle' }],
+    }));
+
+    try {
+      await page.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`).click();
+      await expect(page.locator('[data-testid="project-context-menu"]')).toHaveCount(0);
+      await expect(page.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`)).toBeVisible();
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('clicking a background project\'s indicator calls openProject exactly once', async () => {
+    // Pins the stopPropagation guard on the indicator's onClick/onPointerDown.
+    // ProjectListItem's row has onSelect={openProject}; without the guard, a
+    // click on the indicator bubbles to the row (which calls openProject once)
+    // AND runs handleOpenCommandTerminals (which calls openProject again for a
+    // background project), firing two concurrent opens instead of one.
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_B_ID, id: 'ct-b1', activity: 'idle' }],
+    }));
+
+    try {
+      await page.evaluate(() => {
+        window.electronAPI.projects.__openCalls.length = 0;
+      });
+
+      await page.locator(`[data-testid="project-terminals-${PROJECT_B_ID}"]`).click();
+
+      await expect.poll(async () => {
+        return page.evaluate(async () => {
+          const project = await window.electronAPI.projects.getCurrent();
+          return project?.id ?? null;
+        });
+      }, { timeout: 5000 }).toBe(PROJECT_B_ID);
+
+      const openCalls = await page.evaluate(() => window.electronAPI.projects.__openCalls as string[]);
+      expect(openCalls).toEqual([PROJECT_B_ID]);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('the sidebar renders the terminal icon at 14px, not the title bar\'s default 20px', async () => {
+    // CommandTerminalIcon defaults size to 20 (the title bar toggle); the
+    // sidebar passes size={14} explicitly. Pins that the prop is actually
+    // threaded through rather than the icon silently rendering at the default.
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_A_ID, id: 'ct-a1', activity: 'idle' }],
+    }));
+
+    try {
+      const icon = page.locator(`[data-testid="project-terminal-icon-${PROJECT_A_ID}"]`);
+      await expect(icon).toHaveAttribute('width', '14');
+      await expect(icon).toHaveAttribute('height', '14');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('labelFor pins the singular noun and "needs you" wording for a lone idle terminal', async () => {
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_A_ID, id: 'ct-a1', activity: 'idle' }],
+    }));
+
+    try {
+      const indicator = page.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`);
+      await expect(indicator).toHaveAttribute('aria-label', /1 Command Terminal running \(needs you\)/);
+      await expect(indicator).toHaveAttribute('title', /1 Command Terminal running \(needs you\)/);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('labelFor pins the plural noun and "working" wording for two thinking terminals', async () => {
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [
+        { project: PROJECT_A_ID, id: 'ct-a1', activity: 'thinking' },
+        { project: PROJECT_A_ID, id: 'ct-a2', activity: 'thinking' },
+      ],
+    }));
+
+    try {
+      const indicator = page.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`);
+      await expect(indicator).toHaveAttribute('aria-label', /2 Command Terminals running \(working\)/);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('labelFor says "resting", never "idle", for a terminal with no activity yet (red-green for FIX A)', async () => {
+    // FIX A: the rest branch used to render the word "idle", which is this
+    // app's word for "needs you". A lone resting terminal must not read as
+    // needing the user. This fails if the rest branch regresses to "idle".
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_A_ID, id: 'ct-a1' }],
+    }));
+
+    try {
+      const indicator = page.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`);
+      await expect(indicator).toHaveAttribute('aria-label', /1 Command Terminal running \(resting\)/);
+      const ariaLabel = await indicator.getAttribute('aria-label');
+      expect(ariaLabel).not.toContain('idle');
+    } finally {
+      await browser.close();
+    }
+  });
+});
+
+test.describe('Collapsed rail Command Terminal dot', () => {
+  async function collapseSidebar(page: Page): Promise<void> {
+    await page.locator('button[title^="Hide sidebar"]').click();
+    await page.locator('[data-testid="sidebar-expand-button"]').waitFor({ state: 'attached', timeout: 5000 });
+  }
+
+  test('a project with terminals gets a tone dot; one without does not', async () => {
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_B_ID, id: 'ct-b1', activity: 'thinking' }],
+    }));
+
+    try {
+      await collapseSidebar(page);
+
+      const betaDot = page.locator(`[data-testid="rail-project-terminals-${PROJECT_B_ID}"]`);
+      await expect(betaDot).toBeVisible();
+      await expect(betaDot).toHaveAttribute('data-activity', 'thinking');
+      await expect(betaDot).toHaveClass(/bg-active/);
+
+      await expect(page.locator(`[data-testid="rail-project-terminals-${PROJECT_A_ID}"]`)).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('the rail dot is a plain span, never the arc-bearing glyph', async () => {
+    // The rail deliberately carries no icon: at 28px a partial-arc glyph reads as
+    // a broken icon overflowing the project initial. The dot must not reintroduce
+    // one, and must not shadow the agent-activity absence assertions either.
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_A_ID, id: 'ct-a1', activity: 'idle' }],
+    }));
+
+    try {
+      await collapseSidebar(page);
+
+      const alphaButton = page.locator(`[data-testid="rail-project-${PROJECT_A_ID}"]`);
+      await expect(alphaButton.locator('svg.text-attention')).toHaveCount(0);
+      await expect(alphaButton.locator('svg.text-active')).toHaveCount(0);
+      await expect(alphaButton.locator(`[data-testid="rail-project-terminals-${PROJECT_A_ID}"]`)).toBeVisible();
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('the rail tooltip stays the plain project name', async () => {
+    // Guards the existing regression rule: the title must not grow a compound
+    // "Alpha - 1 terminal" form. Terminal state rides on aria-label instead.
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_A_ID, id: 'ct-a1', activity: 'idle' }],
+    }));
+
+    try {
+      await collapseSidebar(page);
+
+      const alphaButton = page.locator(`[data-testid="rail-project-${PROJECT_A_ID}"]`);
+      await expect(alphaButton).toHaveAttribute('title', 'Project Alpha');
+      await expect(alphaButton).toHaveAttribute('aria-label', /Project Alpha.*Command Terminals/);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('a resting terminal gets the muted rail dot', async () => {
+    // RAIL_DOT_CLASS.rest had zero direct coverage: the existing rest-tone test
+    // ('the rail dot is a plain span...') only asserts the absence of an icon,
+    // not this dot's own color class.
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_B_ID, id: 'ct-b1' }],
+    }));
+
+    try {
+      await collapseSidebar(page);
+
+      const betaDot = page.locator(`[data-testid="rail-project-terminals-${PROJECT_B_ID}"]`);
+      await expect(betaDot).toBeVisible();
+      await expect(betaDot).toHaveAttribute('data-activity', 'rest');
+      await expect(betaDot).toHaveClass(/bg-fg-muted/);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('a needs-you terminal gets the amber rail dot', async () => {
+    // RAIL_DOT_CLASS.idle had zero direct coverage; mirrors the existing
+    // thinking-tone test's toHaveClass(/bg-active/) assertion.
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_B_ID, id: 'ct-b1', activity: 'idle' }],
+    }));
+
+    try {
+      await collapseSidebar(page);
+
+      const betaDot = page.locator(`[data-testid="rail-project-terminals-${PROJECT_B_ID}"]`);
+      await expect(betaDot).toBeVisible();
+      await expect(betaDot).toHaveAttribute('data-activity', 'idle');
+      await expect(betaDot).toHaveClass(/bg-attention/);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('the rail aria-label speaks "needs you" for an idle terminal (red-green for FIX B)', async () => {
+    // FIX B: the rail button's aria-label used to be the tone-blind
+    // "<name>, Command Terminals running". It now speaks the tone via
+    // RAIL_TERMINAL_LABEL. This fails if the label regresses to the
+    // tone-blind string. title stays the bare project name either way.
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_A_ID, id: 'ct-a1', activity: 'idle' }],
+    }));
+
+    try {
+      await collapseSidebar(page);
+
+      const alphaButton = page.locator(`[data-testid="rail-project-${PROJECT_A_ID}"]`);
+      await expect(alphaButton).toHaveAttribute('title', 'Project Alpha');
+      await expect(alphaButton).toHaveAttribute(
+        'aria-label',
+        /Project Alpha, Command Terminals running \(needs you\)/,
+      );
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('the rail aria-label speaks "working" for a thinking terminal', async () => {
+    const { browser, page } = await launchWithState(preConfig({
+      terminals: [{ project: PROJECT_A_ID, id: 'ct-a1', activity: 'thinking' }],
+    }));
+
+    try {
+      await collapseSidebar(page);
+
+      const alphaButton = page.locator(`[data-testid="rail-project-${PROJECT_A_ID}"]`);
+      await expect(alphaButton).toHaveAttribute('title', 'Project Alpha');
+      await expect(alphaButton).toHaveAttribute('aria-label', /\(working\)/);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/ui/test-globals.d.ts
+++ b/tests/ui/test-globals.d.ts
@@ -34,6 +34,11 @@ declare global {
     __mockUpdateDownloadedListeners?: Array<(info: { version: string; releaseNotes: string }) => void>;
     /** Fires the update-downloaded push to every registered subscriber. Installed eagerly at mock-bootstrap time. */
     __mockFireUpdateDownloaded?: (info: { version: string; releaseNotes: string }) => void;
+
+    /** Subscribers registered via `notifications.onClicked`; fired by `__mockFireNotificationClicked`. */
+    __mockNotificationClickListeners?: Array<(projectId: string, taskId: string) => void>;
+    /** Fires the notification-clicked push to every registered subscriber. Installed eagerly at mock-bootstrap time; throws if no subscriber has registered yet. */
+    __mockFireNotificationClicked?: (projectId: string, taskId: string) => void;
   }
 }
 

--- a/tests/unit/command-terminal-summary.test.ts
+++ b/tests/unit/command-terminal-summary.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for `selectCommandTerminalSummary`, the per-project Command Terminal
+ * count + activity tone that drives BOTH the title-bar glyph and the project
+ * sidebar's per-row indicator.
+ *
+ * Two contracts matter here:
+ *
+ * 1. It reads the SESSIONS list, not the `transientSessions` map. That map is
+ *    renderer-owned window pairing whose hard-reload recovery only re-pairs the
+ *    current project, so a map-based count reads zero for every background project
+ *    after a reload. `session:list` is unscoped and main stamps `projectId` +
+ *    `transient` on every row, so this selector stays correct cross-project.
+ * 2. Tone precedence is WORKING-wins, bucketed only through the shared
+ *    idle-vs-active classifiers, so a `permission`-blocked terminal counts as
+ *    needing the user rather than as working.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { selectCommandTerminalSummary } from '../../src/renderer/stores/session-store/transient-session-slice';
+import type { ActivityState, Session } from '../../src/shared/types';
+
+const PROJECT_A = 'proj-a';
+const PROJECT_B = 'proj-b';
+
+function makeSession(overrides: Partial<Session> & { id: string }): Session {
+  return {
+    taskId: `task-${overrides.id}`,
+    projectId: PROJECT_A,
+    pid: 1234,
+    status: 'running',
+    shell: 'bash',
+    cwd: '/mock/project',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    exitCode: null,
+    resuming: false,
+    agentSessionId: null,
+    transient: true,
+    ...overrides,
+  };
+}
+
+describe('selectCommandTerminalSummary', () => {
+  it('returns an empty summary when there is no project', () => {
+    const sessions = [makeSession({ id: 'sess-1' })];
+    expect(selectCommandTerminalSummary(sessions, {}, null)).toEqual({ count: 0, tone: 'rest' });
+  });
+
+  it('returns an empty summary for an empty session list', () => {
+    expect(selectCommandTerminalSummary([], {}, PROJECT_A)).toEqual({ count: 0, tone: 'rest' });
+  });
+
+  it('ignores non-transient (task agent) sessions', () => {
+    const sessions = [makeSession({ id: 'sess-agent', transient: undefined })];
+    expect(selectCommandTerminalSummary(sessions, {}, PROJECT_A)).toEqual({ count: 0, tone: 'rest' });
+  });
+
+  it('ignores terminals belonging to another project', () => {
+    const sessions = [makeSession({ id: 'sess-other', projectId: PROJECT_B })];
+    expect(selectCommandTerminalSummary(sessions, {}, PROJECT_A)).toEqual({ count: 0, tone: 'rest' });
+  });
+
+  it('ignores terminals that are no longer running', () => {
+    const sessions = [
+      makeSession({ id: 'sess-exited', status: 'exited' }),
+      makeSession({ id: 'sess-suspended', status: 'suspended' }),
+    ];
+    expect(selectCommandTerminalSummary(sessions, {}, PROJECT_A)).toEqual({ count: 0, tone: 'rest' });
+  });
+
+  it('counts only this project\'s live terminals', () => {
+    const sessions = [
+      makeSession({ id: 'sess-1' }),
+      makeSession({ id: 'sess-2' }),
+      makeSession({ id: 'sess-3' }),
+      makeSession({ id: 'sess-other-project', projectId: PROJECT_B }),
+      makeSession({ id: 'sess-agent', transient: undefined }),
+      makeSession({ id: 'sess-dead', status: 'exited' }),
+    ];
+    expect(selectCommandTerminalSummary(sessions, {}, PROJECT_A).count).toBe(3);
+  });
+
+  it('is rest when a live terminal has no activity yet', () => {
+    const sessions = [makeSession({ id: 'sess-1' })];
+    expect(selectCommandTerminalSummary(sessions, {}, PROJECT_A)).toEqual({ count: 1, tone: 'rest' });
+  });
+
+  it('is thinking when a terminal is working', () => {
+    const sessions = [makeSession({ id: 'sess-1' })];
+    const activity: Record<string, ActivityState> = { 'sess-1': 'thinking' };
+    expect(selectCommandTerminalSummary(sessions, activity, PROJECT_A)).toEqual({ count: 1, tone: 'thinking' });
+  });
+
+  it('is idle when a terminal is waiting on the user', () => {
+    const sessions = [makeSession({ id: 'sess-1' })];
+    const activity: Record<string, ActivityState> = { 'sess-1': 'idle' };
+    expect(selectCommandTerminalSummary(sessions, activity, PROJECT_A)).toEqual({ count: 1, tone: 'idle' });
+  });
+
+  it('treats a permission-blocked terminal as needing the user, not as working', () => {
+    // The bug class the shared classifier exists to prevent: `permission` is not
+    // 'idle' by string, but it does require user interaction.
+    const sessions = [makeSession({ id: 'sess-1' })];
+    const activity: Record<string, ActivityState> = { 'sess-1': 'permission' };
+    expect(selectCommandTerminalSummary(sessions, activity, PROJECT_A)).toEqual({ count: 1, tone: 'idle' });
+  });
+
+  it('lets working win over needs-you when both are present', () => {
+    const sessions = [makeSession({ id: 'sess-idle' }), makeSession({ id: 'sess-working' })];
+    const activity: Record<string, ActivityState> = { 'sess-idle': 'idle', 'sess-working': 'thinking' };
+    expect(selectCommandTerminalSummary(sessions, activity, PROJECT_A)).toEqual({ count: 2, tone: 'thinking' });
+  });
+
+  it('lets working win regardless of iteration order', () => {
+    // Guards the early-exit shape: a working terminal seen AFTER an idle one must
+    // still take precedence.
+    const sessions = [makeSession({ id: 'sess-working' }), makeSession({ id: 'sess-idle' })];
+    const activity: Record<string, ActivityState> = { 'sess-working': 'thinking', 'sess-idle': 'permission' };
+    expect(selectCommandTerminalSummary(sessions, activity, PROJECT_A).tone).toBe('thinking');
+  });
+
+  it('scores each project independently from one unscoped session list', () => {
+    // The cross-project property the sidebar depends on: one list, many projects.
+    const sessions = [
+      makeSession({ id: 'sess-a1' }),
+      makeSession({ id: 'sess-b1', projectId: PROJECT_B }),
+      makeSession({ id: 'sess-b2', projectId: PROJECT_B }),
+    ];
+    const activity: Record<string, ActivityState> = { 'sess-a1': 'idle', 'sess-b1': 'thinking' };
+    expect(selectCommandTerminalSummary(sessions, activity, PROJECT_A)).toEqual({ count: 1, tone: 'idle' });
+    expect(selectCommandTerminalSummary(sessions, activity, PROJECT_B)).toEqual({ count: 2, tone: 'thinking' });
+  });
+
+  it('ignores activity belonging to a session that is not a live terminal', () => {
+    // A stale activity entry for an exited terminal must not colour the tone.
+    const sessions = [makeSession({ id: 'sess-live' }), makeSession({ id: 'sess-dead', status: 'exited' })];
+    const activity: Record<string, ActivityState> = { 'sess-dead': 'thinking' };
+    expect(selectCommandTerminalSummary(sessions, activity, PROJECT_A)).toEqual({ count: 1, tone: 'rest' });
+  });
+});


### PR DESCRIPTION
## What

Surfaces live Command Terminal presence per project in the project sidebar.

Each project row now carries the title bar's terminal glyph plus a count, in the row's
right-aligned cluster beside the agent idle/thinking counts. Clicking it switches to that project
and reopens its Command Terminal layer. The collapsed rail carries the same state as a tone dot.

- `selectCommandTerminalSummary` (new, pure) in `stores/session-store/transient-session-slice.ts`
- `CommandTerminalIcon` extracted from `TitleBar.tsx` into `components/command-bar/`
- `SidebarCommandTerminalIndicator` (new) in `components/sidebar/project-sidebar/`
- `ProjectListItem`, `ProjectSidebar`, `CollapsedRail`, `TitleBar` wiring

## Why

Command Terminal PTYs stay alive when the layer is hidden and across project switches. The only
signal that a project had live terminals was the title-bar glyph, which reflects the **current**
project only. Switch away and those terminals keep running, invisible, consuming CPU and memory,
with nothing anywhere in the UI to say so.

## How

**Count and tone derive from the UNSCOPED `sessions` list, not the `transientSessions` map.** The
map is renderer-owned window pairing, and its hard-reload recovery only re-pairs the *current*
project (`session-store.ts`), so a map-based count would read zero for every background project
after a reload. `session:list` takes no projectId and main stamps `projectId` + `transient` on
every row, so the sessions list is correct cross-project and across reloads. The title bar now
reads the same selector, so the toggle and the sidebar can never disagree, and the tone aggregate
gains unit coverage it previously lacked. No new IPC.

**Layout.** The indicator sits beside the agent counts rather than merged into them (a Command
Terminal is not a task agent) and always prints its count, even at 1, so the three indicators form
matching icon+digit pairs that stack into one tabular column. A name-adjacent placement was built
and reverted: project names vary enough that the glyph landed at a different x on every row and cut
across the count column. It mounts *after* `SidebarActivityCounts` because several existing specs
resolve the envelope and spinner positionally via `.first()`.

**Collapsed rail** gets a plain tone dot rather than the glyph: at the rail's 28px width an
arc-bearing glyph reads as a broken icon over the project initial, which is the documented reason
rail activity icons were removed previously. Rendered as a `<span>`, so the existing
`svg.text-active` absence assertions keep their meaning, and the rail `title` stays the bare project
name (a test pins that exactly) with terminal state on `aria-label`.

**Reopen arms only once the switch is CONFIRMED.** `openProject` also resolves *without* switching
when a folder has moved (it catches the missing-path error and routes to the "Locate Folder"
dialog), so both call sites re-read the store after the await rather than arming on the bare
settle. Arming there would open the layer on the outgoing project.

Trade-off worth a reviewer's attention: this adds a third indicator to a row that already carried
two plus a kebab. Verified the worst case (long name, all three indicators) at the 200px minimum
sidebar width; the name truncates rather than the row overflowing. Row density is #449's call.

## Breaking changes

None.

## Tests

- **Unit (new):** `tests/unit/command-terminal-summary.test.ts`, 14 tests on the pure selector -
  project scoping, transient/running filtering, tone precedence, `permission` bucketing as
  needs-you, and cross-project independence from one unscoped list.
- **UI (new):** `tests/ui/sidebar-command-terminals.spec.ts`, 26 tests - presence/absence, count,
  tones, background-project visibility, side-by-side with agent counts, click-to-jump on both the
  active and a background project, the moved-folder arm that must NOT open the layer, icon sizing,
  accessible labels, and the rail dot.
- **Coverage gap closed:** the switch-confirmed arm had no assertion at either call site. Both were
  red-greened against the un-fixed behavior; the `App.tsx` case reproduces the literal pre-fix code.
- **Regression:** `project-session-scope.spec.ts`, `collapsed-rail.spec.ts`, and
  `command-terminal.spec.ts` all pass unchanged (96 UI tests green locally across the four specs).
  The one edit to an existing spec replaces a positional `[aria-label]` lookup with a `data-testid`,
  so it can no longer silently re-point when the row is rearranged.

Generated with [Claude Code](https://claude.com/claude-code)
