### PR TITLE
test(ui): share browsers and shard by describe to cut the UI tier

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -218,6 +218,56 @@ npx playwright test --project=ui
 - **Mock:** `tests/ui/mock-electron-api.js` injects a full in-memory mock of `window.electronAPI` via `addInitScript()`. Supports full CRUD for projects, tasks, swimlanes, actions, sessions, config, attachments.
 - **Pre-configure:** `window.__mockPreConfigure(fn)` lets tests set up mock state before React mounts
 
+#### Share the browser, reset with `goto()`
+
+`chromium.launch()` costs ~1-2s, so launching one per test is the single most expensive thing a UI
+spec can do. Launch once per describe and reset per test instead, using the two helpers in
+`tests/ui/helpers.ts`:
+
+```ts
+let browser: Browser;
+let page: Page;
+
+test.beforeAll(async () => {
+  ({ browser, page } = await launchSharedBrowser(optionalPreConfigScript));
+});
+test.afterAll(async () => { await browser?.close(); });
+test.beforeEach(async () => { await resetPage(page); });
+```
+
+`resetPage()` re-navigates to the app shell, which re-runs every registered `addInitScript` and
+rebuilds the mock's state from scratch, so tests stay isolated without a fresh browser. Anything a
+test needs on top of that (a project, a seeded fetch preset, a route interception) goes in the test
+itself, after the reset. `command-terminal.spec.ts` is the reference consumer.
+
+Keep a per-test launch only when the test genuinely needs a fresh document: a different viewport, a
+`page.route()` that must be installed before the first navigation, or per-document state that a
+prior load would mask (see `stats-lazy-retry.spec.ts`).
+
+#### Sharding granularity: `parallel` outside, `default` inside
+
+Playwright shards by test GROUP, and by default a whole spec file is one group -- so a 40-test file
+lands entirely on one shard and cannot be split. `test.describe.configure({ mode: 'parallel' })`
+alone is often the wrong fix: it scatters each test to its own worker, which breaks any describe
+whose tests hand state to each other.
+
+The middle setting is `mode: 'parallel'` at file level plus `mode: 'default'` on each top-level
+describe. That makes **each top-level describe its own shardable group** while keeping the tests
+inside a describe in order on one worker, so existing shared-page ordering is preserved exactly.
+Nested describes collapse to the outermost `'default'` one, so a file's group count is its
+top-level describe count.
+
+Two things to check before applying it:
+
+- **No cross-describe dependency.** Groups can land on different shards, so a describe that relies
+  on data an earlier describe created will fail. Classifier: run each shard slice cold
+  (`--shard=i/N`) and confirm it passes alone. This is deterministic, not a flake.
+- **`beforeAll` cost.** A file-level `beforeAll` now runs once per describe group. Only apply where
+  `beforeAll cost x describe count` stays well under the file's current serial span.
+
+Confirm the split with `npx playwright test --project=ui <file> --shard=i/4 --list`: before, one
+shard reports every test and the rest report zero.
+
 ### E2E Tests (`tests/e2e/`)
 
 ```bash

--- a/tests/ui/add-project-flow.spec.ts
+++ b/tests/ui/add-project-flow.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import type { Browser, Page } from '@playwright/test';
-import { launchPage, waitForBoard, createProject, dismissOnboardingChecklist } from './helpers';
+import { launchSharedBrowser, resetPage, waitForBoard, createProject, dismissOnboardingChecklist } from './helpers';
 
 /**
  * Coverage for useAddProject's branches (src/renderer/hooks/useAddProject.ts): the
@@ -14,15 +14,31 @@ import { launchPage, waitForBoard, createProject, dismissOnboardingChecklist } f
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('Add project flow', () => {
+  // Pins this describe to ONE group. Without it the tests land in Playwright's
+  // `parallelWithHooks` bucket, which chunks them into `ceil(tests / shardTotal)`
+  // groups - and since CI passes shardTotal=9, a file with fewer than 9 tests would
+  // get one group (and one browser launch) per test, undoing the sharing below.
+  test.describe.configure({ mode: 'default' });
+
   let browser: Browser;
   let page: Page;
 
-  test.afterEach(async () => {
+  // One browser per worker group instead of one per test. Every test here starts from
+  // the welcome screen, which page.goto() restores: the mock's project list is rebuilt
+  // empty on every navigation.
+  test.beforeAll(async () => {
+    ({ browser, page } = await launchSharedBrowser());
+  });
+
+  test.afterAll(async () => {
     await browser?.close();
   });
 
+  test.beforeEach(async () => {
+    await resetPage(page);
+  });
+
   test('reopens the existing project instead of creating a new one when probePath reports it already registered', async () => {
-    ({ browser, page } = await launchPage());
     await createProject(page, 'add-project-existing-a');
     const firstProjectIdOrNull = await page.evaluate(async () => {
       const current = await window.electronAPI.projects.getCurrent();
@@ -59,7 +75,6 @@ test.describe('Add project flow', () => {
   });
 
   test('shows an error toast and creates nothing when the folder cannot be opened', async () => {
-    ({ browser, page } = await launchPage());
     await expect(page.locator('[data-testid="welcome-open-project"]')).toBeVisible();
 
     await page.evaluate(() => {
@@ -82,7 +97,6 @@ test.describe('Add project flow', () => {
   });
 
   test('opens the project anyway and shows a warning toast when git setup fails', async () => {
-    ({ browser, page } = await launchPage());
 
     await page.evaluate(() => {
       (window as unknown as { __mockEnsureGitResult: Record<string, unknown> }).__mockEnsureGitResult = {
@@ -110,7 +124,6 @@ test.describe('Add project flow', () => {
   });
 
   test('opens the project and shows an info toast when a git repo is freshly created', async () => {
-    ({ browser, page } = await launchPage());
 
     await page.evaluate(() => {
       (window as unknown as { __mockEnsureGitResult: Record<string, unknown> }).__mockEnsureGitResult = {
@@ -134,7 +147,6 @@ test.describe('Add project flow', () => {
   });
 
   test("names the new project from probePath's suggestedName, not the folder's own basename", async () => {
-    ({ browser, page } = await launchPage());
 
     await page.evaluate(() => {
       (window as unknown as { __mockProbePathOverrides: Record<string, unknown> }).__mockProbePathOverrides = {

--- a/tests/ui/asana-auth.spec.ts
+++ b/tests/ui/asana-auth.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect, type Page } from '@playwright/test';
-import { launchPage, createProject } from './helpers';
+import { test, expect, type Browser, type Page } from '@playwright/test';
+import { launchSharedBrowser, resetPage, createProject } from './helpers';
 
 // Each describe is isolated per worker (separate process; per-test page launch / goto reset),
 // so the file's tests can fan out across the UI workers safely.
@@ -30,23 +30,38 @@ async function openAsanaProvider(page: Page): Promise<void> {
 }
 
 test.describe('Asana setup dialog (first-time)', () => {
+  // Pins this describe to ONE group, so the shared browser below is actually shared.
+  // Without it these tests land in Playwright's `parallelWithHooks` bucket, chunked
+  // into `ceil(tests / shardTotal)` groups - one group per test at CI's shardTotal=9.
+  test.describe.configure({ mode: 'default' });
+
+  let browser: Browser;
+  let page: Page;
+
+  // One browser per worker group instead of one per test; each test creates its own
+  // project after the goto reset below.
+  test.beforeAll(async () => {
+    ({ browser, page } = await launchSharedBrowser());
+  });
+
+  test.afterAll(async () => {
+    await browser?.close();
+  });
+
   test.beforeEach(async ({ }, testInfo) => {
     testInfo.setTimeout(30000);
+    await resetPage(page);
   });
 
   test('selecting Asana with no credentials opens the PAT setup dialog', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'asana-pat-test');
 
     await openAsanaProvider(page);
     await expect(page.locator('[data-testid="asana-setup-dialog"]')).toBeVisible();
     await expect(page.locator('[data-testid="asana-setup-pat-input"]')).toBeVisible();
-
-    await browser.close();
   });
 
   test('dialog rejects an obviously-too-short token with a clear error', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'asana-pat-test');
 
     await openAsanaProvider(page);
@@ -56,15 +71,12 @@ test.describe('Asana setup dialog (first-time)', () => {
     const error = page.locator('[data-testid="asana-setup-error"]');
     await expect(error).toBeVisible();
     await expect(page.locator('[data-testid="asana-setup-dialog"]')).toBeVisible();
-
-    await browser.close();
   });
 
   test('whitespace-only token shows the empty-token error, not the format error', async () => {
     // The dialog trims the token before the length check. Pasting spaces should
     // produce "Paste your Personal Access Token..." rather than the format-hint
     // message that appears for a real-but-short string.
-    const { browser, page } = await launchPage();
     await createProject(page, 'asana-pat-whitespace-test');
 
     await openAsanaProvider(page);
@@ -80,12 +92,9 @@ test.describe('Asana setup dialog (first-time)', () => {
     // The dialog must remain open - no navigation to the URL step.
     await expect(page.locator('[data-testid="asana-setup-dialog"]')).toBeVisible();
     await expect(page.locator('[data-testid="import-source-url-input"]')).toBeHidden();
-
-    await browser.close();
   });
 
   test('saving a valid token closes the dialog and advances to the URL step', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'asana-pat-test');
 
     await openAsanaProvider(page);
@@ -94,12 +103,9 @@ test.describe('Asana setup dialog (first-time)', () => {
 
     await expect(page.locator('[data-testid="asana-setup-dialog"]')).toBeHidden();
     await expect(page.locator('[data-testid="import-source-url-input"]')).toBeVisible();
-
-    await browser.close();
   });
 
   test('PAT visibility toggle switches the input type', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'asana-pat-test');
 
     await openAsanaProvider(page);
@@ -111,12 +117,9 @@ test.describe('Asana setup dialog (first-time)', () => {
 
     await page.locator('[data-testid="asana-setup-toggle-token-btn"]').click();
     await expect(tokenInput).toHaveAttribute('type', 'password');
-
-    await browser.close();
   });
 
   test('an invalid token surfaces a readable error without closing the dialog', async () => {
-    const { browser, page } = await launchPage();
     await page.evaluate((invalid) => {
       (window as unknown as { __mockAsanaPreset?: unknown }).__mockAsanaPreset = {
         invalidToken: invalid,
@@ -132,25 +135,34 @@ test.describe('Asana setup dialog (first-time)', () => {
     await expect(error).toBeVisible();
     await expect(error).toContainText(/validation failed|invalid/i);
     await expect(page.locator('[data-testid="asana-setup-dialog"]')).toBeVisible();
-
-    await browser.close();
   });
 });
 
 test.describe('Asana provider when already connected', () => {
+  test.describe.configure({ mode: 'default' });
+
+  let browser: Browser;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    ({ browser, page } = await launchSharedBrowser());
+  });
+
+  test.afterAll(async () => {
+    await browser?.close();
+  });
+
   test.beforeEach(async ({ }, testInfo) => {
     testInfo.setTimeout(30000);
+    await resetPage(page);
   });
 
   test('selecting Asana when connected jumps straight to the URL input step', async () => {
-    const { browser, page } = await launchPage();
     await preconnectAsana(page);
     await createProject(page, 'asana-pat-connected-test');
 
     await openAsanaProvider(page);
     await expect(page.locator('[data-testid="import-source-url-input"]')).toBeVisible();
     await expect(page.locator('[data-testid="asana-setup-dialog"]')).toBeHidden();
-
-    await browser.close();
   });
 });

--- a/tests/ui/backlog.spec.ts
+++ b/tests/ui/backlog.spec.ts
@@ -1,18 +1,31 @@
-import { test, expect, chromium, type Browser, type Page } from '@playwright/test';
-import { launchPage, createProject, waitForBoard } from './helpers';
+import { test, expect, type Browser, type Page } from '@playwright/test';
+import { launchSharedBrowser, resetPage, createProject, waitForBoard } from './helpers';
 
-// Each describe is isolated per worker (separate process). Within a worker, tests either
-// launch their own browser ('Backlog View') or reset shared store state between tests
-// ('Backlog Search and Filter'), so the file's tests can fan out across the UI workers safely.
+// Each describe is isolated per worker (separate process). Within a worker, both describes
+// share one browser and reset between tests - 'Backlog View' via page.goto(), 'Backlog Search
+// and Filter' via a store reset - so the file's tests can fan out across the UI workers safely.
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('Backlog View', () => {
+  let browser: Browser;
+  let page: Page;
+
+  // One browser per worker group instead of one per test. Every test creates its own
+  // project after the reset below, so nothing carries between tests.
+  test.beforeAll(async () => {
+    ({ browser, page } = await launchSharedBrowser());
+  });
+
+  test.afterAll(async () => {
+    await browser?.close();
+  });
+
   test.beforeEach(async ({ }, testInfo) => {
     testInfo.setTimeout(30000);
+    await resetPage(page);
   });
 
   test('view toggle shows Board and Backlog tabs', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-test');
 
     const boardTab = page.locator('[data-testid="view-toggle-board"]');
@@ -20,12 +33,9 @@ test.describe('Backlog View', () => {
     await expect(boardTab).toBeVisible();
     await expect(backlogTab).toBeVisible();
     await expect(boardTab).toHaveText('Board');
-
-    await browser.close();
   });
 
   test('clicking Backlog tab switches to backlog view', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-test');
 
     // Board view should be active by default
@@ -41,22 +51,16 @@ test.describe('Backlog View', () => {
     // Switch back to board
     await page.locator('[data-testid="view-toggle-board"]').click();
     await expect(page.locator('[data-swimlane-name="To Do"]')).toBeVisible();
-
-    await browser.close();
   });
 
   test('backlog shows empty state when no items', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-test');
 
     await page.locator('[data-testid="view-toggle-backlog"]').click();
     await expect(page.locator('text=Backlog is empty')).toBeVisible();
-
-    await browser.close();
   });
 
   test('can create a backlog task', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-test');
 
     await page.locator('[data-testid="view-toggle-backlog"]').click();
@@ -77,12 +81,9 @@ test.describe('Backlog View', () => {
     // Item should appear in the table
     await expect(page.locator('[data-testid="backlog-task-row"]')).toBeVisible();
     await expect(page.locator('text=Test backlog task')).toBeVisible();
-
-    await browser.close();
   });
 
   test('backlog count badge updates in view toggle', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-test');
 
     await page.locator('[data-testid="view-toggle-backlog"]').click();
@@ -98,12 +99,9 @@ test.describe('Backlog View', () => {
     // Count badge should show 2
     const backlogTab = page.locator('[data-testid="view-toggle-backlog"]');
     await expect(backlogTab).toContainText('2');
-
-    await browser.close();
   });
 
   test('can search backlog tasks', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-test');
 
     await page.locator('[data-testid="view-toggle-backlog"]').click();
@@ -126,12 +124,9 @@ test.describe('Backlog View', () => {
     // Clear search
     await page.locator('[data-testid="backlog-search"]').fill('');
     await expect(page.locator('text=Add dark mode')).toBeVisible();
-
-    await browser.close();
   });
 
   test('can delete a backlog task', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-test');
 
     await page.locator('[data-testid="view-toggle-backlog"]').click();
@@ -152,12 +147,9 @@ test.describe('Backlog View', () => {
 
     // Item should be gone
     await expect(page.locator('text=Delete me')).not.toBeVisible();
-
-    await browser.close();
   });
 
   test('can edit a backlog task', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-test');
 
     await page.locator('[data-testid="view-toggle-backlog"]').click();
@@ -181,24 +173,18 @@ test.describe('Backlog View', () => {
     // Updated title should appear
     await expect(page.locator('text=Updated title')).toBeVisible();
     await expect(page.locator('text=Original title')).not.toBeVisible();
-
-    await browser.close();
   });
 
   test('toolbar shows Labels and Priorities buttons', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-test');
 
     await page.locator('[data-testid="view-toggle-backlog"]').click();
 
     await expect(page.locator('[data-testid="manage-labels-btn"]')).toBeVisible();
     await expect(page.locator('[data-testid="manage-priorities-btn"]')).toBeVisible();
-
-    await browser.close();
   });
 
   test('filter button shows and works', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-test');
 
     await page.locator('[data-testid="view-toggle-backlog"]').click();
@@ -212,12 +198,9 @@ test.describe('Backlog View', () => {
 
     // Priority section should be visible
     await expect(page.locator('text=PRIORITY')).toBeVisible();
-
-    await browser.close();
   });
 
   test('create backlog task with attachment passes pendingAttachments', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-attach-test');
 
     await page.locator('[data-testid="view-toggle-backlog"]').click();
@@ -263,12 +246,9 @@ test.describe('Backlog View', () => {
       );
     });
     expect(attachmentCount).toBe(1);
-
-    await browser.close();
   });
 
   test('edit backlog task with new attachment updates attachment_count', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-edit-attach-test');
 
     await page.locator('[data-testid="view-toggle-backlog"]').click();
@@ -314,12 +294,9 @@ test.describe('Backlog View', () => {
       );
     });
     expect(attachmentCount).toBe(1);
-
-    await browser.close();
   });
 
   test('context menu on multi-selected items shows count and moves all', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-ctx-multi');
 
     await page.locator('[data-testid="view-toggle-backlog"]').click();
@@ -352,12 +329,9 @@ test.describe('Backlog View', () => {
     // Only one item should remain in the backlog
     await expect(rows).toHaveCount(1);
     await expect(page.locator('text=Task C')).toBeVisible();
-
-    await browser.close();
   });
 
   test('bulk delete via context menu opens ConfirmDialog and removes both rows', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-bulk-delete');
 
     await page.locator('[data-testid="view-toggle-backlog"]').click();
@@ -397,12 +371,9 @@ test.describe('Backlog View', () => {
     await expect(rows).toHaveCount(0);
     await expect(page.locator('text=Delete Alpha')).not.toBeVisible();
     await expect(page.locator('text=Delete Beta')).not.toBeVisible();
-
-    await browser.close();
   });
 
   test('dialog state survives BacklogView unmount when toggling to board and back', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-dialog-persist');
 
     await page.locator('[data-testid="view-toggle-backlog"]').click();
@@ -447,12 +418,9 @@ test.describe('Backlog View', () => {
     // Dialog should be visible again because the store-lifted state survived unmount.
     // If someone adds a clearDialogState() call on BacklogView unmount, this breaks.
     await expect(page.locator('[data-testid="new-backlog-task-dialog"]')).toBeVisible();
-
-    await browser.close();
   });
 
   test('context menu on unselected item resets selection', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'backlog-ctx-reset');
 
     await page.locator('[data-testid="view-toggle-backlog"]').click();
@@ -482,8 +450,6 @@ test.describe('Backlog View', () => {
     await expect(page.locator('[data-testid="context-move-to-board"]').first()).toBeVisible();
     await expect(page.locator('text=Delete 2 items')).not.toBeVisible();
     await expect(page.locator('[data-testid="context-delete-item"]')).toHaveText('Delete');
-
-    await browser.close();
   });
 });
 
@@ -499,13 +465,17 @@ test.describe('Backlog View', () => {
  *   Board task D - "Board task only" labels:['board-only']  (board task, NOT in backlog)
  */
 test.describe('Backlog Search and Filter', () => {
+  // Pins this describe to ONE group, so its beforeAll fixture is built once. Without
+  // it these tests land in Playwright's `parallelWithHooks` bucket, chunked into
+  // `ceil(tests / shardTotal)` groups - one group, and one full fixture rebuild, per
+  // test at CI's shardTotal=9.
+  test.describe.configure({ mode: 'default' });
+
   let browser: Browser;
   let page: Page;
 
   test.beforeAll(async () => {
-    const result = await launchPage();
-    browser = result.browser;
-    page = result.page;
+    ({ browser, page } = await launchSharedBrowser());
 
     await createProject(page, `backlog-filter-test-${Date.now()}`);
     await waitForBoard(page);

--- a/tests/ui/board-config.spec.ts
+++ b/tests/ui/board-config.spec.ts
@@ -1,26 +1,65 @@
-import { test, expect } from '@playwright/test';
-import { launchPage, waitForBoard, createProject } from './helpers';
+import { test, expect, type Browser, type Page } from '@playwright/test';
+import { launchSharedBrowser, resetPage, waitForBoard, createProject } from './helpers';
+
+// File-level parallel + per-describe default makes each top-level describe its own
+// shardable test group while keeping the tests inside it in order on one worker.
+test.describe.configure({ mode: 'parallel' });
+
+/** Add a ghost swimlane to the mock board, then reload the board store. */
+async function addGhostColumn(page: Page, name: string): Promise<void> {
+  await page.evaluate((laneName: string) => {
+    const api = (window as unknown as {
+      electronAPI: {
+        swimlanes: {
+          create: (input: {
+            name: string;
+            color: string;
+            is_ghost: boolean;
+            auto_spawn: boolean;
+          }) => Promise<unknown>;
+        };
+      };
+    }).electronAPI;
+    const stores = (window as unknown as {
+      __zustandStores?: { board: { getState: () => { loadBoard: () => void } } };
+    }).__zustandStores;
+    api.swimlanes.create({
+      name: laneName,
+      color: '#888888',
+      is_ghost: true,
+      auto_spawn: false,
+    }).then(() => {
+      stores?.board.getState().loadBoard();
+    });
+  }, name);
+}
 
 test.describe('Ghost Columns', () => {
+  test.describe.configure({ mode: 'default' });
+
+  let browser: Browser;
+  let page: Page;
+
+  // One browser for the describe instead of one per test; page.goto() in beforeEach
+  // rebuilds the mock state so each test still starts clean.
+  test.beforeAll(async () => {
+    ({ browser, page } = await launchSharedBrowser());
+  });
+
+  test.afterAll(async () => {
+    await browser?.close();
+  });
+
+  test.beforeEach(async () => {
+    await resetPage(page);
+  });
+
   test('ghost column renders with dimmed style and tooltip', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'ghost-test');
     await waitForBoard(page);
 
     // Add a ghost column to the mock swimlanes after project setup, then reload board
-    await page.evaluate(() => {
-      const api = (window as any).electronAPI;
-      const stores = (window as any).__zustandStores;
-      // Use the swimlanes.create mock to add a ghost lane
-      api.swimlanes.create({
-        name: 'Deprecated Review',
-        color: '#888888',
-        is_ghost: true,
-        auto_spawn: false,
-      }).then(() => {
-        stores.board.getState().loadBoard();
-      });
-    });
+    await addGhostColumn(page, 'Deprecated Review');
 
     const ghostColumn = page.locator('[data-swimlane-name="Deprecated Review"]');
     await expect(ghostColumn).toBeVisible();
@@ -33,28 +72,14 @@ test.describe('Ghost Columns', () => {
 
     // Verify tooltip
     await expect(ghostColumn).toHaveAttribute('title', 'Removed from team config. Move tasks to continue.');
-
-    await browser.close();
   });
 
   test('ghost column has no add task button', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'ghost-no-add');
     await waitForBoard(page);
 
     // Add a ghost column after project setup
-    await page.evaluate(() => {
-      const api = (window as any).electronAPI;
-      const stores = (window as any).__zustandStores;
-      api.swimlanes.create({
-        name: 'Old Column',
-        color: '#888888',
-        is_ghost: true,
-        auto_spawn: false,
-      }).then(() => {
-        stores.board.getState().loadBoard();
-      });
-    });
+    await addGhostColumn(page, 'Old Column');
 
     const ghostColumn = page.locator('[data-swimlane-name="Old Column"]');
     await expect(ghostColumn).toBeVisible();
@@ -66,20 +91,38 @@ test.describe('Ghost Columns', () => {
     // "Removed from team config" text should be present
     const removedText = ghostColumn.locator('text=Removed from team config');
     await expect(removedText).toBeVisible();
-
-    await browser.close();
   });
 });
 
 test.describe('Config Warning Banner', () => {
+  test.describe.configure({ mode: 'default' });
+
+  let browser: Browser;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    ({ browser, page } = await launchSharedBrowser());
+  });
+
+  test.afterAll(async () => {
+    await browser?.close();
+  });
+
+  test.beforeEach(async () => {
+    await resetPage(page);
+  });
+
   test('warning banner shows and can be dismissed', async () => {
-    const { browser, page } = await launchPage();
     await createProject(page, 'warning-test');
     await waitForBoard(page);
 
     // Inject config warnings into the board store
     await page.evaluate(() => {
-      const stores = (window as any).__zustandStores;
+      const stores = (window as unknown as {
+        __zustandStores?: {
+          board: { getState: () => { setConfigWarnings: (warnings: string[]) => void } };
+        };
+      }).__zustandStores;
       if (stores?.board) {
         stores.board.getState().setConfigWarnings([
           'kangentic.json has a syntax error. Board loaded from local database.',
@@ -97,7 +140,5 @@ test.describe('Config Warning Banner', () => {
 
     // Banner should be gone
     await expect(banner).not.toBeVisible();
-
-    await browser.close();
   });
 });

--- a/tests/ui/changes-file-history.spec.ts
+++ b/tests/ui/changes-file-history.spec.ts
@@ -153,6 +153,13 @@ test.describe('Changes panel: per-file history popover', () => {
     // 15000ms for real margin, leaving the purely-synchronous steps (menu
     // open/close, which is a plain right-click -> setState -> render with no
     // IPC) at their original tighter budgets.
+    //
+    // That pass widened the file-tree ROW (below) but left the file-tree
+    // CONTAINER's own wait at 8000ms, even though it sits earlier in the very
+    // same async chain this comment describes and therefore carries strictly
+    // MORE of it (dialog open animation + toggle click + diffFiles + render).
+    // It duly flaked on CI at exactly that line (failed at 8s, passed on
+    // retry). Both now use the same 15000ms budget.
     test.slow();
     const card = page.locator('[data-swimlane-name="Code Review"]').locator('text=File History Task').first();
     await card.click();
@@ -164,7 +171,7 @@ test.describe('Changes panel: per-file history popover', () => {
     if (!(await fileTree.isVisible())) {
       await page.locator('[data-testid="changes-toggle"]').click();
     }
-    await fileTree.waitFor({ state: 'visible', timeout: 8000 });
+    await fileTree.waitFor({ state: 'visible', timeout: 15000 });
 
     const fileRow = fileTree.getByRole('button', { name: /index\.ts/ });
     await fileRow.waitFor({ state: 'visible', timeout: 15000 });

--- a/tests/ui/commit-detail-selection.spec.ts
+++ b/tests/ui/commit-detail-selection.spec.ts
@@ -122,6 +122,12 @@ const preConfig = `
   });
 `;
 
+// File-level parallel + per-describe default makes each top-level describe its own
+// shardable test group, while keeping the tests inside a describe in order on one
+// worker. The beforeAll runs once per group (a preconfigured launch, no UI-driven
+// project setup), which is cheap next to the file's serial span.
+test.describe.configure({ mode: 'parallel' });
+
 let browser: Browser;
 let page: Page;
 
@@ -137,6 +143,8 @@ test.afterAll(async () => {
 });
 
 test.describe('Changes panel: commit-detail selection', () => {
+  test.describe.configure({ mode: 'default' });
+
   test('selecting a commit scopes the detail pane to its diff; Uncommitted returns to the working diff', async () => {
     const card = page.locator('[data-swimlane-name="Code Review"]').locator('text=Commit Detail Task').first();
     await card.click();
@@ -273,6 +281,8 @@ const restorePreConfig = `
 `;
 
 test.describe('Changes panel: commit-detail header restore fallback', () => {
+  test.describe.configure({ mode: 'default' });
+
   let restoreBrowser: Browser;
   let restorePage: Page;
 
@@ -468,6 +478,8 @@ function fileRowButton(page: Page, filePath: string) {
 }
 
 test.describe('Changes panel: file-content cache key isolation across commit selection', () => {
+  test.describe.configure({ mode: 'default' });
+
   let cacheBrowser: Browser;
   let cachePage: Page;
 

--- a/tests/ui/commit-graph-panel.spec.ts
+++ b/tests/ui/commit-graph-panel.spec.ts
@@ -108,6 +108,12 @@ const preConfig = `
   });
 `;
 
+// File-level parallel + per-describe default makes each top-level describe its own
+// shardable test group, while keeping the tests inside a describe in order on one
+// worker (the commit-history tests below hand state to each other through the
+// per-task changesSelectedCommit the close helper resets).
+test.describe.configure({ mode: 'parallel' });
+
 let browser: Browser;
 let page: Page;
 
@@ -149,6 +155,8 @@ async function closeChangesPanelAndDialog(dialog: Locator): Promise<void> {
 }
 
 test.describe('Task Detail Changes panel - commit-history browser', () => {
+  test.describe.configure({ mode: 'default' });
+
   test('shows the graph immediately with Uncommitted selected by default, selecting a commit shows its detail, and Uncommitted returns to the working diff', async () => {
     const dialog = await openDialogWithChangesPanel('Commit Graph Task', 'Code Review');
 
@@ -396,6 +404,8 @@ const prBadgePreConfig = `
 `;
 
 test.describe('Commit graph PR-head ref badge', () => {
+  test.describe.configure({ mode: 'default' });
+
   let prBadgeBrowser: Browser;
   let prBadgePage: Page;
 

--- a/tests/ui/helpers.ts
+++ b/tests/ui/helpers.ts
@@ -1,4 +1,4 @@
-import { chromium, type Browser, type Page } from '@playwright/test';
+import { chromium, type Browser, type BrowserContext, type Page } from '@playwright/test';
 import path from 'node:path';
 
 const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
@@ -47,10 +47,21 @@ export async function waitForViteReady(url: string = VITE_URL, timeoutMs = 30000
 }
 
 /**
- * Launch a headless Chromium page with the electronAPI mock injected.
+ * Launch a headless Chromium browser with the electronAPI mock injected, plus an
+ * optional per-suite pre-configuration script, and navigate to the app shell.
+ *
+ * This is the launcher behind the suite's shared-browser pattern: launch ONCE in a
+ * describe's `beforeAll`, then call `resetPage()` in `beforeEach` so every test
+ * starts from fresh state. `chromium.launch()` costs ~1-2s, and the UI tier used to
+ * pay it per test in a dozen specs; `page.goto()` re-runs every registered
+ * addInitScript on the context, so it gives the same isolation for a fraction of the
+ * cost. `command-terminal.spec.ts` is the reference consumer.
+ *
  * The Vite dev server must be running (started by playwright webServer config).
  */
-export async function launchPage(): Promise<{ browser: Browser; page: Page }> {
+export async function launchSharedBrowser(
+  preConfigScript?: string,
+): Promise<{ browser: Browser; context: BrowserContext; page: Page }> {
   await waitForViteReady();
   const browser = await chromium.launch({ headless: true });
   const context = await browser.newContext({
@@ -61,12 +72,39 @@ export async function launchPage(): Promise<{ browser: Browser; page: Page }> {
 
   // Inject the mock before any page scripts run
   await page.addInitScript({ path: MOCK_SCRIPT });
+  if (preConfigScript) {
+    await page.addInitScript(preConfigScript);
+  }
 
   await page.goto(VITE_URL);
   await page.waitForLoadState('load');
   // Wait for React to render the app shell
   await page.waitForSelector('text=Kangentic', { timeout: 15000 });
 
+  return { browser, context, page };
+}
+
+/**
+ * Re-navigate a shared page to the app shell, re-running every registered
+ * addInitScript and discarding all in-memory store state. The `beforeEach` half of
+ * the shared-browser pattern above.
+ *
+ * Suites that need the board (rather than the welcome screen) still call
+ * `createProject()` after this: the mock's project list is re-seeded from scratch on
+ * every navigation.
+ */
+export async function resetPage(page: Page): Promise<void> {
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+}
+
+/**
+ * Launch a one-off browser for a single test. Prefer `launchSharedBrowser` +
+ * `resetPage` when several tests share the same starting state.
+ */
+export async function launchPage(): Promise<{ browser: Browser; page: Page }> {
+  const { browser, page } = await launchSharedBrowser();
   return { browser, page };
 }
 

--- a/tests/ui/import-filter.spec.ts
+++ b/tests/ui/import-filter.spec.ts
@@ -100,8 +100,8 @@
  *     state to the "filters excluded everything" branch when nothing was
  *     actually excluded.
  */
-import { test, expect, type Page } from '@playwright/test';
-import { launchPage, createProject, collectPageErrors } from './helpers';
+import { test, expect, type Browser, type Page } from '@playwright/test';
+import { launchSharedBrowser, resetPage, createProject, collectPageErrors } from './helpers';
 
 // Each describe is isolated per worker (separate process; per-test page launch / goto reset),
 // so the file's tests can fan out across the UI workers safely.
@@ -235,13 +235,26 @@ async function getFetchCallCount(page: Page): Promise<number> {
 // ---------------------------------------------------------------------------
 
 test.describe('ImportDialog - filter and streaming behaviour', () => {
+  let browser: Browser;
+  let page: Page;
+
+  // One browser per worker group instead of one per test. Every test seeds its own
+  // source, fetch preset, and uniquely-named project AFTER the reset below, so the
+  // shared page carries nothing across tests.
+  test.beforeAll(async () => {
+    ({ browser, page } = await launchSharedBrowser());
+  });
+
+  test.afterAll(async () => {
+    await browser?.close();
+  });
+
   test.beforeEach(async ({ }, testInfo) => {
     testInfo.setTimeout(30000);
+    await resetPage(page);
   });
 
   test('typing a search term with no match shows "No items match your filters" with Clear button', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     await page.evaluate((issue) => {
@@ -263,13 +276,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
 
     await expect(page.locator('[data-testid="import-empty-state-message"]')).toBeVisible({ timeout: 3000 });
     await expect(page.locator('[data-testid="import-clear-filters-btn"]')).toBeVisible();
-
-    await browser.close();
   });
 
   test('clearFilters clears the client-side filter without triggering a refetch', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     await page.evaluate(() => {
@@ -305,13 +314,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     // Clearing filters never refetches - it is purely client-side state.
     const countAfterClear = await getFetchCallCount(page);
     expect(countAfterClear).toBe(countAfterOpen);
-
-    await browser.close();
   });
 
   test('typing narrows visible rows immediately with no server round-trip', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     await page.evaluate(
@@ -343,13 +348,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     // Filtering is purely client-side - no new fetch should have fired.
     const countAfterTyping = await getFetchCallCount(page);
     expect(countAfterTyping).toBe(countBeforeTyping);
-
-    await browser.close();
   });
 
   test('clicking a single row checkbox checks only that row', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     await page.evaluate(
@@ -378,13 +379,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     await expect(betaRow.locator('input[type="checkbox"]')).not.toBeChecked();
 
     await expect(page.locator('[data-testid="import-execute-btn"]')).toContainText('Import (1)');
-
-    await browser.close();
   });
 
   test('filter facets populate as later pages stream in, with no manual load-more', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     await page.evaluate(
@@ -412,13 +409,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     await page.locator('button', { hasText: 'Status' }).click();
     await expect(page.locator('[data-testid="filter-option-status-open"]')).toBeVisible();
     await expect(page.locator('[data-testid="filter-option-status-triaged"]')).toBeVisible();
-
-    await browser.close();
   });
 
   test('a filter set while a later page is still loading keeps matching items that arrive after', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     await page.evaluate(
@@ -449,13 +442,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     // must appear - the filter must not have been frozen against page 1 only.
     await waitForStreamingSettled(page);
     await expect(page.locator('[data-testid="import-issue-late-issue"]')).toBeVisible({ timeout: 3000 });
-
-    await browser.close();
   });
 
   test('virtualization renders a windowed subset of a large list', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     // The dialog sorts newest-first, so index 0 gets the newest timestamp to
@@ -489,13 +478,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     const renderedRowCount = await page.locator('[data-testid^="import-issue-bulk-"]').count();
     expect(renderedRowCount).toBeGreaterThan(0);
     expect(renderedRowCount).toBeLessThan(issueCount);
-
-    await browser.close();
   });
 
   test('switching the state filter mid-stream cancels the previous filter\'s in-flight page', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     // A delay long enough that the "open" filter's page 2 is still in flight
@@ -544,13 +529,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     // replaced, not appended-to: "closed"'s first page should REPLACE the
     // "open" filter's page 1 rather than accumulate alongside it.
     await expect(page.locator('[data-testid="import-issue-open-page1-issue"]')).toHaveCount(0);
-
-    await browser.close();
   });
 
   test('closing the dialog mid-stream stops further fetches with no unmounted-component error', async () => {
-    const { browser, page } = await launchPage();
-
     const consoleErrors: string[] = [];
     page.on('console', (message) => {
       if (message.type() === 'error') consoleErrors.push(message.text());
@@ -605,13 +586,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
 
     expect(getPageErrors()).toEqual([]);
     expect(consoleErrors).toEqual([]);
-
-    await browser.close();
   });
 
   test('a fetch failure mid-stream shows the error banner, and Retry clears it once it succeeds', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     await page.evaluate(() => {
@@ -649,13 +626,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
 
     await expect(errorBanner).toHaveCount(0, { timeout: 5000 });
     await expect(page.locator('[data-testid="import-issue-retry-success-issue"]')).toBeVisible({ timeout: 5000 });
-
-    await browser.close();
   });
 
   test('select-all becomes unchecked once a later page streams in more selectable items', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     await page.evaluate(
@@ -692,13 +665,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     // selectedIds.size (1) no longer equals selectableIssues.length (2).
     await expect(selectAllCheckbox).not.toBeChecked();
     await expect(page.locator('[data-testid="import-execute-btn"]')).toContainText('Import (1)');
-
-    await browser.close();
   });
 
   test('the all-imported empty state shows Refresh, and clicking it re-streams via loadAllIssues', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     await page.evaluate((issue) => {
@@ -726,13 +695,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     // Refresh must call loadAllIssues(stateFilter) again - a real re-stream,
     // not a dead handler - so the fetch call count must increase.
     await expect.poll(async () => getFetchCallCount(page), { timeout: 3000 }).toBeGreaterThan(countBeforeRefresh);
-
-    await browser.close();
   });
 
   test('the all-imported empty-state message is suppressed while a later page is still streaming', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     await page.evaluate(
@@ -769,13 +734,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
 
     await waitForStreamingSettled(page);
     await expect(page.locator('[data-testid="import-issue-midstream-fresh-2"]')).toBeVisible({ timeout: 3000 });
-
-    await browser.close();
   });
 
   test('a malformed page response (non-array issues) shows the error banner with Retry', async () => {
-    const { browser, page } = await launchPage();
-
     const getPageErrors = collectPageErrors(page);
 
     await seedGitHubSource(page);
@@ -812,13 +773,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     // throw rather than it surfacing as an unhandled rejection (the failure
     // mode the catch exists to prevent, per the comment in loadAllIssues).
     expect(getPageErrors()).toEqual([]);
-
-    await browser.close();
   });
 
   test('a duplicate externalId across two streamed pages is deduped, not double-rendered', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     // A source can return the same item on two pages when its ordering shifts
@@ -853,13 +810,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     // The footer's loaded count reflects the deduped total (3 unique issues),
     // not the raw sum of both pages' issues arrays (4).
     await expect(page.locator('text=/3 of 3 items/')).toBeVisible();
-
-    await browser.close();
   });
 
   test('searching an issue number matches the ID the row prints, with or without the "#"', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     // The target's number appears nowhere in its title or body, so it is reachable
@@ -899,13 +852,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     await page.locator('[data-testid="import-search"]').fill('  #276  ');
     await expect(page.locator('[data-testid="import-issue-276"]')).toBeVisible({ timeout: 3000 });
     await expect(page.locator('[data-testid="import-issue-981"]')).toHaveCount(0, { timeout: 3000 });
-
-    await browser.close();
   });
 
   test('searching a number on a github_projects source matches the URL-derived ID, not externalId', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubProjectsSource(page);
 
     // A project item's externalId is an opaque node id that does NOT contain the
@@ -952,13 +901,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     await page.locator('[data-testid="import-search"]').fill('#512');
     await expect(targetRow).toBeVisible({ timeout: 3000 });
     await expect(siblingRow).toHaveCount(0, { timeout: 3000 });
-
-    await browser.close();
   });
 
   test('searching matches the other fields the row prints - a label and an assignee', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     // Neither term appears in either row's ID or title, so each hit can only come
@@ -1004,13 +949,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     await page.locator('[data-testid="import-search"]').fill('@ryan-tuck');
     await expect(targetRow).toBeVisible({ timeout: 3000 });
     await expect(siblingRow).toHaveCount(0, { timeout: 3000 });
-
-    await browser.close();
   });
 
   test('searching text that appears only in an issue description matches nothing', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     // The body is NOT searchable: no row renders it, so a body hit would look like
@@ -1062,13 +1003,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     await page.locator('[data-testid="import-search"]').fill('335');
     await expect(crossReferencingRow).toBeVisible({ timeout: 3000 });
     await expect(plainBodyRow).toHaveCount(0, { timeout: 3000 });
-
-    await browser.close();
   });
 
   test('a query spanning two haystack fields (no separator) matches nothing, but a query within one field still matches', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     // The target's rendered id is '#501', its title ends with 'redesign', and its
@@ -1126,13 +1063,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     await page.locator('[data-testid="import-search"]').fill('designb');
     await expect(targetRow).toHaveCount(0, { timeout: 3000 });
     await expect(siblingRow).toHaveCount(0, { timeout: 3000 });
-
-    await browser.close();
   });
 
   test('a literal internal "#" in the query is preserved, not globally stripped', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     // The target's title contains a literal 'c#'; the sibling's title contains a
@@ -1172,13 +1105,9 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     await page.locator('[data-testid="import-search"]').fill('c#');
     await expect(targetRow).toBeVisible({ timeout: 3000 });
     await expect(siblingRow).toHaveCount(0, { timeout: 3000 });
-
-    await browser.close();
   });
 
   test('a query that normalizes to empty (a lone "#") is not treated as an active filter', async () => {
-    const { browser, page } = await launchPage();
-
     await seedGitHubSource(page);
 
     await page.evaluate(() => {
@@ -1203,7 +1132,5 @@ test.describe('ImportDialog - filter and streaming behaviour', () => {
     await expect(page.getByText('No items found')).toBeVisible({ timeout: 3000 });
     await expect(page.locator('[data-testid="import-empty-state-message"]')).toHaveCount(0);
     await expect(page.locator('[data-testid="import-clear-filters-btn"]')).toHaveCount(0);
-
-    await browser.close();
   });
 });

--- a/tests/ui/label-input.spec.ts
+++ b/tests/ui/label-input.spec.ts
@@ -11,13 +11,15 @@
  *    Fixed by portaling it to document.body via OverlayPopover + usePopoverPosition
  *    (the same pattern KebabMenu uses).
  *
- * Each test launches its own page (mode: 'parallel'), per the no-cross-test-state
- * convention used across this suite (see pr-url.spec.ts, label-promotion.spec.ts).
+ * The two new-task-dialog tests share one browser and reset via page.goto() in
+ * beforeEach, per the no-cross-test-state convention used across this suite. The
+ * clipping test keeps its own launch: it needs a narrower viewport and a seeded
+ * task, so there is nothing to share.
  */
 import { test, expect } from '@playwright/test';
 import { chromium, type Browser, type Page } from '@playwright/test';
 import path from 'node:path';
-import { launchPage, createProject, waitForViteReady } from './helpers';
+import { launchSharedBrowser, resetPage, createProject, waitForViteReady } from './helpers';
 
 test.describe.configure({ mode: 'parallel' });
 
@@ -42,9 +44,27 @@ async function seedLabelColors(page: Page, labelColors: Record<string, string>):
   }, labelColors);
 }
 
-test('clicking a label suggestion commits the clicked label, not the typed text', async () => {
-  const { browser, page } = await launchPage();
-  try {
+test.describe('LabelInput autocomplete in the New Task dialog', () => {
+  // One group, one browser: the two tests below want the same starting state, so
+  // sharing beats paying a launch each.
+  test.describe.configure({ mode: 'default' });
+
+  let browser: Browser;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    ({ browser, page } = await launchSharedBrowser());
+  });
+
+  test.afterAll(async () => {
+    await browser?.close();
+  });
+
+  test.beforeEach(async () => {
+    await resetPage(page);
+  });
+
+  test('clicking a label suggestion commits the clicked label, not the typed text', async () => {
     await createProject(page, `LabelAutocompleteClick ${Date.now()}`);
     await seedLabelColors(page, {
       research: '#3b82f6',
@@ -79,14 +99,9 @@ test('clicking a label suggestion commits the clicked label, not the typed text'
     // Exact-array equality: pre-fix this would be ['res'] (the blur-committed
     // partial text), not the clicked suggestion.
     expect(task!.labels).toEqual(['research']);
-  } finally {
-    await browser.close();
-  }
-});
+  });
 
-test('clicking outside the field closes the suggestion dropdown', async () => {
-  const { browser, page } = await launchPage();
-  try {
+  test('clicking outside the field closes the suggestion dropdown', async () => {
     await createProject(page, `LabelAutocompleteOutsideClick ${Date.now()}`);
     await seedLabelColors(page, {
       research: '#3b82f6',
@@ -128,9 +143,7 @@ test('clicking outside the field closes the suggestion dropdown', async () => {
     const task = taskData.find((t: { title: string }) => t.title === 'Outside click test');
     expect(task).toBeDefined();
     expect(task!.labels).toEqual([]);
-  } finally {
-    await browser.close();
-  }
+  });
 });
 
 const CLIP_PROJECT_ID = 'proj-label-input-clip';

--- a/tests/ui/label-promotion.spec.ts
+++ b/tests/ui/label-promotion.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect, type Page } from '@playwright/test';
-import { launchPage, createProject, waitForBoard } from './helpers';
+import { test, expect, type Browser, type Page } from '@playwright/test';
+import { launchSharedBrowser, resetPage, createProject, waitForBoard } from './helpers';
 
 // Each describe is isolated per worker (separate process; per-test page launch / goto reset),
 // so the file's tests can fan out across the UI workers safely.
@@ -43,165 +43,161 @@ async function getFirstSwimlaneId(page: Page): Promise<string> {
 }
 
 test.describe('Label and Priority Promotion', () => {
+  // Pins this describe to ONE group, so the shared browser below is actually shared.
+  // Without it these tests land in Playwright's `parallelWithHooks` bucket, chunked
+  // into `ceil(tests / shardTotal)` groups - one group per test at CI's shardTotal=9.
+  test.describe.configure({ mode: 'default' });
+
+  let browser: Browser;
+  let page: Page;
+
+  // One browser per worker group instead of one per test; each test creates its own
+  // project after the goto reset below.
+  test.beforeAll(async () => {
+    ({ browser, page } = await launchSharedBrowser());
+  });
+
+  test.afterAll(async () => {
+    await browser?.close();
+  });
+
   test.beforeEach(async ({ }, testInfo) => {
     testInfo.setTimeout(30000);
+    await resetPage(page);
   });
 
   test('promoted backlog task carries labels and priority to board task', async () => {
-    const { browser, page } = await launchPage();
-    try {
-      await createProject(page, 'LabelTest');
+    await createProject(page, 'LabelTest');
 
-      const swimlaneId = await getFirstSwimlaneId(page);
-      const itemId = await createBacklogTaskWithLabels(page, 'Labeled task', ['bug', 'ui'], 3);
-      await promoteToBoard(page, [itemId], swimlaneId);
+    const swimlaneId = await getFirstSwimlaneId(page);
+    const itemId = await createBacklogTaskWithLabels(page, 'Labeled task', ['bug', 'ui'], 3);
+    await promoteToBoard(page, [itemId], swimlaneId);
 
-      // Reload the board to pick up the new task
-      await page.evaluate(() => window.electronAPI.tasks.list());
+    // Reload the board to pick up the new task
+    await page.evaluate(() => window.electronAPI.tasks.list());
 
-      // Verify the task has labels and priority via API
-      const tasks = await page.evaluate(() => window.electronAPI.tasks.list());
-      const promotedTask = (tasks as Array<{ title: string; labels: string[]; priority: number }>)
-        .find((task) => task.title === 'Labeled task');
+    // Verify the task has labels and priority via API
+    const tasks = await page.evaluate(() => window.electronAPI.tasks.list());
+    const promotedTask = (tasks as Array<{ title: string; labels: string[]; priority: number }>)
+      .find((task) => task.title === 'Labeled task');
 
-      expect(promotedTask).toBeDefined();
-      expect(promotedTask!.labels).toEqual(['bug', 'ui']);
-      expect(promotedTask!.priority).toBe(3);
-    } finally {
-      await browser.close();
-    }
+    expect(promotedTask).toBeDefined();
+    expect(promotedTask!.labels).toEqual(['bug', 'ui']);
+    expect(promotedTask!.priority).toBe(3);
   });
 
   test('demoted task preserves labels and priority on backlog task', async () => {
-    const { browser, page } = await launchPage();
-    try {
-      await createProject(page, 'DemoteTest');
+    await createProject(page, 'DemoteTest');
 
-      const swimlaneId = await getFirstSwimlaneId(page);
-      const itemId = await createBacklogTaskWithLabels(page, 'Demote test', ['feature'], 2);
-      await promoteToBoard(page, [itemId], swimlaneId);
+    const swimlaneId = await getFirstSwimlaneId(page);
+    const itemId = await createBacklogTaskWithLabels(page, 'Demote test', ['feature'], 2);
+    await promoteToBoard(page, [itemId], swimlaneId);
 
-      // Get the created task
-      const tasks = await page.evaluate(() => window.electronAPI.tasks.list());
-      const task = (tasks as Array<{ id: string; title: string }>)
-        .find((task) => task.title === 'Demote test');
-      expect(task).toBeDefined();
+    // Get the created task
+    const tasks = await page.evaluate(() => window.electronAPI.tasks.list());
+    const task = (tasks as Array<{ id: string; title: string }>)
+      .find((task) => task.title === 'Demote test');
+    expect(task).toBeDefined();
 
-      // Demote back to backlog (no explicit labels/priority - should use task values)
-      await page.evaluate(
-        (taskId: string) => window.electronAPI.backlog.demote({ taskId }),
-        task!.id,
-      );
+    // Demote back to backlog (no explicit labels/priority - should use task values)
+    await page.evaluate(
+      (taskId: string) => window.electronAPI.backlog.demote({ taskId }),
+      task!.id,
+    );
 
-      // Verify the backlog task has the original labels and priority
-      const items = await page.evaluate(() => window.electronAPI.backlog.list());
-      const demotedItem = (items as Array<{ title: string; labels: string[]; priority: number }>)
-        .find((item) => item.title === 'Demote test');
+    // Verify the backlog task has the original labels and priority
+    const items = await page.evaluate(() => window.electronAPI.backlog.list());
+    const demotedItem = (items as Array<{ title: string; labels: string[]; priority: number }>)
+      .find((item) => item.title === 'Demote test');
 
-      expect(demotedItem).toBeDefined();
-      expect(demotedItem!.labels).toEqual(['feature']);
-      expect(demotedItem!.priority).toBe(2);
-    } finally {
-      await browser.close();
-    }
+    expect(demotedItem).toBeDefined();
+    expect(demotedItem!.labels).toEqual(['feature']);
+    expect(demotedItem!.priority).toBe(2);
   });
 
   test('renameLabel updates both backlog tasks and board tasks', async () => {
-    const { browser, page } = await launchPage();
-    try {
-      await createProject(page, 'RenameTest');
+    await createProject(page, 'RenameTest');
 
-      const swimlaneId = await getFirstSwimlaneId(page);
+    const swimlaneId = await getFirstSwimlaneId(page);
 
-      // Create a backlog task and a promoted task, both with 'old-label'
-      await createBacklogTaskWithLabels(page, 'Backlog task', ['old-label'], 0);
-      const promoteItemId = await createBacklogTaskWithLabels(page, 'Board task', ['old-label'], 1);
-      await promoteToBoard(page, [promoteItemId], swimlaneId);
+    // Create a backlog task and a promoted task, both with 'old-label'
+    await createBacklogTaskWithLabels(page, 'Backlog task', ['old-label'], 0);
+    const promoteItemId = await createBacklogTaskWithLabels(page, 'Board task', ['old-label'], 1);
+    await promoteToBoard(page, [promoteItemId], swimlaneId);
 
-      // Rename the label
-      await page.evaluate(() => window.electronAPI.backlog.renameLabel('old-label', 'new-label'));
+    // Rename the label
+    await page.evaluate(() => window.electronAPI.backlog.renameLabel('old-label', 'new-label'));
 
-      // Verify backlog task was updated
-      const items = await page.evaluate(() => window.electronAPI.backlog.list());
-      const backlogTask = (items as Array<{ title: string; labels: string[] }>)
-        .find((item) => item.title === 'Backlog task');
-      expect(backlogTask!.labels).toEqual(['new-label']);
+    // Verify backlog task was updated
+    const items = await page.evaluate(() => window.electronAPI.backlog.list());
+    const backlogTask = (items as Array<{ title: string; labels: string[] }>)
+      .find((item) => item.title === 'Backlog task');
+    expect(backlogTask!.labels).toEqual(['new-label']);
 
-      // Verify board task was updated
-      const tasks = await page.evaluate(() => window.electronAPI.tasks.list());
-      const boardTask = (tasks as Array<{ title: string; labels: string[] }>)
-        .find((task) => task.title === 'Board task');
-      expect(boardTask!.labels).toEqual(['new-label']);
-    } finally {
-      await browser.close();
-    }
+    // Verify board task was updated
+    const tasks = await page.evaluate(() => window.electronAPI.tasks.list());
+    const boardTask = (tasks as Array<{ title: string; labels: string[] }>)
+      .find((task) => task.title === 'Board task');
+    expect(boardTask!.labels).toEqual(['new-label']);
   });
 
   test('deleteLabel removes from both backlog tasks and board tasks', async () => {
-    const { browser, page } = await launchPage();
-    try {
-      await createProject(page, 'DeleteTest');
+    await createProject(page, 'DeleteTest');
 
-      const swimlaneId = await getFirstSwimlaneId(page);
+    const swimlaneId = await getFirstSwimlaneId(page);
 
-      // Create items with the label to delete
-      await createBacklogTaskWithLabels(page, 'Backlog task', ['keep', 'remove'], 0);
-      const promoteItemId = await createBacklogTaskWithLabels(page, 'Board task', ['keep', 'remove'], 0);
-      await promoteToBoard(page, [promoteItemId], swimlaneId);
+    // Create items with the label to delete
+    await createBacklogTaskWithLabels(page, 'Backlog task', ['keep', 'remove'], 0);
+    const promoteItemId = await createBacklogTaskWithLabels(page, 'Board task', ['keep', 'remove'], 0);
+    await promoteToBoard(page, [promoteItemId], swimlaneId);
 
-      // Delete the label
-      await page.evaluate(() => window.electronAPI.backlog.deleteLabel('remove'));
+    // Delete the label
+    await page.evaluate(() => window.electronAPI.backlog.deleteLabel('remove'));
 
-      // Verify backlog task only has 'keep'
-      const items = await page.evaluate(() => window.electronAPI.backlog.list());
-      const backlogTask = (items as Array<{ title: string; labels: string[] }>)
-        .find((item) => item.title === 'Backlog task');
-      expect(backlogTask!.labels).toEqual(['keep']);
+    // Verify backlog task only has 'keep'
+    const items = await page.evaluate(() => window.electronAPI.backlog.list());
+    const backlogTask = (items as Array<{ title: string; labels: string[] }>)
+      .find((item) => item.title === 'Backlog task');
+    expect(backlogTask!.labels).toEqual(['keep']);
 
-      // Verify board task only has 'keep'
-      const tasks = await page.evaluate(() => window.electronAPI.tasks.list());
-      const boardTask = (tasks as Array<{ title: string; labels: string[] }>)
-        .find((task) => task.title === 'Board task');
-      expect(boardTask!.labels).toEqual(['keep']);
-    } finally {
-      await browser.close();
-    }
+    // Verify board task only has 'keep'
+    const tasks = await page.evaluate(() => window.electronAPI.tasks.list());
+    const boardTask = (tasks as Array<{ title: string; labels: string[] }>)
+      .find((task) => task.title === 'Board task');
+    expect(boardTask!.labels).toEqual(['keep']);
   });
 
   test('label pills render on board task cards', async () => {
-    const { browser, page } = await launchPage();
-    try {
-      await createProject(page, 'PillTest');
-      await waitForBoard(page);
+    await createProject(page, 'PillTest');
+    await waitForBoard(page);
 
-      // Create a task with labels directly via the tasks API and reload the board store
-      const swimlaneId = await getFirstSwimlaneId(page);
-      await page.evaluate(
-        ({ swimlaneId }) => {
-          return window.electronAPI.tasks.create({
-            title: 'Pill display task',
-            description: '',
-            swimlane_id: swimlaneId,
-            labels: ['bug', 'frontend'],
-            priority: 2,
-          }).then(() => {
-            const stores = (window as any).__zustandStores;
-            if (stores?.board) stores.board.getState().loadBoard();
-          });
-        },
-        { swimlaneId },
-      );
+    // Create a task with labels directly via the tasks API and reload the board store
+    const swimlaneId = await getFirstSwimlaneId(page);
+    await page.evaluate(
+      ({ swimlaneId }) => {
+        return window.electronAPI.tasks.create({
+          title: 'Pill display task',
+          description: '',
+          swimlane_id: swimlaneId,
+          labels: ['bug', 'frontend'],
+          priority: 2,
+        }).then(() => {
+          const stores = (window as unknown as {
+            __zustandStores?: { board: { getState: () => { loadBoard: () => void } } };
+          }).__zustandStores;
+          if (stores?.board) stores.board.getState().loadBoard();
+        });
+      },
+      { swimlaneId },
+    );
 
-      // Wait for the board to re-render with the new task
-      const taskCard = page.locator('text=Pill display task');
-      await expect(taskCard).toBeVisible({ timeout: 5000 });
+    // Wait for the board to re-render with the new task
+    const taskCard = page.locator('text=Pill display task');
+    await expect(taskCard).toBeVisible({ timeout: 5000 });
 
-      // Label pills should be rendered within the card
-      const cardContainer = taskCard.locator('..').locator('..');
-      await expect(cardContainer.locator('text=bug')).toBeVisible();
-      await expect(cardContainer.locator('text=frontend')).toBeVisible();
-    } finally {
-      await browser.close();
-    }
+    // Label pills should be rendered within the card
+    const cardContainer = taskCard.locator('..').locator('..');
+    await expect(cardContainer.locator('text=bug')).toBeVisible();
+    await expect(cardContainer.locator('text=frontend')).toBeVisible();
   });
 });

--- a/tests/ui/new-task-dialog.spec.ts
+++ b/tests/ui/new-task-dialog.spec.ts
@@ -2,6 +2,13 @@ import { test, expect } from '@playwright/test';
 import { launchPage, waitForBoard, createProject, createTask } from './helpers';
 import type { Browser, Page } from '@playwright/test';
 
+// File-level parallel + per-describe default makes each top-level describe its own
+// shardable test group. It does NOT raise the worker count (playwright.config.ts pins
+// the ui project to 3), so the per-page CPU headroom the Escape-to-close-dropdown test
+// below depends on is unchanged - only which file occupies a worker changes. Tests
+// inside a describe still run in order on one worker.
+test.describe.configure({ mode: 'parallel' });
+
 const PROJECT_NAME = `NewTaskDialog Test ${Date.now()}`;
 let browser: Browser;
 let page: Page;
@@ -32,6 +39,8 @@ async function closeDialog() {
 }
 
 test.describe('BranchPicker', () => {
+  test.describe.configure({ mode: 'default' });
+
   test('chip renders with default branch name', async () => {
     await openNewTaskDialog();
 
@@ -104,6 +113,8 @@ test.describe('BranchPicker', () => {
 });
 
 test.describe('Worktree Toggle', () => {
+  test.describe.configure({ mode: 'default' });
+
   test('toggle is visible in New Task dialog', async () => {
     await openNewTaskDialog();
 
@@ -242,6 +253,8 @@ test.describe('Worktree Toggle', () => {
 });
 
 test.describe('To Do Edit Branch Config', () => {
+  test.describe.configure({ mode: 'default' });
+
   test('backlog edit shows full branch config UI', async () => {
     await createTask(page, 'Branch Config Task');
 
@@ -493,6 +506,8 @@ test.describe('To Do Edit Branch Config', () => {
 });
 
 test.describe('Save double-submit guard', () => {
+  test.describe.configure({ mode: 'default' });
+
   test('Save disables while in flight and calls tasks.update exactly once', async () => {
     const uniqueTitle = `Save Double Submit Guard ${Date.now()}`;
 
@@ -580,6 +595,8 @@ test.describe('Save double-submit guard', () => {
 });
 
 test.describe('Create double-submit guard', () => {
+  test.describe.configure({ mode: 'default' });
+
   test('Create disables while in flight and creates exactly one task', async () => {
     const uniqueTitle = `Double Submit Guard ${Date.now()}`;
     await openNewTaskDialog();

--- a/tests/ui/project-groups.spec.ts
+++ b/tests/ui/project-groups.spec.ts
@@ -1,21 +1,27 @@
-import { test, expect, type Page } from '@playwright/test';
-import { launchPage, waitForBoard, createProject } from './helpers';
+import { test, expect, type Browser, type Page } from '@playwright/test';
+import { launchSharedBrowser, resetPage, waitForBoard, createProject } from './helpers';
 
-// Each describe is isolated per worker (separate process; per-test page launch / goto reset),
+// Each describe is isolated per worker (separate process; goto reset in beforeEach),
 // so the file's tests can fan out across the UI workers safely.
 test.describe.configure({ mode: 'parallel' });
 
+let browser: Browser;
 let page: Page;
 
-test.beforeEach(async () => {
-  const launched = await launchPage();
-  page = launched.page;
-  await createProject(page, 'Alpha');
-  await createProject(page, 'Beta');
+// One browser per worker group instead of one per test: page.goto() re-runs the
+// mock's init scripts, so each test still starts from a clean store.
+test.beforeAll(async () => {
+  ({ browser, page } = await launchSharedBrowser());
 });
 
-test.afterEach(async () => {
-  await page.context().browser()?.close();
+test.afterAll(async () => {
+  await browser?.close();
+});
+
+test.beforeEach(async () => {
+  await resetPage(page);
+  await createProject(page, 'Alpha');
+  await createProject(page, 'Beta');
 });
 
 /**

--- a/tests/ui/project-sidebar-actions.spec.ts
+++ b/tests/ui/project-sidebar-actions.spec.ts
@@ -1,23 +1,34 @@
-import { test, expect, type Page } from '@playwright/test';
-import { launchPage, createProject } from './helpers';
+import { test, expect, type Browser, type Page } from '@playwright/test';
+import { launchSharedBrowser, resetPage, createProject } from './helpers';
 
-// Each describe is isolated per worker (separate process; per-test page launch / goto reset),
+// Each describe is isolated per worker (separate process; goto reset in beforeEach),
 // so the file's tests can fan out across the UI workers safely.
 test.describe.configure({ mode: 'parallel' });
 
+let browser: Browser;
 let page: Page;
 
+// One browser per worker group instead of one per test: page.goto() re-runs the
+// mock's init scripts, so each test still starts from a clean store.
+test.beforeAll(async () => {
+  ({ browser, page } = await launchSharedBrowser());
+});
+
+test.afterAll(async () => {
+  await browser?.close();
+});
+
 test.beforeEach(async () => {
-  const launched = await launchPage();
-  page = launched.page;
+  await resetPage(page);
   await createProject(page, 'TestProject');
 });
 
-test.afterEach(async () => {
-  await page.context().browser()?.close();
-});
-
+// `mode: 'default'` on each describe pins it to ONE group. Without it these tests land
+// in Playwright's `parallelWithHooks` bucket, chunked into `ceil(tests / shardTotal)`
+// groups - six groups, and six browser launches, at CI's shardTotal=9.
 test.describe('Project Sidebar Actions', () => {
+  test.describe.configure({ mode: 'default' });
+
   test('active project row shows accent left border and no inline action buttons', async () => {
     const sidebar = page.locator('.bg-surface-raised').first();
     const row = sidebar.locator('[role="button"]:has-text("TestProject")').first();
@@ -144,6 +155,8 @@ test.describe('Project Sidebar Actions', () => {
 });
 
 test.describe('Project Relocation', () => {
+  test.describe.configure({ mode: 'default' });
+
   test('settings General tab Move confirms and updates the project path', async () => {
     // The folder picker returns the destination PARENT (consume-once
     // override); the project folder keeps its name and moves into it.

--- a/tests/ui/project-sidebar-search.spec.ts
+++ b/tests/ui/project-sidebar-search.spec.ts
@@ -1,30 +1,38 @@
-import { test, expect, type Page } from '@playwright/test';
-import { chromium } from '@playwright/test';
-import path from 'node:path';
-import { launchPage, createProject, waitForViteReady } from './helpers';
+import { test, expect, type Browser, type Page } from '@playwright/test';
+import { launchSharedBrowser, resetPage, createProject } from './helpers';
 
-// Each describe is isolated per worker (separate process; per-test page launch / goto reset),
+// Each describe is isolated per worker (separate process; goto reset in beforeEach),
 // so the file's tests can fan out across the UI workers safely.
 test.describe.configure({ mode: 'parallel' });
 
-const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
-const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
-
-let page: Page;
-
-test.beforeEach(async () => {
-  const launched = await launchPage();
-  page = launched.page;
-  await createProject(page, 'Alpha');
-  await createProject(page, 'Beta');
-  await createProject(page, 'Gamma');
-});
-
-test.afterEach(async () => {
-  await page.context().browser()?.close();
-});
-
 test.describe('Project Sidebar Search', () => {
+  // Pins this describe to ONE group, so the shared browser below is actually shared.
+  // Without it these tests land in Playwright's `parallelWithHooks` bucket, chunked
+  // into `ceil(tests / shardTotal)` groups - one group per test at CI's shardTotal=9.
+  test.describe.configure({ mode: 'default' });
+
+  let browser: Browser;
+  let page: Page;
+
+  // One browser per worker group instead of one per test, and scoped to THIS
+  // describe: the group edge cases below bring their own pre-configured browser,
+  // so a file-level hook would make them pay for three project creations they
+  // immediately discard.
+  test.beforeAll(async () => {
+    ({ browser, page } = await launchSharedBrowser());
+  });
+
+  test.afterAll(async () => {
+    await browser?.close();
+  });
+
+  test.beforeEach(async () => {
+    await resetPage(page);
+    await createProject(page, 'Alpha');
+    await createProject(page, 'Beta');
+    await createProject(page, 'Gamma');
+  });
+
   test('typing filters the project list by name', async () => {
     const sidebar = page.locator('.bg-surface-raised').first();
     const search = page.locator('[data-testid="project-sidebar-search"]');
@@ -66,22 +74,6 @@ test.describe('Project Sidebar Search', () => {
 });
 
 // ─── Group + search edge cases ─────────────────────────────────────────────
-
-async function launchWithGroupSearch(preConfigScript: string): Promise<{ browser: any; page: Page }> {
-  await waitForViteReady(VITE_URL);
-  const browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
-  const newPage = await context.newPage();
-
-  await newPage.addInitScript({ path: MOCK_SCRIPT });
-  await newPage.addInitScript(preConfigScript);
-
-  await newPage.goto(VITE_URL);
-  await newPage.waitForLoadState('load');
-  await newPage.waitForSelector('text=Kangentic', { timeout: 15000 });
-
-  return { browser, page: newPage };
-}
 
 /**
  * Pre-configure a collapsed group containing "InGroup" project, plus an
@@ -143,48 +135,55 @@ function collapsedGroupPreConfig(): string {
 }
 
 test.describe('Project Sidebar Search - group edge cases', () => {
+  test.describe.configure({ mode: 'default' });
+
+  let groupBrowser: Browser;
+  let groupPage: Page;
+
+  // Both tests want the same pre-configured state, so they share one browser and
+  // reset via page.goto() (which re-runs the preconfig init script) rather than
+  // launching per test.
+  test.beforeAll(async () => {
+    ({ browser: groupBrowser, page: groupPage } = await launchSharedBrowser(
+      collapsedGroupPreConfig(),
+    ));
+  });
+
+  test.afterAll(async () => {
+    await groupBrowser?.close();
+  });
+
+  test.beforeEach(async () => {
+    await resetPage(groupPage);
+    // Wait for the board (project is open)
+    await groupPage.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+  });
+
   test('collapsed group force-expands when its children match the search query', async () => {
-    const { browser, page: groupPage } = await launchWithGroupSearch(collapsedGroupPreConfig());
+    // Initially the group is collapsed so InGroup is hidden
+    const sidebar = groupPage.locator('.bg-surface-raised').first();
+    await expect(sidebar.locator('[role="button"]:has-text("InGroup")')).toBeHidden();
 
-    try {
-      // Wait for the board (project is open)
-      await groupPage.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+    // Searching for the project name should force-expand the group
+    const search = groupPage.locator('[data-testid="project-sidebar-search"]');
+    await search.fill('InGroup');
 
-      // Initially the group is collapsed so InGroup is hidden
-      const sidebar = groupPage.locator('.bg-surface-raised').first();
-      await expect(sidebar.locator('[role="button"]:has-text("InGroup")')).toBeHidden();
-
-      // Searching for the project name should force-expand the group
-      const search = groupPage.locator('[data-testid="project-sidebar-search"]');
-      await search.fill('InGroup');
-
-      await expect(sidebar.locator('[role="button"]:has-text("InGroup")')).toBeVisible();
-    } finally {
-      await browser.close();
-    }
+    await expect(sidebar.locator('[role="button"]:has-text("InGroup")')).toBeVisible();
   });
 
   test('group with zero matching children is hidden entirely during search', async () => {
-    const { browser, page: groupPage } = await launchWithGroupSearch(collapsedGroupPreConfig());
+    // The group header should be visible before filtering
+    await expect(groupPage.locator('[data-testid^="project-group-"]')).toBeVisible();
 
-    try {
-      await groupPage.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+    // Search for a term that only matches the ungrouped project
+    const search = groupPage.locator('[data-testid="project-sidebar-search"]');
+    await search.fill('Ungrouped');
 
-      // The group header should be visible before filtering
-      await expect(groupPage.locator('[data-testid^="project-group-"]')).toBeVisible();
+    // Group header should be hidden (no matching children)
+    await expect(groupPage.locator('[data-testid^="project-group-"]')).toBeHidden();
 
-      // Search for a term that only matches the ungrouped project
-      const search = groupPage.locator('[data-testid="project-sidebar-search"]');
-      await search.fill('Ungrouped');
-
-      // Group header should be hidden (no matching children)
-      await expect(groupPage.locator('[data-testid^="project-group-"]')).toBeHidden();
-
-      // But the ungrouped project is still visible
-      const sidebar = groupPage.locator('.bg-surface-raised').first();
-      await expect(sidebar.locator('[role="button"]:has-text("Ungrouped")')).toBeVisible();
-    } finally {
-      await browser.close();
-    }
+    // But the ungrouped project is still visible
+    const sidebar = groupPage.locator('.bg-surface-raised').first();
+    await expect(sidebar.locator('[role="button"]:has-text("Ungrouped")')).toBeVisible();
   });
 });

--- a/tests/ui/release-notes-modal.spec.ts
+++ b/tests/ui/release-notes-modal.spec.ts
@@ -1,20 +1,31 @@
-import { test, expect, type Page } from '@playwright/test';
-import { launchPage, createProject } from './helpers';
+import { test, expect, type Browser, type Page } from '@playwright/test';
+import { launchSharedBrowser, resetPage, createProject } from './helpers';
 
-// Each describe is isolated per worker (separate process; per-test page launch / goto reset),
+// Each describe is isolated per worker (separate process; goto reset in beforeEach),
 // so the file's tests can fan out across the UI workers safely.
 test.describe.configure({ mode: 'parallel' });
 
+let browser: Browser;
 let page: Page;
 
-test.beforeEach(async () => {
-  const launched = await launchPage();
-  page = launched.page;
-  await createProject(page, 'TestProject');
+// One browser per worker group instead of one per test: page.goto() re-runs the
+// mock's init scripts, so each test still starts from a clean store.
+//
+// The `mode: 'default'` on the describe below pins it to ONE group. Without it these
+// tests land in Playwright's `parallelWithHooks` bucket, chunked into
+// `ceil(tests / shardTotal)` groups - one group, and one launch, per test at CI's
+// shardTotal=9, which would undo the sharing entirely.
+test.beforeAll(async () => {
+  ({ browser, page } = await launchSharedBrowser());
 });
 
-test.afterEach(async () => {
-  await page.context().browser()?.close();
+test.afterAll(async () => {
+  await browser?.close();
+});
+
+test.beforeEach(async () => {
+  await resetPage(page);
+  await createProject(page, 'TestProject');
 });
 
 async function fireUpdateDownloaded(target: Page, info: { version: string; releaseNotes: string }) {
@@ -42,6 +53,8 @@ async function readLastSeenReleaseNotesVersion(target: Page): Promise<string> {
 }
 
 test.describe('Release notes modal', () => {
+  test.describe.configure({ mode: 'default' });
+
   test('update-downloaded with notes opens the modal with rendered markdown', async () => {
     await fireUpdateDownloaded(page, {
       version: '9.9.9',

--- a/tests/ui/settings-panel.spec.ts
+++ b/tests/ui/settings-panel.spec.ts
@@ -3,6 +3,13 @@ import { launchPage, createProject } from './helpers';
 import type { Browser, Page } from '@playwright/test';
 import { MCP_TOOL_MANIFEST, mcpToolDocsUrl } from '../../src/shared/mcp-tool-manifest';
 
+// File-level parallel + per-describe default makes each top-level describe its own
+// shardable test group, so this file stops being one 40-plus-test atomic unit pinned
+// to a single shard. Tests INSIDE a describe still run in order on one worker, which
+// is what the self-reverting config mutations below rely on. The beforeAll runs once
+// per describe group (four launches instead of one), well under the file's serial span.
+test.describe.configure({ mode: 'parallel' });
+
 let browser: Browser;
 let page: Page;
 
@@ -39,6 +46,8 @@ async function closeSettings() {
 }
 
 test.describe('Settings Panel', () => {
+  test.describe.configure({ mode: 'default' });
+
   test('titlebar gear opens Settings panel with project and system tabs when project is open', async () => {
     await openSettings();
     await expect(page.locator('h2:has-text("Settings")')).toBeVisible();
@@ -713,6 +722,8 @@ test.describe('Settings Panel', () => {
 });
 
 test.describe('Project Settings via Sidebar', () => {
+  test.describe.configure({ mode: 'default' });
+
   test('sidebar context menu opens Settings panel', async () => {
     // Right-click the project row to open the context menu
     const projectRow = page.locator('[role="button"]').filter({ hasText: 'Settings Test' }).first();
@@ -766,6 +777,8 @@ test.describe('Project Settings via Sidebar', () => {
 });
 
 test.describe('Shared Settings Tooltip', () => {
+  test.describe.configure({ mode: 'default' });
+
   test('Behavior tab has tooltip "Applies to all projects"', async () => {
     await openSettings();
     const behaviorTab = page.getByRole('button', { name: 'Behavior' });
@@ -775,6 +788,8 @@ test.describe('Shared Settings Tooltip', () => {
 });
 
 test.describe('Settings Search', () => {
+  test.describe.configure({ mode: 'default' });
+
   test('search bar is visible in Settings', async () => {
     await openSettings();
     await expect(page.getByTestId('settings-search')).toBeVisible();

--- a/tests/ui/stats-lazy-retry.spec.ts
+++ b/tests/ui/stats-lazy-retry.spec.ts
@@ -30,6 +30,11 @@ import { waitForViteReady } from './helpers';
 const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
 const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
 
+// File-level parallel + per-describe default makes each top-level describe its own
+// shardable test group. It does NOT scatter tests within a describe, so the
+// per-document isolation the header describes is untouched.
+test.describe.configure({ mode: 'parallel' });
+
 const PROJECT_ID = 'proj-stats-lazy';
 
 const preConfig = `
