### PR TITLE
fix(monitor): show honest telemetry instead of a fabricated 0% or 'Claude' fallback

### DIFF
--- a/src/main/monitor/monitor-aggregator.ts
+++ b/src/main/monitor/monitor-aggregator.ts
@@ -198,7 +198,14 @@ export function buildMonitorSnapshot(context: IpcContext): MonitorSnapshot {
       // Prefer the agent-reported live model (what the card shows); fall back to
       // the persisted applied model, which is all we have before first output
       // and after exit. Null means "the agent's own default".
-      modelDisplayName: usage?.model.displayName ?? record?.applied_model ?? null,
+      //
+      // `|| undefined` before the `??` chain, not a second `??`: UsageAccumulator
+      // seeds `displayName: ''` (emptyUsage) and status.json can omit
+      // `display_name` (status-parser.ts uses `?? ''`), so an empty string is a
+      // real, reachable value here - and `??` treats '' as present, never falling
+      // through to `applied_model`. `||` is deliberately safe on this field: a
+      // model display name is never legitimately falsy other than ''.
+      modelDisplayName: (usage?.model.displayName || undefined) ?? record?.applied_model ?? null,
       // Prefer the agent-reported live effort (status.json) over the value the
       // session was spawned with, mirroring how model is resolved above.
       effort: usage?.model.effort ?? record?.applied_effort ?? null,

--- a/src/renderer/components/board/ContextUsageFooter.tsx
+++ b/src/renderer/components/board/ContextUsageFooter.tsx
@@ -14,13 +14,23 @@ import { getProgressColor } from '../../utils/progress-color';
  * carries the same clamped value), so this component stays presentational.
  */
 export function ContextUsageFooter({
-  modelName, percent, windowKnown = true, testId = 'usage-bar', className = '', divider = true,
+  modelName, percent, windowKnown = true, unknownLabel, testId = 'usage-bar', className = '', divider = true,
 }: {
   /** Human model name (e.g. "Opus 5"). Never the raw model id - users don't read those. */
   modelName: string;
   percent: number;
   /** False when the agent has not reported a usable context window; the track sits at 0. */
   windowKnown?: boolean;
+  /**
+   * Replaces the percent label with this text when `windowKnown` is false. Omit
+   * to keep printing `{percent}%` regardless, which is the board's behavior:
+   * TaskCard deliberately holds the track at 0% until a known window arrives
+   * (see the comment above its call site), so the label reads as the value of
+   * the track it labels rather than contradicting it. The monitor card has no
+   * such track-matching intent and passes `"-"`, the unknown state
+   * `MonitorTable` already renders for the same null `contextPercent`.
+   */
+  unknownLabel?: string;
   testId?: string;
   className?: string;
   /**
@@ -37,6 +47,7 @@ export function ContextUsageFooter({
   divider?: boolean;
 }) {
   const clamped = Math.min(Math.max(percent, 0), 100);
+  const percentLabel = !windowKnown && unknownLabel != null ? unknownLabel : `${clamped}%`;
   // `pt-2` exists to clear the RULE, so it goes with it. Left in, a divider-less
   // footer sat 16px below the content above it while every other gap on the card
   // is 6-8px, which read as a missing element rather than as breathing room.
@@ -47,9 +58,13 @@ export function ContextUsageFooter({
       data-testid={testId}
       data-context-window={windowKnown ? undefined : 'unknown'}
     >
+      {/* Both halves carry their own testid. The model name and the unknown-window
+          label can render the SAME text ("-"), so an assertion scoped to the whole
+          footer cannot tell which half produced it - which is exactly how a test
+          meant to pin the percent label passes on the model name instead. */}
       <div className="flex items-center justify-between mb-1.5">
-        <span className="text-xs text-fg-faint truncate">{modelName}</span>
-        <span className="text-xs text-fg-faint">{clamped}%</span>
+        <span className="text-xs text-fg-faint truncate" data-testid={`${testId}-model`}>{modelName}</span>
+        <span className="text-xs text-fg-faint" data-testid={`${testId}-percent`}>{percentLabel}</span>
       </div>
       <div className="w-full h-1 bg-surface-hover rounded-full overflow-hidden">
         <div

--- a/src/renderer/components/monitor/MonitorCard.tsx
+++ b/src/renderer/components/monitor/MonitorCard.tsx
@@ -7,7 +7,6 @@ import { PrLink } from '../PrLink';
 import { ElapsedTime } from '../terminal/ElapsedTime';
 import { ContextUsageFooter } from '../board/ContextUsageFooter';
 import { formatActivityReasonText } from '../board/ActivityReasonTooltip';
-import { agentDisplayName } from '../../utils/agent-display-name';
 import { bucketOf, formatMonitorStatus, needsUser } from './monitor-view-model';
 
 /**
@@ -315,10 +314,16 @@ function MonitorCardInner({
           card with no label pills the well's bottom edge and the rule land within
           a few pixels of each other. The board card keeps the rule, having no
           well of its own to do that job. */}
