### PR TITLE
chore(deps): adopt branding's re-hinted agent-idle (18x16) and re-derive pinned geometry claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,20 +190,22 @@ won't be found.
   Two keylines, one per role - 18 for indicators, 20 for controls. Size floors are 12 for
   indicators and 16 for controls, which is why `TerminalPanel`'s 8px session dot stays lucide.
   The two control marks render at size 20: their r=10 ring draws 18.33px, a pixel match for the
-  lucide `Circle` they replaced. Upstream geometry has already moved twice (2.5.0 squared the
-  envelope to 18x18 and shrank the controls to r=9; 2.6.0 reversed both), so
+  lucide `Circle` they replaced. Upstream geometry has already moved three times (2.5.0 squared
+  the envelope to 18x18 and shrank the controls to r=9; 2.6.0 reversed both to 18 x 14.4; 2.7.1
+  moved the envelope to 18 x 16 so its y edges sit on the integer lattice at 4 / 20), so
   `tests/unit/activity-mark.test.ts` pins the r=10 control ring, the r=9 agent ring, and the
-  envelope's 18 x 14.4 box as the guard against a silent upstream reshape. The envelope's height
-  is load-bearing beyond legibility: a card swaps idle for working IN PLACE, and at 18x18 the
-  envelope enclosed 26% more than the ring, so the indicator visibly grew on every state change.
-  At 14.4 the two are within 0.5%, which holds only while `agent-working` stays r=9. Indicators
-  render at 16 (`TaskCard` and both sidebar components), NOT the 14 the lucide glyphs used: the
-  branding envelope is 18 wide where lucide's `Mail` was 20, so a same-number swap silently
-  shrinks it ~10%. 15 restored the drawn size production shipped; 16 is a deliberate one-step
-  legibility bump on top of that. Move the sidebar's two indicator components together or the
-  row goes ragged. lucide stays everywhere
-  else (140+ files), and `utils/swimlane-icons.tsx` needs its whole glyph map
-  because column icon names are persisted as kebab-case strings in the DB.
+  envelope's 18 x 16 box as the guard against a silent upstream reshape. The envelope's height
+  is load-bearing beyond legibility: a card swaps idle for working IN PLACE, so what the eye
+  judges is apparent size, and at 18x18 the envelope enclosed 26% more than the ring and visibly
+  grew on every state change. 18 x 14.4 held that to +0.5%; 18 x 16 gives that parity up at
+  +11.8% (284.6 units against the r=9 ring's 254), accepted upstream as the price of the hinting
+  fix and checked on a rendered idle/working swap strip. Indicators render at 16 (`TaskCard` and
+  both sidebar components), NOT the 14 the lucide glyphs used: the branding envelope is 18 wide
+  where lucide's `Mail` was 20, so a same-number swap silently shrinks it ~10%. 15 restored the
+  drawn size production shipped; 16 is a deliberate one-step legibility bump on top of that.
+  Move the sidebar's two indicator components together or the row goes ragged. lucide stays
+  everywhere else (140+ files), and `utils/swimlane-icons.tsx` needs its whole glyph map because
+  column icon names are persisted as kebab-case strings in the DB.
 - **Settings tab separator** - Each tab in `SETTINGS_TABS` (`settings-tabs.ts`) declares a
   `category`. `'project'` tabs (General, Theme, Agent, Git, Browser, Shortcuts) are per-project
   settings, saved to `.kangentic/config.json`, and hidden when no project is selected.

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@electron/fuses": "^2.1.1",
         "@electron/notarize": "^3.1.1",
         "@eslint/js": "^9.39.4",
-        "@kangentic/branding": "^2.7.0",
+        "@kangentic/branding": "^2.7.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.3.0",
@@ -2502,9 +2502,9 @@
       }
     },
     "node_modules/@kangentic/branding": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@kangentic/branding/-/branding-2.7.0.tgz",