@@ -68,6 +73,8 @@ async function launchPage(): Promise<{ browser: Browser; page: Page }> {
 }
 
 test.describe('usage stats: lazy-import failure is scoped and recoverable', () => {
+  test.describe.configure({ mode: 'default' });
+
   let browser: Browser;
   let page: Page;
 
@@ -123,6 +130,8 @@ test.describe('usage stats: lazy-import failure is scoped and recoverable', () =
 });
 
 test.describe('usage stats: cold open paints the layout skeleton, then the dashboard', () => {
+  test.describe.configure({ mode: 'default' });
+
   let browser: Browser;
   let page: Page;
 

--- a/tests/ui/task-detail-split-divider.spec.ts
+++ b/tests/ui/task-detail-split-divider.spec.ts
@@ -25,6 +25,16 @@ import { chromium, type Browser, type Page } from '@playwright/test';
 import path from 'node:path';
 import { waitForViteReady } from './helpers';
 
+// File-level parallel + per-describe default makes each top-level describe its own
+// shardable test group. Each describe already launches its own browser in beforeAll,
+// so this costs nothing and stops the file being one atomic unit on one shard.
+//
+// It is deliberately NOT a bare file-level `mode: 'parallel'`: that scatters every
+// test to its own worker, which would break the persistence describe below, whose two
+// tests are an ordered pair (the first writes the ratio, the second reads it back).
+// `mode: 'default'` keeps each describe's tests in order on one worker.
+test.describe.configure({ mode: 'parallel' });
+
 const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
 const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
 
@@ -212,6 +222,8 @@ async function setStoredDividerRatioAndWait(page: Page, taskId: string, ratio: n
 // ---------------------------------------------------------------------------
 
 test.describe('Task Detail split divider: presence', () => {
+  test.describe.configure({ mode: 'default' });
+
   let browser: Browser;
   let page: Page;
 
@@ -310,6 +322,8 @@ test.describe('Task Detail split divider: presence', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('Task Detail split divider: drag to resize', () => {
+  test.describe.configure({ mode: 'default' });
+
   let browser: Browser;
   let page: Page;
 
@@ -478,6 +492,9 @@ test.describe('Task Detail split divider: drag to resize', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('Task Detail split divider: persistence', () => {
+  // Ordered pair: the drag test writes the ratio the reopen test reads back.
+  test.describe.configure({ mode: 'default' });
+
   let browser: Browser;
   let page: Page;
 
@@ -557,6 +574,8 @@ test.describe('Task Detail split divider: persistence', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('Task Detail split divider: shared ratio across panel views', () => {
+  test.describe.configure({ mode: 'default' });
+
   let browser: Browser;
   let page: Page;
 
@@ -629,6 +648,8 @@ test.describe('Task Detail split divider: shared ratio across panel views', () =
 // ---------------------------------------------------------------------------
 
 test.describe('Task Detail split divider: resize overlay visibility', () => {
+  test.describe.configure({ mode: 'default' });
+
   let browser: Browser;
   let page: Page;
 
@@ -696,6 +717,8 @@ test.describe('Task Detail split divider: resize overlay visibility', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('Task Detail split divider: terminal-panel-resize event', () => {
+  test.describe.configure({ mode: 'default' });
+
   let browser: Browser;
   let page: Page;
 


### PR DESCRIPTION
## What

Two structural changes to the `tests/ui/` tier, plus the developer-guide section documenting both.

**Remove per-test browser launches.** `tests/ui/helpers.ts` gains `launchSharedBrowser(preConfigScript?)` and `resetPage(page)` - the launch-once-per-describe, reset-via-`goto()` pattern that six-plus specs were each hand-rolling as a file-local copy. Twelve specs are converted off per-test `chromium.launch()`. `launchPage()` stays as a thin wrapper for genuine one-off launches. Static launch sites across the converted files: 129 -> 26.

**Shard at describe granularity.** File-level `mode: 'parallel'` plus `mode: 'default'` on each top-level describe, applied to seven multi-describe serial specs.

| file | groups before | groups after |
|---|---|---|
| `settings-panel` | 1 (`42, 0, 0, 0` across 4 shards) | 4 (`28, 0, 4, 10`) |
| `new-task-dialog` | 1 | 5 |
| `task-detail-split-divider` | 1 | 6 |
| `commit-detail-selection` | 1 | 3 |
| `commit-graph-panel`, `board-config`, `stats-lazy-retry`, `label-input` | 1 each | 2 each |

## Why

The 9-shard UI matrix is the entire CI critical path. On the baseline run its slowest shard finished at 01:13:18 while E2E (01:11:22), unit (01:11:36), and lint/typecheck/build (01:10:21) all finished roughly two minutes earlier, so every second saved anywhere else was invisible. Nothing regressed; the suite roughly doubled since late June and CI went 140s -> ~235s.

The task framed this as test-count imbalance, but re-deriving from the shard logs plus the real job timings says otherwise. Every shard ran 129-131 tests but 262-413s of measured work, and wall time does not follow measured test time: regressing wall on summed per-test duration across the 9 shards gives r ~ 0.25, carried entirely by one shard - drop it and r goes slightly negative. Shard 7 did 306s of tests in 119s; shard 2 did 264s in 170s. In-shard utilisation ranged 1.68x to 3.04x at `workers: 3`.

The variance lives in time Playwright never attributes to a test - browser launches and `createProject()` flows inside hooks - plus tail effects from coarse test groups. Shard 2's reconstructed timeline showed 136 idle worker-seconds over a 156s span (29% of the 3-worker budget), with the last spec file starting at +150s. So: cut launch cost, then cut group size. Weight-based rebalancing is a separate follow-up that needs this branch's own green run as its input.

## How

`mode: 'default'` inside a `mode: 'parallel'` file is the load-bearing detail. Per `createTestGroups` (`node_modules/playwright/lib/runner/index.js`), `insideParallel` goes true and `outerMostSequentialSuite` resolves to the `'default'` describe, so the group key is that describe: one shardable group per describe, tests inside it still in order on one worker. That preserves every existing shared-page ordering guarantee, which is why it works on files a bare `mode: 'parallel'` would break - including the split-divider persistence pair, where one test writes the ratio the next reads back. It is deliberately not `mode: 'serial'`, which would add skip-the-rest-on-failure and whole-describe retry.

`app.spec.ts` is excluded on purpose: its dependency is cross-DESCRIBE (a test creates the project later describes need, while the first test requires that no project exists). That is the one failure mode this primitive does not fix, and at 0.57s/test its 21s serial span is not a meaningful floor.

Trap worth flagging for reviewers: `createTestGroups`'s `parallelWithHooks` bucket chunks tests into `ceil(tests / expectedParallelism)` groups, and `expectedParallelism` is `shard.total` (9 on CI) but `config.workers` (3) on a local unsharded run. A shared-browser file with fewer than 9 tests therefore gets one group - and one browser launch - **per test on CI** while measuring fine locally. Five converted files hit exactly this; per-describe `mode: 'default'` is shardTotal-independent and fixes it. Verified with `--shard=1/9 --list`.

## Breaking changes

None. Test-tier and docs only; no `src/` changes.

## Tests

- All 207 tests in the 17 modified specs pass.
- Cross-describe isolation classifier: every `--shard=i/4` slice of each regrouped file passes cold, in its own process.
- `new-task-dialog` (named in `playwright.config.ts` as one of the two flakes that forced `workers: 3`) passed 3 consecutive runs.
- 153 tests in 6 untouched specs that consume the changed `launchPage` helper still pass.
- `npm run typecheck` and `npm run lint` clean.
- Measured locally over the 17 specs: aggregate reported test time 251.6s -> 201.2s, wall 108s -> 90s. Directional only - local grouping is not CI grouping, per the trap above. This PR's own shard timings are the real measurement.

Generated with [Claude Code](https://claude.com/claude-code)
