### PR TITLE
feat(code-review): commit the review pass so the worktree hands off clean

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Review git changes for quality and conventions via parallel reviewer subagents synthesized in the main agent (auto-fixes findings and fills red-green test-coverage holes by default)
+description: Review git changes for quality and conventions via parallel reviewer subagents synthesized in the main agent (auto-fixes findings, fills red-green test-coverage holes, and commits that pass locally by default)
 allowed-tools: Read, Glob, Grep, Edit, Write, Bash(git:*), Bash(npm:*), Bash(npx:*), Agent
 argument-hint: [base-ref] [review-only]
 ---
@@ -10,11 +10,11 @@ Review the changes that make up this branch's work - commits on the branch **plu
 
 ## Modes
 
-- **Default** (`/code-review`) - review, then immediately apply every safely-fixable finding, re-run typecheck, and report `Changes Applied` + `Skipped (with reason)`.
+- **Default** (`/code-review`) - review, then immediately apply every safely-fixable finding, re-run typecheck, commit this pass's own work locally (never pushed), and report `Changes Applied` + `Skipped (with reason)`.
 - **Review-only** (`/code-review review-only`) - findings table + Verdict footer only, no edits applied.
 
 The skill reads `$ARGUMENTS`, which may carry up to two independent tokens in any order:
-- `review-only` - skip the Apply Phase and Re-typecheck steps and emit the legacy Verdict footer instead of the Changes/Skipped report.
+- `review-only` - skip the Apply Phase, Re-typecheck, and commit steps (it writes nothing at all) and emit the legacy Verdict footer instead of the Changes/Skipped report.
 - a **base ref** (any token that is not `review-only`, e.g. `origin/main`, `develop`, or a commit SHA) - overrides the auto-detected base branch the diff is scoped against (see Step 3). Mirrors `claude ultrareview origin/main`. A base ref is diff-*scoping* metadata, not author intent - it never tells the reviewer what the change was "supposed" to do (see "Reviewer independence").
 
 **User-provided arguments (if any):** $ARGUMENTS
@@ -45,10 +45,17 @@ The skill is a thin driver that runs in the main loop. All commands below run fr
    - **Uncommitted (staged + unstaged):** `git diff HEAD` and `git diff HEAD --stat` (`git diff HEAD` captures index + working tree in one command).
    - **Untracked new files:** `git ls-files --others --exclude-standard`. No diff shows these, but they are part of the change - `Read` each listed file in full and append it to `diffText` as a synthetic added-file block (`+++ b/<path>` header followed by the full contents) so the finders see it.
    If the committed diff, the uncommitted diff, **and** the untracked list are all empty, emit "No changes to review." and stop. Otherwise `diffText` = committed diff + uncommitted diff + the synthetic untracked blocks, and `changedFiles` = the deduped union of file paths across the committed `--stat`, the uncommitted `--stat`, and the untracked list. Also compute the compact **signature delta** from the diff alone (the integration finder consumes it; see "## Finders").
