### PR TITLE
fix(pty): replay the parsed grid for alt-screen terminal sessions

### DIFF
--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -299,13 +299,20 @@ The handoff is transparent to the user - the task card shows spawn progress phas
 - PTY `onData` accumulates into a per-session buffer.
 - A 16ms flush interval (~60fps) emits buffered data via IPC `session:data`.
 - A 512KB scrollback ring buffer per session supports terminal restoration.
-- **Do not trim the replay to the last full-screen clear.** Tried and reverted: it cut a 512KB ring
-  to ~1.5KB but produced a permanently black terminal on a fast open/close/reopen. A raw byte
-  replay is not a frame snapshot - a fullscreen TUI leaves write-once static cells undrawn after a
-  clear (the reason the mobile seed uses the headless PARSED grid, `getSerializedFrame`, instead of
-  this byte replay). Slicing at the last clear discards those cells, and a sample landing at or just
-  after a clear replays a clear with nothing after it. If the replay cost is worth attacking, the
-  safe shape is a parsed-grid snapshot, not a byte-offset heuristic.
+- **Alt-screen sessions replay the parsed grid, not the byte tail.** A raw byte replay is not a
+  frame snapshot: a fullscreen TUI leaves write-once static cells (box rules, mode labels)
+  undrawn after a clear, so once a session outgrows the 512KB ring their drawing bytes are gone
+  and a remount at unchanged geometry (no SIGWINCH, so no fresh repaint) paints a permanently
+  holed frame. `PtyBufferManager.getReplaySnapshot` therefore serves the headless PARSED grid
+  (the same serialized frame `getSerializedFrame` gives the mobile seed) when the session is in
+  the alt screen, and the raw byte replay otherwise - a plain shell's scrollback IS the bytes,
+  and truncation there only loses old history.
+- **Do not trim the byte replay to the last full-screen clear.** Tried and reverted: it cut a
+  512KB ring to ~1.5KB but produced a permanently black terminal on a fast open/close/reopen.
+  Slicing at the last clear discards write-once cells, and a sample landing at or just after a
+  clear replays a clear with nothing after it. The parsed-grid snapshot above is the safe shape,
+  not a byte-offset heuristic; and since the byte path now serves normal-buffer sessions, a trim
+  there would discard genuine user-scrollable history, not just a TUI's redraw bytes.
 - **One grid width per mount (deterministic fit).** `proposeDimensions` (`src/renderer/addons/fit-addon.ts`)
   is a pure function of container geometry. It must not read anything that can change while a
   terminal is mounting, because every distinct column count costs a PTY resize and a full agent
@@ -445,15 +452,19 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   selection lives in `src/main/pty/buffer/output-peek.ts`.
 - **DEC private mode and alt-screen re-assert on replay.** `xterm.reset()` on the renderer wipes
   every DEC private mode xterm is tracking, and the original mode-set bytes usually scroll out of
-  the 512KB scrollback window on a long-running session. `PtyBufferManager` tracks DEC private
-  input/reporting modes (DECCKM, mouse tracking, bracketed paste, ...) from the live stream and
-  re-asserts them as a prefix on `getScrollback` (#313). Alt-screen (mode 1049/47/1047) is tracked
-  separately as `inAltScreen` and re-asserted with its own `\x1b[?1049h` prefix, gated on the
-  session currently being in the alt buffer - a classic (normal-buffer) session's replay is
-  unaffected, but a fullscreen-TUI session's replay now paints into the alt buffer instead of the
-  normal buffer (previously the cause of a cursor left visually disconnected from the TUI frame). A
-  synchronized-output frame (mode 2026) left open by a mid-frame sample is closed with a trailing
-  `\x1b[?2026l` so it cannot stall the renderer's ~1s safety timeout.
+  the 512KB scrollback window on a long-running session. On the byte-replay path,
+  `PtyBufferManager` tracks DEC private input/reporting modes (DECCKM, mouse tracking, bracketed
+  paste, ...) from the live stream and re-asserts them as a prefix on `getScrollback` (#313), and
+  a synchronized-output frame (mode 2026) left open by a mid-frame sample is closed with a
+  trailing `\x1b[?2026l` so it cannot stall the renderer's ~1s safety timeout. Alt-screen (mode
+  1049/47/1047) is tracked separately as `inAltScreen`; it routes the replay (see
+  `getReplaySnapshot` above), and a session in the alt screen gets a serialized frame that carries
+  its own addon-emitted alt-screen switch and mode re-asserts (mid-stream, after the serialized
+  normal buffer - not a leading prefix, so nothing may `startsWith` on it), so the replay paints
+  into the alt buffer with the right input modes (a replay landing in the normal buffer was
+  previously the cause of a cursor left visually disconnected from the TUI frame). `getScrollback`
+  itself retains the `\x1b[?1049h` prefix gate, reachable now only via direct byte-path reads and
+  `getReplaySnapshot`'s serialize-deadline fallback.
 - **Hold, not drop, live output across a renderer-side replay.** While a scrollback replay is in
   flight (`scrollbackPendingRef`), the renderer's incoming-write queue HOLDS (retains, does not
   ack) rather than drops live PTY bytes, and flushes them in order once the replay's `afterWrite`
@@ -464,8 +475,12 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   `scrollbackPendingRef` true indefinitely, which would otherwise drop all live output forever.
 - **But the held bytes that PREDATE the sample are dropped, not flushed.** The hold above must not
   be read as "every held byte is flushed after the replay": bytes main flushed BEFORE the
