### PR TITLE
refactor(description): drop the "Markdown supported" hint from the empty state

### DIFF
--- a/src/renderer/components/DescriptionEditor.tsx
+++ b/src/renderer/components/DescriptionEditor.tsx
@@ -273,23 +273,21 @@ export function DescriptionEditor({
             40% opacity until the textarea was focused, which faded it exactly
             when it is most needed: an unfocused empty box is the moment someone
             is deciding what to type, and on a fresh dialog focus starts in the
-            title field, so the placeholder and the markdown hint were barely
-            legible. The muted tokens already carry the "this is placeholder,
-            not content" signal without a second multiplier. */}
+            title field, so the placeholder was barely legible. The muted tokens
+            already carry the "this is placeholder, not content" signal without a
+            second multiplier. */}
         {!value && !showPreview && (
           <div className="absolute inset-0 pointer-events-none">
             {/* Two independent layers rather than one column. Stacking them made
                 the drop hint centre itself in the space LEFT OVER under the
                 text, which reads as sitting too low; centring it on the whole
                 box instead puts it where the eye expects. */}
+            {/* Placeholder only. A "Markdown supported" line used to sit under
+                it and was cut: this dialog is opened constantly, and a standing
+                label restating what the Preview pill already implies reads as
+                overbearing. Do not restore it. */}
             <div className="absolute inset-x-0 top-0 pl-3 pr-28 py-2">
               <span className="block text-sm text-fg-faint">{placeholder}</span>
-              {/* The toggle says what the button does; this says what the box
-                  accepts. Same split GitHub uses ("Styling with Markdown is
-                  supported" sits outside the Write/Preview tabs), and folding it
-                  into the existing empty state costs no extra chrome while
-                  surfacing it exactly when someone is deciding how to type. */}
-              <span className="mt-0.5 block text-xs text-fg-disabled">Markdown supported</span>
             </div>
             {/* A single compact row, not a stacked panel: the editor rests at
                 160px, so the old 20px icon over its own line of text took up

--- a/tests/ui/task-attachments.spec.ts
+++ b/tests/ui/task-attachments.spec.ts
@@ -77,14 +77,15 @@ test.describe('New Task Dialog Layout', () => {
     await openNewTaskDialog();
     await expect(page.locator('text=Describe the task for the agent...')).toBeVisible();
     await expect(page.locator('text=Paste or drop files here')).toBeVisible();
-    // The empty state is where markdown support is advertised: the toggle says
-    // what the button does, this says what the box accepts.
-    await expect(page.locator('text=Markdown supported')).toBeVisible();
+    // The empty state carries no markdown hint. That line was cut on purpose -
+    // the Preview toggle is the affordance, and a standing label restating it in
+    // a constantly-opened dialog reads as overbearing. Asserted as an absence so
+    // a well-meaning restore fails here rather than shipping.
+    await expect(page.locator('text=Markdown supported')).toHaveCount(0);
     // Placeholder disappears when user types
     const textarea = page.locator('textarea');
     await textarea.fill('hello');
     await expect(page.locator('text=Paste or drop files here')).not.toBeVisible();
-    await expect(page.locator('text=Markdown supported')).not.toBeVisible();
     // Form is dirty (text typed) - Cancel shows "Discard unsaved changes?" confirm.
     // Dismiss via Discard so the dialog fully closes before the next test opens it.
     await page.locator('button:has-text("Cancel")').click();


### PR DESCRIPTION
## What

Deletes the `Markdown supported` hint from the description editor's empty state.

`src/renderer/components/DescriptionEditor.tsx` loses one `<span>`; `tests/ui/task-attachments.spec.ts` is updated to match. The string was a hardcoded default with no prop, so the cut lands on all three hosts of the shared editor: the New Task dialog, the task-detail edit form, and the backlog dialog.

## Why

The New Task dialog reads as too texty, and the empty description box was the worst offender: the only place in the dialog where three hint strings competed for the same pixels at once (the placeholder, `Markdown supported` stacked beneath it, and the centred `Paste or drop files here` pill), plus the `Preview` pill in the corner. Nowhere else in the dialog stacks more than one.

This dialog is opened constantly, so the bar for standing text is essential AND non-obvious. A label that teaches a feature is paid for on every open, while the user meets the feature once. The `Preview` pill sits in the same box doing exactly that job, so the sentence was restating an affordance already on screen.

## How

A deletion, not a rearrangement. Three consolidation layouts were costed first (a bottom-anchored capability strip, a two-chip variant, and widening the existing centred pill) and all were rejected: each kept the same sentences and only moved them.

Kept deliberately:

- **`Paste or drop files here`** - it teaches a genuinely hidden gesture, and its compact centred single-row form has revert history behind it.
- **The `Preview` pill as a labelled control** - a bare icon was tried before and read as decoration in a large empty field.
- **The 160px editor floor** and the placeholder wording, both of which have revert history in both directions.

Also left alone, having been costed and judged not worth forcing: the two run-mode card descriptions (tuned deliberately in #442/#443, where one-line headers and a visible unselected description are what let a user tell the branches apart) and the branch hint line. Worth flagging for a future change: the branch-hint JSX is duplicated verbatim in `NewTaskDialog.tsx` and `task-detail/useBranchConfig.tsx`, so any edit there has to land twice or be extracted first.

**Known trade-off:** markdown support is now signalled only by the `Preview` pill and its tooltip, so it is no longer discoverable without hover. That is the accepted cost of the cut, not an oversight.

## Breaking changes

None. Copy-only; no API, config, or behavioral change.

## Tests

`tests/ui/task-attachments.spec.ts` gains a `toHaveCount(0)` assertion rather than simply dropping the two it had. The old negative assertion would have passed vacuously against a deleted string; an absence assertion makes a well-meaning restore fail in CI instead. It is non-vacuous because the two `toBeVisible()` assertions immediately above it pin the empty state as actually mounted first.

The empty state is an absolutely-positioned overlay, so removing content from it moves no geometry. `tests/ui/description-editor-file-mentions.spec.ts` is unchanged and still passes: editor height identical empty vs filled, the preview toggle's scrollbar gutter, and the run-mode controls plus Create button all still in viewport.

Verified locally before pushing: typecheck, lint, and 36/36 across both affected specs. Before and after screenshots of the New Task dialog and the task-detail edit form were captured in a dark and a light theme; the only pixel difference is the removed line. A `test-builder` coverage pass returned a deliberate no-op, on the grounds that all three hosts render identical component code so a per-host duplicate assertion would prove nothing new. Everything else is CI's job.

Generated with [Claude Code](https://claude.com/claude-code)
