### PR TITLE
refactor(title-bar): drop the dictation mic button

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,13 +128,13 @@ won't be found.
   of any existing terminal - a fresh terminal has no activity to reflect. A thin divider (matching
   the one before the Windows min/max/close controls) sits right after "New terminal", so it reads
   as a transient action distinct from the permanent icon cluster to its right (toggle, Quick Find,
-  mic, stats, settings); the divider mounts/unmounts together with the button so it never leaves
+  stats, settings); the divider mounts/unmounts together with the button so it never leaves
   an orphan line when the layer is closed. This pair is the LEFT-MOST icons in the title bar's
   right-aligned button row (before Quick Find), deliberately: that row is right-anchored (a
   `flex-1` spacer eats the space to its left), so an element's on-screen distance from the window
   edge is fixed by whatever comes AFTER it, never before it. Keeping "New terminal" + the divider
   + the toggle first means the conditionally-mounted "New terminal" button
-  appearing/disappearing as the layer opens/closes never shifts Quick Find, the mic, stats,
+  appearing/disappearing as the layer opens/closes never shifts Quick Find, stats,
   settings, or the OS window controls - only this pair's own position moves. The toggle glyph's
   stroke color is the aggregate activity of the project's terminals (active-green working /
   attention-amber needs-you / muted rest, via the central `--kng-active` / `--kng-attention`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -337,7 +337,7 @@ config-only (driven by the Mode preset + Live/Refinement model dropdowns).
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `dictation.enabled` | boolean | `false` | Master on/off. Shows the mic button and enables push-to-talk. (Transcription section row.) |
+| `dictation.enabled` | boolean | `false` | Master on/off. Enables push-to-talk. (Transcription section row.) |
 | `dictation.language` | string (BCP-47) | `'en'` | Spoken language. The Live/Refinement model dropdowns narrow to models that support it; non-English uses the multilingual Whisper builds. (Transcription section row.) |
 | `dictation.punctuation` | boolean | `true` | Add punctuation + capitalization to the committed text. (Transcription section row.) |
 | `dictation.autoSubmit` | boolean | `true` | Press Enter automatically after inserting (via the paste engine's settle -> Enter -> evidence path), or leave the text in the input for review. (Input section row.) |

--- a/src/renderer/components/dialogs/AdvancedOverridesSection.tsx
+++ b/src/renderer/components/dialogs/AdvancedOverridesSection.tsx
@@ -160,10 +160,11 @@ export function AdvancedOverridesSection({
   const boardProfiles = useBoardStore((state) => state.boardProfiles);
   const openBoardManager = useBoardStore((state) => state.openBoardManager);
   const globalPermissionMode = useConfigStore((state) => state.config.agent.permissionMode);
-  // The three-arg PROJECT open, never `openSettingsToTab`: the Agent tab's
+  // The three-arg PROJECT open, never a bare open-to-tab: the Agent tab's
   // Project Defaults are `scope: 'project'`, and `updateProjectOverride`
-  // returns early when `projectSettingsPath` is null, so the panel would open
-  // and silently drop the Permission write (.claude/rules/settings-tab-scope.md).
+  // returns early when `projectSettingsPath` is null, so a panel opened
+  // without a project path would silently drop the Permission write
+  // (.claude/rules/settings-tab-scope.md).
   const openProjectSettings = useConfigStore((state) => state.openProjectSettings);
   // Effective-agent resolution for the New Task / Edit dialog: user pick
   // wins over the destination column's override, then the project default,

--- a/src/renderer/components/layout/TitleBar.tsx
+++ b/src/renderer/components/layout/TitleBar.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { ChartColumn, CloudDownload, Command, Compass, Mic, Minus, Settings, Square, X } from 'lucide-react';
+import { ChartColumn, CloudDownload, Command, Compass, Minus, Settings, Square, X } from 'lucide-react';
 import { useProjectStore } from '../../stores/project-store';
 import { useConfigStore } from '../../stores/config-store';
-import { useDictationStore } from '../../stores/dictation-store';
 import { useSessionStore } from '../../stores/session-store';
 import { useUpdaterStore } from '../../stores/updater-store';
 import { useUsageDashboardStore } from '../../stores/usage-dashboard-store';
@@ -42,17 +41,9 @@ export function TitleBar({
   const setOnboardingChecklistOpen = useConfigStore((s) => s.setOnboardingChecklistOpen);
   const setSettingsOpen = useConfigStore((s) => s.setSettingsOpen);
   const openProjectSettings = useConfigStore((s) => s.openProjectSettings);
-  const openSettingsToTab = useConfigStore((s) => s.openSettingsToTab);
 
   const pendingUpdate = useUpdaterStore((s) => s.pendingUpdate);
   const openUpdateModal = useUpdaterStore((s) => s.openModal);
-
-  // Voice dictation mic button: shown only when dictation is enabled; its color
-  // reflects whether a push-to-talk session is live (active token), matching the
-  // command-terminal glyph's activity language.
-  const dictationEnabled = useConfigStore((s) => s.globalConfig.dictation?.enabled ?? false);
-  const dictationStatus = useDictationStore((s) => s.status);
-  const dictationActive = dictationStatus === 'recording' || dictationStatus === 'finalizing';
 
   // Aggregate activity across THIS project's Command Terminal sessions, surfaced
   // as the title-bar terminal icon's COLOR (the same active/idle language as the
@@ -94,16 +85,6 @@ export function TitleBar({
       openProjectSettings(currentProject.path, currentProject.name);
     } else {
       setSettingsOpen(true);
-    }
-  };
-
-  // Push-to-talk is the primary trigger; clicking the mic opens settings directly
-  // to the Dictation tab (works with or without a project, since it is global).
-  const handleMicClick = () => {
-    if (currentProject) {
-      openProjectSettings(currentProject.path, currentProject.name, 'dictation');
-    } else {
-      openSettingsToTab('dictation');
     }
   };
 
@@ -178,7 +159,7 @@ export function TitleBar({
             position is fixed by whatever comes AFTER it, not before it. Keeping
             this pair first means the conditional "New terminal" button
             mounting/unmounting as the layer opens/closes never shifts Quick
-            Find / mic / stats / settings / the window controls - only this
+            Find / stats / settings / the window controls - only this
             pair's own position moves. "New terminal" sits to the LEFT of the
             toggle (reads outward from the toggle as the layer gains a spawn
             affordance) and reuses the same terminal glyph with the center `+`
@@ -229,19 +210,6 @@ export function TitleBar({
             data-testid="open-search-button"
           >
             <Command size={20} />
-          </button>
-        )}
-        {dictationEnabled && (
-          <button
-            onClick={handleMicClick}
-            className={`p-1.5 hover:bg-surface-hover rounded transition-colors ${
-              dictationActive ? 'text-active' : 'text-fg-muted hover:text-fg'
-            }`}
-            title={dictationActive ? 'Listening...' : 'Voice dictation'}
-            aria-label={dictationActive ? 'Listening' : 'Voice dictation'}
-            data-testid="dictation-mic-button"
-          >
-            <Mic size={20} />
           </button>
         )}
         <button

--- a/src/renderer/stores/config-store.ts
+++ b/src/renderer/stores/config-store.ts
@@ -110,10 +110,6 @@ interface ConfigStore {
   // -- Settings panel UI --
   settingsOpen: boolean;
   setSettingsOpen: (open: boolean) => void;
-  /** Open the settings panel directly to a given tab (used by the title-bar
-   *  mic button to jump to the global Dictation tab). Works with or without a
-   *  project open, since the target may be a shared (global) tab. */
-  openSettingsToTab: (tabId: string) => void;
   /** Last settings tab the user viewed, so closing and reopening the panel
    *  returns to the same section instead of resetting to the first tab. */
   lastSettingsTab: string | null;
@@ -407,10 +403,6 @@ export const useConfigStore = create<ConfigStore>((set, get) => {
         };
         return { onboardingStepsCompleted: onboardingStepsCompletedHmr };
       });
-    },
-
-    openSettingsToTab: (tabId) => {
-      set({ settingsOpen: true, projectSettingsInitialTab: tabId });
     },
 
     setSettingsOpen: (open) => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2224,7 +2224,7 @@ export interface AppConfig {
    * by the `dictation.pushToTalk` keybinding-registry id.
    */
   dictation?: {
-    /** Master toggle: show the mic button and enable push-to-talk. Default false. */
+    /** Master toggle: enable push-to-talk dictation. Default false. */
     enabled?: boolean;
     /** Engine selection. `auto` tiers by detected hardware. Default `auto`. */
     engineMode?: DictationEngineMode;

--- a/tests/ui/task-level-overrides.spec.ts
+++ b/tests/ui/task-level-overrides.spec.ts
@@ -178,11 +178,11 @@ test.describe('NewTaskDialog Advanced section', () => {
   });
 
   test('the agent edit button opens Settings scoped to THIS project, so a picked default actually persists', async () => {
-    // Distinct failure mode from the visibility test above: `openSettingsToTab`
-    // (the sibling action on config-store.ts) never sets `projectSettingsPath`,
-    // and `updateProjectOverride` returns early when that path is null - so
-    // swapping the pencil's call from `openProjectSettings` to
-    // `openSettingsToTab('agent')` would open the SAME-LOOKING Agent tab (the
+    // Distinct failure mode from the visibility test above: opening the panel to
+    // a tab WITHOUT a project path (setting only `settingsOpen` +
+    // `projectSettingsInitialTab`) leaves `projectSettingsPath` null, and
+    // `updateProjectOverride` returns early when that path is null - so a pencil
+    // that opened the Agent tab that way would show the SAME-LOOKING tab (the
     // "Project Defaults" header above renders unconditionally from
     // project-store's currentProject, not from projectSettingsPath) while
     // silently dropping every write made from it. Permission Mode


### PR DESCRIPTION
## What

Removes the dictation mic button from the title bar's right-aligned control cluster, and the
`openSettingsToTab` config-store action that existed only to serve it.

Touched: `TitleBar.tsx` (the button, `handleMicClick`, three dictation reads, two imports),
`config-store.ts` (the dead action), plus prose in `types.ts`, `docs/configuration.md`, and
`CLAUDE.md` that claimed a mic button exists.

## Why

The title bar is permanent chrome: every icon there is visible on every boot, in every project.
The mic did not earn that slot. It did exactly two things, and both are already covered elsewhere:

- **Its only action** was opening Settings to the Dictation tab. It never started or stopped a
  capture. The sole trigger is push-to-talk (`dictation.pushToTalk`, default `Mouse:Back`), and
  the Dictation tab is two clicks from the settings gear. It is a `category: 'system'` tab, so
  that path works with no project open.
- **Its only state** was turning `text-active` while recording. `LiveDictationChip` already
  surfaces that better: the streaming transcript, model-download progress, errors, and a clear
  button, anchored to the focused terminal rather than the window edge. Push-to-talk is a HELD
  control besides, so the user has it physically pressed for the entire capture.

## How

The dictation feature is untouched. The settings tab, `dictation-store.ts` (including its
Pattern-E HMR pinning), the keybinding, `LiveDictationChip`, and the capture pipeline all stay.
`dictation-store` loses no consumer that orphans a field: `LiveDictationChip` still reads
`status`. Only the title-bar entry point goes away.

Two things worth a reviewer's eye:

- **`openSettingsToTab` is deleted, not orphaned.** `TitleBar.tsx:106` was its only call site
  repo-wide. Two comments elsewhere warned *against* using it (it never sets
  `projectSettingsPath`, so `updateProjectOverride` silently drops writes, the
  `settings-tab-scope.md` trap). Deleting the action removes that footgun outright; both comments
  are reworded to describe the hazard without naming a symbol that no longer exists.
  `projectSettingsInitialTab` stays alive - `openProjectSettings` still sets it.
- **Row geometry.** The button sat between Quick Find and stats. That row is right-anchored (a
  `flex-1` spacer eats the space to its left), so removing an element shifts only what comes
  BEFORE it: the update indicator, "New terminal" and its divider, the Command Terminal toggle,
  and Quick Find move right by one button width. Stats, settings, and the OS window controls do
  not move. The "New terminal" divider lives inside the same conditional as its button, so no
  orphan divider is possible.

## Breaking changes

None. No config key, IPC channel, or persisted value changed. `dictation.enabled` still exists
and still gates push-to-talk; only its JSDoc dropped the "shows the mic button" clause.

## Tests

No new tests. A repo-wide sweep found exactly one `dictation-mic-button` reference: the source
line this PR deletes. No spec asserts on the title-bar row's composition, and a negative
existence assertion on deleted UI would be noise.

Verified locally, all clean:

- `npm run typecheck`
- `npm run lint` (`--max-warnings 0`) - the real guard here, since every risk in a removal diff
  is an unused import or binding
- `npx playwright test tests/ui/task-level-overrides.spec.ts --project=ui` - 54 passed (I edited
  a comment in that spec)
- `npx vitest run tests/unit/no-em-dashes.test.ts` - passed (scans the `src/` prose I rewrote)

A `doc-auditor` pass confirmed all 11 `dictation.*` keys still match between `types.ts` and
`docs/configuration.md`, that no enumerable anchor item was added or removed, and that no
"mic button" prose survives anywhere in `docs/`.

The full unit, UI, and E2E tiers run as CI checks on this PR.

Generated with [Claude Code](https://claude.com/claude-code)