-  `getScrollback` reply are, by construction, already inside the replay (main appends to its ring
-  and its pending buffer from the same bytes and clears the pending buffer when it samples), so
+  `getScrollback` reply are, by construction, already inside the replay whichever shape it takes
+  (a byte replay: main appends to its ring and its pending buffer from the same bytes and clears
+  the pending buffer when it samples; a parsed-grid frame: the serialize is atomic with the
+  parser's flush barrier so every pre-sample byte is baked in, bytes racing the sample ride the
+  reply as an appended tail, and main holds the session's flush ticks for the sample's duration
+  so nothing can be flushed ahead of the reply), so
   flushing them afterwards repaints a pre-sample frame ON TOP of the fresh one. Because a TUI then
   sends only differential updates, nothing repairs it and the terminal shows the previous geometry's
   frame until the next SIGWINCH - a task detail opening on a session at the bottom panel's 14 rows

--- a/src/main/pty/buffer/headless-frame.ts
+++ b/src/main/pty/buffer/headless-frame.ts
@@ -25,10 +25,10 @@ type HeadlessTerminalAddon = ITerminalAddon;
  * A per-session HEADLESS xterm parser kept in the MAIN process, fed the same
  * PTY output as the raw scrollback ring. Its serialized frame is a snapshot of
  * the PARSED grid - every currently-visible cell whatever its draw age - which
