### PR TITLE
feat(sidebar): give the footer a split button and the list a background menu

### DIFF
--- a/src/renderer/components/sidebar/ProjectSidebar.tsx
+++ b/src/renderer/components/sidebar/ProjectSidebar.tsx
@@ -5,7 +5,7 @@ import {
 } from '@dnd-kit/core';
 import { SortableContext, rectSortingStrategy, arrayMove } from '@dnd-kit/sortable';
 import {
-  Folder, ChevronsLeft, FolderPlus, FolderTree, Search, X,
+  Folder, ChevronsLeft, FolderTree, Search, X,
 } from 'lucide-react';
 import { useProjectStore } from '../../stores/project-store';
 import { useConfigStore } from '../../stores/config-store';
@@ -22,6 +22,8 @@ import {
   GroupHeader,
   ProjectContextMenu,
   GroupContextMenu,
+  SidebarFooterActions,
+  SidebarBackgroundMenu,
   useSidebarDragDrop,
 } from './project-sidebar';
 
@@ -56,6 +58,7 @@ export function ProjectSidebar({ onToggleSidebar }: ProjectSidebarProps) {
   const newGroupInputRef = useRef<HTMLInputElement>(null);
   const [contextMenu, setContextMenu] = useState<{ position: { x: number; y: number }; project: Project } | null>(null);
   const [groupContextMenu, setGroupContextMenu] = useState<{ position: { x: number; y: number }; group: ProjectGroup } | null>(null);
+  const [backgroundMenu, setBackgroundMenu] = useState<{ x: number; y: number } | null>(null);
   const [renamingProjectId, setRenamingProjectId] = useState<string | null>(null);
   const [renamingGroupId, setRenamingGroupId] = useState<string | null>(null);
   const [search, setSearch] = useState('');
@@ -315,7 +318,18 @@ export function ProjectSidebar({ onToggleSidebar }: ProjectSidebarProps) {
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto">
+      {/* Right-clicking the list's empty space used to fall through to
+          Electron's native Copy / Paste / Select All menu, which offers nothing
+          a project list can act on. Rows and group headers stopPropagation in
+          their own handlers, so this only fires on genuine dead space. */}
+      <div
+        className="flex-1 overflow-y-auto"
+        data-testid="sidebar-project-list"
+        onContextMenu={(event) => {
+          event.preventDefault();
+          setBackgroundMenu({ x: event.clientX, y: event.clientY });
+        }}
+      >
         <DndContext
           key={hmrGeneration}
           sensors={sensors}
@@ -364,6 +378,9 @@ export function ProjectSidebar({ onToggleSidebar }: ProjectSidebarProps) {
                   ref={newGroupInputRef}
                   value={newGroupName}
                   onChange={(e) => setNewGroupName(e.target.value)}
+                  // Keeps the native Copy / Paste menu on the text field: the
+                  // list container's own handler would otherwise swallow it.
+                  onContextMenu={(event) => event.stopPropagation()}
                   onBlur={() => {
                     setCreatingGroup(false);
                     setNewGroupName('');
@@ -404,7 +421,7 @@ export function ProjectSidebar({ onToggleSidebar }: ProjectSidebarProps) {
           <div className="p-6 text-center">
             <Folder size={32} className="mx-auto text-fg-disabled mb-2" />
             <div className="text-sm text-fg-faint">No projects yet</div>
-            <div className="text-xs text-fg-disabled mt-1">Use the buttons below to open a folder</div>
+            <div className="text-xs text-fg-disabled mt-1">Use Add project below to open a folder</div>
           </div>
         )}
         {projects.length > 0 && isSearching && totalFilteredCount === 0 && (
@@ -416,29 +433,16 @@ export function ProjectSidebar({ onToggleSidebar }: ProjectSidebarProps) {
         )}
       </div>
 
-      <div className="px-3 py-2 border-t border-edge flex items-center gap-1.5">
-        <button
-          type="button"
-          onClick={startAddProject}
-          className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-edge/60 text-fg-muted hover:text-fg hover:bg-surface-hover/40 hover:border-edge transition-colors"
-          title="Open folder as project"
-          data-testid="sidebar-new-project-button"
-        >
-          <FolderPlus size={14} />
-          Add project
-        </button>
-        <button
-          type="button"
-          onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
-          onClick={handleNewGroup}
-          className="flex-shrink-0 inline-flex items-center justify-center w-8 h-[30px] rounded-md border border-edge/60 text-fg-muted hover:text-fg hover:bg-surface-hover/40 hover:border-edge transition-colors"
-          title="New group"
-          data-testid="sidebar-new-group-button"
-          aria-label="New group"
-        >
-          <FolderTree size={14} />
-        </button>
-      </div>
+      <SidebarFooterActions onAddProject={startAddProject} onNewGroup={handleNewGroup} />
+
+      {backgroundMenu && (
+        <SidebarBackgroundMenu
+          position={backgroundMenu}
+          onAddProject={startAddProject}
+          onNewGroup={handleNewGroup}
+          onClose={() => setBackgroundMenu(null)}
+        />
+      )}
 
       {/* Project context menu */}
       {contextMenu && (

--- a/src/renderer/components/sidebar/project-sidebar/SidebarBackgroundMenu.tsx
+++ b/src/renderer/components/sidebar/project-sidebar/SidebarBackgroundMenu.tsx
@@ -1,0 +1,86 @@
+import React, { useRef, useEffect } from 'react';
+import { FolderPlus, FolderTree } from 'lucide-react';
+
+export interface SidebarBackgroundMenuProps {
+  position: { x: number; y: number };
+  onAddProject: () => void;
+  onNewGroup: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Right-click menu for the empty space below the project list.
+ *
+ * Without it that area falls through to Electron's native Copy / Paste /
+ * Select All menu, which offers nothing a project list can act on and reads as
+ * a bug. The two entries mirror the footer's actions, so the gesture people
+ * reach for on a list background lands somewhere useful.
+ *
+ * Shell mirrors ProjectContextMenu / GroupContextMenu: cursor-anchored and
+ * `position: fixed`, which `popover-escapes-clipping.md` exempts from the
+ * portal rule since it is positioned at the pointer, not against a trigger.
+ */
+export function SidebarBackgroundMenu({
+  position,
+  onAddProject,
+  onNewGroup,
+  onClose,
+}: SidebarBackgroundMenuProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [onClose]);
+
+  const menuStyle: React.CSSProperties = {
+    left: Math.min(position.x, window.innerWidth - 200),
+    top: Math.min(position.y, window.innerHeight - 90),
+  };
+
+  const itemClass = 'flex items-center gap-2 w-full px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-hover transition-colors text-left';
+
+  return (
+    <div
+      ref={containerRef}
+      role="menu"
+      data-testid="sidebar-background-menu"
+      className="fixed bg-surface-raised border border-edge rounded-md shadow-lg z-50 py-1 min-w-[160px] overlay-popover-in"
+      style={{ ...menuStyle, transformOrigin: 'top left' }}
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => { onClose(); onAddProject(); }}
+        className={itemClass}
+        data-testid="sidebar-background-add-project"
+      >
+        <FolderPlus size={14} className="text-fg-faint" />
+        Add project
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={() => { onClose(); onNewGroup(); }}
+        className={itemClass}
+        data-testid="sidebar-background-new-group"
+      >
+        <FolderTree size={14} className="text-fg-faint" />
+        New group
+      </button>
+    </div>
+  );
+}

--- a/src/renderer/components/sidebar/project-sidebar/SidebarFooterActions.tsx
+++ b/src/renderer/components/sidebar/project-sidebar/SidebarFooterActions.tsx
@@ -1,0 +1,127 @@
+import { useRef, useState, useEffect } from 'react';
+import { FolderPlus, FolderTree, ChevronUp } from 'lucide-react';
+import { OverlayPopover } from '../../OverlayPopover';
+import { usePopoverPosition } from '../../../hooks/usePopoverPosition';
+
+export interface SidebarFooterActionsProps {
+  onAddProject: () => void;
+  onNewGroup: () => void;
+}
+
+/**
+ * The sidebar's footer: one split button.
+ *
+ * Adding a project is a constant action and new group is a rare one, so they
+ * are no longer two same-weight buttons competing for the same strip. The
+ * primary action fills the footer and the secondary lives behind the caret,
+ * which also removes the hand-tuned icon-button height that had to be kept in
+ * sync with the text button's padding by hand.
+ */
+export function SidebarFooterActions({ onAddProject, onNewGroup }: SidebarFooterActionsProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const caretRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // The menu portals to the body: the footer sits below a `overflow-y-auto`
+  // list and inside the sidebar's own stacking context, and it opens upward
+  // because it is pinned to the bottom of the window.
+  //
+  // `preferRight` is pinned rather than left at `'auto'`: auto left-aligns any
+  // trigger in the viewport's left half, which the sidebar caret always is, so
+  // the menu would hang off the sidebar's right edge and float over the board.
+  // Right-aligning pins the menu's right edge to the caret's, inside the rail.
+  const { style, placement } = usePopoverPosition(caretRef, menuRef, menuOpen, {
+    mode: 'dropdown',
+    strategy: 'fixed',
+    preferVertical: 'above',
+    preferRight: true,
+  });
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    // Checks BOTH refs: once portaled, a click inside the menu is no longer a
+    // descendant of the trigger and would otherwise read as "outside".
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (menuRef.current?.contains(target) || containerRef.current?.contains(target)) return;
+      setMenuOpen(false);
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setMenuOpen(false);
+    };
+    document.addEventListener('mousedown', handlePointerDown, true);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown, true);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [menuOpen]);
+
+  return (
+    <div className="px-3 py-2 border-t border-edge">
+      <div
+        ref={containerRef}
+        className="flex items-stretch rounded-md border border-edge/60 overflow-hidden focus-within:border-edge"
+      >
+        <button
+          type="button"
+          // Closes the caret menu too: this button is inside `containerRef`, so
+          // the outside-click handler reads a click on it as "inside" and would
+          // leave the menu floating behind the folder picker.
+          onClick={() => {
+            setMenuOpen(false);
+            onAddProject();
+          }}
+          className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium cursor-pointer text-fg-muted hover:text-fg hover:bg-surface-hover/40 transition-colors"
+          title="Open folder as project"
+          data-testid="sidebar-new-project-button"
+        >
+          <FolderPlus size={14} />
+          Add project
+        </button>
+        <button
+          ref={caretRef}
+          type="button"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => setMenuOpen((open) => !open)}
+          className="flex-shrink-0 inline-flex items-center justify-center w-7 border-l border-edge/60 cursor-pointer text-fg-muted hover:text-fg hover:bg-surface-hover/40 transition-colors"
+          title="More project actions"
+          aria-label="More project actions"
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          data-testid="sidebar-footer-more-button"
+        >
+          <ChevronUp size={14} />
+        </button>
+      </div>
+
+      <OverlayPopover
+        open={menuOpen}
+        popoverRef={menuRef}
+        style={style}
+        portal
+        transformOrigin={placement.vertical === 'above' ? 'bottom center' : 'top center'}
+        role="menu"
+        data-testid="sidebar-footer-menu"
+        className="fixed z-[2147483646] min-w-[170px] bg-surface-raised border border-edge-input rounded-md shadow-xl py-1"
+      >
+        <button
+          type="button"
+          role="menuitem"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => {
+            setMenuOpen(false);
+            onNewGroup();
+          }}
+          className="w-full text-left px-3 py-1.5 text-xs transition-colors flex items-center gap-2 text-fg-tertiary hover:bg-surface-hover hover:text-fg"
+          title="New group"
+          data-testid="sidebar-new-group-button"
+        >
+          <FolderTree size={14} className="text-fg-faint" />
+          New group
+        </button>
+      </OverlayPopover>
+    </div>
+  );
+}

--- a/src/renderer/components/sidebar/project-sidebar/index.ts
+++ b/src/renderer/components/sidebar/project-sidebar/index.ts
@@ -4,4 +4,6 @@ export { ProjectContextMenu } from './ProjectContextMenu';
 export { GroupContextMenu } from './GroupContextMenu';
 export { SidebarActivityCounts } from './SidebarActivityCounts';
 export { SidebarCommandTerminalIndicator } from './SidebarCommandTerminalIndicator';
+export { SidebarFooterActions } from './SidebarFooterActions';
+export { SidebarBackgroundMenu } from './SidebarBackgroundMenu';
 export { useSidebarDragDrop } from './useSidebarDragDrop';

--- a/tests/ui/project-groups.spec.ts
+++ b/tests/ui/project-groups.spec.ts
@@ -80,6 +80,33 @@ test.describe('Project Groups', () => {
     await expect(page.locator('text=FromBackgroundMenu').first()).toBeVisible();
   });
 
+  test('background menu "Add project" reaches the add-project flow and closes the menu', async () => {
+    // Neutralize the add-project pipeline the same way the footer-menu test
+    // does below, so it toasts-and-returns instead of opening a real project.
+    // The resulting error toast is the only externally-observable proof that
+    // this specific entry's onClick actually invoked onAddProject rather than
+    // just closing the menu - "New group" above already covers the sibling
+    // entry, so this test is scoped to the wiring the background menu adds.
+    await page.evaluate(() => {
+      (window as unknown as { __mockProbePathOverrides: Record<string, unknown> })
+        .__mockProbePathOverrides = { exists: false };
+    });
+
+    const projectList = page.getByTestId('sidebar-project-list');
+    const box = await projectList.boundingBox();
+    if (!box) throw new Error('Sidebar project list has no layout');
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height - 20, { button: 'right' });
+
+    const menu = page.getByTestId('sidebar-background-menu');
+    await expect(menu).toBeVisible();
+    await menu.getByTestId('sidebar-background-add-project').click();
+
+    await expect(page.getByTestId('sidebar-background-menu')).toHaveCount(0);
+    const errorToast = page.locator('[data-testid="toast"]')
+      .filter({ hasText: 'That folder could not be opened. It may have been moved or renamed.' });
+    await expect(errorToast).toBeVisible({ timeout: 5000 });
+  });
+
   test('right-clicking a project row does not open the background menu', async () => {
     // Rows stopPropagation their own context-menu event; the list container's
     // onContextMenu handler underneath must never also fire for a row click.
@@ -102,6 +129,25 @@ test.describe('Project Groups', () => {
     const groupMenu = page.locator('.fixed.bg-surface-raised').filter({ hasText: 'Move up' });
     await expect(groupMenu).toBeVisible();
     await expect(page.getByTestId('sidebar-background-menu')).toHaveCount(0);
+  });
+
+  test('right-clicking the inline group-name input does not open the background menu', async () => {
+    // The input lives inside the list container, so without its own
+    // stopPropagation the container's onContextMenu would preventDefault the
+    // event and swallow the text field's native Copy / Paste menu - the third
+    // sibling of the row/group-header guards above, and the only one that
+    // costs the user a working control if it regresses.
+    await clickNewGroup(page);
+    const input = page.locator('input[placeholder="Group name"]');
+    await expect(input).toBeVisible();
+
+    await input.click({ button: 'right' });
+
+    await expect(page.getByTestId('sidebar-background-menu')).toHaveCount(0);
+    // Guards the vacuous pass: if the right-click had blurred the input away
+    // instead of being stopped, the count assertion above would hold for the
+    // wrong reason.
+    await expect(input).toBeVisible();
   });
 
   test('Escape cancels group creation', async () => {
@@ -302,6 +348,30 @@ test.describe('Sidebar Footer Actions', () => {
     await expect(menu).toBeVisible();
 
     await page.getByTestId('sidebar-new-project-button').click();
+
+    // The popover stays mounted through its exit animation (see clickNewGroup above).
+    await menu.waitFor({ state: 'detached', timeout: 5000 });
+  });
+
+  test('Escape closes the footer caret menu', async () => {
+    await page.getByTestId('sidebar-footer-more-button').click();
+    const menu = page.getByTestId('sidebar-footer-menu');
+    await expect(menu).toBeVisible();
+
+    await page.keyboard.press('Escape');
+
+    // The popover stays mounted through its exit animation (see clickNewGroup above).
+    await menu.waitFor({ state: 'detached', timeout: 5000 });
+  });
+
+  test('clicking outside the footer caret menu closes it', async () => {
+    await page.getByTestId('sidebar-footer-more-button').click();
+    const menu = page.getByTestId('sidebar-footer-menu');
+    await expect(menu).toBeVisible();
+
+    // Far from both the portaled menu and the split-button container, mirroring
+    // the outside-click point the group context menu test below uses.
+    await page.mouse.click(900, 300);
 
     // The popover stays mounted through its exit animation (see clickNewGroup above).
     await menu.waitFor({ state: 'detached', timeout: 5000 });

--- a/tests/ui/project-groups.spec.ts
+++ b/tests/ui/project-groups.spec.ts
@@ -18,8 +18,22 @@ test.afterEach(async () => {
   await page.context().browser()?.close();
 });
 
+/**
+ * "New group" is a rare action and now sits behind the footer split button's
+ * caret, so the constantly-used "Add project" stands alone in the footer.
+ */
+async function clickNewGroup(page: Page): Promise<void> {
+  await page.getByTestId('sidebar-footer-more-button').click();
+  await page.getByTestId('sidebar-new-group-button').click();
+  // The popover stays mounted through its exit animation. Later assertions in
+  // this file locate context menus by `.fixed.bg-surface-raised`, which the
+  // closing footer menu also matches, so wait it out rather than leaving a
+  // second match behind for whichever test runs next.
+  await page.getByTestId('sidebar-footer-menu').waitFor({ state: 'detached', timeout: 5000 });
+}
+
 async function createGroup(page: Page, name: string): Promise<void> {
-  await page.locator('button[title="New group"]').click();
+  await clickNewGroup(page);
   const input = page.locator('input[placeholder="Group name"]');
   await expect(input).toBeVisible();
   await input.fill(name);
@@ -42,20 +56,67 @@ test.describe('Project Groups', () => {
     await expect(page.locator('text=Work').first()).toBeVisible();
   });
 
+  test('right-clicking the list background offers the create actions', async () => {
+    // That area used to fall through to Electron's native Copy / Paste menu,
+    // which offers nothing a project list can act on.
+    const projectList = page.getByTestId('sidebar-project-list');
+    const box = await projectList.boundingBox();
+    if (!box) throw new Error('Sidebar project list has no layout');
+    // Derived from the scrolling list container's OWN layout, not the
+    // sidebar's total height minus a hardcoded footer offset - the footer
+    // lives outside this container, so a footer height change can never move
+    // this point onto the footer or a project row.
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height - 20, { button: 'right' });
+
+    const menu = page.getByTestId('sidebar-background-menu');
+    await expect(menu).toBeVisible();
+    await expect(menu.getByTestId('sidebar-background-add-project')).toBeVisible();
+
+    await menu.getByTestId('sidebar-background-new-group').click();
+    const input = page.locator('input[placeholder="Group name"]');
+    await expect(input).toBeVisible();
+    await input.fill('FromBackgroundMenu');
+    await input.press('Enter');
+    await expect(page.locator('text=FromBackgroundMenu').first()).toBeVisible();
+  });
+
+  test('right-clicking a project row does not open the background menu', async () => {
+    // Rows stopPropagation their own context-menu event; the list container's
+    // onContextMenu handler underneath must never also fire for a row click.
+    await page.locator('.truncate.font-medium:text("Alpha")').click({ button: 'right' });
+
+    // Scoped by an item only ProjectContextMenu renders - both menus share
+    // the ".fixed.bg-surface-raised" shell, so a bare selector on that class
+    // would also match SidebarBackgroundMenu.
+    const projectMenu = page.locator('.fixed.bg-surface-raised').filter({ hasText: 'Open in Explorer' });
+    await expect(projectMenu).toBeVisible();
+    await expect(page.getByTestId('sidebar-background-menu')).toHaveCount(0);
+  });
+
+  test('right-clicking a group header does not open the background menu', async () => {
+    await createGroup(page, 'NoBackgroundLeak');
+    const groupHeader = page.locator('[data-testid^="project-group-"]');
+    await groupHeader.click({ button: 'right' });
+
+    // Scoped by an item only GroupContextMenu renders, for the same reason as above.
+    const groupMenu = page.locator('.fixed.bg-surface-raised').filter({ hasText: 'Move up' });
+    await expect(groupMenu).toBeVisible();
+    await expect(page.getByTestId('sidebar-background-menu')).toHaveCount(0);
+  });
+
   test('Escape cancels group creation', async () => {
-    await page.locator('button[title="New group"]').click();
+    await clickNewGroup(page);
     const input = page.locator('input[placeholder="Group name"]');
     await expect(input).toBeVisible();
     await input.press('Escape');
     await expect(input).toBeHidden();
   });
 
-  test('clicking Group button again cancels creation', async () => {
-    const groupButton = page.locator('button[title="New group"]');
-    await groupButton.click();
+  test('choosing New group again cancels creation', async () => {
+    await clickNewGroup(page);
     const input = page.locator('input[placeholder="Group name"]');
     await expect(input).toBeVisible();
-    await groupButton.click();
+    await clickNewGroup(page);
     await expect(input).toBeHidden();
   });
 
@@ -203,16 +264,60 @@ test.describe('Project Groups', () => {
   });
 });
 
+test.describe('Sidebar Footer Actions', () => {
+  test('footer caret menu stays inside the sidebar', async () => {
+    const sidebar = page.locator('.bg-surface-raised').first();
+    const sidebarBox = await sidebar.boundingBox();
+    if (!sidebarBox) throw new Error('Sidebar has no layout');
+
+    await page.getByTestId('sidebar-footer-more-button').click();
+    const menu = page.getByTestId('sidebar-footer-menu');
+    await expect(menu).toBeVisible();
+
+    const menuBox = await menu.boundingBox();
+    if (!menuBox) throw new Error('Footer menu has no layout');
+
+    // Before the fix, the default auto alignment left-aligned the menu to the
+    // caret (auto left-aligns any trigger in the viewport's left half, which
+    // the sidebar caret always is), so the menu hung off the sidebar's right
+    // edge and floated over the board. A couple of pixels of tolerance for
+    // cross-platform sub-pixel rounding (cross-platform-parity.md); not an
+    // exact-equality check.
+    expect(menuBox.x + menuBox.width).toBeLessThanOrEqual(sidebarBox.x + sidebarBox.width + 2);
+  });
+
+  test('clicking Add project from the footer menu closes it', async () => {
+    // Neutralize the add-project flow so it toasts-and-returns instead of
+    // opening or creating a project. A real project open re-renders the
+    // sidebar for reasons unrelated to the fix under test, which could close
+    // the menu (or not) independent of the setMenuOpen(false) call this test
+    // is pinning.
+    await page.evaluate(() => {
+      (window as unknown as { __mockProbePathOverrides: Record<string, unknown> })
+        .__mockProbePathOverrides = { exists: false };
+    });
+
+    await page.getByTestId('sidebar-footer-more-button').click();
+    const menu = page.getByTestId('sidebar-footer-menu');
+    await expect(menu).toBeVisible();
+
+    await page.getByTestId('sidebar-new-project-button').click();
+
+    // The popover stays mounted through its exit animation (see clickNewGroup above).
+    await menu.waitFor({ state: 'detached', timeout: 5000 });
+  });
+});
+
 test.describe('GroupContextMenu - move up/down', () => {
   test('Move down reorders the group one position later', async () => {
     // Create two groups so we can move First down
-    await page.locator('button[title="New group"]').click();
+    await clickNewGroup(page);
     const input = page.locator('input[placeholder="Group name"]');
     await input.fill('First');
     await input.press('Enter');
     await expect(input).toBeHidden();
 
-    await page.locator('button[title="New group"]').click();
+    await clickNewGroup(page);
     const input2 = page.locator('input[placeholder="Group name"]');
     await input2.fill('Second');
     await input2.press('Enter');
@@ -236,13 +341,13 @@ test.describe('GroupContextMenu - move up/down', () => {
   });
 
   test('Move up reorders the group one position earlier', async () => {
-    await page.locator('button[title="New group"]').click();
+    await clickNewGroup(page);
     const input = page.locator('input[placeholder="Group name"]');
     await input.fill('GroupA');
     await input.press('Enter');
     await expect(input).toBeHidden();
 
-    await page.locator('button[title="New group"]').click();
+    await clickNewGroup(page);
     const input2 = page.locator('input[placeholder="Group name"]');
     await input2.fill('GroupB');
     await input2.press('Enter');
@@ -268,7 +373,7 @@ test.describe('GroupContextMenu - move up/down', () => {
   test('Move up is disabled when group is first', async () => {
     await createGroup(page, 'OnlyGroup');
 
-    // Right-click the only group -- Move up should be disabled
+    // Right-click the only group - Move up should be disabled
     const groupHeader = page.locator('[data-testid^="project-group-"]');
     await groupHeader.click({ button: 'right' });
     const contextMenu = page.locator('.fixed.bg-surface-raised');
@@ -280,7 +385,7 @@ test.describe('GroupContextMenu - move up/down', () => {
   test('Move down is disabled when group is last', async () => {
     await createGroup(page, 'LoneGroup');
 
-    // Right-click the only group -- Move down should be disabled
+    // Right-click the only group - Move down should be disabled
     const groupHeader = page.locator('[data-testid^="project-group-"]');
     await groupHeader.click({ button: 'right' });
     const contextMenu = page.locator('.fixed.bg-surface-raised');


### PR DESCRIPTION
## What

Two affordances in the project sidebar (`src/renderer/components/sidebar/`):

- **The footer is now one split button.** `SidebarFooterActions` renders "Add project" as the
  primary action filling the strip, with a caret opening a menu that holds "New group".
- **Right-clicking the empty space below the project list opens a menu** with those same two
  create actions (`SidebarBackgroundMenu`).

## Why

Both are places a user reaches for an action and finds the wrong thing.

The footer weighted two actions equally that are not: "Add project" is used constantly and "New
group" maybe twice in a project's life, yet they sat as same-size outline buttons. They were held
to a matching height by a hand-tuned `w-8 h-[30px]` that had to be re-tuned whenever the text
button's padding moved.

Right-clicking the list background fell through to Electron's native Copy / Paste / Select All
menu, which offers nothing a project list can act on and reads as a bug.

## How

The footer menu is portaled with `strategy: 'fixed'` per `popover-escapes-clipping.md`: it is
anchored to a trigger inside the sidebar's stacking context and below an `overflow-y-auto` list.
`preferRight` is pinned rather than left at `'auto'`, which would left-align any trigger in the
viewport's left half (the sidebar caret always is) and hang the menu over the board.

The background menu is cursor-anchored `position: fixed`, which that rule explicitly exempts. Its
handler sits on the list container; rows and group headers already `stopPropagation` in their own
context handlers, so it only fires on genuine dead space. The inline group-name input stops
propagation too, so native text-field paste keeps working there.

Trade-off worth a reviewer's attention: `SidebarBackgroundMenu` repeats the cursor-anchored shell
(outside-click, Escape, viewport clamp) that `ProjectContextMenu` and `GroupContextMenu` already
carry. Extracting a shared shell was considered and left out to keep this diff small; it is a
reasonable follow-up now that there are three copies.

Scope note: this branch started as a broader visual redesign of the sidebar. That work was
reverted after review, and only these two additive affordances remain. The row, group-header,
rail, and header styling are untouched.

## Breaking changes

None. No schema, IPC, or config changes.

## Tests

`tests/ui/project-groups.spec.ts` (26 tests, all passing locally):

- The pre-existing group tests now route through a `clickNewGroup` helper that opens the caret
  menu. The helper waits for the popover to detach, because `OverlayPopover` keeps it mounted
  through its exit animation, where it would otherwise match the `.fixed.bg-surface-raised`
  locator other tests in the file use.
- New: the background menu's two entries; the footer caret menu's Escape and outside-click
  dismissal; the caret menu staying inside the sidebar; and that right-clicking a project row, a
  group header, or the inline group-name input does not open the background menu.

Each new test was red-greened by mutating the source and restoring it. Verified stable at
`--repeat-each=3` (78/78). Typecheck and lint clean; the remaining tiers run as CI checks here.

Generated with [Claude Code](https://claude.com/claude-code)
