### PR TITLE
fix(pr): stop linking a PR URL cited in a task description

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -121,6 +121,10 @@ Create a task on the board (default: the To Do column on the active board) or in
 | `autoCommand` | string | No | Slash command to run once the agent spawns for this task (e.g. `"/code-review"`, `"/release"`). Overrides the destination column's `auto_command` for this task only. MCP-only - not surfaced in the New Task dialog. |
 | `profile` | string | No | Board Profile this task rides (name or id) - an alternate set of per-column agent/model/effort settings, applied as the task moves. Omit for "Default" (every column uses its own settings). See [kangentic_list_board_profiles](#kangentic_list_board_profiles). |
 | `runMode` | string | No | How the task gets its agent settings: `"column_settings"` (the default - follow each column as the task moves) or `"agent_override"` (pin agent/model/effort/permission for the task's whole life). Any of the four `*Override` params implies `"agent_override"`, so pass this only to choose override mode without pinning anything - fields left unset then resolve dynamically until the task first spawns, which locks all four. Passing a pin together with `"column_settings"` is rejected as a contradiction. |
+| `prUrl` | string | No | Pull request URL this task is about (e.g. `https://github.com/owner/repo/pull/123`). Board tasks only. |
+| `prNumber` | number | No | Pull request number this task is about. This is the field the linker actually anchors on (Tier 1); it is derived from `prUrl` when omitted, so passing the URL alone is enough for a standard `/pull/<n>` URL. Board tasks only. |
+
+**Filing a review task:** `prUrl` / `prNumber` are how a task names the PR it is about, and they are what links it. Writing the URL into `description` instead does **not** link it - the linker's anchors are git state and the stored `pr_number` only, never authored prose (see [PR Integration](pr-integration.md#the-confidence-ladder)). Both are applied as a follow-up update immediately after the row is created, so `pr_state` starts null and the next resolve fills in the live PR state.
 
 `profile` is **mutually exclusive** with `agentOverride` / `modelOverride` / `effortOverride` / `permissionMode` / `runMode: "agent_override"`: a profile changes settings per column, those pin one value for the task's whole life. Passing both is rejected and nothing is created, rather than silently discarding one side (the repository enforces the same exclusivity on write). An unknown profile name is an error too - a typo must not quietly produce a task that looks tiered and runs on the plain board settings.
 
@@ -352,8 +356,8 @@ Update a task's title, description (full replace, in-place find/replace edits, o
 | `description` | string | No | New description, replaces the entire description (max 50000 chars). Mutually exclusive with `descriptionEdits` and `appendDescription`; for an incremental change to a long description, prefer those instead - they cost far fewer tokens and cannot silently drop untouched sections. |
 | `descriptionEdits` | array | No | Ordered exact-string replacements applied to the current description, like the file `Edit` tool: `[{ find: string, replace: string }]` (1-100 edits; each `find`/`replace` up to 50000 chars). Each `find` must be present and unique in the text as it stands after prior edits in the list, or the whole call fails and nothing is written. Mutually exclusive with `description`; may combine with `appendDescription` (edits apply first). |
 | `appendDescription` | string | No | Text appended to the end of the current description, exactly as given (no separator inserted, max 50000 chars). Mutually exclusive with `description`; may combine with `descriptionEdits` (edits apply first, then this append). |
-| `prUrl` | string | No | Pull request URL (e.g. `https://github.com/owner/repo/pull/123`) |
-| `prNumber` | number | No | Pull request number |
+| `prUrl` | string | No | Pull request URL (e.g. `https://github.com/owner/repo/pull/123`). This is what links the task to a PR; a URL written into `description` does not. |
+| `prNumber` | number | No | Pull request number. The field the linker anchors on (Tier 1); derived from `prUrl` when omitted, so a URL-only write can never strand the previous PR's number. A number-only write leaves `pr_url` until the next resolve re-points it, which is harmless: the resolve follows the number you gave. |
 | `agent` | string | No | Agent name to assign (e.g. `"claude"`, `"codex"`). Empty string clears. |
 | `priority` | number | No | Task priority 0-4 (0=none, 4=highest) |
 | `labels` | string[] | No | Replace the task's label list. Pass `[]` to clear. |
@@ -367,6 +371,8 @@ Update a task's title, description (full replace, in-place find/replace edits, o
 | `attachments` | array | No | File attachments to ADD to the task: `[{ filePath: string, filename?: string }]`. Additive - existing attachments are kept, not replaced. Use `kangentic_remove_task_attachment` to remove one. |
 
 At least one updatable field is required.
+
+Setting `prUrl` or `prNumber` also clears the task's stored PR state, so the three PR columns never disagree. The next resolve fills the state back in from the PR itself. See [PR Integration](pr-integration.md#where-pr-state-is-persisted).
 
 `profile` is **mutually exclusive** with `model` / `effort` / `permissionMode` / `runMode:
 "agent_override"` (and the task's `agent_override`): setting a profile clears the pins and forces

--- a/docs/pr-integration.md
+++ b/docs/pr-integration.md
@@ -1,6 +1,6 @@
 # PR Integration
 
-Kangentic links each task to its pull request and keeps that link fresh: it detects a PR from terminal scrollback or a task description, authoritatively resolves the PR's state through a hosting-provider CLI, and persists `pr_url` / `pr_number` / `pr_state` on the task so the board can show it. GitHub is the only provider wired today, but every provider is wrapped behind a common `PRConnector` interface so detection and resolution logic stays isolated to a single folder per platform.
+Kangentic links each task to its pull request and keeps that link fresh: it detects a PR from terminal scrollback, authoritatively resolves the PR's state through a hosting-provider CLI, and persists `pr_url` / `pr_number` / `pr_state` on the task so the board can show it. GitHub is the only provider wired today, but every provider is wrapped behind a common `PRConnector` interface so detection and resolution logic stays isolated to a single folder per platform.
 
 This doc covers the connector system, the confidence ladder that picks the strongest anchor, the background refresh sweep, and how to add a new hosting provider.
 
@@ -33,7 +33,6 @@ Every hosting provider implements this contract. The registry calls it without k
 | `name` | yes | Platform name for logging (e.g. `"GitHub"`). |
 | `matchesCommand(commandDetail)` | yes | Whether a Bash command detail looks like a PR command for this platform (drives activity flagging). |
 | `extract(scrollback)` | yes | Extract a PR URL + number from raw PTY scrollback text (no network). Returns the most recent match. |
-| `extractCanonical?(text)` | optional | Extract the single canonical PR from authored text (a task description), or null when the text names zero or several distinct PRs. Deliberately conservative so a description is never guessed at. |
 | `resolveForBranch?(repoCwd, branchName, baseBranch?)` | optional | Authoritatively resolve the PR for a branch via the platform API, run inside the repo/worktree at `repoCwd`. Returns null when no PR matches the head ref; throws `PRResolverUnavailableError` when the CLI is unavailable. |
 | `resolveByNumber?(repoCwd, prNumber)` | optional | Resolve a PR by its number, the most exact anchor and immune to branch renames. Used to refresh an already-linked PR's state. |
 | `resolveByCommit?(repoCwd, commitSha, branchHint?)` | optional | Resolve the PR associated with a commit SHA, an immutable anchor that survives worktree deletion and branch renames. `branchHint` disambiguates when a commit belongs to several PRs. |
@@ -49,7 +48,7 @@ The subsystem uses a consistent verb prefix across modules:
 
 ### `DetectedPR`
 
-Result of a no-network detection (`extract` / `extractCanonical`).
+Result of a no-network detection (`extract`).
 
 | Field | Required | Purpose |
 |-------|----------|---------|
@@ -96,7 +95,6 @@ const connectors: PRConnector[] = [
 |----------|---------|
 | `matchesPRCommand(commandDetail)` | True if any connector recognizes the Bash command as a PR command. |
 | `detectPR(scrollback)` | Try every connector's `extract` against scrollback; return the first match. |
-| `detectCanonicalPR(text)` | Return the single PR a task description names, via the first connector that finds an unambiguous match. |
 | `resolvePRForBranch(repoCwd, branchName, baseBranch?)` | First connector that supports `resolveForBranch` and returns a match. |
 | `resolvePRByNumber(repoCwd, prNumber)` | First connector that supports `resolveByNumber`. |
 | `resolvePRByCommit(repoCwd, commitSha, branchHint?)` | First connector that supports `resolveByCommit`. |
@@ -109,7 +107,7 @@ The registry also re-exports the contract types and both error classes, so consu
 
 `gitHubPRConnector` resolves PRs through the `gh` CLI and detects PR URLs from terminal output. It reuses the board importer's `gh` client (`GitHubImporter` from `boards/adapters/github-common/gh-client.ts`) so binary detection and auth plumbing are shared; a module-level singleton avoids re-probing `gh` per call.
 
-**Detection.** `extract` strips ANSI escape sequences from the tail of scrollback (a 4096-byte scan window) and matches `https://github.com/<owner>/<repo>/pull/<number>`, returning the last (most recent) match. It handles `gh pr create` stdout, `gh pr view` TTY and non-TTY output, and `gh pr view --json`. It deliberately does not match `git push`'s `/pull/new/<branch>` output (no numeric id) or `gh pr merge`'s `owner/repo#123` short form (no full URL). `extractCanonical` collects every distinct full PR URL in the text and returns a match only when there is exactly one.
+**Detection.** `extract` strips ANSI escape sequences from the tail of scrollback (a 4096-byte scan window) and matches `https://github.com/<owner>/<repo>/pull/<number>`, returning the last (most recent) match. It handles `gh pr create` stdout, `gh pr view` TTY and non-TTY output, and `gh pr view --json`. It deliberately does not match `git push`'s `/pull/new/<branch>` output (no numeric id) or `gh pr merge`'s `owner/repo#123` short form (no full URL). Detection runs against terminal scrollback only: there is deliberately no scraper for authored text such as a task description (see "The confidence ladder" below).
 
 **Resolution.** The three resolve methods call the shared `gh` client (`resolvePRByBranch`, `resolvePRByNumber`, `resolvePRByCommit`) and normalize the result:
 
@@ -131,13 +129,14 @@ The registry also re-exports the contract types and both error classes, so consu
 
 | Tier | Anchor | Why |
 |------|--------|-----|
-| 0 | Description PR URL | Authoritative for a code-review task, whose worktree sits on the base branch with no commits of its own, so the git tiers below would resolve the wrong PR. Resolved by number for fresh state; links url+number with unknown state if it cannot be confirmed, and never falls through to the git tiers. |
-| 1 | `pr_number` | Exact and branch-independent, best for refreshing an existing link's state. |
+| 1 | `pr_number` | Exact and branch-independent, best for refreshing an existing link's state. Also how a review task names the PR it is about. |
 | 2 | Worktree HEAD branch | The real branch while the task is actively worked. |
 | 3 | Commit SHA | Immutable, survives Done / worktree deletion and branch renames. Guarded by a commits-ahead-of-base check so a fresh worktree on base's tip does not link the last-merged PR. |
 | 4 | Stored slug branch | Weak last resort when there is no worktree. |
 
 A `PRResolverUnavailableError` from any tier propagates so the caller can degrade.
+
+**A PR URL in the task description is not an anchor.** Every tier above is git state or an explicitly stored number. Scraping the description was tried and removed: a URL cited as background ("this follows on from `<url>`") is textually identical to one naming the task's own PR, so the linker stamped a sibling task's PR onto unrelated tasks - and because that tier always produced a link, the confident-not-found clear could never fire, so the wrong link was permanent. A review task names its PR through the structured `pr_url` / `pr_number` fields (the task-detail edit form, `kangentic_create_task`'s `prUrl` / `prNumber`, or `kangentic_update_task`), which lands on Tier 1. The commits-ahead-of-base guard on Tier 3 independently covers the base-tip case the description tier was originally written for.
 
 ### Persist and degrade behavior
 
@@ -159,7 +158,7 @@ A `PRResolverUnavailableError` from any tier propagates so the caller can degrad
 
 `refreshProjectPRs` re-resolves every eligible task through the `linkPR` backbone (unchanged, non-force). This both refreshes an already-linked PR's state (so an off-app merge/close shows on the board) and discovers a PR for a still-unlinked task with a live worktree (e.g. an agent created the PR mid-session on a renamed branch and no other trigger caught it).
 
-A task is eligible when its PR can still change or be found: a non-terminal linked PR (`pr_number`), a live worktree (`worktree_path`), or a description PR anchor. Terminal `merged` / `closed` PRs are skipped first, and `head_sha` is deliberately not an anchor here (nearly every historical task has one, which would make the sweep unbounded). The sweep is sequential and best-effort: a per-task failure is swallowed, and the backbone's `onLinked` pushes `TASK_UPDATED_BY_AGENT` so cards update live.
+A task is eligible when its PR can still change or be found: a non-terminal linked PR (`pr_number`) or a live worktree (`worktree_path`). Terminal `merged` / `closed` PRs are skipped first, as are tasks in a To Do lane (To Do resets the task, so there is no PR to link there - the same gate `autoLinkPRForTask` applies to every implicit trigger). `head_sha` is deliberately not an anchor here (nearly every historical task has one, which would make the sweep unbounded), and neither is a PR URL in the description (see the ladder above). The sweep is sequential and best-effort: a per-task failure is swallowed, and the backbone's `onLinked` pushes `TASK_UPDATED_BY_AGENT` so cards update live.
 
 ### The scheduler
 
@@ -181,6 +180,10 @@ PR state lives on three columns of the per-project `tasks` table (`src/main/db/m
 | `pr_state` | TEXT | Normalized `PRState` (`open` / `draft` / `merged` / `closed`), null when no PR is linked or it predates state tracking. |
 
 The companion `head_sha` column stores the last-captured worktree HEAD commit as the immutable Tier-3 anchor.
+
+**The three PR columns always move together.** Every writer leaves all three agreeing: the linker (on link and on the confident-not-found clear) and the task-detail edit form (`buildPrFields` in `useTaskActions.ts`) write all three in one update; MCP `update_task` / `create_task` write `pr_url` + `pr_number` and null `pr_state` (on create it is already null from `TaskRepository.create`). Setting or clearing a URL without its state leaves the inconsistent row the linker forbids, and a stranded terminal `merged` / `closed` short-circuits every non-force resolve, so the task can never recover from a wrong link. A manual write leaves `pr_state` null and lets the next resolve fill it in.
+
+`pr_url` and `pr_number` must name the same PR, because Tier 1 treats `pr_number` as authoritative: a row whose URL was re-pointed while the old number survived resolves the old PR and silently reverts the URL. So every writer that accepts a URL derives the number from it when one is not supplied - `buildPrFields` in the renderer, `prNumberFromUrl` in the MCP handlers.
 
 ### IPC channel
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -185,7 +185,7 @@ Click a task card to open the detail dialog. From here you can:
   - **Edit** - switch to edit mode for title and description
   - **Open folder** - open the worktree or project directory in your file manager
   - **View conversation** - same as the header pill
-  - **View PR** - open the associated pull request. PR URLs are populated automatically when an agent runs `gh pr create` or `gh pr view` (GitHub), explicitly via the `kangentic_update_task` MCP tool (any platform), or manually through the PR URL field in edit mode. Also shown as a pill in the header bar and a clickable badge on the task card.
+  - **View PR** - open the associated pull request. PR URLs are populated automatically when an agent runs `gh pr create` or `gh pr view` (GitHub), explicitly via the `kangentic_create_task` / `kangentic_update_task` MCP tools (any platform), or manually through the PR URL field in edit mode. Those are the only ways to link a PR: writing a PR URL into the task description does not link it, so you can cite another task's PR as background without it being mistaken for this task's own. Also shown as a pill in the header bar and a clickable badge on the task card.
   - **Commands & Skills** - submenu of available Claude Code commands and skills (same as the header popover)
   - **Pause / Resume session** - manually suspend or resume the agent
   - **Move to** - submenu listing all other columns as move targets

--- a/src/main/agent/commands/task-commands.ts
+++ b/src/main/agent/commands/task-commands.ts
@@ -78,6 +78,23 @@ export function computeUpdatedDescription(
   return { success: true, text };
 }
 
+/**
+ * The PR number a PR URL names, or null when the URL carries none.
+ *
+ * `pr_url` and `pr_number` must always name the SAME PR: the linker writes the
+ * three PR columns atomically, and Tier 1 of the confidence ladder treats
+ * `pr_number` as authoritative. A caller naturally passes `prUrl` alone (the URL
+ * already encodes the number), which would otherwise leave the OLD number in the
+ * row - the next non-force resolve then resolves that stale number and silently
+ * overwrites the URL back to the previous PR. Deriving it here keeps the two in
+ * agreement, and mirrors `buildPrFields` in the task-detail edit form, which has
+ * always derived the number from the URL the same way.
+ */
+function prNumberFromUrl(prUrl: string): number | null {
+  const prNumberMatch = prUrl.match(/\/pull\/(\d+)/);
+  return prNumberMatch ? parseInt(prNumberMatch[1], 10) : null;
+}
+
 export const handleCreateTask: CommandHandler = (
   params: Record<string, unknown>,
   context: CommandContext,
@@ -98,6 +115,10 @@ export const handleCreateTask: CommandHandler = (
   const autoCommand = params.autoCommand as string | null;
   const profileSelector = params.profile as string | null;
   const runMode = params.runMode as TaskRunMode | null;
+  // Normalized to null so an omitted key reads the same as the explicit `null`
+  // the MCP tool layer forwards - a direct handler call passes neither.
+  const prUrl = (params.prUrl as string | null | undefined) ?? null;
+  const prNumber = (params.prNumber as number | null | undefined) ?? null;
 
   // Observability for the "labels dropped on a large description" bug
   // (task #229). Logs what `labels` actually reached the handler. If it is
@@ -187,6 +208,26 @@ export const handleCreateTask: CommandHandler = (
     ...(runMode ? { run_mode: runMode } : {}),
   });
 
+  // A review task names the PR it is about up front, so the linker's pr_number
+  // tier resolves it (a PR URL in the DESCRIPTION is deliberately not an anchor -
+  // see the ladder comment in pr-linking.ts). Applied as a follow-up update
+  // rather than through TaskCreateInput on purpose: `TaskRepository.create`
+  // always writes the three PR columns null, and keeping that invariant means
+  // the create path has exactly one shape. pr_state stays null and the next
+  // resolve fills it in.
+  let createdTask = task;
+  if (prUrl !== null || prNumber !== null) {
+    // An explicit prNumber wins; otherwise derive it from the URL, so a caller
+    // passing prUrl alone still lands on Tier 1 instead of producing a row that
+    // shows a PR badge but has no anchor to ever resolve it.
+    const linkedPrNumber = prNumber !== null ? Number(prNumber) : prNumberFromUrl(String(prUrl));
+    createdTask = taskRepo.update({
+      id: task.id,
+      ...(prUrl !== null ? { pr_url: String(prUrl) } : {}),
+      ...(linkedPrNumber !== null ? { pr_number: linkedPrNumber } : {}),
+    });
+  }
+
   // Persist label colors to config if any were provided
   if (Object.keys(labelColorMap).length > 0) {
     context.onLabelColorsChanged(labelColorMap);
@@ -206,12 +247,12 @@ export const handleCreateTask: CommandHandler = (
     }
   }
 
-  context.onTaskCreated(task, targetSwimlane.name, targetSwimlane.id);
+  context.onTaskCreated(createdTask, targetSwimlane.name, targetSwimlane.id);
 
   return {
     success: true,
-    data: { taskId: task.id, displayId: task.display_id, title: task.title, column: targetSwimlane.name },
-    message: `Created task "${task.title}" in ${targetSwimlane.name} column (#${task.display_id}, id: ${task.id})`,
+    data: { taskId: createdTask.id, displayId: createdTask.display_id, title: createdTask.title, column: targetSwimlane.name },
+    message: `Created task "${createdTask.title}" in ${targetSwimlane.name} column (#${createdTask.display_id}, id: ${createdTask.id})`,
   };
 };
 
@@ -287,7 +328,17 @@ export const handleUpdateTask: CommandHandler = (
   }
 
   if (newPrUrl !== null) updates.pr_url = String(newPrUrl);
+  // An explicit prNumber wins; otherwise derive it from the URL. Writing the URL
+  // alone would leave the OLD number behind, and the next resolve would take that
+  // stale number as authoritative and revert the URL to the previous PR.
   if (newPrNumber !== null) updates.pr_number = Number(newPrNumber);
+  else if (newPrUrl !== null) updates.pr_number = prNumberFromUrl(String(newPrUrl));
+  // Re-pointing the link invalidates any state carried over from the old PR. The
+  // three fields must always agree (the linker writes them atomically), and a
+  // stale terminal `merged`/`closed` would otherwise short-circuit every
+  // non-force resolve, freezing the task on a PR it no longer points at. The
+  // next resolve refills it.
+  if (newPrUrl !== null || newPrNumber !== null) updates.pr_state = null;
   if (newAgent !== null) updates.agent = newAgent;
   if (newPriority !== null) updates.priority = Number(newPriority);
   if (newLabels !== null) updates.labels = newLabels;

--- a/src/main/agent/mcp-http/task-tools.ts
+++ b/src/main/agent/mcp-http/task-tools.ts
@@ -78,11 +78,13 @@ export function registerTaskTools(
         autoCommand: z.string().max(4000).optional().describe('Slash command to run once the agent spawns for this task (e.g. "/code-review", "/release"). Overrides the destination column\'s auto_command for this task only. Not surfaced in the UI - MCP-only.'),
         profile: z.string().optional().describe('Board Profile this task rides (name or id) - an alternate set of per-column agent/model/effort settings, applied as the task moves. Mutually exclusive with the four *Override fields above: a profile changes per column, those pin one value for the task\'s whole life, so passing both is rejected. Omit for "Default" (every column uses its own settings). Use kangentic_list_board_profiles to see the board\'s profiles.'),
         runMode: RUN_MODE_SCHEMA.optional().describe('How this task gets its agent settings. "column_settings" (the default) follows each column the task moves through. "agent_override" pins agent/model/effort/permission for the task\'s whole life; any field you leave unset is resolved dynamically until the task first spawns, which then locks all four. Pass "agent_override" on its own to pin whatever the task would resolve to today. Passing any of the four *Override fields implies "agent_override", so you only need this to choose override mode without pinning anything - and pairing a pin with "column_settings" is rejected as a contradiction. Mutually exclusive with `profile`.'),
+        prUrl: z.string().url().optional().describe('Pull request URL this task is about (e.g. https://github.com/owner/repo/pull/123). Set this when filing a review task for an existing PR - it is what links the task to that PR. Writing the URL into `description` instead does NOT link it. Board tasks only - ignored for backlog.'),
+        prNumber: z.number().int().positive().optional().describe('Pull request number this task is about. Pass alongside `prUrl`. Board tasks only - ignored for backlog.'),
         project: z.string().optional().describe(PROJECT_SELECTOR_DESCRIPTION),
       }),
       annotations: MUTATING_ANNOTATIONS,
     },
-    async ({ title, description, column, priority, labels, branchName, baseBranch, useWorktree, attachments, agentOverride, modelOverride, effortOverride, permissionMode, autoCommand, profile, runMode, project }) => withProject(resolver, project, (ctx, resolved) => {
+    async ({ title, description, column, priority, labels, branchName, baseBranch, useWorktree, attachments, agentOverride, modelOverride, effortOverride, permissionMode, autoCommand, profile, runMode, prUrl, prNumber, project }) => withProject(resolver, project, (ctx, resolved) => {
       // Rejected rather than silently resolved: the repository enforces
       // exclusivity by clearing whichever side the write did not set, so
       // accepting both would quietly discard half of what the caller asked for.
@@ -154,6 +156,8 @@ export function registerTaskTools(
         autoCommand: autoCommand ?? null,
         profile: profile ?? null,
         runMode: runMode ?? null,
+        prUrl: prUrl ?? null,
+        prNumber: prNumber ?? null,
       }, ctx, 'Failed to create task');
     }, { alwaysAnnotate: true }),
   );

--- a/src/main/pr/adapters/github/github-connector.ts
+++ b/src/main/pr/adapters/github/github-connector.ts
@@ -153,25 +153,6 @@ export const gitHubPRConnector: PRConnector = {
     return lastMatch;
   },
 
-  extractCanonical(text: string): DetectedPR | null {
-    if (!text) return null;
-
-    // Collect every distinct full PR URL the text mentions. Bare `#702` and
-    // `git log` "Merge pull request #702" lines never match (no full URL), so a
-    // base-branch merge-commit reference cannot be misread as the task's PR.
-    const byUrl = new Map<string, number>();
-    let match: RegExpExecArray | null;
-    GITHUB_PR_URL_PATTERN.lastIndex = 0;
-    while ((match = GITHUB_PR_URL_PATTERN.exec(text)) !== null) {
-      byUrl.set(match[0], parseInt(match[1], 10));
-    }
-
-    // Only an unambiguous single PR is canonical; zero or several -> don't guess.
-    if (byUrl.size !== 1) return null;
-    const [[url, prNumber]] = byUrl;
-    return { url, number: prNumber };
-  },
-
   async resolveForBranch(repoCwd: string, branchName: string, baseBranch?: string): Promise<ResolvedPR | null> {
     return viaGh(async () => {
       const items = await ghImporter.resolvePRByBranch(repoCwd, branchName);

--- a/src/main/pr/pr-linking.ts
+++ b/src/main/pr/pr-linking.ts
@@ -7,10 +7,8 @@ import {
   resolvePRByNumber,
   resolvePRByCommit,
   detectPR,
-  detectCanonicalPR,
   PRResolverUnavailableError,
   PRResolverTransientError,
-  type DetectedPR,
 } from './pr-registry';
 import type { TaskRepository } from '../db/repositories/task-repository';
 import type { Task, PRState, PRLinkStatus, TaskUpdateInput } from '../../shared/types';
@@ -57,21 +55,29 @@ export interface PRLinkDeps {
 
 /**
  * A PR linked to a task: the subset of `ResolvedPR` the linker persists. `state`
- * is nullable here (unlike `ResolvedPR.state`) because the Tier 0 description
- * anchor links url+number even when the PR's state cannot be confirmed.
+ * is nullable here (unlike `ResolvedPR.state`) because the scrollback degradation
+ * fallback links url+number even when the PR's state cannot be confirmed.
  */
 type LinkedPR = { url: string; number: number; state: PRState | null };
 
 /**
  * The confidence ladder - resolve a task's PR via the strongest available anchor
  * first, short-circuiting on the first hit:
- *   0. description PR URL -> authoritative: the only anchor that knows a
- *      code-review task's PR, whose worktree sits on the base branch
  *   1. pr_number  -> exact, branch-independent (best for refreshing state)
  *   2. worktree HEAD branch -> the real branch while actively worked
  *   3. commit SHA -> immutable, survives Done/worktree deletion and renames
  *   4. stored slug branch -> weak last resort when there is no worktree
  * A `PRResolverUnavailableError` from any tier propagates so the caller degrades.
+ *
+ * Every anchor is git state or an explicitly stored number. A PR URL written into
+ * the task DESCRIPTION is deliberately not an anchor: a URL cited as background
+ * ("this follows on from <that PR's url>") is textually identical to one naming
+ * the task's own PR, so scraping prose stamped citations onto unrelated tasks -
+ * and because that tier always produced a link, the confident-not-found clear
+ * below could never fire, making the wrong link permanent. A review task
+ * names its PR through the structured `pr_url` / `pr_number` fields instead (the
+ * task-detail edit form, `kangentic_create_task`, or `kangentic_update_task`),
+ * which lands on Tier 1.
  */
 async function resolvePRViaLadder(args: {
   task: Task;
@@ -80,22 +86,8 @@ async function resolvePRViaLadder(args: {
   branch: string | null;
   effectiveSha: string | null;
   baseBranch: string;
-  descriptionPR: DetectedPR | null;
 }): Promise<LinkedPR | null> {
-  const { task, cwd, projectPath, branch, effectiveSha, baseBranch, descriptionPR } = args;
-
-  // Tier 0: a single PR URL written into the task description is authoritative.
-  // A code-review worktree is branched from the base branch with no commits of
-  // its own, so the branch/commit anchors below resolve the base branch's own
-  // merge commit (e.g. `Merge pull request #702`), not the PR being reviewed.
-  // The description is the only place that names the right PR. Resolve by number
-  // for fresh state, but never fall through to the structurally-wrong git tiers
-  // once the description has named a PR - link url+number with unknown state if
-  // it cannot be confirmed.
-  if (descriptionPR) {
-    const byDescription = await resolvePRByNumber(cwd, descriptionPR.number);
-    return byDescription ?? { url: descriptionPR.url, number: descriptionPR.number, state: null };
-  }
+  const { task, cwd, projectPath, branch, effectiveSha, baseBranch } = args;
 
   if (task.pr_number != null) {
     const byNumber = await resolvePRByNumber(cwd, task.pr_number);
@@ -172,10 +164,10 @@ export async function linkPRForTask(taskId: string, deps: PRLinkDeps): Promise<P
     const effectiveSha = freshSha ?? task.head_sha;
     const baseBranch = task.base_branch ?? deps.defaultBaseBranch ?? 'main';
 
-    // Nothing to resolve from at all. A PR URL in the description is itself an
-    // anchor (Tier 0), so a task with no git state still resolves from it.
-    const descriptionPR = detectCanonicalPR(task.description ?? '');
-    if (!cwd || (task.pr_number == null && !branch && !effectiveSha && descriptionPR == null)) {
+    // Nothing to resolve from at all. Mirrors `autoLinkPRForTask`'s gate: a task
+    // with no stored number and no git state has no anchor, whatever its
+    // description happens to mention.
+    if (!cwd || (task.pr_number == null && !branch && !effectiveSha)) {
       // Still persist a freshly-read SHA if we have one (rare: detached HEAD worktree).
       if (freshSha && freshSha !== task.head_sha) {
         return { status: 'no-anchor', task: deps.tasks.update({ id: task.id, head_sha: freshSha }) };
@@ -191,7 +183,7 @@ export async function linkPRForTask(taskId: string, deps: PRLinkDeps): Promise<P
     let degradeMessage: string | undefined;
 
     try {
-      const resolved = await resolvePRViaLadder({ task, cwd, projectPath: deps.projectPath, branch, effectiveSha, baseBranch, descriptionPR });
+      const resolved = await resolvePRViaLadder({ task, cwd, projectPath: deps.projectPath, branch, effectiveSha, baseBranch });
       if (resolved) next = { url: resolved.url, number: resolved.number, state: resolved.state };
     } catch (error) {
       if (error instanceof PRResolverUnavailableError || error instanceof PRResolverTransientError) {

--- a/src/main/pr/pr-refresh.ts
+++ b/src/main/pr/pr-refresh.ts
@@ -13,7 +13,6 @@
  */
 
 import { getProjectRepos } from '../ipc/helpers/project-repos';
-import { detectCanonicalPR } from './pr-registry';
 import { linkPR } from './pr-linking';
 import type { Task } from '../../shared/types';
 import type { IpcContext } from '../ipc/ipc-context';
@@ -26,18 +25,21 @@ import type { IpcContext } from '../ipc/ipc-context';
  *     live HEAD branch resolves the PR even after the agent renamed the branch.
  *     Only active tasks have a worktree (To Do clears it, Done reclaims it), so
  *     this stays a small bounded set, further bounded by the per-task 60s TTL and
- *     the global `gh` concurrency cap;
- *   - a PR URL anchor in the description.
- * Terminal merged/closed PRs never change and are skipped first. A task with none
- * of these has nothing to resolve. (`tasks.list()` already excludes archived
- * tasks.) `head_sha` is deliberately NOT an anchor here: nearly every historical
- * task carries one, so it would make the sweep unbounded.
+ *     the global `gh` concurrency cap.
+ * Terminal merged/closed PRs never change and are skipped first, as are tasks
+ * sitting in a To Do lane (To Do resets a task, so there is no PR to link there -
+ * the same gate `autoLinkPRForTask` applies to every implicit trigger). A task
+ * with none of these has nothing to resolve. (`tasks.list()` already excludes
+ * archived tasks.) `head_sha` is deliberately NOT an anchor here: nearly every
+ * historical task carries one, so it would make the sweep unbounded. Neither is a
+ * PR URL in the description - see the ladder comment in `pr-linking.ts` for why
+ * scraping prose stamped cited PRs onto unrelated tasks.
  */
-function isEligibleForRefresh(task: Task): boolean {
+function isEligibleForRefresh(task: Task, isTodoLane: boolean): boolean {
+  if (isTodoLane) return false;
   if (task.pr_state === 'merged' || task.pr_state === 'closed') return false;
   if (task.pr_number != null) return true;
-  if (task.worktree_path != null) return true;
-  return detectCanonicalPR(task.description ?? '') != null;
+  return task.worktree_path != null;
 }
 
 /**
@@ -51,8 +53,18 @@ function isEligibleForRefresh(task: Task): boolean {
 export async function refreshProjectPRs(context: IpcContext, projectId: string): Promise<void> {
   let eligible: Task[];
   try {
-    const { tasks } = getProjectRepos(context, projectId);
-    eligible = tasks.list().filter(isEligibleForRefresh);
+    const { tasks, swimlanes } = getProjectRepos(context, projectId);
+    // Resolve the To Do lanes once rather than per task - the sweep can run over
+    // every task on the board. Guarded separately from the task read: the lane
+    // gate is a filter, so losing it must degrade to "no lane is To Do" rather
+    // than take the whole sweep down with it.
+    let todoLaneIds: Set<string>;
+    try {
+      todoLaneIds = new Set(swimlanes.list().filter((lane) => lane.role === 'todo').map((lane) => lane.id));
+    } catch {
+      todoLaneIds = new Set();
+    }
+    eligible = tasks.list().filter((task) => isEligibleForRefresh(task, todoLaneIds.has(task.swimlane_id)));
   } catch {
     // Project DB unavailable (e.g. closed mid-switch) - nothing to refresh.
     return;

--- a/src/main/pr/pr-registry.ts
+++ b/src/main/pr/pr-registry.ts
@@ -4,7 +4,6 @@
  *
  *   matchesPRCommand(detail)  - flag a Bash command as a PR command (activity)
  *   detectPR(scrollback)      - extract a PR URL from terminal scrollback
- *   detectCanonicalPR(text)   - extract the single PR a task description names
  *   resolvePR*(...)           - authoritative provider lookups (CLI / API)
  *
  * To add a provider: implement the `PRConnector` contract under
@@ -37,21 +36,6 @@ export function matchesPRCommand(commandDetail: string): boolean {
 export function detectPR(scrollback: string): DetectedPR | null {
   for (const connector of connectors) {
     const result = connector.extract(scrollback);
-    if (result) return result;
-  }
-  return null;
-}
-
-/**
- * Extract a single canonical PR reference from authored text (a task
- * description) via the first connector that recognizes exactly one PR. Returns
- * null when no connector finds an unambiguous match - so a description that
- * names several PRs, or none, is never guessed at.
- */
-export function detectCanonicalPR(text: string): DetectedPR | null {
-  for (const connector of connectors) {
-    if (!connector.extractCanonical) continue;
-    const result = connector.extractCanonical(text);
     if (result) return result;
   }
   return null;

--- a/src/main/pr/shared/pr-connector.ts
+++ b/src/main/pr/shared/pr-connector.ts
@@ -43,15 +43,6 @@ export interface PRConnector {
   extract(scrollback: string): DetectedPR | null;
 
   /**
-   * Extract the single canonical PR reference from authored text (a task
-   * description), or null when the text names zero or several distinct PRs.
-   * Unlike `extract` - which returns the most recent of many scrollback URLs -
-   * this is deliberately conservative: it returns a match only when there is no
-   * ambiguity, so a description is never guessed at. Optional per platform.
-   */
-  extractCanonical?(text: string): DetectedPR | null;
-
-  /**
    * Authoritatively resolve the PR for a branch via the platform API, run from
    * inside the repo/worktree at `repoCwd`. Returns null when no PR matches the
    * head ref; throws `PRResolverUnavailableError` when the CLI is unavailable so

--- a/src/renderer/components/dialogs/task-detail/useTaskActions.ts
+++ b/src/renderer/components/dialogs/task-detail/useTaskActions.ts
@@ -243,15 +243,26 @@ export function useTaskActions(input: {
     input.setIsEditing(false);
   };
 
-  /** Build pr_url/pr_number fields if the PR URL changed. */
-  const buildPrUrlFields = (): Pick<Parameters<typeof input.updateTask>[0], 'pr_url' | 'pr_number'> => {
+  /**
+   * Build the pr_url/pr_number/pr_state fields if the PR URL changed. All three
+   * move together, exactly as the linker writes them: leaving a stale `pr_state`
+   * behind produces the inconsistent row the linker forbids, and a terminal
+   * `merged`/`closed` value short-circuits every non-force resolve, freezing the
+   * task on a PR it no longer points at. The state is nulled on both branches
+   * (cleared and re-pointed) and refilled by the next resolve.
+   */
+  const buildPrFields = (): Pick<Parameters<typeof input.updateTask>[0], 'pr_url' | 'pr_number' | 'pr_state'> => {
     const trimmedPrUrl = input.prUrl.trim();
     if (trimmedPrUrl === (input.task.pr_url ?? '')) return {};
     if (trimmedPrUrl) {
       const prNumberMatch = trimmedPrUrl.match(/\/pull\/(\d+)/);
-      return { pr_url: trimmedPrUrl, pr_number: prNumberMatch ? parseInt(prNumberMatch[1], 10) : null };
+      return {
+        pr_url: trimmedPrUrl,
+        pr_number: prNumberMatch ? parseInt(prNumberMatch[1], 10) : null,
+        pr_state: null,
+      };
     }
-    return { pr_url: null, pr_number: null };
+    return { pr_url: null, pr_number: null, pr_state: null };
   };
 
   const executeSave = async (
@@ -268,7 +279,7 @@ export function useTaskActions(input: {
     setSaving(true);
     try {
       const needsSwitchBranch = (input.task.worktree_path && branchChanged) || enablingWorktree;
-      const prUrlFields = buildPrUrlFields();
+      const prFields = buildPrFields();
 
       // Per-task overrides: empty string in the form maps to null in the DB.
       // Always include them in the payload (even when unchanged) so a user
@@ -302,7 +313,7 @@ export function useTaskActions(input: {
           }, useProjectStore.getState().currentProject?.id ?? null);
           if (input.title !== input.task.title
             || input.description !== input.task.description
-            || prUrlFields.pr_url !== undefined
+            || prFields.pr_url !== undefined
             || JSON.stringify(input.labels) !== JSON.stringify(input.task.labels ?? [])
             || input.priority !== (input.task.priority ?? 0)
             || (input.agentOverride || null) !== input.task.agent_override
@@ -317,7 +328,7 @@ export function useTaskActions(input: {
               description: input.description,
               labels: input.labels,
               priority: input.priority,
-              ...prUrlFields,
+              ...prFields,
               ...overrideFields,
             });
           }
@@ -337,7 +348,7 @@ export function useTaskActions(input: {
           description: input.description,
           labels: input.labels,
           priority: input.priority,
-          ...prUrlFields,
+          ...prFields,
           ...overrideFields,
         };
 

--- a/src/renderer/hooks/useOverlayPhase.ts
+++ b/src/renderer/hooks/useOverlayPhase.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { getIsHmrReload } from '../utils/hmr-flag';
 
 /**
@@ -78,11 +78,28 @@ export function useOverlayPhase(
     skipEnter || (skipEnterOnHmr && getIsHmrReload()) ? 'visible' : 'entering',
   );
 
+  /**
+   * Set synchronously by `requestClose`, so it is readable the instant a close
+   * is asked for - before React has committed the `'exiting'` phase.
+   *
+   * Closing an overlay DURING its entrance animation queues two updates in the
+   * same fold: `requestClose`'s `'exiting'`, then the entrance animation's own
+   * genuine `animationend`. Without this flag that second handler unconditionally
+   * set `'visible'`, and being later in the fold it won - `'exiting'` was
+   * computed but never committed, nothing re-drove the exit (`closing` does not
+   * change again), and the overlay was left permanently stuck open while its
+   * owner's state already read closed. A ref rather than state because the race
+   * is one of commit ORDER, not staleness: a re-render would be too late.
+   */
+  const closeRequestedRef = useRef(false);
+
   const requestClose = useCallback(() => {
+    closeRequestedRef.current = true;
     setPhase((currentPhase) => (currentPhase === 'exiting' ? currentPhase : 'exiting'));
   }, []);
 
   const reset = useCallback(() => {
+    closeRequestedRef.current = false;
     setPhase('entering');
   }, []);
 
@@ -90,8 +107,13 @@ export function useOverlayPhase(
     (event: React.AnimationEvent) => {
       // Ignore animations bubbling up from descendants of the content element.
       if (event.target !== event.currentTarget) return;
-      if (phase === 'entering') setPhase('visible');
-      else if (phase === 'exiting') onClose();
+      // The exit branch is deliberately checked FIRST and is never gated on the
+      // flag: it is the only path to `onClose()`, so skipping it would strand
+      // the overlay mounted forever - stuck the opposite way.
+      if (phase === 'exiting') onClose();
+      // A close already asked for wins over the entrance finishing. Leaving the
+      // phase alone lets the pending `'exiting'` commit and play its exit.
+      else if (phase === 'entering' && !closeRequestedRef.current) setPhase('visible');
     },
     [phase, onClose],
   );

--- a/tests/ui/label-input.spec.ts
+++ b/tests/ui/label-input.spec.ts
@@ -249,25 +249,35 @@ test('label suggestion dropdown escapes the task-detail edit form and stays with
     // Width-match proof: the fixed-strategy popover lost the old `left-0
     // right-0` in-flow stretch, so LabelInput measures the bordered input
     // container (containerRef) via useLayoutEffect and applies it as an
-    // explicit `width` style on the portaled popover. Assert the two widths
-    // line up (both box-border, small tolerance per cross-platform-parity).
+    // explicit `width` style on the portaled popover. Compare LAYOUT widths
+    // (offsetWidth), not boundingBox()/getBoundingClientRect(): both of those
+    // report the ANIMATED rect, and OverlayPopover plays a scale-from-trigger
+    // entrance transform (`popover-in`, index.css) on every open, so a rect
+    // read right after toBeVisible() can land mid-animation and measure a
+    // visually-shrunk transformed box even though the underlying box-model
+    // width is already correct (CSS `transform` never affects layout).
+    // offsetWidth ignores transforms entirely, so it proves the same
+    // box-model width LabelInput's useLayoutEffect applies, without waiting
+    // out an animation - and it's an integer layout value, not a freshly
+    // measured float, so a small tolerance stays meaningful per
+    // cross-platform-parity (no pixel-exact / zero-tolerance assertions).
     const container = labelInput.locator('xpath=ancestor::div[contains(@class,"border-edge-input")][1]');
     await expect(container).toHaveCount(1);
-    const containerBox = await container.boundingBox();
-    expect(containerBox).not.toBeNull();
-    expect(containerBox!.width).toBeGreaterThan(0);
-    // OverlayPopover plays a scale-from-trigger entrance animation, so a
-    // boundingBox taken right after toBeVisible() can land mid-animation and
-    // read a visually-shrunk transformed rect even though the underlying
-    // layout width is already correct. Poll past the transform settle
-    // instead of a fixed wait (see anti-pattern 1 in the test-builder guide).
+    const initialContainerWidth = await container.evaluate((element) => (element as HTMLElement).offsetWidth);
+    expect(initialContainerWidth).toBeGreaterThan(0);
+    // Re-measure both elements on every poll iteration (never compare against
+    // a stale one-shot snapshot); a couple of quick retries cover the tick
+    // between the dropdown mounting and its width style landing.
     await expect
       .poll(
         async () => {
-          const currentBox = await dropdown.boundingBox();
-          return currentBox ? Math.abs(currentBox.width - containerBox!.width) : null;
+          const [dropdownWidth, containerWidth] = await Promise.all([
+            dropdown.evaluate((element) => (element as HTMLElement).offsetWidth),
+            container.evaluate((element) => (element as HTMLElement).offsetWidth),
+          ]);
+          return Math.abs(dropdownWidth - containerWidth);
         },
-        { timeout: 2000, intervals: [100, 200, 300] },
+        { timeout: 3000, intervals: [100, 200, 300] },
       )
       .toBeLessThan(2);
   } finally {

--- a/tests/ui/pr-url.spec.ts
+++ b/tests/ui/pr-url.spec.ts
@@ -36,9 +36,13 @@ const PROJECT_ID = 'proj-pr-url-test';
 const TASK_TODO_ID = 'task-pr-url-todo';
 const TASK_PLANNING_FILL_ID = 'task-pr-url-planning-fill';
 const TASK_PLANNING_CLEAR_ID = 'task-pr-url-planning-clear';
+const TASK_PLANNING_REPOINT_ID = 'task-pr-url-planning-repoint';
+
+const REPOINT_ORIGINAL_PR_URL = 'https://github.com/owner/repo/pull/50';
+const REPOINT_NEW_PR_URL = 'https://github.com/owner/repo/pull/77';
 
 /**
- * Launch a fresh headless page with a project and all three test tasks
+ * Launch a fresh headless page with a project and all four test tasks
  * pre-seeded into their target swimlanes.
  *
  * Seeding tasks directly into Planning avoids any UI-driven move, which would
@@ -49,6 +53,10 @@ const TASK_PLANNING_CLEAR_ID = 'task-pr-url-planning-clear';
  * - TASK_PLANNING_CLEAR_ID: placed in Planning already pre-seeded with
  *   pr_url='https://github.com/owner/repo/pull/99' and pr_number=99, so test 3
  *   does not depend on test 2 having saved anything.
+ * - TASK_PLANNING_REPOINT_ID: placed in Planning already pre-seeded with
+ *   pr_url=REPOINT_ORIGINAL_PR_URL, pr_number=50, AND a terminal pr_state of
+ *   'merged', so the re-point test starts from the same stranded shape as the
+ *   clear test but edits the URL to a DIFFERENT PR instead of clearing it.
  */
 async function launchWithSeededState(): Promise<{ browser: Browser; page: Page }> {
   await waitForViteReady(VITE_URL);
@@ -139,9 +147,13 @@ async function launchWithSeededState(): Promise<{ browser: Browser; page: Page }
         updated_at: ts,
       });
 
-      // Task 3: sits in Planning already bearing a PR URL and pr_number.
-      // This makes test 3 independent of test 2 - it does not need test 2 to
-      // have saved the value; the value is seeded here at page load.
+      // Task 3: sits in Planning already bearing a PR URL, pr_number, AND a
+      // terminal pr_state. This makes test 3 independent of test 2 - it does not
+      // need test 2 to have saved the value; the value is seeded here at page
+      // load. The 'merged' state is the load-bearing part: it is the shape a
+      // wrongly-linked task is stuck in, and clearing the URL must take the
+      // state with it (a stranded terminal state short-circuits every non-force
+      // resolve, so the task could never be re-resolved).
       state.tasks.push({
         id: '${TASK_PLANNING_CLEAR_ID}',
         title: 'PR URL Clear Task',
@@ -154,7 +166,36 @@ async function launchWithSeededState(): Promise<{ browser: Browser; page: Page }
         branch_name: null,
         pr_number: 99,
         pr_url: 'https://github.com/owner/repo/pull/99',
-        pr_state: null,
+        pr_state: 'merged',
+        base_branch: null,
+        use_worktree: 0,
+        labels: [],
+        priority: 0,
+        attachment_count: 0,
+        archived_at: null,
+        created_at: ts,
+        updated_at: ts,
+      });
+
+      // Task 4: sits in Planning already bearing a PR URL, pr_number, AND a
+      // terminal pr_state, same as the Clear task above - but this test edits
+      // the URL to point at a DIFFERENT PR instead of clearing it. The SET /
+      // re-point branch of buildPrFields is only reached when the field starts
+      // non-empty and ends non-empty with a NEW value; the Fill task (starts
+      // null) and the Clear task (ends empty) both miss it.
+      state.tasks.push({
+        id: '${TASK_PLANNING_REPOINT_ID}',
+        title: 'PR URL Repoint Task',
+        description: '',
+        swimlane_id: laneIds['Planning'],
+        position: 2,
+        agent: 'claude',
+        session_id: null,
+        worktree_path: null,
+        branch_name: null,
+        pr_number: 50,
+        pr_url: '${REPOINT_ORIGINAL_PR_URL}',
+        pr_state: 'merged',
         base_branch: null,
         use_worktree: 0,
         labels: [],
@@ -261,6 +302,81 @@ test.describe('PR URL in Edit Form', () => {
       await expect(
         clearTaskCard.locator('[data-testid="task-card-pr-link"]'),
       ).not.toBeVisible({ timeout: 5000 });
+
+      // All three PR fields must be nulled together. Clearing only pr_url and
+      // pr_number would leave the seeded pr_state:'merged' behind - the exact
+      // inconsistent row the linker forbids, and one whose terminal state makes
+      // every subsequent non-force resolve short-circuit, so the task can never
+      // recover from a wrong link.
+      const findClearCall = () => page.evaluate((taskId) => {
+        const calls = (window as unknown as {
+          electronAPI: { tasks: { __updateCalls: Array<Record<string, unknown>> } };
+        }).electronAPI.tasks.__updateCalls;
+        return calls.find((call) => call.id === taskId && call.pr_url === null) ?? null;
+      }, TASK_PLANNING_CLEAR_ID);
+
+      await expect.poll(findClearCall, { timeout: 5000 }).not.toBeNull();
+      expect(await findClearCall()).toMatchObject({ pr_url: null, pr_number: null, pr_state: null });
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('re-pointing PR URL to a different PR nulls the stale pr_state', async () => {
+    const { browser, page } = await launchWithSeededState();
+
+    try {
+      await page.locator('[data-swimlane-name="Planning"]').waitFor({ state: 'visible', timeout: 15000 });
+
+      // Click the task card seeded into Planning that ALREADY has pr_url,
+      // pr_number=50, AND pr_state='merged'. This is the shape a mislinked
+      // task is stuck in: a terminal state that short-circuits every
+      // non-force resolve until something clears it.
+      const planningColumn = page.locator('[data-swimlane-name="Planning"]');
+      await planningColumn.locator('text=PR URL Repoint Task').first().click();
+
+      // Wait for the task-detail window edit form to mount
+      await page.locator('input[placeholder="Task title"]').waitFor({ state: 'visible', timeout: 5000 });
+
+      // The PR URL field must already show the seeded value
+      const prUrlInput = page.locator('[data-testid="pr-url-input"]');
+      await expect(prUrlInput).toHaveValue(REPOINT_ORIGINAL_PR_URL, { timeout: 3000 });
+
+      // Edit to a DIFFERENT PR URL (not clearing it) and save. This is the
+      // SET / re-point branch of buildPrFields, not the CLEAR branch: the
+      // field starts non-empty and ends non-empty with a new value.
+      await prUrlInput.fill(REPOINT_NEW_PR_URL);
+      await page.locator('button:has-text("Save")').click();
+
+      // The card must now show the badge for the NEW PR number.
+      const repointTaskCard = planningColumn.locator(`[data-task-id="${TASK_PLANNING_REPOINT_ID}"]`);
+      const prBadge = repointTaskCard.locator('[data-testid="task-card-pr-link"]');
+      await expect(prBadge).toBeVisible({ timeout: 5000 });
+      await expect(prBadge).toHaveText('PR #77');
+
+      // The re-pointed pr_state must be nulled, exactly like the clear branch
+      // above. Leaving the seeded 'merged' behind would freeze the task on a
+      // PR it no longer points at: a stale terminal pr_state short-circuits
+      // every non-force resolve, so the next linker pass would never refill
+      // pr_state for the NEW PR. Filtered on pr_url (not pr_state) so the
+      // poll resolves even if pr_state comes back wrong - a wrong pr_state
+      // then fails the assertion below for the right reason, instead of the
+      // poll itself timing out.
+      const findRepointCall = () => page.evaluate(({ taskId, expectedPrUrl }) => {
+        const calls = (window as unknown as {
+          electronAPI: { tasks: { __updateCalls: Array<Record<string, unknown>> } };
+        }).electronAPI.tasks.__updateCalls;
+        return calls.find((call) => call.id === taskId && call.pr_url === expectedPrUrl) ?? null;
+      }, { taskId: TASK_PLANNING_REPOINT_ID, expectedPrUrl: REPOINT_NEW_PR_URL });
+
+      await expect.poll(findRepointCall, { timeout: 5000 }).not.toBeNull();
+      const capturedCall = await findRepointCall();
+      expect(capturedCall).toMatchObject({ pr_url: REPOINT_NEW_PR_URL, pr_number: 77 });
+      // Asserted separately (not folded into the toMatchObject above) so a
+      // deleted `pr_state: null,` in the SET branch of buildPrFields - which
+      // drops the key entirely rather than sending an explicit null - fails
+      // on a named field instead of a vaguer object-shape mismatch.
+      expect(capturedCall?.pr_state).toBeNull();
     } finally {
       await browser.close();
     }

--- a/tests/unit/github-pr-detector.test.ts
+++ b/tests/unit/github-pr-detector.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { gitHubPRConnector } from '../../src/main/pr/adapters/github/github-connector';
-import { matchesPRCommand, detectPR, detectCanonicalPR } from '../../src/main/pr/pr-registry';
+import * as prRegistry from '../../src/main/pr/pr-registry';
+import { matchesPRCommand, detectPR } from '../../src/main/pr/pr-registry';
 
 describe('gitHubPRConnector.extract', () => {
   it('extracts PR URL from gh pr create bare output', () => {
@@ -115,38 +116,6 @@ describe('gitHubPRConnector.extract', () => {
   });
 });
 
-describe('gitHubPRConnector.extractCanonical', () => {
-  const canonical = (text: string) => gitHubPRConnector.extractCanonical?.(text) ?? null;
-
-  it('returns the single PR URL named in a task description', () => {
-    const text = 'This task reviews https://github.com/owner/repo/pull/708 for the blog fix.';
-    expect(canonical(text)).toEqual({ url: 'https://github.com/owner/repo/pull/708', number: 708 });
-  });
-
-  it('returns the match when the same PR URL appears more than once', () => {
-    const text = 'See https://github.com/owner/repo/pull/708 - again at https://github.com/owner/repo/pull/708';
-    expect(canonical(text)).toEqual({ url: 'https://github.com/owner/repo/pull/708', number: 708 });
-  });
-
-  it('returns null when the description names several distinct PRs (ambiguous)', () => {
-    const text = 'Compare https://github.com/owner/repo/pull/708 against https://github.com/owner/repo/pull/702';
-    expect(canonical(text)).toBeNull();
-  });
-
-  it('does not match a bare "Merge pull request #702" git log line', () => {
-    const text = 'cac5dbf Merge pull request #702 from Troy-Web-Consulting/fix/682-blog-not-publishing-prod';
-    expect(canonical(text)).toBeNull();
-  });
-
-  it('does not match a bare owner/repo#123 shorthand', () => {
-    expect(canonical('Fixed in owner/repo#123')).toBeNull();
-  });
-
-  it('returns null for empty text', () => {
-    expect(canonical('')).toBeNull();
-  });
-});
-
 describe('gitHubPRConnector.matchesCommand', () => {
   it('matches gh pr create', () => {
     expect(gitHubPRConnector.matchesCommand('gh pr create --title "Fix bug" --body "desc"')).toBe(true);
@@ -188,14 +157,14 @@ describe('PR connector registry', () => {
     expect(detectPR('no PR URLs here')).toBeNull();
   });
 
-  it('detectCanonicalPR returns the single PR named in text', () => {
-    expect(detectCanonicalPR('Review https://github.com/owner/repo/pull/42')).toEqual({
-      url: 'https://github.com/owner/repo/pull/42',
-      number: 42,
-    });
-  });
-
-  it('detectCanonicalPR returns null on ambiguous text', () => {
-    expect(detectCanonicalPR('https://github.com/o/r/pull/1 and https://github.com/o/r/pull/2')).toBeNull();
+  // Deliberately removed, and asserted gone: a PR URL cited in a task description
+  // as background reads exactly like one naming the task's own PR, so scraping
+  // authored prose stamped a sibling task's PR onto unrelated tasks (with no way
+  // to clear it, since the tier could never return "no PR"). A task names its PR
+  // through the structured pr_url / pr_number fields instead. Reintroducing either
+  // surface reintroduces the mislink.
+  it('exposes no description-prose PR scraper on the connector or the registry', () => {
+    expect('extractCanonical' in gitHubPRConnector).toBe(false);
+    expect('detectCanonicalPR' in prRegistry).toBe(false);
   });
 });

--- a/tests/unit/mcp-task-pr-fields.test.ts
+++ b/tests/unit/mcp-task-pr-fields.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Unit tests for the PR fields on the MCP task handlers.
+ *
+ * A task names its PR through the structured pr_url / pr_number columns - a PR
+ * URL in the DESCRIPTION is deliberately not an anchor, because a URL cited as
+ * background reads exactly like one naming the task's own PR. Two consequences
+ * are covered here:
+ *
+ *   handleCreateTask - accepts prUrl / prNumber so a review task can be filed
+ *     already linked in one call, applied as a follow-up update because
+ *     TaskRepository.create always writes the PR columns null.
+ *
+ *   handleUpdateTask - nulls pr_state whenever the link is re-pointed or set.
+ *     The three fields must always agree (the linker writes them atomically),
+ *     and a stale terminal 'merged' short-circuits every non-force resolve,
+ *     freezing the task on a PR it no longer points at.
+ *
+ * Strategy mirrors mcp-update-task-description-edits.test.ts: mock the
+ * repositories so no better-sqlite3 binary is needed, and assert on captured
+ * repository calls.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks - must be registered before the import under test
+// ---------------------------------------------------------------------------
+
+const {
+  mockTaskRepoCreate,
+  mockTaskRepoUpdate,
+  mockTaskRepoGetById,
+  mockTaskRepoGetByDisplayId,
+  mockResolveColumn,
+} = vi.hoisted(() => ({
+  mockTaskRepoCreate: vi.fn(),
+  mockTaskRepoUpdate: vi.fn(),
+  mockTaskRepoGetById: vi.fn(),
+  mockTaskRepoGetByDisplayId: vi.fn(),
+  mockResolveColumn: vi.fn(),
+}));
+
+vi.mock('../../src/main/db/repositories/task-repository', () => ({
+  TaskRepository: class {
+    create = mockTaskRepoCreate;
+    update = mockTaskRepoUpdate;
+    getById = mockTaskRepoGetById;
+    getByDisplayId = mockTaskRepoGetByDisplayId;
+  },
+}));
+
+vi.mock('../../src/main/agent/commands/column-resolver', () => ({
+  resolveColumn: mockResolveColumn,
+}));
+
+vi.mock('../../src/main/db/repositories/attachment-repository', () => ({
+  AttachmentRepository: class {
+    add = vi.fn();
+    getById = vi.fn();
+    remove = vi.fn();
+  },
+}));
+
+vi.mock('../../src/main/db/repositories/backlog-attachment-repository', () => ({
+  BacklogAttachmentRepository: class {
+    getById = vi.fn();
+    remove = vi.fn();
+  },
+}));
+
+vi.mock('../../src/main/db/repositories/attachment-utils', () => ({
+  readFileAsAttachment: vi.fn(),
+}));
+
+// Defensive: transitively imported by task-commands.ts but unused by the
+// handlers under test here.
+vi.mock('../../src/main/db/repositories/session-repository', () => ({
+  SessionRepository: class {},
+}));
+vi.mock('../../src/main/db/repositories/backlog-repository', () => ({
+  BacklogRepository: class {},
+}));
+vi.mock('../../src/main/pr/pr-linking', () => ({
+  linkPRForTask: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after all mocks are registered)
+// ---------------------------------------------------------------------------
+
+import { handleCreateTask, handleUpdateTask } from '../../src/main/agent/commands/task-commands';
+import type { CommandContext } from '../../src/main/agent/commands/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const REVIEWED_PR_URL = 'https://github.com/owner/repo/pull/98';
+
+function makeContext(overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    getProjectDb: vi.fn(() => ({}) as never),
+    getProjectPath: vi.fn(() => '/mock/project'),
+    onBacklogChanged: vi.fn(),
+    onLabelColorsChanged: vi.fn(),
+    onTaskCreated: vi.fn(),
+    onTaskUpdated: vi.fn(),
+    onTaskDeleted: vi.fn(),
+    onTaskMove: vi.fn(async () => {}),
+    onSwimlaneUpdated: vi.fn(),
+    ...overrides,
+  };
+}
+
+/** The real tools forward every omitted field as an explicit `null`, not `undefined`. */
+function createTaskParams(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    title: 'Review PR #98',
+    description: '',
+    column: null,
+    priority: null,
+    labels: null,
+    branchName: null,
+    baseBranch: null,
+    useWorktree: null,
+    attachments: null,
+    agentOverride: null,
+    modelOverride: null,
+    effortOverride: null,
+    permissionMode: null,
+    autoCommand: null,
+    profile: null,
+    runMode: null,
+    prUrl: null,
+    prNumber: null,
+    ...overrides,
+  };
+}
+
+function updateTaskParams(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    taskId: 'task-uuid-1',
+    title: null,
+    description: null,
+    descriptionEdits: null,
+    appendDescription: null,
+    prUrl: null,
+    prNumber: null,
+    agent: null,
+    priority: null,
+    labels: null,
+    baseBranch: null,
+    useWorktree: null,
+    attachments: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockResolveColumn.mockReturnValue({ swimlane: { id: 'lane-1', name: 'Code Review' } });
+  mockTaskRepoCreate.mockReturnValue({ id: 'task-uuid-1', display_id: 7, title: 'Review PR #98' });
+  mockTaskRepoUpdate.mockImplementation((patch: Record<string, unknown>) => ({
+    id: 'task-uuid-1', display_id: 7, title: 'Review PR #98', ...patch,
+  }));
+  mockTaskRepoGetById.mockReturnValue({
+    id: 'task-uuid-1', display_id: 7, title: 'Existing', description: '', attachment_count: 0,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCreateTask - filing a review task already linked to its PR
+// ---------------------------------------------------------------------------
+
+describe('handleCreateTask PR fields', () => {
+  it('applies prUrl / prNumber as a follow-up update, keeping create PR-column-free', () => {
+    const response = handleCreateTask(
+      createTaskParams({ prUrl: REVIEWED_PR_URL, prNumber: 98 }),
+      makeContext(),
+    );
+
+    expect(response.success).toBe(true);
+    // The create input never carries PR columns: TaskRepository.create always
+    // writes them null, and keeping that invariant means one create shape.
+    const createInput = mockTaskRepoCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(createInput).not.toHaveProperty('pr_url');
+    expect(createInput).not.toHaveProperty('pr_number');
+    // pr_state is deliberately left alone (null from create); the next resolve
+    // fills it in from the PR itself.
+    expect(mockTaskRepoUpdate).toHaveBeenCalledWith({
+      id: 'task-uuid-1',
+      pr_url: REVIEWED_PR_URL,
+      pr_number: 98,
+    });
+  });
+
+  it('links by prNumber alone, with no prUrl to derive it from', () => {
+    // Mirrors handleUpdateTask's "nulls pr_state when only the PR number is set"
+    // - the schema admits prNumber with no prUrl (mcp-task-tools-pr-fields-schema
+    // asserts this), so a caller who already knows the number but not the full
+    // URL is a reachable call shape on create too.
+    handleCreateTask(createTaskParams({ prNumber: 98 }), makeContext());
+
+    expect(mockTaskRepoUpdate).toHaveBeenCalledWith({ id: 'task-uuid-1', pr_number: 98 });
+  });
+
+  it('derives pr_number from prUrl when only the URL is passed', () => {
+    // A URL already encodes its number, so passing prUrl alone is the natural
+    // call. Without the derivation the row gets a pr_url and no pr_number, and
+    // the ladder anchors on pr_number - so the task shows a PR badge that no
+    // resolve can ever reach (the no-anchor gate never inspects pr_url).
+    handleCreateTask(createTaskParams({ prUrl: REVIEWED_PR_URL }), makeContext());
+
+    expect(mockTaskRepoUpdate).toHaveBeenCalledWith({
+      id: 'task-uuid-1',
+      pr_url: REVIEWED_PR_URL,
+      pr_number: 98,
+    });
+  });
+
+  it('omits pr_number when the URL names no PR number', () => {
+    // z.string().url() admits any URL, not just a /pull/<n> one. Writing no
+    // number is right here: a wrong number is worse than none, since Tier 1
+    // would treat it as authoritative.
+    handleCreateTask(createTaskParams({ prUrl: 'https://example.com/not-a-pr' }), makeContext());
+
+    expect(mockTaskRepoUpdate).toHaveBeenCalledWith({
+      id: 'task-uuid-1',
+      pr_url: 'https://example.com/not-a-pr',
+    });
+  });
+
+  it('does not touch the PR columns when neither field is passed', () => {
+    const response = handleCreateTask(createTaskParams(), makeContext());
+
+    expect(response.success).toBe(true);
+    expect(mockTaskRepoUpdate).not.toHaveBeenCalled();
+  });
+
+  it('treats omitted PR keys the same as the explicit nulls the tool layer forwards', () => {
+    // The MCP tool always forwards `?? null`, but a direct handler call (and
+    // several existing suites) pass neither key. `undefined !== null`, so
+    // reading them raw would fire a pointless follow-up update on every create.
+    const response = handleCreateTask({ title: 'Plain task', description: '' }, makeContext());
+
+    expect(response.success).toBe(true);
+    expect(mockTaskRepoUpdate).not.toHaveBeenCalled();
+  });
+
+  it('reports the updated task, so the linked row is what the caller is told about', () => {
+    const context = makeContext();
+    handleCreateTask(createTaskParams({ prUrl: REVIEWED_PR_URL, prNumber: 98 }), context);
+
+    expect(context.onTaskCreated).toHaveBeenCalledWith(
+      expect.objectContaining({ pr_url: REVIEWED_PR_URL, pr_number: 98 }),
+      'Code Review',
+      'lane-1',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleUpdateTask - re-pointing a link must not strand the old state
+// ---------------------------------------------------------------------------
+
+describe('handleUpdateTask PR fields', () => {
+  it('nulls pr_state when the PR URL is set, so a stale merged never lingers', () => {
+    handleUpdateTask(updateTaskParams({ prUrl: REVIEWED_PR_URL }), makeContext());
+
+    expect(mockTaskRepoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ pr_url: REVIEWED_PR_URL, pr_state: null }),
+    );
+  });
+
+  it('nulls pr_state when only the PR number is set', () => {
+    handleUpdateTask(updateTaskParams({ prNumber: 98 }), makeContext());
+
+    expect(mockTaskRepoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ pr_number: 98, pr_state: null }),
+    );
+  });
+
+  it('re-points pr_number along with the URL, so the old number cannot revert the link', () => {
+    // The silent-revert path: writing only pr_url leaves the OLD pr_number in
+    // the row, and the next non-force resolve takes that stale number as
+    // authoritative (Tier 1) and overwrites pr_url back to the previous PR. The
+    // caller's edit disappears with no error, so both fields move together.
+    handleUpdateTask(updateTaskParams({ prUrl: REVIEWED_PR_URL }), makeContext());
+
+    expect(mockTaskRepoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ pr_url: REVIEWED_PR_URL, pr_number: 98, pr_state: null }),
+    );
+  });
+
+  it('nulls a stale pr_number when the new URL names no PR number', () => {
+    handleUpdateTask(updateTaskParams({ prUrl: 'https://example.com/not-a-pr' }), makeContext());
+
+    expect(mockTaskRepoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ pr_url: 'https://example.com/not-a-pr', pr_number: null }),
+    );
+  });
+
+  it('lets an explicit prNumber win over the one the URL names', () => {
+    handleUpdateTask(updateTaskParams({ prUrl: REVIEWED_PR_URL, prNumber: 12 }), makeContext());
+
+    expect(mockTaskRepoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ pr_url: REVIEWED_PR_URL, pr_number: 12 }),
+    );
+  });
+
+  it('leaves pr_state alone on an update that does not touch the PR', () => {
+    handleUpdateTask(updateTaskParams({ title: 'Renamed' }), makeContext());
+
+    const patch = mockTaskRepoUpdate.mock.calls[0][0] as Record<string, unknown>;
+    expect(patch).not.toHaveProperty('pr_state');
+  });
+});

--- a/tests/unit/mcp-task-tools-pr-fields-schema.test.ts
+++ b/tests/unit/mcp-task-tools-pr-fields-schema.test.ts
@@ -1,0 +1,136 @@
+/**
+ * MCP task tools: the `prUrl` / `prNumber` zod constraints on
+ * `kangentic_create_task` and `kangentic_update_task` (task-tools.ts) are
+ * never exercised by any existing test.
+ *
+ * `tests/unit/mcp-task-pr-fields.test.ts` covers the same two fields, but at
+ * the `handleCreateTask` / `handleUpdateTask` command-handler layer - it
+ * calls the handlers directly, bypassing the zod `inputSchema` entirely. A
+ * handler call can't reject a malformed `prUrl` or a negative `prNumber`,
+ * because zod already stripped the field-shape problem out of the picture
+ * before the handler saw the arguments. Reverting `z.string().url()` to a
+ * bare `z.string()`, or `z.number().int().positive()` to a bare `z.number()`,
+ * fails nothing in that file.
+ *
+ * This test reflects on the ACTUAL zod schema captured off a real
+ * `registerTaskTools` registration (the same fake-McpServer capture pattern
+ * as mcp-task-tools-run-mode-schema.test.ts and mcp-profile-tools-schema.test.ts)
+ * so it fails the same way a real MCP call would, rather than re-declaring
+ * the accepted shape as a second hardcoded assertion that could drift from
+ * the real schema.
+ *
+ * Both `kangentic_create_task` and `kangentic_update_task` declare `prUrl` /
+ * `prNumber` as two SEPARATE inline schemas (unlike `runMode`, which shares
+ * one `RUN_MODE_SCHEMA` const) - each tool is exercised so a constraint
+ * change to only one of the two inline copies is caught.
+ *
+ * `handler-helpers` is mocked before importing task-tools.ts because it pulls
+ * in `../commands` -> better-sqlite3, which this unit test does not need:
+ * `registerTool` only ever STORES the config here, it never invokes a handler.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+vi.mock('../../src/main/agent/mcp-http/handler-helpers', () => ({
+  callHandler: vi.fn(),
+  runHandler: vi.fn(),
+  withProject: vi.fn(),
+  detectCrossProjectMention: vi.fn(() => []),
+  sanitizeProjectName: vi.fn((name: string) => name),
+  PROJECT_SELECTOR_DESCRIPTION: 'optional project selector',
+}));
+
+import { registerTaskTools } from '../../src/main/agent/mcp-http/task-tools';
+
+// ---------------------------------------------------------------------------
+// Fake McpServer: captures each registerTool(...) call's inputSchema so the
+// test reflects on the REAL zod schema object built by production code.
+// ---------------------------------------------------------------------------
+
+interface FakeToolConfig {
+  description?: string;
+  inputSchema: z.ZodType;
+}
+
+function makeServerWithTaskTools() {
+  const registeredConfigs = new Map<string, FakeToolConfig>();
+  const server = {
+    registerTool: vi.fn((toolName: string, toolConfig: FakeToolConfig) => {
+      registeredConfigs.set(toolName, toolConfig);
+    }),
+    getInputSchema(toolName: string): z.ZodType {
+      const toolConfig = registeredConfigs.get(toolName);
+      if (!toolConfig) throw new Error(`Tool "${toolName}" was not registered`);
+      return toolConfig.inputSchema;
+    },
+  };
+  const taskCounter = { tryReserve: () => true, limit: () => 100 };
+  registerTaskTools(server as never, {} as never, taskCounter as never);
+  return server;
+}
+
+type TaskToolName = 'kangentic_create_task' | 'kangentic_update_task';
+
+/**
+ * The minimal params each tool needs to validate on its own, so a test can
+ * add only the prUrl/prNumber fields under test without also tripping an
+ * unrelated "missing required field" failure.
+ * `kangentic_create_task` requires `title`; `kangentic_update_task` requires
+ * `taskId`.
+ */
+const REQUIRED_BASE_PARAMS: Record<TaskToolName, Record<string, unknown>> = {
+  kangentic_create_task: { title: 'Review an existing PR' },
+  kangentic_update_task: { taskId: 'task-1' },
+};
+
+describe.each(Object.keys(REQUIRED_BASE_PARAMS) as TaskToolName[])(
+  '%s prUrl / prNumber schema constraints',
+  (toolName) => {
+    const baseParams = REQUIRED_BASE_PARAMS[toolName];
+
+    it('rejects a malformed prUrl', () => {
+      const inputSchema = makeServerWithTaskTools().getInputSchema(toolName);
+
+      expect(inputSchema.safeParse({ ...baseParams, prUrl: 'not-a-url' }).success).toBe(false);
+    });
+
+    it('accepts a well-formed prUrl', () => {
+      const inputSchema = makeServerWithTaskTools().getInputSchema(toolName);
+
+      expect(
+        inputSchema.safeParse({ ...baseParams, prUrl: 'https://github.com/owner/repo/pull/42' }).success,
+      ).toBe(true);
+    });
+
+    it('rejects a negative prNumber', () => {
+      const inputSchema = makeServerWithTaskTools().getInputSchema(toolName);
+
+      expect(inputSchema.safeParse({ ...baseParams, prNumber: -1 }).success).toBe(false);
+    });
+
+    it('rejects a zero prNumber', () => {
+      const inputSchema = makeServerWithTaskTools().getInputSchema(toolName);
+
+      expect(inputSchema.safeParse({ ...baseParams, prNumber: 0 }).success).toBe(false);
+    });
+
+    it('rejects a non-integer prNumber', () => {
+      const inputSchema = makeServerWithTaskTools().getInputSchema(toolName);
+
+      expect(inputSchema.safeParse({ ...baseParams, prNumber: 1.5 }).success).toBe(false);
+    });
+
+    it('accepts a positive integer prNumber', () => {
+      const inputSchema = makeServerWithTaskTools().getInputSchema(toolName);
+
+      expect(inputSchema.safeParse({ ...baseParams, prNumber: 42 }).success).toBe(true);
+    });
+
+    it('accepts the call with prUrl and prNumber both absent, since both are optional', () => {
+      const inputSchema = makeServerWithTaskTools().getInputSchema(toolName);
+
+      expect(inputSchema.safeParse(baseParams).success).toBe(true);
+    });
+  },
+);

--- a/tests/unit/pr-link-ladder.test.ts
+++ b/tests/unit/pr-link-ladder.test.ts
@@ -24,7 +24,6 @@ const conn = vi.hoisted(() => ({
   byBranch: null as unknown,
   byCommit: null as unknown,
   detect: null as unknown,
-  canonical: null as unknown,
   calls: [] as string[],
   // Args the last call to each resolver received, so a test can assert which
   // branch/commit was queried (e.g. the live HEAD branch, not the stored slug).
@@ -63,7 +62,6 @@ vi.mock('../../src/main/pr/pr-registry', () => {
     resolvePRForBranch: make('byBranch'),
     resolvePRByCommit: make('byCommit'),
     detectPR: () => conn.detect ?? null,
-    detectCanonicalPR: () => conn.canonical ?? null,
   };
 });
 
@@ -96,7 +94,7 @@ function depsFor(task: Task, opts: { updateSpy?: ReturnType<typeof vi.fn>; force
 const resolved = (number: number, state = 'open') => ({ url: `u${number}`, number, state });
 
 beforeEach(() => {
-  conn.byNumber = null; conn.byBranch = null; conn.byCommit = null; conn.detect = null; conn.canonical = null; conn.calls = []; conn.lastArgs = {};
+  conn.byNumber = null; conn.byBranch = null; conn.byCommit = null; conn.detect = null; conn.calls = []; conn.lastArgs = {};
   git.branch = 'real-branch'; git.sha = 'sha-current'; git.aheadCount = '1';
 });
 
@@ -227,60 +225,109 @@ describe('linkPRForTask confidence ladder', () => {
   });
 });
 
-describe('linkPRForTask description anchor (tier 0)', () => {
-  it('tier 0: a PR URL in the description wins over the develop-tip commit anchor', async () => {
-    conn.canonical = { url: 'https://github.com/o/r/pull/708', number: 708 };
-    conn.byNumber = resolved(708, 'open');
-    conn.byCommit = resolved(702, 'merged'); // what the develop-tip merge commit would resolve to
-    const task = makeTask({ head_sha: 'develop-tip', description: 'Reviews https://github.com/o/r/pull/708' });
+/**
+ * A PR URL in the task DESCRIPTION is not an anchor. A URL cited as background
+ * ("this follows on from <url>") is textually identical to one naming the task's
+ * own PR, so scraping prose stamped citations onto unrelated tasks. A review task
+ * names its PR through the structured pr_url / pr_number fields instead, which
+ * lands on Tier 1.
+ *
+ * `CITED_PR_URL` is deliberately a real, well-formed PR URL: the point of each
+ * case is that the linker sees it and still ignores it.
+ */
+describe('linkPRForTask description PR URLs are never an anchor', () => {
+  const CITED_PR_URL = 'https://github.com/o/r/pull/9';
+  const CITING_DESCRIPTION = `Follows on from the previous task, branch \`own-the-icons-e1547bbf\`, PR ${CITED_PR_URL}.`;
+
+  it('the code-review shape resolves by pr_number, not by the base-tip commit', async () => {
+    // The shape tier 0 was originally written for: a review worktree branched
+    // from base with no commits of its own, so its HEAD is base's tip. The
+    // commits-ahead-of-base guard now blocks the commit tier there, and the PR
+    // the task is reviewing is named by pr_number rather than scraped from prose.
+    git.aheadCount = '0';
+    git.branch = 'code-review-32-1dbcebe5';
+    conn.byNumber = resolved(32, 'open');
+    conn.byCommit = resolved(702, 'merged'); // what base's tip would have magneted onto
+    const task = makeTask({
+      pr_number: 32,
+      branch_name: 'code-review-32-1dbcebe5',
+      head_sha: 'base-tip',
+      description: `Review ${CITED_PR_URL}`,
+    });
     const result = await linkPRForTask(task.id, depsFor(task));
-    expect(result.task?.pr_number).toBe(708);
+    expect(result.task?.pr_number).toBe(32);
     expect(result.task?.pr_state).toBe('open');
     expect(conn.calls).not.toContain('byCommit');
-    expect(conn.calls).not.toContain('byBranch');
   });
 
-  it('tier 0 self-heals an already-mislinked task (pr_number flips on the next resolve)', async () => {
-    conn.canonical = { url: 'https://github.com/o/r/pull/706', number: 706 };
-    conn.byNumber = resolved(706, 'open');
-    const task = makeTask({ pr_number: 702, pr_url: 'u702', pr_state: 'merged', head_sha: 'develop-tip' });
-    const result = await linkPRForTask(task.id, depsFor(task));
-    expect(result.status).toBe('linked');
-    expect(result.task?.pr_number).toBe(706);
-    expect(result.task?.pr_state).toBe('open');
+  it('regression: a cited PR URL with no git state is no-anchor, not a link', async () => {
+    // The mislink this rule exists for: a task that was never started, citing a
+    // sibling task's PR as background. No pr_number, branch, head_sha, or
+    // worktree - nothing to resolve from, whatever the description mentions.
+    const updateSpy = vi.fn();
+    const task = makeTask({
+      pr_number: null, branch_name: null, head_sha: null, worktree_path: null,
+      description: CITING_DESCRIPTION,
+    });
+    const result = await linkPRForTask(task.id, depsFor(task, { updateSpy }));
+    expect(result.status).toBe('no-anchor');
+    expect(result.task?.pr_number).toBeNull();
+    expect(result.task?.pr_url).toBeNull();
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(conn.calls).toEqual([]); // the resolver was never consulted
   });
 
-  it('tier 0 links url+number with unknown state when the named PR cannot be confirmed', async () => {
-    conn.canonical = { url: 'https://github.com/o/r/pull/708', number: 708 };
-    conn.byNumber = null; // gh ran cleanly but matched nothing
-    conn.byCommit = resolved(702, 'merged');
-    const task = makeTask({ head_sha: 'develop-tip' });
+  it('recovery: an already-mislinked task is cleared once its git anchors find no PR', async () => {
+    // The stuck row the mislink leaves behind: pr_number/url/state all pointing
+    // at the cited PR. With the description inert, every tier returns null, so
+    // the confident-not-found clear finally fires and all three fields go null.
+    conn.byNumber = null;   // the cited PR is not this task's, and the number no longer resolves for it
+    conn.byBranch = null;   // no PR exists for this task's own branch
+    const updateSpy = vi.fn((patch: Partial<Task>) => patch as Task);
+    const task = makeTask({
+      pr_number: 9, pr_url: CITED_PR_URL, pr_state: 'merged',
+      branch_name: 're-review-the-icons-bf9efd2b',
+      description: CITING_DESCRIPTION,
+    });
+    const result = await linkPRForTask(task.id, depsFor(task, { updateSpy }));
+    expect(result.status).toBe('not-found');
+    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ pr_number: null, pr_url: null, pr_state: null }));
+  });
+
+  it('a manually-set pr_number is cleared when it cannot be confirmed, even with a URL in the description', async () => {
+    // Deliberate consequence of the description being inert: a stored number that
+    // resolves to nothing is a broken link and is cleared, rather than being
+    // silently re-supplied from prose. This is the one case where the failure
+    // mode is a badge that disappears rather than one that never appears.
+    git.aheadCount = '0'; // review shape: commit tier blocked
+    conn.byNumber = null; // gh ran cleanly and matched nothing
+    conn.byBranch = null;
+    const task = makeTask({
+      pr_number: 9, pr_url: CITED_PR_URL, pr_state: 'open',
+      head_sha: 'base-tip',
+      description: CITING_DESCRIPTION,
+    });
     const result = await linkPRForTask(task.id, depsFor(task));
-    expect(result.task?.pr_number).toBe(708);
+    expect(result.status).toBe('not-found');
+    expect(result.task?.pr_number).toBeNull();
+    expect(result.task?.pr_url).toBeNull();
     expect(result.task?.pr_state).toBeNull();
-    expect(conn.calls).not.toContain('byCommit');
   });
 
-  it('tier 0 degrades to the scraper when the resolver is unavailable (error propagates, not swallowed)', async () => {
-    conn.canonical = { url: 'https://github.com/o/r/pull/708', number: 708 };
-    conn.byNumber = new PRResolverUnavailableError('gh CLI not found'); // gh down on the Tier 0 lookup
-    conn.byCommit = resolved(702, 'merged'); // the wrong PR the commit tier would have linked
-    const task = makeTask({ head_sha: 'develop-tip' });
-    const result = await linkPRForTask(task.id, depsFor(task)); // no getScrollback -> nothing to scrape
+  it('degrades rather than clearing when the resolver is unavailable', async () => {
+    // A degraded resolve must never be mistaken for a confident not-found: the
+    // existing link survives, and the description is not consulted as a fallback.
+    conn.byNumber = new PRResolverUnavailableError('gh CLI not found');
+    const updateSpy = vi.fn();
+    const task = makeTask({
+      pr_number: 60, pr_url: 'u60', pr_state: 'open',
+      worktree_path: null, description: CITING_DESCRIPTION,
+    });
+    const result = await linkPRForTask(task.id, depsFor(task, { updateSpy })); // no getScrollback -> nothing to scrape
     expect(result.status).toBe('resolver-unavailable');
     expect(result.message).toMatch(/gh/i);
-    expect(conn.calls).not.toContain('byCommit'); // never fell through to the wrong git tiers
-  });
-
-  it('tier 0: a description PR URL is itself an anchor when the task has no git state', async () => {
-    conn.canonical = { url: 'https://github.com/o/r/pull/708', number: 708 };
-    conn.byNumber = resolved(708, 'open');
-    // No pr_number, branch, head_sha, or worktree - the old guard would no-anchor bail here.
-    const task = makeTask({ pr_number: null, branch_name: null, head_sha: null, worktree_path: null });
-    const result = await linkPRForTask(task.id, depsFor(task));
-    expect(result.status).toBe('linked');
-    expect(result.task?.pr_number).toBe(708);
-    expect(result.task?.pr_state).toBe('open');
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(result.task?.pr_number).toBe(60);
   });
 });
 

--- a/tests/unit/pr-refresh-sweep.test.ts
+++ b/tests/unit/pr-refresh-sweep.test.ts
@@ -1,22 +1,18 @@
 /**
  * Unit tests for the background PR-refresh sweep (refreshProjectPRs): which tasks
- * are eligible (non-terminal linked PR, a live worktree, or a description PR
- * anchor) and that the backbone is invoked NON-FORCE exactly once per eligible
- * task. The live-worktree case is the discovery path - an unlinked task whose PR
- * was created mid-session is found on the next sweep.
+ * are eligible (a non-terminal linked PR or a live worktree, in a non-To Do lane)
+ * and that the backbone is invoked NON-FORCE exactly once per eligible task. The
+ * live-worktree case is the discovery path - an unlinked task whose PR was created
+ * mid-session is found on the next sweep.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Task } from '../../src/shared/types';
+import type { Swimlane, Task } from '../../src/shared/types';
 
 // getProjectRepos pulls in the DB/electron chain - stub it.
 vi.mock('../../src/main/ipc/helpers/project-repos', () => ({ getProjectRepos: vi.fn() }));
 // The sweep funnels each eligible task through linkPR (the wrapper).
 vi.mock('../../src/main/pr/pr-linking', () => ({ linkPR: vi.fn(async () => ({ status: 'unchanged', task: null })) }));
-// detectCanonicalPR decides the description-anchor branch of eligibility.
-vi.mock('../../src/main/pr/pr-registry', () => ({
-  detectCanonicalPR: vi.fn((text: string) => (text.includes('/pull/') ? { url: 'u', number: 99 } : null)),
-}));
 
 import { refreshProjectPRs } from '../../src/main/pr/pr-refresh';
 import { getProjectRepos } from '../../src/main/ipc/helpers/project-repos';
@@ -35,8 +31,27 @@ function makeTask(overrides: Partial<Task> = {}): Task {
   };
 }
 
+function makeSwimlane(overrides: Partial<Swimlane> = {}): Swimlane {
+  return {
+    id: 'lane', name: 'In Progress', description: null, role: null, position: 0, color: '#888',
+    icon: null, is_archived: false, is_ghost: false, permission_mode: null, auto_spawn: false,
+    auto_command: null, plan_exit_target_id: null, agent_override: null, model_override: null,
+    effort_override: null, handoff_context: false, session_target: 'main',
+    session_spawn_strategy: 'create_or_resume', created_at: 't', ...overrides,
+  };
+}
+
+/** Two lanes: `lane` is an ordinary working lane, `todo-lane` carries role 'todo'. */
+const LANES: Swimlane[] = [
+  makeSwimlane({ id: 'lane', name: 'In Progress', position: 1 }),
+  makeSwimlane({ id: 'todo-lane', name: 'To Do', position: 0, role: 'todo' }),
+];
+
 function withTasks(tasks: Task[]): void {
-  vi.mocked(getProjectRepos).mockReturnValue({ tasks: { list: () => tasks } } as never);
+  vi.mocked(getProjectRepos).mockReturnValue({
+    tasks: { list: () => tasks },
+    swimlanes: { list: () => LANES },
+  } as never);
 }
 
 function linkedTaskIds(): string[] {
@@ -48,23 +63,48 @@ beforeEach(() => {
 });
 
 describe('refreshProjectPRs eligibility', () => {
-  it('links non-terminal PRs (open / draft / null-state) and description-anchored tasks; skips terminal and no-anchor', async () => {
+  it('links non-terminal PRs (open / draft / null-state); skips terminal and no-anchor', async () => {
     const open = makeTask({ id: 'open', pr_number: 1, pr_state: 'open' });
     const draft = makeTask({ id: 'draft', pr_number: 2, pr_state: 'draft' });
     const unknownState = makeTask({ id: 'unknown', pr_number: 3, pr_state: null });
     const merged = makeTask({ id: 'merged', pr_number: 4, pr_state: 'merged' });
     const closed = makeTask({ id: 'closed', pr_number: 5, pr_state: 'closed' });
-    const descAnchored = makeTask({ id: 'desc', pr_number: null, pr_state: null, description: 'see https://github.com/o/r/pull/7' });
-    // No pr_number, no description anchor, AND no worktree -> genuinely no anchor.
+    // No pr_number AND no worktree -> genuinely no anchor.
     const noAnchor = makeTask({ id: 'none', pr_number: null, pr_state: null, description: 'no pr here', worktree_path: null });
-    withTasks([open, draft, unknownState, merged, closed, descAnchored, noAnchor]);
+    withTasks([open, draft, unknownState, merged, closed, noAnchor]);
 
     await refreshProjectPRs({} as never, 'proj-1');
 
-    expect(linkedTaskIds()).toEqual(['open', 'draft', 'unknown', 'desc']);
+    expect(linkedTaskIds()).toEqual(['open', 'draft', 'unknown']);
     expect(linkedTaskIds()).not.toContain('merged');
     expect(linkedTaskIds()).not.toContain('closed');
     expect(linkedTaskIds()).not.toContain('none');
+  });
+
+  it('a PR URL in the description is not an anchor (a cited PR is never the task\'s own)', async () => {
+    // The mislink this gate exists for: a task citing a sibling task's PR as
+    // background, with no pr_number and no worktree of its own. Scraping the
+    // description used to make it sweep-eligible and stamp the cited PR onto it.
+    const cited = makeTask({
+      id: 'cited', pr_number: null, pr_state: null, worktree_path: null,
+      description: 'Follows on from the previous task, PR https://github.com/o/r/pull/9.',
+    });
+    withTasks([cited]);
+
+    await refreshProjectPRs({} as never, 'proj-1');
+
+    expect(linkPR).not.toHaveBeenCalled();
+  });
+
+  it('skips a To Do lane task even with a live worktree (To Do resets the task)', async () => {
+    // Mirrors autoLinkPRForTask's lane gate, which every implicit trigger honors.
+    const inTodo = makeTask({ id: 'todo', swimlane_id: 'todo-lane', pr_number: 1, pr_state: 'open' });
+    const working = makeTask({ id: 'working', swimlane_id: 'lane', pr_number: 2, pr_state: 'open' });
+    withTasks([inTodo, working]);
+
+    await refreshProjectPRs({} as never, 'proj-1');
+
+    expect(linkedTaskIds()).toEqual(['working']);
   });
 
   it('invokes linkPR non-force (no force flag) so terminal-skip + TTL coalesce stay in effect', async () => {
@@ -91,7 +131,7 @@ describe('refreshProjectPRs eligibility', () => {
     expect(linkPR).not.toHaveBeenCalled();
   });
 
-  it('discovers an unlinked task with a live worktree (no pr_number, no description anchor)', async () => {
+  it('discovers an unlinked task with a live worktree (no pr_number)', async () => {
     const wtOnly = makeTask({ id: 'wt-only', pr_number: null, pr_state: null, description: '', worktree_path: '/mock/worktrees/wt' });
     const bare = makeTask({ id: 'bare', pr_number: null, pr_state: null, description: '', worktree_path: null, branch_name: null });
     // Terminal guard runs before the worktree check: a merged PR is never swept,
@@ -115,5 +155,49 @@ describe('refreshProjectPRs eligibility', () => {
 
     await expect(refreshProjectPRs({} as never, 'proj-1')).resolves.toBeUndefined();
     expect(linkPR).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('refreshProjectPRs repo-read degradation', () => {
+  it('a throwing swimlanes.list() degrades to "no To Do lanes" but the sweep still runs', async () => {
+    // The lane gate is a filter layered on top of the eligibility check, guarded
+    // separately from the task read on purpose: losing the lane read must not
+    // take the whole sweep down with it. `inTodo` actually sits in the To Do
+    // lane and would be excluded if the lane read succeeded (see the "skips a
+    // To Do lane task" test above) - sweeping it here proves the degraded gate
+    // falls back to treating every lane as non-To-Do, not to aborting.
+    const inTodo = makeTask({ id: 'todo', swimlane_id: 'todo-lane', pr_number: 1, pr_state: 'open' });
+    const working = makeTask({ id: 'working', swimlane_id: 'lane', pr_number: 2, pr_state: 'open' });
+    vi.mocked(getProjectRepos).mockReturnValue({
+      tasks: { list: () => [inTodo, working] },
+      swimlanes: {
+        list: () => {
+          throw new Error('swimlane read failed');
+        },
+      },
+    } as never);
+
+    await expect(refreshProjectPRs({} as never, 'proj-1')).resolves.toBeUndefined();
+
+    expect(linkedTaskIds()).toEqual(['todo', 'working']);
+  });
+
+  it('a throwing tasks.list() is swallowed by the outer catch; the sweep returns silently', async () => {
+    // tasks.list() sits inside the SAME outer try as the lane read, unlike the
+    // lane read's own inner try/catch: a task-read failure (e.g. the project DB
+    // closed mid-switch) has nothing left to sweep, so it must propagate to the
+    // outer catch and return rather than degrade to an empty task list.
+    vi.mocked(getProjectRepos).mockReturnValue({
+      tasks: {
+        list: () => {
+          throw new Error('project DB unavailable');
+        },
+      },
+      swimlanes: { list: () => LANES },
+    } as never);
+
+    await expect(refreshProjectPRs({} as never, 'proj-1')).resolves.toBeUndefined();
+
+    expect(linkPR).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

Removes the description-URL anchor ("Tier 0") from the PR confidence ladder, and makes a task's PR link recoverable when it is wrong.

- `src/main/pr/pr-linking.ts` - Tier 0 deleted; the ladder is now tiers 1-4 (`pr_number`, worktree HEAD branch, commit SHA, slug branch). The no-anchor bail no longer counts a description URL.
- `src/main/pr/pr-registry.ts`, `shared/pr-connector.ts`, `adapters/github/github-connector.ts` - `detectCanonicalPR` / `extractCanonical` deleted, including the optional slot on the `PRConnector` contract.
- `src/main/pr/pr-refresh.ts` - sweep eligibility drops the description branch and gains a To Do lane-role gate.
- `src/main/agent/mcp-http/task-tools.ts`, `commands/task-commands.ts` - `kangentic_create_task` accepts `prUrl` / `prNumber`; both MCP paths derive `pr_number` from `prUrl` and null `pr_state` when the link is set or re-pointed.
- `src/renderer/.../task-detail/useTaskActions.ts` - `buildPrUrlFields` becomes `buildPrFields` and writes `pr_state: null` on both the clear and re-point branches.

## Why

A task that merely **cited** another task's PR as background context had that PR stamped as its own. On the kangentic-branding board, a task sitting untouched in To Do (no branch, no worktree, no `head_sha`, no session, zero rows in `sessions`) showed a `PR #9 merged` badge 81 seconds after creation, because its description said "this board, ... branch `own-the-activity-ico-e1547bbf`, PR &lt;url&gt;".

Three behaviors compounded:

1. `extractCanonical` returned any single full `github.com/<owner>/<repo>/pull/<n>` URL found in the description. A URL cited as history is textually identical to one naming the task's own PR.
2. Tier 0 returned unconditionally, ahead of every git anchor, and linked `{url, number, state: null}` even when the PR could not be confirmed. It could never return null.
3. The background sweep had no lane gate, unlike `autoLinkPRForTask`, which already skipped To Do lanes and required some git state.

It was also permanent. Non-force resolves short-circuit on terminal PR state, a force refresh re-ran Tier 0 and re-linked the same wrong PR, and `prCleared` requires the ladder to return null, which Tier 0 could not do. Blanking the URL in the edit form nulled `pr_url` and `pr_number` but left `pr_state = 'merged'` behind, producing exactly the inconsistent row the linker's own comment says must never exist.

## How

**Tier 0 was an over-general guard, not a feature, and the evidence settled it before any code changed:**

- Its origin commit `42be3e99` wrote it for a code-review worktree "branched from the base branch with no commits of its own" - a shape that *always* has git state. Every real review task in the DB (9 of them, going back to June) carries `branch_name` + `head_sha`. The mislinked task had none of the four.
- Its defensive role is already dead. `056c691c` added `hasCommitsAheadOfBase`, which independently blocks the commit tier for a base-tip HEAD, so removing the description tier cannot reintroduce the mislink Tier 0 was written to prevent. The worst case of removing it is a *missing* badge, never a wrong one.
- Nothing in `.claude/` or `src/` has ever written a PR URL into a task description. `/pull-request` already links via `kangentic_update_task`'s `prUrl` / `prNumber`. Tier 0 only ever served hand-written prose.
- Across both boards, the only non-archived task with a real PR URL in its description was the bug itself. Already-linked tasks keep their link through Tier 1, so deletion clears nobody's correct badge.

So the tier is deleted outright rather than gated: that is what lets the ladder return null again, which is what lets `prCleared` self-heal a mislink for the first time. A review task now names its PR through the structured fields, which land on Tier 1.

**Two defects found while wiring the replacement:**

- Passing `prUrl` alone (the natural call, since a URL encodes its number) left the **old** `pr_number` in the row. The next resolve would take that stale number as authoritative and revert the URL to the previous PR. Both MCP paths now derive the number from the URL, matching what the edit form has always done.
- `prUrl` / `prNumber` are applied as a follow-up `update` after create rather than through `TaskCreateInput`, because `TaskRepository.create` deliberately writes all three PR columns null. Keeping that invariant means the create path has exactly one shape.

**Trade-off worth a reviewer's attention:** with the description inert, a stored `pr_number` that the resolver cannot confirm is now cleared rather than silently re-supplied from prose. That already happened for a task without a description URL (`056c691c` intended it), so this is an extension rather than a new behavior, but it is the one case where the failure mode is a badge that disappears rather than one that never appears. It is pinned by a named test so it stays a chosen behavior, not an emergent one.

## Breaking changes

None for users, but one behavior change to be aware of: a task in a **To Do** lane with an open or draft PR no longer gets background state refreshes. The sweep was its only trigger, since `autoLinkPRForTask` already skipped To Do lanes, and merged/closed were skipped anyway. The newly affected set is a task pushed back to To Do while its PR is still open. An explicit refresh (kebab "Refresh PR", `kangentic_link_pr`) still works.

## Tests

The CI checks (lint, typecheck, unit, build, UI shards, Linux Electron E2E shards), plus:

- `tests/unit/pr-link-ladder.test.ts` - the tier-0 describe is rewritten, not dropped. The old "a description PR URL is itself an anchor when the task has no git state" case becomes the real code-review shape found in the DB (worktree on a generated slug branch, HEAD on base's tip with zero commits ahead, `pr_number` set structurally) resolving via Tier 1 with the commit tier never consulted. New cases cover the reported mislink (`no-anchor`, nothing written, resolver never called), the recovery clear, the manually-set-number clear noted in the trade-off above, and degrade-not-clear.
- `tests/unit/github-pr-detector.test.ts` - the `extractCanonical` suite is replaced by an assertion that the scraper surface is **gone** from both the connector and the registry. This is the load-bearing guard: it goes red if the tier is ever reintroduced.
- `tests/unit/pr-refresh-sweep.test.ts` - description-is-not-an-anchor, the To Do lane gate, and both repo-read degradation paths (a throwing `swimlanes.list()` must degrade to "no To Do lanes" rather than kill the sweep; a throwing `tasks.list()` still returns silently).
- `tests/unit/mcp-task-pr-fields.test.ts` (new) - handler-layer create/update PR-field behavior, including `pr_number` derivation, the no-parseable-`/pull/<n>` case, and omitted-vs-explicit-null keys.
- `tests/unit/mcp-task-tools-pr-fields-schema.test.ts` (new) - the zod constraints on both tools, reflected off a real `registerTaskTools` registration rather than a re-declared shape.
- `tests/ui/pr-url.spec.ts` - the clear test now seeds the stuck `pr_state: 'merged'` shape and asserts all three fields are nulled together; a new test covers the re-point branch (edit to a *different* PR), which the fill and clear tests both miss.

Every added test was red-green verified against the old behavior.

**Not covered, and deliberately left as follow-up:** `task-tools.ts`'s `prUrl ?? null` / `prNumber ?? null` forwarding into `callHandler` has no test. The schema test mocks `handler-helpers` so the callback never runs, and the handler test bypasses zod entirely, so deleting those two lines would stay green. Closing it needs a third mocking strategy that makes `withProject`'s callback actually invoke.

**Also still outstanding:** the kangentic-branding board's task #9 is still mislinked in the live DB. It cannot be repaired from this branch, since the running app serves the old code and MCP `update_task` can neither clear a URL nor null `pr_state`. Once this merges: open the task, Edit, blank the Pull Request field, Save. A force refresh alone will not heal it, because `pr_number = 9` is still stamped and Tier 1 would re-resolve it.

Generated with [Claude Code](https://claude.com/claude-code)