+      {/* `'-'` on an unresolved model, matching MonitorTable's Model column for the
+          same null. This slot names the MODEL; the table surfaces the agent in a
+          separate Agent column, which the card has no room for. If agent identity
+          is ever wanted here, the helper documented for a model-slot fallback is
+          `agentShortName` ("Claude"), not `agentDisplayName` ("Claude Code"). */}
       <ContextUsageFooter
-        modelName={row.modelDisplayName ?? agentDisplayName(row.agentName)}
+        modelName={row.modelDisplayName ?? '-'}
         percent={row.contextPercent ?? 0}
         windowKnown={row.contextPercent !== null}
+        unknownLabel="-"
         divider={false}
         testId="monitor-card-usage"
       />

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2162,7 +2162,8 @@ export interface MonitorSessionRow {
   prState: PRState | null;
   /** Adapter name captured at spawn (e.g. "claude"). Null for a pre-adapter session. */
   agentName: string | null;
-  /** The model the session was actually spawned/resumed/switched with. Null = agent default. */
+  /** The agent-reported live model when available, else the model the session was
+   *  spawned/resumed/switched with. Null = agent default with no live report yet. */
   modelDisplayName: string | null;
   /** Reasoning effort the session was actually spawned/resumed/switched with
    *  (`applied_effort`). Null = the agent's own default, or an agent with no

--- a/tests/ui/agent-monitor.spec.ts
+++ b/tests/ui/agent-monitor.spec.ts
@@ -423,6 +423,65 @@ test.describe('agent monitor', () => {
     }
   });
 
+  test('an unknown context window reads "-", never a fabricated 0%', async () => {
+    // sess-other-project, sess-paused, and sess-command-terminal all carry
+    // contextPercent: null (no status.json has arrived for them yet). Before
+    // this fix MonitorCard passed `percent={row.contextPercent ?? 0}` straight
+    // through, so ContextUsageFooter printed a confident "0%" for a value it
+    // never actually had - indistinguishable from a session that is genuinely
+    // empty. sess-working's known, nonzero window (62%) proves the known path
+    // is untouched.
+    //
+    // Scoped to the percent span (`monitor-card-usage-percent`), not the whole
+    // footer: the model-name span can independently render "-" (sess-paused
+    // has no modelDisplayName), so an assertion against the footer as a whole
+    // is satisfied by either half and does not actually pin the percent label.
+    const { browser, page } = await launchWithState(monitorPreConfig());
+    try {
+      await openMonitor(page);
+
+      const unknownIds = ['sess-other-project', 'sess-paused', 'sess-command-terminal'];
+      for (const id of unknownIds) {
+        const footer = page.locator(`[data-session-id="${id}"] [data-testid="monitor-card-usage"]`);
+        const percentLabel = footer.locator('[data-testid="monitor-card-usage-percent"]');
+        await expect(percentLabel).toHaveText('-');
+        await expect(footer).toHaveAttribute('data-context-window', 'unknown');
+      }
+
+      const knownFooter = page.locator('[data-session-id="sess-working"] [data-testid="monitor-card-usage"]');
+      await expect(knownFooter.locator('[data-testid="monitor-card-usage-percent"]')).toHaveText('62%');
+      await expect(knownFooter).not.toHaveAttribute('data-context-window', 'unknown');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('the footer model name falls back to a bare "-", never a derived agent display name', async () => {
+    // Guard against `modelName={row.modelDisplayName ?? agentDisplayName(row.agentName)}`
+    // returning: sess-paused has modelDisplayName: null and agentName: 'claude', so that
+    // older fallback rendered "Claude Code" (agent-display-name.ts) instead of the flat "-"
+    // MonitorCard now passes for an unresolved model. sess-working's known model name
+    // ("Opus 5") is asserted alongside it so the test cannot pass vacuously against an
+    // always-"-" implementation.
+    const { browser, page } = await launchWithState(monitorPreConfig());
+    try {
+      await openMonitor(page);
+
+      const pausedModel = page.locator(
+        '[data-session-id="sess-paused"] [data-testid="monitor-card-usage-model"]',
+      );
+      await expect(pausedModel).toHaveText('-');
+      await expect(pausedModel).not.toHaveText('Claude Code');
+
+      const workingModel = page.locator(
+        '[data-session-id="sess-working"] [data-testid="monitor-card-usage-model"]',
+      );
+      await expect(workingModel).toHaveText('Opus 5');
+    } finally {
+      await browser.close();
+    }
+  });
+
   test('opens from the keybinding and closes via X and Escape', async () => {
     const { browser, page } = await launchWithState(monitorPreConfig());
     try {

--- a/tests/ui/task-card-context-window.spec.ts
+++ b/tests/ui/task-card-context-window.spec.ts
@@ -237,4 +237,38 @@ test.describe('TaskCard context-window render gate', () => {
       await browser.close();
     }
   });
+
+  test('unknown window (contextWindowSize: 0) still prints "0%", never a fabricated dash', async () => {
+    // TaskCard's ContextUsageFooter call omits `unknownLabel` deliberately (see
+    // the comment above its call site in TaskCard.tsx): the track is held at
+    // 0% rather than swapped for a placeholder, because a resized label would
+    // trip dnd-kit's per-card ResizeObserver re-measure mid-drag. This is the
+    // call-site half of that contract - ContextUsageFooter's own unit tests
+    // (tests/unit/context-usage-footer.test.ts) prove the component honors an
+    // omitted `unknownLabel`, but only reading TaskCard's actual props here
+    // proves TaskCard still omits it. contextWindowDisplayPercent(0, 0, 0)
+    // (src/renderer/utils/format-tokens.ts) returns 0 for an unknown window,
+    // so "0%" is the function's contract, not a value copied from a run.
+    const { browser, page } = await launchWithState(makePreConfig({
+      usedPercentage: 0,
+      usedTokens: 0,
+      cacheTokens: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      contextWindowSize: 0,
+    }));
+    try {
+      await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+      const usageBar = page.locator(`[data-task-id="${TASK_ID}"] [data-testid="usage-bar"]`);
+      await expect(usageBar).toBeVisible({ timeout: 10000 });
+
+      const percentLabel = usageBar.locator('[data-testid="usage-bar-percent"]');
+      await expect(percentLabel).toHaveText('0%');
+      await expect(percentLabel).not.toHaveText('-');
+      await expect(usageBar).toHaveAttribute('data-context-window', 'unknown');
+    } finally {
+      await browser.close();
+    }
+  });
 });

--- a/tests/unit/context-usage-footer.test.ts
+++ b/tests/unit/context-usage-footer.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit coverage for `ContextUsageFooter`'s `unknownLabel` prop, in isolation
+ * from both consumers (TaskCard, MonitorCard). `ContextUsageFooter` is a
+ * hookless function component, so - following the established pattern in
+ * `panel-error-boundary.test.ts` / `dialog-form-primitives.test.ts` /
+ * `activity-mark-render.test.ts` (this project's vitest config has no jsdom
+ * environment and no @testing-library/react dependency) - it is called
+ * directly as a plain function and its real `React.createElement` output
+ * (`{ type, props }`) is walked without a renderer.
+ *
+ * What this closes: the component itself declares two behaviors in its own
+ * JSDoc - (1) omitting `unknownLabel` keeps printing `{percent}%` even when
+ * the window is unknown (the board's TaskCard behavior, load-bearing for
+ * dnd-kit's per-card ResizeObserver re-measure during drag - see the comment
+ * above TaskCard's call site), and (2) `unknownLabel` only replaces the label
+ * when `windowKnown` is false (a known window's real percentage must never be
+ * swapped for the placeholder). Neither was asserted against the component
+ * directly before this file - only indirectly, through MonitorCard
+ * (tests/ui/agent-monitor.spec.ts), which passes `unknownLabel="-"` on every
+ * case and so cannot prove the omitted-prop default.
+ *
+ * The call-site question - does TaskCard actually omit `unknownLabel`? - is a
+ * different risk (this file passing does not stop a future TaskCard edit from
+ * adding the prop) and is covered separately by a case added to
+ * tests/ui/task-card-context-window.spec.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { ContextUsageFooter } from '../../src/renderer/components/board/ContextUsageFooter';
+
+interface ElementLike {
+  type: unknown;
+  props: Record<string, unknown>;
+}
+
+function isElementLike(node: unknown): node is ElementLike {
+  return typeof node === 'object' && node !== null && 'props' in node;
+}
+
+function collectText(node: unknown): string {
+  if (node === null || node === undefined || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join('');
+  if (isElementLike(node)) return collectText(node.props.children);
+  return '';
+}
+
+/** Depth-first search for the first element whose data-testid === testId. */
+function findByTestId(node: unknown, testId: string): ElementLike | null {
+  if (node === null || node === undefined || typeof node === 'boolean') return null;
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findByTestId(child, testId);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (isElementLike(node)) {
+    if (node.props['data-testid'] === testId) return node;
+    return findByTestId(node.props.children, testId);
+  }
+  return null;
+}
+
+describe('ContextUsageFooter unknownLabel', () => {
+  it('keeps printing the percent when unknownLabel is omitted, even with an unknown window (the board default)', () => {
+    const output = ContextUsageFooter({
+      modelName: 'Opus 5',
+      percent: 0,
+      windowKnown: false,
+      testId: 'usage-bar',
+    });
+    const percentSpan = findByTestId(output, 'usage-bar-percent');
+    if (!percentSpan) throw new Error('expected a usage-bar-percent span in the output');
+
+    expect(collectText(percentSpan)).toBe('0%');
+  });
+
+  it('replaces the percent label with unknownLabel when the window is unknown', () => {
+    const output = ContextUsageFooter({
+      modelName: 'Claude',
+      percent: 0,
+      windowKnown: false,
+      unknownLabel: '-',
+      testId: 'usage-bar',
+    });
+    const percentSpan = findByTestId(output, 'usage-bar-percent');
+    if (!percentSpan) throw new Error('expected a usage-bar-percent span in the output');
+
+    expect(collectText(percentSpan)).toBe('-');
+  });
+
+  it('ignores unknownLabel when the window IS known, never masking a real percentage', () => {
+    const output = ContextUsageFooter({
+      modelName: 'Opus 5',
+      percent: 62,
+      windowKnown: true,
+      unknownLabel: '-',
+      testId: 'usage-bar',
+    });
+    const percentSpan = findByTestId(output, 'usage-bar-percent');
+    if (!percentSpan) throw new Error('expected a usage-bar-percent span in the output');
+
+    expect(collectText(percentSpan)).toBe('62%');
+  });
+
+  it('sets data-context-window to the literal string "unknown" only when windowKnown is false', () => {
+    const knownOutput = ContextUsageFooter({ modelName: 'Opus 5', percent: 10, windowKnown: true });
+    if (!isElementLike(knownOutput)) throw new Error('ContextUsageFooter did not return an element');
+    // Not merely falsy/absent-looking: this is `undefined` in the React prop
+    // graph pre-DOM-serialization (same trap activity-mark-render.test.ts
+    // documents for `aria-hidden`), so assert the exact value.
+    expect(knownOutput.props['data-context-window']).toBeUndefined();
+
+    const unknownOutput = ContextUsageFooter({ modelName: 'Opus 5', percent: 10, windowKnown: false });
+    if (!isElementLike(unknownOutput)) throw new Error('ContextUsageFooter did not return an element');
+    expect(unknownOutput.props['data-context-window']).toBe('unknown');
+  });
+});

--- a/tests/unit/monitor-aggregator.test.ts
+++ b/tests/unit/monitor-aggregator.test.ts
@@ -247,6 +247,7 @@ function registerSessionRecord(projectId: string, sessionId: string, record: Fak
 function makeContext(
   summaries: ManagedSessionSummary[],
   eventsBySessionId: Record<string, SessionEvent[]> = {},
+  usageBySessionId: Record<string, SessionUsage> = {},
 ): IpcContext {
   return {
     projectRepo: {
@@ -257,7 +258,7 @@ function makeContext(
       getActivityCache: vi.fn((): Record<string, ActivityState> => ({})),
       getActivityReasonsCache: vi.fn((): Record<string, ActivityReason> => ({})),
       getEventsCache: vi.fn((): Record<string, SessionEvent[]> => eventsBySessionId),
-      getUsageCache: vi.fn((): Record<string, SessionUsage> => ({})),
+      getUsageCache: vi.fn((): Record<string, SessionUsage> => usageBySessionId),
       // The peek is read per session while building a row. Stubbed empty here;
       // the extraction rule itself is covered against captured real grids in
       // tests/unit/output-peek.test.ts. Without this the aggregator's per-session
@@ -285,6 +286,27 @@ function makeFullSessionEvent(overrides: Partial<SessionEvent> & Pick<SessionEve
     inputTokens: 512,
     outputTokens: 128,
     ...overrides,
+  };
+}
+
+/** A SessionUsage fixture with every required field, so a test only has to
+ *  override what it is exercising (usually contextWindow and/or model). */
+function makeSessionUsage(overrides: {
+  contextWindow?: Partial<SessionUsage['contextWindow']>;
+  model?: Partial<SessionUsage['model']>;
+} = {}): SessionUsage {
+  return {
+    contextWindow: {
+      usedPercentage: 0,
+      usedTokens: 0,
+      cacheTokens: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      contextWindowSize: 0,
+      ...overrides.contextWindow,
+    },
+    cost: { totalCostUsd: 0, totalDurationMs: 0 },
+    model: { id: '', displayName: '', ...overrides.model },
   };
 }
 
@@ -569,6 +591,192 @@ describe('buildMonitorSnapshot', () => {
     const generatedAtMs = Date.parse(snapshot.generatedAt);
     expect(generatedAtMs).toBeGreaterThanOrEqual(before);
     expect(generatedAtMs).toBeLessThanOrEqual(after);
+  });
+
+  // =========================================================================
+  // modelDisplayName (live telemetry vs the persisted applied_model fallback)
+  // =========================================================================
+
+  describe('modelDisplayName', () => {
+    it('falls back to applied_model when the usage cache has no entry for the session', () => {
+      registerHealthyProject('project-a', { tasksById: new Map([['task-a', makeTask('task-a')]]) });
+      registerSessionRecord('project-a', 'session-a', {
+        exited_at: null,
+        applied_model: 'claude-opus-4-8',
+        applied_effort: null,
+        permission_mode: null,
+      });
+      const context = makeContext([
+        makeManagedSummary({ id: 'session-a', projectId: 'project-a', taskId: 'task-a' }),
+      ]);
+
+      const snapshot = buildMonitorSnapshot(context);
+
+      expect(snapshot.rows[0].modelDisplayName).toBe('claude-opus-4-8');
+    });
+
+    it('falls back to applied_model when the cached usage carries an empty displayName', () => {
+      // UsageAccumulator.emptyUsage() seeds displayName: '', and status.json can
+      // omit display_name (status-parser.ts uses `?? ''`), so an empty string is
+      // a real, reachable value here - not just an absent one. `??` alone treats
+      // '' as present and never falls through, which is the bug this covers.
+      registerHealthyProject('project-a', { tasksById: new Map([['task-a', makeTask('task-a')]]) });
+      registerSessionRecord('project-a', 'session-a', {
+        exited_at: null,
+        applied_model: 'claude-opus-4-8',
+        applied_effort: null,
+        permission_mode: null,
+      });
+      const context = makeContext(
+        [makeManagedSummary({ id: 'session-a', projectId: 'project-a', taskId: 'task-a' })],
+        {},
+        { 'session-a': makeSessionUsage({ model: { displayName: '' } }) },
+      );
+
+      const snapshot = buildMonitorSnapshot(context);
+
+      expect(snapshot.rows[0].modelDisplayName).toBe('claude-opus-4-8');
+    });
+
+    it('prefers a nonempty live displayName over applied_model', () => {
+      registerHealthyProject('project-a', { tasksById: new Map([['task-a', makeTask('task-a')]]) });
+      registerSessionRecord('project-a', 'session-a', {
+        exited_at: null,
+        applied_model: 'claude-opus-4-8',
+        applied_effort: null,
+        permission_mode: null,
+      });
+      const context = makeContext(
+        [makeManagedSummary({ id: 'session-a', projectId: 'project-a', taskId: 'task-a' })],
+        {},
+        { 'session-a': makeSessionUsage({ model: { displayName: 'Haiku 4.5' } }) },
+      );
+
+      const snapshot = buildMonitorSnapshot(context);
+
+      expect(snapshot.rows[0].modelDisplayName).toBe('Haiku 4.5');
+    });
+
+    it('is null when neither live usage nor applied_model has a value', () => {
+      registerHealthyProject('project-a', { tasksById: new Map([['task-a', makeTask('task-a')]]) });
+      const context = makeContext([
+        makeManagedSummary({ id: 'session-a', projectId: 'project-a', taskId: 'task-a' }),
+      ]);
+
+      const snapshot = buildMonitorSnapshot(context);
+
+      expect(snapshot.rows[0].modelDisplayName).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // contextPercent (resolveContextPercent, exercised through the built row)
+  // =========================================================================
+
+  describe('contextPercent', () => {
+    it('is null when the session has no cached usage at all', () => {
+      registerHealthyProject('project-a', { tasksById: new Map([['task-a', makeTask('task-a')]]) });
+      const context = makeContext([
+        makeManagedSummary({ id: 'session-a', projectId: 'project-a', taskId: 'task-a' }),
+      ]);
+
+      const snapshot = buildMonitorSnapshot(context);
+
+      expect(snapshot.rows[0].contextPercent).toBeNull();
+    });
+
+    it('is null when the window size is unknown (the transcript-fallback sentinel)', () => {
+      registerHealthyProject('project-a', { tasksById: new Map([['task-a', makeTask('task-a')]]) });
+      const context = makeContext(
+        [makeManagedSummary({ id: 'session-a', projectId: 'project-a', taskId: 'task-a' })],
+        {},
+        {
+          'session-a': makeSessionUsage({
+            contextWindow: { contextWindowSize: 0, usedPercentage: 0 },
+          }),
+        },
+      );
+
+      const snapshot = buildMonitorSnapshot(context);
+
+      expect(snapshot.rows[0].contextPercent).toBeNull();
+    });
+
+    it('is 0, not null, for a genuinely empty session with a KNOWN window', () => {
+      // Distinguishes "no usage yet" (null, renders "-") from "usage confirmed
+      // empty" (0, renders "0%") - a real zero must not collapse into the
+      // unknown-window display path.
+      registerHealthyProject('project-a', { tasksById: new Map([['task-a', makeTask('task-a')]]) });
+      const context = makeContext(
+        [makeManagedSummary({ id: 'session-a', projectId: 'project-a', taskId: 'task-a' })],
+        {},
+        {
+          'session-a': makeSessionUsage({
+            contextWindow: { contextWindowSize: 1000000, usedPercentage: 0 },
+          }),
+        },
+      );
+
+      const snapshot = buildMonitorSnapshot(context);
+
+      expect(snapshot.rows[0].contextPercent).toBe(0);
+    });
+
+    it('rounds a known window/percentage', () => {
+      registerHealthyProject('project-a', { tasksById: new Map([['task-a', makeTask('task-a')]]) });
+      const context = makeContext(
+        [makeManagedSummary({ id: 'session-a', projectId: 'project-a', taskId: 'task-a' })],
+        {},
+        {
+          'session-a': makeSessionUsage({
+            contextWindow: { contextWindowSize: 200000, usedPercentage: 61.6 },
+          }),
+        },
+      );
+
+      const snapshot = buildMonitorSnapshot(context);
+
+      expect(snapshot.rows[0].contextPercent).toBe(62);
+    });
+
+    it('clamps an over-budget percentage to 100', () => {
+      // Genuinely reachable, not a defensive-only branch: usage-accumulator's
+      // over-budget pairing path (src/main/activity-engine/usage-accumulator.ts)
+      // computes usedPercentage from usedTokens / knownWindow with no upper
+      // clamp of its own, so a session that has burned past its reported window
+      // arrives here above 100.
+      registerHealthyProject('project-a', { tasksById: new Map([['task-a', makeTask('task-a')]]) });
+      const context = makeContext(
+        [makeManagedSummary({ id: 'session-a', projectId: 'project-a', taskId: 'task-a' })],
+        {},
+        {
+          'session-a': makeSessionUsage({
+            contextWindow: { contextWindowSize: 200000, usedPercentage: 143.2 },
+          }),
+        },
+      );
+
+      const snapshot = buildMonitorSnapshot(context);
+
+      expect(snapshot.rows[0].contextPercent).toBe(100);
+    });
+
+    it('clamps a negative percentage to 0', () => {
+      registerHealthyProject('project-a', { tasksById: new Map([['task-a', makeTask('task-a')]]) });
+      const context = makeContext(
+        [makeManagedSummary({ id: 'session-a', projectId: 'project-a', taskId: 'task-a' })],
+        {},
+        {
+          'session-a': makeSessionUsage({
+            contextWindow: { contextWindowSize: 200000, usedPercentage: -4 },
+          }),
+        },
+      );
+
+      const snapshot = buildMonitorSnapshot(context);
+
+      expect(snapshot.rows[0].contextPercent).toBe(0);
+    });
   });
 
   // =========================================================================


### PR DESCRIPTION
## What

The Agent Monitor card showed a fabricated `0%` context reading (indistinguishable from a
session that is genuinely empty) and, when no model was known at all, printed the agent name
("Claude") in the model slot instead of anything model-shaped. `MonitorTable` already rendered
`-` for the same null `contextPercent`; the card view disagreed with it.

- `ContextUsageFooter` (shared between the board's `TaskCard` and the Agent Monitor's
  `MonitorCard`) gains an opt-in `unknownLabel` prop. When the context window is unknown and
  `unknownLabel` is set, it replaces the `{percent}%` label.
- `MonitorCard` passes `unknownLabel="-"` (matching `MonitorTable`) and no longer substitutes
  the agent name for an unknown model - it falls back to `-` instead.
- `monitor-aggregator.ts`'s `modelDisplayName` resolution closed an empty-string hole:
  `UsageAccumulator.emptyUsage()` seeds `displayName: ''`, which `??` treats as present, so the
  fallback to the persisted `applied_model` was permanently dead once any usage entry existed.

## Why

Filed as task #476: a single Agent Monitor screen could show `Haiku` on one card and
`Haiku 4.5` on another for the same underlying model, alongside a confident `0%` on an
unvisited session.

Investigation found this is two separate issues with different fixability, not "one bug, two
symptoms" as originally framed:

- **The model-name mismatch needs no code change.** Claude's transcript-fallback telemetry
  (`session-history-parser.ts`, tails the session's native JSONL regardless of whether the TUI
  ever paints) already converges the spawn-seeded name to the confirmed one with no renderer
  gating. Confirmed empirically: zero bare-alias model names (`haiku`) across 1026 status.json
  files and the sessions table on the dogfooding instance - every session that used `--model`
  passed a full id. `Haiku` and `Haiku 4.5` side by side were the same model at two points in
  one convergence.
- **The `0%` is a real, fixable display defect.** `resolveContextPercent` already correctly
  returns `null` for "no usable window"; `MonitorCard` threw that signal away with
  `percent={row.contextPercent ?? 0}` while `windowKnown={false}` sat inert as a data attribute
  only.

## How

Reused the existing `windowKnown` prop on the shared footer rather than adding a second flag.
The board's `TaskCard` default (a stable `0%`) is untouched and still passes nothing for
`unknownLabel` - it needs the fixed footer height for dnd-kit's mid-drag re-measure, which is
why the monitor's fix is a new opt-in prop rather than a change to the shared default.

## Breaking changes

None.

## Tests

- `tests/unit/monitor-aggregator.test.ts` - new `modelDisplayName` and `contextPercent`
  `describe` blocks (8 tests), including the empty-string fallthrough and the "0 with a known
  window vs null with an unknown one" distinction.
- `tests/ui/agent-monitor.spec.ts` - asserts the unknown-window rows render `-` (never `0%`)
  with `data-context-window="unknown"`, a known row keeps `62%`, and the model-name fallback is
  a bare `-`, never the agent name.
- `tests/unit/context-usage-footer.test.ts` (new) - the `unknownLabel` prop's own contract in
  isolation.
- `tests/ui/task-card-context-window.spec.ts` - a real board `TaskCard` with an unknown window
  still prints `0%`, proving the shared default is unchanged.

CI: typecheck, lint, unit, UI, and the sharded Electron E2E checks on this PR.

Generated with [Claude Code](https://claude.com/claude-code)
