### PR TITLE
perf: defer terminal init a frame and gate monitor snapshot pushes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,10 +197,11 @@ won't be found.
   is load-bearing beyond legibility: a card swaps idle for working IN PLACE, and at 18x18 the
   envelope enclosed 26% more than the ring, so the indicator visibly grew on every state change.
   At 14.4 the two are within 0.5%, which holds only while `agent-working` stays r=9. Indicators
-  render at 15 (`TaskCard` and both sidebar components), NOT the 14 the lucide glyphs used: the
+  render at 16 (`TaskCard` and both sidebar components), NOT the 14 the lucide glyphs used: the
   branding envelope is 18 wide where lucide's `Mail` was 20, so a same-number swap silently
-  shrinks it ~10%. 15 restores the drawn size production shipped. Move the sidebar's two
-  indicator components together or the row goes ragged. lucide stays everywhere
+  shrinks it ~10%. 15 restored the drawn size production shipped; 16 is a deliberate one-step
+  legibility bump on top of that. Move the sidebar's two indicator components together or the
+  row goes ragged. lucide stays everywhere
   else (140+ files), and `utils/swimlane-icons.tsx` needs its whole glyph map
   because column icon names are persisted as kebab-case strings in the DB.
 - **Settings tab separator** - Each tab in `SETTINGS_TABS` (`settings-tabs.ts`) declares a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,7 +221,7 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 |---------|---------|---------|
 | `usage:getDashboardStats` | invoke | Composite usage-statistics payload for the dashboard (KPIs, bucketed token/cost time series, by-model / by-agent breakdowns), for one project or rolled up across every registered project, over the Live/Today/Week/Month/All Time ranges. Sources from the append-only `usage_history` + `conversation_turn_usage` ledgers so totals survive task deletion, bulk-archive, and revert-to-backlog; also merges in-flight sessions from the live `SessionManager` on top (skipped for a day drill or custom window, which are pure ledger accounting) so the SESSIONS KPI and Live view are not undercounted. Read-only; the explicit scope argument carries the project id. |
 
-### Agent Monitor (4 channels)
+### Agent Monitor (6 channels)
 Machine-global, like the Mobile Bridge channels: the monitor aggregates live sessions across
 **every** registered project, so no channel here takes a trailing `projectId`. The one exception
 is `monitor:getTaskDetail`, which names a project explicitly because it reads ONE task from a
@@ -229,9 +229,11 @@ project that may not be the open one.
 | Channel | Pattern | Purpose |
 |---------|---------|---------|
 | `monitor:getSnapshot` | invoke | Cross-project snapshot of every live and recently-finished agent session: owning project, task title / ticket number / column, activity state and reason, agent, model, runtime, last event, and context-window usage. Built by joining the process-global session registry and activity/event/usage caches against each owning project's DB. Per-project setup is memoized once per snapshot; the row build itself is one indexed task read plus one session read per monitored session. Read-only. |
+| `monitor:subscribe` | invoke | Register the calling renderer as a live monitor consumer and return a fresh snapshot in the same round trip, so a mounting monitor cannot race the next push for its first frame. Main builds and fans out `monitor:changed` only while at least one subscriber is registered; with every monitor closed, a session event costs no snapshot build at all. Main drops the registration itself when the renderer closes, crashes, or hard-reloads (the task-detail-ownership teardown trio), so a lost renderer cannot pin the pipeline on. |
+| `monitor:unsubscribe` | invoke | Explicit counterpart of `monitor:subscribe`, called when the monitor closes. |
 | `monitor:getTaskDetail` | invoke | Everything the task-detail surface needs about a task's OWN project (task row, project name/path, swimlanes, shortcuts, label colors, base branch, worktree/browser flags), so a host that is not that project's board can render it. One bundle rather than stamping five read channels with a projectId. Returns null when the project or task is gone, so the caller closes rather than rendering a husk. Read-only. |
 | `monitor:revealTask` | invoke | Ask main to reveal a task in the MAIN window (switching project if needed) and focus it. Used by the DETACHED monitor, which is its own renderer with its own stores and so cannot open a task by setting local state. Re-emits the existing `notification:clicked` push so there is one reveal path, not two. |
-| `monitor:changed` | on | Fanned to every window (main + open pop-outs) when the DB-resident half of a row changes (a session spawned or exited, or an agent retitled/moved a task), debounced at 250ms. Live activity does NOT come through here - it rides the unbuffered `session:activity` push and is patched onto rows in place, so a state change needs no round trip. |
+| `monitor:changed` | on | Fanned to every window (main + open pop-outs) when the DB-resident half of a row changes (a session spawned or exited, or an agent retitled/moved a task), debounced at 250ms and gated on a live `monitor:subscribe` registration. Live activity does NOT come through here - it rides the unbuffered `session:activity` push and is patched onto rows in place, so a state change needs no round trip. |
 
 ### Task Detail Ownership (5 channels)
 Machine-global, and deliberately outside the `task:` prefix: these mutate no task, they arbitrate

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -335,7 +335,10 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   marker-only settle - the first marker may be the previous width's late repaint - and require
   marker AND quiesce, falling back to the ceiling while streaming. Concurrent samplers of the SAME
   resize (a bottom-panel tab and a detail window overlapping during a handover; in dev, StrictMode's
-  double mount) share ONE wait: the second joins the first rather than starting its own. Two
+  double mount of a Command Terminal window - TerminalTab itself now defers its init by one
+  animation frame, which lets StrictMode's synchronous unmount cancel the first scheduled init, so
+  its pair collapses to a single fetch) share ONE wait: the second joins the first rather than
+  starting its own. Two
   independent waits could not both work, because the first to settle clears the pending-repaint
   state that the other's early-settle scan offset points at, so the loser could never settle early
   and rode the full ceiling out - a deterministic ~415ms added to that open. A resize that arrives

--- a/src/main/ipc/handlers/monitor.ts
+++ b/src/main/ipc/handlers/monitor.ts
@@ -14,6 +14,7 @@
  *   - There is no timer. Elapsed time ticks client-side.
  */
 import { ipcMain } from 'electron';
+import type { WebContents } from 'electron';
 import { IPC } from '../../../shared/ipc-channels';
 import { broadcast } from '../../pop-out/window-broadcast';
 import { buildMonitorSnapshot } from '../../monitor/monitor-aggregator';
