### PR TITLE
feat(activity): adopt the @kangentic/branding activity marks

### DIFF
--- a/.claude/rules/restore-no-animation-replay.md
+++ b/.claude/rules/restore-no-animation-replay.md
@@ -57,5 +57,6 @@ when the same UI is reconstructed or re-pointed by a restore.
 
 Renderer UI under `src/renderer/`. Governs motion that fires on mount or on a value change for
 surfaces reconstructed/re-pointed by a restore. Does not govern ongoing ambient motion
-(`animate-spin`, `animate-pulse-subtle`, the activity `march-border`) or genuinely user-initiated
-open/close animations, which are intentional and stay.
+(`animate-spin`, `animate-pulse-subtle`, and the activity marks' `.kng-march` from
+`@kangentic/branding/assets/activity/activity.css`) or genuinely user-initiated open/close
+animations, which are intentional and stay.

--- a/.claude/rules/ui-conventions.md
+++ b/.claude/rules/ui-conventions.md
@@ -10,7 +10,13 @@ chrome unless these are stated.
 
 ## The rule
 
-- **Icons:** use Lucide React icons. No inline SVGs.
+- **Icons:** use Lucide React icons. No inline SVGs. Exactly three files are exempt, each
+  consuming a shipped `@kangentic/branding` asset that cannot be a lucide glyph:
+  `components/BrandMark.tsx` (the brandmark lockup), `components/ActivityMark.tsx` (the nine
+  activity marks, shared with the website and mobile app), and
+  `components/command-bar/CommandTerminalIcon.tsx` (a wrapper over `ActivityMark`). Each carries
+  a comment naming this rule. Adding a fourth needs the same justification, not a silent inline
+  `<svg>`.
 - **Dropdowns:** use the shared `Select` component from
   `src/renderer/components/settings/shared.tsx`, never a raw `<select>` with inline classes.
   The shared component renders `appearance-none` with a custom ChevronDown for correct spacing.
@@ -45,6 +51,10 @@ chrome unless these are stated.
   rule's `src/renderer/**` auto-load; the copy convention on adapter files
   (`src/main/agent/adapters/**`) is caught by the always-on conventions finder instead, which runs
   regardless of which files changed.
+- **Test (inline-SVG allowlist only):** `tests/unit/branding-assets.test.ts` asserts which
+  branding asset each of the three exempt files imports, so the allowlist above is anchored to
+  real imports rather than being a fourth list that drifts. It does not detect a NEW inline
+  `<svg>` elsewhere; that stays review-caught.
 - No dedicated mechanical test yet. Candidate future checks: a scan for raw `<select>` and for
   `text-[10px]` (or smaller) under `src/renderer/`; a scan of `SETTINGS_REGISTRY` label/description
   fields for raw hex / byte-code literals (`0x`, `\x`, `\u`, `U+`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,8 +138,11 @@ won't be found.
   settings, or the OS window controls - only this pair's own position moves. The toggle glyph's
   stroke color is the aggregate activity of the project's terminals (active-green working /
   attention-amber needs-you / muted rest, via the central `--kng-active` / `--kng-attention`
-  tokens) and the working border MARCHES (`@keyframes march-border` + a `pathLength`-normalized
-  stroke-dash). The toggle reflects only the CURRENT project, so the same glyph is mirrored
+  tokens) and the working border MARCHES (`.kng-march` + a `pathLength`-normalized stroke-dash,
+  both shipped with the mark). The glyph itself is no longer hand-authored: `CommandTerminalIcon`
+  is a thin wrapper over `components/ActivityMark.tsx`, which renders the `terminal-idle` /
+  `terminal-working` / `terminal-new` marks from `@kangentic/branding`. See the Activity marks
+  section below. The toggle reflects only the CURRENT project, so the same glyph is mirrored
   per project in the sidebar (`SidebarCommandTerminalIndicator` in each `ProjectListItem` row,
   plus a plain tone dot on `CollapsedRail`'s 28px buttons, where an arc-bearing glyph would read
   as broken). Both the toggle and the sidebar read one shared selector,
@@ -170,6 +173,36 @@ won't be found.
   `useEnsureCommandWindow` for the app-restart blob-restore path), because a carried-over window
   committed into the store would otherwise spawn a fresh PTY under the wrong project before a
   bridge-effect reconcile could close it.
+- **Activity marks** - The nine glyphs that express agent/terminal activity are owned upstream in
+  `@kangentic/branding` (`assets/activity/`), NOT hand-authored here, so desktop, web, and mobile
+  cannot drift. `components/ActivityMark.tsx` is the only consumer: it imports each mark with
+  `?raw`, strips the packaged `<svg>` wrapper, and injects the inner markup into a `<g>` under a
+  React-authored root. That root shape is load-bearing and must not become `BrandMark`'s wrapper-
+  `<span>` form: React forbids `children` next to `dangerouslySetInnerHTML` on one element, and
+  `TaskCard` passes a `<title>` child for its hover tooltip. Marks are `currentColor` only, so the
+  CALL SITE supplies `text-active` / `text-attention` / `text-fg-muted` - never hardcode a hex,
+  since `--kng-active` / `--kng-attention` are desktop-only values that mobile and web
+  deliberately diverge from. There is no `-rest` mark: rest is the `-idle` geometry in a muted
+  tone. `data-rest` on the root is the reduced-motion strategy (`static` / `keep-dash` /
+  `drop-dash`), NOT a tone; test selectors key off `data-mark`. The set's grid is a WIDTH
+  KEYLINE, not a square ink box: each mark fills its slot's width and takes the height its form
+  needs (width is the advance that shifts a row; height is absorbed by `align-items: center`).
+  Two keylines, one per role - 18 for indicators, 20 for controls. Size floors are 12 for
+  indicators and 16 for controls, which is why `TerminalPanel`'s 8px session dot stays lucide.
+  The two control marks render at size 20: their r=10 ring draws 18.33px, a pixel match for the
+  lucide `Circle` they replaced. Upstream geometry has already moved twice (2.5.0 squared the
+  envelope to 18x18 and shrank the controls to r=9; 2.6.0 reversed both), so
+  `tests/unit/activity-mark.test.ts` pins the r=10 control ring, the r=9 agent ring, and the
+  envelope's 18 x 14.4 box as the guard against a silent upstream reshape. The envelope's height
+  is load-bearing beyond legibility: a card swaps idle for working IN PLACE, and at 18x18 the
+  envelope enclosed 26% more than the ring, so the indicator visibly grew on every state change.
+  At 14.4 the two are within 0.5%, which holds only while `agent-working` stays r=9. Indicators
+  render at 15 (`TaskCard` and both sidebar components), NOT the 14 the lucide glyphs used: the
+  branding envelope is 18 wide where lucide's `Mail` was 20, so a same-number swap silently
+  shrinks it ~10%. 15 restores the drawn size production shipped. Move the sidebar's two
+  indicator components together or the row goes ragged. lucide stays everywhere
+  else (140+ files), and `utils/swimlane-icons.tsx` needs its whole glyph map
+  because column icon names are persisted as kebab-case strings in the DB.
 - **Settings tab separator** - Each tab in `SETTINGS_TABS` (`settings-tabs.ts`) declares a
   `category`. `'project'` tabs (General, Theme, Agent, Git, Browser, Shortcuts) are per-project
   settings, saved to `.kangentic/config.json`, and hidden when no project is selected.

--- a/docs/activity-detection.md
+++ b/docs/activity-detection.md
@@ -117,7 +117,12 @@ The renderer uses it to show elapsed wait time ("Idle for 12m") in the TaskCard 
 (`formatActivityReasonText` / `ActivityReasonTooltip` in
 `src/renderer/components/board/ActivityReasonTooltip.tsx`).
 
-The renderer uses `reason.kind` to pick a Lucide icon (Wrench / Users / Terminal / Lock / Loader2 / Mail) and inline label for the TaskCard hover tooltip.
+The renderer uses `reason.kind` to pick an icon and inline label for the TaskCard hover tooltip. The
+two kinds that describe agent activity itself render the shared `@kangentic/branding` activity marks
+via `ActivityMark`, so they match the TaskCard indicator exactly (`idle` -> `agent-idle`,
+`turn-active` -> `agent-working`); the kinds that name a specific cause have no counterpart in that
+set and stay Lucide (`tool` -> Wrench, `subagent` -> Users, `background-shell` -> Terminal,
+`permission` -> Lock).
 
 ### Durable activity-interval history
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@electron/fuses": "^2.1.1",
         "@electron/notarize": "^3.1.1",
         "@eslint/js": "^9.39.4",
-        "@kangentic/branding": "^2.3.0",
+        "@kangentic/branding": "^2.6.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.3.0",
@@ -2502,9 +2502,9 @@
       }
     },
     "node_modules/@kangentic/branding": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@kangentic/branding/-/branding-2.3.0.tgz",
-      "integrity": "sha512-0WMbthxl6HSZtLQ9Kzd12h+ICx0QlhI0iPQ0/Ak4BjhRNgh4VOo04hpKq/vEoVACAyTAhF1Gm3+nX9huXipOww==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@kangentic/branding/-/branding-2.6.0.tgz",
+      "integrity": "sha512-H3HDDQx5HlQ3wO4DypdpJmleIbk7kbZ/TWtyaZHG86G2l2ldSByX38NClGdMMPvgpnc7lJZrvDi690U7ZyJ2nA==",
       "dev": true,
       "license": "AGPL-3.0-only"
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@electron/fuses": "^2.1.1",
     "@electron/notarize": "^3.1.1",
     "@eslint/js": "^9.39.4",
-    "@kangentic/branding": "^2.3.0",
+    "@kangentic/branding": "^2.6.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.0",

--- a/src/renderer/assets/assets.d.ts
+++ b/src/renderer/assets/assets.d.ts
@@ -15,9 +15,11 @@ declare module '*?url' {
   export default url;
 }
 
