### PR TITLE
refactor(mascot): read the mount set from branding 2.7.0's mountFrames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@electron/fuses": "^2.1.1",
         "@electron/notarize": "^3.1.1",
         "@eslint/js": "^9.39.4",
-        "@kangentic/branding": "^2.6.0",
+        "@kangentic/branding": "^2.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.3.0",
@@ -2502,9 +2502,9 @@
       }
     },
     "node_modules/@kangentic/branding": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@kangentic/branding/-/branding-2.6.0.tgz",
-      "integrity": "sha512-H3HDDQx5HlQ3wO4DypdpJmleIbk7kbZ/TWtyaZHG86G2l2ldSByX38NClGdMMPvgpnc7lJZrvDi690U7ZyJ2nA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@kangentic/branding/-/branding-2.7.0.tgz",
+      "integrity": "sha512-DYfsBBSYVo/EtLUNijSQygG8uxNtkkwi214Q56acL5WCcT2tFL0f81qeTKEjvXmUHZIDaQGChhAuVq2i617yGQ==",
       "dev": true,
       "license": "AGPL-3.0-only"
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@electron/fuses": "^2.1.1",
     "@electron/notarize": "^3.1.1",
     "@eslint/js": "^9.39.4",
-    "@kangentic/branding": "^2.6.0",
+    "@kangentic/branding": "^2.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.0",

--- a/src/renderer/components/onboarding/OverseerMascot.tsx
+++ b/src/renderer/components/onboarding/OverseerMascot.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import animations from '@kangentic/branding/assets/mascot/animations.json';
 import overseerRestUrl from '@kangentic/branding/assets/mascot/overseer.svg?url';
 import overseerBlinkUrl from '@kangentic/branding/assets/mascot/overseer-blink.svg?url';
 import overseerWaveUrl from '@kangentic/branding/assets/mascot/overseer-wave.svg?url';
@@ -15,12 +16,65 @@ const FRAME_URLS: Record<string, string> = {
   wave: overseerWaveUrl,
 };
 