@@ -30,7 +31,50 @@ const MONITOR_PUSH_DEBOUNCE_MS = 250;
 export function registerMonitorHandlers(context: IpcContext): void {
   let pushTimer: ReturnType<typeof setTimeout> | null = null;
 
-  ipcMain.handle(IPC.MONITOR_GET_SNAPSHOT, () => {
+  /**
+   * Renderers with a live monitor mounted, keyed by webContents id. The push
+   * pipeline below builds and broadcasts snapshots only while this set is
+   * non-empty, so with no monitor open anywhere a session event costs no
+   * snapshot build, no serialization, and no renderer deserialization (#464
+   * finding 2; measured 112KB -> 19.6KB earlier, this removes the residual
+   * per-event build entirely).
+   */
+  const subscribers = new Set<number>();
+  /** Senders whose lifecycle hooks are currently armed, so repeated
+   *  subscribe/unsubscribe cycles from one renderer never stack listeners. */
+  const hookedSenders = new Set<number>();
+
+  const hookSenderLifecycle = (sender: WebContents): void => {
+    if (hookedSenders.has(sender.id)) return;
+    hookedSenders.add(sender.id);
+    const senderId = sender.id;
+    const dropSubscription = (): void => {
+      subscribers.delete(senderId);
+    };
+    // Same teardown trio as task-detail-ownership.ts: a closed window, a crashed
+    // renderer, and a hard reload all invalidate the renderer-side listener
+    // without an unsubscribe call. The reload case matters most in dev - the
+    // webContents survives with the same id, so without the navigation hook a
+    // Ctrl+R with the monitor open would leave main pushing snapshots to a page
+    // that no longer listens. In-page HMR does not navigate, so a dev session
+    // keeps its subscription. Same-document (hash / history) navigations do not
+    // tear the page down and are ignored. Registered with `on`, not `once`, and
+    // the sender stays in `hookedSenders` across reloads (the webContents
+    // survives), so a re-subscribe after a reload never stacks a second
+    // listener; only real teardown unhooks.
+    sender.on('did-start-navigation', (details) => {
+      if (!details.isMainFrame || details.isSameDocument) return;
+      dropSubscription();
+    });
+    const dropOnTeardown = (): void => {
+      dropSubscription();
+      hookedSenders.delete(senderId);
+    };
+    sender.once('destroyed', dropOnTeardown);
+    sender.once('render-process-gone', dropOnTeardown);
+  };
+
+  const buildSnapshotSafe = () => {
     try {
       return buildMonitorSnapshot(context);
     } catch (error) {
@@ -42,6 +86,20 @@ export function registerMonitorHandlers(context: IpcContext): void {
       console.error('[monitor] Failed to build snapshot for fetch:', error);
       return { rows: [], generatedAt: new Date().toISOString() };
     }
+  };
+
+  ipcMain.handle(IPC.MONITOR_GET_SNAPSHOT, () => buildSnapshotSafe());
+
+  ipcMain.handle(IPC.MONITOR_SUBSCRIBE, (event) => {
+    subscribers.add(event.sender.id);
+    hookSenderLifecycle(event.sender);
+    // One round trip: registering and seeding are the same call, so a mounting
+    // monitor cannot race the next push for its first frame of data.
+    return buildSnapshotSafe();
+  });
+
+  ipcMain.handle(IPC.MONITOR_UNSUBSCRIBE, (event) => {
+    subscribers.delete(event.sender.id);
   });
 
   /**
@@ -76,9 +134,15 @@ export function registerMonitorHandlers(context: IpcContext): void {
   });
 
   const schedulePush = (): void => {
+    // No monitor mounted anywhere: skip the whole pipeline. Checked again when
+    // the debounce fires, because the last subscriber can vanish inside the
+    // window. A monitor that mounts BETWEEN events needs no catch-up push -
+    // subscribing returned it a fresh snapshot.
+    if (subscribers.size === 0) return;
     if (pushTimer) return;
     pushTimer = setTimeout(() => {
       pushTimer = null;
+      if (subscribers.size === 0) return;
       if (context.mainWindow.isDestroyed()) return;
       try {
         // broadcast (not webContents.send) so a detached monitor window receives

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -395,6 +395,8 @@ const api: ElectronAPI = {
   // spans every registered project by design.
   monitor: {
     getSnapshot: () => ipcRenderer.invoke(IPC.MONITOR_GET_SNAPSHOT),
+    subscribe: () => ipcRenderer.invoke(IPC.MONITOR_SUBSCRIBE),
+    unsubscribe: () => ipcRenderer.invoke(IPC.MONITOR_UNSUBSCRIBE),
     revealTask: (projectId, taskId) => ipcRenderer.invoke(IPC.MONITOR_REVEAL_TASK, projectId, taskId),
     // Explicit projectId, unlike the rest of this group: this one read IS
     // project-scoped (it is the monitor asking about ONE row's own project).

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -419,9 +419,12 @@ export function App() {
     const monitorApi = window.electronAPI?.monitor;
     if (monitorApi?.onChanged) {
       cleanups.push(monitorApi.onChanged((snapshot) => {
-        // Applied unconditionally, not gated on the monitor being open: the
-        // snapshot is cheap to hold, and this keeps a reopen instant instead of
-        // showing a stale frame while the refetch lands.
+        // Applied unconditionally, not gated on the monitor being open. Main
+        // only pushes while SOME renderer is subscribed (monitor:subscribe), so
+        // with every monitor closed nothing arrives here at all; when the
+        // pop-out is the subscriber, applying the broadcast keeps this window's
+        // cache warm too. Reopen freshness does not depend on this: attach()
+        // seeds from the snapshot the subscription handshake returns.
         useMonitorStore.getState().applySnapshot(snapshot);
       }));
     }

--- a/src/renderer/components/board/TaskCard.tsx
+++ b/src/renderer/components/board/TaskCard.tsx
@@ -318,7 +318,7 @@ const TaskCardInner = function TaskCard({ task, isDragOverlay, compact, onDelete
           {(isIdle || isThinking) && (
             <ActivityMark
               mark={isThinking ? 'agent-working' : 'agent-idle'}
-              size={15}
+              size={16}
               className={`${isThinking ? 'text-active' : 'text-attention'} shrink-0`}
               aria-label={
                 activityReason

--- a/src/renderer/components/monitor/MonitorTaskDetailHost.tsx
+++ b/src/renderer/components/monitor/MonitorTaskDetailHost.tsx
@@ -44,16 +44,19 @@ export function MonitorTaskDetailHost({
   onUnavailable,
 }: MonitorTaskDetailHostProps) {
   const [bundle, setBundle] = useState<TaskDetailBundle | null>(null);
-  // Any monitor change can also mean this task changed (retitled, moved column),
-  // so the bundle refetches on the same signal the rows do rather than polling.
-  const monitorRows = useMonitorStore((state) => state.rows);
+  // Any SNAPSHOT change can also mean this task changed (retitled, moved
+  // column), so the bundle refetches on the snapshot generation rather than
+  // polling. Deliberately NOT the `rows` identity: an activity tick on ANY
+  // tracked session (in any project) replaces the rows array, so keying on it
+  // fired a `getTaskDetail` round trip per cross-project activity tick for as
+  // long as a detail was open. The generation only moves when the DB-resident
+  // half of some row actually changed.
+  const snapshotGeneration = useMonitorStore((state) => state.snapshotGeneration);
   const settingsOpen = useConfigStore((state) => state.settingsOpen);
 
-  /** Bumped per fetch so a slow response cannot overwrite a newer one. Any
-   *  monitor row change re-fires the effect below, and an activity tick on ANY
-   *  tracked session (in any project) gives `rows` a new reference, so several
-   *  `getTaskDetail` calls are routinely in flight at once and can resolve out of
-   *  order. Without this, the older reply wins and the detail shows stale data. */
+  /** Bumped per fetch so a slow response cannot overwrite a newer one: a
+   *  snapshot push can re-fire the effect below while an earlier fetch is
+   *  still in flight, and the older reply must not win over the newer one. */
   const requestGenerationRef = useRef(0);
 
   const refresh = useCallback(async () => {
@@ -78,7 +81,7 @@ export function MonitorTaskDetailHost({
     // Invalidate this fetch on unmount / re-fire, so a reply that lands after the
     // host has moved to another task cannot call setBundle or onUnavailable.
     return () => { requestGenerationRef.current += 1; };
-  }, [refresh, monitorRows]);
+  }, [refresh, snapshotGeneration]);
 
   const value = useMemo<TaskDetailHostValue | null>(() => {
     if (!bundle) return null;

--- a/src/renderer/components/sidebar/project-sidebar/SidebarActivityCounts.tsx
+++ b/src/renderer/components/sidebar/project-sidebar/SidebarActivityCounts.tsx
@@ -18,14 +18,16 @@ export const SidebarActivityCounts = React.memo(function SidebarActivityCounts({
   const hasIdle = idleCount > 0;
   if (!hasThinking && !hasIdle) return null;
 
-  // 15, the same size `TaskCard` renders these two marks at - one mark, one meaning, one size.
+  // 16, the same size `TaskCard` renders these two marks at - one mark, one meaning, one size.
   // Not 14, which is what the lucide glyphs used: the branding envelope is 18 wide where
-  // lucide's Mail was 20, so a same-number swap silently shrank it ~10%. 15 restores the drawn
-  // size production actually shipped (11.25 x 9.0px against the old 11.67 x 9.33).
+  // lucide's Mail was 20, so a same-number swap silently shrank it ~10%. 15 restored the drawn
+  // size production shipped (11.25 x 9.0px against the old 11.67 x 9.33); 16 is a deliberate
+  // one-step bump on top of that for legibility. Keep in step with TaskCard's mark and
+  // SidebarCommandTerminalIndicator - the three indicators form one tabular column.
   //
   // 12 is the floor: below it the 2px stroke scales to a sub-pixel hairline and smears, which
   // is why the branding set declares `floors.indicator = 12`.
-  const iconSize = size === 'group' ? 12 : 15;
+  const iconSize = size === 'group' ? 12 : 16;
   const labelParts: string[] = [];
   if (hasIdle) labelParts.push(`${idleCount} idle`);
   if (hasThinking) labelParts.push(`${thinkingCount} thinking`);

--- a/src/renderer/components/sidebar/project-sidebar/SidebarCommandTerminalIndicator.tsx
+++ b/src/renderer/components/sidebar/project-sidebar/SidebarCommandTerminalIndicator.tsx
@@ -79,12 +79,12 @@ export const SidebarCommandTerminalIndicator = React.memo(function SidebarComman
       data-activity={tone}
       data-count={count}
     >
-      {/* 15 to match SidebarActivityCounts' row size, so all three indicators stay one
+      {/* 16 to match SidebarActivityCounts' row size, so all three indicators stay one
           tabular column. Change both together or the row goes ragged. */}
-      <CommandTerminalIcon size={15} tone={tone} testId={`project-terminal-icon-${projectId}`} />
+      <CommandTerminalIcon size={16} tone={tone} testId={`project-terminal-icon-${projectId}`} />
       {/* The count always prints, even at 1. Suppressing it left a lone glyph in a row
           of icon+digit pairs, where it read as a count that had lost its number. */}
-      <span className="flex items-center justify-center min-w-[1ch] font-semibold" style={{ height: 15 }}>
+      <span className="flex items-center justify-center min-w-[1ch] font-semibold" style={{ height: 16 }}>
         {count}
       </span>
     </button>

--- a/src/renderer/components/terminal/TerminalTab.tsx
+++ b/src/renderer/components/terminal/TerminalTab.tsx
@@ -115,38 +115,56 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
 
   const initialized = useRef(false);
 
-  // Init terminal once the container has real pixel dimensions.
+  // Init terminal once the container has real pixel dimensions, deferred by one
+  // frame: the commit that mounts this pane already pays the panel subtree
+  // render, and folding the xterm construction (open + WebGL context + fit,
+  // ~10ms) into that same task produced a 40-60ms pointer-thread stall when a
+  // spawning session's pane mounted mid-drag (task #468). The deferral is
+  // pixel-invisible - the replay veil / LaunchOverlay cover the pane from the
+  // first frame, and the container div paints the terminal background either
+  // way. It also makes StrictMode's mount -> unmount -> remount construct ONE
+  // terminal instead of two: the first mount's cleanup cancels its scheduled
+  // init before it ever runs. This is NOT the reverted drag-end deferral: the
+  // init lands on the very next frame, before the active effect's FIT_DELAY_MS
+  // corrective fit, so the fit sequence is unchanged.
   // The cleanup resets initialized so React StrictMode's
   // mount→unmount→remount cycle re-creates the terminal properly.
   useEffect(() => {
     const el = terminalRef.current;
     if (!el) return;
 
-    // Try to init immediately if container already has dimensions
-    const tryInit = () => {
-      if (initialized.current) return;
-      if (el.offsetWidth > 0 && el.offsetHeight > 0) {
-        initTerminal();
-        initialized.current = true;
-      }
-    };
+    let initRafId: number | null = null;
 
-    tryInit();
-
-    // If container didn't have dimensions yet, watch for them
-    let observer: ResizeObserver | null = null;
-    if (!initialized.current) {
-      observer = new ResizeObserver(() => {
-        tryInit();
-        if (initialized.current) {
-          observer?.disconnect();
+    // Init on the next frame if the container has dimensions by then
+    const scheduleInit = () => {
+      if (initialized.current || initRafId !== null) return;
+      initRafId = requestAnimationFrame(() => {
+        initRafId = null;
+        if (initialized.current) return;
+        if (el.offsetWidth > 0 && el.offsetHeight > 0) {
+          initTerminal();
+          initialized.current = true;
+          observer.disconnect();
         }
       });
-      observer.observe(el);
-    }
+    };
+
+    // If the container has no dimensions yet (a display:none tab), the rAF
+    // above no-ops and this observer re-schedules when dimensions arrive.
+    const observer: ResizeObserver = new ResizeObserver(() => {
+      if (initialized.current) {
+        observer.disconnect();
+        return;
+      }
+      scheduleInit();
+    });
+    observer.observe(el);
+
+    scheduleInit();
 
     return () => {
-      observer?.disconnect();
+      if (initRafId !== null) cancelAnimationFrame(initRafId);
+      observer.disconnect();
       initialized.current = false;
       // Reset ONLY when the overlay would genuinely be wanted on the next mount, i.e.
       // a session that has not produced anything yet. If the store still holds

--- a/src/renderer/stores/monitor-rows.ts
+++ b/src/renderer/stores/monitor-rows.ts
@@ -1,9 +1,10 @@
 /**
  * Row-identity reconciliation for the Agent Monitor snapshot.
  *
- * `MONITOR_CHANGED` is pushed unconditionally (debounced 250ms) whenever a session
- * is spawned, changes status, or exits, and the payload crosses the IPC boundary by
- * structured clone. That means EVERY row object is a fresh identity on every push,
+ * `MONITOR_CHANGED` is pushed (debounced 250ms, and only while some renderer holds
+ * a live `monitor:subscribe` registration) whenever a session is spawned, changes
+ * status, or exits, and the payload crosses the IPC boundary by structured clone.
+ * That means EVERY row object is a fresh identity on every push,
  * even when nothing about it changed. Applied naively, that is a guaranteed store
  * write on a 250ms cadence for as long as session events flow, and with the monitor
  * open it cascades: the body's `useShallow` selector fails, the `units` memo

--- a/src/renderer/stores/monitor-store.ts
+++ b/src/renderer/stores/monitor-store.ts
@@ -2,10 +2,13 @@
  * Agent Monitor store: the cross-project aggregate view's open/closed state, its
  * rows, and the user's persisted view preference.
  *
- * Two data paths, deliberately:
- *   - `loadSnapshot()` pulls the full cross-project snapshot from main. Cheap, but
- *     it is a round trip, so it is debounced and only fires when the DB-resident
- *     half of a row can have changed.
+ * Three data paths, deliberately:
+ *   - `attach()` / `detach()` bracket an open monitor. Attach registers this
+ *     renderer with main - which builds and pushes MONITOR_CHANGED only while at
+ *     least one renderer is subscribed - and seeds the rows from the snapshot
+ *     the handshake returns, so opening is one round trip.
+ *   - `loadSnapshot()` pulls the full cross-project snapshot from main without
+ *     touching the subscription (the board-driven refetch and the HMR resync).
  *   - `applyActivity()` patches a single row in place from the SESSION_ACTIVITY
  *     push, which already flows unbuffered and cross-project. This is the common
  *     case (an agent starting to wait on you) and it costs no round trip at all.
@@ -28,6 +31,12 @@ const VIEW_PERSIST_DEBOUNCE_MS = 400;
 interface MonitorState {
   monitorOpen: boolean;
   rows: MonitorSessionRow[];
+  /** Bumped only when a SNAPSHOT actually changed the rows (never by an
+   *  `applyActivity` patch). Consumers that must refetch when the DB-resident
+   *  half of a row may have changed (MonitorTaskDetailHost's bundle) key on
+   *  this instead of the `rows` identity, which every cross-project activity
+   *  tick replaces. */
+  snapshotGeneration: number;
   /** True until the first snapshot lands, so the body can show a cold-load skeleton. */
   loading: boolean;
   loaded: boolean;
@@ -36,6 +45,14 @@ interface MonitorState {
   open: () => void;
   close: () => void;
   toggle: () => void;
+  /** Register this renderer as a live monitor consumer with main and seed the
+   *  rows from the snapshot the subscription handshake returns. Main only
+   *  builds/pushes MONITOR_CHANGED while a subscriber exists, so this is what
+   *  turns the push pipeline on. */
+  attach: () => Promise<void>;
+  /** Counterpart of attach; turns main's push pipeline back off for this
+   *  renderer. Window close and hard reload are handled by main itself. */
+  detach: () => void;
   loadSnapshot: () => Promise<void>;
   applySnapshot: (snapshot: MonitorSnapshot) => void;
   applyActivity: (sessionId: string, activity: ActivityState, reason: ActivityReason | null) => void;
@@ -50,38 +67,80 @@ function createMonitorStore() {
   let inFlight: Promise<void> | null = import.meta.hot?.data?.monitorInFlight ?? null;
   // @ts-expect-error -- Vite handles import.meta.hot
   let persistTimer: ReturnType<typeof setTimeout> | null = import.meta.hot?.data?.monitorPersistTimer ?? null;
+  /** Orders the two fetch-and-apply paths (attach's subscribe, loadSnapshot's
+   *  getSnapshot), which are NOT deduped against each other - attach must always
+   *  reach main to register the subscription. A reply applies only while it is
+   *  still the newest fetch, so an older reply cannot overwrite a newer snapshot
+   *  or double-bump `snapshotGeneration`. Pushes bypass this deliberately: they
+   *  carry the newest build, and the next push heals any transient skew. */
+  // @ts-expect-error -- Vite handles import.meta.hot
+  let fetchOrdinal: number = import.meta.hot?.data?.monitorFetchOrdinal ?? 0;
 
   // @ts-expect-error -- Vite handles import.meta.hot
   import.meta.hot?.dispose((data: Record<string, unknown>) => {
     data.monitorInFlight = inFlight;
     data.monitorPersistTimer = persistTimer;
+    data.monitorFetchOrdinal = fetchOrdinal;
   });
 
   const store = create<MonitorState>((set, get) => ({
     monitorOpen: false,
     rows: [],
+    snapshotGeneration: 0,
     loading: false,
     loaded: false,
     view: DEFAULT_CONFIG.monitor,
 
     open: () => {
       set({ monitorOpen: true });
-      void get().loadSnapshot();
+      void get().attach();
     },
-    close: () => set({ monitorOpen: false }),
+    close: () => {
+      set({ monitorOpen: false });
+      get().detach();
+    },
     toggle: () => (get().monitorOpen ? get().close() : get().open()),
 
+    attach: async () => {
+      const monitorApi = window.electronAPI?.monitor;
+      if (!monitorApi?.subscribe) return;
+      const ordinal = ++fetchOrdinal;
+      if (!get().loaded) set({ loading: true });
+      try {
+        const snapshot = await monitorApi.subscribe();
+        if (ordinal === fetchOrdinal) get().applySnapshot(snapshot);
+      } catch (error) {
+        // Sticky by design: pushes are gated on the subscription, so no
+        // MONITOR_CHANGED arrives to self-heal a failed handshake - closing and
+        // reopening the monitor re-runs it. Not worth a retry loop for a local
+        // ipcRenderer.invoke that only fails once the app is tearing down.
+        console.error('[monitor] Failed to subscribe:', error);
+      } finally {
+        set({ loading: false });
+      }
+    },
+
+    detach: () => {
+      void window.electronAPI?.monitor?.unsubscribe?.().catch((error) => {
+        console.error('[monitor] Failed to unsubscribe:', error);
+      });
+    },
+
     loadSnapshot: async () => {
-      // Dedupe concurrent callers (open + a push arriving together) onto one round trip.
+      // Dedupe concurrent loadSnapshot callers (a board-change refetch and an
+      // HMR resync arriving together) onto one round trip. attach() deliberately
+      // does NOT route through this gate - it must always reach main to register
+      // the subscription - so `fetchOrdinal` orders the two paths instead.
       if (inFlight) return inFlight;
       const monitorApi = window.electronAPI?.monitor;
       if (!monitorApi) return;
 
+      const ordinal = ++fetchOrdinal;
       if (!get().loaded) set({ loading: true });
       const request = (async () => {
         try {
           const snapshot = await monitorApi.getSnapshot();
-          get().applySnapshot(snapshot);
+          if (ordinal === fetchOrdinal) get().applySnapshot(snapshot);
         } catch (error) {
           console.error('[monitor] Failed to load snapshot:', error);
         } finally {
@@ -105,7 +164,7 @@ function createMonitorStore() {
     applySnapshot: (snapshot) => set((state) => {
       const rows = reconcileMonitorRows(state.rows, snapshot.rows);
       if (rows === state.rows && state.loaded) return state;
-      return { rows, loaded: true };
+      return { rows, loaded: true, snapshotGeneration: state.snapshotGeneration + 1 };
     }),
 
     /**

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -248,6 +248,13 @@ export const IPC = {
   // config merge (`config.set`), so there is one persistence path, not two.
   MONITOR_GET_SNAPSHOT: 'monitor:getSnapshot',
   MONITOR_CHANGED: 'monitor:changed',
+  // Subscription handshake for MONITOR_CHANGED. Main builds and pushes the
+  // cross-project snapshot only while at least one renderer is subscribed;
+  // with no monitor mounted anywhere, every session event skips the snapshot
+  // build entirely. Subscribe returns a fresh snapshot so mounting is one
+  // round trip, not subscribe-then-fetch.
+  MONITOR_SUBSCRIBE: 'monitor:subscribe',
+  MONITOR_UNSUBSCRIBE: 'monitor:unsubscribe',
   // Reveal a task in the MAIN window. Needed because the detached monitor is its
   // own renderer with its own stores, so it cannot open a task by setting local
   // state - the request has to travel through main.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4634,6 +4634,14 @@ export interface ElectronAPI {
      *  250ms, so this is cheap in practice - but it is not the O(projects) it was
      *  once described as, and a project with many concurrent agents pays per agent. */
     getSnapshot: () => Promise<MonitorSnapshot>;
+    /** Register this renderer as a live monitor consumer and get a fresh snapshot
+     *  back. Main only builds and pushes MONITOR_CHANGED snapshots while at least
+     *  one renderer is subscribed, so an unmounted monitor costs no per-event
+     *  snapshot builds. Main drops the subscription itself when the renderer
+     *  navigates or is destroyed. */
+    subscribe: () => Promise<MonitorSnapshot>;
+    /** Explicit counterpart of subscribe, called when the monitor closes. */
+    unsubscribe: () => Promise<void>;
     /** Ask MAIN to reveal a task in the main window. Used by the detached monitor,
      *  whose own stores cannot reach the board. */
     revealTask: (projectId: string, taskId: string) => Promise<void>;

--- a/tests/ui/activity-marks.spec.ts
+++ b/tests/ui/activity-marks.spec.ts
@@ -146,13 +146,14 @@ test.describe('Activity marks', () => {
     // every measured rect inside it is uniformly smaller than its layout size.
     const { browser, page } = await launch('thinking');
     try {
-      // 15, not 14: the branding envelope is 18 wide where lucide's Mail was 20, so keeping the
-      // old number would have shrunk the drawn mark ~10% against what production shipped.
+      // 16, not 14: the branding envelope is 18 wide where lucide's Mail was 20, so keeping the
+      // old number would have shrunk the drawn mark ~10% against what production shipped; 15
+      // restored that size and 16 is a deliberate one-step legibility bump on top.
       const cardMark = page.locator(`[data-task-id="${TASK_ID}"] [data-mark="agent-working"]`);
       await expect(cardMark).toBeVisible({ timeout: 15000 });
       await expect
         .poll(() => cardMark.evaluate((node) => getComputedStyle(node).width))
-        .toBe('15px');
+        .toBe('16px');
 
       await page.locator('text=Mark Test Task').first().click();
       const dialog = page.locator('[data-testid="task-detail-dialog"]');
@@ -189,11 +190,11 @@ test.describe('Activity marks', () => {
       await expect(mark).toBeVisible({ timeout: 15000 });
       await expect(mark).toHaveAttribute('data-rest', 'static');
       await expect(mark.locator('.kng-march')).toHaveCount(0);
-      // The idle branch carries its own `size={15}` literal in TaskCard, separate from the
+      // The idle branch carries its own `size={16}` literal in TaskCard, separate from the
       // thinking branch the size test above measures, so it can regress on its own.
       await expect
         .poll(() => mark.evaluate((node) => getComputedStyle(node).width))
-        .toBe('15px');
+        .toBe('16px');
     } finally {
       await browser.close();
     }

--- a/tests/ui/agent-monitor.spec.ts
+++ b/tests/ui/agent-monitor.spec.ts
@@ -214,16 +214,30 @@ test.describe('agent monitor', () => {
     try {
       const overlay = page.locator('[data-testid="monitor-page"]');
 
+      const subscriptionCounts = () =>
+        page.evaluate(() => {
+          const monitorMock = (window as unknown as {
+            electronAPI: { monitor: { __subscribeCalls: number; __unsubscribeCalls: number } };
+          }).electronAPI.monitor;
+          return { subscribes: monitorMock.__subscribeCalls, unsubscribes: monitorMock.__unsubscribeCalls };
+        });
+
       await page.keyboard.press('Control+Shift+M');
       await overlay.waitFor({ state: 'visible', timeout: 10000 });
+      // Opening registers the renderer as a live monitor consumer; main only
+      // builds and pushes snapshots while some renderer is subscribed.
+      await expect.poll(async () => (await subscriptionCounts()).subscribes).toBe(1);
 
       await page.locator('[data-testid="monitor-close"]').click();
       await overlay.waitFor({ state: 'hidden', timeout: 10000 });
+      await expect.poll(async () => (await subscriptionCounts()).unsubscribes).toBe(1);
 
       await page.locator('[data-testid="agent-monitor-button"]').click();
       await overlay.waitFor({ state: 'visible', timeout: 10000 });
+      await expect.poll(async () => (await subscriptionCounts()).subscribes).toBe(2);
       await page.keyboard.press('Escape');
       await overlay.waitFor({ state: 'hidden', timeout: 10000 });
+      await expect.poll(async () => (await subscriptionCounts()).unsubscribes).toBe(2);
     } finally {
       await browser.close();
     }
@@ -588,6 +602,71 @@ test.describe('agent monitor', () => {
         () => page.evaluate(() => window.__zustandStores?.session?.getState().dialogSessionIds ?? []),
         { timeout: 10000 },
       ).toEqual([]);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  /**
+   * `MonitorTaskDetailHost` refetches its bundle on `snapshotGeneration`, not on
+   * the store's `rows` identity - `applyActivity` replaces `rows` on EVERY
+   * cross-project activity tick, so keying the effect on `rows` fired a
+   * `getTaskDetail` round trip per tick for as long as a detail stayed open.
+   * `sess-other-project` is chosen deliberately: it is a session the seeded
+   * snapshot already tracks (so `applyActivity` actually replaces `rows`,
+   * proving the tick applied), and it belongs to a DIFFERENT task than the one
+   * whose detail is open, so this is a genuinely unrelated tick.
+   */
+  test('a monitor task detail does not refetch its bundle per activity tick', async () => {
+    const { browser, page } = await launchWithState(monitorPreConfig());
+    try {
+      await openMonitor(page);
+      await page.locator('[data-session-id="sess-working"] [data-testid="monitor-card-title"]').click();
+      await expect.poll(() => ownerHosts(page), { timeout: 10000 })
+        .toHaveProperty(`${PROJECT_A}:task-a`, 'monitor');
+      await page.locator('[data-testid="task-detail-dialog"]').waitFor({ state: 'visible', timeout: 10000 });
+
+      const getTaskDetailCalls = () => page.evaluate(() => (window as unknown as {
+        electronAPI: { monitor: { __getTaskDetailCalls: number } };
+      }).electronAPI.monitor.__getTaskDetailCalls);
+
+      // StrictMode double-invokes the mount effect in dev, so the initial fetch
+      // can still be settling right after the dialog appears. Poll for the call
+      // count to stop growing before recording the baseline (mirrors the
+      // scrollback-stability pattern for a settling async count).
+      let lastCount = -1;
+      await expect.poll(async () => {
+        const current = await getTaskDetailCalls();
+        const stable = current === lastCount && current > 0;
+        lastCount = current;
+        return stable;
+      }, { timeout: 5000, intervals: [200, 200, 200, 200, 200] }).toBe(true);
+      const initialCalls = lastCount;
+
+      // Fire several activity pushes for a DIFFERENT session that IS present in
+      // the seeded snapshot. `applyActivity` drops an unknown session id without
+      // touching `rows` at all, so a tick for an untracked session would pass
+      // vacuously even against the buggy `rows`-keyed effect - `sess-other-project`
+      // avoids that.
+      for (let tick = 0; tick < 5; tick += 1) {
+        await page.evaluate(() => {
+          (window as unknown as {
+            __mockFireActivity: (
+              id: string, state: string, reason: unknown, projectId: string, taskId: string,
+            ) => void;
+          }).__mockFireActivity(
+            'sess-other-project', 'permission', { kind: 'permission', since: Date.now() },
+            'proj-monitor-b', 'task-b',
+          );
+        });
+      }
+
+      // Confirm the ticks actually applied (rows array replaced) before trusting
+      // the non-occurrence assertion below: sess-other-project moves into the
+      // needs-you bucket, which the summary tile counts across every project.
+      await expect(page.locator('[data-testid="monitor-summary-needs-you-value"]')).toHaveText('1');
+
+      expect(await getTaskDetailCalls()).toBe(initialCalls);
     } finally {
       await browser.close();
     }

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -3267,6 +3267,20 @@
           generatedAt: '2026-01-01T00:00:00.000Z',
         });
       },
+      // Subscription handshake (monitor:subscribe / monitor:unsubscribe). The
+      // mock has no push pipeline to gate, so subscribe just returns the same
+      // seeded snapshot getSnapshot serves; the call log lets a spec assert the
+      // monitor registered/unregistered itself.
+      __subscribeCalls: 0,
+      __unsubscribeCalls: 0,
+      subscribe: function () {
+        window.electronAPI.monitor.__subscribeCalls += 1;
+        return window.electronAPI.monitor.getSnapshot();
+      },
+      unsubscribe: function () {
+        window.electronAPI.monitor.__unsubscribeCalls += 1;
+        return Promise.resolve();
+      },
       // Call log for assertions: the detached monitor routes clicks through here.
       __revealCalls: [],
       revealTask: function (projectId, taskId) {
@@ -3277,7 +3291,11 @@
       // project's board. Resolves from the SAME seeded state the rest of the mock
       // uses, so a monitor-hosted detail sees exactly what the board would - a
       // spec cannot accidentally prove the surface works against invented data.
+      // Call log for test assertions (mirrors __subscribeCalls): pins that a
+      // detail refetches on a real snapshot change but NOT on every activity tick.
+      __getTaskDetailCalls: 0,
       getTaskDetail: function (projectId, taskId) {
+        window.electronAPI.monitor.__getTaskDetailCalls += 1;
         var project = null;
         for (var p = 0; p < projects.length; p++) {
           if (projects[p].id === projectId) { project = projects[p]; break; }

--- a/tests/ui/sidebar-command-terminals.spec.ts
+++ b/tests/ui/sidebar-command-terminals.spec.ts
@@ -317,6 +317,28 @@ test.describe('Sidebar Command Terminal indicator', () => {
     }
   });
 
+  test('the row-size agent activity mark renders at 16px, not the group branch\'s 12px', async () => {
+    // Pins SidebarActivityCounts' `iconSize = size === 'group' ? 12 : 16` for the
+    // default 'row' branch (ProjectListItem never passes `size`). The neighbouring
+    // "read side by side" test above only checks the two glyphs AGREE on a size;
+    // this pins the literal drawn size, since nothing else in the UI tier measures
+    // it. Scoped to Alpha's row specifically, so a future fixture giving Beta its
+    // own counts cannot turn this into a strict-mode violation.
+    const { browser, page } = await launchWithState(preConfig({ agentIdleOnAlpha: true }));
+
+    try {
+      const mark = page.locator(`[data-testid="project-row-${PROJECT_A_ID}"] [data-testid="sidebar-activity-counts"] [data-mark="agent-idle"]`);
+      await expect(mark).toBeVisible();
+      // Computed style, not the `width` attribute: pins what the browser actually
+      // draws, matching the pattern activity-marks.spec.ts uses for TaskCard.
+      await expect
+        .poll(() => mark.evaluate((node) => getComputedStyle(node).width))
+        .toBe('16px');
+    } finally {
+      await browser.close();
+    }
+  });
+
   test('clicking a background project\'s indicator switches project and opens the layer', async () => {
     const { browser, page } = await launchWithState(preConfig({
       terminals: [{ project: PROJECT_B_ID, id: 'ct-b1', activity: 'idle' }],
@@ -460,9 +482,9 @@ test.describe('Sidebar Command Terminal indicator', () => {
     }
   });
 
-  test('the sidebar renders the terminal icon at 15px, not the title bar\'s default 20px', async () => {
+  test('the sidebar renders the terminal icon at 16px, not the title bar\'s default 20px', async () => {
     // CommandTerminalIcon defaults size to 20 (the title bar toggle); the
-    // sidebar passes size={15} explicitly. Pins that the prop is actually
+    // sidebar passes size={16} explicitly. Pins that the prop is actually
     // threaded through rather than the icon silently rendering at the default,
     // and that it stays in step with SidebarActivityCounts' row size so the
     // three indicators keep forming one tabular column.
@@ -472,8 +494,8 @@ test.describe('Sidebar Command Terminal indicator', () => {
 
     try {
       const icon = page.locator(`[data-testid="project-terminal-icon-${PROJECT_A_ID}"]`);
-      await expect(icon).toHaveAttribute('width', '15');
-      await expect(icon).toHaveAttribute('height', '15');
+      await expect(icon).toHaveAttribute('width', '16');
+      await expect(icon).toHaveAttribute('height', '16');
     } finally {
       await browser.close();
     }

--- a/tests/unit/branding-assets.test.ts
+++ b/tests/unit/branding-assets.test.ts
@@ -470,7 +470,7 @@ describe('activity marks', () => {
 
   it('pins the size floors the call sites are written against', () => {
     // SidebarActivityCounts' group rows render at 12 (the indicator floor exactly), TaskCard and
-    // the sidebar project rows at 15, and the pause/stop controls at 20. If upstream raises a
+    // the sidebar project rows at 16, and the pause/stop controls at 20. If upstream raises a
     // floor, those call sites need revisiting - the 12px group row has no headroom at all.
     const contract: ActivityContractJson = JSON.parse(fs.readFileSync(ACTIVITY_JSON, 'utf-8'));
     expect(contract.floors.indicator, 'indicator floor changed; recheck the 12px sidebar group size').toBe(12);

--- a/tests/unit/hmr-resync.test.ts
+++ b/tests/unit/hmr-resync.test.ts
@@ -260,7 +260,7 @@ describe('HMR store re-sync', () => {
   // back, and self-accept so editing the store's own code forces a clean reload
   // instead of running stale closures. See .claude/rules/hmr-patterns.md.
   it('instance-pinned stores read, write, and self-accept across HMR (Pattern E)', () => {
-    const PATTERN_E_STORES = ['board-store.ts', 'backlog-store.ts', 'project-store.ts', 'dictation-store.ts', 'usage-dashboard-store.ts', 'pop-out-store.ts', 'updater-store.ts'];
+    const PATTERN_E_STORES = ['board-store.ts', 'backlog-store.ts', 'project-store.ts', 'dictation-store.ts', 'usage-dashboard-store.ts', 'pop-out-store.ts', 'updater-store.ts', 'monitor-store.ts'];
     const violations: string[] = [];
     for (const fileName of PATTERN_E_STORES) {
       const source = fs.readFileSync(path.join(STORES_DIR, fileName), 'utf-8');

--- a/tests/unit/monitor-push-gate.test.ts
+++ b/tests/unit/monitor-push-gate.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Unit tests for the subscriber gate in `registerMonitorHandlers`
+ * (src/main/ipc/handlers/monitor.ts).
+ *
+ * #464 finding 2: `schedulePush` used to build and broadcast the full
+ * cross-project snapshot on EVERY session event, monitor mounted or not, so
+ * with the monitor closed every spawn/exit/board change still paid the
+ * per-session DB reads, the serialization, and each renderer's
+ * structured-clone deserialization. The gate makes the push pipeline
+ * subscription-driven: main builds only while at least one renderer holds a
+ * live `monitor:subscribe` registration, and the subscription handshake
+ * returns a fresh snapshot so a mounting monitor needs no catch-up push.
+ *
+ * `electron` is mocked (ipcMain + a fake WebContents on an EventEmitter, same
+ * pattern as task-detail-ownership-handlers.test.ts); the aggregator and
+ * broadcast are mocked so the assertions are about WHEN they run, not what
+ * they produce. Timers are faked to step through the 250ms debounce.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { IPC } from '../../src/shared/ipc-channels';
+import type { IpcContext } from '../../src/main/ipc/ipc-context';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockHandle, mockBroadcast, mockBuildSnapshot } = vi.hoisted(() => ({
+  mockHandle: vi.fn(),
+  mockBroadcast: vi.fn(),
+  mockBuildSnapshot: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: mockHandle },
+}));
+
+vi.mock('../../src/main/pop-out/window-broadcast', () => ({
+  broadcast: mockBroadcast,
+}));
+
+vi.mock('../../src/main/monitor/monitor-aggregator', () => ({
+  buildMonitorSnapshot: mockBuildSnapshot,
+}));
+
+vi.mock('../../src/main/monitor/task-detail-bundle', () => ({
+  buildTaskDetailBundle: vi.fn(),
+}));
+
+import { registerMonitorHandlers } from '../../src/main/ipc/handlers/monitor';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeWebContents extends EventEmitter {
+  constructor(readonly id: number) {
+    super();
+  }
+}
+
+interface FakeNavigationDetails {
+  isMainFrame: boolean;
+  isSameDocument: boolean;
+}
+
+type InvokeHandler = (event: { sender: FakeWebContents }) => unknown;
+
+function makeContext(): { context: IpcContext; fireSessionChanged: () => void } {
+  const sessionEvents = new EventEmitter();
+  const context = {
+    mainWindow: { isDestroyed: () => false },
+    sessionManager: {
+      on: (event: string, listener: () => void) => sessionEvents.on(event, listener),
+    },
+    boardEvents: {
+      onBoardChanged: (listener: () => void) => sessionEvents.on('board-changed', listener),
+    },
+  } as unknown as IpcContext;
+  return {
+    context,
+    fireSessionChanged: () => sessionEvents.emit('session-changed'),
+  };
+}
+
+function getHandler(channel: string): InvokeHandler {
+  const registration = mockHandle.mock.calls.find(([registeredChannel]) => registeredChannel === channel);
+  if (!registration) throw new Error(`No ipcMain.handle registration for ${channel}`);
+  return registration[1] as InvokeHandler;
+}
+
+const MONITOR_PUSH_DEBOUNCE_MS = 250;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockHandle.mockClear();
+  mockBroadcast.mockClear();
+  mockBuildSnapshot.mockClear();
+  mockBuildSnapshot.mockReturnValue({ rows: [], generatedAt: '2026-01-01T00:00:00.000Z' });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('monitor push gate', () => {
+  it('with no subscriber, a session event builds and pushes nothing', () => {
+    const { context, fireSessionChanged } = makeContext();
+    registerMonitorHandlers(context);
+
+    fireSessionChanged();
+    vi.advanceTimersByTime(MONITOR_PUSH_DEBOUNCE_MS + 50);
+
+    expect(mockBuildSnapshot).not.toHaveBeenCalled();
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('subscribe returns a snapshot and turns the push pipeline on', () => {
+    const { context, fireSessionChanged } = makeContext();
+    registerMonitorHandlers(context);
+    const sender = new FakeWebContents(7);
+
+    const snapshot = getHandler(IPC.MONITOR_SUBSCRIBE)({ sender });
+    expect(snapshot).toEqual({ rows: [], generatedAt: '2026-01-01T00:00:00.000Z' });
+    expect(mockBuildSnapshot).toHaveBeenCalledTimes(1);
+
+    fireSessionChanged();
+    vi.advanceTimersByTime(MONITOR_PUSH_DEBOUNCE_MS + 50);
+    expect(mockBroadcast).toHaveBeenCalledTimes(1);
+    expect(mockBroadcast.mock.calls[0][1]).toBe(IPC.MONITOR_CHANGED);
+  });
+
+  it('unsubscribe turns the pipeline back off', () => {
+    const { context, fireSessionChanged } = makeContext();
+    registerMonitorHandlers(context);
+    const sender = new FakeWebContents(7);
+
+    getHandler(IPC.MONITOR_SUBSCRIBE)({ sender });
+    getHandler(IPC.MONITOR_UNSUBSCRIBE)({ sender });
+    mockBuildSnapshot.mockClear();
+
+    fireSessionChanged();
+    vi.advanceTimersByTime(MONITOR_PUSH_DEBOUNCE_MS + 50);
+    expect(mockBuildSnapshot).not.toHaveBeenCalled();
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('a subscriber vanishing INSIDE the debounce window skips the deferred build', () => {
+    const { context, fireSessionChanged } = makeContext();
+    registerMonitorHandlers(context);
+    const sender = new FakeWebContents(7);
+
+    getHandler(IPC.MONITOR_SUBSCRIBE)({ sender });
+    mockBuildSnapshot.mockClear();
+
+    fireSessionChanged();
+    vi.advanceTimersByTime(100);
+    getHandler(IPC.MONITOR_UNSUBSCRIBE)({ sender });
+    vi.advanceTimersByTime(MONITOR_PUSH_DEBOUNCE_MS);
+
+    expect(mockBuildSnapshot).not.toHaveBeenCalled();
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('a destroyed renderer drops its subscription without an unsubscribe call', () => {
+    const { context, fireSessionChanged } = makeContext();
+    registerMonitorHandlers(context);
+    const sender = new FakeWebContents(7);
+
+    getHandler(IPC.MONITOR_SUBSCRIBE)({ sender });
+    sender.emit('destroyed');
+    mockBuildSnapshot.mockClear();
+
+    fireSessionChanged();
+    vi.advanceTimersByTime(MONITOR_PUSH_DEBOUNCE_MS + 50);
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('a crashed renderer (render-process-gone) drops its subscription', () => {
+    const { context, fireSessionChanged } = makeContext();
+    registerMonitorHandlers(context);
+    const sender = new FakeWebContents(7);
+
+    getHandler(IPC.MONITOR_SUBSCRIBE)({ sender });
+    sender.emit('render-process-gone');
+    mockBuildSnapshot.mockClear();
+
+    fireSessionChanged();
+    vi.advanceTimersByTime(MONITOR_PUSH_DEBOUNCE_MS + 50);
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('a hard reload (main-frame did-start-navigation) drops the subscription; same-document does not', () => {
+    const { context, fireSessionChanged } = makeContext();
+    registerMonitorHandlers(context);
+    const sender = new FakeWebContents(7);
+
+    getHandler(IPC.MONITOR_SUBSCRIBE)({ sender });
+    sender.emit('did-start-navigation', { isMainFrame: true, isSameDocument: true } satisfies FakeNavigationDetails);
+    mockBuildSnapshot.mockClear();
+    fireSessionChanged();
+    vi.advanceTimersByTime(MONITOR_PUSH_DEBOUNCE_MS + 50);
+    expect(mockBroadcast).toHaveBeenCalledTimes(1);
+
+    mockBroadcast.mockClear();
+    sender.emit('did-start-navigation', { isMainFrame: true, isSameDocument: false } satisfies FakeNavigationDetails);
+    fireSessionChanged();
+    vi.advanceTimersByTime(MONITOR_PUSH_DEBOUNCE_MS + 50);
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('re-subscribing after a reload works and never stacks navigation listeners', () => {
+    const { context, fireSessionChanged } = makeContext();
+    registerMonitorHandlers(context);
+    const sender = new FakeWebContents(7);
+    const subscribe = getHandler(IPC.MONITOR_SUBSCRIBE);
+
+    for (let cycle = 0; cycle < 5; cycle += 1) {
+      subscribe({ sender });
+      sender.emit('did-start-navigation', { isMainFrame: true, isSameDocument: false } satisfies FakeNavigationDetails);
+    }
+    expect(sender.listenerCount('did-start-navigation')).toBe(1);
+
+    subscribe({ sender });
+    mockBroadcast.mockClear();
+    fireSessionChanged();
+    vi.advanceTimersByTime(MONITOR_PUSH_DEBOUNCE_MS + 50);
+    expect(mockBroadcast).toHaveBeenCalledTimes(1);
+  });
+
+  it('the plain getSnapshot fetch does not subscribe', () => {
+    const { context, fireSessionChanged } = makeContext();
+    registerMonitorHandlers(context);
+    const sender = new FakeWebContents(7);
+
+    getHandler(IPC.MONITOR_GET_SNAPSHOT)({ sender });
+    mockBuildSnapshot.mockClear();
+
+    fireSessionChanged();
+    vi.advanceTimersByTime(MONITOR_PUSH_DEBOUNCE_MS + 50);
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/monitor-store.test.ts
+++ b/tests/unit/monitor-store.test.ts
@@ -369,4 +369,60 @@ describe('monitor-store', () => {
       await Promise.resolve();
     });
   });
+
+  describe('fetchOrdinal (attach vs loadSnapshot race)', () => {
+    // attach() and loadSnapshot() are NOT deduped against each other - attach
+    // must always reach main to register the subscription, even while a
+    // loadSnapshot is in flight. `fetchOrdinal` is the module-scope counter
+    // that orders the two instead: a reply applies only while it is still the
+    // newest outstanding fetch. Without it, whichever round trip happens to
+    // land LAST wins even if it was issued first, so a slow attach() reply
+    // arriving after a fast loadSnapshot() reply (or vice versa) would
+    // clobber the newer rows and double-bump snapshotGeneration.
+    it('a stale attach() reply landing after a newer loadSnapshot() reply does not apply', async () => {
+      let resolveSubscribe: (snapshot: { rows: MonitorSessionRow[]; generatedAt: string }) => void = () => {};
+      subscribeMock.mockImplementation(() => new Promise((resolve) => { resolveSubscribe = resolve; }));
+      getSnapshotMock.mockResolvedValue({
+        rows: [makeRow({ sessionId: 'from-loadSnapshot' })],
+        generatedAt: 'y',
+      });
+
+      // attach() issues its subscribe first, but it does not resolve yet.
+      const attachPromise = useMonitorStore.getState().attach();
+      // loadSnapshot() issues and resolves second, so it is the newest fetch.
+      await useMonitorStore.getState().loadSnapshot();
+      expect(useMonitorStore.getState().rows.map((row) => row.sessionId)).toEqual(['from-loadSnapshot']);
+      const generationAfterLoadSnapshot = useMonitorStore.getState().snapshotGeneration;
+
+      // The stale subscribe now resolves with different rows.
+      resolveSubscribe({ rows: [makeRow({ sessionId: 'from-stale-attach' })], generatedAt: 'x' });
+      await attachPromise;
+
+      expect(useMonitorStore.getState().rows.map((row) => row.sessionId)).toEqual(['from-loadSnapshot']);
+      expect(useMonitorStore.getState().snapshotGeneration).toBe(generationAfterLoadSnapshot);
+    });
+
+    it('a stale loadSnapshot() reply landing after a newer attach() reply does not apply', async () => {
+      let resolveGetSnapshot: (snapshot: { rows: MonitorSessionRow[]; generatedAt: string }) => void = () => {};
+      getSnapshotMock.mockImplementation(() => new Promise((resolve) => { resolveGetSnapshot = resolve; }));
+      subscribeMock.mockResolvedValue({
+        rows: [makeRow({ sessionId: 'from-attach' })],
+        generatedAt: 'y',
+      });
+
+      // loadSnapshot() issues its getSnapshot first, but it does not resolve yet.
+      const loadSnapshotPromise = useMonitorStore.getState().loadSnapshot();
+      // attach() issues and resolves second, so it is the newest fetch.
+      await useMonitorStore.getState().attach();
+      expect(useMonitorStore.getState().rows.map((row) => row.sessionId)).toEqual(['from-attach']);
+      const generationAfterAttach = useMonitorStore.getState().snapshotGeneration;
+
+      // The stale getSnapshot now resolves with different rows.
+      resolveGetSnapshot({ rows: [makeRow({ sessionId: 'from-stale-loadSnapshot' })], generatedAt: 'x' });
+      await loadSnapshotPromise;
+
+      expect(useMonitorStore.getState().rows.map((row) => row.sessionId)).toEqual(['from-attach']);
+      expect(useMonitorStore.getState().snapshotGeneration).toBe(generationAfterAttach);
+    });
+  });
 });

--- a/tests/unit/monitor-store.test.ts
+++ b/tests/unit/monitor-store.test.ts
@@ -24,11 +24,13 @@ import { DEFAULT_CONFIG } from '../../src/shared/types';
 
 const configSetMock = vi.fn<(patch: Partial<AppConfig>) => Promise<void>>();
 const getSnapshotMock = vi.fn();
+const subscribeMock = vi.fn();
+const unsubscribeMock = vi.fn();
 
 (globalThis as Record<string, unknown>).window = {
   electronAPI: {
     config: { set: configSetMock },
-    monitor: { getSnapshot: getSnapshotMock },
+    monitor: { getSnapshot: getSnapshotMock, subscribe: subscribeMock, unsubscribe: unsubscribeMock },
   },
 };
 
@@ -76,7 +78,13 @@ describe('monitor-store', () => {
     vi.clearAllMocks();
     vi.useRealTimers();
     configSetMock.mockResolvedValue(undefined);
-    useMonitorStore.setState({ view: DEFAULT_CONFIG.monitor, rows: [], loaded: false });
+    useMonitorStore.setState({
+      view: DEFAULT_CONFIG.monitor,
+      rows: [],
+      loaded: false,
+      monitorOpen: false,
+      snapshotGeneration: 0,
+    });
   });
 
   describe('hydrateView', () => {
@@ -304,6 +312,61 @@ describe('monitor-store', () => {
       useMonitorStore.setState({ rows });
       useMonitorStore.getState().applyActivity('unknown', 'idle', null);
       expect(useMonitorStore.getState().rows).toBe(rows);
+    });
+  });
+
+  describe('snapshotGeneration', () => {
+    // MonitorTaskDetailHost keys its bundle refetch on this counter. The
+    // contract that stops the getTaskDetail amplification: only a snapshot that
+    // actually changed the rows moves it; an activity patch never does, no
+    // matter how many arrive.
+    it('bumps when a snapshot changes the rows', () => {
+      const before = useMonitorStore.getState().snapshotGeneration;
+      useMonitorStore.getState().applySnapshot({ rows: [makeRow({ sessionId: 'a' })], generatedAt: 'x' });
+      expect(useMonitorStore.getState().snapshotGeneration).toBe(before + 1);
+    });
+
+    it('does not bump on an equivalent (no-op) snapshot', () => {
+      useMonitorStore.getState().applySnapshot({ rows: [makeRow({ sessionId: 'a' })], generatedAt: 'x' });
+      const before = useMonitorStore.getState().snapshotGeneration;
+      useMonitorStore.getState().applySnapshot({ rows: [makeRow({ sessionId: 'a' })], generatedAt: 'y' });
+      expect(useMonitorStore.getState().snapshotGeneration).toBe(before);
+    });
+
+    it('never bumps on applyActivity, however many ticks arrive', () => {
+      useMonitorStore.getState().applySnapshot({
+        rows: [makeRow({ sessionId: 'a' }), makeRow({ sessionId: 'b' })],
+        generatedAt: 'x',
+      });
+      const before = useMonitorStore.getState().snapshotGeneration;
+      for (let tick = 0; tick < 25; tick += 1) {
+        useMonitorStore.getState().applyActivity(tick % 2 === 0 ? 'a' : 'b', 'idle', null);
+        useMonitorStore.getState().applyActivity(tick % 2 === 0 ? 'a' : 'b', 'thinking', null);
+      }
+      expect(useMonitorStore.getState().snapshotGeneration).toBe(before);
+    });
+  });
+
+  describe('attach / detach (monitor:subscribe handshake)', () => {
+    it('attach seeds the rows from the snapshot the subscription returns', async () => {
+      subscribeMock.mockResolvedValue({ rows: [makeRow({ sessionId: 'a' })], generatedAt: 'x' });
+      await useMonitorStore.getState().attach();
+      expect(subscribeMock).toHaveBeenCalledTimes(1);
+      expect(useMonitorStore.getState().rows.map((row) => row.sessionId)).toEqual(['a']);
+      expect(useMonitorStore.getState().loaded).toBe(true);
+      expect(useMonitorStore.getState().loading).toBe(false);
+    });
+
+    it('open attaches and close detaches', async () => {
+      subscribeMock.mockResolvedValue({ rows: [], generatedAt: 'x' });
+      unsubscribeMock.mockResolvedValue(undefined);
+      useMonitorStore.getState().open();
+      expect(useMonitorStore.getState().monitorOpen).toBe(true);
+      expect(subscribeMock).toHaveBeenCalledTimes(1);
+      useMonitorStore.getState().close();
+      expect(useMonitorStore.getState().monitorOpen).toBe(false);
+      expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+      await Promise.resolve();
     });
   });
 });

--- a/tests/unit/terminal-tab-deferred-init.test.ts
+++ b/tests/unit/terminal-tab-deferred-init.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit coverage for TerminalTab's DEFERRED init contract (task #468).
+ *
+ * The mount effect in TerminalTab.tsx schedules `initTerminal()` into a
+ * requestAnimationFrame instead of calling it synchronously in the commit that
+ * mounts the pane. That deferral is a measured perf contract, not a stylistic
+ * choice: folding the xterm construction (open + WebGL context + fit, ~10ms)
+ * into the mount commit produced a 40-60ms pointer-thread stall when a
+ * spawning session's pane mounted mid-drag, and StrictMode's dev-only
+ * mount -> unmount -> remount built TWO xterm instances per mount (one
+ * discarded). With the rAF, the first mount's cleanup cancels its scheduled
+ * init before it runs, so exactly one terminal is constructed.
+ *
+ * Same trade as use-terminal-scrollback.test.ts: this project's vitest config
+ * has no jsdom environment, so the effect body is replicated here verbatim
+ * (reading the same globals, which the tests stub deterministically) and the
+ * OBSERVABLE contract is asserted. If TerminalTab's effect shape changes, keep
+ * this replica in sync - the assertions below are the contract:
+ *
+ *   1. No init in the mount tick - the commit frame never pays the xterm cost.
+ *   2. Init runs on the next animation frame when the host has dimensions.
+ *   3. Cleanup cancels a pending scheduled init (rAF never fires -> no init).
+ *   4. A StrictMode-shaped mount/cleanup/mount sequence inits exactly ONCE.
+ *   5. A zero-dimension host no-ops the rAF and retries via ResizeObserver
+ *      when dimensions arrive (the display:none tab path).
+ *   6. Once initialized, later observer fires and re-schedules are no-ops.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Deterministic rAF + ResizeObserver stubs
+// ---------------------------------------------------------------------------
+
+type FrameCallback = (now: number) => void;
+
+const scheduledFrames = new Map<number, FrameCallback>();
+let nextFrameHandle = 1;
+
+function flushAnimationFrame(): void {
+  const callbacks = [...scheduledFrames.values()];
+  scheduledFrames.clear();
+  for (const callback of callbacks) callback(0);
+}
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+  observedTargets: unknown[] = [];
+  disconnected = false;
+  constructor(private readonly callback: () => void) {
+    FakeResizeObserver.instances.push(this);
+  }
+  observe(target: unknown): void {
+    this.observedTargets.push(target);
+  }
+  disconnect(): void {
+    this.disconnected = true;
+  }
+  fire(): void {
+    if (!this.disconnected) this.callback();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The effect body, replicated from TerminalTab.tsx's init effect. `el` stands
+// in for terminalRef.current, `initialized` for the initialized ref.
+// ---------------------------------------------------------------------------
+
+interface HostElement {
+  offsetWidth: number;
+  offsetHeight: number;
+}
+
+function runInitEffect(
+  el: HostElement,
+  initialized: { current: boolean },
+  initTerminal: () => void,
+): () => void {
+  let initRafId: number | null = null;
+
+  const scheduleInit = () => {
+    if (initialized.current || initRafId !== null) return;
+    initRafId = requestAnimationFrame(() => {
+      initRafId = null;
+      if (initialized.current) return;
+      if (el.offsetWidth > 0 && el.offsetHeight > 0) {
+        initTerminal();
+        initialized.current = true;
+        observer.disconnect();
+      }
+    });
+  };
+
+  const observer: ResizeObserver = new ResizeObserver(() => {
+    if (initialized.current) {
+      observer.disconnect();
+      return;
+    }
+    scheduleInit();
+  });
+  observer.observe(el as unknown as Element);
+
+  scheduleInit();
+
+  return () => {
+    if (initRafId !== null) cancelAnimationFrame(initRafId);
+    observer.disconnect();
+    initialized.current = false;
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  scheduledFrames.clear();
+  nextFrameHandle = 1;
+  FakeResizeObserver.instances = [];
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameCallback): number => {
+    const handle = nextFrameHandle;
+    nextFrameHandle += 1;
+    scheduledFrames.set(handle, callback);
+    return handle;
+  });
+  vi.stubGlobal('cancelAnimationFrame', (handle: number): void => {
+    scheduledFrames.delete(handle);
+  });
+  vi.stubGlobal('ResizeObserver', FakeResizeObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('TerminalTab deferred init contract', () => {
+  it('never inits synchronously in the mount tick', () => {
+    const initTerminal = vi.fn();
+    runInitEffect({ offsetWidth: 800, offsetHeight: 300 }, { current: false }, initTerminal);
+    expect(initTerminal).not.toHaveBeenCalled();
+  });
+
+  it('inits on the next animation frame when the host has dimensions', () => {
+    const initTerminal = vi.fn();
+    const initialized = { current: false };
+    runInitEffect({ offsetWidth: 800, offsetHeight: 300 }, initialized, initTerminal);
+    flushAnimationFrame();
+    expect(initTerminal).toHaveBeenCalledTimes(1);
+    expect(initialized.current).toBe(true);
+  });
+
+  it('cleanup cancels a pending scheduled init', () => {
+    const initTerminal = vi.fn();
+    const cleanup = runInitEffect({ offsetWidth: 800, offsetHeight: 300 }, { current: false }, initTerminal);
+    cleanup();
+    flushAnimationFrame();
+    expect(initTerminal).not.toHaveBeenCalled();
+  });
+
+  it('a StrictMode mount/cleanup/mount sequence constructs exactly one terminal', () => {
+    const initTerminal = vi.fn();
+    const initialized = { current: false };
+    const el = { offsetWidth: 800, offsetHeight: 300 };
+    // StrictMode runs the first effect pass and its cleanup back to back,
+    // before any frame can fire, then mounts again for real.
+    const firstCleanup = runInitEffect(el, initialized, initTerminal);
+    firstCleanup();
+    runInitEffect(el, initialized, initTerminal);
+    flushAnimationFrame();
+    expect(initTerminal).toHaveBeenCalledTimes(1);
+    expect(initialized.current).toBe(true);
+  });
+
+  it('a zero-dimension host defers to the ResizeObserver and inits when sized', () => {
+    const initTerminal = vi.fn();
+    const initialized = { current: false };
+    const el = { offsetWidth: 0, offsetHeight: 0 };
+    runInitEffect(el, initialized, initTerminal);
+    // The scheduled frame fires while the host is still 0x0: no init.
+    flushAnimationFrame();
+    expect(initTerminal).not.toHaveBeenCalled();
+    expect(initialized.current).toBe(false);
+    // The host gains dimensions; the observer re-schedules; the next frame inits.
+    el.offsetWidth = 800;
+    el.offsetHeight = 300;
+    FakeResizeObserver.instances[0].fire();
+    flushAnimationFrame();
+    expect(initTerminal).toHaveBeenCalledTimes(1);
+    expect(initialized.current).toBe(true);
+  });
+
+  it('observer fires after initialization are no-ops (no second init, observer disconnects)', () => {
+    const initTerminal = vi.fn();
+    const initialized = { current: false };
+    const el = { offsetWidth: 800, offsetHeight: 300 };
+    runInitEffect(el, initialized, initTerminal);
+    flushAnimationFrame();
+    const observer = FakeResizeObserver.instances[0];
+    expect(observer.disconnected).toBe(true);
+    observer.fire();
+    flushAnimationFrame();
+    expect(initTerminal).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

Fixes the ~50ms board drag hitch that landed at the exact moment a spawning agent's session first appeared, and closes out the agent-monitor performance audit that hitch was spun out of. Touches the terminal panel mount path (`TerminalTab`), the monitor push pipeline (`ipc/handlers/monitor.ts` plus the full 7-layer IPC bridge for two new channels), the monitor store/detail host, and the activity-mark indicator size.

## Why

Dragging a card while an agent spawned produced a measured 48.6-55.6ms main-thread block (a longtask starting at the exact session-upsert timestamp) on the pointer thread. Attribution with performance marks showed the cost was NOT the suspected panel resize, dnd-kit re-measurement, or store fan-out (all measured ~0): it was the TerminalTab subtree mount running xterm construction synchronously inside the commit, doubled by StrictMode (two full xterm + WebGL constructions per mount, one discarded). Separately, the audit found the cross-project monitor snapshot was built and broadcast on every session/board event even with no monitor open anywhere, and an open monitor-hosted task detail refired a `monitor:getTaskDetail` IPC round trip on every activity tick in any project.

## How

- `TerminalTab` schedules `initTerminal()` into a `requestAnimationFrame` (always-on, not drag-gated). The mount commit no longer pays the xterm cost, and StrictMode's synchronous unmount cancels the first scheduled init, so dev constructs one terminal. Visually free: the replay veil / launch overlay cover the pane from its first frame, and the init lands before the delayed corrective fit, so the fit sequence is unchanged (this is deliberately NOT the previously reverted drag-end deferral, which starved those fits).
- New `monitor:subscribe` / `monitor:unsubscribe` channels gate the snapshot push on live subscribers. Subscribe returns a fresh snapshot in the same round trip, so a mounting monitor cannot race the next push; main drops registrations on renderer close, crash, or main-frame navigation (the same teardown trio as task-detail ownership), with listener non-stacking across reload cycles.
- The monitor store gains a `snapshotGeneration` counter bumped only when a snapshot actually changes rows; `MonitorTaskDetailHost` keys its bundle refetch on it instead of the `rows` array identity, which every cross-project activity patch replaces.
- Activity-mark indicators (task card + both sidebar indicators) render at 16 instead of 15, a deliberate legibility bump kept in step across the three coordinated sites.

Measured before/after on a worktree preview with a deterministic rig (synthetic held drag + store-level session injection, validated against a real spawn mid-drag): injection frame 48.6-55.6ms with longtasks became 27.7-41.6ms with zero longtasks; a real spawn mid-drag went from a 55ms longtask to a 34.8ms worst frame; monitor-closed board events went from one full snapshot build+broadcast each to zero; activity ticks with a hosted detail open went from one getTaskDetail round trip each to zero.

## Breaking changes

None.

## Tests

- New `tests/unit/terminal-tab-deferred-init.test.ts`: the rAF deferral contract (no sync init in the mount tick, next-frame init, cancel on cleanup, StrictMode single-create, zero-dimension ResizeObserver retry).
- New `tests/unit/monitor-push-gate.test.ts`: the subscriber gate (no-subscriber skip, pipeline on/off, mid-debounce vanish, teardown trio, re-subscribe listener non-stacking).
- `tests/unit/monitor-store.test.ts`: snapshotGeneration contract (never bumped by activity patches), attach/detach handshake, and red-greened stale-reply ordering races between attach and loadSnapshot.
- `tests/ui/agent-monitor.spec.ts`: subscription lifecycle on open/close, and a no-refetch-per-activity-tick assertion for the monitor-hosted detail.
- `tests/ui/activity-marks.spec.ts` / `tests/ui/sidebar-command-terminals.spec.ts`: re-pinned at 16px.
- CI checks (lint, typecheck, unit, build, UI shards, Linux E2E shards) are the full gate.

Generated with [Claude Code](https://claude.com/claude-code)