-// Vite `?raw` suffix: inlines the referenced file's contents as a string. Used
-// to load the AudioWorklet processor source and register it via a Blob URL,
-// which `audioWorklet.addModule` supports reliably across platforms.
+// Vite `?raw` suffix: inlines the referenced file's contents as a string. Three uses:
+// the AudioWorklet processor source, registered via a Blob URL because
+// `audioWorklet.addModule` supports that reliably across platforms; and the branding
+// brandmark (`BrandMark.tsx`) and activity marks (`ActivityMark.tsx`), inlined so their
+// strokes inherit `currentColor` instead of being opaque `<img>` pixels.
 declare module '*?raw' {
   const content: string;
   export default content;

--- a/src/renderer/components/ActivityMark.tsx
+++ b/src/renderer/components/ActivityMark.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import '@kangentic/branding/assets/activity/activity.css';
+import activityJson from '@kangentic/branding/assets/activity/activity.json';
+import agentIdleSvg from '@kangentic/branding/assets/activity/agent-idle.svg?raw';
+import agentWorkingSvg from '@kangentic/branding/assets/activity/agent-working.svg?raw';
+import controlPauseIdleSvg from '@kangentic/branding/assets/activity/control-pause-idle.svg?raw';
+import controlPauseWorkingSvg from '@kangentic/branding/assets/activity/control-pause-working.svg?raw';
+import controlStopIdleSvg from '@kangentic/branding/assets/activity/control-stop-idle.svg?raw';
+import controlStopWorkingSvg from '@kangentic/branding/assets/activity/control-stop-working.svg?raw';
+import terminalIdleSvg from '@kangentic/branding/assets/activity/terminal-idle.svg?raw';
+import terminalNewSvg from '@kangentic/branding/assets/activity/terminal-new.svg?raw';
+import terminalWorkingSvg from '@kangentic/branding/assets/activity/terminal-working.svg?raw';
+
+/**
+ * The activity marks, owned upstream in `@kangentic/branding` (`assets/activity/`) and shared
+ * with the website and the mobile app. Nine marks over five silhouettes (`activity.json` counts
+ * `control-pause` and `control-stop` separately) on one 24 grid at stroke 2, `currentColor` only,
+ * motion via a marching `stroke-dashoffset`.
+ *
+ * The grid is a WIDTH KEYLINE, not a square ink box: every mark fills its slot's width and
+ * takes whatever height its form actually needs. Two keylines, one per role - 18 for
+ * indicators, 20 for controls. Width is what has to match, because icons in a row behave like
+ * glyphs in a line of type: width is the advance and shifts everything after it, while height
+ * is absorbed by `align-items: center`. Branding 2.5.0 briefly read the grid as a literal
+ * 18x18 ink box, squared the envelope to fit, and it stopped reading as an envelope on a task
+ * card; 2.6.0 reframed it to this model.
+ *
+ * A deliberate inline-SVG exception to the lucide-only icon convention (`ui-conventions.md`),
+ * and the third in that chain after `BrandMark.tsx` and `command-bar/CommandTerminalIcon.tsx`
+ * (which is now a wrapper over this): no lucide glyph carries a marching activity border, and
+ * these marks must stay byte-identical across three surfaces. The `?raw` sources are trusted
+ * build-time package assets.
+ *
+ * Tone is the CALLER's job. The marks paint in `currentColor`, so a call site applies
+ * `text-active` / `text-attention` / `text-fg-muted` exactly as it did to the lucide glyph it
+ * replaced. Never hardcode a hex here: `--kng-active` / `--kng-attention` are desktop-only
+ * values and mobile/web deliberately differ.
+ *
+ * There is no `-rest` mark on purpose. Upstream ships rest as the `-idle` GEOMETRY in a muted
+ * tone, so a rest twin cannot drift from its idle counterpart.
+ */
+export const ACTIVITY_MARK_NAMES = [
+  'agent-idle',
+  'agent-working',
+  'terminal-idle',
+  'terminal-working',
+  'terminal-new',
+  'control-pause-idle',
+  'control-pause-working',
+  'control-stop-idle',
+  'control-stop-working',
+] as const;
+
+export type ActivityMarkName = (typeof ACTIVITY_MARK_NAMES)[number];
+
+const RAW_MARKS: Record<ActivityMarkName, string> = {
+  'agent-idle': agentIdleSvg,
+  'agent-working': agentWorkingSvg,
+  'terminal-idle': terminalIdleSvg,
+  'terminal-working': terminalWorkingSvg,
+  'terminal-new': terminalNewSvg,
+  'control-pause-idle': controlPauseIdleSvg,
+  'control-pause-working': controlPauseWorkingSvg,
+  'control-stop-idle': controlStopIdleSvg,
+  'control-stop-working': controlStopWorkingSvg,
+};
+
+interface ActivityMarkMeta {
+  file: string;
+  /** Reduced-motion strategy, NOT a tone: 'static' | 'keep-dash' | 'drop-dash'. */
+  reducedMotion: string;
+  minPx: number;
+}
+
+/**
+ * The shipped contract, re-declared so the wide inferred JSON type is not indexed directly.
+ *
+ * `marks` is PARTIAL on purpose. This is package data crossing the TypeScript boundary, so a
+ * total `Record` would be a claim the type system cannot check: a branding release that drops or
+ * renames a mark still typechecks, and `CONTRACT.marks[mark].reducedMotion` would then throw
+ * mid-render. `TaskCard` renders a mark per board card and nothing above it catches, so that
+ * throw takes the whole renderer down rather than blanking one icon.
+ * `tests/unit/branding-assets.test.ts` fails CI on that drift; the `?? 'static'` below is the
+ * runtime floor for anyone running against a package the test never saw.
+ */
+interface ActivityContract {
+  marks: Partial<Record<ActivityMarkName, ActivityMarkMeta>>;
+}
+
+const CONTRACT = activityJson as unknown as ActivityContract;
+
+/**
+ * Drops the packaged file's own `<svg>` wrapper so React can own the root element.
+ *
+ * Exported for `tests/unit/activity-mark.test.ts`, which asserts per mark that the expected
+ * leaf content survived. "Non-empty" is not a sufficient check: `[^>]*` stops at the first
+ * `>`, which is correct for these single-line generated files but would silently strip into
+ * the body if upstream ever emitted a `>` inside an attribute value.
+ */
+export function innerMarkup(raw: string): string {
+  return raw.replace(/^[\s\S]*?<svg\b[^>]*>/, '').replace(/<\/svg>\s*$/, '');
+}
+
+const MARK_INNER: Record<ActivityMarkName, string> = Object.fromEntries(
+  ACTIVITY_MARK_NAMES.map((name) => [name, innerMarkup(RAW_MARKS[name])]),
+) as Record<ActivityMarkName, string>;
+
+export interface ActivityMarkProps extends React.SVGProps<SVGSVGElement> {
+  mark: ActivityMarkName;
+  /** Rendered width and height in px. Floors: 12 for indicators, 16 for controls. */
+  size?: number;
+}
+
+/**
+ * Renders one activity mark.
+ *
+ * The `<svg>` root is authored HERE and only the mark's INNER markup is injected, into a `<g>`.
+ * That shape is load-bearing and must not be "simplified" into `BrandMark`'s wrapper-`<span>` +
+ * `dangerouslySetInnerHTML` form:
+ *
+ *  1. React forbids `children` alongside `dangerouslySetInnerHTML` on the same element, and
+ *     `TaskCard` passes a `<title>` child for its native hover tooltip. On a sibling `<g>`,
+ *     children stay free.
+ *  2. The packaged files carry a hardcoded `width="24" height="24"`; a React-authored root
+ *     overrides them directly instead of needing a `[&>svg]:h-full` neutralisation wrapper.
+ *  3. A wrapper `<span>` carrying the tone class would break the sidebar specs, which assert
+ *     that `span.text-active` / `span.text-attention` resolve to the count digits alone.
+ *
+ * The extra `<g>` is harmless to the packaged CSS: `.kng-march` is a class selector and the
+ * reduced-motion rule is `svg[data-rest="drop-dash"] *`, so both still match one level deeper.
+ */
+export function ActivityMark({
+  mark,
+  size = 24,
+  strokeWidth = 2,
+  children,
+  ...rest
+}: ActivityMarkProps): React.ReactNode {
+  // Decorative by default; a call site that names the mark (aria-label) or supplies a <title>
+  // child is exposing it to assistive tech, so it must not also be aria-hidden.
+  const isLabelled = rest['aria-label'] !== undefined || children !== undefined;
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...rest}
+      data-mark={mark}
+      data-rest={CONTRACT.marks[mark]?.reducedMotion ?? 'static'}
+      role={isLabelled ? 'img' : undefined}
+      aria-hidden={isLabelled ? undefined : true}
+    >
+      <g dangerouslySetInnerHTML={{ __html: MARK_INNER[mark] }} />
+      {children}
+    </svg>
+  );
+}

--- a/src/renderer/components/board/ActivityReasonTooltip.tsx
+++ b/src/renderer/components/board/ActivityReasonTooltip.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
-import { Wrench, Users, Terminal, Lock, Loader2, Mail } from 'lucide-react';
+import { Wrench, Users, Terminal, Lock } from 'lucide-react';
+import { ActivityMark } from '../ActivityMark';
 import { formatDurationBetween } from '../../lib/datetime';
 import type { ActivityReason } from '../../../shared/types';
 