-/** Which frames each sequence needs mounted, per animations.json. */
-const SEQUENCE_FRAMES: Record<OverseerSequence, string[]> = {
-  none: ['rest'],
-  'wave-once': ['rest', 'wave'],
-  'blink-loop': ['rest', 'blink'],
-};
+/**
+ * The frame KEYS this component can render. Exported for `tests/unit/branding-assets.test.ts`,
+ * read from the real map rather than a hand-copied twin (as `ActivityMark`'s mark list is).
+ *
+ * `mountFramesFor` silently DROPS a name with no `FRAME_URLS` entry, so a branding release that
+ * renamed a key while shipping the same file (`rest` -> `idle`, still `overseer.svg`) would filter
+ * every frame out and render an empty div. That test's file-name check cannot see a key rename,
+ * because the file it looks for is still imported; comparing key sets can.
+ */
+export const RENDERABLE_FRAME_KEYS = Object.keys(FRAME_URLS);
+
+/**
+ * The shipped contract, re-declared so the wide inferred JSON type is not indexed directly.
+ *
+ * `sequences` is PARTIAL on purpose, for the same reason `ActivityMark`'s `marks` is: this is
+ * package data crossing the TypeScript boundary, so a total `Record` would be a claim the type
+ * system cannot check. A branding release that renamed a sequence would still typecheck, and the
+ * `?? []` below is the runtime floor. `tests/unit/branding-assets.test.ts` fails CI on that drift.
+ *
+ * Exported because `mountFramesFor` takes it as a parameter, so the tests can build fabricated
+ * contracts for the drift cases the installed package never produces.
+ */
+export interface MascotAnimations {
+  restFrame: string;
+  sequences: Partial<Record<OverseerSequence, { mountFrames?: string[] }>>;
+}
+
+const CONTRACT = animations as unknown as MascotAnimations;
+
+/**
+ * Every frame div the given sequences need MOUNTED, read from the package's `mountFrames`.
+ *
+ * `mountFrames` is not `clip`: `clip` is what to PLAY, `mountFrames` is what to MOUNT. A sequence
+ * rests on `restFrame` when it ends and under reduced motion even when its clip never names that
+ * frame, so deriving the set from the clip mounts too little. Upstream's own example: `running-loop`
+ * plays step-a and step-b but mounts step-a, step-b and rest, and mounting only the played pair
+ * renders nothing at all once motion is off.
+ *
+ * `restFrame` is unioned in unconditionally rather than trusted to appear in every sequence's
+ * `mountFrames`, because the base `.overseer-frame--rest { visibility: visible }` rule needs that
+ * div to exist for the mascot to render at all.
+ *
+ * Names with no `FRAME_URLS` entry are dropped: this component imports only the frames its three
+ * supported sequences use, so an upstream addition must not render `<img src={undefined}>`.
+ *
+ * Takes the contract as a parameter rather than closing over `CONTRACT` so the three drift branches
+ * above (rest unioned in, unknown name dropped, sequence absent) can be pinned against fabricated
+ * contracts in `tests/unit/overseer-mascot-frames.test.ts`. None of them fires against the
+ * installed package, so without that they would read as untested defensive code.
+ */
+export function mountFramesFor(contract: MascotAnimations, sequences: OverseerSequence[]): string[] {
+  const frameKeys = new Set<string>([contract.restFrame]);
+  for (const sequenceKey of sequences) {
+    for (const frameKey of contract.sequences[sequenceKey]?.mountFrames ?? []) {
+      frameKeys.add(frameKey);
+    }
+  }
+  return [...frameKeys].filter((frameKey) => frameKey in FRAME_URLS);
+}
 
 export interface OverseerMascotProps {
   /** Integer multiple of the 18x12 pixel grid. Width-only; height derives
@@ -38,7 +92,8 @@ export interface OverseerMascotProps {
  * Renders the Overseer mascot via the shipped @kangentic/branding animation
  * contract (assets/mascot/animations.css + animations.json). No hand-written
  * keyframes or durations - pixel-art-conventions.md forbids re-authoring the
- * timings a consumer imports.
+ * timings a consumer imports - and no hand-written frame list either: the mount
+ * set comes from each sequence's `mountFrames` (see `mountFramesFor`).
  *
  * The intro -> sequence handoff is driven by `animationend`, never a timer, so
  * the one-shot's duration stays owned by the package. Per motion-craft, JS here
@@ -69,10 +124,7 @@ export function OverseerMascot({ scale, sequence = 'none', intro, className = ''
   // Mount the union of both sequences' frames so the handoff never remounts an
   // <img> mid-animation. A frame the active sequence does not name simply keeps
   // the base `.overseer-frame` visibility:hidden.
-  const mountedFrames = [...new Set([
-    ...SEQUENCE_FRAMES[sequence],
-    ...(intro ? SEQUENCE_FRAMES[intro] : []),
-  ])];
+  const mountedFrames = mountFramesFor(CONTRACT, intro ? [sequence, intro] : [sequence]);
 
   const sequenceClass = activeSequence === 'none' ? '' : `overseer--${activeSequence}`;
 

--- a/tests/ui/onboarding-welcome-screen.spec.ts
+++ b/tests/ui/onboarding-welcome-screen.spec.ts
@@ -186,6 +186,18 @@ test.describe('Welcome screen readiness', () => {
     // the very mount-set regression these two tests exist to catch.
     await expect(mascot.locator('.overseer-frame--wave')).toHaveCount(1);
     await expect(mascot.locator('.overseer-frame--wave')).toBeHidden();
+
+    // Prove the emulation is actually in force, mirroring the `.no-motion` test above: without
+    // this, every assertion so far also passes on the normal animated path, since blink-loop
+    // rests on this same frame between blinks and wave-once ends on it too. The packaged CSS
+    // reduced-motion query sets `animation: none` (not just a zeroed duration, which is
+    // `.no-motion`'s distinct mechanism), so `animationName` reads the literal string 'none'.
+    const restFrameAnimationName = await mascot.locator('.overseer-frame--rest')
+      .evaluate((element) => getComputedStyle(element).animationName);
+    expect(
+      restFrameAnimationName,
+      'prefers-reduced-motion emulation never took effect, so this test was exercising the normal animated path',
+    ).toBe('none');
   });
 
   test('the app version renders as a pill, not near-invisible micro text', async () => {

--- a/tests/ui/onboarding-welcome-screen.spec.ts
+++ b/tests/ui/onboarding-welcome-screen.spec.ts
@@ -10,13 +10,27 @@ test.describe.configure({ mode: 'parallel' });
 const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
 const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
 
+interface LaunchMotionOptions {
+  /** Emulate the OS-level `prefers-reduced-motion: reduce` preference. */
+  reducedMotion?: boolean;
+  /** Add `.no-motion` to `<html>` before React paints, which is what the app's
+   *  Animations-off setting does (`config-store.ts`). Set the class directly
+   *  rather than seeding `animationsEnabled: false`: that subscription fires
+   *  only on a CHANGE, so a pre-seeded false never toggles the class on. */
+  noMotionClass?: boolean;
+}
+
 async function launchWithOverrides(
   overrides: Record<string, unknown>,
   configOverrides?: Record<string, unknown>,
+  motion?: LaunchMotionOptions,
 ): Promise<{ browser: Browser; page: Page }> {
   await waitForViteReady(VITE_URL);
   const browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const context = await browser.newContext({
+    viewport: { width: 1920, height: 1080 },
+    ...(motion?.reducedMotion ? { reducedMotion: 'reduce' as const } : {}),
+  });
   const page = await context.newPage();
   await page.addInitScript((args: { agents: Record<string, unknown>; config: Record<string, unknown> | null }) => {
     (window as unknown as { __mockAgentListOverrides: Record<string, unknown> }).__mockAgentListOverrides = args.agents;
@@ -24,6 +38,18 @@ async function launchWithOverrides(
       (window as unknown as { __mockConfigOverrides: Record<string, unknown> }).__mockConfigOverrides = args.config;
     }
   }, { agents: overrides, config: configOverrides ?? null });
+  if (motion?.noMotionClass) {
+    await page.addInitScript(() => {
+      // Applied twice on purpose. DOMContentLoaded is the reliable pass, because an init script
+      // runs at document-start where `documentElement` may not exist yet; it still lands before
+      // the mascot's first paint, since React's initial commit is scheduled asynchronously and
+      // runs after that event even though the deferred module script executes before it. The
+      // immediate pass just removes the dependency on that ordering.
+      const applyNoMotion = () => document.documentElement?.classList.add('no-motion');
+      applyNoMotion();
+      document.addEventListener('DOMContentLoaded', applyNoMotion);
+    });
+  }
   await page.addInitScript({ path: MOCK_SCRIPT });
   await page.goto(VITE_URL);
   await page.waitForLoadState('load');
@@ -110,6 +136,56 @@ test.describe('Welcome screen readiness', () => {
     await expect(mascot.locator('.overseer-frame--rest')).toHaveCount(1);
     await expect(mascot.locator('.overseer-frame--blink')).toHaveCount(1);
     await expect(mascot.locator('.overseer-frame--wave')).toHaveCount(1);
+  });
+
+  // The mount set comes from each sequence's `mountFrames` in the branding package, which is NOT
+  // the set its `clip` plays: a sequence rests on `restFrame` when it ends and under reduced
+  // motion even when the clip never names that frame. Mount only the played poses and the mascot
+  // renders NOTHING once motion is off, because `.overseer-frame` is `visibility: hidden` by
+  // default and only `.overseer-frame--rest` unhides. These two tests are the guard: they assert
+  // the rest frame is actually VISIBLE (Playwright honors `visibility: hidden`), which is what a
+  // mount-set regression would break. Upstream shipped this bug twice, so pin both motion paths -
+  // they are not equivalent (`.no-motion` zeroes `animation-duration`; the media query sets
+  // `animation: none`).
+  test('with the Animations setting off, the mascot rests on the canonical frame', async () => {
+    ({ browser, page } = await launchWithOverrides({}, undefined, { noMotionClass: true }));
+
+    const mascot = page.getByRole('img', { name: 'Pixel-art Kangentic mascot' });
+    await expect(mascot).toBeVisible();
+    await expect(mascot.locator('.overseer-frame--rest')).toBeVisible();
+
+    // The intro is a one-shot whose animationend still fires at 0s, so it must have handed off
+    // rather than leaving the hero frozen mid-wave.
+    await expect.poll(
+      async () => mascot.getAttribute('class'),
+      { timeout: 5000 },
+    ).toContain('overseer--blink-loop');
+    await expect(mascot.locator('.overseer-frame--rest')).toBeVisible();
+
+    // Prove the setting is actually in force, or this test cannot go red for its own premise: the
+    // 600ms intro hands off well inside the poll above and the rest frame is visible for most of
+    // both cycles, so every assertion so far passes identically on the normal animated path.
+    // blink-loop's rest track reads '3.807s' there.
+    const restFrameDuration = await mascot.locator('.overseer-frame--rest')
+      .evaluate((element) => getComputedStyle(element).animationDuration);
+    expect(
+      restFrameDuration,
+      '.no-motion never took effect, so this test was exercising the normal animated path',
+    ).toBe('0s');
+  });
+
+  test('under prefers-reduced-motion, the mascot rests on the canonical frame', async () => {
+    ({ browser, page } = await launchWithOverrides({}, undefined, { reducedMotion: true }));
+
+    const mascot = page.getByRole('img', { name: 'Pixel-art Kangentic mascot' });
+    await expect(mascot).toBeVisible();
+    // The packaged CSS sets `animation: none` here, so no animationend ever fires and the intro
+    // never hands off. Resting is reached by doing nothing, which is the correct rendering.
+    await expect(mascot.locator('.overseer-frame--rest')).toBeVisible();
+    // Count first: `toBeHidden` also passes for an ABSENT element, so on its own it would survive
+    // the very mount-set regression these two tests exist to catch.
+    await expect(mascot.locator('.overseer-frame--wave')).toHaveCount(1);
+    await expect(mascot.locator('.overseer-frame--wave')).toBeHidden();
   });
 
   test('the app version renders as a pill, not near-invisible micro text', async () => {

--- a/tests/unit/branding-assets.test.ts
+++ b/tests/unit/branding-assets.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { ACTIVITY_MARK_NAMES } from '../../src/renderer/components/ActivityMark';
+import { RENDERABLE_FRAME_KEYS } from '../../src/renderer/components/onboarding/OverseerMascot';
 
 // Desktop icons are consumed directly from node_modules/@kangentic/branding (see
 // electron-builder.yml and src/main/window-utils.ts resolveIconPath) instead of a hand-placed
@@ -29,8 +30,9 @@ const COLOR_MARK_CONSUMER = 'src/renderer/components/layout/WelcomeScreen.tsx';
 
 // The Overseer mascot: consumed via the shipped animation contract
 // (assets/mascot/animations.css + animations.json), never hand-authored
-// timings (pixel-art-conventions.md). OverseerMascot.tsx supports a subset of
-// the package's sequences; this pins that subset's frames against the
+// timings (pixel-art-conventions.md) and never a hand-authored frame list.
+// OverseerMascot.tsx supports a subset of the package's sequences and mounts
+// each one's declared `mountFrames`; this pins that subset against the
 // installed package so a branding upgrade that renames/drops a frame file
 // fails here instead of shipping a broken <img>.
 const MASCOT_DIR = path.join(BRANDING_ROOT, 'assets', 'mascot');
@@ -41,7 +43,17 @@ const MASCOT_IMPORTERS = [
   'src/renderer/components/layout/WelcomeScreen.tsx',
   'src/renderer/components/onboarding/WelcomeChecklistDialog.tsx',
 ];
-const SUPPORTED_SEQUENCES = ['wave-once', 'blink-loop'];
+// 'none' is included: OverseerMascot's default `sequence`, and a real entry in animations.json
+// (mountFrames ['rest']). Leaving it out let the one sequence the component falls back to go
+// unchecked by the frame-import test below.
+const SUPPORTED_SEQUENCES = ['none', 'wave-once', 'blink-loop'];
+// Which of those the PACKAGE must keep declaring. 'none' is deliberately absent: it is the
+// component's own default meaning "no animation", and `mountFramesFor` falls back to restFrame when
+// a sequence is missing, so upstream dropping that degenerate entry (`clip: []`) cannot break the
+// mascot. Requiring it would redden CI on a package change with no consumer impact. The two
+// ANIMATED sequences are different - losing one leaves the mascot frozen on its first frame.
+// Derived, not a second hand-maintained list: a fourth supported sequence must be required too.
+const REQUIRED_SEQUENCES = SUPPORTED_SEQUENCES.filter((key) => key !== 'none');
 
 // The activity marks: the nine glyphs that express agent/terminal activity, consumed via the
 // shipped contract (assets/activity/activity.css + activity.json) rather than hand-authored
@@ -81,20 +93,29 @@ interface ActivityContractJson {
 }
 
 interface MascotAnimationsJson {
+  restFrame: string;
   frames: Record<string, { file: string }>;
-  sequences: Record<string, {
-    idle?: { frame: string };
-    clip: Array<{ frame: string }>;
-  }>;
+  sequences: Record<string, { mountFrames?: string[] }>;
 }
 
-/** Every frame key a sequence actually renders: clip poses plus its idle rest frame, if any. */
+/**
+ * Every frame key a sequence needs MOUNTED: mirrors OverseerMascot's `mountFramesFor` exactly -
+ * the declared `mountFrames`, with `restFrame` unioned in unconditionally.
+ *
+ * This used to be derived as "clip poses plus the idle rest frame", which was only ACCIDENTALLY
+ * right for the three sequences the component supports. `clip` is what to PLAY; `mountFrames` is
+ * what to MOUNT, and a sequence rests on `restFrame` when it ends and under reduced motion even
+ * when its clip never names that frame. `running-loop` is the counterexample: clip+idle derives
+ * step-a and step-b, misses rest, and a component mounting only that pair renders nothing at all
+ * with motion off - while this test certified the set as complete. Read the declared contract.
+ *
+ * Deliberately tolerant of a missing sequence or absent `mountFrames`, exactly as the component is.
+ * The dedicated mountFrames test below is what fails on that drift, with a better message than a
+ * throw from inside this helper.
+ */
 function framesUsedBySequence(animations: MascotAnimationsJson, sequenceKey: string): string[] {
-  const sequence = animations.sequences[sequenceKey];
-  if (!sequence) throw new Error(`animations.json has no sequence "${sequenceKey}"`);
-  const frameKeys = new Set(sequence.clip.map((pose) => pose.frame));
-  if (sequence.idle) frameKeys.add(sequence.idle.frame);
-  return [...frameKeys];
+  const mountFrames = animations.sequences[sequenceKey]?.mountFrames ?? [];
+  return [...new Set([...mountFrames, animations.restFrame])];
 }
 
 // electron-builder.yml has five distinct icon sites that were repointed at the
@@ -107,7 +128,7 @@ function framesUsedBySequence(animations: MascotAnimationsJson, sequenceKey: str
 // that site's test.
 const BRANDING_DESKTOP_PREFIX = 'node_modules/@kangentic/branding/resources/desktop/';
 
-/** Extract the full indented body of a top-level YAML key (e.g. "win", "mac", "linux") --
+/** Extract the full indented body of a top-level YAML key (e.g. "win", "mac", "linux"):
  *  every line following "<key>:\n" up to (not including) the next unindented line. */
 function extractTopLevelBlock(yamlSource: string, topLevelKey: string): string {
   const match = yamlSource.match(new RegExp(`\\n${topLevelKey}:\\n((?:[ \\t].*\\n?)*)`));
@@ -266,12 +287,67 @@ describe('Overseer mascot', () => {
     expect(missing, `animations.json names frame files that do not exist:\n${missing.join('\n')}`).toEqual([]);
   });
 
-  it('animations.json still declares every sequence OverseerMascot.tsx supports', () => {
+  it('animations.json still declares every animated sequence OverseerMascot.tsx plays', () => {
     const animations: MascotAnimationsJson = JSON.parse(fs.readFileSync(MASCOT_JSON, 'utf-8'));
-    const missing = SUPPORTED_SEQUENCES.filter((key) => !animations.sequences[key]);
+    const missing = REQUIRED_SEQUENCES.filter((key) => !animations.sequences[key]);
     expect(
       missing,
-      `@kangentic/branding dropped sequence(s) OverseerMascot.tsx still supports:\n${missing.join('\n')}`,
+      `@kangentic/branding dropped animated sequence(s) OverseerMascot.tsx still plays; the mascot would freeze on its first frame:\n${missing.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('every sequence declares a non-empty mountFrames', () => {
+    // `mountFrames` is what OverseerMascot mounts (branding 2.7.0+). A sequence that lost it would
+    // fall back to restFrame alone and silently mount too little, so fail here instead. Checked
+    // across EVERY sequence, not just the supported three, because the next sequence the component
+    // adopts must already be safe to read.
+    const animations: MascotAnimationsJson = JSON.parse(fs.readFileSync(MASCOT_JSON, 'utf-8'));
+    const withoutMountFrames = Object.entries(animations.sequences)
+      .filter(([, sequence]) => !sequence.mountFrames?.length)
+      .map(([key]) => key);
+    expect(
+      withoutMountFrames,
+      `animations.json sequence(s) declare no mountFrames; OverseerMascot reads it to decide what to mount:\n${withoutMountFrames.join('\n')}`,
+    ).toEqual([]);
+    expect(animations.restFrame, 'animations.json must name a restFrame').toBeTruthy();
+  });
+
+  it('the shipped mascot CSS fills no animation, in either the longhand or the shorthand', () => {
+    // Load-bearing for the app's Animations-off toggle, which zeroes `animation-duration` rather
+    // than setting `animation: none` (see index.css `.no-motion`). A FILLED zero-duration animation
+    // snaps to its 100% keyframe instead of resting on the canonical frame, so the mascot would
+    // freeze mid-wave with motion off. Every track carries an explicit terminal keyframe instead.
+    // OverseerMascot's docblock states this assumption; this is the check behind it.
+    //
+    // BOTH forms are checked. The shipped CSS writes its tracks as the `animation:` shorthand, so a
+    // fill regression would most likely arrive as `... step-end 1 forwards`, which never contains
+    // the longhand property name. Comments are stripped first: the double-arm-wave prose contains
+    // the word "both", which would otherwise false-positive.
+    const mascotCss = fs.readFileSync(MASCOT_CSS, 'utf-8');
+    const declarations = mascotCss.replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(
+      /animation-fill-mode/.test(declarations),
+      'assets/mascot/animations.css now sets animation-fill-mode; with Animations off (.no-motion zeroes animation-duration) a filled animation snaps to its 100% keyframe instead of resting on the canonical frame',
+    ).toBe(false);
+    expect(
+      /animation:[^;}]*\b(?:forwards|backwards|both)\b/.test(declarations),
+      'assets/mascot/animations.css now passes a fill-mode keyword in an `animation:` shorthand; same freeze-on-the-100%-keyframe consequence as the longhand above',
+    ).toBe(false);
+  });
+
+  it('every frame key the supported sequences mount is one OverseerMascot can render', () => {
+    // The file-name check below cannot see a KEY rename: upstream could rename `rest` to `idle`
+    // while still shipping overseer.svg, the import would still be there, and that test would stay
+    // green. `mountFramesFor` filters on the key, so the renamed frame would be dropped and the
+    // default `sequence='none'` would mount NOTHING - a blank div, no crash, no error. Compare the
+    // key sets instead, reading the component's own map rather than a hand-copied twin.
+    const animations: MascotAnimationsJson = JSON.parse(fs.readFileSync(MASCOT_JSON, 'utf-8'));
+    const unrenderable = [...new Set(
+      SUPPORTED_SEQUENCES.flatMap((sequenceKey) => framesUsedBySequence(animations, sequenceKey)),
+    )].filter((frameKey) => !RENDERABLE_FRAME_KEYS.includes(frameKey));
+    expect(
+      unrenderable,
+      `animations.json names frame key(s) ${MASCOT_COMPONENT}'s FRAME_URLS does not declare; mountFramesFor drops them silently, so the mascot renders an empty div:\n${unrenderable.join('\n')}`,
     ).toEqual([]);
   });
 
@@ -279,13 +355,18 @@ describe('Overseer mascot', () => {
     const animations: MascotAnimationsJson = JSON.parse(fs.readFileSync(MASCOT_JSON, 'utf-8'));
     const mascotSource = fs.readFileSync(path.join(REPO_ROOT, MASCOT_COMPONENT), 'utf-8');
 
-    const requiredFrameFiles = new Set<string>();
-    for (const sequenceKey of SUPPORTED_SEQUENCES) {
-      for (const frameKey of framesUsedBySequence(animations, sequenceKey)) {
-        requiredFrameFiles.add(animations.frames[frameKey].file);
-      }
-    }
+    const requiredFrameKeys = [...new Set(
+      SUPPORTED_SEQUENCES.flatMap((sequenceKey) => framesUsedBySequence(animations, sequenceKey)),
+    )];
+    // Assert the keys resolve BEFORE indexing `frames`, so an upstream `mountFrames` entry naming a
+    // frame the package no longer declares fails with this message instead of a raw TypeError.
+    const undeclared = requiredFrameKeys.filter((frameKey) => !animations.frames[frameKey]);
+    expect(
+      undeclared,
+      `animations.json mounts frame key(s) it does not declare under "frames":\n${undeclared.join('\n')}`,
+    ).toEqual([]);
 
+    const requiredFrameFiles = new Set(requiredFrameKeys.map((frameKey) => animations.frames[frameKey].file));
     const missingImports = [...requiredFrameFiles].filter(
       (file) => !mascotSource.includes(`@kangentic/branding/assets/mascot/${file}`),
     );

--- a/tests/unit/overseer-mascot-frames.test.ts
+++ b/tests/unit/overseer-mascot-frames.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  mountFramesFor,
+  RENDERABLE_FRAME_KEYS,
+  type MascotAnimations,
+} from '../../src/renderer/components/onboarding/OverseerMascot';
+
+// `mountFramesFor` decides which frame divs the mascot mounts, reading @kangentic/branding's
+// `animations.json` rather than a hand-written list. Its three drift branches - rest unioned in,
+// an unknown name dropped, a sequence missing entirely - are the whole point of reading the
+// package instead of hardcoding, and NONE of them fires against the installed 2.7.0 contract:
+// all three supported sequences already list `rest` in their own `mountFrames`, name only frames
+// the component imports, and exist. Delete any one branch and every other test in the repo stays
+// green. So they are pinned here, against fabricated contracts.
+//
+// `tests/unit/branding-assets.test.ts` is the complementary half: it checks the INSTALLED package
+// still matches what the component consumes. This file checks the derivation itself.
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const MASCOT_JSON = path.join(
+  REPO_ROOT, 'node_modules', '@kangentic', 'branding', 'assets', 'mascot', 'animations.json',
+);
+
+describe('mountFramesFor', () => {
+  it('unions the contract restFrame in even when a sequence does not name it', () => {
+    // The base `.overseer-frame--rest { visibility: visible }` rule needs that div to exist for
+    // the mascot to render at all - a sequence rests there when it ends and under reduced motion.
+    // `running-loop` is the shipped precedent for a clip that never plays rest.
+    const contract: MascotAnimations = {
+      restFrame: 'rest',
+      sequences: { 'blink-loop': { mountFrames: ['blink'] } },
+    };
+    expect(mountFramesFor(contract, ['blink-loop'])).toEqual(['rest', 'blink']);
+  });
+
+  it('drops a frame name the component has no asset import for', () => {
+    // The component imports only the three frames its supported sequences use. An upstream release
+    // that added `look` to blink-loop's mountFrames must not render `<img src={undefined}>`.
+    const contract: MascotAnimations = {
+      restFrame: 'rest',
+      sequences: { 'blink-loop': { mountFrames: ['blink', 'look', 'step-a'] } },
+    };
+    expect(mountFramesFor(contract, ['blink-loop'])).toEqual(['rest', 'blink']);
+    expect(RENDERABLE_FRAME_KEYS).not.toContain('look');
+  });
+
+  it('falls back to the rest frame alone when the contract has no such sequence', () => {
+    // This is why `branding-assets.test.ts` deliberately does not require the degenerate 'none'
+    // entry: upstream dropping it degrades to resting, which is the correct rendering for it.
+    const contract: MascotAnimations = { restFrame: 'rest', sequences: {} };
+    expect(mountFramesFor(contract, ['none'])).toEqual(['rest']);
+    expect(mountFramesFor(contract, ['blink-loop', 'wave-once'])).toEqual(['rest']);
+  });
+
+  it('unions both sequences for the intro handoff, rest first, without duplicating a shared frame', () => {
+    // DOM order matters: the frames are absolutely stacked, and the handoff must not remount an
+    // <img> mid-animation, so the union is mounted once for both sequences.
+    const contract: MascotAnimations = {
+      restFrame: 'rest',
+      sequences: {
+        'blink-loop': { mountFrames: ['rest', 'blink'] },
+        'wave-once': { mountFrames: ['rest', 'wave'] },
+      },
+    };
+    expect(mountFramesFor(contract, ['blink-loop', 'wave-once'])).toEqual(['rest', 'blink', 'wave']);
+  });
+
+  it('derives the shipped welcome-hero mount set from the installed package', () => {
+    // The end-to-end case: the real 2.7.0 contract, the real call the WelcomeScreen makes
+    // (sequence 'blink-loop' with a 'wave-once' intro). Pins that reading the package still
+    // produces exactly the set the hand-written map used to.
+    const contract: MascotAnimations = JSON.parse(fs.readFileSync(MASCOT_JSON, 'utf-8'));
+    expect(mountFramesFor(contract, ['none'])).toEqual(['rest']);
+    expect(mountFramesFor(contract, ['blink-loop', 'wave-once'])).toEqual(['rest', 'blink', 'wave']);
+  });
+});


### PR DESCRIPTION
## What

Adopts `@kangentic/branding` 2.7.0 and makes `OverseerMascot` read its mount set from the package's new per-sequence `mountFrames` instead of a hand-maintained frame table.

- `package.json` / `package-lock.json`: `^2.6.0` -> `^2.7.0`
- `src/renderer/components/onboarding/OverseerMascot.tsx`: `SEQUENCE_FRAMES` replaced by an exported `mountFramesFor(contract, sequences)` that reads `animations.json`
- `tests/unit/overseer-mascot-frames.test.ts` (new), `tests/unit/branding-assets.test.ts`, `tests/ui/onboarding-welcome-screen.spec.ts`

## Why

`mountFrames` is not `clip`. `clip` is what to PLAY; `mountFrames` is what to MOUNT. A sequence rests on `restFrame` when it ends and under reduced motion even when its clip never names that frame, and `.overseer-frame` is `visibility: hidden` by default with only `.overseer-frame--rest` unhiding it. Mount too few frames and the mascot renders nothing at all once motion is off.

There is no live bug on this branch: the three sequences the component supports already had a hand-written frame set matching 2.7.0's `mountFrames` exactly. But that table and the test helper that derived frames from `clip` + `idle` were only **accidentally** correct for that subset. Add `running-loop` and the heuristic derives `step-a` and `step-b`, misses `rest`, and the mascot renders nothing with motion off while the test certifies the mount set as complete. Reading the declared contract removes that whole class of drift, which is what the branding package exists to do.

## How

`mountFramesFor` takes the contract as a parameter rather than closing over the module-level constant, so its three drift branches can be pinned against fabricated contracts. It unions `restFrame` in unconditionally rather than trusting it to appear in every sequence's `mountFrames`, and drops any frame key the component has no asset import for, so an upstream addition cannot render `<img src={undefined}>`.

**The bump itself is inert, and that was verified rather than assumed.** Comparing every asset's integrity hash between 2.6.0 and 2.7.0 shows exactly two changed files, both mascot: `animations.json` gains `mountFrames`, and `animations.css` is comment-only (confirmed by diff). Every activity SVG, `activity.css`, `activity.json`, all five brandmarks and `ui/kanban.svg` are byte-identical, so no geometry moved, `activity-mark.test.ts` passes untouched, and the mount set resolves to exactly what the hand-written table produced.

### Scope notes

Four of the five items on the original task turned out to be already shipped, from when 2.5.0 and 2.6.0 were adopted:

- the hand-computed `47 16` dash is gone (the dash rides the packaged SVG's own `pathLength` and `stroke-dasharray`; the only `47 16` left in `src/` is a historical comment)
- the control marks already draw `r=10`, with `activity-mark.test.ts` pinning it
- no `animation-fill-mode` exists anywhere in `src/`
- `BrandMark` already inlines `brandmark-mono-amber.svg?raw`

Deliberately left out: `assets/ui/kanban.svg` has no consumer to replace. `ViewToggle`, the only board nav, is text-only; `LayoutGrid` and `SquareKanban` are settings-tab icons; and the `KanbanSquare` glyphs in `import-providers.tsx` and `AsanaSetupDialog.tsx` stand for third-party boards, where substituting Kangentic's own mark would be wrong. Adding a consumer would also cost a fourth `ui-conventions.md` inline-SVG exemption for no visible change.

## Breaking changes

None. The mount set is provably identical to what shipped, and no rendered geometry changed.

## Tests

CI: lint, typecheck, unit, build, the UI shards, and the Linux Electron E2E shards.

Added or reworked, all red-green verified:

- `tests/unit/overseer-mascot-frames.test.ts` (new, 5 tests) pins `mountFramesFor`'s three drift branches against fabricated contracts, since none of them fires against the installed package and they would otherwise read as untested defensive code.
- `tests/unit/branding-assets.test.ts` now reads `mountFrames` instead of the clip+idle heuristic, and gains guards for a non-empty `mountFrames`, a frame-key rename (a key rename shipping the same filename was invisible to the existing file-name check), and the absence of `animation-fill-mode` in the shipped CSS. That last one is load-bearing: the app's Animations-off setting zeroes `animation-duration`, and a filled zero-duration animation would snap to its 100% keyframe instead of resting on the canonical frame. It was previously asserted only in a code comment.
- `tests/ui/onboarding-welcome-screen.spec.ts` gains two tests asserting the mascot rests on the canonical frame with animations off and under `prefers-reduced-motion`. Both paths are pinned because they are not equivalent mechanisms: `.no-motion` zeroes the duration, the media query sets `animation: none`. Each also asserts the motion suppression is genuinely in force, so the test cannot pass while silently exercising the normal animated path.

Verified locally: typecheck, lint, 42 unit tests, 12 UI tests. Red-green evidence for the mount-set guard: temporarily dropping `restFrame` from the mount set turns both new UI tests red on "element(s) not found", and running the new unit assertions against 2.6.0's `animations.json` fails every one.

Generated with [Claude Code](https://claude.com/claude-code)
