### PR TITLE
fix(dictation): give the live chip a real capture signal

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -14,6 +14,7 @@ import { useUpdaterStore } from './stores/updater-store';
 import { useUsageDashboardStore } from './stores/usage-dashboard-store';
 import { useMonitorStore } from './stores/monitor-store';
 import { usePopOutStore } from './stores/pop-out-store';
+import { useDictationStore } from './stores/dictation-store';
 import { useProjectSwitchEffect } from './hooks/useProjectSwitchEffect';
 import { useAgentDrivenInvalidation } from './hooks/useAgentDrivenInvalidation';
 import { invalidateProject } from './stores/project-cache';
@@ -800,5 +801,6 @@ if (import.meta.env.DEV) {
     commandWindow: commandWindowManager.store,
     usageDashboard: useUsageDashboardStore,
     popOut: usePopOutStore,
+    dictation: useDictationStore,
   };
 }

--- a/src/renderer/components/dictation/LiveDictationChip.tsx
+++ b/src/renderer/components/dictation/LiveDictationChip.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from 'react';
 import { Download, Mic, RotateCcw } from 'lucide-react';
 import { useDictationStore } from '../../stores/dictation-store';
+import { useConfigStore } from '../../stores/config-store';
 import { useOverlayPhase } from '../../hooks/useOverlayPhase';
 import { useFocusedTerminalRect } from '../../hooks/useFocusedTerminalRect';
 import { dictationPopupActions } from '../../hooks/useDictation';