- * the mobile seed uses instead of a raw 512KB byte replay. A raw replay drops
- * the write-once static cells of a fullscreen TUI (e.g. Claude Code's static
- * status-line segment) once the bytes that drew them age out of the byte
- * window; the parsed grid always carries them.
+ * the mobile seed and the desktop alt-screen replay use instead of a raw 512KB
+ * byte replay. A raw replay drops the write-once static cells of a fullscreen
+ * TUI (e.g. Claude Code's static status-line segment) once the bytes that drew
+ * them age out of the byte window; the parsed grid always carries them.
  *
  * Never call `.open()`: `@xterm/headless` has no DOM and runs the VT parser
  * plus buffer only.
@@ -73,7 +73,7 @@ export class HeadlessFrameBuffer {
    * that produced output, twice a second.
    *
    * Unlike `serialize()` these do NOT flush first, so they can read a grid that
-   * is one macrotask behind the newest chunk (see `flush`). That is deliberate:
+   * is one macrotask behind the newest chunk (see `serialize`). That is deliberate:
    * the peek is sampled on a repeating timer and self-heals on the next tick, so
    * paying a flush barrier per sample would buy nothing. Do not "fix" it by
    * making these async.
@@ -105,34 +105,42 @@ export class HeadlessFrameBuffer {
   }
 
   /**
-   * Drain the write buffer. xterm parses a normal `write()` asynchronously (it
-   * schedules the parse on a macrotask, not synchronously), so serializing
-   * right after the last `write()` would snapshot a STALE grid. A zero-length
-   * write's callback fires only once every queued chunk ahead of it has been
-   * parsed, which is exactly the flush barrier we need.
-   */
-  private flush(): Promise<void> {
-    return new Promise<void>((resolve) => {
-      this.terminal.write('', resolve);
-    });
-  }
-
-  /**
-   * Snapshot the parsed grid as a self-contained escape-sequence frame the
-   * phone can cold-replay into a fresh xterm. Flushes pending writes first so
-   * the frame reflects every byte fed so far.
+   * Snapshot the parsed grid as a self-contained escape-sequence frame a fresh
+   * xterm can cold-replay (the mobile seed, and the desktop alt-screen replay
+   * via PtyBufferManager.getReplaySnapshot).
    *
-   * The serialize addon includes the alt buffer (`excludeAltBuffer` left at its
-   * false default) and the active terminal modes (`excludeModes` left false):
-   * it emits `\x1b[?1049h` when the session is in the alt screen and re-asserts
+   * The snapshot is ATOMIC WITH THE FLUSH BARRIER. xterm parses `write()`
+   * chunks asynchronously (the parse runs on a later macrotask), so a
+   * zero-length write's callback is the point where every chunk fed BEFORE
+   * this call has been parsed - and the grid is serialized synchronously
+   * inside that callback, before the parse loop can consume chunks queued
+   * BEHIND the barrier. That makes the frame's content boundary exact: bytes
+   * fed before serialize() are in, bytes fed after are out, deterministically.
+   * getReplaySnapshot's exactly-once accounting of bytes that race a sample
+   * rests on this; do not move the serialize back out to a post-await line.
+   *
+   * The serialize addon includes the alt buffer (`excludeAltBuffer` left at
+   * its false default) and the active terminal modes (`excludeModes` left
+   * false): it emits the serialized normal buffer first, then the
+   * `\x1b[?1049h` switch MID-STREAM followed by the alt grid, and re-asserts
    * DECCKM / mouse-tracking / bracketed-paste / focus modes from
-   * `terminal.modes`. So the frame carries its own mode/alt-screen preamble -
-   * the phone lands in the right screen with the right input modes without any
-   * extra prefix, matching what the raw scrollback path prepended by hand.
+   * `terminal.modes`. So the frame is self-contained - the receiver lands in
+   * the right screen with the right input modes without any extra prefix -
+   * but the switch is not a leading marker; never `startsWith` on it.
    */
   async serialize(): Promise<string> {
-    await this.flush();
-    return this.serializer.serialize({ scrollback: SERIALIZED_SCROLLBACK_LINES });
+    return new Promise<string>((resolve, reject) => {
+      this.terminal.write('', () => {
+        // The callback runs inside xterm's parse loop, so a throw here (e.g. a
+        // serializer disposed mid-sample) would otherwise escape as an uncaught
+        // main-process exception instead of rejecting this promise.
+        try {
+          resolve(this.serializer.serialize({ scrollback: SERIALIZED_SCROLLBACK_LINES }));
+        } catch (error) {
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      });
+    });
   }
 
   dispose(): void {

--- a/src/main/pty/buffer/pty-buffer-manager.ts
+++ b/src/main/pty/buffer/pty-buffer-manager.ts
@@ -209,6 +209,18 @@ function updateModeState(state: ModeState, text: string): void {
  */
 const FULL_FRAME_CLEAR = '\x1b[2J';
 
+/**
+ * Hard ceiling on getReplaySnapshot's wait for the headless serialize. The
+ * barrier normally resolves in a few milliseconds; it can only hang when the
+ * headless terminal is disposed mid-sample (removeSession racing a replay) or
+ * wedged behind a pathological parse backlog. Mirrors waitForResizeRepaint's
+ * REPAINT_MAX_WAIT_MS discipline: every await on the replay path carries a
+ * teardown check and a deadline, so an IPC reply can never hang on a disposed
+ * parser (the renderer's replay watchdog stays a last resort, not the primary
+ * bound). On deadline the sample degrades to the byte replay.
+ */
+const REPLAY_SERIALIZE_MAX_WAIT_MS = 1000;
+
 function buildDecPrivateModePrefix(activeModes: Set<number>): string {
   if (activeModes.size === 0) return '';
   const sortedModes = Array.from(activeModes).sort((first, second) => first - second);
@@ -222,6 +234,15 @@ interface PtyBufferManagerCallbacks {
 interface BufferState {
   buffer: string;
   flushScheduled: boolean;
+  /** Count of getReplaySnapshot samples currently awaiting their serialize.
+   *  While > 0, scheduleFlush's tick re-arms instead of emitting, so no flush
+   *  can slip between a sample's drain and its IPC reply - the renderer drops
+   *  held bytes it believes the reply already contains, so an early flush here
+   *  would get those bytes silently discarded. A counter (not a boolean)
+   *  because staggered samplers can overlap; bounded by the sample's serialize
+   *  deadline and decremented in its finally, so a tick is deferred at most
+   *  one sample's duration. */
+  replaySamplesInFlight: number;
   scrollback: string;
   lastCols: number;
   /** The row count the bytes currently in the scrollback were drawn for,
@@ -277,11 +298,12 @@ interface BufferState {
    *  set split across two PTY chunks is parsed whole. Bounded in onData(). */
   modeParseCarry: string;
   /** Per-session headless xterm parser, fed the SAME bytes as `scrollback`.
-   *  Its serialized frame is a snapshot of the PARSED grid, used as the mobile
-   *  seed instead of the raw byte replay so write-once static TUI cells (whose
-   *  drawing bytes have aged out of the 512KB window) survive a cold replay.
-   *  Desktop consumers still read the raw `scrollback`; only getSerializedFrame
-   *  reads this. Disposed in removeSession. */
+   *  Its serialized frame is a snapshot of the PARSED grid, served instead of
+   *  the raw byte replay so write-once static TUI cells (whose drawing bytes
+   *  have aged out of the 512KB window) survive a cold replay. Two consumers:
+   *  the mobile seed (getSerializedFrame) and the desktop alt-screen replay
+   *  (getReplaySnapshot); desktop non-alt sessions still read the raw
+   *  `scrollback`. Disposed in removeSession. */
   headless: HeadlessFrameBuffer;
 }
 
@@ -319,6 +341,7 @@ export class PtyBufferManager {
     this.buffers.set(sessionId, {
       buffer: '',
       flushScheduled: false,
+      replaySamplesInFlight: 0,
       scrollback: previousScrollback,
       lastCols: initialCols,
       lastRows: initialRows,
@@ -406,6 +429,14 @@ export class PtyBufferManager {
       const current = this.buffers.get(sessionId);
       if (!current) return;
       current.flushScheduled = false;
+      // A replay snapshot is mid-sample: hold this tick (re-arm, do not emit)
+      // so no flush lands between the sample's drain and its reply. The
+      // sample's tail fold delivers whatever is buffered; anything left on its
+      // degraded paths rides the re-armed tick once the counter drops.
+      if (current.replaySamplesInFlight > 0) {
+        this.scheduleFlush(sessionId, current);
+        return;
+      }
       if (!current.buffer) return;
       const end = current.buffer.length > MAX_BYTES_PER_FLUSH
         ? surrogateSafeFlushEnd(current.buffer, MAX_BYTES_PER_FLUSH)
@@ -797,9 +828,12 @@ export class PtyBufferManager {
     // a clear with nothing after it: black, until something happens to force a
     // full redraw.
     //
-    // If the replay cost is worth attacking, the safe shape is a PARSED-grid
-    // snapshot like `getSerializedFrame`, which reconstructs the screen rather
-    // than betting that the bytes after some marker are sufficient to draw it.
+    // The alt-screen replay path now does take the safe shape: getReplaySnapshot
+    // serves the PARSED-grid frame (which reconstructs the screen rather than
+    // betting that the bytes after some marker are sufficient to draw it) when
+    // the session is in the alt buffer, so a ring capped past a write-once
+    // region no longer loses those cells on remount. This byte path remains the
+    // replay for non-alt sessions, where the warning above still stands.
     //
     // The in-memory buffer is trimmed on hysteresis (onData lets it grow to
     // SCROLLBACK_TRIM_THRESHOLD before slicing, to amortize the O(n) trim off
@@ -818,9 +852,13 @@ export class PtyBufferManager {
     // into it, so the input-mode reassert and the replayed frame land where
     // the session actually is. Gated on inAltScreen so a classic normal-buffer
     // session's replay is byte-for-byte unchanged (see the #313 comment on
-    // RESTORABLE_DEC_PRIVATE_MODES). A dangling synchronized-output frame is
-    // closed at the very end so a mid-frame sample can't stall xterm's
-    // renderer for its ~1s safety timeout.
+    // RESTORABLE_DEC_PRIVATE_MODES). Through the app's replay path this branch
+    // now fires only rarely: getReplaySnapshot routes an alt-screen session to
+    // the parsed-grid frame and reaches here alt-gated only via its
+    // serialize-deadline fallback, so in normal operation this method serves
+    // non-alt sessions (plus direct callers and unit tests). A dangling
+    // synchronized-output frame is closed at the very end so a mid-frame
+    // sample can't stall xterm's renderer for its ~1s safety timeout.
     return (state.inAltScreen ? '\x1b[?1049h' : '')
       + buildDecPrivateModePrefix(state.decPrivateModes)
       + '\x1b[0m'
@@ -845,17 +883,103 @@ export class PtyBufferManager {
 
   /**
    * Snapshot of the PARSED grid as a self-contained escape-sequence frame, for
-   * the MOBILE seed only. Unlike getScrollback (a raw 512KB byte replay), this
-   * reconstructs every currently-visible cell whatever its draw age, so a
-   * fullscreen TUI's write-once static regions are never dropped. The frame
-   * carries its own alt-screen + mode preamble (the serialize addon emits it),
-   * so the phone lands in the correct screen with the correct input modes.
+   * the mobile seed (getReplaySnapshot serves the desktop equivalent). Unlike
+   * getScrollback (a raw 512KB byte replay), this reconstructs every
+   * currently-visible cell whatever its draw age, so a fullscreen TUI's
+   * write-once static regions are never dropped. The frame carries its own
+   * alt-screen switch and mode re-asserts (emitted by the serialize addon
+   * mid-stream, after the serialized normal buffer - not a leading prefix), so
+   * the phone lands in the correct screen with the correct input modes.
    * Returns '' for an unknown session.
    */
   async getSerializedFrame(sessionId: string): Promise<string> {
     const state = this.buffers.get(sessionId);
     if (!state) return '';
     return state.headless.serialize();
+  }
+
+  /**
+   * The desktop replay payload: the parsed-grid serialized frame when the
+   * session is in the alt screen, the raw byte replay (getScrollback)
+   * otherwise.
+   *
+   * A fullscreen TUI does not redraw every cell after every clear, so once the
+   * ring outgrows MAX_SCROLLBACK the bytes that drew its write-once static
+   * regions are gone and no byte replay can reconstruct them - a remount at
+   * unchanged geometry (no SIGWINCH, so no fresh repaint to wait for) paints a
+   * permanently holed frame until a cols-changing resize. The parsed grid
+   * reconstructs every visible cell whatever its draw age, and the alt buffer
+   * has no user-reachable scrollback, so serving the frame there loses nothing
+   * the user could scroll to. Non-alt sessions (plain shells, agents without a
+   * TUI) keep the byte replay: their scrollback IS the bytes, and truncation
+   * there only loses old history.
+   *
+   * The frame is returned bare except for a possible tail of bytes that raced
+   * the sample - the serialize addon emits its own alt-screen switch and
+   * DEC-mode re-asserts (mid-stream, after the serialized normal buffer, not a
+   * leading prefix), so none of the byte path's hand-built prefix applies.
+   */
+  async getReplaySnapshot(sessionId: string): Promise<string> {
+    const state = this.buffers.get(sessionId);
+    if (!state?.scrollback) return '';
+    if (!state.inAltScreen) {
+      const scrollback = this.getScrollback(sessionId);
+      traceTerminal(sessionId, 'scrollback-sample', { source: 'byte-replay', bytes: scrollback.length });
+      return scrollback;
+    }
+    // Exactly-once accounting for bytes that race the sample. The drain and
+    // the serialize() call are back-to-back synchronous statements, so the
+    // drained set is exactly the bytes fed to the headless parser before the
+    // barrier - and the serialize (atomic with its barrier, see
+    // HeadlessFrameBuffer.serialize) bakes all of them into the frame and none
+    // that arrive later. Bytes arriving DURING the await land in the emptied
+    // pending buffer; the tick hold (replaySamplesInFlight, see scheduleFlush)
+    // keeps them from being flushed ahead of the reply (the renderer drops
+    // held bytes as already-replayed), and the tail fold below ships them with
+    // the frame instead. The deadline and the post-await teardown check mirror
+    // waitForResizeRepaint's discipline: this await must never leave the IPC
+    // reply hanging on a disposed parser.
+    state.buffer = '';
+    state.replaySamplesInFlight += 1;
+    try {
+      let deadlineTimer: NodeJS.Timeout | undefined;
+      let frame: string | null;
+      try {
+        frame = await Promise.race([
+          state.headless.serialize(),
+          new Promise<null>((resolve) => {
+            deadlineTimer = setTimeout(() => resolve(null), REPLAY_SERIALIZE_MAX_WAIT_MS);
+          }),
+        ]);
+      } finally {
+        if (deadlineTimer) clearTimeout(deadlineTimer);
+      }
+      if (!this.buffers.get(sessionId)) {
+        // Torn down mid-sample (removeSession disposed the parser): nothing to
+        // replay; the renderer's empty-scrollback path flushes its held bytes.
+        traceTerminal(sessionId, 'scrollback-sample', { source: 'parsed-grid-torn-down', bytes: 0 });
+        return '';
+      }
+      if (frame === null) {
+        // Deadline: the parser is wedged or was disposed without settling its
+        // barrier. Degrade to the byte replay (whose alt-screen branch
+        // hand-builds the \x1b[?1049h + mode prefix for exactly this case)
+        // rather than replying with a black frame.
+        const scrollback = this.getScrollback(sessionId);
+        traceTerminal(sessionId, 'scrollback-sample', { source: 'byte-replay-deadline', bytes: scrollback.length });
+        return scrollback;
+      }
+      // Tail fold: bytes that arrived during the await postdate the frame, so
+      // appending them replays them exactly once, in order. Draining them here
+      // keeps the held flush tick silent once it re-fires.
+      const tail = state.buffer;
+      state.buffer = '';
+      const payload = frame + tail;
+      traceTerminal(sessionId, 'scrollback-sample', { source: 'parsed-grid', bytes: payload.length, tailBytes: tail.length });
+      return payload;
+    } finally {
+      state.replaySamplesInFlight -= 1;
+    }
   }
 
   /**

--- a/src/main/pty/session-manager.ts
+++ b/src/main/pty/session-manager.ts
@@ -1265,20 +1265,24 @@ export class SessionManager extends EventEmitter {
     if (this.registry.get(sessionId)?.pty) {
       await this.bufferManager.waitForResizeRepaint(sessionId);
     }
-    return this.bufferManager.getScrollback(sessionId);
+    // Alt-screen sessions get the parsed-grid frame, everything else the raw
+    // byte replay - see PtyBufferManager.getReplaySnapshot for why a capped
+    // byte ring cannot reconstruct a fullscreen TUI's write-once cells.
+    return this.bufferManager.getReplaySnapshot(sessionId);
   }
 
   /**
    * The MOBILE seed frame: a snapshot of the PARSED grid from the per-session
    * headless xterm, serialized as a self-contained escape-sequence frame the
-   * phone cold-replays into a fresh terminal. Unlike getScrollback's raw 512KB
-   * byte replay, this never drops a fullscreen TUI's write-once static cells
-   * whose drawing bytes have aged out of the byte window.
+   * phone cold-replays into a fresh terminal. Unlike a raw 512KB byte replay,
+   * this never drops a fullscreen TUI's write-once static cells whose drawing
+   * bytes have aged out of the byte window (getScrollback serves the same
+   * frame to the desktop when the session is in the alt screen).
    *
    * Preserves the same repaint settle as getScrollback (awaits
    * waitForResizeRepaint, and like getScrollback skips it when no live PTY can
    * deliver a repaint) so the grid is never serialized mid-repaint at a stale
-   * geometry. Desktop consumers keep using getScrollback unchanged.
+   * geometry.
    */
   async getSerializedFrame(sessionId: string): Promise<string> {
     if (this.registry.get(sessionId)?.pty) {

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -333,12 +333,17 @@ export function useTerminal(options: UseTerminalOptions) {
    * then repainted the 14-row frame over it from the held queue.
    *
    * Everything main flushed to this renderer before the getScrollback REPLY is
-   * by construction inside `scrollback`: main appends to its ring and its
-   * pending buffer from the same bytes, clears the pending buffer at sample
-   * time (PtyBufferManager.getScrollback), and IPC replies are ordered against
-   * the flush stream. Main's half of the double-delivery guard has always been
-   * there; this is the renderer's half, for the bytes main can no longer
-   * recall.
+   * by construction inside `scrollback`, whichever shape the sample takes. A
+   * byte replay: main appends to its ring and its pending buffer from the same
+   * bytes, clears the pending buffer at sample time, and IPC replies are
+   * ordered against the flush stream. A parsed-grid frame (an alt-screen
+   * session's sample, PtyBufferManager.getReplaySnapshot): every byte fed
+   * before the sample is baked into the frame (the serialize is atomic with
+   * the parser's flush barrier), bytes racing the sample ride the reply as an
+   * appended tail, and main holds the session's flush ticks for the sample's
+   * duration so none of those bytes can arrive here ahead of the reply. Main's
+   * half of the double-delivery guard has always been there; this is the
+   * renderer's half, for the bytes main can no longer recall.
    *
    * Called in the same microtask as the resolve, so no post-sample flush (a
    * separate macrotask) can be caught by it. That rests on the resize reply

--- a/tests/e2e/terminal-fullscreen-select-replay-focus.spec.ts
+++ b/tests/e2e/terminal-fullscreen-select-replay-focus.spec.ts
@@ -300,12 +300,17 @@ test.describe('Fullscreen TUI select prompt - input/focus survives a scrollback 
     await closeTaskWindow(page);
     await openTaskWindow(page, taskTitle);
 
-    // The freshly re-fetched scrollback must lead with the alt-screen
-    // re-assert, so the replay paints into the alt buffer, not the normal
-    // buffer (the secondary defect: the cursor left disconnected from the
-    // TUI frame).
+    // The freshly re-fetched replay must carry the alt-screen switch, so it
+    // paints into the alt buffer, not the normal buffer (the secondary defect:
+    // the cursor left disconnected from the TUI frame). An alt-screen session's
+    // replay is now a parsed-grid serialized frame
+    // (PtyBufferManager.getReplaySnapshot): the serialize addon emits the
+    // serialized normal buffer first and the \x1b[?1049h switch mid-stream, so
+    // the sequence is contained, not leading. The post-replay ArrowDown below
+    // (no manual re-click) is the functional proof the replay landed in the
+    // right buffer with focus intact.
     const freshScrollback = await scrollbackForTask(page, taskId);
-    expect(freshScrollback.startsWith('\x1b[?1049h')).toBe(true);
+    expect(freshScrollback).toContain('\x1b[?1049h');
 
     // Second arrow-down WITHOUT an explicit click: proves focus landed
     // automatically after the replay (the primary defect - previously, keys

--- a/tests/unit/headless-frame.test.ts
+++ b/tests/unit/headless-frame.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { HeadlessFrameBuffer } from '../../src/main/pty/buffer/headless-frame';
+
+/**
+ * HeadlessFrameBuffer.serialize underlies both the mobile seed
+ * (PtyBufferManager.getSerializedFrame) and the desktop alt-screen replay
+ * (PtyBufferManager.getReplaySnapshot). Both call sites, and the atomic
+ * flush-barrier boundary that makes serialize()'s content cutoff exact, are
+ * already exercised through PtyBufferManager in pty-buffer-manager.test.ts.
+ *
+ * This file targets the one behavior that lives entirely inside
+ * HeadlessFrameBuffer and is not observable through those higher-level
+ * callers: serialize() REJECTS (rather than throwing into xterm's own
+ * write/parse loop as an uncaught main-process exception) when the
+ * serializer itself throws mid-callback.
+ *
+ * Real timers throughout: serialize() awaits xterm's own macrotask flush
+ * barrier (a zero-length terminal.write callback), matching the real-timer
+ * discipline of the getSerializedFrame / getReplaySnapshot blocks in
+ * pty-buffer-manager.test.ts.
+ */
+describe('HeadlessFrameBuffer', () => {
+  describe('serialize', () => {
+    it('rejects, rather than throwing uncaught, when the serializer throws mid-callback', async () => {
+      const buffer = new HeadlessFrameBuffer(80, 24);
+      buffer.write('some content');
+
+      // The callback that invokes serializer.serialize() runs inside xterm's
+      // own write/parse loop (see the comment on HeadlessFrameBuffer.serialize),
+      // not in this test's stack frame - so reaching into the private
+      // serializer to force a throw from exactly there is the only way to
+      // exercise the boundary the try/catch guards. A cast through `unknown`
+      // (never `any`) is the narrowest way to reach it from a test.
+      interface SerializerAccessor {
+        serializer: { serialize: (...args: unknown[]) => string };
+      }
+      (buffer as unknown as SerializerAccessor).serializer.serialize = () => {
+        throw new Error('serializer disposed mid-sample');
+      };
+
+      await expect(buffer.serialize()).rejects.toThrow('serializer disposed mid-sample');
+
+      buffer.dispose();
+    });
+  });
+});

--- a/tests/unit/pty-buffer-manager.test.ts
+++ b/tests/unit/pty-buffer-manager.test.ts
@@ -1436,6 +1436,127 @@ describe('PtyBufferManager', () => {
     });
   });
 
+  describe('getReplaySnapshot (desktop replay payload)', () => {
+    // Real timers, like the getSerializedFrame block above: the frame branch
+    // awaits the headless parser's macrotask flush barrier.
+    it('serves a parsed-grid frame that keeps static cells a capped byte replay drops', async () => {
+      const manager = new PtyBufferManager({ onFlush: vi.fn() });
+      manager.initSession(SESSION, '', 80, 24);
+
+      // Same fixture as the getSerializedFrame regression above: a write-once
+      // static cell, then a >512KB dynamic flood that never redraws it.
+      const STATIC_SEGMENT = 'auto mode on';
+      manager.onData(SESSION, `\x1b[?1049h\x1b[2J\x1b[1;1H${STATIC_SEGMENT}`);
+      const MAX_SCROLLBACK = 512 * 1024;
+      const dynamicUnit = '\x1b[24;1H' + 'x'.repeat(20); // stays on row 24, 20 cols < 80: no wrap, no scroll
+      const dynamicChunk = dynamicUnit.repeat(80);
+      let floodedBytes = 0;
+      while (floodedBytes < MAX_SCROLLBACK + 400 * 1024) {
+        manager.onData(SESSION, dynamicChunk);
+        floodedBytes += dynamicChunk.length;
+      }
+
+      // Precondition: the ring is genuinely truncated past the write-once
+      // region, so the raw byte replay has lost the static cell.
+      expect(manager.getScrollback(SESSION)).not.toContain(STATIC_SEGMENT);
+
+      // The replay payload the desktop mount receives reconstructs it.
+      const snapshot = await manager.getReplaySnapshot(SESSION);
+      expect(snapshot).toContain(STATIC_SEGMENT);
+      // The frame carries its own alt-screen switch, and exactly one: the
+      // snapshot path must not prepend the byte path's hand-built preamble on
+      // top of the one the serialize addon emits.
+      expect(snapshot.split('\x1b[?1049h').length - 1).toBe(1);
+      // And the switch precedes the alt-grid content: the addon serializes the
+      // normal buffer first, then switches, so a frame emitting alt rows ahead
+      // of the switch would paint them into the wrong buffer.
+      expect(snapshot.indexOf('\x1b[?1049h')).toBeLessThan(snapshot.indexOf(STATIC_SEGMENT));
+
+      manager.removeSession(SESSION);
+    });
+
+    it('passes a non-alt-screen session through to the raw byte replay', async () => {
+      const manager = new PtyBufferManager({ onFlush: vi.fn() });
+      manager.initSession(SESSION, '', 80, 24);
+      manager.onData(SESSION, 'plain shell output\r\nsecond line');
+
+      const snapshot = await manager.getReplaySnapshot(SESSION);
+      // Byte-for-byte the getScrollback value (stable across reads with no new
+      // data), preamble and all.
+      expect(snapshot).toBe(manager.getScrollback(SESSION));
+      expect(snapshot).toContain('plain shell output');
+
+      manager.removeSession(SESSION);
+    });
+
+    it('drains the pending buffer on the frame branch like getScrollback does', async () => {
+      const onFlush = vi.fn();
+      const manager = new PtyBufferManager({ onFlush });
+      manager.initSession(SESSION, '', 80, 24);
+      manager.onData(SESSION, '\x1b[?1049h\x1b[2J\x1b[1;1Hpending frame bytes');
+
+      const snapshot = await manager.getReplaySnapshot(SESSION);
+      expect(snapshot).toContain('pending frame bytes');
+      expect(manager.getBufferStats(SESSION)?.pendingBytes).toBe(0);
+      // The already-queued 16ms flush finds an empty buffer and stays silent,
+      // so nothing baked into the frame is delivered a second time.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(onFlush).not.toHaveBeenCalled();
+
+      manager.removeSession(SESSION);
+    });
+
+    it('returns empty string for an unknown or empty session', async () => {
+      const manager = new PtyBufferManager({ onFlush: vi.fn() });
+      expect(await manager.getReplaySnapshot('nonexistent')).toBe('');
+      manager.initSession(SESSION, '', 80, 24);
+      expect(await manager.getReplaySnapshot(SESSION)).toBe('');
+      manager.removeSession(SESSION);
+    });
+
+    it('folds bytes that race the sample into the reply exactly once, never via a flush', async () => {
+      const onFlush = vi.fn();
+      const manager = new PtyBufferManager({ onFlush });
+      manager.initSession(SESSION, '', 80, 24);
+      manager.onData(SESSION, '\x1b[?1049h\x1b[2J\x1b[1;1Halt frame');
+
+      const pendingSnapshot = manager.getReplaySnapshot(SESSION); // do not await yet
+      manager.onData(SESSION, 'RACE_BYTES'); // lands during the await window
+      const snapshot = await pendingSnapshot;
+
+      // The atomic serialize (see HeadlessFrameBuffer.serialize) bakes in only
+      // the bytes fed before the drain, so the race bytes cannot land inside
+      // the frame itself - they can only appear once, as the tail folded on
+      // after the await.
+      expect(snapshot.split('RACE_BYTES').length - 1).toBe(1);
+
+      // The held flush tick (replaySamplesInFlight, see scheduleFlush) must
+      // never deliver them a second time via onFlush: the tail fold already
+      // drained state.buffer, so the re-armed tick finds nothing to emit.
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      for (const call of onFlush.mock.calls) {
+        expect(call[1]).not.toContain('RACE_BYTES');
+      }
+
+      manager.removeSession(SESSION);
+    });
+
+    it('resolves empty when the session is torn down mid-sample', async () => {
+      const manager = new PtyBufferManager({ onFlush: vi.fn() });
+      manager.initSession(SESSION, '', 80, 24);
+      manager.onData(SESSION, '\x1b[?1049h\x1b[2J\x1b[1;1Halt frame');
+
+      const pendingSnapshot = manager.getReplaySnapshot(SESSION); // do not await yet
+      manager.removeSession(SESSION);
+
+      // The post-await teardown check must settle the reply to an empty
+      // string rather than leaving it hanging on a disposed parser, whether
+      // the serialize barrier resolves before or after REPLAY_SERIALIZE_MAX_WAIT_MS.
+      const snapshot = await pendingSnapshot;
+      expect(snapshot).toBe('');
+    });
+  });
+
   describe('getOutputPeek (live PTY-grid-to-peek wiring)', () => {
     // Real timers, mirroring the getSerializedFrame block above: the headless
     // parser drains its write buffer on a macrotask. getOutputPeek itself is

--- a/tests/unit/pty-buffer-manager.test.ts
+++ b/tests/unit/pty-buffer-manager.test.ts
@@ -1555,6 +1555,64 @@ describe('PtyBufferManager', () => {
       const snapshot = await pendingSnapshot;
       expect(snapshot).toBe('');
     });
+
+    it('resumes normal flush delivery once a sample completes (replaySamplesInFlight must not stick)', async () => {
+      const onFlush = vi.fn();
+      const manager = new PtyBufferManager({ onFlush });
+      manager.initSession(SESSION, '', 80, 24);
+      manager.onData(SESSION, '\x1b[?1049h\x1b[2J\x1b[1;1Halt frame');
+
+      await manager.getReplaySnapshot(SESSION);
+
+      // The frame branch drains everything into the reply (see "drains the
+      // pending buffer" above), so nothing should have flushed yet.
+      expect(onFlush).not.toHaveBeenCalled();
+
+      // Bytes fed AFTER the sample has fully resolved must still reach
+      // onFlush on the ordinary 16ms tick. If replaySamplesInFlight's finally
+      // decrement were ever lost (an early return before it, an off-by-one),
+      // the counter would stay above zero, scheduleFlush's tick would re-arm
+      // forever, and this data would never be delivered - the renderer would
+      // go permanently silent for the session.
+      manager.onData(SESSION, 'POST_SAMPLE_BYTES');
+      await expect
+        .poll(
+          () => onFlush.mock.calls.some((call) => typeof call[1] === 'string' && call[1].includes('POST_SAMPLE_BYTES')),
+          { timeout: 2000, interval: 20 },
+        )
+        .toBe(true);
+
+      manager.removeSession(SESSION);
+    });
+
+    it('propagates a HeadlessFrameBuffer.serialize rejection rather than swallowing it', async () => {
+      const manager = new PtyBufferManager({ onFlush: vi.fn() });
+      manager.initSession(SESSION, '', 80, 24);
+      manager.onData(SESSION, '\x1b[?1049h\x1b[2J\x1b[1;1Halt frame');
+
+      // Force the underlying serializer to throw. HeadlessFrameBuffer.serialize's
+      // own try/catch (see tests/unit/headless-frame.test.ts) turns that into a
+      // REJECTED promise rather than an uncaught main-process exception - but
+      // getReplaySnapshot has no catch of its own around the Promise.race, so
+      // that rejection must propagate all the way out to the caller
+      // (SessionManager.getScrollback, then the IPC reply) rather than resolve
+      // to a frame, the byte replay, or an empty string. The renderer's
+      // existing getScrollback().catch() (useTerminal.ts) is the actual safety
+      // net downstream; this pins that getReplaySnapshot itself does not
+      // silently absorb the failure first.
+      interface ManagerInternals {
+        buffers: Map<string, { headless: { serializer: { serialize: (...args: unknown[]) => string } } }>;
+      }
+      const bufferState = (manager as unknown as ManagerInternals).buffers.get(SESSION);
+      if (!bufferState) throw new Error('test setup: session buffer state missing');
+      bufferState.headless.serializer.serialize = () => {
+        throw new Error('serializer disposed mid-sample');
+      };
+
+      await expect(manager.getReplaySnapshot(SESSION)).rejects.toThrow('serializer disposed mid-sample');
+
+      manager.removeSession(SESSION);
+    });
   });
 
   describe('getOutputPeek (live PTY-grid-to-peek wiring)', () => {

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -160,6 +160,33 @@ describe('Scrollback', () => {
     expect(scrollback.length).toBeLessThanOrEqual(512 * 1024 + 4);
     expect(scrollback.length).toBeGreaterThan(512 * 1024 - 32);
   });
+
+  it('serves the parsed grid for an alt-screen session, not the byte log', async () => {
+    const { session, feedData } = await spawnSession();
+
+    // A fullscreen TUI: enter the alt screen, draw AAA, then overwrite the
+    // same cells with BBB.
+    feedData('\x1b[?1049h\x1b[2J\x1b[1;1HAAA');
+    feedData('\x1b[1;1HBBB');
+
+    const replay = await manager.getScrollback(session.id);
+    // A byte log carries both draws; the parsed-grid frame holds only the
+    // cells as they stand now, and its own alt-screen switch.
+    expect(replay).toContain('BBB');
+    expect(replay).not.toContain('AAA');
+    expect(replay).toContain('\x1b[?1049h');
+  });
+
+  it('keeps the byte replay, history included, for a non-alt-screen session', async () => {
+    const { session, feedData } = await spawnSession();
+
+    feedData('first draw AAA\r\n');
+    feedData('second draw BBB\r\n');
+
+    const replay = await manager.getScrollback(session.id);
+    expect(replay).toContain('AAA');
+    expect(replay).toContain('BBB');
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Alt-screen terminal sessions now replay the headless parser's PARSED-grid serialized frame instead of the raw byte tail of the 512KB scrollback ring. Non-alt sessions (plain shells, agents without a TUI) keep the byte replay unchanged.

- `PtyBufferManager.getReplaySnapshot` (new): routes on `inAltScreen`; drains the pending buffer; holds flush ticks while a sample is in flight; folds bytes that race the sample onto the reply as an appended tail; 1s serialize deadline degrading to the byte replay; teardown check settling the reply if `removeSession` races it. Emits a `scrollback-sample` trace event (`source=parsed-grid | byte-replay | byte-replay-deadline | parsed-grid-torn-down`) for the devtools terminal-state timeline.
- `HeadlessFrameBuffer.serialize`: now atomic with its flush barrier (serializes synchronously inside the barrier callback, so the frame's content boundary is exact) and rejects instead of throwing uncaught into xterm's parse loop.
- `SessionManager.getScrollback`: one-line delegate swap to `getReplaySnapshot`; the repaint settle and its live-PTY gate are unchanged. No IPC surface changes.
- Renderer: no code changes (the replay payload is written verbatim into a fresh/reset xterm, and the mobile client already cold-replays exactly this frame shape).

## Why

A task-detail terminal opening (or re-opening) on a long-running fullscreen TUI painted a frame with cells permanently missing: prompt-box rules absent, the footer's `auto mode on (shift+tab to cycle)` prefix blank, suffix correctly positioned. Only a cols-changing resize repaired it.

Root cause: the replay was a raw byte log off a ring capped at 512KB. A fullscreen TUI draws static regions once and never again, so once a session outgrows the cap those drawing bytes age out and no byte replay can reconstruct them. The trigger is a remount whose fit produces no geometry change: no SIGWINCH, so no fresh full-frame repaint ever lands in the ring (`settle: not-armed` is correct behavior there, not the defect). The mobile seed already served the parsed grid for exactly this reason; the desktop path never got it.

Verified live before and after: the broken mounts trace `replay-write bytes=524,327` (the cap plus preamble) on rings past the cap; with the fix the same trigger traces `scrollback-sample source=parsed-grid` at a few KB and paints complete, confirmed on a real 649KB-ring repro session across layer toggles, HMR remounts, and panel-to-window handoffs.

## How

The alt buffer has no user-reachable scrollback, so replacing bytes with a parsed frame there loses nothing scrollable, and a frame is a few KB against 512KB (a mount-time win). The frame ships bare: the serialize addon emits its own alt-screen switch and DEC-mode re-asserts mid-stream after the serialized normal buffer, so the byte path's hand-built preamble does not apply (and nothing may `startsWith` on the switch).

The sampling race is closed with exactly-once accounting: the drain and serialize are back-to-back against an atomic barrier, flush ticks are held while a sample is in flight (`replaySamplesInFlight`) so the renderer's drop-held guard cannot discard bytes it believes are in the reply, and those bytes ride the reply as a tail instead. Every await on the replay path carries a deadline and a teardown check, so an IPC reply can never hang on a wedged or disposed parser.

Trade-off stated knowingly: an alt-screen replay carries 500 rows of normal-buffer history (`SERIALIZED_SCROLLBACK_LINES`) instead of the byte tail's remnant; the byte path already sliced from the first `\x1b[2J`, so nothing user-reachable is lost.

## Breaking changes

None.

## Tests

- `tests/unit/pty-buffer-manager.test.ts`: new `getReplaySnapshot` block (real timers) - floods a ring 400KB past the cap over a write-once cell and asserts the replay payload reconstructs it with exactly one alt-screen switch preceding the content; non-alt byte-for-byte passthrough; pending-buffer drain with silent stale flush; race bytes folded exactly once and never re-delivered via a flush; torn-down mid-sample resolves empty; flush delivery resumes after a sample; serialize rejection propagates.
- `tests/unit/headless-frame.test.ts` (new): serialize rejects rather than throwing uncaught when the serializer throws mid-callback.
- `tests/unit/session-manager.test.ts`: alt-screen routing (overwritten cells drop out of the frame) and non-alt history retention through the settle path.
- `tests/e2e/terminal-fullscreen-select-replay-focus.spec.ts`: leading-preamble assertion updated to containment (the switch is mid-stream by design); the no-reclick ArrowDown remains the functional proof the replay lands in the alt buffer. Ran green locally along with `terminal-fit-invariant.spec.ts`.
- CI checks on this PR are the full gate (lint, typecheck, unit, build, UI shards, Linux Electron E2E shards).

Generated with [Claude Code](https://claude.com/claude-code)
