### PR TITLE
docs(protocol): backfill the missing changelog entries and guard the gap

### DIFF
--- a/.claude/rules/protocol-release-parity.md
+++ b/.claude/rules/protocol-release-parity.md
@@ -1,0 +1,59 @@
+---
+paths:
+  - "packages/protocol/**"
+---
+# Rule: every published protocol version has a changelog entry
+
+`@kangentic/protocol` ships on its own cadence through `/release-protocol`, which bumps the
+version, writes a `CHANGELOG.md` entry, commits `chore(protocol-release): protocol-vX.Y.Z`, tags,
+and pushes. The tag push is what triggers `publish-protocol.yml`, so a tag is a publish.
+
+That coupling is exactly where it drifted. Eight versions (0.2.0, 0.3.0, 0.6.0, 0.8.0, 0.9.0,
+0.10.0, 0.11.0, 0.11.1) went to npm with no changelog entry, because the tags were created by
+hand directly on the feature and fix commits instead of on a `chore(protocol-release):` commit.
+Nothing noticed: the skill only ever prepends the newest entry, so it wrote 0.7.0 on top of a
+hole and never looked down. The gap ran for six releases and was found by accident, during an
+unrelated desktop `/release`, when the package read 0.11.1 and the changelog read 0.7.0. It was
+backfilled in v0.32.0 by reconstructing every entry from the tag ranges.
+
+The convention that makes this easy to get wrong is deliberate and stays: a feature commit MAY
+bump `packages/protocol/package.json` ahead of its changelog entry (see 4e126bd3, "the changelog
+entry lands at release time as usual"). So a version with no entry is normal before a release and
+a defect after one. The tag, not the version field, is the line.
+
+## The rule
+
+1. **Never hand-tag a protocol release.** Creating `protocol-vX.Y.Z` and pushing it is a publish.
+   It goes through `/release-protocol` so the changelog entry, the release commit, and the tag are
+   produced together. A `protocol-v*` tag pointing at anything other than a
+   `chore(protocol-release):` commit is the signature of a bypass.
+2. **Every `protocol-v*` tag has a matching `## [protocol-vX.Y.Z]` entry** in
+   `packages/protocol/CHANGELOG.md`. That file is canonical for the package. `docs/mobile-bridge.md`
+   carries the same history as narrative for the bridge feature; it is not a substitute.
+3. **Do not write a bare `#N` in the changelog.** The repo is public and the package is published,
+   so a private board task id renders as a GitHub issue link to an unrelated issue. Describe the
+   change instead. `68afad59`'s subject carries a `(#172)` that was dropped for this reason.
+4. **Backfill on sight.** If you find a published or tagged version with no entry, reconstruct it
+   from `git log <previousTag>..<tag> -- packages/protocol/src` and the commit messages, rather
+   than leaving the hole for the next release to paper over.
+
+## Enforcement (self-maintaining)
+
+- **Skill (pre-flight):** `/release-protocol` verifies tag-to-entry parity across the whole
+  `protocol-v*` sequence before it releases, and backfills any gap it finds. This is what turns a
+  single missed release into a self-healing one instead of a permanent hole.
+- **Skill (recurring):** `/release` Step 1.5 checks the same parity during every desktop release.
+  Desktop releases are frequent and protocol releases are not, so this is the check most likely
+  to actually fire.
+- **Gap, deliberate:** there is no mechanical CI guard. A `tests/unit/` check cannot see the tag
+  list (`actions/checkout` does not fetch tags by default), and the package version legitimately
+  runs ahead of the changelog between releases, so there is no static invariant to assert. The
+  strongest available fix is a step in `.github/workflows/publish-protocol.yml` that fails the
+  publish when `CHANGELOG.md` has no entry for `github.ref_name`, which would block the bypass
+  outright rather than detecting it later. Not implemented; flagged here so the gap is explicit.
+
+## Scope
+
+`@kangentic/protocol` releases and `packages/protocol/CHANGELOG.md`. The desktop app's own
+`CHANGELOG.md` and `RELEASE_NOTES.md` are `/release`'s concern and are not governed here. The two
+version sequences are deliberately decoupled and must not be synchronized.

--- a/.claude/skills/release-protocol/SKILL.md
+++ b/.claude/skills/release-protocol/SKILL.md
@@ -53,8 +53,25 @@ tag sequences never collide.
 3. **Fetch latest:** Run `git fetch origin main`.
 4. **Verify up-to-date:** Run `git diff HEAD origin/main --stat`. Must be empty. If not, stop with: "Local main is behind origin/main. Run `git pull` first."
 5. **Install dependencies:** Run `npm ci`.
+6. **Verify changelog parity across the whole tag sequence.** This step exists because the
+   sequence has already drifted once: eight versions reached npm with no entry, because the tags
+   were hand-created on feature commits instead of through this skill, and Step 3 only ever
+   prepends the newest entry so it never looked down. See
+   `.claude/rules/protocol-release-parity.md`.
+   - List every tag: `git tag --list "protocol-v*"`.
+   - Grep the entry headers: `Grep` for `^## \[protocol-v` in `packages/protocol/CHANGELOG.md`.
+   - Every tag must have a matching `## [protocol-vX.Y.Z]` entry. A version that was bumped but
+     never tagged is NOT a gap (the changelog entry lands at release time by convention); a
+     tagged version with no entry is.
+   - **Backfill any gap before continuing, do not just report it.** For each missing version,
+     reconstruct the entry from `git log <previousTag>..<thatTag> --oneline --no-decorate --
+     packages/protocol/src` plus the individual commit messages, and insert it in descending
+     order. Fold the backfill into this release's commit in Step 4.
+   - Note that a tag pointing at anything other than a `chore(protocol-release):` commit is the
+     signature of a past bypass, and is the fastest way to spot which releases to check first.
 
-Report the current protocol version, the bump type, and the new version before proceeding.
+Report the current protocol version, the bump type, the new version, and any backfill you
+performed before proceeding.
 
 ## Step 1 -- Validate
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -67,9 +67,20 @@ what it finds. There is no skip and no confirmation prompt here.
    extras, fix stale references. Do not ask the user; do not offer a skip.
 3. **Document every undocumented `feat:` commit** since the previous tag: scan for features not
    covered in `docs/` and write the missing coverage. Unconditional - do not ask.
-4. Stage the changed doc files (e.g. `git add docs/foo.md docs/bar.md`). They ride into the
+4. **Check `@kangentic/protocol` changelog parity.** Desktop releases are frequent and protocol
+   releases are not, so this is the check most likely to catch a protocol release that bypassed
+   `/release-protocol`. It is a read-and-fix check, not a protocol release: never bump, tag, or
+   publish the protocol package from here.
+   - List the tags: `git tag --list "protocol-v*"`.
+   - Grep the entry headers: `Grep` for `^## \[protocol-v` in `packages/protocol/CHANGELOG.md`.
+   - Every tag must have a matching entry. Backfill any that do not, reconstructing each from
+     `git log <previousTag>..<thatTag> --oneline --no-decorate -- packages/protocol/src` and the
+     commit messages, and stage `packages/protocol/CHANGELOG.md` with the other doc files.
+   - A version bumped but never tagged is NOT a gap. See
+     `.claude/rules/protocol-release-parity.md` for why the tag is the line.
+5. Stage the changed doc files (e.g. `git add docs/foo.md docs/bar.md`). They ride into the
    release commit in Step 4.
-5. Report what was fixed: list the changed doc files. A large doc pass folded into the
+6. Report what was fixed: list the changed doc files. A large doc pass folded into the
    version-bump commit is expected and desired - do not treat it as scope creep.
 
 ## Step 2 -- Version Bump

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,6 +339,7 @@ session; rules with one load when you touch matching files. Each rule names its 
 - `cli-features-over-custom-layers.md` - do not shadow an agent CLI's native controls (`src/main/agent/`).
 - `dev-tooling-build-exclusion.md` - dev tooling build-excluded via `__KANGENTIC_DEV__` (`src/devtools/`).
 - `docs-stay-in-sync.md` - update docs when changing anchor source files (types, IPC, migrations, adapters, settings).
+- `protocol-release-parity.md` - every `protocol-v*` tag needs a `CHANGELOG.md` entry; never hand-tag a protocol release (`packages/protocol/`).
 - `skill-authoring.md` - when to fork a skill and how to route agents (`.claude/`).
 - `board-config-parity.md` - team-shared swimlane fields must round-trip to `kangentic.json`.
 - `external-scripts-parity.md` - unbundled bridge/plugin scripts must register in `EXTERNAL_SCRIPTS` and be copied by both `build.js` and `dev.js`.

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -2,6 +2,95 @@
 
 <!-- releases -->
 
+## [protocol-v0.11.1] - 2026-07-26
+
+### Fixes
+- `isSecureRelayAddress` parses the URL authority instead of prefix-matching
+  it (1a6b492f)
+
+  `ws://127.0.0.1:8080@evil.test` returned true. Everything before an '@' in
+  a URL authority is credentials, so that address dials evil.test, and the
+  pairing token IS the Noise PSK, dialed verbatim as the relay's `?slot=`.
+  One crafted QR field therefore put the PSK on the wire in cleartext to an
+  attacker-chosen host, which was then persisted to the trust anchor for
+  every later session. The loopback carve-out is not behind a dev gate, so
+  this applied to production builds. Parsing subsumes the old boundary check
+  (`localhost.evil.com` is simply a different host rather than a prefix
+  needing a special case), and the IPv6 branch rejects trailing garbage
+  after the closing bracket rather than trimming to it.
+
+## [protocol-v0.11.0] - 2026-07-26
+
+All additive; wire `PROTOCOL_VERSION` stays '2'.
+
+### Features
+- project groups on the project listing: `ReadBoardProjectGroup`, optional
+  `groupId` / `position` on `ReadBoardProjectSummary`, and an optional
+  `groups` array on the project-list response (c606221f)
+
+  A malformed group entry is dropped rather than failing the whole listing:
+  the projects are what the phone cannot work without, and grouping degrades
+  to the flat list it rendered before.
+
+## [protocol-v0.10.0] - 2026-07-26
+
+All additive; wire `PROTOCOL_VERSION` stays '2'.
+
+### Features
+- read-board `archived` action: one page of completed tasks, newest first,
+  each carrying its lifetime session summary (4ac99209)
+
+  An action rather than a field on the snapshot, deliberately: a board
+  subscription re-snapshots on every board change and the archive only
+  grows, so folding it in would re-send an ever-larger payload for the life
+  of the connection, the exact cost the 0.9.0 projections were added to
+  remove.
+
+### Fixes
+- the board-profile commands are classified for the phone's capability
+  allowlist (81ac8ee6)
+
+## [protocol-v0.9.0] - 2026-07-24
+
+All additive; wire `PROTOCOL_VERSION` stays '2'.
+
+### Features
+- board projections: the read-board subscribe `view` field
+  ('full' | 'sessions'), the `view` echo and `taskCountsByColumnId` on the
+  snapshot response, and an optional `backlog` (7e9b8986)
+
+  Additive in both directions: a pre-0.9.0 phone sends no `view` and gets
+  the old payload verbatim; a 0.9.0 phone against a pre-0.9.0 desktop gets a
+  full board with no `view` echo, which is exactly how it knows the snapshot
+  was not filtered.
+- pairing: the sealed pairing-confirm frame (`pairing/confirm.ts`,
+  `sealPairingConfirm` / `openPairingConfirm`) and key fingerprints
+  (`roster/fingerprint.ts`, `formatKeyFingerprint`) (2ca5832a)
+
+## [protocol-v0.8.0] - 2026-07-24
+
+All additive; wire `PROTOCOL_VERSION` stays '2'.
+
+### Features
+- the read-stream subscribe `terminal` flag, so a subscriber can opt out of
+  the PTY stream (a5a2c241)
+
+  `event:terminal` streamed continuously to a phone showing no terminal at
+  all (~13MB/hour), because every subscription carried PTY bytes the phone
+  discards by design at its own terminal boundary.
+- the `message-preview` activity payload: the one line a phone's session
+  list renders (cc1ec5f6)
+- optional `since` (epoch ms the session first needed the user) on
+  `ActivityReasonWire`'s idle and permission variants (a187cbdd)
+- `pairing/relay-address.ts`: a dependency-free leaf carrying
+  `MAX_RELAY_ADDRESS_LENGTH` and `isSecureRelayAddress`, so the desktop's
+  relay validator cannot drift from the phone's and the renderer bundle does
+  not pull in the rest of the package's @noble/* crypto (8c608c1e)
+
+### Fixes
+- `get_activity_intervals` is classified as a mobile board-tool read
+  (eed683d8)
+
 ## [protocol-v0.7.0] - 2026-07-20
 
 ### Breaking Changes
@@ -15,6 +104,23 @@
   / MCP's `input_required` rather than Claude-specific naming.
   `RegisterPushRequestPayload` gains an optional `categories` field so a
   device can register only the categories it wants pushed.
+
+## [protocol-v0.6.0] - 2026-07-20
+
+All additive; wire `PROTOCOL_VERSION` stays '2'.
+
+### Features
+- prompt option labels, so the phone can label a pending prompt's answer
+  buttons instead of answering blind: `awaitedPromptOptions?: string[] | null`
+  on the read-stream subscribe snapshot, and `options?: string[]` on the
+  activity event's permission variant (4e126bd3)
+
+  Both carry the prompt dialog's numbered labels in keystroke order
+  (options[0] is answered with "1\r"). Absent or null means unknown, and the
+  phone falls back to its blind approve/deny keystrokes.
+- optional `showTicketNumbers` on the read-board snapshot, so the phone's
+  task cards follow the desktop's Layout setting instead of guessing; absent
+  means true, the desktop default (67c56254)
 
 ## [protocol-v0.5.0] - 2026-07-16
 
@@ -37,6 +143,20 @@ protocol-v0.3.0 (the 0.4.0 terminal-geometry work shipped unpublished).
 ### Fixes
 - `terminal-resize` accepted by the envelope decoder's event validator
   (`validateEvent`), not only `isBridgeEvent`
+
+## [protocol-v0.3.0] - 2026-07-14
+
+### Features
+- chunked delta transcript streaming, windowed history, and compression
+  (68afad59)
+
+## [protocol-v0.2.0] - 2026-07-13
+
+### Features
+- typed feed payloads, board-tool tuples, and read-stream gap fixes
+  (b7accca6)
+- Phase 2 capability handlers, data feeds, and the board-tool surface
+  (8bfa87d1)
 
 ## [protocol-v0.1.1] - 2026-07-10
 


### PR DESCRIPTION
## What

Backfills `packages/protocol/CHANGELOG.md` for eight published versions that never got an entry
(0.2.0, 0.3.0, 0.6.0, 0.8.0, 0.9.0, 0.10.0, 0.11.0, 0.11.1), and adds guards so the gap cannot
silently reopen.

- `packages/protocol/CHANGELOG.md` - the eight missing entries
- `.claude/rules/protocol-release-parity.md` - new rule: a `protocol-v*` tag is a publish, so it
  goes through `/release-protocol` and every tag needs a matching entry
- `.claude/skills/release-protocol/SKILL.md` - pre-flight that verifies parity across the whole tag
  sequence and backfills any gap it finds
- `.claude/skills/release/SKILL.md` - the same parity check on each desktop release
- `CLAUDE.md` - rules index entry

## Why

All eight versions are on npm and tagged, so this is a record-keeping gap rather than unreleased
work. The cause: those tags were created by hand directly on feature and fix commits instead of
through `/release-protocol`, so no `chore(protocol-release)` commit and no changelog entry was ever
written. Nothing detected it because Step 3 of that skill only prepends the newest entry, so it
wrote 0.7.0 on top of a hole and never looked down. It surfaced by accident during the v0.32.0
desktop release, when the package read 0.11.1 and the changelog read 0.7.0.

## How

Each entry is reconstructed from its own tag range and the commit messages, so the wire-surface
claims match what actually shipped. `68afad59`'s subject carries a `(#172)` that is dropped here:
the repo is public and the package is published, so a private board id would render as a link to an
unrelated GitHub issue.

The prevention is layered so a single missed release becomes self-healing rather than a permanent
hole. Desktop releases are frequent and protocol releases are not, so the check added to `/release`
is the one most likely to actually fire.

The rule names its own uncovered gap rather than implying full coverage: there is no mechanical CI
guard, because a unit test cannot see the tag list and the package version legitimately runs ahead
of the changelog between releases. The strongest remaining fix would be a step in
`publish-protocol.yml` that fails the publish when the changelog has no entry for
`github.ref_name`.

## Breaking changes

None. Documentation, a rule, and two skill definitions. No version bump, no tag, no publish, and no
runtime code.

## Tests

No code changes, so no tests were added. Verified by the CI gate on this PR.

This commit was authored earlier on the local `main` checkout and had never run CI. It is routed
through a PR here rather than pushed directly, both to get it that CI run and because it is
substantially more than the one-line hotfix the direct-push escape hatch is for.

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] No em-dashes or `--` used as punctuation
- [ ] Tests added or updated for this change
- [x] Docs updated if anchor source changed (types, IPC channels, migrations, adapters, settings)
- [ ] Ran `npm run lint`, `npm run typecheck`, and the relevant tests locally (no code changes; CI is the verification)
- [ ] Screenshot or clip included (UI changes)
- [x] CLA signed (or will sign on first PR)

Generated with [Claude Code](https://claude.com/claude-code)