+
+   **Record `preexistingDirty`** = the union of `git diff HEAD --name-only` and the untracked list: everything already dirty before this pass touched anything. Step 8 subtracts it to decide what it may commit. This is deliberately **narrower than `changedFiles`**, which also includes the committed-vs-base paths - conflating the two makes Step 8's set difference empty, so nothing would ever commit.
+
+   **Use `--name-only`, never the `--stat` paths, for this set.** `--stat` abbreviates a long path to fit its column budget (`src/renderer/components/sidebar/project-sidebar/SidebarCommandTerminalIndicator.tsx`, already in this repo at 83 chars, renders as `.../sidebar/project-sidebar/SidebarCommandTerminalIndicator.tsx`). Step 8 compares against `git diff HEAD --name-only`, which never truncates, so a `--stat`-derived entry would fail to string-match its own full path, drop out of the subtraction, and get committed - the precise outcome this design exists to prevent. Keep the `--stat` capture for the human-readable summary only.
+
+   **Persist it immediately, do not just remember it.** Write the list (one path per line) to `.kangentic/REVIEW_PREEXISTING_DIRTY.tmp` with the `Write` tool as soon as you compute it. Step 8 is many steps, a five-subagent fan-out, and a whole Apply Phase later, so this value has to survive a context compaction in between. If it does not survive, the set difference silently UNDER-counts and Step 8 commits the task agent's unfinished work - the exact outcome this design exists to prevent. `.kangentic/` is gitignored, so the file never stages itself and needs no cleanup.
 5. **Fan out reviewer subagents (the `Agent` tool, ALL in ONE message so they run concurrently).** Every finder is a **read-only** subagent in its own fresh context window; only the driver (main loop) mutates the working tree, in the Apply Phase. Give each finder the diff (or, when it is very large, the Step 4 gather commands so it reproduces the diff itself) plus the changed-file list, and instruct it to read the full changed files for surrounding context. See "## Finders" for the exact set, the gates, the per-finder criteria, and the required return shape. The universal dimension finders always run; the domain auditors run only when their changed-file glob matches.
 6. **Synthesize + verify (main agent).** Collect every finder's findings. For each, **verify it against the actual code** - read the cited `file:line`, confirm the issue is real, and refute (drop) anything the code does not substantiate or that cannot be stated falsifiably (judge the code, not assumed intent). Dedup findings the same issue surfaced from multiple dimensions (e.g. an `any` flagged by both correctness and conventions), keeping the highest severity and clearest recommendation. Fold in the pre-flight signals: Step 1 type errors as Critical rows; a Step 2 vitest failure as a Critical row with the assertion message verbatim. Sort by severity. If a finder returned nothing usable (it errored or came back empty), note the dropped dimension in the Summary.
 7. **Apply Phase + Re-typecheck** (skip both in `review-only` mode). Apply every safely-fixable finding with `Edit`/`Write` (each fix is its own atomic unit - skip-with-reason on failure, keep the others), then re-run `npm run typecheck` (and the Step 2 vitest if an HMR fix landed). If a fix introduces a new type error, revert that specific edit and move the finding to `Skipped` with reason `"Fix introduced type error: <message>"`; do not roll back unrelated fixes. The Apply Phase also **fills coverage holes**: for each red-green hole the coverage finder reports on diff-introduced behavior, delegate to the `test-builder` agent to author the test (unit/UI written and run scoped to green; E2E flagged, not written inline). See "## Apply Phase".
-8. Emit the **Output Format** below.
+8. **Commit the pass** (skip in `review-only` mode, which writes nothing). Commit this pass's own work so the worktree returns to clean and the next agent inherits an attributed commit instead of a mystery. See "## Committing the pass" for the set rule, the exact commands, and the mixed-authorship case.
+9. Emit the **Output Format** below.
 
 ## Finders
 