@@ -40,20 +41,22 @@ export function formatActivityReasonText(reason: ActivityReason): string {
  * for the current activity state. Used as the body of a hover
  * tooltip on the TaskCard's activity indicator.
  *
- * Lucide icons map directly to reason kinds:
+ * Icons map directly to reason kinds. The two that describe agent activity itself come from
+ * the shared branding set (so they match the TaskCard indicator exactly); the rest name a
+ * specific cause and have no counterpart there, so they stay lucide:
+ *   idle             - ActivityMark 'agent-idle'    (matches the TaskCard idle indicator)
+ *   turn-active      - ActivityMark 'agent-working' (matches the TaskCard thinking indicator)
  *   tool             - Wrench
  *   subagent         - Users
  *   background-shell - Terminal
  *   permission       - Lock
- *   turn-active      - Loader2 (spinning)
- *   idle             - Mail (matches the existing TaskCard idle icon)
  */
 export function ActivityReasonTooltip({ reason }: { reason: ActivityReason }): ReactNode {
   switch (reason.kind) {
     case 'idle':
       return (
         <span className="inline-flex items-center gap-1.5 text-xs text-fg-faint">
-          <Mail size={12} className="text-attention" />
+          <ActivityMark mark="agent-idle" size={12} className="text-attention" />
           <span>Idle for {formatDurationBetween(reason.since, Date.now())}</span>
         </span>
       );
@@ -93,7 +96,7 @@ export function ActivityReasonTooltip({ reason }: { reason: ActivityReason }): R
     case 'turn-active':
       return (
         <span className="inline-flex items-center gap-1.5 text-xs text-fg-faint">
-          <Loader2 size={12} className="text-active animate-spin" />
+          <ActivityMark mark="agent-working" size={12} className="text-active" />
           <span>Thinking</span>
         </span>
       );

--- a/src/renderer/components/board/TaskCard.tsx
+++ b/src/renderer/components/board/TaskCard.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Loader2, CirclePause, Mail, Paperclip, Trash2 } from 'lucide-react';
+import { Loader2, CirclePause, Paperclip, Trash2 } from 'lucide-react';
 import { formatRelativeTime } from '../../lib/datetime';
 import { TaskChangesDialog } from '../dialogs/TaskChangesDialog';
 import { ConfirmDialog } from '../dialogs/ConfirmDialog';
@@ -17,6 +17,7 @@ import { useTaskProgress } from '../../utils/task-progress';
 import { isContextWindowKnown, contextWindowDisplayPercent } from '../../utils/format-tokens';
 import { requiresUserInteraction, isActive } from '../../../shared/activity-state';
 import { getProgressColor } from '../../utils/progress-color';
+import { ActivityMark } from '../ActivityMark';
 import { LabelPills } from '../Pill';
 import { PrLink } from '../PrLink';
 import type { Task } from '../../../shared/types';
@@ -276,22 +277,24 @@ const TaskCardInner = function TaskCard({ task, isDragOverlay, compact, onDelete
       >
         <div className="flex items-center gap-1.5">
           {isIdle && (
-            <Mail
-              size={14}
+            <ActivityMark
+              mark="agent-idle"
+              size={15}
               className="text-attention shrink-0"
               aria-label={activityReason ? formatActivityReasonText(activityReason) : 'Idle'}
             >
               {activityReason && <title>{formatActivityReasonText(activityReason)}</title>}
-            </Mail>
+            </ActivityMark>
           )}
           {isThinking && (
-            <Loader2
-              size={14}
-              className="text-active animate-spin shrink-0"
+            <ActivityMark
+              mark="agent-working"
+              size={15}
+              className="text-active shrink-0"
               aria-label={activityReason ? formatActivityReasonText(activityReason) : 'Thinking'}
             >
               {activityReason && <title>{formatActivityReasonText(activityReason)}</title>}
-            </Loader2>
+            </ActivityMark>
           )}
           <div className="text-sm text-fg font-medium truncate flex-1 min-w-0">{task.title}</div>
           {displayIdBadge}

--- a/src/renderer/components/command-bar/CommandTerminalIcon.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalIcon.tsx
@@ -1,24 +1,26 @@
 import React from 'react';
+import { ActivityMark, type ActivityMarkName } from '../ActivityMark';
 import type { CommandTerminalTone } from '../../stores/session-store/transient-session-slice';
 
 /**
- * The Command Terminal glyph: a custom terminal icon whose state lives IN the
- * glyph rather than in a separate corner badge. The stroke color is the aggregate
- * activity of a project's terminals (green while working / warm amber when one
- * needs you / muted rest, via the --kng-active / --kng-attention tokens), and the
- * working border MARCHES (a dash flows around the perimeter). The center morphs
- * from the shell prompt to a `+` when rendered for the "New terminal" button, so
- * that button reads as a terminal glyph (not a bare plus). 24 viewBox at
- * strokeWidth 2 to match the neighbouring lucide icons.
+ * The Command Terminal glyph: a terminal icon whose state lives IN the glyph rather than in a
+ * separate corner badge. The stroke color is the aggregate activity of a project's terminals
+ * (green while working / warm amber when one needs you / muted rest, via the --kng-active /
+ * --kng-attention tokens), and the working border MARCHES (a dash flows around the perimeter).
+ * The center morphs from the shell prompt to a `+` when rendered for the "New terminal" button,
+ * so that button reads as a terminal glyph (not a bare plus).
  *
- * A deliberate inline-SVG exception to the lucide-only icon convention
- * (`ui-conventions.md`): no lucide glyph carries a marching activity border, and
- * the prompt/plus morph is specific to this control.
+ * One of the three files `ui-conventions.md` exempts from the lucide-only / no-inline-SVG rule,
+ * and the only one that holds the exemption second-hand: it draws nothing itself, it wraps
+ * `ActivityMark`. The geometry comes from `@kangentic/branding`'s `terminal-*` marks.
+ * It was previously hand-authored here and was byte-identical to the packaged art (same rect,
+ * chevron, plus, and `65 35` dash), which is exactly the duplication the shared set exists to
+ * remove. This component stays as the app-facing wrapper because it owns the tone -> mark
+ * mapping and the `data-activity` / `data-plus` test contract.
  *
- * Shared by the title bar (20px, the project-wide toggle) and the project sidebar
- * (14px, per project row). Callers outside the title bar MUST pass their own
- * `testId`: the default belongs to the title-bar toggle, and reusing it would make
- * that button's test locators ambiguous.
+ * Shared by the title bar (20px, the project-wide toggle) and the project sidebar (14px, per
+ * project row). Callers outside the title bar MUST pass their own `testId`: the default belongs
+ * to the title-bar toggle, and reusing it would make that button's test locators ambiguous.
  */
 export function CommandTerminalIcon({
   tone,
@@ -37,47 +39,24 @@ export function CommandTerminalIcon({
   const isWorking = tone === 'thinking'; // activity-state-ok: presentational tone, not an ActivityState
   const needsAttention = tone === 'idle'; // activity-state-ok: presentational tone, not an ActivityState
   const colorClass = isWorking ? 'text-active' : needsAttention ? 'text-attention' : '';
+
+  // `showPlus` wins: the "New terminal" button is an ACTION, so it never marches. Rest and
+  // needs-you share the `terminal-idle` geometry and differ only in tone, which is why the
+  // packaged set ships no separate `-rest` mark.
+  const mark: ActivityMarkName = showPlus
+    ? 'terminal-new'
+    : isWorking
+      ? 'terminal-working'
+      : 'terminal-idle';
+
   return (
-    <svg
-      viewBox="0 0 24 24"
-      width={size}
-      height={size}
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
+    <ActivityMark
+      mark={mark}
+      size={size}
       className={colorClass}
       data-testid={testId}
       data-activity={tone}
       data-plus={showPlus ? 'true' : 'false'}
-      aria-hidden="true"
-    >
-      {/* Terminal screen border. While an agent works it marches (a dash flows
-          around the perimeter); pathLength normalizes the dash math to 100. */}
-      <rect
-        x="3"
-        y="3"
-        width="18"
-        height="18"
-        rx="3"
-        pathLength={100}
-        strokeDasharray={isWorking ? '65 35' : undefined}
-        className={isWorking ? 'animate-march-border' : undefined}
-      />
-      {showPlus ? (
-        // The add affordance, centered in the terminal (replaces the prompt).
-        <>
-          <path d="M12 8.5 V15.5" />
-          <path d="M8.5 12 H15.5" />
-        </>
-      ) : (
-        // The shell prompt: chevron + caret line.
-        <>
-          <path d="M7.5 9.5 L10.5 12 L7.5 14.5" />
-          <path d="M12.5 14.5 H16.5" />
-        </>
-      )}
-    </svg>
+    />
   );
 }

--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -19,7 +19,8 @@
 
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Circle, CircleStop, FolderOpen, FolderGit, GitBranch, GitCompare, Loader2, Maximize2, Minimize2, PictureInPicture2, SquareChevronRight, Zap } from 'lucide-react';
+import { CircleStop, FolderOpen, FolderGit, GitBranch, GitCompare, Loader2, Maximize2, Minimize2, PictureInPicture2, SquareChevronRight, Zap } from 'lucide-react';
+import { ActivityMark } from '../ActivityMark';
 import { BranchPicker } from '../dialogs/BranchPicker';
 import { LaunchOverlay } from '../LaunchOverlay';
 import { HeaderActionButton } from '../HeaderActionButton';
@@ -52,41 +53,26 @@ import { PanelErrorBoundary } from '../PanelErrorBoundary';
 const ChangesPanel = lazy(() => import('../dialogs/task-detail/changes/ChangesPanel').then((module) => ({ default: module.ChangesPanel })));
 
 /**
- * The centered stop glyph: one small rounded square, sized + colored to sit dead
- * center in the 20px activity ring (the stop counterpart to task-detail's
- * `PauseBars`). `colorClass` is a `bg-*` matching the ring.
- */
-function StopSquare({ colorClass }: { colorClass: string }): ReactNode {
-  return (
-    <span data-testid="stop-square" className="col-start-1 row-start-1 flex items-center justify-center">
-      <span className={`w-[8px] h-[8px] rounded-[2px] ${colorClass}`} />
-    </span>
-  );
-}
-
-/**
- * The Stop button glyph, carrying the same activity ring the task-detail header
- * folds into its pause button (`PauseButtonIcon`), but with a STOP square centered
- * instead of pause bars - the command terminal stops (kills the PTY); it never
- * pauses. Activity is encoded by the surrounding ring:
- *   - thinking (agent working): a spinning active ring around the stop square.
+ * The Stop button glyph, carrying the same activity ring the task-detail header folds into its
+ * pause button (`PauseButtonIcon`), but with a STOP square centered instead of pause bars - the
+ * command terminal stops (kills the PTY); it never pauses. Activity is encoded by the ring:
+ *   - thinking (agent working): a marching active ring around the stop square.
  *   - idle/permission (needs you): a static attention ring around the stop square.
  *   - not yet running / no activity: the plain red CircleStop (rest state).
+ *
+ * Ring and square are one packaged mark, so the hand-computed `47 16` dash that used to be
+ * duplicated here and in `TaskDetailHeader` is gone. See `PauseButtonIcon` for why 20 is the
+ * size that reproduces the old glyph exactly.
  */
 function StopButtonIcon({ isThinking, isIdle }: { isThinking: boolean; isIdle: boolean }): ReactNode {
-  if (isThinking) {
+  if (isThinking || isIdle) {
     return (
-      <span className="grid place-items-center">
-        <Circle size={20} className="col-start-1 row-start-1 text-active animate-spin [stroke-dasharray:47_16]" />
-        <StopSquare colorClass="bg-active" />
-      </span>
-    );
-  }
-  if (isIdle) {
-    return (
-      <span className="grid place-items-center">
-        <Circle size={20} className="col-start-1 row-start-1 text-attention" />
-        <StopSquare colorClass="bg-attention" />
+      <span className="grid place-items-center w-5 h-5">
+        <ActivityMark
+          mark={isThinking ? 'control-stop-working' : 'control-stop-idle'}
+          size={20}
+          className={isThinking ? 'text-active' : 'text-attention'}
+        />
       </span>
     );
   }

--- a/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
+++ b/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
@@ -1,10 +1,11 @@
 import { useState, useRef, useMemo, useEffect, type ReactNode } from 'react';
 import { useCopyDisplayId } from './useCopyDisplayId';
-import { X, Trash2, Pencil, Loader2, Circle, FolderGit2, FolderGit, GitPullRequest, GitCompare, ArrowRightLeft, ChevronRight, ChevronLeft, CirclePause, CirclePlay, Clock, SquareChevronRight, Zap, Archive, Inbox, Copy, Check, Globe, RefreshCw, PictureInPicture2, MessageSquare, AlignLeft } from 'lucide-react';
+import { X, Trash2, Pencil, Loader2, FolderGit2, FolderGit, GitPullRequest, GitCompare, ArrowRightLeft, ChevronRight, ChevronLeft, CirclePause, CirclePlay, Clock, SquareChevronRight, Zap, Archive, Inbox, Copy, Check, Globe, RefreshCw, PictureInPicture2, MessageSquare, AlignLeft } from 'lucide-react';
 import { usePopoverPosition } from '../../../hooks/usePopoverPosition';
 import { useFormattedCombo } from '../../../hooks/useKeybinding';
 import { getSwimlaneIcon } from '../../../utils/swimlane-icons';
 import { ICON_REGISTRY } from '../../../utils/swimlane-icons';
+import { ActivityMark } from '../../ActivityMark';
 import { HeaderActionButton } from '../../HeaderActionButton';
 import { IsolatedBadge } from '../../IsolatedBadge';
 import { KebabMenu, KebabMenuItem, KebabMenuDivider } from '../../KebabMenu';
@@ -19,22 +20,6 @@ import { captureTerminalScrollback } from '../../../utils/terminal-capture-regis
 import type { Task, AgentCommand, ShortcutConfig, Swimlane } from '../../../../shared/types';
 import { type TilePreset } from '../../../window-manager/tiling/presets';
 import { WindowLayoutMenu } from '../WindowLayoutMenu';
-
-/**
- * The centered pause: two short, thin upright bars overlaid on the ring.
- * Drawn as solid `bg-*` bars (not the stroked lucide `Pause`, which renders
- * ragged at this size) and sized to match the CirclePause proportions, so the
- * bars stay crisp and the icon reads cleanly at ~20px. `colorClass` is a
- * `bg-*` utility matching the ring (attention for idle, active for working).
- */
-function PauseBars({ colorClass }: { colorClass: string }): ReactNode {
-  return (
-    <span data-testid="pause-bars" className="col-start-1 row-start-1 flex items-center gap-[2px]">
-      <span className={`w-[2px] h-[8px] rounded-full ${colorClass}`} />
-      <span className={`w-[2px] h-[8px] rounded-full ${colorClass}`} />
-    </span>
-  );
-}
 
 /**
  * The pause/resume button glyph. The pause stays centered and visible for a
@@ -64,27 +49,22 @@ function PauseButtonIcon({
 }): ReactNode {
   if (toggling) return <Loader2 size={18} className="animate-spin" />;
 
-  // Active: the SAME Circle as idle (identical radius/size - lucide's Loader2 is
-  // radius 9 vs Circle's 10, which rendered ~10% smaller) but active-green, spinning,
-  // and dashed so the spin reads as a loading arc. The pause shares the grid cell
-  // (place-items-center) so it sits dead-center in the 20px ring.
-  if (isThinking) {
+  // Active and idle/permission share one packaged mark, differing only by color and motion
+  // (a marching dash vs a static ring), so the two states read as one visual language.
+  //
+  // Rendered at 20 in a 20px box, which is a pixel-for-pixel match for the lucide Circle +
+  // hand-drawn bars this replaced: the packaged control ring is r=10 on a 20-unit ink box, so
+  // 20 * (2*10+2)/24 draws the same 18.33px outer diameter, and its bars come out 2.0 x 8.0
+  // with a 2.0 gap against the old fixed 2 x 8 / 2. No size compensation is needed - and none
+  // should be reintroduced, since ring and bars are now one SVG that scales together.
+  if (isThinking || isIdle) {
     return (
-      <span className="grid place-items-center">
-        <Circle size={20} className="col-start-1 row-start-1 text-active animate-spin [stroke-dasharray:47_16]" />
-        <PauseBars colorClass="bg-active" />
-      </span>
-    );
-  }
-
-  // Idle/permission: the same ring + pause as active, but an attention static ring
-  // (a full circle, no spin) so the two states share one visual language and
-  // differ only by color and motion.
-  if (isIdle) {
-    return (
-      <span className="grid place-items-center">
-        <Circle size={20} className="col-start-1 row-start-1 text-attention" />
-        <PauseBars colorClass="bg-attention" />
+      <span className="grid place-items-center w-5 h-5">
+        <ActivityMark
+          mark={isThinking ? 'control-pause-working' : 'control-pause-idle'}
+          size={20}
+          className={isThinking ? 'text-active' : 'text-attention'}
+        />
       </span>
     );
   }

--- a/src/renderer/components/sidebar/project-sidebar/SidebarActivityCounts.tsx
+++ b/src/renderer/components/sidebar/project-sidebar/SidebarActivityCounts.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Loader2, Mail } from 'lucide-react';
+import { ActivityMark } from '../../ActivityMark';
 
 export interface SidebarActivityCountsProps {
   thinkingCount: number;
@@ -18,10 +18,14 @@ export const SidebarActivityCounts = React.memo(function SidebarActivityCounts({
   const hasIdle = idleCount > 0;
   if (!hasThinking && !hasIdle) return null;
 
-  // Match the row's sibling icons (project name text, kebab) and the task-card
-  // indicator at 14px: the lucide Mail/Loader2 glyphs smear at 11-12px because the
-  // 2px stroke scales down to a sub-pixel hairline.
-  const iconSize = size === 'group' ? 12 : 14;
+  // 15, the same size `TaskCard` renders these two marks at - one mark, one meaning, one size.
+  // Not 14, which is what the lucide glyphs used: the branding envelope is 18 wide where
+  // lucide's Mail was 20, so a same-number swap silently shrank it ~10%. 15 restores the drawn
+  // size production actually shipped (11.25 x 9.0px against the old 11.67 x 9.33).
+  //
+  // 12 is the floor: below it the 2px stroke scales to a sub-pixel hairline and smears, which
+  // is why the branding set declares `floors.indicator = 12`.
+  const iconSize = size === 'group' ? 12 : 15;
   const labelParts: string[] = [];
   if (hasIdle) labelParts.push(`${idleCount} idle`);
   if (hasThinking) labelParts.push(`${thinkingCount} thinking`);
@@ -36,7 +40,7 @@ export const SidebarActivityCounts = React.memo(function SidebarActivityCounts({
     >
       {hasIdle && (
         <span className="flex items-center gap-1" aria-hidden>
-          <Mail size={iconSize} className="text-attention flex-shrink-0" />
+          <ActivityMark mark="agent-idle" size={iconSize} className="text-attention flex-shrink-0" />
           <span
             className="flex items-center justify-center min-w-[1ch] font-semibold text-attention"
             style={countBoxStyle}
@@ -47,7 +51,7 @@ export const SidebarActivityCounts = React.memo(function SidebarActivityCounts({
       )}
       {hasThinking && (
         <span className="flex items-center gap-1" aria-hidden>
-          <Loader2 size={iconSize} className="text-active animate-spin flex-shrink-0" />
+          <ActivityMark mark="agent-working" size={iconSize} className="text-active flex-shrink-0" />
           <span
             className="flex items-center justify-center min-w-[1ch] font-semibold text-active"
             style={countBoxStyle}

--- a/src/renderer/components/sidebar/project-sidebar/SidebarCommandTerminalIndicator.tsx
+++ b/src/renderer/components/sidebar/project-sidebar/SidebarCommandTerminalIndicator.tsx
@@ -79,10 +79,12 @@ export const SidebarCommandTerminalIndicator = React.memo(function SidebarComman
       data-activity={tone}
       data-count={count}
     >
-      <CommandTerminalIcon size={14} tone={tone} testId={`project-terminal-icon-${projectId}`} />
+      {/* 15 to match SidebarActivityCounts' row size, so all three indicators stay one
+          tabular column. Change both together or the row goes ragged. */}
+      <CommandTerminalIcon size={15} tone={tone} testId={`project-terminal-icon-${projectId}`} />
       {/* The count always prints, even at 1. Suppressing it left a lone glyph in a row
           of icon+digit pairs, where it read as a count that had lost its number. */}
-      <span className="flex items-center justify-center min-w-[1ch] font-semibold" style={{ height: 14 }}>
+      <span className="flex items-center justify-center min-w-[1ch] font-semibold" style={{ height: 15 }}>
         {count}
       </span>
     </button>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -393,17 +393,11 @@
   z-index: 0;
 }
 
-/* Command Terminal activity: a dash marches around the terminal icon's own
-   square border while an agent is working (the square-fitting counterpart to the
-   circular spinner used by the task-detail / Stop buttons). `pathLength="100"` on
-   the rect normalizes the rounded-square perimeter to 100 units, so the dash math
-   is geometry-independent. */
-@keyframes march-border {
-  to { stroke-dashoffset: -100; }
-}
-.animate-march-border {
-  animation: march-border 1.4s linear infinite;
-}
+/* The activity marks' marching-border animation used to live here as
+   `@keyframes march-border` / `.animate-march-border`. It now ships with the marks themselves,
+   in `@kangentic/branding/assets/activity/activity.css` (`kng-activity-march` / `.kng-march`,
+   same 1.4s linear dashoffset), imported by `components/ActivityMark.tsx` - so the keyframe
+   and the geometry it animates can no longer drift apart. */
 
 /* xterm: fill parent height so scrollbar is flush with bottom edge.
    xterm.js creates a .xterm child div that is content-sized (rows * cellHeight)

--- a/tests/ui/activity-marks.spec.ts
+++ b/tests/ui/activity-marks.spec.ts
@@ -1,0 +1,237 @@
+/**
+ * UI coverage for the @kangentic/branding activity marks (`components/ActivityMark.tsx`).
+ *
+ * The per-feature specs (task-activity-indicators, command-terminal, sidebar-command-terminals)
+ * already assert WHICH mark each state renders. This file covers the three things that are
+ * properties of the packaged set itself, and that fail silently everywhere else:
+ *
+ *  1. The packaged `activity.css` reaches the renderer's cascade. `.kng-march` is an unscoped
+ *     global arriving from node_modules, so a mark can render perfectly and simply never move.
+ *     No `data-mark` assertion catches that.
+ *  2. The marks render at the size their call site asked for. The packaged SVGs carry a
+ *     hardcoded `width="24" height="24"`, so a regression in ActivityMark's root would silently
+ *     paint every indicator at 24px.
+ *  3. `prefers-reduced-motion` is honored, including the `drop-dash` strategy that needs
+ *     `data-rest` to survive into the DOM.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-mark-test';
+const TASK_ID = 'task-mark-test';
+const SESSION_ID = 'sess-mark-test';
+const TRANSIENT_SESSION_ID = 'sess-mark-terminal';
+
+/**
+ * `transientActivity` seeds a running Command Terminal PTY in that state, which is what makes the
+ * title-bar toggle render a `terminal-*` mark. Omit it and the toggle sits at `terminal-idle`.
+ */
+function preConfig(activity: string, transientActivity?: string): string {
+  const transientSession = transientActivity
+    ? `
+      state.sessions.push({
+        id: '${TRANSIENT_SESSION_ID}', taskId: 'task-${TRANSIENT_SESSION_ID}',
+        projectId: '${PROJECT_ID}', pid: 8888, status: 'running', shell: 'bash',
+        cwd: '/mock/mark-test', startedAt: ts, exitCode: null, transient: true,
+      });
+      state.activityCache['${TRANSIENT_SESSION_ID}'] = '${transientActivity}';
+      `
+    : '';
+  return `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+      state.projects.push({
+        id: '${PROJECT_ID}', name: 'Mark Test', path: '/mock/mark-test',
+        github_url: null, default_agent: 'claude', last_opened: ts, created_at: ts,
+      });
+      state.DEFAULT_SWIMLANES.forEach(function (swimlane, index) {
+        state.swimlanes.push({
+          id: 'lane-mark-' + index, name: swimlane.name, role: swimlane.role, color: swimlane.color,
+          icon: swimlane.icon, is_archived: swimlane.is_archived,
+          permission_strategy: swimlane.permission_strategy ?? null,
+          auto_spawn: swimlane.auto_spawn ?? false, position: index, created_at: ts,
+        });
+      });
+      var execLane = state.swimlanes.find(function (swimlane) { return swimlane.name === 'Executing'; });
+      state.sessions.push({
+        id: '${SESSION_ID}', taskId: '${TASK_ID}', projectId: '${PROJECT_ID}', pid: 9999,
+        status: 'running', shell: 'bash', cwd: '/mock/mark-test',
+        startedAt: ts, exitCode: null,
+      });
+      state.activityCache['${SESSION_ID}'] = '${activity}';
+      ${transientSession}
+      state.tasks.push({
+        id: '${TASK_ID}', title: 'Mark Test Task', description: '',
+        swimlane_id: execLane.id, position: 0, agent: 'claude',
+        model_override: null, effort_override: null, session_id: '${SESSION_ID}',
+        worktree_path: null, branch_name: null, pr_number: null, pr_url: null,
+        base_branch: null, archived_at: null, created_at: ts, updated_at: ts,
+      });
+      return { currentProjectId: '${PROJECT_ID}' };
+    });
+  `;
+}
+
+async function launch(
+  activity: string,
+  reducedMotion?: 'reduce',
+  transientActivity?: string,
+): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1600, height: 1000 }, reducedMotion });
+  const page = await context.newPage();
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(preConfig(activity, transientActivity));
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  return { browser, page };
+}
+
+/**
+ * Every computed-style read below goes through `expect.poll`, NOT a one-shot `locator.evaluate`.
+ *
+ * `evaluate` resolves the element and then runs the callback; if the board re-renders in that
+ * gap the handle is detached, and `getComputedStyle` on a detached node returns `''` for every
+ * property rather than throwing - so the assertion fails with an empty string instead of
+ * retrying. The bare-`evaluate` form failed roughly one run in four at the UI tier's 3 workers
+ * while passing 12/12 at `--workers=1`: exactly the load-dependent shape that is green locally
+ * and red on CI. Polling re-resolves the element on each attempt.
+ */
+
+test.describe('Activity marks', () => {
+  test('the packaged activity.css reaches the cascade and drives the march', async () => {
+    const { browser, page } = await launch('thinking');
+    try {
+      const mark = page.locator(`[data-task-id="${TASK_ID}"] [data-mark="agent-working"]`);
+      await expect(mark).toBeVisible({ timeout: 15000 });
+
+      await expect
+        .poll(
+          () => mark.locator('.kng-march').evaluate((node) => {
+            const style = getComputedStyle(node);
+            return {
+              name: style.animationName,
+              duration: style.animationDuration,
+              timing: style.animationTimingFunction,
+              iteration: style.animationIterationCount,
+            };
+          }),
+          {
+            message:
+              'activity.css did not reach the cascade: .kng-march resolved to no animation, so every working mark is frozen',
+          },
+        )
+        .toEqual({
+          name: 'kng-activity-march',
+          duration: '1.4s',
+          timing: 'linear',
+          iteration: 'infinite',
+        });
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('marks render at their call site size, not the packaged 24px', async () => {
+    // Computed style, not boundingBox: the task-detail window carries a scale transform, so
+    // every measured rect inside it is uniformly smaller than its layout size.
+    const { browser, page } = await launch('thinking');
+    try {
+      // 15, not 14: the branding envelope is 18 wide where lucide's Mail was 20, so keeping the
+      // old number would have shrunk the drawn mark ~10% against what production shipped.
+      const cardMark = page.locator(`[data-task-id="${TASK_ID}"] [data-mark="agent-working"]`);
+      await expect(cardMark).toBeVisible({ timeout: 15000 });
+      await expect
+        .poll(() => cardMark.evaluate((node) => getComputedStyle(node).width))
+        .toBe('15px');
+
+      await page.locator('text=Mark Test Task').first().click();
+      const dialog = page.locator('[data-testid="task-detail-dialog"]');
+      await dialog.waitFor({ state: 'visible', timeout: 5000 });
+      const pauseButton = dialog.locator('button[title="Pause session"]');
+      const ring = pauseButton.locator('[data-mark="control-pause-working"]');
+      await expect(ring).toBeVisible({ timeout: 10000 });
+
+      // The control mark is r=10, so 20 * (2*10+2)/24 = 18.33px of drawn ring - a pixel match
+      // for the lucide Circle it replaced. No size compensation, and none should come back.
+      await expect
+        .poll(() => ring.evaluate((node) => getComputedStyle(node).width), {
+          message: 'control marks must render at 20 to match the lucide Circle they replaced',
+        })
+        .toBe('20px');
+
+      // The slot is pinned so the button does not resize as the activity state flips.
+      await expect
+        .poll(
+          () => pauseButton.locator('span.grid').first()
+            .evaluate((node) => getComputedStyle(node).width),
+          { message: 'the icon slot must stay 20px' },
+        )
+        .toBe('20px');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('a static mark carries no marching group at all', async () => {
+    const { browser, page } = await launch('idle');
+    try {
+      const mark = page.locator(`[data-task-id="${TASK_ID}"] [data-mark="agent-idle"]`);
+      await expect(mark).toBeVisible({ timeout: 15000 });
+      await expect(mark).toHaveAttribute('data-rest', 'static');
+      await expect(mark.locator('.kng-march')).toHaveCount(0);
+      // The idle branch carries its own `size={15}` literal in TaskCard, separate from the
+      // thinking branch the size test above measures, so it can regress on its own.
+      await expect
+        .poll(() => mark.evaluate((node) => getComputedStyle(node).width))
+        .toBe('15px');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('prefers-reduced-motion stops the march and drops the drop-dash dash', async () => {
+    // The transient terminal is seeded 'thinking' on purpose. `terminal-working` is the ONLY
+    // mark that declares `drop-dash`, and it renders only when a running transient PTY is
+    // active: `selectCommandTerminalSummary` counts `transient && running` sessions, so the
+    // task's own (non-transient) session never drives the toggle no matter what its activity
+    // is. Without this the toggle sits at `terminal-idle` / `static` and the dash assertion
+    // below has nothing to check.
+    const { browser, page } = await launch('thinking', 'reduce', 'thinking');
+    try {
+      const mark = page.locator(`[data-task-id="${TASK_ID}"] [data-mark="agent-working"]`);
+      await expect(mark).toBeVisible({ timeout: 15000 });
+      await expect
+        .poll(
+          () => mark.locator('.kng-march').evaluate((node) => getComputedStyle(node).animationName),
+          { message: 'prefers-reduced-motion should disable the march' },
+        )
+        .toBe('none');
+
+      // Under reduced motion a `drop-dash` mark must lose its dash outright, not merely freeze
+      // it mid-gap. That rule is `svg[data-rest="drop-dash"] *`, so it only fires if `data-rest`
+      // survives the packaged-wrapper strip into the React-authored root.
+      const terminalMark = page.getByTestId('quick-session-icon');
+      await expect(terminalMark).toHaveAttribute('data-mark', 'terminal-working', { timeout: 10000 });
+      await expect(terminalMark).toHaveAttribute('data-rest', 'drop-dash');
+      await expect
+        .poll(
+          () => terminalMark.locator('rect').first()
+            .evaluate((node) => getComputedStyle(node).strokeDasharray),
+          { message: 'a drop-dash mark should lose its dash under reduced motion' },
+        )
+        .toBe('none');
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/ui/command-terminal.spec.ts
+++ b/tests/ui/command-terminal.spec.ts
@@ -642,6 +642,10 @@ test.describe('Command Terminal', () => {
         // The icon should reflect that, whether or not the bar is open.
         // Poll to allow the activity store to hydrate.
         await expect(icon).toHaveAttribute('data-activity', 'idle', { timeout: 5000 });
+        // Needs-you renders the static geometry. The branding set ships no `-rest` mark by
+        // design (rest is the `-idle` geometry in a muted tone), so both the 'idle' and 'rest'
+        // tones land on terminal-idle and only the color differs - pin that here.
+        await expect(icon).toHaveAttribute('data-mark', 'terminal-idle');
 
         // Open overlay and close it - session stays alive
         await sharedPage.keyboard.press('Control+Shift+P');
@@ -1140,11 +1144,17 @@ test.describe('Command Terminal', () => {
         const toggleIcon = page.getByTestId('quick-session-icon');
         await expect(toggleIcon).toHaveAttribute('data-activity', 'thinking', { timeout: 3000 });
         await expect(toggleIcon).toHaveClass(/text-active/);
+        // Tone and geometry must agree. CommandTerminalIcon maps tone -> mark itself, so without
+        // this pairing a 'thinking' tone could render the static mark (or vice versa) and every
+        // data-activity and data-mark assertion elsewhere would still pass.
+        await expect(toggleIcon).toHaveAttribute('data-mark', 'terminal-working');
 
         // The "New terminal" icon must stay uncolored and report 'rest' regardless.
         const newTerminalIcon = page.getByTestId('quick-session-new-terminal-icon');
         await expect(newTerminalIcon).toHaveAttribute('data-activity', 'rest');
         await expect(newTerminalIcon).toHaveAttribute('data-plus', 'true');
+        // showPlus wins over tone: the action mark, which never marches.
+        await expect(newTerminalIcon).toHaveAttribute('data-mark', 'terminal-new');
         await expect(newTerminalIcon).not.toHaveClass(/text-active/);
         await expect(newTerminalIcon).not.toHaveClass(/text-attention/);
       } finally {
@@ -1957,9 +1967,13 @@ test.describe('Command Terminal', () => {
   // Stop activity ring - the Stop button in CommandTerminalWindow carries the
   // same ring affordance as the task-detail pause button, but with a stop square
   // instead of pause bars. Three ring states:
-  //   thinking (isActive)          -> spinning active Circle + active stop-square
-  //   idle/permission (requiresUI) -> static attention Circle + attention stop-square
-  //   no session / not running     -> plain CircleStop, no stop-square
+  //   thinking (isActive)          -> the control-stop-working mark, tinted text-active
+  //   idle/permission (requiresUI) -> the control-stop-idle mark, tinted text-attention
+  //   no session / not running     -> plain lucide CircleStop, no mark at all
+  //
+  // Ring and square are ONE packaged @kangentic/branding mark, so `data-mark` carries both
+  // "a ring is showing" and "which state it is": there is no separate stop-square element to
+  // assert, and no animate-spin class (the working mark marches via .kng-march instead).
   //
   // Each test uses a deterministic spawnTransient override (known session id) so
   // page.evaluate can call updateActivity + markFirstOutput on that exact id
@@ -2047,10 +2061,10 @@ test.describe('Command Terminal', () => {
       // We assert the activity-specific state in each individual test instead.
     }
 
-    test('thinking activity shows spinning active ring and active stop-square', async () => {
+    test('thinking activity shows the marching active stop ring', async () => {
       // Derives expected behavior from the contract in CommandTerminalWindow.tsx:
       //   isThinking = sessionRunning && isActive(activity)
-      //   -> spinning Circle with text-active animate-spin, plus StopSquare bg-active
+      //   -> the control-stop-working mark, tinted text-active
       const { browser, page } = await launchWithState(
         ringBasePreConfig() + deterministicSpawn
       );
@@ -2071,32 +2085,24 @@ test.describe('Command Terminal', () => {
 
         const stopButton = page.getByTestId('command-bar-terminate-button');
 
-        // stop-square must be present (the StopSquare inner span inside the ring)
-        await expect(stopButton.getByTestId('stop-square')).toBeVisible({ timeout: 3000 });
+        // The working mark: ring + stop square in one SVG, tinted active-green.
+        const ring = stopButton.locator('[data-mark="control-stop-working"]');
+        await expect(ring).toBeVisible({ timeout: 3000 });
+        await expect(ring).toHaveClass(/text-active/);
 
-        // The stop-square inner span carries bg-active for thinking
-        const squareInner = stopButton.getByTestId('stop-square').locator('span');
-        await expect(squareInner).toHaveClass(/bg-active/);
-
-        // The animated active ring (Circle svg) must also be present
-        // lucide-circle is the CSS class Lucide attaches to the Circle component
-        await expect(stopButton.locator('.lucide-circle')).toBeVisible();
-        const ringCircle = stopButton.locator('.lucide-circle');
-        await expect(ringCircle).toHaveClass(/text-active/);
-        await expect(ringCircle).toHaveClass(/animate-spin/);
-
-        // The plain rest-state icon (CircleStop) must NOT be present when thinking
+        // Neither the idle ring nor the plain rest-state icon may be present when thinking.
+        await expect(stopButton.locator('[data-mark="control-stop-idle"]')).toHaveCount(0);
         await expect(stopButton.locator('.lucide-circle-stop')).toHaveCount(0);
       } finally {
         await browser.close();
       }
     });
 
-    test('idle activity shows static attention ring and attention stop-square', async () => {
+    test('idle activity shows the static attention stop ring', async () => {
       // Derives expected behavior from the contract in CommandTerminalWindow.tsx:
       //   isIdle = sessionRunning && requiresUserInteraction(activity)
       //   requiresUserInteraction('idle') = true (ACTIVITY_DISPOSITION idle -> 'idle')
-      //   -> static Circle with text-attention (no animate-spin), plus StopSquare bg-attention
+      //   -> the control-stop-idle mark, tinted text-attention, with no march
       const { browser, page } = await launchWithState(
         ringBasePreConfig() + deterministicSpawn
       );
@@ -2117,20 +2123,14 @@ test.describe('Command Terminal', () => {
 
         const stopButton = page.getByTestId('command-bar-terminate-button');
 
-        // stop-square must be present for idle state
-        await expect(stopButton.getByTestId('stop-square')).toBeVisible({ timeout: 3000 });
+        // The idle mark: ring + stop square in one SVG, tinted attention-amber.
+        const ring = stopButton.locator('[data-mark="control-stop-idle"]');
+        await expect(ring).toBeVisible({ timeout: 3000 });
+        await expect(ring).toHaveClass(/text-attention/);
 
-        // The stop-square inner span carries bg-attention for idle
-        const squareInner = stopButton.getByTestId('stop-square').locator('span');
-        await expect(squareInner).toHaveClass(/bg-attention/);
-
-        // The static attention ring (Circle svg) must be present and NOT spinning
-        await expect(stopButton.locator('.lucide-circle')).toBeVisible();
-        const ringCircle = stopButton.locator('.lucide-circle');
-        await expect(ringCircle).toHaveClass(/text-attention/);
-        // Idle ring is static: no animate-spin class
-        const ringClass = await ringCircle.getAttribute('class');
-        expect(ringClass).not.toContain('animate-spin');
+        // Idle is static. The marching variant is a DIFFERENT mark, so its absence is the
+        // assertion - there is no motion class to check on the idle one.
+        await expect(stopButton.locator('[data-mark="control-stop-working"]')).toHaveCount(0);
 
         // The plain rest-state icon (CircleStop) must NOT be present when idle
         await expect(stopButton.locator('.lucide-circle-stop')).toHaveCount(0);
@@ -2164,18 +2164,12 @@ test.describe('Command Terminal', () => {
 
         const stopButton = page.getByTestId('command-bar-terminate-button');
 
-        // stop-square must be present for permission state
-        await expect(stopButton.getByTestId('stop-square')).toBeVisible({ timeout: 3000 });
-
-        // The stop-square inner span carries bg-attention for permission (same as idle)
-        const squareInner = stopButton.getByTestId('stop-square').locator('span');
-        await expect(squareInner).toHaveClass(/bg-attention/);
-
-        // Static attention ring (no spin) - permission maps to idle disposition
-        await expect(stopButton.locator('.lucide-circle')).toBeVisible();
-        const ringClass = await stopButton.locator('.lucide-circle').getAttribute('class');
-        expect(ringClass).toContain('text-attention');
-        expect(ringClass).not.toContain('animate-spin');
+        // Static attention ring - permission maps to the idle disposition, so it renders the
+        // SAME mark as idle, not the marching one.
+        const ring = stopButton.locator('[data-mark="control-stop-idle"]');
+        await expect(ring).toBeVisible({ timeout: 3000 });
+        await expect(ring).toHaveClass(/text-attention/);
+        await expect(stopButton.locator('[data-mark="control-stop-working"]')).toHaveCount(0);
 
         // No plain CircleStop for permission state
         await expect(stopButton.locator('.lucide-circle-stop')).toHaveCount(0);
@@ -2184,7 +2178,7 @@ test.describe('Command Terminal', () => {
       }
     });
 
-    test('no active session shows plain CircleStop (no stop-square, no ring)', async () => {
+    test('no active session shows plain CircleStop (no activity mark at all)', async () => {
       // When the session has not yet started (terminalReady=false, so sessionRunning=false),
       // or activity is undefined, StopButtonIcon renders the rest-state <CircleStop>.
       // This test opens the overlay WITHOUT calling markFirstOutput, so terminalReady
@@ -2210,11 +2204,11 @@ test.describe('Command Terminal', () => {
         // Plain rest-state icon must be present
         await expect(stopButton.locator('.lucide-circle-stop')).toBeVisible({ timeout: 3000 });
 
-        // No ring (no stop-square, no spinning/static Circle ring)
+        // No activity mark of either state.
         // Intentional fixed wait: we cannot poll for non-occurrence.
         // 800ms is enough for any pending microtask queue to flush.
         await page.waitForTimeout(800);
-        await expect(stopButton.getByTestId('stop-square')).toHaveCount(0);
+        await expect(stopButton.locator('[data-mark^="control-stop-"]')).toHaveCount(0);
       } finally {
         await browser.close();
       }

--- a/tests/ui/sidebar-command-terminals.spec.ts
+++ b/tests/ui/sidebar-command-terminals.spec.ts
@@ -298,6 +298,20 @@ test.describe('Sidebar Command Terminal indicator', () => {
       // ...while the terminal indicator sits beside it with its own tone.
       const indicator = alphaRow.locator(`[data-testid="project-terminals-${PROJECT_A_ID}"]`);
       await expect(indicator).toHaveAttribute('data-activity', 'thinking');
+
+      // The agent counts and the terminal indicator are separate components that size
+      // themselves independently, so pin that they AGREE: a row with one glyph at 15 and its
+      // neighbour at 14 goes visibly ragged, and nothing else would catch it. Asserted as a
+      // relationship rather than a literal, so a deliberate resize only has to move both.
+      const agentMark = alphaRow.locator('[data-mark="agent-idle"]');
+      await expect(agentMark).toBeVisible();
+      const agentMarkSize = await agentMark.getAttribute('width');
+      expect(agentMarkSize).toBeTruthy();
+      const terminalIcon = alphaRow.locator(`[data-testid="project-terminal-icon-${PROJECT_A_ID}"]`);
+      expect(
+        await terminalIcon.getAttribute('width'),
+        'the sidebar agent marks and the terminal glyph must render at the same size',
+      ).toBe(agentMarkSize);
     } finally {
       await browser.close();
     }
@@ -446,18 +460,20 @@ test.describe('Sidebar Command Terminal indicator', () => {
     }
   });
 
-  test('the sidebar renders the terminal icon at 14px, not the title bar\'s default 20px', async () => {
+  test('the sidebar renders the terminal icon at 15px, not the title bar\'s default 20px', async () => {
     // CommandTerminalIcon defaults size to 20 (the title bar toggle); the
-    // sidebar passes size={14} explicitly. Pins that the prop is actually
-    // threaded through rather than the icon silently rendering at the default.
+    // sidebar passes size={15} explicitly. Pins that the prop is actually
+    // threaded through rather than the icon silently rendering at the default,
+    // and that it stays in step with SidebarActivityCounts' row size so the
+    // three indicators keep forming one tabular column.
     const { browser, page } = await launchWithState(preConfig({
       terminals: [{ project: PROJECT_A_ID, id: 'ct-a1', activity: 'idle' }],
     }));
 
     try {
       const icon = page.locator(`[data-testid="project-terminal-icon-${PROJECT_A_ID}"]`);
-      await expect(icon).toHaveAttribute('width', '14');
-      await expect(icon).toHaveAttribute('height', '14');
+      await expect(icon).toHaveAttribute('width', '15');
+      await expect(icon).toHaveAttribute('height', '15');
     } finally {
       await browser.close();
     }

--- a/tests/ui/task-activity-indicators.spec.ts
+++ b/tests/ui/task-activity-indicators.spec.ts
@@ -162,8 +162,8 @@ test.describe('Task Activity Indicators', () => {
       // After activity sync, idle activity shows mail icon (no spinner)
       const title = page.locator('text=Test Initializing Task').first();
       const titleRow = title.locator('..');
-      await expect(titleRow.locator('.lucide-loader-circle')).not.toBeVisible({ timeout: 10000 });
-      await expect(titleRow.locator('.lucide-mail')).toBeVisible({ timeout: 10000 });
+      await expect(titleRow.locator('[data-mark="agent-working"]')).not.toBeVisible({ timeout: 10000 });
+      await expect(titleRow.locator('[data-mark="agent-idle"]')).toBeVisible({ timeout: 10000 });
     });
 
     test('running idle with events but no usage shows mail icon and usage bar', async () => {
@@ -177,8 +177,8 @@ test.describe('Task Activity Indicators', () => {
 
         const title = eventPage.locator('text=Test Initializing Task').first();
         const titleRow = title.locator('..');
-        await expect(titleRow.locator('.lucide-loader-circle')).not.toBeVisible({ timeout: 10000 });
-        await expect(titleRow.locator('.lucide-mail')).toBeVisible({ timeout: 10000 });
+        await expect(titleRow.locator('[data-mark="agent-working"]')).not.toBeVisible({ timeout: 10000 });
+        await expect(titleRow.locator('[data-mark="agent-idle"]')).toBeVisible({ timeout: 10000 });
       } finally {
         await eventBrowser.close();
       }
@@ -196,8 +196,8 @@ test.describe('Task Activity Indicators', () => {
         // Thinking activity: spinner icon in title row
         const title = thinkPage.locator('text=Test Initializing Task').first();
         const titleRow = title.locator('..');
-        await expect(titleRow.locator('.lucide-loader-circle')).toBeVisible();
-        await expect(titleRow.locator('.lucide-mail')).not.toBeVisible();
+        await expect(titleRow.locator('[data-mark="agent-working"]')).toBeVisible();
+        await expect(titleRow.locator('[data-mark="agent-idle"]')).not.toBeVisible();
       } finally {
         await thinkBrowser.close();
       }
@@ -225,8 +225,8 @@ test.describe('Task Activity Indicators', () => {
       await expect(card).toBeVisible();
 
       const titleRow = card.locator('..');
-      await expect(titleRow.locator('.lucide-mail')).toBeVisible();
-      await expect(titleRow.locator('.lucide-loader-circle')).not.toBeVisible();
+      await expect(titleRow.locator('[data-mark="agent-idle"]')).toBeVisible();
+      await expect(titleRow.locator('[data-mark="agent-working"]')).not.toBeVisible();
 
       const cardEl = page.locator(`[data-task-id="${TASK_ID}"]`);
       await expect(cardEl.locator('[data-testid="usage-bar"]')).toBeVisible();
@@ -352,7 +352,7 @@ test.describe('Task Activity Indicators', () => {
       await expect(card).toBeVisible();
 
       const titleRow = card.locator('..');
-      await expect(titleRow.locator('.lucide-loader-circle')).not.toBeVisible();
+      await expect(titleRow.locator('[data-mark="agent-working"]')).not.toBeVisible();
       await expect(page.locator('[data-testid="status-bar"]')).not.toBeVisible();
     });
 
@@ -368,8 +368,8 @@ test.describe('Task Activity Indicators', () => {
         await expect(card).toBeVisible();
 
         const titleRow = card.locator('..');
-        await expect(titleRow.locator('.lucide-loader-circle')).not.toBeVisible();
-        await expect(titleRow.locator('.lucide-mail')).not.toBeVisible();
+        await expect(titleRow.locator('[data-mark="agent-working"]')).not.toBeVisible();
+        await expect(titleRow.locator('[data-mark="agent-idle"]')).not.toBeVisible();
         await expect(stalePage.locator('[data-testid="status-bar"]')).not.toBeVisible();
       } finally {
         await staleBrowser.close();
@@ -398,8 +398,8 @@ test.describe('Task Activity Indicators', () => {
       await expect(card).toBeVisible();
 
       const titleRow = card.locator('..');
-      await expect(titleRow.locator('.lucide-mail')).not.toBeVisible();
-      await expect(titleRow.locator('.lucide-loader-circle')).not.toBeVisible();
+      await expect(titleRow.locator('[data-mark="agent-idle"]')).not.toBeVisible();
+      await expect(titleRow.locator('[data-mark="agent-working"]')).not.toBeVisible();
     });
 
     test('suspended task shows "Paused" bottom bar with pause icon', async () => {
@@ -458,7 +458,7 @@ test.describe('Task Activity Indicators', () => {
       await expect(bottomBar.locator('.lucide-loader-circle')).toBeVisible();
 
       const titleRow = card.locator('text=Test Initializing Task').first().locator('..');
-      await expect(titleRow.locator('.lucide-mail')).not.toBeVisible();
+      await expect(titleRow.locator('[data-mark="agent-idle"]')).not.toBeVisible();
     });
   });
 
@@ -722,8 +722,11 @@ test.describe('Task Activity Indicators', () => {
         // Human-readable pill text
         await expect(usageBar).toContainText('Telemetry: TUI only');
 
-        // No spinner -- the indefinite Loader2 must be absent
-        await expect(usageBar.locator('.lucide-loader-2')).toHaveCount(0);
+        // No spinner - the indefinite Loader2 must be absent. Asserted on
+        // `.lucide-loader-circle`, the class lucide actually emits: `Loader2` is an alias for
+        // `LoaderCircle`, so the old `.lucide-loader-2` selector matched nothing and this
+        // assertion passed no matter what rendered.
+        await expect(usageBar.locator('.lucide-loader-circle')).toHaveCount(0);
 
         // No "Starting agent..." or "Resuming agent..." copy
         await expect(usageBar).not.toContainText('Starting agent...');
@@ -759,8 +762,8 @@ test.describe('Task Activity Indicators', () => {
         await expect(page.locator('[data-testid="usage-bar"]').first()).toBeVisible({ timeout: 10000 });
 
         const titleRow = page.locator('text=Test Initializing Task').first().locator('..');
-        await expect(titleRow.locator('.lucide-mail')).toBeVisible({ timeout: 10000 });
-        await expect(titleRow.locator('.lucide-loader-circle')).not.toBeVisible();
+        await expect(titleRow.locator('[data-mark="agent-idle"]')).toBeVisible({ timeout: 10000 });
+        await expect(titleRow.locator('[data-mark="agent-working"]')).not.toBeVisible();
       } finally {
         await browser.close();
       }
@@ -1247,10 +1250,10 @@ test.describe('Task Activity Indicators', () => {
         const titleRow = page.locator('text=Test Initializing Task').first().locator('..');
 
         // permission maps to isIdle=true: Mail icon appears (amber, "needs attention")
-        await expect(titleRow.locator('.lucide-mail')).toBeVisible({ timeout: 10000 });
+        await expect(titleRow.locator('[data-mark="agent-idle"]')).toBeVisible({ timeout: 10000 });
 
         // Spinner must NOT appear - permission is not a thinking state
-        await expect(titleRow.locator('.lucide-loader-circle')).not.toBeVisible();
+        await expect(titleRow.locator('[data-mark="agent-working"]')).not.toBeVisible();
       } finally {
         await browser.close();
       }
@@ -1298,7 +1301,7 @@ test.describe('Task Activity Indicators', () => {
         const titleRow = page.locator('text=Test Initializing Task').first().locator('..');
 
         // Confirm we start in permission (mail icon visible)
-        await expect(titleRow.locator('.lucide-mail')).toBeVisible({ timeout: 10000 });
+        await expect(titleRow.locator('[data-mark="agent-idle"]')).toBeVisible({ timeout: 10000 });
 
         // Push activity update: permission -> thinking (simulates engine re-arming turnActive)
         await page.evaluate((sessionId) => {
@@ -1309,10 +1312,10 @@ test.describe('Task Activity Indicators', () => {
         }, SESSION_ID);
 
         // Spinner must appear (thinking is now active)
-        await expect(titleRow.locator('.lucide-loader-circle')).toBeVisible({ timeout: 5000 });
+        await expect(titleRow.locator('[data-mark="agent-working"]')).toBeVisible({ timeout: 5000 });
 
         // Mail icon must be absent in the thinking state (no idle flash)
-        await expect(titleRow.locator('.lucide-mail')).not.toBeVisible();
+        await expect(titleRow.locator('[data-mark="agent-idle"]')).not.toBeVisible();
       } finally {
         await browser.close();
       }
@@ -1352,9 +1355,10 @@ test.describe('Task Activity Indicators', () => {
 
         const pauseButton = dialog.locator('button[title="Pause session"]');
         await expect(pauseButton).toBeVisible({ timeout: 10000 });
-        // Active: a spinning ring (animate-spin) + the centered pause.
-        await expect(pauseButton.locator('.lucide-circle.animate-spin')).toBeVisible();
-        await expect(pauseButton.locator('[data-testid="pause-bars"]')).toBeVisible();
+        // Active: the marching ring with the pause centered inside it. Ring and bars are one
+        // packaged mark now, so the mark's identity carries both facts.
+        await expect(pauseButton.locator('[data-mark="control-pause-working"]')).toBeVisible();
+        await expect(pauseButton.locator('[data-mark="control-pause-idle"]')).toHaveCount(0);
       } finally {
         await browser.close();
       }
@@ -1370,10 +1374,9 @@ test.describe('Task Activity Indicators', () => {
 
         const pauseButton = dialog.locator('button[title="Pause session"]');
         await expect(pauseButton).toBeVisible({ timeout: 10000 });
-        // Idle: a static amber ring + the centered pause; the ring does not spin.
-        await expect(pauseButton.locator('.lucide-circle')).toBeVisible();
-        await expect(pauseButton.locator('[data-testid="pause-bars"]')).toBeVisible();
-        await expect(pauseButton.locator('.lucide-circle.animate-spin')).toHaveCount(0);
+        // Idle: the static amber ring + the centered pause; the ring does not march.
+        await expect(pauseButton.locator('[data-mark="control-pause-idle"]')).toBeVisible();
+        await expect(pauseButton.locator('[data-mark="control-pause-working"]')).toHaveCount(0);
       } finally {
         await browser.close();
       }
@@ -1389,11 +1392,11 @@ test.describe('Task Activity Indicators', () => {
 
         const pauseButton = dialog.locator('button[title="Pause session"]');
         await expect(pauseButton).toBeVisible({ timeout: 10000 });
-        // Permission maps to idle: a static amber ring, never the spinner.
-        await expect(pauseButton.locator('.lucide-circle')).toBeVisible();
-        await expect(pauseButton.locator('.lucide-circle.animate-spin')).toHaveCount(0);
+        // Permission maps to idle: the static amber ring, never the marching one.
+        await expect(pauseButton.locator('[data-mark="control-pause-idle"]')).toBeVisible();
+        await expect(pauseButton.locator('[data-mark="control-pause-working"]')).toHaveCount(0);
 
-        // Drive permission -> thinking; the static ring becomes the spinning ring.
+        // Drive permission -> thinking; the static ring becomes the marching ring.
         await page.evaluate((sessionId) => {
           const stores = (window as unknown as {
             __zustandStores: { session: { getState: () => { updateActivity: (id: string, state: string) => void } } };
@@ -1401,9 +1404,9 @@ test.describe('Task Activity Indicators', () => {
           stores.session.getState().updateActivity(sessionId, 'thinking');
         }, SESSION_ID);
 
-        await expect(pauseButton.locator('.lucide-circle.animate-spin')).toBeVisible({ timeout: 5000 });
-        // The pause stays centered through the transition.
-        await expect(pauseButton.locator('[data-testid="pause-bars"]')).toBeVisible();
+        // The pause stays centered through the transition: it is part of the mark.
+        await expect(pauseButton.locator('[data-mark="control-pause-working"]')).toBeVisible({ timeout: 5000 });
+        await expect(pauseButton.locator('[data-mark="control-pause-idle"]')).toHaveCount(0);
       } finally {
         await browser.close();
       }
@@ -1453,12 +1456,12 @@ test.describe('Task Activity Indicators', () => {
         // Body: the muted launch overlay surfaces the spawn status.
         await expect(dialog.getByText('Creating worktree...').first()).toBeVisible({ timeout: 10000 });
 
-        // Header: a muted (grey) launch spinner - a Loader2, NOT the green active
-        // ring - with no pause bars yet (the agent has not started).
+        // Header: a muted (grey) launch spinner - still a lucide Loader2, since "waiting to
+        // start" is not agent activity and the branding set has no loading mark - with no
+        // activity ring at all yet (the agent has not started).
         const pauseButton = dialog.locator('button[title="Pause session"]');
         await expect(pauseButton.locator('.lucide-loader-circle')).toBeVisible();
-        await expect(pauseButton.locator('[data-testid="pause-bars"]')).toHaveCount(0);
-        await expect(pauseButton.locator('.lucide-circle')).toHaveCount(0);
+        await expect(pauseButton.locator('[data-mark^="control-pause-"]')).toHaveCount(0);
       } finally {
         await browser.close();
       }

--- a/tests/unit/activity-mark-render.test.ts
+++ b/tests/unit/activity-mark-render.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit coverage for three red-green coverage holes a /code-review pass found on
+ * ActivityMark.tsx and CommandTerminalIcon.tsx (both hookless function components
+ * introduced with the activity-marks work):
+ *
+ *   1. ActivityMark's isLabelled derivation (role / aria-hidden), which nothing
+ *      previously asserted.
+ *   2. The structural claim in ActivityMark's own JSDoc that the mark's inner
+ *      markup goes into a sibling <g> so a <title> child stays free (React
+ *      forbids `children` alongside `dangerouslySetInnerHTML` on ONE element).
+ *   3. CommandTerminalIcon's `showPlus` ternary precedence over `isWorking`.
+ *
+ * This project's vitest config has no jsdom environment and no
+ * @testing-library/react dependency (see panel-error-boundary.test.ts and
+ * dialog-form-primitives.test.ts for the established rationale and pattern),
+ * so - same as those two files - both components are called directly as
+ * plain functions and their real `React.createElement` output
+ * (`{ type, props }`) is walked without a renderer. Both components are
+ * hookless (no state, no effects), so this is safe without a reconciler.
+ */
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { ActivityMark, type ActivityMarkProps } from '../../src/renderer/components/ActivityMark';
+import { CommandTerminalIcon } from '../../src/renderer/components/command-bar/CommandTerminalIcon';
+
+interface ElementLike {
+  type: unknown;
+  props: Record<string, unknown>;
+}
+
+function isElementLike(node: unknown): node is ElementLike {
+  return typeof node === 'object' && node !== null && 'props' in node;
+}
+
+function collectText(node: unknown): string {
+  if (node === null || node === undefined || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join('');
+  if (isElementLike(node)) return collectText(node.props.children);
+  return '';
+}
+
+describe('ActivityMark isLabelled derivation (role / aria-hidden)', () => {
+  it('is aria-hidden with no role when unlabelled (SidebarActivityCounts usage)', () => {
+    const output = ActivityMark({ mark: 'terminal-idle' });
+    if (!isElementLike(output)) throw new Error('ActivityMark did not return an element');
+
+    expect(output.props.role).toBeUndefined();
+    // aria-hidden is a real boolean in the prop graph (React only serializes
+    // it to the string "true" once it reaches the DOM).
+    expect(output.props['aria-hidden']).toBe(true);
+  });
+
+  it('is role=img and not aria-hidden when labelled via aria-label (TaskCard usage)', () => {
+    const output = ActivityMark({ mark: 'agent-idle', 'aria-label': 'Idle' });
+    if (!isElementLike(output)) throw new Error('ActivityMark did not return an element');
+
+    expect(output.props.role).toBe('img');
+    expect(output.props['aria-hidden']).toBeUndefined();
+  });
+
+  it('is role=img and not aria-hidden when labelled via a <title> child alone, with no aria-label', () => {
+    // Pins the `|| children !== undefined` half of the isLabelled derivation
+    // specifically: the aria-label case above alone would stay green even if
+    // that clause were deleted.
+    const output = ActivityMark({
+      mark: 'agent-idle',
+      children: React.createElement('title', null, 'Idle for 3m'),
+    });
+    if (!isElementLike(output)) throw new Error('ActivityMark did not return an element');
+
+    expect(output.props.role).toBe('img');
+    expect(output.props['aria-hidden']).toBeUndefined();
+  });
+});
+
+describe('ActivityMark <title> child renders alongside the injected mark geometry', () => {
+  it('injects the mark geometry into a sibling <g>, not the root <svg>, so a <title> child stays free', () => {
+    const title = React.createElement('title', null, 'Idle for 3m');
+    const output = ActivityMark({ mark: 'agent-idle', 'aria-label': 'Idle', children: title });
+    if (!isElementLike(output)) throw new Error('ActivityMark did not return an element');
+
+    // The root element must be the <svg> itself (not a wrapper <span>), and it
+    // must not carry dangerouslySetInnerHTML directly - that is exactly the
+    // shape the JSDoc warns against ("must not be simplified into BrandMark's
+    // wrapper-<span> + dangerouslySetInnerHTML form"), and it is what would
+    // collide with the <title> child on a real reconciler.
+    expect(output.type).toBe('svg');
+    expect(output.props.dangerouslySetInnerHTML).toBeUndefined();
+
+    const children = output.props.children;
+    if (!Array.isArray(children)) {
+      throw new Error('expected <svg> to have both the injected <g> and the <title> as children');
+    }
+    const [markGroup, titleChild] = children;
+
+    if (!isElementLike(markGroup)) throw new Error('expected the first child to be the injected <g>');
+    expect(markGroup.type).toBe('g');
+    const markup = markGroup.props.dangerouslySetInnerHTML;
+    if (typeof markup !== 'object' || markup === null || !('__html' in markup)) {
+      throw new Error('expected the <g> to carry dangerouslySetInnerHTML with the mark geometry');
+    }
+    expect((markup as { __html: string }).__html.length).toBeGreaterThan(0);
+
+    // The <title> must survive as a direct sibling of the <g>, not be
+    // swallowed by it.
+    expect(titleChild).toBe(title);
+    expect(collectText(titleChild)).toBe('Idle for 3m');
+  });
+});
+
+describe('CommandTerminalIcon showPlus precedence', () => {
+  it('renders terminal-new even when tone is thinking (showPlus wins over the working mark)', () => {
+    const iconElement = CommandTerminalIcon({ tone: 'thinking', showPlus: true });
+    if (!isElementLike(iconElement)) throw new Error('CommandTerminalIcon did not return an element');
+
+    // CommandTerminalIcon renders <ActivityMark ... /> unrendered (nothing
+    // here goes through a reconciler), so confirm the wrapped component is
+    // still ActivityMark before invoking it directly to reach the <svg>.
+    expect(iconElement.type).toBe(ActivityMark);
+
+    const markElement = (iconElement.type as (props: ActivityMarkProps) => React.ReactNode)(
+      iconElement.props as ActivityMarkProps,
+    );
+    if (!isElementLike(markElement)) throw new Error('ActivityMark did not return an element');
+
+    expect(markElement.props['data-mark']).toBe('terminal-new');
+  });
+});

--- a/tests/unit/activity-mark.test.ts
+++ b/tests/unit/activity-mark.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { innerMarkup, ACTIVITY_MARK_NAMES } from '../../src/renderer/components/ActivityMark';
+
+// ActivityMark renders a React-authored <svg> root and injects only the packaged file's INNER
+// markup, so `innerMarkup` has to drop the shipped <svg> wrapper exactly. Its regex stops the
+// opening tag at the first `>`, which is correct for these single-line generated files but would
+// silently strip into the body if upstream ever emitted a `>` inside an attribute value. A
+// "non-empty, contains no <svg" check passes on that partial strip, so every assertion below
+// names the leaf content the app actually depends on.
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const ACTIVITY_DIR = path.join(REPO_ROOT, 'node_modules', '@kangentic', 'branding', 'assets', 'activity');
+
+function readMark(markName: string): string {
+  return fs.readFileSync(path.join(ACTIVITY_DIR, `${markName}.svg`), 'utf-8');
+}
+
+describe('innerMarkup', () => {
+  it('drops the packaged <svg> wrapper for every mark', () => {
+    const leaked = ACTIVITY_MARK_NAMES.filter((markName) => {
+      const inner = innerMarkup(readMark(markName));
+      return inner.includes('<svg') || inner.includes('</svg>') || inner.trim() === '';
+    });
+    expect(
+      leaked,
+      `innerMarkup left an <svg> wrapper (or produced nothing) for:\n${leaked.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('keeps the marching group and its dash on the working marks', () => {
+    // The march is a <g class="kng-march"> wrapper plus a pathLength-normalized dash. Losing
+    // either leaves a working mark that renders but never animates.
+    const broken = ACTIVITY_MARK_NAMES.filter((markName) => markName.endsWith('-working')).filter(
+      (markName) => {
+        const inner = innerMarkup(readMark(markName));
+        return !inner.includes('class="kng-march"') || !inner.includes('stroke-dasharray');
+      },
+    );
+    expect(broken, `working marks missing their march group or dash:\n${broken.join('\n')}`).toEqual([]);
+  });
+
+  it('keeps the control ring at r=10, which the size-20 call sites depend on', () => {
+    // TaskDetailHeader and CommandTerminalWindow render these at size 20, where an r=10 ring
+    // draws 20 * (2*10+2)/24 = 18.33px - a pixel match for the lucide Circle they replaced.
+    // The radius already moved once (r=9 in branding 2.5.0, r=10 in 2.6.0) and this assertion
+    // is what caught it, so keep it pinned: a silent radius change resizes both controls.
+    const controlMarks = ACTIVITY_MARK_NAMES.filter((markName) => markName.startsWith('control-'));
+    const wrongRadius = controlMarks.filter((markName) => !innerMarkup(readMark(markName)).includes('r="10"'));
+    expect(
+      wrongRadius,
+      `control marks no longer draw an r=10 ring; the size={20} call sites in TaskDetailHeader and CommandTerminalWindow are stale - recompute size so that size * (2r+2)/24 stays 18.33px:\n${wrongRadius.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('keeps the agent ring at r=9, matching the lucide Loader2 it replaced', () => {
+    // The indicator ring did NOT move when the controls went to r=10, which is what lets the
+    // indicator call sites sit at 15 while the controls sit at 20. Pinned separately so the two
+    // radii cannot silently converge and quietly resize the board card.
+    expect(innerMarkup(readMark('agent-working'))).toContain('r="9"');
+  });
+
+  it('draws the needs-you envelope in landscape, not square', () => {
+    // Branding 2.5.0 squared the envelope to 18x18 and it stopped reading as an envelope on the
+    // board (it looked like a photo placeholder); 2.6.0 restored 18 x 14.4, a uniform 0.9 scale
+    // of the reference Mail glyph. That single change fixes three things at once, which is why
+    // the height is pinned here rather than left to the grid contract:
+    //   1. aspect 1.25, the proportion people actually read as mail;
+    //   2. the flap vertex angle, which scaling preserves - 2.5.0's square box had dragged it
+    //      to 108.8 degrees against the 120.4 reference, a second defect on the same glyph;
+    //   3. area parity with agent-working, which is the one that matters most on a task card.
+    //
+    // (3) is easy to miss: the card swaps idle for working IN PLACE, so what the eye judges is
+    // apparent size, not outline length. The square envelope enclosed 321 units against the
+    // ring's 254 (+26%), so an agent going idle made the indicator visibly grow. At 18 x 14.4
+    // it encloses 256 (+0.5%) - the envelope is shorter, but a circle leaves its corners empty,
+    // so the two land within half a percent. That parity falls out of the aspect fix; it holds
+    // only while agent-working stays r=9, which the assertion above pins.
+    const inner = innerMarkup(readMark('agent-idle'));
+    expect(inner, 'agent-idle must stay 18 wide so it holds the indicator keyline').toContain('width="18"');
+    expect(inner, 'agent-idle must stay 14.4 tall (aspect 1.25); 18 reads as a square photo icon').toContain('height="14.4"');
+  });
+
+  it('keeps the control glyph as a sibling of the marching group, not inside it', () => {
+    // The pause bars / stop square must NOT march with the ring. They are siblings of the
+    // <g class="kng-march"> in the packaged file; a strip that reordered or nested them would
+    // set the whole glyph spinning.
+    for (const markName of ['control-stop-working', 'control-pause-working']) {
+      const inner = innerMarkup(readMark(markName));
+      const marchEnd = inner.indexOf('</g>');
+      expect(marchEnd, `${markName} has no closing </g> for its march group`).toBeGreaterThan(-1);
+      expect(
+        inner.slice(marchEnd).includes('fill="currentColor"'),
+        `${markName} should carry its filled glyph AFTER the march group, so it does not animate`,
+      ).toBe(true);
+    }
+  });
+
+  it('keeps the terminal prompt paths the Command Terminal icon reads as a shell', () => {
+    const inner = innerMarkup(readMark('terminal-working'));
+    expect(inner).toContain('M7.5 9.5 L10.5 12 L7.5 14.5');
+    expect(inner).toContain('M12.5 14.5 H16.5');
+    expect(inner).toContain('stroke-dasharray="65 35"');
+  });
+
+  it('keeps the plus glyph on the new-terminal action mark', () => {
+    const inner = innerMarkup(readMark('terminal-new'));
+    expect(inner).toContain('M12 8.5 V15.5');
+    expect(inner).toContain('M8.5 12 H15.5');
+    // The action mark never marches: it represents a spawn, not a running terminal.
+    expect(inner).not.toContain('kng-march');
+  });
+});

--- a/tests/unit/activity-reason-tooltip.test.ts
+++ b/tests/unit/activity-reason-tooltip.test.ts
@@ -5,11 +5,55 @@
  * unaffected.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { formatActivityReasonText } from '../../src/renderer/components/board/ActivityReasonTooltip';
+import {
+  formatActivityReasonText,
+  ActivityReasonTooltip,
+} from '../../src/renderer/components/board/ActivityReasonTooltip';
+import { ActivityMark } from '../../src/renderer/components/ActivityMark';
 import type { ActivityReason } from '../../src/shared/types';
 
 afterEach(() => {
   vi.useRealTimers();
+});
+
+interface ElementLike {
+  type: unknown;
+  props: Record<string, unknown>;
+}
+
+function isElementLike(node: unknown): node is ElementLike {
+  return typeof node === 'object' && node !== null && 'props' in node;
+}
+
+/**
+ * `ActivityReasonTooltip` renders unrendered (no reconciler in this project's vitest config -
+ * see activity-mark-render.test.ts for the established rationale), so the returned element's
+ * first child is the raw <ActivityMark mark="..." /> element, not yet invoked. The mark NAME
+ * this picks is exactly the branch-selection logic under test, so read it straight off that
+ * child's props instead of invoking through to the rendered <svg>'s data-mark (which would
+ * only re-prove what activity-mark-render.test.ts already covers for ActivityMark itself).
+ */
+function markPropOfFirstChild(output: unknown): string {
+  if (!isElementLike(output)) throw new Error('ActivityReasonTooltip did not return an element');
+  const children = output.props.children;
+  const markElement = Array.isArray(children) ? children[0] : children;
+  if (!isElementLike(markElement)) {
+    throw new Error('expected the first child to be an <ActivityMark /> element');
+  }
+  expect(markElement.type).toBe(ActivityMark);
+  return markElement.props.mark as string;
+}
+
+describe('ActivityReasonTooltip mark selection', () => {
+  it('idle renders the agent-idle mark (matches the TaskCard idle indicator)', () => {
+    const output = ActivityReasonTooltip({ reason: { kind: 'idle', since: Date.now() } });
+    expect(markPropOfFirstChild(output)).toBe('agent-idle');
+  });
+
+  it('turn-active renders the agent-working mark (matches the TaskCard thinking indicator)', () => {
+    const output = ActivityReasonTooltip({ reason: { kind: 'turn-active' } });
+    expect(markPropOfFirstChild(output)).toBe('agent-working');
+  });
 });
 
 describe('formatActivityReasonText', () => {

--- a/tests/unit/branding-assets.test.ts
+++ b/tests/unit/branding-assets.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import { ACTIVITY_MARK_NAMES } from '../../src/renderer/components/ActivityMark';
 
 // Desktop icons are consumed directly from node_modules/@kangentic/branding (see
 // electron-builder.yml and src/main/window-utils.ts resolveIconPath) instead of a hand-placed
@@ -41,6 +42,43 @@ const MASCOT_IMPORTERS = [
   'src/renderer/components/onboarding/WelcomeChecklistDialog.tsx',
 ];
 const SUPPORTED_SEQUENCES = ['wave-once', 'blink-loop'];
+
+// The activity marks: the nine glyphs that express agent/terminal activity, consumed via the
+// shipped contract (assets/activity/activity.css + activity.json) rather than hand-authored
+// here, so desktop, web, and mobile cannot drift. ActivityMark.tsx is the single consumer; this
+// pins the marks it renders against the installed package, so a branding upgrade that renames or
+// drops one fails here instead of shipping a blank icon.
+const ACTIVITY_DIR = path.join(BRANDING_ROOT, 'assets', 'activity');
+const ACTIVITY_CSS = path.join(ACTIVITY_DIR, 'activity.css');
+const ACTIVITY_JSON = path.join(ACTIVITY_DIR, 'activity.json');
+const ACTIVITY_COMPONENT = 'src/renderer/components/ActivityMark.tsx';
+// Read from the component's own export, never a hand-copied twin. These two tests exist to catch
+// a mark the component renders but the package no longer ships; against a duplicate list they
+// would keep passing while checking a name nobody renders, which is the drift they guard against.
+const SUPPORTED_MARKS: readonly string[] = ACTIVITY_MARK_NAMES;
+// Every renderer file that shows an activity mark goes through the shared component. Rendering a
+// lucide glyph (or a fresh inline <svg>) for one of these states is the drift this set removes.
+const ACTIVITY_MARK_CONSUMERS = [
+  'src/renderer/components/board/TaskCard.tsx',
+  'src/renderer/components/board/ActivityReasonTooltip.tsx',
+  'src/renderer/components/sidebar/project-sidebar/SidebarActivityCounts.tsx',
+  'src/renderer/components/command-bar/CommandTerminalIcon.tsx',
+  'src/renderer/components/command-bar/CommandTerminalWindow.tsx',
+  'src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx',
+];
+// `ui-conventions.md` exempts exactly these three files from "use lucide, no inline SVGs", each
+// because it consumes a shipped branding asset. Anchoring the allowlist to real imports keeps the
+// rule's list from becoming a fourth thing that drifts.
+const INLINE_SVG_EXEMPT_FILES = [
+  BRAND_MARK_COMPONENT,
+  ACTIVITY_COMPONENT,
+  'src/renderer/components/command-bar/CommandTerminalIcon.tsx',
+];
+
+interface ActivityContractJson {
+  floors: { indicator: number; control: number };
+  marks: Record<string, { file: string; reducedMotion: string; minPx: number }>;
+}
 
 interface MascotAnimationsJson {
   frames: Record<string, { file: string }>;
@@ -273,6 +311,99 @@ describe('Overseer mascot', () => {
     expect(
       notReferencing,
       `These renderer files should render the shared OverseerMascot component:\n${notReferencing.join('\n')}`,
+    ).toEqual([]);
+  });
+});
+
+describe('activity marks', () => {
+  it('ships the activity contract (activity.css + activity.json)', () => {
+    expect(fs.existsSync(ACTIVITY_CSS), '@kangentic/branding is missing assets/activity/activity.css').toBe(true);
+    expect(fs.existsSync(ACTIVITY_JSON), '@kangentic/branding is missing assets/activity/activity.json').toBe(true);
+  });
+
+  it('every mark activity.json names exists as a file in assets/activity/', () => {
+    const contract: ActivityContractJson = JSON.parse(fs.readFileSync(ACTIVITY_JSON, 'utf-8'));
+    const missing = Object.entries(contract.marks)
+      .filter(([, mark]) => !fs.existsSync(path.join(ACTIVITY_DIR, mark.file)))
+      .map(([key, mark]) => `${key} -> ${mark.file}`);
+    expect(missing, `activity.json names mark files that do not exist:\n${missing.join('\n')}`).toEqual([]);
+  });
+
+  it('activity.json still declares every mark ActivityMark.tsx renders', () => {
+    const contract: ActivityContractJson = JSON.parse(fs.readFileSync(ACTIVITY_JSON, 'utf-8'));
+    const missing = SUPPORTED_MARKS.filter((key) => !contract.marks[key]);
+    expect(
+      missing,
+      `@kangentic/branding dropped mark(s) ActivityMark.tsx still renders:\n${missing.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('every mark declares a reducedMotion strategy the CSS and the specs know', () => {
+    // ActivityMark copies this value straight onto the root as `data-rest`, and the packaged
+    // rule that kills a dash under reduced motion is `svg[data-rest="drop-dash"] *`. An upstream
+    // rename to a fourth value would still render, still typecheck, and silently stop honoring
+    // prefers-reduced-motion, so pin the closed set rather than just "is a string".
+    const contract: ActivityContractJson = JSON.parse(fs.readFileSync(ACTIVITY_JSON, 'utf-8'));
+    const strategies = ['static', 'keep-dash', 'drop-dash'];
+    const unknown = SUPPORTED_MARKS
+      .filter((key) => !strategies.includes(contract.marks[key]?.reducedMotion))
+      .map((key) => `${key} -> ${contract.marks[key]?.reducedMotion}`);
+    expect(
+      unknown,
+      `mark(s) declare a reducedMotion strategy outside ${strategies.join(' | ')}:\n${unknown.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('ActivityMark.tsx imports every supported mark as raw SVG', () => {
+    // `?raw` (not `?url`) is required: the marks paint in currentColor so a call site can tint
+    // them with text-active / text-attention, which an <img> could not inherit.
+    const source = fs.readFileSync(path.join(REPO_ROOT, ACTIVITY_COMPONENT), 'utf-8');
+    const missing = SUPPORTED_MARKS.filter(
+      (key) => !source.includes(`@kangentic/branding/assets/activity/${key}.svg?raw`),
+    );
+    expect(
+      missing,
+      `${ACTIVITY_COMPONENT} is missing a ?raw import for mark(s):\n${missing.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('ActivityMark.tsx imports the shared activity stylesheet', () => {
+    const source = fs.readFileSync(path.join(REPO_ROOT, ACTIVITY_COMPONENT), 'utf-8');
+    expect(
+      source.includes('@kangentic/branding/assets/activity/activity.css'),
+      `${ACTIVITY_COMPONENT} should import the shipped activity.css rather than hand-writing keyframes`,
+    ).toBe(true);
+  });
+
+  it('pins the size floors the call sites are written against', () => {
+    // SidebarActivityCounts' group rows render at 12 (the indicator floor exactly), TaskCard and
+    // the sidebar project rows at 15, and the pause/stop controls at 20. If upstream raises a
+    // floor, those call sites need revisiting - the 12px group row has no headroom at all.
+    const contract: ActivityContractJson = JSON.parse(fs.readFileSync(ACTIVITY_JSON, 'utf-8'));
+    expect(contract.floors.indicator, 'indicator floor changed; recheck the 12px sidebar group size').toBe(12);
+    expect(contract.floors.control, 'control floor changed; recheck the pause/stop button sizes').toBe(16);
+  });
+
+  it('every activity surface renders the shared ActivityMark component', () => {
+    const notReferencing = ACTIVITY_MARK_CONSUMERS.filter((relativePath) => {
+      const source = fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf-8');
+      return !source.includes('ActivityMark');
+    });
+    expect(
+      notReferencing,
+      `These renderer files should render the shared ActivityMark component:\n${notReferencing.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('the inline-SVG exemption in ui-conventions.md matches the files that actually consume branding art', () => {
+    const notExempt = INLINE_SVG_EXEMPT_FILES.filter((relativePath) => {
+      const source = fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf-8');
+      // Either it pulls a branding asset directly, or it wraps the component that does.
+      return !source.includes('@kangentic/branding/assets') && !source.includes('ActivityMark');
+    });
+    expect(
+      notExempt,
+      `ui-conventions.md exempts these from the lucide-only rule, but they no longer consume branding art:\n${notExempt.join('\n')}`,
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

Replaces the hand-authored agent and terminal activity glyphs with the nine packaged marks from `@kangentic/branding` (bumped 2.3.0 -> 2.6.0), consumed through one new component, `src/renderer/components/ActivityMark.tsx`.

Affected surfaces: the board card indicator, the activity-reason tooltip, the sidebar agent counts and Command Terminal indicator, the Command Terminal glyph, and the task-detail pause / Command Terminal stop controls.

## Why

The set is owned upstream and shared with the website and the mobile app, so the same geometry can no longer drift across the three surfaces. What this deletes is the actual motivation:

- The `[stroke-dasharray:47_16]` dash on the pause and stop controls, hand computed for r=10 and **duplicated verbatim** in `TaskDetailHeader` and `CommandTerminalWindow`. It broke silently if the radius ever changed.
- `CommandTerminalIcon`'s hand-authored SVG, which was byte-identical to the packaged `terminal-*` marks (same rect, chevron, plus, and `65 35` dash).
- The `march-border` keyframes in `index.css`, now shipped with the marks as `.kng-march`.
- The `StopSquare` / `PauseBars` helpers, whose fixed-px geometry had to be hand-synced with a ring drawn separately.

Net effect on source is a deletion; the additions are almost entirely tests.

## How

`ActivityMark` imports each mark with `?raw` (the `BrandMark.tsx` precedent), strips the packaged `<svg>` wrapper, and injects the inner markup into a sibling `<g>` under a React-authored `<svg>` root. That root shape is load-bearing and documented in the file: React forbids `children` alongside `dangerouslySetInnerHTML` on one element, and `TaskCard` passes a `<title>` child for its hover tooltip. A wrapper `<span>` would also have broken the sidebar specs that assert `span.text-active` resolves to the count digits alone.

Marks are `currentColor` only, so every existing `text-active` / `text-attention` tone class is unchanged.

**Two sizes are deliberately not the obvious number**, and both are commented at the call site:

- Indicators render at **15**, not the 14 the lucide glyphs used. The branding envelope is 18 units wide where lucide's `Mail` was 20, so a same-number swap silently shrank it ~10%; 15 restores the drawn size production shipped.
- Controls render at **20**, where their r=10 ring draws the same 18.33px outer diameter as the lucide `Circle` they replace.

**Upstream geometry has already moved twice** (2.5.0 squared the envelope and shrank the controls to r=9; 2.6.0 reversed both), so `tests/unit/activity-mark.test.ts` pins the r=10 control ring, the r=9 agent ring, and the envelope's 18 x 14.4 box. That guard is not theoretical: it is what caught the r=9 -> r=10 change during the 2.6.0 bump, with a message naming all four control marks. The envelope's height is load-bearing beyond legibility, too: a card swaps idle for working *in place*, and at 18x18 the envelope enclosed 26% more than the ring, so the indicator visibly grew on every state change. At 14.4 the two are within 0.5%.

**lucide stays everywhere else** (146 imports across 144 files). `utils/swimlane-icons.tsx` needs its whole glyph map because column icon names are persisted as kebab-case strings in the database. Three sites are excluded deliberately: `StatusBar` (a session *count*, not an activity state), `TerminalPanel`'s 8px session dot (below the set's 12px indicator floor), and the launch / queued spinners (waiting to start is not agent activity, and the set has no loading mark).

Test selectors move from `.lucide-*` classes to the `data-mark` attribute the packaged SVGs carry. One dead assertion is fixed on the way: `.lucide-loader-2` never matched anything, because lucide aliases `Loader2` to `LoaderCircle`, so that `toHaveCount(0)` had always passed vacuously.

## Breaking changes

None. No API, config, or persisted-data change. Purely presentational, plus a semver-compatible dependency bump.

## Tests

CI runs lint, typecheck, unit, build, and the sharded UI and Linux Electron E2E tiers.

Added:

- `tests/unit/activity-mark.test.ts` - the `innerMarkup()` wrapper strip for all nine marks, per-mark leaf content (march group, dash, sibling filled glyph, prompt paths), and the three geometry pins above.
- `tests/unit/activity-mark-render.test.ts` - `ActivityMark`'s `isLabelled` derivation (role / aria-hidden across both branches), the sibling-`<g>` structural claim, and `CommandTerminalIcon`'s `showPlus` precedence.
- `tests/ui/activity-marks.spec.ts` - that the packaged `activity.css` actually reaches the renderer's cascade and drives `.kng-march`. This has no other coverage and its failure mode is invisible: marks that render perfectly and never move. Plus call-site sizes and `prefers-reduced-motion` (including the `drop-dash` strategy).
- `tests/unit/branding-assets.test.ts` - extended with the activity contract, the mark set the app renders, the size floors, and the `ui-conventions` inline-SVG allowlist.
- `tests/unit/activity-reason-tooltip.test.ts` - extended to pin the reason-kind to mark-name mapping, which the whole-file guard could not catch.

Migrated `task-activity-indicators.spec.ts`, `command-terminal.spec.ts` and `sidebar-command-terminals.spec.ts` onto `data-mark`, and added two relationship assertions: `data-activity` cross-checked against `data-mark` on the same element (tone and geometry can otherwise disagree silently), and the sidebar's two independent indicator components asserted to render at the *same* size rather than at a literal.

Locally verified: typecheck, lint, production build, 41 unit tests, 128 UI tests. The Electron E2E tier was left to CI.

Generated with [Claude Code](https://claude.com/claude-code)
