### PR TITLE
fix(import): match the search box against the fields a row displays

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -294,7 +294,8 @@ Click **Import** in the backlog toolbar to pull tasks from external project mana
 
 **Importing items:**
 1. Click a saved source to open the import dialog
-2. Browse items with filtering by title, type, status, assignee, and labels
+2. Browse items with filtering by ID, title, type, status, assignee, and labels (the search box
+   matches only what a row displays, so every hit is explainable from the row itself)
 3. Use the "Imported" toggle to hide already-imported items (on by default)
 4. Click anywhere on a row to select it (or use the checkbox)
 5. Click **Import (N)** to pull selected items into the backlog

--- a/src/renderer/components/backlog/ImportDialog.tsx
+++ b/src/renderer/components/backlog/ImportDialog.tsx
@@ -30,6 +30,63 @@ function sortByCreatedDesc(list: ExternalIssue[]): ExternalIssue[] {
   );
 }
 
+/** For project items, extract the linked issue number from the external URL if available. */
+function displayId(issue: ExternalIssue): string {
+  if (issue.externalSource === 'github_projects') {
+    const issueNumberMatch = /\/issues\/(\d+)$/.exec(issue.externalUrl);
+    if (issueNumberMatch) return `#${issueNumberMatch[1]}`;
+    return '';
+  }
+  return `#${issue.externalId}`;
+}
+
+// Lowercased searchable blob per issue, so a keystroke costs one substring scan per
+// row rather than rebuilding that blob for every row on every keystroke.
+// Keyed by object identity, which can never go stale: a streamed page appends
+// without recreating prior items, so it only builds haystacks for its new issues;
+// a refetch (state filter switch, Retry, Refresh) arrives over IPC as fresh objects,
+// so the old entries are garbage-collected with their issues and the new ones build
+// once.
+// hmr-safe: a lost cache is rebuilt on demand.
+const searchHaystackCache = new WeakMap<ExternalIssue, string>();
+
+/**
+ * The searchable text for one issue: exactly the fields `ImportIssueRow` prints, so
+ * every hit is explainable from the row itself. The ID comes from the same
+ * `displayId` the row renders, so what the user sees is what the search matches.
+ *
+ * `body` is deliberately EXCLUDED even though it is the richest field. No row renders
+ * it, so a body hit looks like a phantom match, and the damage is worst for the ID
+ * search this predicate exists to serve: issue bodies cross-reference each other by
+ * number constantly ("Fixed by #332", "Blocked by #123"), so including body made a
+ * number query return every issue that merely MENTIONS that number alongside the one
+ * that IS it.
+ *
+ * Also excluded, though the row does print them: the relative timestamp and the
+ * attachment count. Both render as formatted numbers, and matching digits against
+ * them would reintroduce the same numeric noise from the other direction.
+ *
+ * The `\n` separators keep a query from spanning two fields.
+ */
+function searchHaystack(issue: ExternalIssue): string {
+  const cached = searchHaystackCache.get(issue);
+  if (cached !== undefined) return cached;
+  const haystack = [
+    displayId(issue),
+    issue.title,
+    issue.workItemType ?? '',
+    // The row hides the placeholder 'unknown' state, so the search does too.
+    issue.state === 'unknown' ? '' : issue.state,
+    // Every label, not just the 4 the row shows before collapsing to "+N": the
+    // overflow count tells the user more exist, and the Label dropdown lists them all.
+    ...issue.labels,
+    // Matches the row's rendering, so both 'ryan' and '@ryan' hit.
+    issue.assignee ? `@${issue.assignee}` : '',
+  ].join('\n').toLowerCase();
+  searchHaystackCache.set(issue, haystack);
+  return haystack;
+}
+
 export function ImportDialog({ source, onClose }: ImportDialogProps) {
   const [issues, setIssues] = useState<ExternalIssue[]>([]);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -187,7 +244,11 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
 
   // Defer the search input so typing stays responsive even with a large loaded set.
   const deferredFilterText = useDeferredValue(filterText);
-  const titleSearchLower = deferredFilterText.toLowerCase();
+  // Trimmed so a pasted ID still matches. Both '276' and the '#276' the row prints
+  // already match by plain substring, so dropping a LEADING '#' is what additionally
+  // lets an ID-style '#276' query hit a bare '276' in the title or body. Only the
+  // leading one: an internal '#' stays, so a query like 'c#' still means 'c#'.
+  const searchTermLower = deferredFilterText.trim().replace(/^#/, '').toLowerCase();
 
   // Client-side filtering over the full loaded set (pre-sorted by createdAt desc
   // on fetch). This recomputes on every streamed page, so a filter applied
@@ -195,14 +256,14 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
   const filteredIssues = useMemo(() => {
     return issues.filter((issue) => {
       if (hideImported && issue.alreadyImported) return false;
-      if (titleSearchLower && !issue.title.toLowerCase().includes(titleSearchLower)) return false;
+      if (searchTermLower && !searchHaystack(issue).includes(searchTermLower)) return false;
       if (filterStatuses.size > 0 && (!issue.state || !filterStatuses.has(issue.state))) return false;
       if (filterAssignees.size > 0 && (!issue.assignee || !filterAssignees.has(issue.assignee))) return false;
       if (filterTypes.size > 0 && (!issue.workItemType || !filterTypes.has(issue.workItemType))) return false;
       if (filterLabels.size > 0 && !issue.labels.some((label) => filterLabels.has(label))) return false;
       return true;
     });
-  }, [issues, titleSearchLower, filterStatuses, filterAssignees, filterTypes, filterLabels, hideImported]);
+  }, [issues, searchTermLower, filterStatuses, filterAssignees, filterTypes, filterLabels, hideImported]);
 
   const selectableIssues = useMemo(
     () => filteredIssues.filter((issue) => !issue.alreadyImported),
@@ -212,7 +273,10 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
     () => issues.length > 0 && issues.every((issue) => issue.alreadyImported),
     [issues],
   );