@@ -45,16 +46,31 @@ function LiveDictationChipContent() {
   const downloadPercent = downloading && modelProgress.totalBytes > 0
     ? Math.min(100, Math.round((modelProgress.downloadedBytes / modelProgress.totalBytes) * 100))
     : 0;
+  // Whether releasing push-to-talk submits the text or just leaves it in the
+  // input. It is the one thing the terminal itself cannot show you, which is why
+  // it earns the space the old "(typing into the terminal)" hint used to take.
+  const autoSubmit = useConfigStore((state) => state.globalConfig.dictation?.autoSubmit ?? true);
+
+  // Capturing with nowhere to put the text. Its own state, not a suffix: the
+  // words go nowhere, so saying "Listening" in the live tone would be a lie.
+  const noTarget = !targetSessionId && (recording || status === 'finalizing');
 
   const label = error
     ? error
     : downloading
       ? `Preparing model... ${downloadPercent}%`
-      : recording
-        ? 'Listening (typing into the terminal)'
-        : status === 'finalizing'
-          ? 'Inserting...'
-          : 'Dictation';
+      : noTarget
+        ? 'No terminal focused'
+        : recording
+          ? 'Listening'
+          : status === 'finalizing'
+            ? (autoSubmit ? 'Sending...' : 'Inserting...')
+            : 'Dictation';
+
+  // Trailing hint, separated by spacing and a muted tone rather than a glyph.
+  const hint = recording && !noTarget
+    ? (autoSubmit ? 'Release to send' : 'Release to insert')
+    : null;
 
   return (
     <div
@@ -63,33 +79,52 @@ function LiveDictationChipContent() {
       data-testid="dictation-live-chip"
     >
       <div
-        className={`flex items-center gap-2 rounded-full border border-edge bg-surface px-3 py-1.5 shadow-lg ${contentClassName}`}
+        // The min width holds the chip steady across state changes. When anchored
+        // to a focused terminal it is centred with translate(-50%) (see
+        // anchoredStyle above), so a label that shrinks (Listening -> Sending...)
+        // would otherwise snap the whole chip narrower and re-centre it under the
+        // user's cursor at the exact moment they release the key.
+        className={`flex min-w-[min(17rem,80vw)] items-center gap-2 rounded-full border border-edge bg-surface px-3 py-1.5 shadow-lg ${contentClassName}`}
         onAnimationEnd={onAnimationEnd}
       >
         <span className="relative flex items-center justify-center">
           {downloading ? (
             <Download size={14} className="text-accent" />
           ) : (
-            <Mic size={14} className={recording ? 'text-accent' : 'text-fg-muted'} />
+            <Mic size={14} className={status === 'error' ? 'text-danger' : 'text-fg-muted'} />
           )}
+          {/* The dot, not the glyph, carries the live-capture signal: `active` is
+              the one state token every theme leaves alone, and keeping the mic
+              muted is what lets the dot read as a light ON the glyph rather than
+              part of it. Tinting both the same color is what this replaced. */}
           {recording && (
-            <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-accent animate-pulse" />
+            <span
+              className={`absolute -right-1 -top-1 h-2 w-2 rounded-full animate-pulse ${
+                noTarget ? 'bg-attention' : 'bg-active'
+              }`}
+              data-testid="dictation-recording-dot"
+              data-tone={noTarget ? 'attention' : 'active'}
+            />
           )}
         </span>
         <span className="max-w-[280px] truncate text-xs text-fg-secondary">{label}</span>
-        {!targetSessionId && status !== 'error' && (
-          <span className="text-xs text-fg-faint">(no terminal)</span>
-        )}
+        {hint && <span className="truncate text-xs text-fg-faint">{hint}</span>}
         {!downloading && (
-          <button
-            type="button"
-            onClick={() => dictationPopupActions.clear()}
-            className="ml-1 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-fg-muted hover:bg-surface-hover hover:text-fg"
-            data-testid="dictation-live-clear"
-            title="Clear and start over"
-          >
-            <RotateCcw size={12} /> Clear
-          </button>
+          <>
+            {/* Pushes Clear to the trailing edge, so the copy stays left-aligned
+                while the chip holds its min width. */}
+            <span className="flex-1" aria-hidden />
+            <div className="w-px h-4 bg-edge mx-1" aria-hidden />
+            <button
+              type="button"
+              onClick={() => dictationPopupActions.clear()}
+              className="inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-xs text-fg-muted hover:bg-surface-hover hover:text-fg"
+              data-testid="dictation-live-clear"
+              title="Clear and start over"
+            >
+              <RotateCcw size={12} /> Clear
+            </button>
+          </>
         )}
       </div>
     </div>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -597,17 +597,28 @@
 }
 
 /* Honor the OS-level reduced-motion preference (distinct from the in-app
-   Appearance toggle above). Stop the infinite Done-hover spin and the idle
-   pulse, and collapse the completed-card grow-in to a near-instant fade.
-   grow-in keeps a 1ms duration (not `animation: none`) so its `animationend`
-   still fires and DoneSwimlane clears recentlyArchivedId. The drag-to-Done fly
-   is inline-styled, so it reads this preference in JS (see FlyingCard). */
+   Appearance toggle above). Stop the infinite Done-hover spin and every ambient
+   pulse (the card idle pulse and Tailwind's stock one alike), and collapse the
+   completed-card grow-in to a near-instant fade. grow-in keeps a 1ms duration
+   (not `animation: none`) so its `animationend` still fires and DoneSwimlane
+   clears recentlyArchivedId. The drag-to-Done fly is inline-styled, so it reads
+   this preference in JS (see FlyingCard). */
 @media (prefers-reduced-motion: reduce) {
   .drop-zone-active::before {
     animation: none;
   }
 
   .animate-pulse-subtle::before {
+    animation: none;
+  }
+
+  /* Tailwind's stock pulse. Every consumer is an ambient status indicator: the
+     dictation recording dot, TerminalPanel's unseen-attention dot, WindowFrame's
+     focus hairline, QueuedPlaceholder's waiting clock, and the loading skeletons.
+     All of it is infinite, so nothing can be listening for an `animationend` (an
+     infinite animation never fires one) and it is safe to stop dead rather than
+     shrink the way the overlay phases below must. */
+  .animate-pulse {
     animation: none;
   }
 

--- a/src/renderer/stores/dictation-store.ts
+++ b/src/renderer/stores/dictation-store.ts
@@ -4,9 +4,11 @@ import type { DictationModelProgress } from '../../shared/types';
 /**
  * Renderer state for the voice-to-text dictation popup. Push-to-talk drives
  * the lifecycle: `recording` while the key is held (live partials stream in),
- * `finalizing` briefly while the engine flushes, then back to `idle`. The
- * live transcript renders in the popup only; only the finalized text is
- * written into the focused terminal, so a revising hypothesis is safe here.
+ * `finalizing` briefly while the engine flushes, then back to `idle`. While a
+ * terminal is focused, each partial is typed straight into it and erased again
+ * when the next one revises it (`useDictation`'s liveWrite path), so `partialText`
+ * here mirrors what the PTY already shows rather than being a popup-only preview.
+ * With no focused target it still updates, but nothing renders it.
  *
  * This store holds no main-process truth (nothing to re-fetch on HMR), so it
  * needs no `vite:afterUpdate` re-sync registration. Its only module-scope
@@ -99,8 +101,9 @@ if (import.meta.hot) {
   // closures; force a clean full reload instead (rare; prod drops this block).
   // @ts-expect-error -- Vite handles import.meta.hot
   import.meta.hot.accept(() => import.meta.hot.invalidate());
-  // Pattern A snapshot: also preserve the in-flight transcript so a cold reload
-  // mid-dictation does not orphan the popup.
+  // Pattern A snapshot: preserve the in-flight state so a cold reload mid-dictation
+  // does not strand the chip in a torn state, and keep finalText so a reload
+  // between the final transcript and commit() does not drop text already spoken.
   // @ts-expect-error -- Vite handles import.meta.hot
   import.meta.hot.dispose((data: Record<string, unknown>) => {
     const state = useDictationStore.getState();

--- a/tests/ui/dictation-live-chip.spec.ts
+++ b/tests/ui/dictation-live-chip.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Coverage for `LiveDictationChip`'s autoSubmit-driven copy (Priority 2) and its
+ * `noTarget` state (Priority 3). The chip is mounted unconditionally by
+ * `<DictationSurface />` in `AppLayout`, with no project-open gate, so no project
+ * or session needs to exist for these tests.
+ *
+ * Driving `recording` / `finalizing` through the real push-to-talk flow would need
+ * a fake media device, granted mic permission, a loaded AudioWorklet, and a
+ * combo-matched keydown/keyup - and `finalizing` is a single microtask in that path
+ * (the mock's `dictation.stop()` resolves immediately), so it is not reliably
+ * observable even with all of that in place. Instead this drives the dictation
+ * store directly via the `__zustandStores` debug handle (`src/renderer/App.tsx`,
+ * `import.meta.env.DEV`-only), the same pattern `spawn-stall-toast.spec.ts` uses
+ * for the session store's `setSpawnProgress`.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+// Each test launches its own browser: the dictation store is a Fast-Refresh-pinned
+// singleton (module scope), so a shared page would carry `status` across tests.
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+interface DictationStoreState {
+  beginRecording: (dictationSessionId: string, targetSessionId: string | null) => void;
+  setFinalizing: () => void;
+}
+
+interface DictationStoreHandle {
+  getState: () => DictationStoreState;
+}
+
+/**
+ * `dictation.enabled: true` matters beyond arming the (unused) keybinding:
+ * `useDictation`'s teardown effect calls `cancelDictation()` (which resets the
+ * store to idle) whenever `enabled` is false and status is not idle. Leaving it
+ * false would race our direct store writes against that effect.
+ */
+async function launch(autoSubmit: boolean): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  const page = await context.newPage();
+  await page.addInitScript((config: Record<string, unknown>) => {
+    (window as unknown as { __mockConfigOverrides: Record<string, unknown> }).__mockConfigOverrides = config;
+  }, { dictation: { enabled: true, autoSubmit } });
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  return { browser, page };
+}
+
+async function beginRecording(page: Page, targetSessionId: string | null): Promise<void> {
+  await page.evaluate((tid) => {
+    const stores = (window as unknown as { __zustandStores?: { dictation: DictationStoreHandle } }).__zustandStores;
+    if (!stores?.dictation) throw new Error('dictation store not exposed on __zustandStores');
+    stores.dictation.getState().beginRecording('dict-session-1', tid);
+  }, targetSessionId);
+}
+
+async function setFinalizing(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const stores = (window as unknown as { __zustandStores?: { dictation: DictationStoreHandle } }).__zustandStores;
+    if (!stores?.dictation) throw new Error('dictation store not exposed on __zustandStores');
+    stores.dictation.getState().setFinalizing();
+  });
+}
+
+test.describe('LiveDictationChip: autoSubmit-driven copy', () => {
+  test('recording with a focused target: "Listening" + "Release to send" hint (autoSubmit on, the default)', async () => {
+    const { browser, page } = await launch(true);
+    try {
+      await beginRecording(page, 'sess-target-1');
+      const chip = page.locator('[data-testid="dictation-live-chip"]');
+      await expect(chip).toBeVisible();
+      await expect(chip.getByText('Listening', { exact: true })).toBeVisible();
+      await expect(chip.getByText('Release to send', { exact: true })).toBeVisible();
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('recording with a focused target: "Release to insert" hint when autoSubmit is off', async () => {
+    const { browser, page } = await launch(false);
+    try {
+      await beginRecording(page, 'sess-target-1');
+      const chip = page.locator('[data-testid="dictation-live-chip"]');
+      await expect(chip.getByText('Release to insert', { exact: true })).toBeVisible();
+      await expect(chip.getByText('Release to send', { exact: true })).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('finalizing with a focused target: "Sending..." label when autoSubmit is on', async () => {
+    const { browser, page } = await launch(true);
+    try {
+      await beginRecording(page, 'sess-target-1');
+      await setFinalizing(page);
+      const chip = page.locator('[data-testid="dictation-live-chip"]');
+      await expect(chip.getByText('Sending...', { exact: true })).toBeVisible();
+      await expect(chip.getByText('Inserting...', { exact: true })).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('finalizing with a focused target: "Inserting..." label when autoSubmit is off', async () => {
+    const { browser, page } = await launch(false);
+    try {
+      await beginRecording(page, 'sess-target-1');
+      await setFinalizing(page);
+      const chip = page.locator('[data-testid="dictation-live-chip"]');
+      await expect(chip.getByText('Inserting...', { exact: true })).toBeVisible();
+      await expect(chip.getByText('Sending...', { exact: true })).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+});
+
+test.describe('LiveDictationChip: no focused terminal', () => {
+  test('recording with no target: "No terminal focused" label, attention-toned dot, no hint', async () => {
+    const { browser, page } = await launch(true);
+    try {
+      await beginRecording(page, null);
+      const chip = page.locator('[data-testid="dictation-live-chip"]');
+      await expect(chip.getByText('No terminal focused', { exact: true })).toBeVisible();
+      await expect(chip.getByText('Listening', { exact: true })).toHaveCount(0);
+
+      const dot = chip.locator('[data-testid="dictation-recording-dot"]');
+      await expect(dot).toHaveAttribute('data-tone', 'attention');
+      await expect(dot).toHaveClass(/bg-attention/);
+      await expect(dot).not.toHaveClass(/bg-active/);
+
+      // No "Release to..." hint while there is nowhere to release into.
+      await expect(chip.getByText('Release to send', { exact: true })).toHaveCount(0);
+      await expect(chip.getByText('Release to insert', { exact: true })).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('recording with a target: active-toned dot (the contrast case for the noTarget dot above)', async () => {
+    const { browser, page } = await launch(true);
+    try {
+      await beginRecording(page, 'sess-target-1');
+      const chip = page.locator('[data-testid="dictation-live-chip"]');
+      const dot = chip.locator('[data-testid="dictation-recording-dot"]');
+      await expect(dot).toHaveAttribute('data-tone', 'active');
+      await expect(dot).toHaveClass(/bg-active/);
+      await expect(dot).not.toHaveClass(/bg-attention/);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/ui/reduced-motion-animate-pulse.spec.ts
+++ b/tests/ui/reduced-motion-animate-pulse.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Coverage for the `prefers-reduced-motion` rule added to `src/renderer/index.css`
+ * that stops Tailwind's stock `.animate-pulse` utility (`@media (prefers-reduced-motion:
+ * reduce) { .animate-pulse { animation: none } }`). Every current consumer (the
+ * dictation recording dot, TerminalPanel's unseen-attention dot, WindowFrame's focus
+ * hairline, QueuedPlaceholder's waiting clock, and the loading skeletons) shares this
+ * one rule, so the coverage lives here at the generic-rule level rather than on any
+ * one consumer - asserting the dictation dot specifically would prove nothing about
+ * the other five sites, and none of them are needed to prove the rule itself works.
+ *
+ * The probe is a bare synthetic element carrying only the Tailwind class, appended to
+ * the already-booted app page so it inherits the real `index.css` cascade. Mirrors the
+ * CSS-custom-property probe in `task-card-context-window.spec.ts`.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+// Each test launches its own browser so no in-page state (or the reducedMotion
+// context option itself) can leak across tests.
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+async function launch(reducedMotion?: 'reduce'): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 800 },
+    ...(reducedMotion ? { reducedMotion } : {}),
+  });
+  const page = await context.newPage();
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  return { browser, page };
+}
+
+/** Append a bare `.animate-pulse` div to the booted page, read its computed
+ *  `animation-name`, then remove it. No component under test - just the utility
+ *  class against the real cascade. */
+async function probeAnimatePulseName(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const probe = document.createElement('div');
+    probe.className = 'animate-pulse';
+    document.body.appendChild(probe);
+    const animationName = getComputedStyle(probe).animationName;
+    probe.remove();
+    return animationName;
+  });
+}
+
+test.describe('prefers-reduced-motion: Tailwind stock .animate-pulse', () => {
+  test('animates normally without the OS preference', async () => {
+    const { browser, page } = await launch();
+    try {
+      // Baseline: proves the utility itself resolves to a real animation in this
+      // build, so the reduced-motion test's 'none' result below means the rule
+      // fired, not that `.animate-pulse` never animated to begin with. 'pulse' is
+      // Tailwind's own keyframe name for this utility (`--animate-pulse: pulse 2s
+      // ...` in tailwindcss/theme.css) - a future Tailwind major that renames it
+      // would legitimately red this baseline, unrelated to the rule under test.
+      const animationName = await probeAnimatePulseName(page);
+      expect(animationName).toBe('pulse');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('stops animating under prefers-reduced-motion: reduce', async () => {
+    const { browser, page } = await launch('reduce');
+    try {
+      // Prove the emulation is actually in force (mirrors activity-marks.spec.ts /
+      // onboarding-welcome-screen.spec.ts's reduced-motion tests): without this, a
+      // context option that silently failed to apply would still let every
+      // assertion below pass on the normal animated path for the wrong reason.
+      const mediaMatches = await page.evaluate(
+        () => window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+      );
+      expect(mediaMatches, 'prefers-reduced-motion emulation never took effect').toBe(true);
+
+      const animationName = await probeAnimatePulseName(page);
+      expect(animationName).toBe('none');
+    } finally {
+      await browser.close();
+    }
+  });
+});


### PR DESCRIPTION
## What

`LiveDictationChip` now carries a real live-capture signal, and the OS reduced-motion preference
finally reaches Tailwind's stock `.animate-pulse`.

- **The dot** moves from `bg-accent` to `bg-active`, and the mic drops to an unconditional
  `text-fg-muted` so the dot reads as a light ON the glyph rather than part of it.
- **The copy** loses `(typing into the terminal)` and gains `Release to send` / `Release to insert`,
  driven by the real `autoSubmit` setting. `finalizing` says `Sending...` when that setting is on.
- **No focused terminal** becomes its own state (`No terminal focused`, attention-toned dot) instead
  of a contradictory suffix.
- **Layout:** a min-width stops the chip re-centering on every state change, and a divider plus a
  trailing-edge Clear makes that button read as a control.
- **Errors** tint the mic `text-danger`.
- **`index.css`:** `.animate-pulse` is silenced under `prefers-reduced-motion`.

## Why

Closes #462.

The dot was the same per-theme `accent` hue as the mic glyph beside it, so it read as decoration
rather than "you are being recorded". #461 / PR #233 removed the title-bar mic button, which left
this chip as the ONLY surface carrying the live-capture signal, so it has to hold that alone.

Three further problems surfaced while fixing it:

1. `(typing into the terminal)` dates from when `experience` was a three-way setting
   (`popup` / `docked` / `live`). `useDictation` now hardcodes `live`, so the text described the
   only behavior there is, while the user watched it happen, on a chip anchored to the very
   terminal it named.
2. With no focused terminal the chip rendered `Listening (typing into the terminal) (no terminal)`:
   two contradictory parentheticals under a green live dot, while the words went nowhere.
3. `finalizing` always said `Inserting...`, even when it was about to press Enter.

## How

**Why the mic went muted rather than staying `text-accent`.** Tested, not assumed: on forest
(`#68a060`), mint (`#3a8a5e`), and ocean (`#4a9cb0`) the accent sits close enough to `--kng-active`
(`#34d399`) that an accent glyph plus an emerald dot merge into one blob, which is the reported bug
wearing a different hue. `text-fg-muted` is theme-neutral and contrasts against emerald in all 10
themes. It also matches the house pattern in `CollapsedRail` and `TerminalPanel`: keep the surface
neutral, put the tone on the dot. Screenshots across five themes confirmed no ring or halo was
needed, and the dot stays 8px.

**Why the reduced-motion fix is global rather than scoped to this dot.** The block's own comment
already claims to stop "the idle pulse", but it only ever enumerated `.animate-pulse-subtle`.
Silencing the stock utility there fixes this dot plus five other ambient surfaces (TerminalPanel's
attention dot, WindowFrame's focus hairline, QueuedPlaceholder's clock, and the loading skeletons).
Safe to use `animation: none` rather than the 0.01ms shrink the overlay phases need: no element
carrying `animate-pulse` listens for `animationend`, and an infinite animation never fires one.

**Trade-off worth a look:** the min-width (`min-w-[min(17rem,80vw)]`) is a magic number. It is sized
to the widest state so the chip holds still; the `min()` keeps it from overflowing a narrow pane.

Two things fixed in passing: the `dictation-store` docstring claimed partials render in the popup
only and just the finalized text reaches the terminal, but `useDictation` types every partial
straight into the PTY and backspaces it on revision. And `App.tsx` now exposes the dictation store on
the dev-only `__zustandStores` handle, which is what lets the new spec drive the chip without a fake
media device, granted mic permission, and a loaded AudioWorklet.

## Breaking changes

None. No API, config, or persisted-state change. Under OS reduced motion, five surfaces beyond the
dictation dot stop pulsing; that is the intended fix, not a regression.

## Tests

Two new UI specs, plus the standard CI checks (lint, typecheck, unit, build, UI shards, Linux
Electron E2E shards).

- `tests/ui/dictation-live-chip.spec.ts` - 6 tests covering the autoSubmit-driven copy
  (`Release to send` / `Release to insert`, `Sending...` / `Inserting...`) and the `noTarget` state,
  including the `data-tone` contrast case so the attention-dot assertion cannot pass vacuously.
  Drives the store through `__zustandStores` because the real push-to-talk path needs a fake media
  device and a loaded AudioWorklet, and `finalizing` is a single microtask within it.
- `tests/ui/reduced-motion-animate-pulse.spec.ts` - 2 tests on the CSS rule itself via a synthetic
  probe element, with a baseline assertion (`animation-name` is `pulse` without the preference) so
  the `none` result proves the rule fired rather than that the utility never animated, and an
  explicit `matchMedia` check that the emulation actually took effect.

All 8 pass locally. Verification of the visual change itself was by screenshot across five themes
(dark, light, mint, forest, ocean), before and after.

Generated with [Claude Code](https://claude.com/claude-code)
