### PR TITLE
fix(pty): re-assert mouse-encoding modes on the parsed-grid replay

### DIFF
--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -462,9 +462,13 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   its own addon-emitted alt-screen switch and mode re-asserts (mid-stream, after the serialized
   normal buffer - not a leading prefix, so nothing may `startsWith` on it), so the replay paints
   into the alt buffer with the right input modes (a replay landing in the normal buffer was
-  previously the cause of a cursor left visually disconnected from the TUI frame). `getScrollback`
-  itself retains the `\x1b[?1049h` prefix gate, reachable now only via direct byte-path reads and
-  `getReplaySnapshot`'s serialize-deadline fallback.
+  previously the cause of a cursor left visually disconnected from the TUI frame). One mode class
+  the addon cannot emit is the mouse ENCODING modes (1005/1006/1015/1016 - it re-asserts mouse
+  TRACKING only), so `getReplaySnapshot` folds the tracked DEC-mode prefix onto the frame; without
+  it, a same-grid remount left xterm reporting legacy X10 mouse bytes that an SGR-expecting TUI
+  ignores, and wheel scroll went dead until the TUI happened to re-assert its own modes.
+  `getScrollback` itself retains the `\x1b[?1049h` prefix gate, reachable now only via direct
+  byte-path reads and `getReplaySnapshot`'s serialize-deadline fallback.
 - **Hold, not drop, live output across a renderer-side replay.** While a scrollback replay is in
   flight (`scrollbackPendingRef`), the renderer's incoming-write queue HOLDS (retains, does not
   ack) rather than drops live PTY bytes, and flushes them in order once the replay's `afterWrite`