-  const hasActiveFilters = filterText !== '' || filterStatuses.size > 0 || filterAssignees.size > 0 || filterTypes.size > 0 || filterLabels.size > 0;
+  // Reads the normalized term, not the raw input: a query of only whitespace or a
+  // lone '#' narrows nothing, so it must not flip the footer to "N of M" or let the
+  // empty state claim a filter excluded everything when none did.
+  const hasActiveFilters = searchTermLower !== '' || filterStatuses.size > 0 || filterAssignees.size > 0 || filterTypes.size > 0 || filterLabels.size > 0;
 
   const virtualizer = useVirtualizer({
     count: filteredIssues.length,
@@ -413,7 +477,7 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
             type="text"
             value={filterText}
             onChange={(event) => setFilterText(event.target.value)}
-            placeholder="Filter by title..."
+            placeholder="Filter by ID, title, label, or assignee..."
             className="w-full bg-surface/50 border border-edge/50 rounded text-sm text-fg placeholder-fg-disabled pl-8 pr-3 py-1.5 outline-none focus:border-edge-input"
             data-testid="import-search"
           />
@@ -620,16 +684,6 @@ export function ImportDialog({ source, onClose }: ImportDialogProps) {
 }
 
 // --- Individual issue row ---
-
-/** For project items, extract the linked issue number from the external URL if available. */
-function displayId(issue: ExternalIssue): string {
-  if (issue.externalSource === 'github_projects') {
-    const issueNumberMatch = /\/issues\/(\d+)$/.exec(issue.externalUrl);
-    if (issueNumberMatch) return `#${issueNumberMatch[1]}`;
-    return '';
-  }
-  return `#${issue.externalId}`;
-}
 
 const ImportIssueRow = React.memo(function ImportIssueRow({
   issue,

--- a/tests/ui/import-filter.spec.ts
+++ b/tests/ui/import-filter.spec.ts
@@ -65,6 +65,40 @@
  *     ordering shifted between sequential fetches) is deduped to a single
  *     row instead of double-rendering it, and the footer's loaded count
  *     reflects the deduped total, not the raw sum of both pages' arrays.
+ *
+ * 16. The search box matches the ID the row prints, for a plain github_issues
+ *     source, with the leading '#', without it, and with surrounding whitespace
+ *     (the paste case). The seeded item's number appears nowhere in its title, so
+ *     a title-only predicate fails this.
+ *
+ * 17. The same, for a github_projects source, whose externalId is an opaque
+ *     project-item node id - the visible '#N' comes from the external URL. The
+ *     node id deliberately does not contain the number, so matching externalId
+ *     instead of the rendered ID still fails this one.
+ *
+ * 18. The search box matches the other fields the row prints - a label and an
+ *     assignee - so a hit is always explainable from the row.
+ *
+ * 18b. The search box does NOT match the issue description (body), which no row
+ *     renders. Guards the rule directly: issue bodies cross-reference each other
+ *     by number ("Fixed by #332"), so a body in the haystack made an ID search
+ *     return every issue MENTIONING a number alongside the one that IS it.
+ *
+ * 19. The '\n' field separators inside searchHaystack keep a query from
+ *     spanning two fields, at both boundaries (id/title and title/type): a
+ *     query that only forms a contiguous substring when two fields are
+ *     concatenated without a separator (e.g. '501z' spanning '#501' and
+ *     'zebra...', or 'designb' spanning '...redesign' and 'Bug') must match
+ *     nothing, while a query entirely within one field still matches.
+ *
+ * 20. The leading-'#' strip on the search term is anchored ('^#'), not
+ *     global: a literal internal '#' in the query (e.g. 'c#') must be
+ *     preserved rather than degrading to a bare letter that would over-match.
+ *
+ * 21. hasActiveFilters reads the normalized search term, not the raw input:
+ *     a query that normalizes to empty (a lone '#') must not flip the empty
+ *     state to the "filters excluded everything" branch when nothing was
+ *     actually excluded.
  */
 import { test, expect, type Page } from '@playwright/test';
 import { launchPage, createProject, collectPageErrors } from './helpers';
@@ -79,8 +113,12 @@ test.describe.configure({ mode: 'parallel' });
 
 function makeIssue(overrides: Partial<{
   externalId: string;
+  externalSource: string;
+  externalUrl: string;
   title: string;
+  body: string;
   state: string;
+  workItemType: string;
   assignee: string | null;
   labels: string[];
   createdAt: string;
@@ -88,12 +126,18 @@ function makeIssue(overrides: Partial<{
 }>) {
   return {
     externalId: overrides.externalId ?? 'issue-1',
-    externalUrl: `https://github.com/org/repo/issues/${overrides.externalId ?? '1'}`,
+    // A github_projects item's externalId is an opaque project-item node id, so the
+    // visible '#N' is parsed out of this URL instead. Overridable for that reason.
+    externalSource: overrides.externalSource ?? 'github_issues',
+    externalUrl: overrides.externalUrl ?? `https://github.com/org/repo/issues/${overrides.externalId ?? '1'}`,
     title: overrides.title ?? 'An issue',
-    body: '',
+    body: overrides.body ?? '',
     labels: overrides.labels ?? [],
     assignee: overrides.assignee ?? null,
     state: overrides.state ?? 'open',
+    // Empty by default, so the Type dropdown stays absent for every spec that
+    // does not opt in (the row and uniqueTypes both gate on truthiness).
+    workItemType: overrides.workItemType ?? '',
     createdAt: overrides.createdAt ?? new Date('2025-01-01').toISOString(),
     updatedAt: overrides.createdAt ?? new Date('2025-01-01').toISOString(),
     alreadyImported: overrides.alreadyImported ?? false,
@@ -130,11 +174,32 @@ async function seedGitHubSource(page: Page): Promise<void> {
 }
 
 /**
+ * Seed a GitHub Projects import source. Its items resolve their visible '#N' from
+ * the external URL rather than from externalId, which is the branch `displayId`
+ * takes for `github_projects`. Seeded on its own (never alongside the Issues
+ * source) so the popover's source label stays unambiguous for `getByText`.
+ */
+async function seedGitHubProjectsSource(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as unknown as { __mockImportSourcesPreset?: unknown }).__mockImportSourcesPreset = [
+      {
+        id: 'gh-projects-src',
+        source: 'github_projects',
+        label: 'org/repo Roadmap Project',
+        repository: 'org/repo',
+        url: 'https://github.com/orgs/org/projects/7',
+        createdAt: new Date().toISOString(),
+      },
+    ];
+  });
+}
+
+/**
  * Open the import dialog by clicking the pre-seeded source in the backlog popover.
  * Returns when the dialog is visible and the first fetch has settled (loading
  * spinner gone).
  */
-async function openImportDialog(page: Page): Promise<void> {
+async function openImportDialog(page: Page, sourceLabel = 'org/repo GitHub Issues'): Promise<void> {
   // Navigate to backlog view
   await page.locator('[data-testid="view-toggle-backlog"]').click();
 
@@ -144,7 +209,7 @@ async function openImportDialog(page: Page): Promise<void> {
   await expect(page.locator('[data-testid="import-popover"]')).toBeVisible();
 
   // Click the pre-seeded source
-  await page.getByText('org/repo GitHub Issues').click();
+  await page.getByText(sourceLabel).click();
 
   // Wait for the dialog to appear
   await page.locator('[data-testid="import-dialog"]').waitFor({ state: 'visible', timeout: 8000 });
@@ -788,6 +853,356 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     // The footer's loaded count reflects the deduped total (3 unique issues),
     // not the raw sum of both pages' issues arrays (4).
     await expect(page.locator('text=/3 of 3 items/')).toBeVisible();
+
+    await browser.close();
+  });
+
+  test('searching an issue number matches the ID the row prints, with or without the "#"', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubSource(page);
+
+    // The target's number appears nowhere in its title or body, so it is reachable
+    // only through the '#276' the row renders. The sibling is the control: it proves
+    // the filter actually ran rather than simply listing everything.
+    await page.evaluate(
+      ([target, sibling]) => {
+        (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = {
+          issues: [target, sibling],
+          totalCount: 2,
+          hasNextPage: false,
+        };
+      },
+      [
+        makeIssue({ externalId: '276', title: 'Stop a close during the entrance animation sticking open' }),
+        makeIssue({ externalId: '981', title: 'Unrelated sibling issue' }),
+      ],
+    );
+
+    await createProject(page, 'import-id-search-issues-test');
+    await openImportDialog(page);
+
+    await expect(page.locator('[data-testid="import-issue-276"]')).toBeVisible();
+    await expect(page.locator('[data-testid="import-issue-981"]')).toBeVisible();
+
+    // Bare number
+    await page.locator('[data-testid="import-search"]').fill('276');
+    await expect(page.locator('[data-testid="import-issue-276"]')).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[data-testid="import-issue-981"]')).toHaveCount(0, { timeout: 3000 });
+
+    // Same number as it is rendered, with the leading '#'
+    await page.locator('[data-testid="import-search"]').fill('#276');
+    await expect(page.locator('[data-testid="import-issue-276"]')).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[data-testid="import-issue-981"]')).toHaveCount(0, { timeout: 3000 });
+
+    // A pasted ID often carries surrounding whitespace, which the query trims off.
+    await page.locator('[data-testid="import-search"]').fill('  #276  ');
+    await expect(page.locator('[data-testid="import-issue-276"]')).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[data-testid="import-issue-981"]')).toHaveCount(0, { timeout: 3000 });
+
+    await browser.close();
+  });
+
+  test('searching a number on a github_projects source matches the URL-derived ID, not externalId', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubProjectsSource(page);
+
+    // A project item's externalId is an opaque node id that does NOT contain the
+    // issue number - the '#512' the row prints is parsed out of externalUrl. The
+    // node ids below deliberately contain neither '512' nor '640', so a predicate
+    // matching externalId instead of the rendered ID fails this test.
+    await page.evaluate(
+      ([target, sibling]) => {
+        (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = {
+          issues: [target, sibling],
+          totalCount: 2,
+          hasNextPage: false,
+        };
+      },
+      [
+        makeIssue({
+          externalId: 'PVTI_lADOAAAAAAB1c2zgABCDEF',
+          externalSource: 'github_projects',
+          externalUrl: 'https://github.com/org/repo/issues/512',
+          title: 'Project item whose number lives in the URL',
+        }),
+        makeIssue({
+          externalId: 'PVTI_lADOAAAAAAB1c2zgUVWXYZ',
+          externalSource: 'github_projects',
+          externalUrl: 'https://github.com/org/repo/issues/640',
+          title: 'Unrelated project item',
+        }),
+      ],
+    );
+
+    await createProject(page, 'import-id-search-projects-test');
+    await openImportDialog(page, 'org/repo Roadmap Project');
+
+    const targetRow = page.locator('[data-testid="import-issue-PVTI_lADOAAAAAAB1c2zgABCDEF"]');
+    const siblingRow = page.locator('[data-testid="import-issue-PVTI_lADOAAAAAAB1c2zgUVWXYZ"]');
+
+    await expect(targetRow).toBeVisible();
+    await expect(siblingRow).toBeVisible();
+
+    await page.locator('[data-testid="import-search"]').fill('512');
+    await expect(targetRow).toBeVisible({ timeout: 3000 });
+    await expect(siblingRow).toHaveCount(0, { timeout: 3000 });
+
+    await page.locator('[data-testid="import-search"]').fill('#512');
+    await expect(targetRow).toBeVisible({ timeout: 3000 });
+    await expect(siblingRow).toHaveCount(0, { timeout: 3000 });
+
+    await browser.close();
+  });
+
+  test('searching matches the other fields the row prints - a label and an assignee', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubSource(page);
+
+    // Neither term appears in either row's ID or title, so each hit can only come
+    // from the label or the assignee - both of which the row renders.
+    await page.evaluate(
+      ([target, sibling]) => {
+        (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = {
+          issues: [target, sibling],
+          totalCount: 2,
+          hasNextPage: false,
+        };
+      },
+      [
+        makeIssue({
+          externalId: '701',
+          title: 'Drag target keeps its position',
+          labels: ['regression'],
+          assignee: 'Ryan-Tuck',
+        }),
+        makeIssue({ externalId: '702', title: 'Unrelated sibling issue', labels: ['docs'], assignee: 'someone-else' }),
+      ],
+    );
+
+    await createProject(page, 'import-label-assignee-search-test');
+    await openImportDialog(page);
+
+    const targetRow = page.locator('[data-testid="import-issue-701"]');
+    const siblingRow = page.locator('[data-testid="import-issue-702"]');
+    await expect(targetRow).toBeVisible();
+    await expect(siblingRow).toBeVisible();
+
+    // Label
+    await page.locator('[data-testid="import-search"]').fill('regression');
+    await expect(targetRow).toBeVisible({ timeout: 3000 });
+    await expect(siblingRow).toHaveCount(0, { timeout: 3000 });
+
+    // Assignee, bare
+    await page.locator('[data-testid="import-search"]').fill('ryan-tuck');
+    await expect(targetRow).toBeVisible({ timeout: 3000 });
+    await expect(siblingRow).toHaveCount(0, { timeout: 3000 });
+
+    // Assignee, as the row renders it (with the '@')
+    await page.locator('[data-testid="import-search"]').fill('@ryan-tuck');
+    await expect(targetRow).toBeVisible({ timeout: 3000 });
+    await expect(siblingRow).toHaveCount(0, { timeout: 3000 });
+
+    await browser.close();
+  });
+
+  test('searching text that appears only in an issue description matches nothing', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubSource(page);
+
+    // The body is NOT searchable: no row renders it, so a body hit would look like
+    // a phantom match. The realistic failure this guards is the cross-reference
+    // case - '#332' in a body is how issues cite each other, so a body-inclusive
+    // haystack made a number search return every issue that merely mentions it.
+    await page.evaluate(
+      ([crossReferencing, plainBody]) => {
+        (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = {
+          issues: [crossReferencing, plainBody],
+          totalCount: 2,
+          hasNextPage: false,
+        };
+      },
+      [
+        makeIssue({
+          externalId: '335',
+          title: 'Creating a new task should open the task modal directly',
+          body: 'Fixed by #332.',
+        }),
+        makeIssue({
+          externalId: '336',
+          title: 'Unrelated sibling issue',
+          body: 'Mentions the swimlane reordering behaviour.',
+        }),
+      ],
+    );
+
+    await createProject(page, 'import-description-excluded-test');
+    await openImportDialog(page);
+
+    const crossReferencingRow = page.locator('[data-testid="import-issue-335"]');
+    const plainBodyRow = page.locator('[data-testid="import-issue-336"]');
+    await expect(crossReferencingRow).toBeVisible();
+    await expect(plainBodyRow).toBeVisible();
+
+    // '332' appears only inside #335's body, as a cross-reference. Nothing matches.
+    await page.locator('[data-testid="import-search"]').fill('332');
+    await expect(crossReferencingRow).toHaveCount(0, { timeout: 3000 });
+    await expect(plainBodyRow).toHaveCount(0, { timeout: 3000 });
+
+    // Ordinary body prose is unreachable too, not just a '#'-prefixed reference.
+    await page.locator('[data-testid="import-search"]').fill('swimlane');
+    await expect(crossReferencingRow).toHaveCount(0, { timeout: 3000 });
+    await expect(plainBodyRow).toHaveCount(0, { timeout: 3000 });
+
+    // The ID that IS the row still matches, so the row is reachable - this is not
+    // a vacuous "everything is filtered out" pass.
+    await page.locator('[data-testid="import-search"]').fill('335');
+    await expect(crossReferencingRow).toBeVisible({ timeout: 3000 });
+    await expect(plainBodyRow).toHaveCount(0, { timeout: 3000 });
+
+    await browser.close();
+  });
+
+  test('a query spanning two haystack fields (no separator) matches nothing, but a query within one field still matches', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubSource(page);
+
+    // The target's rendered id is '#501', its title ends with 'redesign', and its
+    // work item type is 'Bug'. searchHaystack joins the row's fields with '\n', so
+    // a query spanning either boundary ('501' into 'zebra...', or 'redesign' into
+    // 'bug') only forms a contiguous substring if that separator is dropped - both
+    // boundaries are exercised below. The sibling never contains either spanning
+    // query through any field, so it is the control that proves the filter actually
+    // ran rather than everything matching.
+    await page.evaluate(
+      ([target, sibling]) => {
+        (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = {
+          issues: [target, sibling],
+          totalCount: 2,
+          hasNextPage: false,
+        };
+      },
+      [
+        makeIssue({
+          externalId: '501',
+          title: 'Zebra crossing needs a redesign',
+          workItemType: 'Bug',
+        }),
+        makeIssue({ externalId: '999', title: 'Unrelated sibling issue' }),
+      ],
+    );
+
+    await createProject(page, 'import-id-search-separator-test');
+    await openImportDialog(page);
+
+    const targetRow = page.locator('[data-testid="import-issue-501"]');
+    const siblingRow = page.locator('[data-testid="import-issue-999"]');
+    await expect(targetRow).toBeVisible();
+    await expect(siblingRow).toBeVisible();
+
+    // A query spanning the id/title boundary ('501' + the 'z' from 'zebra')
+    // only forms a contiguous substring if the '\n' separator between fields
+    // is dropped. With the separator present, this must match nothing.
+    await page.locator('[data-testid="import-search"]').fill('501z');
+    await expect(targetRow).toHaveCount(0, { timeout: 3000 });
+    await expect(siblingRow).toHaveCount(0, { timeout: 3000 });
+
+    // A query entirely within the id field alone still matches the row - the
+    // separator only blocks a query from spanning fields, not from matching
+    // inside one.
+    await page.locator('[data-testid="import-search"]').fill('501');
+    await expect(targetRow).toBeVisible({ timeout: 3000 });
+    await expect(siblingRow).toHaveCount(0, { timeout: 3000 });
+
+    // Same guard at the title/type boundary: 'designb' spans 'redesign' and
+    // 'Bug', so it only forms a contiguous substring if that separator is
+    // dropped too. Run last, so this observes a real visible-to-absent
+    // transition from the prior '501' step rather than a vacuous "already
+    // absent" check.
+    await page.locator('[data-testid="import-search"]').fill('designb');
+    await expect(targetRow).toHaveCount(0, { timeout: 3000 });
+    await expect(siblingRow).toHaveCount(0, { timeout: 3000 });
+
+    await browser.close();
+  });
+
+  test('a literal internal "#" in the query is preserved, not globally stripped', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubSource(page);
+
+    // The target's title contains a literal 'c#'; the sibling's title contains a
+    // bare 'c' (several times, via 'references'/'cache') but never 'c#'. Both
+    // externalIds are numeric, so neither row's id can contribute a 'c#' or stray
+    // 'c' hit - only the titles are exercised. Only a LEADING '#' should be
+    // stripped from the query; stripping every '#' would degrade 'c#' down to
+    // a bare 'c', which the sibling's title would then also match.
+    await page.evaluate(
+      ([target, sibling]) => {
+        (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = {
+          issues: [target, sibling],
+          totalCount: 2,
+          hasNextPage: false,
+        };
+      },
+      [
+        makeIssue({
+          externalId: '601',
+          title: 'Cannot detect the c# compiler on PATH',
+        }),
+        makeIssue({
+          externalId: '602',
+          title: 'References the cache subsystem',
+        }),
+      ],
+    );
+
+    await createProject(page, 'import-hash-anchor-search-test');
+    await openImportDialog(page);
+
+    const targetRow = page.locator('[data-testid="import-issue-601"]');
+    const siblingRow = page.locator('[data-testid="import-issue-602"]');
+    await expect(targetRow).toBeVisible();
+    await expect(siblingRow).toBeVisible();
+
+    await page.locator('[data-testid="import-search"]').fill('c#');
+    await expect(targetRow).toBeVisible({ timeout: 3000 });
+    await expect(siblingRow).toHaveCount(0, { timeout: 3000 });
+
+    await browser.close();
+  });
+
+  test('a query that normalizes to empty (a lone "#") is not treated as an active filter', async () => {
+    const { browser, page } = await launchPage();
+
+    await seedGitHubSource(page);
+
+    await page.evaluate(() => {
+      (window as unknown as { __mockImportFetchPreset?: unknown }).__mockImportFetchPreset = {
+        issues: [],
+        totalCount: 0,
+        hasNextPage: false,
+      };
+    });
+
+    await createProject(page, 'import-empty-normalized-filter-test');
+    await openImportDialog(page);
+
+    // Baseline: no issues, no filters - the plain empty state.
+    await expect(page.getByText('No items found')).toBeVisible({ timeout: 3000 });
+
+    // A lone '#' normalizes to '' (the leading '#' is stripped, leaving
+    // nothing), so it must not flip the empty state to the "filters excluded
+    // everything" branch - nothing was actually excluded, since there was
+    // nothing to filter in the first place.
+    await page.locator('[data-testid="import-search"]').fill('#');
+    await expect(page.getByText('No items found')).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[data-testid="import-empty-state-message"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="import-clear-filters-btn"]')).toHaveCount(0);
 
     await browser.close();
   });


### PR DESCRIPTION
## What

The backlog Import dialog's search box now matches the fields a row actually displays, instead of the title alone.

- `src/renderer/components/backlog/ImportDialog.tsx` - new module-scope `searchHaystack` helper; `displayId()` hoisted above the component; predicate, `hasActiveFilters`, and placeholder updated.
- `tests/ui/import-filter.spec.ts` - 7 new scenarios, widened `makeIssue` factory, a GitHub Projects source helper.
- `docs/user-guide.md` - import filter description.

## Why

Typing an issue number returned no results even when a visible row printed that exact number. The filter compared the term against `issue.title` and nothing else, so the hash-prefixed ID on every row was unreachable from the search box.

## How

The predicate matches the same fields `ImportIssueRow` renders: ID, title, work item type, state, labels, and assignee.

**The ID comes from the same `displayId()` the row calls**, which is the load-bearing detail. For `github_projects` sources `externalId` is an opaque project-item node id, and the visible number is parsed out of the external URL, so matching `externalId` would still have failed exactly that case. Reusing `displayId()` means what the user sees is what the search matches. A leading hash is stripped and the term trimmed, so a bare number, a hash-prefixed one, and a pasted value carrying whitespace all match.

**`body` is deliberately excluded**, and that is a reversal worth flagging. It was included at first, then removed after testing against real data: no row renders the description, so a body hit looks like a phantom match, and it broke worst for the ID search this change exists to serve. Issue bodies cross-reference each other by number constantly ("Fixed by" plus a number), so a body-inclusive haystack made a number query return every issue that merely *mentions* that number alongside the one that *is* it. The relative timestamp and attachment count are excluded for the same reason from the other direction, since both render as formatted numbers. The rule is now simply: searchable == visible.

**Performance.** Haystacks are cached in a `WeakMap` keyed by issue identity. A streamed page only builds entries for its new issues; a refetch arrives as fresh objects, so old entries are collected with them. This is a net win on an input deliberately optimized in 2b63c321 (typing lagged 500ms+): the title is no longer re-lowercased on every keystroke.

**Also fixed:** `hasActiveFilters` read the raw input, so a query that normalizes to empty (whitespace, or a lone hash) wrongly drove the empty state to claim a filter had excluded everything.

## Breaking changes

None. Behavior-only change to a client-side filter; no API, config, or persisted state is affected.

## Tests

CI checks (lint, typecheck, unit, build, UI shards, Linux Electron E2E shards), plus 7 new UI-tier scenarios in `tests/ui/import-filter.spec.ts`:

- ID search on a plain `github_issues` source, with the hash, without it, and with surrounding whitespace.
- ID search on a `github_projects` source, whose node id deliberately omits the number so an `externalId`-based predicate fails.
- Label and assignee matches, the assignee both bare and as the row renders it.
- Description text matches nothing, using the real cross-reference shape that motivated the exclusion.
- The `\n` field separators block a query from spanning two fields, at both boundaries.
- The leading-hash strip is anchored, so a literal `c#` stays `c#`.
- A query normalizing to empty is not treated as an active filter.

Verified locally: 22/22 in that spec, typecheck and lint clean. The Projects scenario was mutation-checked - reverting the predicate to match `externalId` turns it red while the plain-issues scenario stays green.

Generated with [Claude Code](https://claude.com/claude-code)