@@ -171,7 +178,13 @@ For a deep, no-expense-spared cloud audit, use the `ultra` built-in instead (see
 
 ## Apply Phase
 
-Default mode applies fixes immediately after the findings table. Fixes land in the working tree only - **never commit**; the user runs `/commit` (then `/pull-request` or `/merge-back`) for that.
+Default mode applies fixes immediately after the findings table, then commits them (Step 8, see "## Committing the pass"). The commit is **local only, never pushed** - landing the branch is still `/pull-request`'s or `/merge-back`'s job.
+
+**This edits and commits in the worktree it is reviewing, and the task agent's own unfinished work is usually already sitting there.** The board spawns this skill from the Code Review column as an `isolated` + `always_spawn_new` session, but `isolated` isolates the **conversation, not the filesystem**: the session's `cwd` is the task's own worktree, the same tree the task agent has been using (`docs/session-lifecycle.md:222` documents the shared worktree).
+
+The two do **not** run concurrently. Entering an isolated column takes the `needsSessionSwitch` branch in `src/main/ipc/handlers/task-move.ts`, which suspends the task agent's main session and kills its PTY (`docs/session-lifecycle.md:228`, plus "one active PTY per task" at `:222`), preserving `agent_session_id` so it resumes when the card leaves. What the suspended agent leaves behind is its **uncommitted working tree** - and by the time you reach Step 8, those files are indistinguishable from your own edits. That is the whole reason Step 8 commits by set math instead of `git add -A`.
+
+Committing the pass is also what keeps the tree legible downstream: a finished pass **normally** leaves a clean tree plus one attributed commit. Normally, not always - a fix that lands on an already-dirty path stays uncommitted by design (see "The mixed-authorship case"), so a dirty tree downstream means one of two things, not one: this pass is still in flight, or it finished and deliberately left those paths mixed. `/pull-request`'s Pre-flight Checks documents both readings.
 
 ### What gets auto-fixed
 
@@ -213,7 +226,47 @@ When the coverage finder reports a red-green hole on behavior **this diff** intr
 4. **Red-green standard.** The test must assert the post-fix behavior such that reverting the change fails it. Where the change is localized, `test-builder` may briefly toggle the fix to confirm the test goes red, then restore it.
 5. If `test-builder` cannot produce a green test (ambiguous behavior, missing fixture), move the hole to Skipped with its reason. Never leave a red or `.skip` test behind.
 
-Tests land in the working tree only - never commit.
+Tests are committed with the rest of the pass (Step 8); they are new untracked files, so they always fall on the committable side of the set rule below.
+
+## Committing the pass
+
+Step 8, default mode only. The goal is that a finished pass leaves the worktree **clean**, with its work in one commit whose message says who wrote it.
+
+### What may be committed
+
+This skill deliberately reviews uncommitted work (Step 3: agents "sometimes commit during the working session, sometimes leave changes in the working tree, sometimes both"), so the tree is often **already dirty with the task agent's own unfinished work** when the pass starts. A blind `git add -A` would commit that work under a `refactor(review):` message, which is worse than leaving the tree dirty. So:
+
+> Commit **only** what became dirty during this pass. Never `git add -A`.
+
+Do not try to track "the files the Apply Phase edited" - there is no such value, and `test-builder` is a subagent whose test-file writes are not driver `Edit`/`Write` calls at all, so it would miss them. Use set math over git state instead, which is provable and needs no subagent cooperation. Each command is its own Bash call:
+
+1. `git diff HEAD --name-only` - tracked files dirty now.
+2. `git ls-files --others --exclude-standard` - untracked files now.
+3. `currentDirty` = the union of those two. **Committable = `currentDirty` minus `preexistingDirty`**, reading `preexistingDirty` back from `.kangentic/REVIEW_PREEXISTING_DIRTY.tmp` (written at Step 4) rather than from memory. If that file is missing or unreadable, do NOT guess and do NOT fall back to `git add -A`: skip the commit, and report that the pass could not establish what it may safely commit so the user can stage it themselves.
+
+Anything dirty now that was not dirty at Step 4 is provably this pass's work, whoever wrote it. The edge cases need no special handling: `test-builder`'s new test files are untracked now and were not before, so they commit; a fix on a path the task agent had already left dirty is in both sets, so it is excluded; a fix auto-reverted by the re-typecheck step returns that file to clean, drops out of `currentDirty`, and is never committed.
+
+If Committable is empty, skip the commit silently and go to the Output Format.
+
+### How to commit
+
+1. Stage each committable path explicitly: `git add <path>`, **one path per Bash tool call** (`.claude/rules/bash-single-command.md` forbids chaining).
+2. Write the message to `.kangentic/COMMIT_MSG.tmp` with the **Write** tool - the relative path, resolved from CWD. `.kangentic/` is gitignored, so it never stages itself and needs no cleanup. Never write to `.git/`; in a worktree `.git` is a file, not a directory.
+3. `git commit <path1> <path2> ... -F .kangentic/COMMIT_MSG.tmp` - **pass every committable path as a pathspec.** One command with several positional args, so it still satisfies `.claude/rules/bash-single-command.md`. Never use `$(...)` or backtick substitution (triggers a safety prompt).
+
+   **A bare `git commit -F` here is a real bug, not a shortcut.** With no pathspec, `git commit` commits the ENTIRE INDEX. The task agent routinely pauses with work already staged (`git add somefile.ts`, no commit yet); Step 4 correctly puts that file in `preexistingDirty` and Step 8 correctly excludes it from Committable, and then a bare commit sweeps it in anyway because it was sitting in the index the whole time - defeating the set math completely. The pathspec form commits only the named paths and leaves a pre-staged file untouched and still staged. As a cheap assertion, `git diff --cached --name-only` should equal Committable immediately before you commit; if it does not, stop rather than commit.
+
+The message is conventional, and the scope is literally `review`: `fix(review):`, `refactor(review):`, or `test(review):`, picked by primary change type. The body lists what was fixed, one line per finding. `allowed-tools` already grants `Bash(git:*)`, so nothing new is needed there.
+
+**Use `review` as the scope even though scope usually names a code area.** A review pass is routinely spread across every area it reviewed - one real pass touched migrations, git, IPC handlers, the transition engine, and the renderer at once - so no single area scope is honest, and the useful grouping is which pass produced the commit. It also makes the commit greppable, which the reading side relies on: `/pull-request`'s Pre-flight tells the next agent to expect exactly a `*(review)` commit and to leave it alone rather than squash or reword it.
+
+**Never push. Never amend an existing commit.** Amending would rewrite the task agent's commit and claim this pass as part of it, which is the misattribution this whole design exists to prevent.
+
+### The mixed-authorship case
+
+When a fix lands on a path that was already dirty, that fix stays uncommitted, mixed into the task agent's work in the same file. The hunks cannot be separated safely, so do not try. Instead the footer must **list those paths by name** - "some fixes left uncommitted" is not enough, because the next agent inherits a dirty tree and needs to know exactly which files hold two authors' work before it stages anything.
+
+**The same split can strand a test.** A coverage-hole test is a new untracked file, so it always falls on the committable side; if the behavior it pins lives in a file that stays uncommitted, the commit lands a test with no corresponding fix in its own history. The working tree is fine (the fix is physically present, just uncommitted), but that commit read in isolation - a bisect, or a later `git stash` of only the dirty paths - is not. When it happens, either move that test to `Skipped` for this pass, or commit it and say so explicitly in the footer: "test committed without its target fix (see the mixed-authorship list)."
 
 ## Output Format
 
@@ -266,6 +319,18 @@ Scoped run: PASS
 | 5 | src/main/baz.ts:88 | Architectural refactor - splits handler across 3 files | Design review |
 | 7 | tests/e2e/Qux.spec.ts | E2E coverage hole (real PTY) - not written inline | Run `/test write` |
 
+### Committed
+
+`refactor(review): <subject>` as `<sha>` - P files.
+
+Then the tree status, which is COMPUTED, not boilerplate: print `Worktree clean.` only when nothing
+was left behind. If anything was, print `N file(s) left uncommitted (mixed authorship).` instead -
+never print "clean" directly above a non-empty list, which is the contradiction this line exists to
+avoid.
+
+Left uncommitted (already dirty before this pass, so they hold two authors' work):
+- src/main/qux.ts
+
 ### Summary
 - Files reviewed: N
 - Findings: A critical, B high, C medium, D low
@@ -279,11 +344,13 @@ Edge cases the footer must handle cleanly:
 - No diff at all (committed-vs-base, uncommitted, and untracked all empty) -> short-circuit at the diff-gather step (Step 4) with `"No changes to review."`
 - Diff exists, zero quality findings -> skip the fix step, but STILL run the coverage pass; if it reports holes on diff-introduced behavior, write them (Tests Added) and report. Only when there are also no coverage holes, emit `"No findings, nothing to fix."`
 - Re-typecheck FAILS -> show the error block, list which fix was reverted, mark Verdict as **Needs revision**
+- Committable set empty at Step 8 (no fixes applied, or every fix landed on an already-dirty path) -> omit the `### Committed` block entirely, but STILL list the mixed-authorship paths and say the worktree was left dirty, so the reader knows the clean-tree handoff did not happen
+- Committable NON-empty while some fixes also landed on already-dirty paths (the common mixed case) -> emit `### Committed` for what did land, and do NOT report "Worktree clean.": print `N file(s) left uncommitted (mixed authorship)` and list them, because the tree is by definition not clean
 - Step 2 hmr-resync vitest FAILS -> the failure output is itself a Critical finding. Include the failing assertion's message verbatim in the findings table, attempt the auto-fix in the Apply Phase (e.g. add the missing store re-sync call to `App.tsx`, add the missing `key={hmrGeneration}` to the new `<DndContext>`, add a `// hmr-safe:` directive or `dispose` block to the new module-scope state), then re-run the vitest in addition to typecheck during the Re-typecheck step. If the test still fails after the fix attempt, mark Verdict as **Needs revision**.
 
 ### Review-only-mode footer
 
-When `review-only` is in `$ARGUMENTS`, skip the Apply Phase and emit the legacy footer:
+When `review-only` is in `$ARGUMENTS`, skip the Apply Phase and the Step 8 commit, and emit the legacy footer:
 
 - **Files reviewed:** N
 - **Findings:** N critical, N high, N medium, N low
@@ -300,4 +367,4 @@ The driver uses `Bash` (git/npm/npx only) for pre-flight + diff gathering, the `
 
 **CRITICAL: Use `git -C <path>` for all git commands in other directories.** Never use `cd <path> && git ...` - the `cd && git` pattern triggers an unbypasable Claude Code security prompt.
 
-**Do not commit.** The skill applies fixes to the working tree only. The user runs `/commit` to commit locally, then lands via the board PR flow (`/pull-request`) or `/merge-back` for a direct quick-push.
+**Commit this pass, and nothing else.** Step 8 commits only what became dirty during this pass, so the worktree returns to clean with the work attributed. Never `git add -A`, never touch work that was already uncommitted when the pass started, never amend, and **never push** - landing the branch stays `/pull-request`'s job, or `/merge-back`'s for a direct quick-push. See "## Committing the pass".

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -66,6 +66,11 @@ Use conventional-commit format (`type(scope): subject`), matching `/merge-back`.
    `.kangentic/COMMIT_MSG.tmp` (resolved from CWD, never an absolute or system-temp path).
    `.kangentic/` is gitignored, so it is never staged and needs no cleanup.
 2. Stage everything: `git add -A`
+
+   If the tree holds changes this session did not write, a `/code-review` pass may still be running
+   in this worktree, or it finished and deliberately left a mixed-authorship path uncommitted -
+   either way `git add -A` would sweep a state you did not author. See the Code Review note in
+   `.claude/skills/pull-request/SKILL.md` **Pre-flight Checks**, and confirm with the user first.
 3. Commit: `git commit -F .kangentic/COMMIT_MSG.tmp`
 
 ## Step 4 - Report

--- a/.claude/skills/merge-back/SKILL.md
+++ b/.claude/skills/merge-back/SKILL.md
@@ -81,6 +81,12 @@ If there are uncommitted changes (non-empty `git status --porcelain` output):
    e. If the agent reports gaps, fix them inline using the `Edit` tool.
    f. No general prose review here (that is `/sync-docs`'s job).
 4. Stage changes: `git add -A`
+
+   **This skill pushes straight to the source branch with no CI gate**, so anything swept in here
+   lands unreviewed. If the tree holds changes this session did not write, a `/code-review` pass may
+   still be running in this worktree, or it finished and deliberately left a mixed-authorship path
+   uncommitted - see the Code Review note in `.claude/skills/pull-request/SKILL.md` **Pre-flight
+   Checks**, and confirm with the user before staging.
 5. Write the commit message using the **Write tool** to the relative path `.kangentic/COMMIT_MSG.tmp` (resolved from CWD - do NOT resolve an absolute path, do NOT use the system temp directory, do NOT use `os.tmpdir()`).
 
    `.kangentic/` is gitignored, so `git add -A` won't stage it and no cleanup is needed.

--- a/.claude/skills/merge-pull-request/SKILL.md
+++ b/.claude/skills/merge-pull-request/SKILL.md
@@ -57,19 +57,28 @@ to the head branch only when there is no stored number.
 Every later `gh pr` command (view, checks, merge) targets `<pr>` or `<prHead>`; the local `<branch>`
 is for local git only.
 
-## Step 1 - Doc review at merge time
+## Step 1 - Doc review at merge time (verify only, never push)
 
-The Tests column normally ran the targeted doc-anchor check at commit time, but it is skipped when
-`/pull-request` had nothing to commit. Re-audit the anchor files across the whole branch diff so a
-gap cannot slip through:
+`/pull-request` already audits doc anchors twice: before the PR opens (its Step 1 item 3, which runs
+against the branch diff even when the tree is clean) and again inside its Step 7 auto-fix loop for
+anchors a CI fix touched. So by the time a PR reaches Ship It the anchors have been audited. This
+step is a cheap BACKSTOP, not a second audit pass.
+
+It deliberately does **not** edit, commit, or push. Pushing to the PR head here re-triggers the full
+CI suite and forces Step 2 item 4 to wait out a second complete run at merge time, minutes after
+Tests already drove the checks green. It also keeps this skill off the staging path entirely, so
+there is no `git add` here to sweep up a dirty tree on the way to an admin merge. A gap found at
+this point means the Tests column missed something, and the fix belongs there where the CI round is
+already being spent.
 
 1. Determine the anchor source files in the branch diff (compare the current diff against
    `origin/<sourceBranch>`), then narrow to files matching the canonical anchor list in
    `.claude/skills/sync-docs/SKILL.md` Step 2. If none, skip to Step 2.
-2. Spawn a `doc-auditor` agent with the matching anchor files. Fix any reported gaps inline with
-   `Edit`.
-3. If docs changed, commit them (`docs:` message via `.kangentic/COMMIT_MSG.tmp`) and push to the
-   PR's remote head: `git push origin HEAD:<prHead> --force-with-lease`.
+2. Spawn a `doc-auditor` agent with the matching anchor files.
+3. If it reports no gap, go to Step 2. This is the expected outcome.
+4. If it reports a gap, **stop and report it**: name the anchor files and the missing doc coverage,
+   and tell the user to move the task back to Tests so `/pull-request` fixes the docs and re-greens
+   CI in one round. Do not `Edit` the docs, do not commit, and do not push from this skill.
 
 ## Step 2 - Re-verify (rebase if main moved, confirm green and mergeable)
 

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Create a PR and drive its CI checks to all-green (auto-fixing code and de-flaking/rewriting tests), then stop. Never merges. This is the Tests column skill. Use /merge-pull-request to merge a green PR.
-allowed-tools: Read, Glob, Grep, Edit, Write, Bash(git:*), Bash(npm:*), Bash(gh:*), Agent
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash(git:*), Bash(npm:*), Bash(npx:*), Bash(gh:*), Agent
 argument-hint: [commit message]
 ---
 
@@ -42,6 +42,27 @@ All git commands below run from the **current working directory** - never use `c
    this skill drives PR checks over `gh` and a long monitor loop must not start unauthenticated.
 
 Report the mode, branch name, source branch, and working tree status before proceeding.
+
+**Expect a commit you did not author.** Upstream of this column, the **Code Review** column runs
+`/code-review` as a separate agent in the SAME worktree (`isolated` isolates the conversation, not
+the filesystem), and it auto-fixes findings, adds tests, and commits that pass itself. So a
+`fix(review):` / `refactor(review):` / `test(review):` commit on the branch is expected, not a
+mistake. Leave it alone: do not squash it, reword it, or fold it into your own message - its
+separate authorship is the point.
+
+**And if the tree is dirty with changes you did not write**, that now means one of exactly two
+things, because a finished review pass leaves the tree clean:
+
+- The review pass is **still running**. Its commit has not landed yet.
+- A review fix touched a file that was already dirty, so it was deliberately left uncommitted and
+  mixed with someone else's work. The review's own footer lists those paths by name.
+
+Either way, **confirm with the user before proceeding** - Step 1's `git add -A` would otherwise
+sweep a half-finished pass, or another agent's work, into a commit claimed as yours and push it.
+Ask concretely rather than vaguely: list the dirty paths by name, say which you did not write, and
+offer the two outcomes - stage only the paths you did write (`git add <path>`, one per Bash call,
+never `git add -A`), or stage everything because the user confirms the extra work belongs in this
+PR. Do not resolve it yourself by running `git add -A` anyway.
 
 **Main repo mode:** If detected, fall back to `/merge-back` behavior (Steps 0-5 of merge-back.md)
 and stop. The PR workflow below applies to worktree mode only.
@@ -113,7 +134,13 @@ If there are uncommitted changes (non-empty `git status --porcelain` output):
    **Never write to `.git/`** - in worktrees `.git` is a file, not a directory.
    **Never use `$(...)` or backtick command substitution** - triggers a safety prompt.
 
-If the working tree is clean, skip to Step 1.5.
+If the working tree is clean, there is nothing to stage - but **do not skip item 3.** A clean tree
+usually means the Code Review pass already committed its own work (see the Pre-flight note), and
+that commit can touch doc anchors nothing has audited yet: in one real case it changed
+`src/main/db/migrations/project-schema.ts` and `src/main/ipc/handlers/task-move.ts`, both glob
+anchors. So run item 3 against the **branch diff** instead of the uncommitted set
+(`git diff --name-only origin/<sourceBranch>...HEAD`), commit any doc fixes it produces with a `docs:`
+message, and then go to Step 1.5.
 
 ## Step 1.5 - Compute the clean PUBLIC branch name (never rename the local branch)
 
@@ -131,6 +158,10 @@ mismatch is a non-issue once Step 5b links the number.
 Compute `<branch>`, the clean public name. The local HEAD is the push SOURCE and is never touched:
 
 1. `<type>` = the conventional prefix of the Step 1 commit message (`feat`, `fix`, `chore`, ...).
+   If Step 1 created NO commit (a clean tree whose item 3 found no doc gap - now the common case,
+   since the Code Review pass commits its own work and leaves the tree clean), there is no Step 1
+   message to read: take the prefix of the most recent commit that is NOT a `*(review)` commit, and
+   if there is none, default to `chore`.
 2. `<desc>` = a clean kebab slug of the work. Resolve the task with `kangentic_get_current_task`
    (pass the worktree cwd + the local branch) and slugify its TITLE: lowercase, words joined by
    single hyphens, drop filler ("build", "the", "a", "add", "support for"), drop any trailing
@@ -182,6 +213,29 @@ Write any missing tests for the new functionality BEFORE the PR is created, so C
 Keep this proportional: a clean no-op on a thin or trivial diff is the expected outcome, so the
 Tests column stays fast.
 
+**Re-run any tests the Code Review pass added.** Those files went green when `/code-review` wrote
+them, but against the tree as it stood **then** - and Step 3 has since rebased onto a source branch
+that may well have moved.
+
+Find them in the review commit rather than in the working tree; the pass committed itself, so they
+are not sitting there untracked. Two Bash calls:
+
+1. `git log --format=%H --grep="(review)" origin/<sourceBranch>..HEAD` to get the review commit(s). Keep
+   the quotes; unquoted parentheses are a shell syntax error.
+2. `git show --name-only --format= <sha>` and take the `tests/` paths. Use `--format=` rather than
+   adding `--stat`: it suppresses the commit header so the output is bare paths, ready to pass
+   straight to a scoped test run.
+
+Then re-run each, scoped to the file itself:
+
+- `npx vitest run tests/unit/<file>.test.ts`
+- `npx playwright test tests/ui/<file>.spec.ts`
+
+Only unit and UI files exist (`/code-review` flags E2E coverage holes rather than writing them), so
+this is cheap. **Keep it scoped** - a scoped run of an added test file is explicitly allowed, but
+`npm run test:unit` or a bare `npx vitest run` is a full-tier run this skill must not do. Fix a
+failure here rather than spending a Step 7 round on it.
+
 ## Step 4 - Push the Branch
 
 Run: `git push origin HEAD:<branch> --force-with-lease`
@@ -192,7 +246,9 @@ fails because someone else pushed to the branch, report it and stop - never bare
 ## Step 5 - Create the Pull Request
 
 1. **Determine PR title:** the first line of the most recent commit. If there are several commits
-   since the source branch, combine them into one concise title.
+   since the source branch, combine them into one concise title. **Skip any `*(review)` commit** when
+   deriving the title - it describes the audit pass, not the change the PR is for, and it is routinely
+   the newest commit on the branch.
 2. **Determine PR body:** write a rich, reviewer-facing body and save it to `.kangentic/PR_BODY.tmp`
    with the Write tool (avoids shell escaping). Mirror the section order of
    `.github/pull_request_template.md` so skill-created PRs match UI-created ones:
@@ -286,13 +342,25 @@ For each round:
      non-trivial test fixes to a `test-builder` agent. Cross-platform parity
      (`.claude/rules/cross-platform-parity.md`) is the usual cause of a test that is green locally
      on Windows but red on CI's Linux runner.
+   - **Review-added test gone stale** (the failing test came from the Code Review pass): it passed
+     when `/code-review` wrote it, but against the pre-rebase base. A failure is more likely drift
+     from the moved base than a regression in your own code, so read what it asserts before
+     changing production code to satisfy it. If Step 3.5 already re-ran it green, this is not the
+     explanation and it is a real regression.
    - **Flaky test** (passed on retry, or intermittent across shards/runs): do NOT accept it.
      Delegate to `test-builder` to rewrite it deterministically (replace fixed waits with conditional
      polls, disambiguate selectors, etc.). If it is genuinely unsalvageable, remove it with an
      explicit justification in the commit body. Leave NO flaky tests behind.
-3. Commit the fixes (conventional message via `.kangentic/COMMIT_MSG.tmp`), then push:
+3. **Re-check doc anchors when a fix touched one.** Step 1 item 3 audited anchors, but it ran before
+   this loop, so a fix committed here can touch an anchor nothing has audited. If any file you just
+   edited matches the canonical anchor list in `.claude/skills/sync-docs/SKILL.md` Step 2, spawn a
+   `doc-auditor` on those files and fix any gap inline before committing. Do it HERE: this push is
+   happening anyway, so it costs no extra CI round, whereas leaving the gap for
+   `/merge-pull-request` to find makes that skill push a `docs:` commit at merge time and wait out a
+   second full CI run.
+4. Commit the fixes (conventional message via `.kangentic/COMMIT_MSG.tmp`), then push:
    `git push origin HEAD:<branch> --force-with-lease`.
-4. Return to Step 6 to re-monitor.
+5. Return to Step 6 to re-monitor.
 
 ## Step 8 - Report (success)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,17 @@ checkout for HMR. PRs are the normal path to `main` (CI gates it); `/merge-back`
 quick-push escape hatch for admins. `/test` is now for **manual local runs** only - it is no longer
 wired to a column.
 
+Upstream of both, the **Code Review** column runs `/code-review` as an isolated column agent in the
+task's OWN worktree (`isolated` isolates the conversation, not the filesystem - see
+[docs/session-lifecycle.md](docs/session-lifecycle.md)). Entering the column suspends the task
+agent's session and kills its PTY, so the two never overlap - but it leaves that agent's
+UNCOMMITTED work in the shared tree, which is why the review pass commits by set math over
+`git status` and never `git add -A`. It auto-fixes findings, adds tests, and commits that pass
+itself, so Tests can open on a branch carrying a `*(review)` commit no local agent authored. That is
+expected, not corruption. A finished pass normally leaves the tree clean; a fix on an already-dirty
+path stays uncommitted by design, so a dirty tree means the pass is either in flight or left those
+paths deliberately mixed.
+
 #### When to test
 
 `/test` is the full local gate (typecheck, build, then unit + UI + E2E, all tests, no selection


### PR DESCRIPTION
## What

`/code-review` now commits its own pass, and the skills downstream of it document what to expect.

- **`.claude/skills/code-review/SKILL.md`** - new Step 8 commits the pass locally (never pushed), by set math rather than `git add -A`. New "Committing the pass" section covers the set rule, the exact commands, and the mixed-authorship case.
- **`.claude/skills/pull-request/SKILL.md`** - Pre-flight explains the expected `*(review)` commit and both readings of a dirty tree. Step 3.5 re-runs review-added tests after the rebase. Step 7 classifies a stale review test. A clean tree no longer skips the doc-anchor check.
- **`.claude/skills/merge-pull-request/SKILL.md`** - its doc audit becomes a verify-only backstop.
- **`.claude/skills/commit/SKILL.md`**, **`.claude/skills/merge-back/SKILL.md`** - one line each at their `git add -A`.
- **`CLAUDE.md`** - the board test gate now describes the Code Review column.

Documentation and agent instructions only. No product code, so no runtime behavior changes for users of the app.

## Why

The Code Review column runs `/code-review` as an isolated agent in the task's own worktree. It auto-fixed findings and added tests but never committed, so the next skill in the pipeline opened on a tree that had gone dirty with work no local agent wrote.

That cost two runs recently. One agent verified its worktree clean, then found 271 lines across 17 files and halted mid-`/pull-request` with a three-option question, purely because it had no name for the phenomenon. Halting was correct while the pass might still have been mid-write, but the surprise was avoidable. Both affected agents, once told what was happening, independently reached for the same remedy: a separate commit crediting the review pass.

So the fix is to make the skill do that itself. A finished pass now leaves a clean tree plus one attributed commit, which turns a fuzzy signal into a binary one. Previously "the tree is dirty" could mean the pass was running, finished, or half-written, and only comparing file mtimes told them apart. Now uncommitted work you did not write means the pass is still in flight.

## How

**It commits by set math, never `git add -A`.** The skill deliberately reviews uncommitted work, so the task agent's own unfinished changes are usually already sitting in the tree. Committing those under a review message would be the original problem inverted, and worse. Committable is the set of paths dirty now minus the paths dirty when the pass started.

That formulation was chosen over the more obvious "commit the paths the Apply Phase edited", which does not work: no such value is tracked, and `test-builder` is a subagent whose test-file writes are not driver edits at all, so they would be invisible to any edited-path list. Set math over git state is provable and needs no subagent cooperation.

Three details are load-bearing and documented as such:

- The set must be read from `git diff HEAD --name-only`, not `--stat`, which abbreviates long paths and would break the string comparison.
- The commit must pass a pathspec. A bare `git commit -F` commits the entire index, which would sweep in work the task agent had already staged.
- The pre-existing set is persisted to a gitignored file, since it has to survive a subagent fan-out and a full Apply Phase before it is used.

**Trade-off:** the review pass's fixes are no longer visible to the user before they are committed. Mitigated by keeping it a local commit that is never pushed, so it is reversible with `git reset --soft HEAD~1`.

## Breaking changes

None for the application. One behavioral change for contributors: `/code-review` previously left every fix uncommitted, and now commits its own work. It still never pushes.

## Tests

No product code changed, so no tier applies and the doc-anchor check has nothing to audit. Verified by:

- `npm run typecheck` and `npm run lint`, both clean.
- Hand-tracing the set rule against two real incidents. In the clean-tree case the rule commits all 17 files, reproducing exactly the commit that agent had written by hand. In the already-dirty case it correctly holds back the mixed paths.
- Running the `git log --grep="(review)"` lookup that the new Step 3.5 prescribes, to confirm the syntax matches rather than leaving it aspirational.
- Confirming no em-dashes and no `--` used as punctuation in the diff, since `.claude/` and `CLAUDE.md` sit outside the mechanical scan.

A `/code-review` pass on this change caught five defects before it landed, including the bare-`git commit` and `--stat` truncation bugs above, and a claim that the review runs *concurrently* with the task agent. That was wrong: entering the column suspends the task agent and kills its PTY, so they run sequentially and the real hazard is the uncommitted tree left behind. Those corrections are folded into the single commit here rather than split out, because they edit the same lines.

Generated with [Claude Code](https://claude.com/claude-code)