-      "integrity": "sha512-DYfsBBSYVo/EtLUNijSQygG8uxNtkkwi214Q56acL5WCcT2tFL0f81qeTKEjvXmUHZIDaQGChhAuVq2i617yGQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@kangentic/branding/-/branding-2.7.1.tgz",
+      "integrity": "sha512-RrkOCYAed0mUUbqTmgRPnyCw+AbYhxaQB7forqjCAzAp+HRHrCMlyum8mW3Qd0DH7v1m1nzywAqF8fRMFfG5yg==",
       "dev": true,
       "license": "AGPL-3.0-only"
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@electron/fuses": "^2.1.1",
     "@electron/notarize": "^3.1.1",
     "@eslint/js": "^9.39.4",
-    "@kangentic/branding": "^2.7.0",
+    "@kangentic/branding": "^2.7.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.0",

--- a/src/renderer/components/sidebar/project-sidebar/SidebarActivityCounts.tsx
+++ b/src/renderer/components/sidebar/project-sidebar/SidebarActivityCounts.tsx
@@ -21,9 +21,12 @@ export const SidebarActivityCounts = React.memo(function SidebarActivityCounts({
   // 16, the same size `TaskCard` renders these two marks at - one mark, one meaning, one size.
   // Not 14, which is what the lucide glyphs used: the branding envelope is 18 wide where
   // lucide's Mail was 20, so a same-number swap silently shrank it ~10%. 15 restored the drawn
-  // size production shipped (11.25 x 9.0px against the old 11.67 x 9.33); 16 is a deliberate
-  // one-step bump on top of that for legibility. Keep in step with TaskCard's mark and
-  // SidebarCommandTerminalIndicator - the three indicators form one tabular column.
+  // WIDTH production shipped (11.25px against the old 11.67); width is the advance that aligns
+  // the row and height is absorbed by centring, which is why the keyline is a width. Height has
+  // since moved anyway: branding 2.7.1's 18 x 16 envelope draws 10.0px tall at 15, where
+  // 18 x 14.4 drew 9.0 against lucide's 9.33. 16 is a deliberate one-step bump on top of that
+  // for legibility. Keep in step with TaskCard's mark and SidebarCommandTerminalIndicator - the
+  // three indicators form one tabular column.
   //
   // 12 is the floor: below it the 2px stroke scales to a sub-pixel hairline and smears, which
   // is why the branding set declares `floors.indicator = 12`.

--- a/tests/unit/activity-mark.test.ts
+++ b/tests/unit/activity-mark.test.ts
@@ -61,25 +61,50 @@ describe('innerMarkup', () => {
     expect(innerMarkup(readMark('agent-working'))).toContain('r="9"');
   });
 
-  it('draws the needs-you envelope in landscape, not square', () => {
-    // Branding 2.5.0 squared the envelope to 18x18 and it stopped reading as an envelope on the
-    // board (it looked like a photo placeholder); 2.6.0 restored 18 x 14.4, a uniform 0.9 scale
-    // of the reference Mail glyph. That single change fixes three things at once, which is why
-    // the height is pinned here rather than left to the grid contract:
-    //   1. aspect 1.25, the proportion people actually read as mail;
-    //   2. the flap vertex angle, which scaling preserves - 2.5.0's square box had dragged it
-    //      to 108.8 degrees against the 120.4 reference, a second defect on the same glyph;
-    //   3. area parity with agent-working, which is the one that matters most on a task card.
+  it('keeps the needs-you envelope on the 18 x 16 box its edges are hinted to', () => {
+    // Branding has reshaped this mark three times, so pin the box rather than trusting the grid
+    // contract: 2.5.0 squared it to 18x18 (it read as a photo placeholder on a board card),
+    // 2.6.0 restored 18 x 14.4 as a uniform 0.9 scale of the reference Mail glyph, and 2.7.1
+    // moved it to 18 x 16 so its y edges sit on the integer lattice at 4 / 20.
     //
-    // (3) is easy to miss: the card swaps idle for working IN PLACE, so what the eye judges is
-    // apparent size, not outline length. The square envelope enclosed 321 units against the
-    // ring's 254 (+26%), so an agent going idle made the indicator visibly grow. At 18 x 14.4
-    // it encloses 256 (+0.5%) - the envelope is shorter, but a circle leaves its corners empty,
-    // so the two land within half a percent. That parity falls out of the aspect fix; it holds
-    // only while agent-working stays r=9, which the assertion above pins.
+    // What 2.7.1 bought: stroke 2 on a 24 grid is fractional at every size in the 12-16
+    // indicator band, so no coordinate puts both stroke edges on a pixel boundary - an integer
+    // coordinate just lands closest. Measured upstream at devicePixelRatio 1, the ring and the
+    // terminal chip both scored 1.92 softness (what any icon-library glyph on an 18 box scores)
+    // while the envelope on y 4.8 / 19.2 was the single outlier at 1.95. The 20 x 16 glyph this
+    // set replaced already sat on y 4 / 20; the 0.9 scale that restored the flap moved it off.
+    //
+    // What it cost, accepted upstream rather than argued away, and NOT to be "fixed" here:
+    //   1. aspect drops from 1.25 to 1.125. The judgement that this reads squat beside the ring
+    //      was outweighed, not overturned.
+    //   2. enclosed area goes from +0.5% to +11.8% against agent-working's ring (284.6 units
+    //      against 254). This is the legible one: a card swaps idle for working IN PLACE, so
+    //      what the eye judges is apparent size, not outline length - at 18x18's +26% the
+    //      indicator visibly grew on every state change. +11.8% was checked on a rendered
+    //      idle/working swap strip before being accepted. The r=9 pin above is what keeps that
+    //      measured figure meaningful; it is no longer a parity guarantee.
+    //
+    // The flap survives both moves intact at 120.4 degrees, because upstream pins a target
+    // angle rather than flap ratios - ratios are fractions of the box, so they do not carry an
+    // angle onto a box of a different aspect.
     const inner = innerMarkup(readMark('agent-idle'));
     expect(inner, 'agent-idle must stay 18 wide so it holds the indicator keyline').toContain('width="18"');
-    expect(inner, 'agent-idle must stay 14.4 tall (aspect 1.25); 18 reads as a square photo icon').toContain('height="14.4"');
+    expect(
+      inner,
+      'agent-idle must stay 16 tall: 18 x 16 puts its y edges on the integer lattice at 4 / 20, '
+      + 'a deliberate hinting trade against aspect and area parity - do not restore 14.4',
+    ).toContain('height="16"');
+    // The box is only half the mark. 2.7.1 moved the flap too (2.7.0 drew M3 7.5 L12 12.6566
+    // L21 7.5), and it is the flap that carries the 120.4 degree vertex the note above claims
+    // survived: atan(9 / 5.1566) * 2, from the vertex out to each flap endpoint. Pinning the box
+    // alone would pass a reshape that kept 18 x 16 and re-angled the flap, which is the one
+    // defect 2.5.0 shipped. terminal-working and terminal-new pin their paths for the same
+    // reason.
+    expect(
+      inner,
+      'agent-idle flap moved: the vertex offset is what holds the 120.4 degree angle across a '
+      + 'box change, so re-derive the angle before re-pinning this path',
+    ).toContain('d="M3 7 L12 12.1566 L21 7"');
   });
 
   it('keeps the control glyph as a sibling of the marching group, not inside it', () => {

--- a/tests/unit/overseer-mascot-frames.test.ts
+++ b/tests/unit/overseer-mascot-frames.test.ts
@@ -10,7 +10,7 @@ import {
 // `mountFramesFor` decides which frame divs the mascot mounts, reading @kangentic/branding's
 // `animations.json` rather than a hand-written list. Its three drift branches - rest unioned in,
 // an unknown name dropped, a sequence missing entirely - are the whole point of reading the
-// package instead of hardcoding, and NONE of them fires against the installed 2.7.0 contract:
+// package instead of hardcoding, and NONE of them fires against the installed contract:
 // all three supported sequences already list `rest` in their own `mountFrames`, name only frames
 // the component imports, and exist. Delete any one branch and every other test in the repo stays
 // green. So they are pinned here, against fabricated contracts.
@@ -68,7 +68,7 @@ describe('mountFramesFor', () => {
   });
 
   it('derives the shipped welcome-hero mount set from the installed package', () => {
-    // The end-to-end case: the real 2.7.0 contract, the real call the WelcomeScreen makes
+    // The end-to-end case: the real installed contract, the real call the WelcomeScreen makes
     // (sequence 'blink-loop' with a 'wave-once' intro). Pins that reading the package still
     // produces exactly the set the hand-written map used to.
     const contract: MascotAnimations = JSON.parse(fs.readFileSync(MASCOT_JSON, 'utf-8'));


### PR DESCRIPTION
## What

Bumps `@kangentic/branding` to 2.7.1 and re-derives the geometry claims it falsifies:

- `tests/unit/activity-mark.test.ts`: renamed the envelope test off its now-false "landscape not square" claim, updated the pinned assertion from `height="14.4"` to `height="16"`, and rewrote the surrounding comment.
- `CLAUDE.md`: updated the same geometry narrative (three upstream moves, not two; area parity is now +11.8%, not +0.5%).
- `SidebarActivityCounts.tsx`: corrected a falsified drawn-height figure in a comment (10.0px, not 9.0px, at size 15) and reframed the comment around width as the load-bearing keyline dimension.

## Why

Upstream `@kangentic/branding` re-hinted the needs-you envelope (`agent-idle`): its box moves from 18 x 14.4 to 18 x 16 so its y edges land on the integer pixel lattice at 4 / 20, fixing a softness defect the old box had at `devicePixelRatio` 1. That box change was cut into branding 2.7.1, clearing the blocker this task started under.

The dependency bump alone would break `tests/unit/activity-mark.test.ts:82`, which pins the old height. Fixing just the assertion isn't enough: the surrounding comment argues three measured claims (aspect, flap angle, area parity), and two of them invert under the new box. The same stale numbers were also asserted in `CLAUDE.md` and a source comment in `SidebarActivityCounts.tsx`, so all three needed re-deriving rather than a digit-only edit.

## How

Verified empirically rather than trusting the task description:
- Hashed all 11 files in the package's `assets/activity/` before and after the bump - only `agent-idle.svg` changed.
- Ran the scoped test before editing and confirmed it failed on exactly the one expected assertion.
- Re-derived the geometry by hand: aspect 1.25 -> 1.125 (inverts), flap vertex angle 120.4 degrees (survives - upstream pins a target angle rather than flap ratios), enclosed area vs the r=9 ring +0.5% -> +11.8% (inverts, accepted upstream as the price of the hinting fix).
- Cross-checked against upstream's own `.claude/rules/activity-icon-geometry.md`, which records the same trade-off in the same terms.

## Breaking changes

None.

## Tests

- `npx vitest run tests/unit/activity-mark.test.ts` - 12/12 pass (red before the edit, on exactly the expected assertion; green after).
- `npx vitest run tests/unit/branding-assets.test.ts` - 29/29 pass (contract/structure checks, unaffected by the geometry change).
- `npx vitest run tests/unit/overseer-mascot-frames.test.ts` - 5/5 pass (re-run after rebase; added by the prior review pass on this branch).
- `npm run typecheck` - clean.
- `npm run lint` - clean.

No behavior change and no new functionality, so no new tests were needed (Step 3.5 coverage pass was a no-op).

Generated with [Claude Code](https://claude.com/claude-code)
