### PR TITLE
test(ui): give the file-tree wait the same 15s budget as its siblings

### DIFF
--- a/tests/ui/changes-file-history.spec.ts
+++ b/tests/ui/changes-file-history.spec.ts
@@ -153,6 +153,13 @@ test.describe('Changes panel: per-file history popover', () => {
     // 15000ms for real margin, leaving the purely-synchronous steps (menu
     // open/close, which is a plain right-click -> setState -> render with no
     // IPC) at their original tighter budgets.
+    //
+    // That pass widened the file-tree ROW (below) but left the file-tree
+    // CONTAINER's own wait at 8000ms, even though it sits earlier in the very
+    // same async chain this comment describes and therefore carries strictly
+    // MORE of it (dialog open animation + toggle click + diffFiles + render).
+    // It duly flaked on CI at exactly that line (failed at 8s, passed on
+    // retry). Both now use the same 15000ms budget.
     test.slow();
     const card = page.locator('[data-swimlane-name="Code Review"]').locator('text=File History Task').first();
     await card.click();
@@ -164,7 +171,7 @@ test.describe('Changes panel: per-file history popover', () => {
     if (!(await fileTree.isVisible())) {
       await page.locator('[data-testid="changes-toggle"]').click();
     }
-    await fileTree.waitFor({ state: 'visible', timeout: 8000 });
+    await fileTree.waitFor({ state: 'visible', timeout: 15000 });
 
     const fileRow = fileTree.getByRole('button', { name: /index\.ts/ });
     await fileRow.waitFor({ state: 'visible', timeout: 15000 });


### PR DESCRIPTION
## What

Widens one `waitFor` in `changes-file-history.spec.ts` from 8000ms to 15000ms, matching its siblings in the same async chain.

## Why

The test flaked on CI: it failed at 8s waiting for `[data-testid="changes-file-tree"]`, then passed on retry.

The file's own comment classifies that step as fetch-gated - "file-tree row: dialog-open -> toggle-click -> diffFiles -> re-render" - and describes an earlier pass that widened every such step to 15000ms for real margin. That pass widened the file-tree ROW but left the file-tree CONTAINER at 8000ms, even though the container sits earlier in the same chain and therefore carries strictly more of it: the dialog's open animation, the toggle click, the `diffFiles` IPC, and the re-render. Under CI worker contention that exceeded 8s.

## How

Both waits now use 15000ms. The purely synchronous steps (menu open/close, a plain right-click -> setState -> render with no IPC) keep their tighter budgets, per the same comment. The comment is extended to record why the container was missed, so a third pass does not have to rediscover it.

No production code changes; this is a test-timeout correction, not a masked regression. Playwright timeouts are ceilings, not runtimes - a passing test returns the instant its condition is true, so this does not slow the suite.

## Breaking changes

None.

## Tests

- `npx playwright test --project=ui tests/ui/changes-file-history.spec.ts` passes locally.
- The CI checks on this PR.

Generated with [Claude Code](https://claude.com/claude-code)