--- a/src/main/pty/buffer/pty-buffer-manager.ts
+++ b/src/main/pty/buffer/pty-buffer-manager.ts
@@ -890,7 +890,11 @@ export class PtyBufferManager {
    * alt-screen switch and mode re-asserts (emitted by the serialize addon
    * mid-stream, after the serialized normal buffer - not a leading prefix), so
    * the phone lands in the correct screen with the correct input modes.
-   * Returns '' for an unknown session.
+   * Known gap, accepted for mobile: the addon cannot emit the mouse ENCODING
+   * modes (1005/1006/1015/1016), which cost the desktop wheel scroll and is
+   * folded back on in getReplaySnapshot; the phone's terminal is touch-driven
+   * and sends no mouse reports, so this frame stays bare until a phone-side
+   * need appears. Returns '' for an unknown session.
    */
   async getSerializedFrame(sessionId: string): Promise<string> {
     const state = this.buffers.get(sessionId);
@@ -914,10 +918,12 @@ export class PtyBufferManager {
    * TUI) keep the byte replay: their scrollback IS the bytes, and truncation
    * there only loses old history.
    *
-   * The frame is returned bare except for a possible tail of bytes that raced
-   * the sample - the serialize addon emits its own alt-screen switch and
-   * DEC-mode re-asserts (mid-stream, after the serialized normal buffer, not a
-   * leading prefix), so none of the byte path's hand-built prefix applies.
+   * The frame carries the addon's own alt-screen switch and mode re-asserts
+   * (mid-stream, after the serialized normal buffer, not a leading prefix),
+   * followed by two appendices of ours: the folded DEC private mode prefix
+   * (the addon cannot emit the mouse ENCODING modes 1005/1006/1015/1016, so
+   * without it wheel scroll died after every same-grid remount - see the tail
+   * fold below) and any bytes that raced the sample.
    */
   async getReplaySnapshot(sessionId: string): Promise<string> {
     const state = this.buffers.get(sessionId);
@@ -974,7 +980,15 @@ export class PtyBufferManager {
       // keeps the held flush tick silent once it re-fires.
       const tail = state.buffer;
       state.buffer = '';
-      const payload = frame + tail;
+      // Re-assert the tracked DEC private modes after the frame. The serialize
+      // addon emits mouse TRACKING from terminal.modes (?1000h etc.) but has no
+      // API for the mouse ENCODING modes (1005/1006/1015/1016), so a bare frame
+      // left xterm reporting legacy X10 bytes that an SGR-expecting TUI
+      // ignores: wheel scroll went dead after every same-grid remount until the
+      // TUI happened to re-assert its own modes in the live stream. The folded
+      // prefix covers every mode in RESTORABLE_DEC_PRIVATE_MODES, and
+      // re-asserting one the addon already emitted is a no-op.
+      const payload = frame + buildDecPrivateModePrefix(state.decPrivateModes) + tail;
       traceTerminal(sessionId, 'scrollback-sample', { source: 'parsed-grid', bytes: payload.length, tailBytes: tail.length });
       return payload;
     } finally {

--- a/tests/e2e/terminal-fullscreen-select-replay-focus.spec.ts
+++ b/tests/e2e/terminal-fullscreen-select-replay-focus.spec.ts
@@ -23,11 +23,13 @@
  * terminal escape sequences at all, so it cannot reproduce a bug that only
  * exists in the alt-screen replay path. Setting MOCK_CLAUDE_FULLSCREEN_SELECT=1
  * switches it to a small interactive select-prompt harness: it enters the alt
- * screen buffer, turns on DECCKM, draws a 3-option menu, and moves the
- * highlight via a cursor-addressed, synchronized-output DIFF on arrow input --
- * never a full repaint - so a lost keystroke or a misplaced replay is
- * directly observable in the scrollback (the highlighted-option marker for
- * the NEXT option only ever appears if the keystroke actually reached the PTY).
+ * screen buffer, turns on DECCKM and SGR-encoded mouse tracking, draws a
+ * 3-option menu, and moves the highlight via a cursor-addressed,
+ * synchronized-output DIFF on arrow-key or SGR wheel-report input --
+ * never a full repaint - so a lost keystroke, a misplaced replay, or a replay
+ * that drops the mouse encoding is directly observable in the scrollback (the
+ * highlighted-option marker for the NEXT option only ever appears if the
+ * input actually reached the PTY in a form the harness parses).
  *
  * This spec drives real, focused Playwright keyboard events into the xterm
  * DOM (not a `sessions.write` IPC bypass), because the bug is specifically
@@ -321,6 +323,40 @@ test.describe('Fullscreen TUI select prompt - input/focus survives a scrollback 
       .poll(() => scrollbackForTask(page, taskId), {
         timeout: 10000,
         message: 'Expected the highlight to advance to option 3 after a post-replay ArrowDown with no manual re-focus',
+      })
+      .toContain(HIGHLIGHT_THIRD);
+
+    // Wheel scroll across the replay: the mock enables SGR-encoded mouse
+    // tracking (?1000h + ?1006h) and parses ONLY SGR wheel reports, like real
+    // Claude. The serialize addon re-asserts mouse TRACKING but cannot emit
+    // the ENCODING, so a replay that fails to restore ?1006h leaves xterm
+    // sending legacy X10 reports the TUI ignores - wheel scroll dead, exactly
+    // the shipped regression this guards. xterm emits ONE report per wheel
+    // EVENT (delta size does not multiply notches), so dispatch three events
+    // per direction and assert on the CLAMPED endpoints (top and bottom
+    // option) - deterministic whether an event maps to one notch or several.
+    const terminalBox = await dialog.locator('.xterm').first().boundingBox();
+    if (!terminalBox) throw new Error('Expected the terminal to have a bounding box');
+    await page.mouse.move(
+      terminalBox.x + terminalBox.width / 2,
+      terminalBox.y + terminalBox.height / 2,
+    );
+    for (let wheelEvent = 0; wheelEvent < 3; wheelEvent++) {
+      await page.mouse.wheel(0, -120);
+    }
+    await expect
+      .poll(() => scrollbackForTask(page, taskId), {
+        timeout: 10000,
+        message: 'Expected wheel-up to reach the PTY as SGR reports and clamp the highlight to option 1 after the replay',
+      })
+      .toContain(HIGHLIGHT_FIRST);
+    for (let wheelEvent = 0; wheelEvent < 3; wheelEvent++) {
+      await page.mouse.wheel(0, 120);
+    }
+    await expect
+      .poll(() => scrollbackForTask(page, taskId), {
+        timeout: 10000,
+        message: 'Expected wheel-down to clamp the highlight back to option 3',
       })
       .toContain(HIGHLIGHT_THIRD);
 

--- a/tests/fixtures/mock-claude.js
+++ b/tests/fixtures/mock-claude.js
@@ -292,11 +292,12 @@ if (process.env.MOCK_CLAUDE_BACKGROUND_BASH === '1' && sessionId && !settingsPat
 // MOCK_CLAUDE_FULLSCREEN_SELECT=1 is set, this branch instead behaves like a
 // real Claude Code fullscreen TUI parked at an AskUserQuestion-style select
 // prompt: it enters the alt screen buffer (1049h), turns on application
-// cursor keys (DECCKM, 1h), draws a 3-option menu, and reacts to arrow-key
-// input by moving the highlight via a cursor-addressed, synchronized-output
+// cursor keys (DECCKM, 1h) and SGR-encoded mouse tracking (1000h + 1006h),
+// draws a 3-option menu, and reacts to arrow-key and SGR wheel-report input
+// by moving the highlight via a cursor-addressed, synchronized-output
 // (2026h/2026l) DIFF - never a full repaint - exactly like the fix this
-// harness verifies (a dropped diff, or a replay landing in the wrong xterm
-// buffer, must not go unnoticed).
+// harness verifies (a dropped diff, a replay landing in the wrong xterm
+// buffer, or a replay that loses the mouse encoding must not go unnoticed).
 const FULLSCREEN_SELECT_OPTIONS = ['First option', 'Second option', 'Third option'];
 
 // Fullscreen TUI that REPAINTS ON RESIZE, for the terminal fit/handoff harness.
@@ -456,6 +457,14 @@ if (process.env.MOCK_CLAUDE_TUI_REPAINT === '1') {
   const drawFullScreen = () => {
     let out = '\x1b[?1049h'; // enter the alt screen buffer
     out += '\x1b[?1h'; // DECCKM: application cursor keys
+    // VT200 mouse tracking in SGR encoding, like Claude's real fullscreen
+    // renderer: wheel scroll arrives as SGR reports (\x1b[<64/65;x;yM), and
+    // the handler below parses ONLY that encoding. This split is load-bearing
+    // for the replay guard: the serialize addon re-asserts TRACKING (?1000h)
+    // but cannot emit the ENCODING (?1006h), so a replay that fails to restore
+    // it leaves xterm sending legacy X10 reports this harness (like real
+    // Claude) ignores - and the wheel assertion in the spec goes red.
+    out += '\x1b[?1000h\x1b[?1006h';
     // Hide the cursor while the TUI manages its own visual indicators. This
     // is also Kangentic's detectFirstOutput heuristic for Claude (see
     // src/main/agent/adapters/claude/claude-adapter.ts) -- without it the
@@ -529,7 +538,21 @@ if (process.env.MOCK_CLAUDE_TUI_REPAINT === '1') {
     if (combined.includes('\x1bOB') || combined.includes('\x1b[B')) {
       moveHighlight(1);
     }
-    const partialEscapeMatch = combined.match(/\x1b(?:O|\[)?$/);
+    // SGR-encoded wheel reports only (button 64 = up, 65 = down), one move per
+    // report. Legacy X10 reports (\x1b[M + 3 raw bytes) are deliberately NOT
+    // parsed - real Claude ignores them too, which is how a replay that drops
+    // the ?1006h encoding manifests as dead scroll. Click reports (\x1b[<0...)
+    // fall through unmatched, like every other unrecognized input.
+    const wheelReports = combined.match(/\x1b\[<6[45];\d+;\d+M/g);
+    if (wheelReports) {
+      for (const report of wheelReports) {
+        moveHighlight(report.startsWith('\x1b[<65') ? 1 : -1);
+      }
+    }
+    // The carry must retain a trailing partial SGR report (\x1b[<64;12 ...) as
+    // well as a bare \x1b / \x1b[ / \x1bO, or a wheel report split across two
+    // PTY chunks loses its head and the notch is silently dropped.
+    const partialEscapeMatch = combined.match(/\x1b(?:\[(?:<[\d;]*)?|O)?$/);
     if (partialEscapeMatch) inputCarry = partialEscapeMatch[0];
   });
   process.stdin.resume();

--- a/tests/unit/pty-buffer-manager.test.ts
+++ b/tests/unit/pty-buffer-manager.test.ts
@@ -1475,6 +1475,28 @@ describe('PtyBufferManager', () => {
       manager.removeSession(SESSION);
     });
 
+    it('re-asserts mouse-encoding modes the serialize addon cannot emit', async () => {
+      const manager = new PtyBufferManager({ onFlush: vi.fn() });
+      manager.initSession(SESSION, '', 80, 24);
+      // A fullscreen TUI with wheel-scroll support: mouse tracking (1000) in
+      // SGR encoding (1006), like Claude Code. The serialize addon re-asserts
+      // TRACKING from terminal.modes (?1000h) but has no API for the ENCODING
+      // modes (1005/1006/1015/1016), so a bare frame leaves xterm reporting
+      // legacy X10 bytes that an SGR-expecting TUI ignores: wheel scroll went
+      // dead after every same-grid remount until the TUI happened to re-assert
+      // its own modes in the live stream.
+      manager.onData(SESSION, '\x1b[?1049h\x1b[?1000h\x1b[?1006h\x1b[2J\x1b[1;1HTUI frame');
+
+      const snapshot = await manager.getReplaySnapshot(SESSION);
+      // The folded DEC prefix (buildDecPrivateModePrefix) re-asserts every
+      // tracked input/reporting mode after the frame; 1006 must be a member
+      // (terminated by ';' or the trailing 'h', never a substring of a longer
+      // parameter).
+      expect(snapshot).toMatch(/\x1b\[\?(?:[0-9]+;)*1006[;h]/);
+
+      manager.removeSession(SESSION);
+    });
+
     it('passes a non-alt-screen session through to the raw byte replay', async () => {
       const manager = new PtyBufferManager({ onFlush: vi.fn() });
       manager.initSession(SESSION, '', 80, 24);


### PR DESCRIPTION
## What

Fixes the wheel-scroll regression the parsed-grid replay (#251) introduced in fullscreen TUI sessions, and adds an end-to-end guard for the input-mode-across-replay class.

- `PtyBufferManager.getReplaySnapshot`: folds `buildDecPrivateModePrefix` onto the serialized frame (before the tail), restoring the mouse ENCODING modes.
- `tests/fixtures/mock-claude.js` fullscreen-select harness: enables SGR mouse tracking (`?1000h` + `?1006h`) and parses ONLY SGR wheel reports, like real Claude; legacy X10 reports are deliberately ignored.
- `tests/e2e/terminal-fullscreen-select-replay-focus.spec.ts`: after the dialog reattach, wheels up and down over the terminal and asserts the highlight tracks to the clamped endpoints.
- One new unit test pinning the 1006 re-assert in the replay payload; docs updated.

## Why

Reported live minutes after #251 shipped: scroll dead in a fullscreen Claude session, intermittently healing after certain open/close cycles. Root cause, confirmed against the serialize addon's source: `_serializeModes` re-asserts mouse TRACKING from `terminal.modes` but has no API for the ENCODING modes (1005/1006/1015/1016). A replayed frame left xterm with tracking on and encoding reset to legacy X10, so wheel events went out as `\x1b[M` byte reports the SGR-expecting TUI ignores. The old byte replay's hand-built #313 prefix carried exactly those modes; the frame shipped bare. The intermittency was the TUI occasionally re-asserting its own modes in the live stream (any full repaint), which is why a geometry-changing reopen healed it and a same-grid remount broke it again.

## How

One line plus rationale: append the ring's tracked DEC private mode prefix after the frame; re-asserting a mode the addon already emitted is an idempotent no-op. The mobile seed (`getSerializedFrame`) deliberately keeps the bare frame - the phone's terminal is touch-driven and sends no mouse reports - with the gap documented at the source.

Both guards were verified red against the deliberately reverted fix: the unit assertion failed with the payload visibly ending at `?1000h` (no 1006), and the E2E run failed with arrows working and the wheel dead - the exact shipped symptom - with the frame tail reading `?1h ?1004h ?1000h`.

## Breaking changes

None.

## Tests

- Unit (`tests/unit/pty-buffer-manager.test.ts`): alt-screen session with `?1000h ?1006h` set gets 1006 re-asserted as a member of the folded prefix. 84/84 in the file.
- E2E (`terminal-fullscreen-select-replay-focus.spec.ts`): post-reattach wheel-up clamps the highlight to option 1 and wheel-down back to option 3, via real CDP wheel events over the xterm (one SGR report per wheel event; clamp-based assertions are notch-count independent). Green locally with the fix, red without it.
- CI checks on this PR are the full gate.

Generated with [Claude Code](https://claude.com/claude-code)
