### PR TITLE
fix(pty): default Claude's full-repaint flag for Windows spawns

### DIFF
--- a/docs/adapter-session-history.md
+++ b/docs/adapter-session-history.md
@@ -319,8 +319,10 @@ The actual root cause of the #255 bug was unrelated to a missing transcript: whe
 launched from inside a Claude Code session it leaked `CLAUDE_CODE_*` markers into spawned agents,
 so a Claude spawned with `--session-id <id>` never persisted a transcript under that id and the
 later `--resume` found nothing. The cure was `buildSpawnEnv` stripping `CLAUDECODE` plus every
-`CLAUDE_CODE_*` marker (`src/main/pty/spawn/pty-spawn.ts`, commit `4b236593`), which makes every
-spawned Claude a clean top-level session that persists its own resumable transcript. With that in
+`CLAUDE_CODE_*` identity marker (`src/main/pty/spawn/pty-spawn.ts`, commit `4b236593`; the sole
+exception is the keeplisted `CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT` renderer flag, which carries no
+session identity), which makes every spawned Claude a clean top-level session that persists its
+own resumable transcript. With that in
 place the resume target reliably exists, so the presence guard earns nothing and was dropped.
 
 The non-Claude agents never exhibited an analogous missing-resume-target failure: each captures

--- a/src/main/pty/spawn/pty-spawn.ts
+++ b/src/main/pty/spawn/pty-spawn.ts
@@ -54,19 +54,47 @@ export function resolveShellArgs(shell: string): ShellInvocation {
  * is lost on a Done -> back round-trip. (Clearing `CLAUDECODE` alone, the prior
  * behavior, only stopped the child from refusing to start.) A Kangentic-spawned
  * agent must always be a clean top-level session, so drop every `CLAUDE_CODE_*`
- * marker. This is the documented practice for tools that spawn the Claude CLI as
- * a subprocess; it is harmless for non-Claude agents, which ignore these vars,
- * and it deliberately leaves `ANTHROPIC_*` keys (BYOK / API auth) untouched.
+ * marker except the keeplisted tuning flag below. This is the documented
+ * practice for tools that spawn the Claude CLI as a subprocess; it is harmless
+ * for non-Claude agents, which ignore these vars, and it deliberately leaves
+ * `ANTHROPIC_*` keys (BYOK / API auth) untouched.
+ *
+ * `platform` is injectable for tests (cross-platform parity); production
+ * callers omit it.
  */
+
+/**
+ * The one `CLAUDE_CODE_*` key that survives the strip, and its Windows
+ * default. Unlike the identity markers above, this is a renderer tuning flag:
+ * it cannot re-parent a child session. Claude Code's fullscreen TUI
+ * intermittently omits history entries from its incremental scrolled-view
+ * updates (deep scroll up, ride back down: entries vanish with the layout
+ * closed up until a re-anchor - anthropics/claude-code#83714, confirmed
+ * producer-side by diffing the raw PTY stream). Full-frame repaints remove
+ * the incremental-update path entirely, and Claude Code's own agent views
+ * enable this automatically on Windows. Defaulted on win32 only, matching
+ * that practice; an explicit value already in the environment (including a
+ * user's opt-out) always wins, and non-Claude agents ignore the var, the
+ * same argument the strip itself relies on. PARTIAL mitigation: it removes
+ * the dominant closed-up flavor, while the rarer blank-band flavor (a
+ * window-assembly defect upstream) persists. Unwind this default once the
+ * upstream issue is fixed.
+ */
+export const FULL_REPAINT_ENV_KEY = 'CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT';
+
 export function buildSpawnEnv(
   inputEnv: Record<string, string> | undefined,
+  platform: NodeJS.Platform = process.platform,
 ): Record<string, string> {
   const merged = { ...process.env, ...inputEnv };
   const result: Record<string, string> = {};
   for (const [key, value] of Object.entries(merged)) {
     if (value === undefined) continue;
-    if (key === 'CLAUDECODE' || key.startsWith('CLAUDE_CODE_')) continue;
+    if (key === 'CLAUDECODE' || (key.startsWith('CLAUDE_CODE_') && key !== FULL_REPAINT_ENV_KEY)) continue;
     result[key] = value;
+  }
+  if (platform === 'win32' && result[FULL_REPAINT_ENV_KEY] === undefined) {
+    result[FULL_REPAINT_ENV_KEY] = '1';
   }
   return result;
 }

--- a/tests/unit/pty-spawn.test.ts
+++ b/tests/unit/pty-spawn.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import os from 'node:os';
 import fs from 'node:fs';
 
@@ -12,6 +12,7 @@ import {
   buildSpawnEnv,
   resolveSpawnCwd,
   diagnoseSpawnFailure,
+  FULL_REPAINT_ENV_KEY,
 } from '../../src/main/pty/spawn/pty-spawn';
 
 describe('resolveShellArgs', () => {
@@ -87,6 +88,56 @@ describe('buildSpawnEnv', () => {
   it('handles undefined input', () => {
     const env = buildSpawnEnv(undefined);
     expect(env.CLAUDECODE).toBeUndefined();
+  });
+});
+
+// Claude Code's fullscreen TUI intermittently omits history entries from its
+// incremental scrolled-view updates (anthropics/claude-code#83714). The
+// full-repaint flag removes the incremental path; Kangentic defaults it on
+// for Windows spawns, matching Claude Code's own agent-view practice. These
+// pin the keeplist so the identity-marker strip cannot silently swallow it,
+// and the default so a refactor cannot silently widen or drop it.
+describe('buildSpawnEnv full-repaint keeplist', () => {
+  let savedHostValue: string | undefined;
+
+  beforeEach(() => {
+    // Hermetic: the host machine may legitimately export the flag globally.
+    savedHostValue = process.env[FULL_REPAINT_ENV_KEY];
+    delete process.env[FULL_REPAINT_ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (savedHostValue === undefined) delete process.env[FULL_REPAINT_ENV_KEY];
+    else process.env[FULL_REPAINT_ENV_KEY] = savedHostValue;
+  });
+
+  it('defaults the flag on for win32 spawns', () => {
+    const env = buildSpawnEnv({}, 'win32');
+    expect(env[FULL_REPAINT_ENV_KEY]).toBe('1');
+  });
+
+  it('does NOT default it on non-Windows platforms', () => {
+    const env = buildSpawnEnv({}, 'linux');
+    expect(env[FULL_REPAINT_ENV_KEY]).toBeUndefined();
+  });
+
+  it('keeps an explicit value over the default (user opt-out wins)', () => {
+    const env = buildSpawnEnv({ [FULL_REPAINT_ENV_KEY]: '0' }, 'win32');
+    expect(env[FULL_REPAINT_ENV_KEY]).toBe('0');
+  });
+
+  it('keeplists the flag through the strip while identity markers still drop', () => {
+    const env = buildSpawnEnv(
+      {
+        [FULL_REPAINT_ENV_KEY]: '1',
+        CLAUDECODE: '1',
+        CLAUDE_CODE_SESSION_ID: 'parent-session-uuid',
+      },
+      'linux',
+    );
+    expect(env[FULL_REPAINT_ENV_KEY]).toBe('1');
+    expect(env.CLAUDECODE).toBeUndefined();
+    expect(env.CLAUDE_CODE_SESSION_ID).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## What

Keeplists `CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT` through `buildSpawnEnv`'s `CLAUDE_CODE_*` identity strip and defaults it to `1` on Windows, at the single spawn chokepoint so every path is covered: agent spawns, resumes, and Command Terminals. Adds an injectable `platform` parameter (the `resolveSpawnCwd` pattern) so the default is testable cross-platform, four pinning unit tests, and a one-line doc correction in `docs/adapter-session-history.md`.

## Why

Claude Code's fullscreen TUI intermittently omits history entries when the user scrolls far up past the history and rides back down: incremental scrolled-view updates seam neighbors together over missing entries (the dominant, most misleading flavor), and a rarer window-assembly defect leaves blank bands. Reported upstream with the full evidence chain as anthropics/claude-code#83714, confirmed producer-side on both v2.1.220 and v2.1.221 by diffing the raw PTY stream against the rendered frame at frozen reproductions.

`CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT=1` makes the CLI repaint the whole screen every frame instead of diffing, removing the incremental-update failure layer entirely. Claude Code enables the same flag for its own agent views on Windows; this applies that practice to the sessions Kangentic hosts.

## How

- The strip's wildcard now carries a single named exception. The flag is a renderer tuning value with no session identity, so the #255 resume protection (the reason the wildcard exists) is unaffected; the four identity markers are still dropped, pinned by tests.
- The default applies only when the environment does not already carry a value, so an explicit user setting (including `0` to opt out) always wins.
- win32-only, matching Claude Code's own selective enablement; CI and other platforms see no change.
- This is a PARTIAL mitigation by design: the blank-band flavor is an upstream window-assembly defect that no repaint mode can mask. The code comment carries the unwind note for when the upstream issue is fixed.

## Breaking changes

None. Users who already export the flag keep their value; setting `CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT=0` restores the previous behavior.

## Tests

- `tests/unit/pty-spawn.test.ts`: four new tests pin the win32 default, the non-Windows absence, the explicit-value opt-out, and that the identity-marker strip still drops everything else (38/38 green locally, typecheck and lint clean).
- Validated live on the dogfooding instance: the previously ~1-in-5-passes closed-up repro stopped reproducing with the flag active; the residual blank-band flavor is documented upstream (anthropics/claude-code#83714, validation comment). Throughput cost measured negligible (a 60-notch scroll burst produces ~71KB against a 256KB/16ms flush budget).

Generated with [Claude Code](https://claude.com/claude-code)
