### PR TITLE
fix(terminal): heal PTY/xterm width drift with a dims echo and owner re-assert

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -177,7 +177,7 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 | `transition:set` | invoke | Set action chain for lane A→B |
 | `transition:getFor` | invoke | Get transitions for lane pair (exact match, then wildcard) |
 
-### Sessions (36 channels)
+### Sessions (37 channels)
 | Channel | Pattern | Purpose |
 |---------|---------|---------|
 | `session:spawn` | invoke | Spawn PTY session (may queue) |
@@ -203,6 +203,7 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 | `session:notifyUserInterrupt` | invoke | Notify telemetry of a user Ctrl+C; arms the 3-second settle timer that synthesizes Interrupted if hooks don't recover |
 | `session:data` | on | Terminal output available (includes `projectId`) |
 | `session:drainAck` | send | Renderer-to-main flow-control ack for per-session PTY backpressure; fire-and-forget (no projectId) |
+| `session:ptyResized` | on | The PTY's grid actually changed (`cols`, `rows`, `PtyResizeOrigin`). Broadcast to every window; the mounted owner xterm uses it to detect and heal a width divergence (xterm re-sends dims only when its own size changes) |
 | `session:firstOutput` | on | Alternate screen buffer detected - TUI ready (includes `projectId`) |
 | `session:exit` | on | Session exited (includes `projectId`) |
 | `session:status` | on | Session changed - pushes full `Session` object (includes `projectId`) |

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -407,6 +407,45 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   `tests/unit/mobile-bridge/read-stream.test.ts`, the change-hook test in
   `tests/unit/mobile-bridge/subscription-registry.test.ts`, and `panelTerminalSessionIdFor` in
   `tests/unit/focused-sessions.test.ts`.
+- **The width-drift self-heal (PTY dims echo + owner re-assert).** xterm re-sends its dimensions
+  only when its OWN size changes, so a PTY reshaped under a mounted xterm (a lost or overridden
+  resize on a surface flip, a respawn at stashed dims, any last-writer-wins race - `resize()`
+  carries no surface identity) used to diverge with NO recovery path: with the Windows
+  full-repaint flag every frame is absolute-positioned at the PTY width, so the mounted grid
+  rendered a staircase (rows shifted progressively right, labels clipped) until the window was
+  resized by hand. Main now broadcasts `session:ptyResized` (`SESSION_PTY_RESIZED`) whenever the
+  PTY's grid ACTUALLY changes - the same-dims short-circuit runs first, so the echo of a
+  terminal's own resize always carries its own dims - with the resize's origin
+  (`PtyResizeOrigin`: `desktop`/`mobile`/`park`/`spawn`). It is a broadcast, not a focus-routed
+  push: a freshly mounted xterm can miss a routed echo during exactly the mount window where a
+  divergence is born, and echoes only fire on real grid changes. The mounted owner's listener
+  (`useTerminal`) compares the echoed dims to its own and, when they disagree, re-asserts its
+  fitted grid after a 150ms coalescing debounce and repairs the already-garbled frame with a
+  `reloadScrollback({ skipResize: true })` replay (the resize it just sent armed the repaint
+  settle, so the reload samples the frame drawn at the corrected width). The guard matrix is the
+  pure `resolvePtyEchoReassert` (exported from `useTerminal.ts`): in-sync self-filter first,
+  then foreign-hold (`mobile`/`park` origins - a phone or the park legitimately holds the grid;
+  `spawn` is healable), refused-hold (see below), parked, replay-in-flight, own-resize-pending,
+  and last a TIME-WINDOWED budget (2 re-asserts per divergence signature per 10s) - deliberately
+  not reset by an in-sync echo, because in a two-surface fight each side's successful re-assert
+  lands an in-sync echo at the other side, so a reset-on-heal budget never binds in exactly the
+  livelock it exists to bound. `resize()` also reports `refused: true` from the mobile sub-floor
+  branch (the one path where main deliberately holds the grid against the caller), which arms a
+  time-stamped refusal hold after a single refused IPC: no further re-asserts for the budget
+  window, whatever dims later echoes carry (time-stamped rather than signature-keyed, because
+  the pre-send fit can move the terminal's own dims and a burned signature would stop binding
+  exactly then). Every renderer resize sender now traces `resize-request` with an origin
+  tag (`mount`/`flush`/`reload`/`echo-reassert`/`debounced-onResize`) and main traces every
+  resize outcome (`resize-applied`/`resize-noop`/`resize-refused`/`resize-stash`/
+  `resize-ignored`/`resize-invalid`), so `kangentic_devtools_terminal_state`'s merged trace
+  names the trigger if a divergence ever recurs. A resize for a queued or suspended session
+  stashes (including suspend's marked-but-alive teardown window, where the PTY is still
+  non-null but must not be reshaped or re-echoed); one for a missing or exited session is
+  ignored. Gated by `tests/unit/pty-resize-echo-reassert.test.ts` (the guard
+  matrix), the emit/refusal pins in `tests/unit/session-manager.test.ts`,
+  `tests/ui/terminal-resize-echo-reassert.spec.ts` (real xterm wiring: re-assert, repair,
+  self-echo no-op, budget bound), and `tests/e2e/terminal-width-drift-selfheal.spec.ts` (a real
+  PTY driven to the incident by a rogue `sessions.resize`, healed back to the owner grid).
 - **Repaint-settled scrollback sampling.** A session spawns at a default 120x30; on a cold launch
   an auto-resumed PTY sits at that size until a card opens and the renderer fits it wider. When a
   geometry-changing resize fires (cols OR rows), a full-screen agent TUI repaints its frame

--- a/src/main/ipc/handlers/sessions.ts
+++ b/src/main/ipc/handlers/sessions.ts
@@ -19,7 +19,7 @@ import { markRecordExited, markRecordSuspended, promoteRecord, recoverStaleSessi
 import { isShuttingDown } from '../../shutdown-state';
 import { applySuspendDbWrites, reconcileTaskSessionRef } from './session-reconcile';
 import { abortInFlightResume, registerResumeController, releaseResumeController } from './session-resume-controllers';
-import type { Session, TaskResolvePrResult } from '../../../shared/types';
+import type { PtyResizeOrigin, Session, TaskResolvePrResult } from '../../../shared/types';
 import type { IpcContext } from '../ipc-context';
 import { isAbortError } from '../../../shared/abort-utils';
 import { broadcast } from '../../pop-out/window-broadcast';
@@ -411,6 +411,20 @@ export function registerSessionHandlers(context: IpcContext): void {
     const projectId = context.sessionManager.getSessionProjectId(sessionId);
     sendToFocusedRenderers(IPC.SESSION_DATA, sessionId, data, projectId);
   });
+
+  // Fires only when the PTY's dims actually changed (SessionManager.resize
+  // short-circuits no-ops before the emit). Broadcast rather than focus-routed:
+  // the mounted owner xterm this echo exists for can be mid-mount (registered
+  // in the mounted set only a microtask later), and a missed echo during that
+  // window is exactly the divergence with no recovery path. Echoes are rare,
+  // so fanning a few no-op sends is the cheaper failure mode.
+  context.sessionManager.on(
+    'pty-resize',
+    (sessionId: string, cols: number, rows: number, origin: PtyResizeOrigin = 'desktop') => {
+      if (context.mainWindow.isDestroyed()) return;
+      broadcast(context.mainWindow, IPC.SESSION_PTY_RESIZED, sessionId, cols, rows, origin);
+    },
+  );
 
   context.sessionManager.on('first-output', (sessionId: string) => {
     const projectId = context.sessionManager.getSessionProjectId(sessionId);

--- a/src/main/pty/lifecycle/session-spawn-flow.ts
+++ b/src/main/pty/lifecycle/session-spawn-flow.ts
@@ -510,7 +510,9 @@ export async function performSpawn(
   // subscriber that snapshotted this session while it was still queued
   // reported the pending/default dims; this closes that gap the same way
   // a live resize does (read-stream forwards it as a terminal-resize event).
-  context.emit('pty-resize', id, spawnCols, spawnRows);
+  // The 'spawn' origin lets a mounted xterm treat a respawn under it like any
+  // desktop reshape: re-assertable if the spawn grid disagrees with its fit.
+  context.emit('pty-resize', id, spawnCols, spawnRows, 'spawn');
 
   // After a brief delay, write any Windows cwd fixup (so the session lands
   // in the real project directory) and then the initial command. The fixup

--- a/src/main/pty/session-manager.ts
+++ b/src/main/pty/session-manager.ts
@@ -27,6 +27,7 @@ import { DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS, performSpawn } from './lifecycle/se
 import { SessionRegistry, toSession, filterCacheByProject, type ManagedSession, type ManagedSessionSummary } from './session-registry';
 import { createWriteQueue, type WriteQueue } from './write-queue';
 import { BackpressureController } from './buffer/backpressure-controller';
+import { traceTerminal } from './terminal-trace';
 import { isShuttingDown } from '../shutdown-state';
 import type { TranscriptRepository } from '../db/repositories/transcript-repository';
 import type {
@@ -37,6 +38,7 @@ import type {
   SessionEvent,
   SpawnSessionInput,
   PerToolStat,
+  PtyResizeOrigin,
 } from '../../shared/types';
 import type { ActivityEngineOptions, ActivityStatsSnapshot } from '../activity-engine/engine';
 
@@ -915,44 +917,73 @@ export class SessionManager extends EventEmitter {
     sessionId: string,
     cols: number,
     rows: number,
-    origin: 'desktop' | 'mobile' | 'park' = 'desktop',
-  ): { colsChanged: boolean } {
+    // 'spawn' is excluded: the spawn grid is announced by performSpawn's own
+    // pty-resize emit, never passed through resize(). Deriving from the shared
+    // type keeps the two unions linked when PtyResizeOrigin grows.
+    origin: Exclude<PtyResizeOrigin, 'spawn'> = 'desktop',
+  ): { colsChanged: boolean; refused?: true } {
     const session = this.registry.get(sessionId);
 
     // Guard against NaN/Infinity from layout edge cases (e.g. getComputedStyle
     // returning "" during unmount, yielding parseInt -> NaN)
-    if (!Number.isFinite(cols) || !Number.isFinite(rows)) return { colsChanged: false };
+    if (!Number.isFinite(cols) || !Number.isFinite(rows)) {
+      traceTerminal(sessionId, 'resize-invalid', { origin, cols, rows });
+      return { colsChanged: false };
+    }
 
     // Clamp to valid dimensions (node-pty throws on 0 or negative)
     const clampedCols = Math.max(2, Math.floor(cols));
     const clampedRows = Math.max(1, Math.floor(rows));
 
-    if (!session?.pty) {
-      // The PTY does not exist yet. A resize can beat the auto-resume spawn (the
-      // renderer mounts and fits before the main-process spawn lands), or arrive
-      // while a session is queued/suspended awaiting (re)spawn. Stash the dims so
-      // performSpawn spawns the PTY at the real size instead of the default,
-      // closing the stale-geometry race at the source. Never stash for an
-      // exited/killed session - it is not coming back, and xterm never re-sends
-      // unchanged dims, so a resurrected 120x30 would stick forever.
-      if (session && (session.status === 'queued' || session.status === 'suspended')) {
-        // The floor applies to the stash too: a sub-floor desktop fit landing
-        // in the pty-null window (mid-suspend, pre-respawn) would otherwise
-        // respawn the PTY at the strip while a phone streams it, and pair the
-        // seed's ptyDimensions with a frame serialized at the old grid. The
-        // desktop's INTENT is still recorded below, exactly like the live
-        // refusal.
-        const subFloorForStreamingPhone =
-          origin === 'desktop' &&
-          clampedRows < MOBILE_USABLE_MIN_ROWS &&
-          this.mobileTerminalProbe?.hasStreamSubscriber(sessionId) === true;
-        if (!subFloorForStreamingPhone) {
-          this.pendingResizes.set(sessionId, { cols: clampedCols, rows: clampedRows });
-        }
-        if (origin === 'desktop') {
-          this.lastDesktopDimensions.set(sessionId, { cols: clampedCols, rows: clampedRows });
-        }
+    // A queued or suspended session stashes the dims instead of reshaping. A
+    // resize can beat the auto-resume spawn (the renderer mounts and fits
+    // before the main-process spawn lands), arrive while a session awaits
+    // (re)spawn, or land in suspend's marked-but-alive window: suspend() sets
+    // status BEFORE gracefulPtyShutdown resolves, so `session.pty` can still be
+    // non-null for up to ~3s of teardown, and reshaping that dying PTY would
+    // SIGWINCH a mid-exit agent and re-broadcast an echo that arms further
+    // re-asserts on other mounted terminals. Stashing records the INTENT so
+    // performSpawn spawns the respawned PTY at the real size, closing the
+    // stale-geometry race at the source.
+    if (session && (session.status === 'queued' || session.status === 'suspended')) {
+      // The floor applies to the stash too: a sub-floor desktop fit landing
+      // in the suspended window (mid-suspend, pre-respawn) would otherwise
+      // respawn the PTY at the strip while a phone streams it, and pair the
+      // seed's ptyDimensions with a frame serialized at the old grid. The
+      // desktop's INTENT is still recorded below, exactly like the live
+      // refusal.
+      const subFloorForStreamingPhone =
+        origin === 'desktop' &&
+        clampedRows < MOBILE_USABLE_MIN_ROWS &&
+        this.mobileTerminalProbe?.hasStreamSubscriber(sessionId) === true;
+      if (!subFloorForStreamingPhone) {
+        this.pendingResizes.set(sessionId, { cols: clampedCols, rows: clampedRows });
       }
+      if (origin === 'desktop') {
+        this.lastDesktopDimensions.set(sessionId, { cols: clampedCols, rows: clampedRows });
+      }
+      traceTerminal(sessionId, 'resize-stash', {
+        origin,
+        cols: clampedCols,
+        rows: clampedRows,
+        status: session.status,
+        stashed: !subFloorForStreamingPhone,
+      });
+      return { colsChanged: false };
+    }
+
+    if (!session?.pty) {
+      // No session, or an exited/killed one. Never stash here - the session is
+      // not coming back, and xterm never re-sends unchanged dims, so a
+      // resurrected 120x30 would stick forever. Distinct trace event from
+      // 'resize-stash' so the merged trace separates "nothing to resize" from
+      // "deferred to the respawn".
+      traceTerminal(sessionId, 'resize-ignored', {
+        origin,
+        cols: clampedCols,
+        rows: clampedRows,
+        status: session?.status ?? 'unknown',
+      });
       return { colsChanged: false };
     }
 
@@ -999,7 +1030,18 @@ export class SessionManager extends EventEmitter {
       // decision re-checks everything at fire time, so this is free when no
       // park is actually due.
       this.reconsiderRestingGrid(sessionId);
-      return { colsChanged: false };
+      traceTerminal(sessionId, 'resize-refused', {
+        origin,
+        cols: clampedCols,
+        rows: clampedRows,
+        ptyCols: session.pty.cols,
+        ptyRows: session.pty.rows,
+        reason: 'sub-floor-mobile-hold',
+      });
+      // `refused` tells the echo re-assert (the width-drift self-heal) that
+      // main is deliberately holding this grid, so it stops immediately
+      // instead of burning its retry budget against the floor.
+      return { colsChanged: false, refused: true };
     }
 
     const colsChanged = this.bufferManager.onResize(sessionId, clampedCols, clampedRows);
@@ -1013,16 +1055,21 @@ export class SessionManager extends EventEmitter {
       // above still ran: the park cancel and the desktop restore target
       // record INTENT, and the buffer manager saw the call so its
       // initial-resize-establishes-dimensions semantics hold.
+      traceTerminal(sessionId, 'resize-noop', { origin, cols: clampedCols, rows: clampedRows });
       return { colsChanged };
     }
     session.pty.resize(clampedCols, clampedRows);
+    traceTerminal(sessionId, 'resize-applied', { origin, cols: clampedCols, rows: clampedRows });
     // Mark resize time so the dispatch can suppress idle->thinking
     // transitions during the redraw burst that follows.
     this.resizeManager.notifyResize(sessionId);
     // The mobile bridge's seam onto grid changes, mirroring 'data-tap':
     // read-stream forwards this to subscribed phones as a terminal-resize
     // event so their renderer matches the grid before the repaint bytes land.
-    this.emit('pty-resize', sessionId, clampedCols, clampedRows);
+    // The IPC handler also forwards it to renderers (SESSION_PTY_RESIZED) so
+    // the mounted owner xterm can detect and heal a width divergence; the
+    // origin lets it leave phone- and park-held grids alone.
+    this.emit('pty-resize', sessionId, clampedCols, clampedRows, origin);
     return { colsChanged };
   }
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import { IPC } from '../shared/ipc-channels';
-import type { ElectronAPI, NotificationInput, Project, Session, SessionUsage, ActivityState, ActivityReason, SessionEvent, UpdateDownloadedInfo, UsageTimePeriod, UsageStatsScope, UsageDayDrill, UsageCustomWindow, TaskBulkDeleteProgress, ProjectMoveProgress, DictationModelProgress, MobilePairingSasPayload, MobilePairingConfirmedPayload, MobilePairingEndedPayload, MonitorSnapshot, TaskDetailHost, TaskDetailRemoteOwner } from '../shared/types';
+import type { ElectronAPI, NotificationInput, Project, PtyResizeOrigin, Session, SessionUsage, ActivityState, ActivityReason, SessionEvent, UpdateDownloadedInfo, UsageTimePeriod, UsageStatsScope, UsageDayDrill, UsageCustomWindow, TaskBulkDeleteProgress, ProjectMoveProgress, DictationModelProgress, MobilePairingSasPayload, MobilePairingConfirmedPayload, MobilePairingEndedPayload, MonitorSnapshot, TaskDetailHost, TaskDetailRemoteOwner } from '../shared/types';
 import { POPOUT_ARG_PREFIX } from '../shared/pop-out';
 import type { PopOutDescriptor, PopOutKind, PopOutParamsByKind } from '../shared/pop-out';
 import { installConsoleCapture } from './diagnostics/console-capture';
@@ -200,6 +200,11 @@ const api: ElectronAPI = {
       return () => ipcRenderer.removeListener(IPC.SESSION_DATA, handler);
     },
     ackData: (id, bytes) => ipcRenderer.send(IPC.SESSION_DRAIN_ACK, id, bytes),
+    onPtyResized: (callback) => {
+      const handler = (_event: Electron.IpcRendererEvent, sessionId: string, cols: number, rows: number, origin: PtyResizeOrigin) => callback(sessionId, cols, rows, origin);
+      ipcRenderer.on(IPC.SESSION_PTY_RESIZED, handler);
+      return () => ipcRenderer.removeListener(IPC.SESSION_PTY_RESIZED, handler);
+    },
     onFirstOutput: (callback) => {
       const handler = (_event: Electron.IpcRendererEvent, sessionId: string, projectId?: string) => callback(sessionId, projectId);
       ipcRenderer.on(IPC.SESSION_FIRST_OUTPUT, handler);

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -12,13 +12,40 @@ import { noteTerminalFocus } from '../utils/dictation-target';
 import { registerTerminalCapture, unregisterTerminalCapture, type TerminalCaptureReader } from '../utils/terminal-capture-registry';
 import { registerDevtoolsTerminal, traceTerminalRenderer } from '../utils/terminal-grid-registry';
 import { registerMountedTerminal } from '../utils/terminal-mount-registry';
-import type { TerminalColorOverrides } from '../../shared/types';
+import type { PtyResizeOrigin, TerminalColorOverrides } from '../../shared/types';
 import '@xterm/xterm/css/xterm.css';
 
 /** Delay before forwarding a resize to the PTY. Coalesces rapid resizes
  *  (panel drag, window resize) into a single PTY resize so the TUI
  *  (Claude Code) only redraws once and scrollback isn't churned. */
 const PTY_RESIZE_DEBOUNCE_MS = 200;
+
+/** Bounded corrective re-asserts per divergence signature inside one budget
+ *  window, so the width-drift self-heal can never fight a grid holder
+ *  unboundedly. The budget is deliberately NOT reset by an in-sync echo: in a
+ *  two-surface fight each side's successful re-assert lands an in-sync echo at
+ *  the OTHER side, so a reset-on-heal budget never binds in exactly the
+ *  livelock it exists to bound. Time decay binds every pattern instead: at
+ *  most this many re-asserts per signature per window, then quiet until the
+ *  window lapses. */
+const MAX_ECHO_REASSERTS_PER_SIGNATURE = 2;
+
+/** See MAX_ECHO_REASSERTS_PER_SIGNATURE. Also times the refusal hold: after
+ *  main refuses a re-assert (the mobile sub-floor guard), no further
+ *  re-asserts fire until this window lapses. The hold is time-stamped rather
+ *  than signature-keyed because the pre-send fit() re-reads the container, so
+ *  this terminal's own dims (and therefore the signature future echoes
+ *  compute) can drift during the debounce - a burned signature would stop
+ *  binding exactly when the container is being resized. */
+const ECHO_REASSERT_BUDGET_WINDOW_MS = 10_000;
+
+/** Delay between a disagreeing PTY-dims echo and the corrective re-assert.
+ *  Coalesces an echo burst (a multi-step reshape emits one echo per real dim
+ *  change) into one corrective pass, and gives an in-flight legitimate resize
+ *  time to land before the disagreement is judged. Kept below
+ *  PTY_RESIZE_DEBOUNCE_MS so this terminal's own pending debounced resize is
+ *  still pending (and therefore detectable) when its echo arrives. */
+const ECHO_REASSERT_DEBOUNCE_MS = 150;
 
 /** Backstop for a scrollback replay whose chunked write never completes (e.g.
  *  a dropped xterm.write callback). Force-clears scrollbackPendingRef and
@@ -199,6 +226,107 @@ export function isSessionSwapWithoutRemount(
   );
 }
 
+/** Re-assert budget bookkeeping, keyed by the divergence signature (echoed
+ *  dims vs own dims). Held in a per-instance ref by the hook; produced and
+ *  consumed by resolvePtyEchoReassert so the budget-window arithmetic lives in
+ *  one place. */
+export interface PtyEchoReassertAttempts {
+  signature: string;
+  count: number;
+  lastScheduledAt: number;
+}
+
+export type PtyEchoSkipReason =
+  | 'in-sync'
+  | 'foreign-hold'
+  | 'refused-hold'
+  | 'parked'
+  | 'replay-in-flight'
+  | 'own-resize-pending'
+  | 'attempt-cap';
+
+export type PtyEchoReassertDecision =
+  | { action: 'reassert'; signature: string; nextAttempts: PtyEchoReassertAttempts }
+  | { action: 'skip'; signature: string; reason: PtyEchoSkipReason };
+
+export interface PtyEchoReassertInput {
+  echoedCols: number;
+  echoedRows: number;
+  ownCols: number;
+  ownRows: number;
+  origin: PtyResizeOrigin;
+  /** scrollbackPendingRef: a mount replay or reload is in flight. */
+  replayPending: boolean;
+  /** isTerminalParked(sessionId): off-view or occluded. */
+  parked: boolean;
+  /** A debounced onResize send is pending for THIS terminal. */
+  ownResizePending: boolean;
+  previousAttempts: PtyEchoReassertAttempts | null;
+  /** When main last REFUSED a re-assert for this terminal (the mobile
+   *  sub-floor guard), or null. Time-stamped, not signature-keyed - see
+   *  ECHO_REASSERT_BUDGET_WINDOW_MS. */
+  lastRefusalAt: number | null;
+  now: number;
+}
+
+/**
+ * The guard matrix of the width-drift self-heal: should this mounted terminal
+ * re-assert its own fitted grid in response to a PTY-dims echo that disagrees
+ * with it? Pure and exported for unit tests (precedent:
+ * isSessionSwapWithoutRemount above).
+ *
+ * Guard order is load-bearing, most-specific first, so the trace names the
+ * REAL reason rather than whichever mechanical guard happened to be checked
+ * first:
+ * - `in-sync`: the echo matches our grid. This is also how the echo of our own
+ *   resize self-filters - main short-circuits same-dims resizes before the
+ *   emit, so every echo carries the dims of an ACTUAL grid change.
+ * - `foreign-hold`: a phone ('mobile') or the resting-grid park ('park')
+ *   legitimately holds the grid; re-asserting would stomp it. 'spawn' is
+ *   treated like 'desktop': nothing legitimately holds a spawn grid against a
+ *   mounted owner, so a respawn under a mounted xterm is healable divergence.
+ * - `refused-hold`: main refused a recent re-assert (it is deliberately
+ *   holding the grid - the mobile sub-floor guard), so healing attempts stop
+ *   until the hold window lapses, whatever dims later echoes carry.
+ * - `parked`: this terminal is off-view; it must not reshape a grid it is not
+ *   showing (the reveal reload re-fits when it comes back).
+ * - `replay-in-flight`: the replay's own fit + resize settle the dims; its
+ *   resize's echo then self-filters as in-sync.
+ * - `own-resize-pending`: our debounced onResize send is about to assert these
+ *   dims anyway.
+ * - `attempt-cap`: the time-windowed budget (see
+ *   MAX_ECHO_REASSERTS_PER_SIGNATURE) is spent for this signature.
+ */
+export function resolvePtyEchoReassert(input: PtyEchoReassertInput): PtyEchoReassertDecision {
+  const signature = `${input.echoedCols}x${input.echoedRows}<-${input.ownCols}x${input.ownRows}`;
+  if (input.echoedCols === input.ownCols && input.echoedRows === input.ownRows) {
+    return { action: 'skip', reason: 'in-sync', signature };
+  }
+  if (input.origin === 'mobile' || input.origin === 'park') {
+    return { action: 'skip', reason: 'foreign-hold', signature };
+  }
+  if (input.lastRefusalAt !== null && input.now - input.lastRefusalAt < ECHO_REASSERT_BUDGET_WINDOW_MS) {
+    return { action: 'skip', reason: 'refused-hold', signature };
+  }
+  if (input.parked) return { action: 'skip', reason: 'parked', signature };
+  if (input.replayPending) return { action: 'skip', reason: 'replay-in-flight', signature };
+  if (input.ownResizePending) return { action: 'skip', reason: 'own-resize-pending', signature };
+  const attemptsForSignature =
+    input.previousAttempts !== null
+    && input.previousAttempts.signature === signature
+    && input.now - input.previousAttempts.lastScheduledAt < ECHO_REASSERT_BUDGET_WINDOW_MS
+      ? input.previousAttempts.count
+      : 0;
+  if (attemptsForSignature >= MAX_ECHO_REASSERTS_PER_SIGNATURE) {
+    return { action: 'skip', reason: 'attempt-cap', signature };
+  }
+  return {
+    action: 'reassert',
+    signature,
+    nextAttempts: { signature, count: attemptsForSignature + 1, lastScheduledAt: input.now },
+  };
+}
+
 export function useTerminal(options: UseTerminalOptions) {
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<Terminal | null>(null);
@@ -233,6 +361,17 @@ export function useTerminal(options: UseTerminalOptions) {
    *  (e.g. TerminalTab) to gate PTY output while a loading overlay is shown. */
   const suppressDataRef = useRef(false);
   const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Debounce timer for the width-drift self-heal's corrective re-assert
+   *  (see the SESSION_PTY_RESIZED listener effect below). Cleared by that
+   *  effect's cleanup, so a session change or unmount never fires a stale
+   *  re-assert. */
+  const echoReassertTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Time-windowed re-assert budget per divergence signature (see
+   *  MAX_ECHO_REASSERTS_PER_SIGNATURE / resolvePtyEchoReassert). */
+  const echoReassertAttemptsRef = useRef<PtyEchoReassertAttempts | null>(null);
+  /** When main last refused a re-assert (the mobile sub-floor guard); arms the
+   *  refused-hold guard in resolvePtyEchoReassert. */
+  const echoRefusedAtRef = useRef<number | null>(null);
   /** Coalesces xterm onData bursts (paste, key-repeat, clipboard callback)
    *  into one IPC write per microtask. */
   const writeBatcherRef = useRef<WriteBatcher | null>(null);
@@ -546,6 +685,7 @@ export function useTerminal(options: UseTerminalOptions) {
       // geometry - no stale frame, no compensating resize needed here. The
       // colsChanged field of the resize result is therefore intentionally
       // unused by the renderer.
+      traceTerminalRenderer(sid, 'resize-request', { cols, rows, origin: 'mount' });
       const resizePromise = window.electronAPI.sessions.resize(sid, cols, rows);
       const scrollbackPromise = suppressScrollback
         ? Promise.resolve<string | null>(null)
@@ -728,6 +868,133 @@ export function useTerminal(options: UseTerminalOptions) {
       queue.reset();
     };
   }, [options.sessionId]);
+
+  /** The corrective half of the width-drift self-heal (scheduled by the
+   *  SESSION_PTY_RESIZED listener effect below): re-fit to the live container,
+   *  re-send OUR grid to the PTY, then repair the already-garbled frame with a
+   *  replay. Reads everything through refs so its identity is stable. */
+  const reassertOwnGrid = useCallback(async (sessionId: string) => {
+    echoReassertTimerRef.current = null;
+    const terminal = xtermRef.current;
+    if (!terminal || !fitAddonRef.current) return;
+    // Re-checked at fire time (the debounce is 150ms of drift): a replay that
+    // started meanwhile owns settling the dims via its own fit + resize, and a
+    // parked terminal must not reshape a grid it is not showing.
+    if (scrollbackPendingRef.current || isTerminalParked(sessionId)) return;
+    // Re-fit first: the container may have moved during the debounce, and our
+    // OWN fitted grid is the thing being re-asserted.
+    const wasAtBottom = isAtBottomRef.current;
+    fitAddonRef.current.fit();
+    if (wasAtBottom) terminal.scrollToBottom();
+    const { cols, rows } = terminal;
+    // The fit may have scheduled the debounced onResize; the direct send below
+    // supersedes it (the flushResize pattern).
+    if (resizeTimerRef.current) {
+      clearTimeout(resizeTimerRef.current);
+      resizeTimerRef.current = null;
+    }
+    traceTerminalRenderer(sessionId, 'resize-request', { cols, rows, origin: 'echo-reassert' });
+    try {
+      const result = await window.electronAPI.sessions.resize(sessionId, cols, rows);
+      if (result?.refused) {
+        // Main is deliberately holding this grid (the mobile sub-floor guard).
+        // Arm the time-stamped refusal hold so later echoes stop after this
+        // single refused IPC instead of retrying to the cap. Time-stamped, not
+        // signature-burned: the fit() above may have moved our own dims during
+        // the debounce, so a signature keyed to the schedule-time dims would
+        // stop matching exactly when the container is being resized.
+        echoRefusedAtRef.current = Date.now();
+        traceTerminalRenderer(sessionId, 'echo-reassert-refused', { cols, rows });
+        return;
+      }
+    } catch {
+      // The session died during the async gap; nothing left to heal.
+      return;
+    }
+    // Re-checked once more after the await: a replay that started during the
+    // IPC round trip (a reveal catch-up, an overlay lift, a remount) owns
+    // settling the dims and the frame. reloadScrollback is last-writer-wins
+    // (it bumps the generation unconditionally), so issuing the repair anyway
+    // would abort that replay mid-flight and drop its focus grant. Same guard
+    // for a terminal disposed or replaced during the gap.
+    if (scrollbackPendingRef.current || isTerminalParked(sessionId) || xtermRef.current !== terminal) return;
+    // Repair the garbled frame. skipResize: the resize above already landed
+    // and armed main's repaint settle (any geometry change stamps
+    // pendingRepaintAt, and getScrollback awaits waitForResizeRepaint
+    // regardless of who resized), so the reload samples the frame drawn at the
+    // corrected width. skipFocus: a heal must never steal focus. A full
+    // replay rather than the bare SIGWINCH, because a diff-only TUI never
+    // repaints the whole viewport and the xterm buffer holds the mis-wrapped
+    // history either way.
+    traceTerminalRenderer(sessionId, 'echo-reassert', { cols, rows });
+    reloadScrollbackRef.current?.({ skipResize: true, skipFocus: true });
+  }, []);
+
+  // The width-drift self-heal. Main broadcasts SESSION_PTY_RESIZED whenever
+  // the PTY's dims actually change, from any origin. xterm re-sends its
+  // dimensions only when its OWN size changes, so a PTY reshaped under this
+  // mounted terminal (a lost resize, another surface's late write, a respawn)
+  // otherwise diverges with no recovery path: live absolute-positioned TUI
+  // output wraps into a staircase until the window is resized by hand. On a
+  // disagreeing echo the mounted owner re-asserts its own fitted grid;
+  // resolvePtyEchoReassert holds the guard matrix that keeps this from
+  // fighting legitimate grid holders (phones, the park), a replay in flight,
+  // or its own pending resize.
+  useEffect(() => {
+    const sessionId = options.sessionId;
+    if (!sessionId) return;
+    const cleanup = window.electronAPI.sessions.onPtyResized((resizedSessionId, cols, rows, origin) => {
+      if (resizedSessionId !== sessionId) return;
+      const terminal = xtermRef.current;
+      // Not initialized yet: the mount replay fits and resizes at the settled
+      // geometry on its own.
+      if (!terminal) return;
+      const decision = resolvePtyEchoReassert({
+        echoedCols: cols,
+        echoedRows: rows,
+        ownCols: terminal.cols,
+        ownRows: terminal.rows,
+        origin,
+        replayPending: scrollbackPendingRef.current,
+        parked: isTerminalParked(sessionId),
+        ownResizePending: resizeTimerRef.current !== null,
+        previousAttempts: echoReassertAttemptsRef.current,
+        lastRefusalAt: echoRefusedAtRef.current,
+        now: Date.now(),
+      });
+      traceTerminalRenderer(sessionId, 'pty-resize-echo', {
+        cols,
+        rows,
+        origin,
+        ownCols: terminal.cols,
+        ownRows: terminal.rows,
+        action: decision.action,
+        reason: decision.action === 'skip' ? decision.reason : undefined,
+      });
+      if (decision.action === 'skip') return;
+      // The budget is spent at SCHEDULE time: an echo burst coalesces into one
+      // debounced pass, but every occurrence counts, so no echo pattern can
+      // queue unbounded corrective work.
+      echoReassertAttemptsRef.current = decision.nextAttempts;
+      if (echoReassertTimerRef.current) clearTimeout(echoReassertTimerRef.current);
+      echoReassertTimerRef.current = setTimeout(() => {
+        void reassertOwnGrid(sessionId);
+      }, ECHO_REASSERT_DEBOUNCE_MS);
+    });
+    return () => {
+      cleanup();
+      if (echoReassertTimerRef.current) {
+        clearTimeout(echoReassertTimerRef.current);
+        echoReassertTimerRef.current = null;
+      }
+      // The budget and the refusal hold belong to THIS session's divergence
+      // history. Panel/detail/spawn grids are structural (306x14, 210x48,
+      // 120x30), so a stale record would collide with the next session's first
+      // real divergence inside the window and suppress its heal.
+      echoReassertAttemptsRef.current = null;
+      echoRefusedAtRef.current = null;
+    };
+  }, [options.sessionId, reassertOwnGrid]);
 
   // Handle context-menu actions dispatched from the main process: Copy, Select
   // All, and Paste. The event detail carries the right-click coordinates so we
@@ -938,6 +1205,7 @@ export function useTerminal(options: UseTerminalOptions) {
     clearTimeout(resizeTimerRef.current);
     resizeTimerRef.current = null;
     const { cols, rows } = xtermRef.current;
+    traceTerminalRenderer(options.sessionId, 'resize-request', { cols, rows, origin: 'flush' });
     window.electronAPI.sessions.resize(options.sessionId, cols, rows);
   }, [options.sessionId]);
 
@@ -998,6 +1266,7 @@ export function useTerminal(options: UseTerminalOptions) {
     // the frame drawn at the fitted geometry.
     // skipResize sends no SIGWINCH: the window manager calls it once resizing
     // has already settled, so there is nothing to wait for.
+    if (!skipResize) traceTerminalRenderer(sessionId, 'resize-request', { cols, rows, origin: 'reload' });
     const resizePromise = skipResize
       ? Promise.resolve(undefined)
       : window.electronAPI.sessions.resize(sessionId, cols, rows);

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -96,6 +96,7 @@ export const IPC = {
   SESSION_GET_SCROLLBACK: 'session:getScrollback',
   SESSION_DATA: 'session:data',
   SESSION_DRAIN_ACK: 'session:drainAck',
+  SESSION_PTY_RESIZED: 'session:ptyResized',
   SESSION_FIRST_OUTPUT: 'session:firstOutput',
   SESSION_GET_FIRST_OUTPUT: 'session:getFirstOutput',
   SESSION_EXIT: 'session:exit',

--- a/src/shared/pop-out.ts
+++ b/src/shared/pop-out.ts
@@ -149,6 +149,12 @@ export const POP_OUT_SURFACES: Readonly<Record<PopOutKind, PopOutSurfaceMeta>> =
       // so a window without that session's terminal never receives its bytes.
       IPC.SESSION_USAGE,
       IPC.SESSION_EVENT,
+      // PTY dims echo for the width-drift self-heal. Unlike SESSION_DATA it IS
+      // fanned to every window: echoes only fire on real dim changes, and a
+      // freshly mounted xterm could miss a focus-routed echo during exactly the
+      // mount window where a divergence is born. Any future pop-out surface
+      // that hosts a terminal must declare this channel too.
+      IPC.SESSION_PTY_RESIZED,
       IPC.TASK_SPAWN_PROGRESS,
     ],
   },

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -536,6 +536,14 @@ export interface SwimlaneTransition {
 
 export type SessionStatus = 'running' | 'queued' | 'exited' | 'suspended';
 
+/**
+ * Who reshaped the PTY. 'spawn' is the grid the PTY spawned at; the rest
+ * mirror SessionManager.resize's origin parameter ('desktop' is any
+ * renderer-driven fit, 'mobile' a paired phone's grid request, 'park' the
+ * resting-grid park for unwatched sessions).
+ */
+export type PtyResizeOrigin = 'desktop' | 'mobile' | 'park' | 'spawn';
+
 export interface Session {
   id: string;
   taskId: string;
@@ -4368,7 +4376,15 @@ export interface ElectronAPI {
     reconcile: (taskId: string, projectId?: string | null) => Promise<Session | null>;
     reset: (taskId: string, projectId?: string | null) => Promise<void>;
     write: (sessionId: string, data: string) => Promise<void>;
-    resize: (sessionId: string, cols: number, rows: number) => Promise<{ colsChanged: boolean }>;
+    /**
+     * `colsChanged` is intentionally unused by the renderer (main orders the
+     * geometry change ahead of any scrollback sample on its own - see the
+     * parallel-IPC note in useTerminal's mount path). `refused` is set only
+     * when main deliberately held the grid against this resize (the mobile
+     * sub-floor guard) and is consumed only by the echo re-assert, which uses
+     * it to stop healing attempts immediately instead of retrying to its cap.
+     */
+    resize: (sessionId: string, cols: number, rows: number) => Promise<{ colsChanged: boolean; refused?: true }>;
     list: () => Promise<Session[]>;
     getScrollback: (sessionId: string) => Promise<string>;
     /**
@@ -4387,6 +4403,19 @@ export interface ElectronAPI {
      * (fire-and-forget send), keyed by sessionId only - not project-scoped.
      */
     ackData: (sessionId: string, bytes: number) => void;
+    /**
+     * The PTY's dimensions actually changed, from any origin: a renderer fit,
+     * a phone's grid request, the resting-grid park, or the spawn itself.
+     * Exists because xterm re-sends dimensions only when its OWN size changes,
+     * so a PTY reshaped under a mounted xterm otherwise diverges with no
+     * recovery path. The mounted owner compares the echoed dims to its own and
+     * re-asserts its fit when they disagree. Broadcast to every window (echoes
+     * only fire on real dim changes); filtered by sessionId in the listener.
+     * Deliberately the one sessions push without a projectId parameter:
+     * session ids are globally-unique UUIDs, so the sessionId filter alone is
+     * unambiguous across projects.
+     */
+    onPtyResized: (callback: (sessionId: string, cols: number, rows: number, origin: PtyResizeOrigin) => void) => () => void;
     onFirstOutput: (callback: (sessionId: string, projectId?: string) => void) => () => void;
     onExit: (callback: (sessionId: string, exitCode: number, projectId?: string, intentional?: boolean) => void) => () => void;
     onStatus: (callback: (sessionId: string, session: Session, projectId?: string) => void) => () => void;

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import { _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
+import { _electron as electron, expect, type ElectronApplication, type Page } from '@playwright/test';
 import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -633,4 +633,72 @@ export async function moveTaskIpc(page: Page, taskId: string, targetSwimlaneId: 
       targetPosition: 0,
     });
   }, { taskId, targetSwimlaneId });
+}
+
+/** One SESSION_PTY_RESIZED echo recorded by armPtyEchoRecorder. */
+export interface PtyEchoEntry {
+  cols: number;
+  rows: number;
+  origin: string;
+}
+
+/**
+ * Subscribe an append-only recorder to the SESSION_PTY_RESIZED broadcast for
+ * one session, via the real preload bridge (production-safe: the bridge is not
+ * tree-shaken, unlike the devtools globals). Re-arming replaces any previous
+ * recorder. Read with readPtyEchoes / settledPtyEchoes.
+ */
+export async function armPtyEchoRecorder(page: Page, sessionId: string): Promise<void> {
+  await page.evaluate((echoSessionIdFilter) => {
+    const globalScope = window as unknown as {
+      __ptyEchoes?: Array<{ cols: number; rows: number; origin: string }>;
+      __ptyEchoUnsubscribe?: () => void;
+    };
+    globalScope.__ptyEchoes = [];
+    globalScope.__ptyEchoUnsubscribe?.();
+    globalScope.__ptyEchoUnsubscribe = window.electronAPI.sessions.onPtyResized(
+      (echoSessionId, cols, rows, origin) => {
+        if (echoSessionId !== echoSessionIdFilter) return;
+        globalScope.__ptyEchoes!.push({ cols, rows, origin });
+      },
+    );
+  }, sessionId);
+}
+
+/** Every echo the recorder has seen so far, in arrival order. */
+export async function readPtyEchoes(page: Page): Promise<PtyEchoEntry[]> {
+  return page.evaluate(() => {
+    const echoes = (window as unknown as { __ptyEchoes?: Array<{ cols: number; rows: number; origin: string }> })
+      .__ptyEchoes ?? [];
+    return echoes.slice();
+  });
+}
+
+/** Poll until the echo log stops growing (two consecutive 500ms reads agree)
+ *  and is non-empty, then return it. */
+export async function settledPtyEchoes(page: Page, timeoutMs: number, message?: string): Promise<PtyEchoEntry[]> {
+  let lastLength = -1;
+  await expect
+    .poll(async () => {
+      const echoes = await readPtyEchoes(page);
+      if (echoes.length === 0) return 'empty';
+      if (echoes.length === lastLength) return 'stable';
+      lastLength = echoes.length;
+      return 'changing';
+    }, {
+      message:
+        message
+        ?? 'The PTY-dims echo log never settled non-empty - either no real grid change '
+        + 'occurred here, or the SESSION_PTY_RESIZED broadcast is broken.',
+      timeout: timeoutMs,
+      intervals: [500],
+    })
+    .toBe('stable');
+  return readPtyEchoes(page);
+}
+
+/** Every width the TUI fixture has drawn a frame at (its RULER-<cols>- marker),
+ *  in scrollback order. */
+export function rulerWidths(scrollback: string): number[] {
+  return Array.from(scrollback.matchAll(/RULER-(\d+)-/g)).map((match) => parseInt(match[1], 10));
 }

--- a/tests/e2e/terminal-fit-invariant.spec.ts
+++ b/tests/e2e/terminal-fit-invariant.spec.ts
@@ -56,6 +56,10 @@ import {
   moveTaskIpc,
   waitForBoard,
   resolveMockAgentPath,
+  armPtyEchoRecorder,
+  readPtyEchoes,
+  settledPtyEchoes,
+  rulerWidths,
 } from './helpers';
 import type { ElectronApplication, Page } from '@playwright/test';
 
@@ -308,6 +312,18 @@ test.describe('terminal fit invariant across rapid detail open/close', () => {
       intervals: [100],
     }).toBe(true);
 
+    // Echo recorder for the post-loop drift epilogue: main broadcasts every
+    // real PTY grid change (SESSION_PTY_RESIZED), so the end state of the
+    // whole open/close churn is observable without perturbing it. Production-
+    // safe: the preload bridge is not tree-shaken.
+    const sessionId: string = await page.evaluate(async (targetTaskId) => {
+      const sessions: Array<{ id: string; taskId: string }> = await window.electronAPI.sessions.list();
+      const session = sessions.find((sessionEntry) => sessionEntry.taskId === targetTaskId);
+      if (!session) throw new Error('no session for task');
+      return session.id;
+    }, taskId);
+    await armPtyEchoRecorder(page, sessionId);
+
     // Open the GENUINE way a user does: click the task's own card. That is the
     // same signal every entry point uses (card click, search palette,
     // notification): each calls `setDetailTaskId`, which TaskCard's
@@ -385,6 +401,16 @@ test.describe('terminal fit invariant across rapid detail open/close', () => {
       + '. For reference, the real app shows panel 306x11 and window 209x48.',
     ).toBe(true);
 
+    // The panel remounts on close and re-asserts its fit, and the surfaces are
+    // proven different just above, so the settled last echo after the control
+    // close is the PANEL's grid - the baseline the post-loop drift epilogue
+    // compares against.
+    const baselineEchoes = await settledPtyEchoes(page, 15000,
+      'The PTY-dims echo log never settled non-empty after the control '
+      + 'open/close, so the panel remount never re-asserted its grid (or the '
+      + 'SESSION_PTY_RESIZED broadcast is broken).');
+    const panelBaseline = baselineEchoes[baselineEchoes.length - 1];
+
     for (let cycle = 1; cycle <= CYCLES; cycle++) {
       await resetGridWidths(page);
       // openDetail waits for the window's own terminal rather than sleeping, so the
@@ -413,11 +439,59 @@ test.describe('terminal fit invariant across rapid detail open/close', () => {
       await page.waitForTimeout(DWELL_MS);
     }
 
+    // EPILOGUE - end-state PTY agreement. Eight open/close handoffs later, the
+    // PTY must be back at the panel's grid (the panel's remount re-asserts its
+    // fit on every close). If any handoff lost or overrode a resize and the
+    // width-drift self-heal failed to recover it, the last echo is a rogue
+    // grid instead and this names it. Growth is asserted FIRST: the surfaces
+    // are proven different by the control, so the loop must have produced new
+    // echoes - without that check, a broadcast that died right after the
+    // baseline was captured would leave the baseline itself as the last entry
+    // and the value comparison would pass having proven nothing.
+    await expect
+      .poll(async () => {
+        const echoes = await readPtyEchoes(page);
+        if (echoes.length <= baselineEchoes.length) return 'no-new-echoes';
+        const last = echoes[echoes.length - 1];
+        return `${last.cols}x${last.rows}`;
+      }, {
+        message:
+          'After the full open/close churn the PTY did not settle back at the '
+          + 'panel baseline grid ' + JSON.stringify(panelBaseline)
+          + ' - either a handoff left the PTY at another surface\'s width and the '
+          + 'self-heal did not recover it, or ("no-new-echoes") the loop produced '
+          + 'no echoes at all and the SESSION_PTY_RESIZED broadcast died after '
+          + 'the baseline was captured.',
+        timeout: 15000,
+        intervals: [250],
+      })
+      .toBe(`${panelBaseline.cols}x${panelBaseline.rows}`);
+
+    if (process.platform !== 'win32') {
+      // One end-state scrollback read - safe HERE and only here: the loop's
+      // measurements are complete, so getScrollback's drain side effect (it
+      // empties the pending flush buffer) can no longer perturb what the
+      // recorder counted. The fixture's last frame must be drawn at the final
+      // PTY width. Linux-gated: on Windows ConPTY never delivers the resize to
+      // the grandchild fixture, so it never redraws (see mock-claude.js).
+      await expect
+        .poll(async () => {
+          const scrollback: string = await page.evaluate(
+            async (scrollbackSessionId) => window.electronAPI.sessions.getScrollback(scrollbackSessionId),
+            sessionId,
+          );
+          const widths = rulerWidths(scrollback);
+          return widths[widths.length - 1] ?? 0;
+        }, { timeout: 15000, intervals: [250] })
+        .toBe(panelBaseline.cols);
+    }
+
     // Print what the oracle saw on EVERY run, pass or fail. A green run whose
     // recorded widths are empty is not a green run, it is a blind one, and that
     // distinction is invisible if only failures report.
     console.log('[fit-invariant] control widths: ' + JSON.stringify(controlWidths));
     console.log('[fit-invariant] per-open widths: ' + JSON.stringify(gridWidthsPerOpen));
+    console.log('[fit-invariant] panel baseline: ' + JSON.stringify(panelBaseline));
 
     // Every cycle must have recorded at least one width, or the loop was inert and
     // the multi-width assertion below would compare empty arrays. This is the

--- a/tests/e2e/terminal-width-drift-selfheal.spec.ts
+++ b/tests/e2e/terminal-width-drift-selfheal.spec.ts
@@ -1,0 +1,354 @@
+/**
+ * The terminal width-drift self-heal, exercised against a real PTY by
+ * deterministically injecting the incident it exists to recover from.
+ *
+ * THE INCIDENT: a task-detail window's xterm at one width while the PTY (and
+ * main's headless parser) draw at another - observed live as a staircased
+ * frame (rows shifted progressively right, labels clipped at the left edge).
+ * xterm re-sends dimensions only when its OWN size changes, so before the
+ * self-heal this divergence had NO recovery path: the window stayed garbled
+ * until resized by hand.
+ *
+ * THE INJECTION: `window.electronAPI.sessions.resize(sessionId, rogue dims)`
+ * from page.evaluate. That call is exactly what any lost or overridden resize
+ * does to the PTY - main honors it (last-writer-wins, no surface identity),
+ * the PTY and headless grid move to the rogue dims, and the mounted window
+ * xterm is left behind at its own fit. Production-safe: the preload bridge is
+ * not tree-shaken (unlike the devtools globals - see terminal-fit-invariant's
+ * header for why nothing here may touch those).
+ *
+ * THE ORACLES:
+ * - The new SESSION_PTY_RESIZED echo (subscribed via the preload bridge):
+ *   main announces every real PTY grid change, so the recorder sees the rogue
+ *   dims land (positive control) and then the owner's dims return (the heal).
+ * - A one-shot destructive probe at the END: resize(owner dims) returning
+ *   `colsChanged: false` proves the PTY is at the owner's grid. Never used as
+ *   a poll - each probe call would itself heal the PTY and mask a broken fix.
+ * - Linux only: the TUI fixture embeds the width it drew at into its ruler
+ *   line (`RULER-<cols>-`), so scrollback shows the rogue-width frame appear
+ *   and the owner-width frame return. Gated off win32: ConPTY delivers no
+ *   SIGWINCH to the grandchild fixture, so it never redraws at new dims there
+ *   (measured; see mock-claude.js). CI's gate is Linux, where the full set runs.
+ * - A grid-width recorder on `.xterm-screen`: the heal must re-assert the
+ *   OWNER's grid, never refit the visible xterm to the rogue dims - exactly
+ *   one distinct detail-window width across injection + heal.
+ */
+import { test, expect } from '@playwright/test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  launchApp,
+  closeApp,
+  createProject,
+  createTask,
+  createTempProject,
+  cleanupTempProject,
+  getTestDataDir,
+  getTaskIdByTitle,
+  moveTaskIpc,
+  waitForBoard,
+  resolveMockAgentPath,
+  armPtyEchoRecorder,
+  readPtyEchoes,
+  settledPtyEchoes,
+  rulerWidths,
+} from './helpers';
+import type { ElectronApplication, Page } from '@playwright/test';
+
+const TEST_NAME = 'terminal-width-drift-selfheal';
+const PROJECT_NAME = 'WidthDriftHeal';
+const TASK_NAME = 'Width drift heal task';
+
+let app: ElectronApplication;
+let page: Page;
+let tmpDir: string;
+let dataDir: string;
+let resizeLogPath: string;
+
+function readLogLines(): string[] {
+  try {
+    return fs.readFileSync(resizeLogPath, 'utf-8').split('\n').filter((line) => line.trim().length > 0);
+  } catch {
+    return [];
+  }
+}
+
+/** True once the fixture process is actually running (see terminal-fit-invariant). */
+function fixtureIsLive(): boolean {
+  return readLogLines().some((line) => line.startsWith('start:'));
+}
+
+async function getSwimlaneByName(target: Page, name: string): Promise<string> {
+  const swimlaneId = await target.evaluate(async (laneName) => {
+    const swimlanes: Array<{ id: string; name: string }> = await window.electronAPI.swimlanes.list();
+    return swimlanes.find((swimlane) => swimlane.name === laneName)?.id ?? null;
+  }, name);
+  if (!swimlaneId) throw new Error(`Swimlane "${name}" not found`);
+  return swimlaneId;
+}
+
+/** First-output latch, polled instead of scrollback content: getScrollback
+ *  drains the pending flush buffer as a side effect, and a read landing inside
+ *  the 16ms flush window starves the latch forever. ORDERING IS LOAD-BEARING -
+ *  no scrollback read (direct or via mounting a terminal) before this is true.
+ *  Full flake history: terminal-fullscreen-select-replay-focus.spec.ts. */
+async function hasFirstOutputForTask(target: Page, targetTaskId: string): Promise<boolean> {
+  return target.evaluate(async (taskId) => {
+    const sessions: Array<{ id: string; taskId: string }> = await window.electronAPI.sessions.list();
+    const session = sessions.find((sessionEntry) => sessionEntry.taskId === taskId);
+    if (!session) return false;
+    const firstOutputCache = await window.electronAPI.sessions.getFirstOutput();
+    return !!firstOutputCache[session.id];
+  }, targetTaskId);
+}
+
+const SETTLE_MESSAGE =
+  'The PTY-dims echo log never settled non-empty. Either this surface flip '
+  + 'produced no real grid change (the two surfaces happened to fit identically '
+  + 'in this window size - see terminal-fit-invariant\'s positive control) or '
+  + 'the SESSION_PTY_RESIZED broadcast is broken.';
+
+async function scrollbackForSession(target: Page, targetSessionId: string): Promise<string> {
+  return target.evaluate(async (sessionId) => window.electronAPI.sessions.getScrollback(sessionId), targetSessionId);
+}
+
+test.beforeAll(async () => {
+  tmpDir = createTempProject(TEST_NAME);
+  dataDir = getTestDataDir(TEST_NAME);
+  resizeLogPath = path.join(dataDir, 'tui-resizes.log');
+  fs.writeFileSync(
+    path.join(dataDir, 'config.json'),
+    JSON.stringify({
+      claude: {
+        cliPath: resolveMockAgentPath('mock-claude'),
+        permissionMode: 'default',
+        maxConcurrentSessions: 5,
+        queueOverflow: 'queue',
+      },
+      git: { worktreesEnabled: false },
+    }),
+  );
+  const result = await launchApp({
+    dataDir,
+    extraEnv: {
+      MOCK_CLAUDE_TUI_REPAINT: '1',
+      // 20ms, deliberately far under the 150ms heal debounce. The fixture
+      // CANCELS and re-arms its repaint timer on every observed resize and
+      // draws at the CURRENT grid when the timer fires (see mock-claude.js
+      // onResizeObserved), so if the heal's corrective SIGWINCH arrives before
+      // the rogue-width draw timer has fired, the rogue frame is silently
+      // superseded and positive control 3 below can never see it. The margin
+      // must absorb CI scheduling drift on the fixture process, not just the
+      // nominal delay.
+      MOCK_CLAUDE_TUI_REPAINT_DELAY_MS: '20',
+      // Diagnostic output only, never an oracle (empty by construction on
+      // Windows - see mock-claude.js). The `start:` line is the liveness signal.
+      MOCK_CLAUDE_RESIZE_LOG: resizeLogPath,
+    },
+  });
+  app = result.app;
+  page = result.page;
+  await createProject(page, PROJECT_NAME, tmpDir);
+});
+
+test.afterAll(async () => {
+  await closeApp(app);
+  cleanupTempProject(TEST_NAME);
+});
+
+test.describe('terminal width-drift self-heal', () => {
+  test.setTimeout(120_000);
+
+  test('a rogue PTY resize under an open task-detail window is healed back to the owner grid', async () => {
+    await waitForBoard(page);
+    await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+    await createTask(page, TASK_NAME);
+    const taskId = await getTaskIdByTitle(page, TASK_NAME);
+    const executingSwimlaneId = await getSwimlaneByName(page, 'Executing');
+    await moveTaskIpc(page, taskId, executingSwimlaneId);
+
+    await page.locator('[data-testid="terminal-session-pane"] .xterm-screen')
+      .first()
+      .waitFor({ state: 'visible', timeout: 30000 });
+    await expect.poll(fixtureIsLive, {
+      message: 'The TUI fixture never announced itself; nothing below would test anything.',
+      timeout: 30000,
+      intervals: [100],
+    }).toBe(true);
+    await expect.poll(() => hasFirstOutputForTask(page, taskId), { timeout: 30000, intervals: [100] }).toBe(true);
+
+    const sessionId: string = await page.evaluate(async (targetTaskId) => {
+      const sessions: Array<{ id: string; taskId: string }> = await window.electronAPI.sessions.list();
+      const session = sessions.find((sessionEntry) => sessionEntry.taskId === targetTaskId);
+      if (!session) throw new Error('no session for task');
+      return session.id;
+    }, taskId);
+
+    // Arm the echo recorder and the grid-width recorder BEFORE opening the
+    // window, so the window's own mount echo and every width it renders are
+    // captured. ORDERING IS LOAD-BEARING for ownerDims below: the recorder is
+    // armed this close to the open so the LAST settled echo after the open is
+    // the window's own mount fit. Armed any earlier (before the task move or
+    // first output), a pre-open echo could be the last entry whenever the
+    // window's fit happens to be a same-dims no-op, silently rebasing the
+    // whole test on the wrong grid.
+    await armPtyEchoRecorder(page, sessionId);
+    await page.evaluate(() => {
+      const globalScope = window as unknown as {
+        __detailWidths?: number[];
+        __detailWidthObserver?: MutationObserver;
+      };
+
+      // Trimmed from terminal-fit-invariant's recorder: every distinct width
+      // the detail window's xterm renders (from `.xterm-screen`'s inline
+      // style, xterm's own authority). Observer-based, not polled, so a width
+      // replaced within one frame is still counted.
+      globalScope.__detailWidths = [];
+      globalScope.__detailWidthObserver?.disconnect();
+      const record = (screen: HTMLElement) => {
+        if (!screen.closest('#window-layer-root')) return;
+        const width = Math.round(parseFloat(screen.style.width || '0'));
+        if (!width) return;
+        const widths = globalScope.__detailWidths!;
+        if (widths[widths.length - 1] !== width) widths.push(width);
+      };
+      const observer = new MutationObserver((records) => {
+        for (const mutation of records) {
+          const target = mutation.target as HTMLElement;
+          if (target.classList?.contains('xterm-screen')) record(target);
+          for (const added of Array.from(mutation.addedNodes)) {
+            if (!(added instanceof HTMLElement)) continue;
+            const screen = added.classList.contains('xterm-screen') ? added : added.querySelector('.xterm-screen');
+            if (screen instanceof HTMLElement) record(screen);
+          }
+        }
+      });
+      observer.observe(document.body, { subtree: true, childList: true, attributes: true, attributeFilter: ['style'] });
+      globalScope.__detailWidthObserver = observer;
+    });
+
+    // Open the task detail the genuine way (card click) and let the handoff
+    // settle: the window's mount fit resizes the PTY, which is the last echo.
+    await page.locator(`[data-task-id="${taskId}"]`).first().click();
+    await page.locator('#window-layer-root .xterm-screen').first().waitFor({ state: 'visible', timeout: 15000 });
+    const settledAfterOpen = await settledPtyEchoes(page, 30000, SETTLE_MESSAGE);
+    const ownerDims = settledAfterOpen[settledAfterOpen.length - 1];
+    expect(ownerDims.cols).toBeGreaterThan(10);
+    expect(ownerDims.rows).toBeGreaterThan(5);
+
+    if (process.platform !== 'win32') {
+      // Baseline control: the fixture repainted at the owner width, so the
+      // ruler oracle is live before the injection relies on it.
+      await expect
+        .poll(async () => {
+          const widths = rulerWidths(await scrollbackForSession(page, sessionId));
+          return widths[widths.length - 1] ?? 0;
+        }, { timeout: 15000, intervals: [250] })
+        .toBe(ownerDims.cols);
+    }
+
+    // THE INJECTION: what a lost or overridden resize does to the PTY. 306x15
+    // is the real incident's bottom-panel strip; shifted if the window
+    // happens to fit at 306 already.
+    const rogueCols = ownerDims.cols === 306 ? 320 : 306;
+    const rogueRows = ownerDims.rows === 15 ? 20 : 15;
+    const injectionResult: { colsChanged: boolean } = await page.evaluate(
+      async ({ sessionId: injectionSessionId, cols, rows }) =>
+        window.electronAPI.sessions.resize(injectionSessionId, cols, rows),
+      { sessionId, cols: rogueCols, rows: rogueRows },
+    );
+
+    // Positive control 1: the PTY actually diverged (main honored the rogue grid).
+    expect(injectionResult.colsChanged).toBe(true);
+
+    // Positive control 2: the divergence was broadcast - the signal the heal
+    // consumes. The recorder log is append-only, so this cannot be masked by
+    // the heal racing it.
+    await expect
+      .poll(async () => {
+        const echoes = await readPtyEchoes(page);
+        return echoes.some((echo) => echo.cols === rogueCols && echo.rows === rogueRows);
+      }, { timeout: 10000, intervals: [100] })
+      .toBe(true);
+
+    if (process.platform !== 'win32') {
+      // Positive control 3: the user-visible incident occurred - the TUI drew
+      // a full frame at the rogue width while the window xterm sat at the
+      // owner grid. The fixture's 20ms repaint delay sits far under the 150ms
+      // heal debounce so the rogue frame lands before the corrective SIGWINCH
+      // even under CI scheduling drift - see the extraEnv comment for why the
+      // margin matters (a late corrective resize CANCELS a still-pending
+      // rogue draw).
+      await expect
+        .poll(async () => rulerWidths(await scrollbackForSession(page, sessionId)), { timeout: 15000, intervals: [250] })
+        .toContain(rogueCols);
+    }
+
+    // THE HEAL: the mounted owner re-asserts its grid; main applies it and
+    // echoes the owner dims back as the final word.
+    await expect
+      .poll(async () => {
+        const echoes = await readPtyEchoes(page);
+        const last = echoes[echoes.length - 1];
+        return last ? `${last.cols}x${last.rows}` : 'none';
+      }, { timeout: 15000, intervals: [250] })
+      .toBe(`${ownerDims.cols}x${ownerDims.rows}`);
+
+    // No resize storm: once healed, the echo log stops moving, and the tail
+    // after the rogue entry is exactly the single corrective re-assert.
+    const finalEchoes = await settledPtyEchoes(page, 15000, SETTLE_MESSAGE);
+    const lastRogueIndex = finalEchoes.map((echo) => echo.cols).lastIndexOf(rogueCols);
+    expect(lastRogueIndex).toBeGreaterThanOrEqual(0);
+    expect(finalEchoes.slice(lastRogueIndex + 1)).toEqual([
+      { cols: ownerDims.cols, rows: ownerDims.rows, origin: 'desktop' },
+    ]);
+
+    if (process.platform !== 'win32') {
+      // The fixture repainted at the healed width: the last frame in the ring
+      // (and therefore what the repair replay painted) is owner-width.
+      await expect
+        .poll(async () => {
+          const widths = rulerWidths(await scrollbackForSession(page, sessionId));
+          return widths[widths.length - 1] ?? 0;
+        }, { timeout: 15000, intervals: [250] })
+        .toBe(ownerDims.cols);
+    }
+
+    // The heal must never "fix" the divergence by refitting the visible xterm
+    // to the rogue dims: the detail window rendered exactly ONE distinct grid
+    // width through injection + heal.
+    const detailWidths: number[] = await page.evaluate(() => {
+      const widths = (window as unknown as { __detailWidths?: number[] }).__detailWidths ?? [];
+      return widths.slice();
+    });
+    expect(
+      new Set(detailWidths).size,
+      'The detail window rendered more than one grid width across the injection and '
+      + 'heal, so the "heal" moved the visible xterm instead of re-asserting its grid. '
+      + 'Recorded widths: ' + JSON.stringify(detailWidths),
+    ).toBe(1);
+
+    // END-ONLY destructive probe (never poll with this - each call would
+    // itself heal the PTY): a no-op resize at the owner dims proves the PTY
+    // is exactly there.
+    const probeResult: { colsChanged: boolean } = await page.evaluate(
+      async ({ sessionId: probeSessionId, cols, rows }) =>
+        window.electronAPI.sessions.resize(probeSessionId, cols, rows),
+      { sessionId, cols: ownerDims.cols, rows: ownerDims.rows },
+    );
+    expect(probeResult.colsChanged).toBe(false);
+
+    console.log('[width-drift-selfheal] echoes: ' + JSON.stringify(finalEchoes));
+    console.log('[width-drift-selfheal] detail widths: ' + JSON.stringify(detailWidths));
+
+    await page.evaluate(() => {
+      const globalScope = window as unknown as {
+        __ptyEchoUnsubscribe?: () => void;
+        __detailWidthObserver?: MutationObserver;
+      };
+      globalScope.__ptyEchoUnsubscribe?.();
+      globalScope.__detailWidthObserver?.disconnect();
+    });
+  });
+});

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -1570,7 +1570,9 @@
       __resizeCalls: [],
       resize: async function (sessionId, cols, rows) {
         window.electronAPI.sessions.__resizeCalls.push({ sessionId: sessionId, cols: cols, rows: rows });
-        return { colsChanged: false };
+        // Tests can force the result (e.g. { colsChanged: false, refused: true }
+        // to exercise the width-drift refusal hold) via window.__mockResizeResult.
+        return window.__mockResizeResult || { colsChanged: false };
       },
       list: async function () {
         return sessions;
@@ -1603,6 +1605,23 @@
       },
       ackData: function () {
         // No-op in the headless mock: backpressure pause/resume has no PTY here.
+      },
+      onPtyResized: function (callback) {
+        // Tests can fire the width-drift echo via
+        // window.__mockFirePtyResized(sessionId, cols, rows, origin).
+        if (!window.__mockPtyResizedListeners) window.__mockPtyResizedListeners = [];
+        window.__mockPtyResizedListeners.push(callback);
+        if (!window.__mockFirePtyResized) {
+          window.__mockFirePtyResized = function (sessionId, cols, rows, origin) {
+            var listeners = (window.__mockPtyResizedListeners || []).slice();
+            for (var i = 0; i < listeners.length; i++) { listeners[i](sessionId, cols, rows, origin || 'desktop'); }
+          };
+        }
+        return function () {
+          var listeners = window.__mockPtyResizedListeners || [];
+          var idx = listeners.indexOf(callback);
+          if (idx >= 0) listeners.splice(idx, 1);
+        };
       },
       onFirstOutput: function (callback) {
         // Tests can fire this via window.__mockFireFirstOutput(sessionId).

--- a/tests/ui/terminal-resize-echo-reassert.spec.ts
+++ b/tests/ui/terminal-resize-echo-reassert.spec.ts
@@ -1,0 +1,554 @@
+/**
+ * UI test for the terminal width-drift self-heal: the SESSION_PTY_RESIZED echo
+ * listener in useTerminal, driven end to end through a REAL mounted xterm.
+ *
+ * The bug family: main's PTY can be reshaped under a mounted xterm (a lost
+ * resize, another surface's late write, a respawn), and xterm re-sends its
+ * dimensions only when its OWN size changes - so the two diverge with no
+ * recovery path, and live absolute-positioned TUI output wraps into a
+ * staircase until the window is resized by hand. Main now broadcasts a dims
+ * echo on every real PTY grid change; the mounted owner compares it to its own
+ * grid and re-asserts its fit, then repairs the frame with a scrollback
+ * replay. The guard matrix itself (resolvePtyEchoReassert) is unit-tested in
+ * tests/unit/pty-resize-echo-reassert.test.ts; this spec pins the WIRING: the
+ * listener reads the real xterm's dims, the re-assert goes out as a real
+ * sessions.resize, the repair replay repaints, and the budget/self-echo guards
+ * are consulted through the real refs.
+ *
+ * Launches with WebGL disabled (the window-park-reveal.spec.ts pattern) so
+ * xterm uses its DOM renderer and terminal content is assertable as text.
+ * The bounded-attempts and self-echo tests read the dev-mode renderer trace
+ * ring (window.__kangenticTerminalTrace, installed by DevtoolsBootstrap under
+ * the Vite dev server) - a deterministic "the echo was processed" signal, so
+ * no negative assertion needs a bare timeout.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+test.describe.configure({ mode: 'parallel' });
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-resize-echo';
+const TASK_ID = 'task-resize-echo';
+const SESSION_ID = 'sess-resize-echo';
+const TASK_TITLE = 'Resize Echo Task';
+
+const INITIAL_CONTENT = 'INITIAL-SCROLLBACK-FRAME';
+const REPAIRED_CONTENT = 'REPAIRED-AT-OWNER-WIDTH';
+
+const preConfig = `
+  window.__mockPreConfigure(function (state) {
+    var ts = new Date().toISOString();
+
+    state.projects.push({
+      id: '${PROJECT_ID}',
+      name: 'Resize Echo Test',
+      path: '/mock/resize-echo-test',
+      github_url: null,
+      default_agent: 'claude',
+      last_opened: ts,
+      created_at: ts,
+    });
+
+    var laneIds = {};
+    state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+      var id = 'lane-' + s.name.toLowerCase().replace(/\\s+/g, '-');
+      laneIds[s.name] = id;
+      state.swimlanes.push(Object.assign({}, s, { id: id, position: i, created_at: ts }));
+    });
+
+    // Running session so the task-detail window opens with a live terminal.
+    state.sessions.push({
+      id: '${SESSION_ID}',
+      taskId: '${TASK_ID}',
+      projectId: '${PROJECT_ID}',
+      pid: 9999,
+      status: 'running',
+      shell: 'bash',
+      cwd: '/mock/resize-echo-test',
+      startedAt: ts,
+      exitCode: null,
+    });
+
+    state.tasks.push({
+      id: '${TASK_ID}',
+      display_id: 1,
+      title: '${TASK_TITLE}',
+      description: 'Task used to verify the width-drift echo re-assert',
+      swimlane_id: laneIds['Code Review'],
+      position: 0,
+      agent: 'claude',
+      session_id: '${SESSION_ID}',
+      worktree_path: null,
+      branch_name: null,
+      pr_number: null,
+      pr_url: null,
+      base_branch: 'main',
+      archived_at: null,
+      created_at: ts,
+      updated_at: ts,
+    });
+
+    return { currentProjectId: '${PROJECT_ID}' };
+  });
+`;
+
+interface ResizeCall {
+  sessionId: string;
+  cols: number;
+  rows: number;
+}
+
+interface RendererTraceEvent {
+  sessionId: string | null;
+  event: string;
+  detail?: Record<string, unknown>;
+}
+
+interface TestWindow {
+  __scrollbackValue?: string;
+  __scrollbackReads?: number;
+  __mockFireSessionData?: (sessionId: string, data: string) => void;
+  __mockFirePtyResized?: (sessionId: string, cols: number, rows: number, origin?: string) => void;
+  __mockResizeResult?: { colsChanged: boolean; refused?: boolean };
+  __kangenticTerminalTrace?: () => RendererTraceEvent[];
+  __zustandStores?: {
+    session?: {
+      getState: () => { markFirstOutput: (id: string) => void };
+    };
+  };
+  electronAPI?: {
+    sessions: {
+      getScrollback: (sessionId: string) => Promise<string>;
+      __resizeCalls: ResizeCall[];
+    };
+  };
+}
+
+async function launchWithState(preConfigScript: string): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  // Disable WebGL so xterm renders through its DOM renderer and terminal
+  // CONTENT is assertable as text (with WebGL, innerText is empty).
+  const browser = await chromium.launch({ headless: true, args: ['--disable-webgl', '--disable-webgl2'] });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(preConfigScript);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+  return { browser, page };
+}
+
+/** Opens the task detail on a settled mount replay and returns the grid the
+ *  window's xterm fitted to (captured from the mount-time resize IPC). */
+async function openDetailAndCaptureOwnerDims(page: Page): Promise<{ cols: number; rows: number }> {
+  await page.locator('[data-swimlane-name="Code Review"]').waitFor({ state: 'visible', timeout: 15000 });
+
+  // Lift the startup overlay (xterm mounts unsuppressed) and point
+  // getScrollback at a mutable value, counting reads for the self-echo test.
+  await page.evaluate(
+    ({ sessionId, initialContent }) => {
+      const testWindow = window as unknown as TestWindow;
+      testWindow.__zustandStores?.session?.getState().markFirstOutput(sessionId);
+      testWindow.__scrollbackValue = `${initialContent}\r\n`;
+      testWindow.__scrollbackReads = 0;
+      if (testWindow.electronAPI) {
+        testWindow.electronAPI.sessions.getScrollback = async () => {
+          const liveWindow = window as unknown as TestWindow;
+          liveWindow.__scrollbackReads = (liveWindow.__scrollbackReads ?? 0) + 1;
+          return liveWindow.__scrollbackValue ?? '';
+        };
+      }
+    },
+    { sessionId: SESSION_ID, initialContent: INITIAL_CONTENT },
+  );
+
+  await page
+    .locator('[data-swimlane-name="Code Review"]')
+    .locator(`text=${TASK_TITLE}`)
+    .first()
+    .click();
+  const dialog = page.locator('[data-testid="task-detail-dialog"]');
+  await dialog.waitFor({ state: 'visible', timeout: 5000 });
+  await dialog.locator('.xterm-helper-textarea').first().waitFor({ state: 'attached', timeout: 10000 });
+  await expect
+    .poll(async () => dialog.locator('.xterm').first().innerText(), { timeout: 10000 })
+    .toContain(INITIAL_CONTENT);
+
+  // The mount replay sent an immediate resize at the fitted grid; the last
+  // recorded call for this session is the owner's dims.
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(
+          (sessionId) =>
+            ((window as unknown as TestWindow).electronAPI?.sessions.__resizeCalls ?? []).filter(
+              (call) => call.sessionId === sessionId,
+            ).length,
+          SESSION_ID,
+        ),
+      { timeout: 5000 },
+    )
+    .toBeGreaterThan(0);
+  const ownerDims: ResizeCall = await page.evaluate((sessionId) => {
+    const calls = ((window as unknown as TestWindow).electronAPI?.sessions.__resizeCalls ?? []).filter(
+      (call) => call.sessionId === sessionId,
+    );
+    return calls[calls.length - 1];
+  }, SESSION_ID);
+  expect(ownerDims.cols).toBeGreaterThan(10);
+  expect(ownerDims.rows).toBeGreaterThan(5);
+
+  // Clean slate for the assertions: only re-assert sends land after this.
+  await page.evaluate(() => {
+    const testWindow = window as unknown as TestWindow;
+    if (testWindow.electronAPI) testWindow.electronAPI.sessions.__resizeCalls.length = 0;
+  });
+
+  return { cols: ownerDims.cols, rows: ownerDims.rows };
+}
+
+async function readEchoTraceEvents(page: Page): Promise<Array<Record<string, unknown>>> {
+  return page.evaluate((sessionId) => {
+    const readTrace = (window as unknown as TestWindow).__kangenticTerminalTrace;
+    if (typeof readTrace !== 'function') return [];
+    return readTrace()
+      .filter((entry) => entry.event === 'pty-resize-echo' && entry.sessionId === sessionId)
+      .map((entry) => entry.detail ?? {});
+  }, SESSION_ID);
+}
+
+/** Same shape as readEchoTraceEvents, but for the DIFFERENT event name
+ *  reassertOwnGrid traces when main refuses a corrective re-assert (the
+ *  mobile sub-floor hold) - a separate reader rather than a shared/parameterized
+ *  one, so this new helper cannot change what the three existing tests read. */
+async function readRefusedTraceEvents(page: Page): Promise<Array<Record<string, unknown>>> {
+  return page.evaluate((sessionId) => {
+    const readTrace = (window as unknown as TestWindow).__kangenticTerminalTrace;
+    if (typeof readTrace !== 'function') return [];
+    return readTrace()
+      .filter((entry) => entry.event === 'echo-reassert-refused' && entry.sessionId === sessionId)
+      .map((entry) => entry.detail ?? {});
+  }, SESSION_ID);
+}
+
+/** Quiescence gate: waits until the renderer trace ring stops growing for two
+ *  consecutive checks. A StrictMode second mount's replay can still be in
+ *  flight right after openDetailAndCaptureOwnerDims resolves (skips a
+ *  disagreeing echo as 'replay-in-flight'), and separately the window's own
+ *  entrance-driven layout resize (debounced PTY_RESIZE_DEBOUNCE_MS = 200ms in
+ *  useTerminal.ts) can still be pending (skips as 'own-resize-pending'). A
+ *  content-only settle (fire data, wait for it to paint) catches the first
+ *  but is blind to the second, since a pending onResize touches no terminal
+ *  content - the gap that let the single-heal and budget-bound tests below
+ *  flake under worker contention (an intermittent skip where the test expects
+ *  a scheduled re-assert). Watching the trace ring's length covers both:
+ *  either state keeps emitting trace events (replay-start/fit/resize-request/
+ *  replay-write/replay-done, or the eventual debounced resize-request) until
+ *  it actually settles. */
+async function waitForTerminalTraceQuiescence(page: Page): Promise<void> {
+  let previousTraceLength = -1;
+  let stableChecks = 0;
+  await expect
+    .poll(async () => {
+      const currentTraceLength = await page.evaluate(
+        (sessionId) =>
+          ((window as unknown as TestWindow).__kangenticTerminalTrace?.() ?? []).filter(
+            (entry) => entry.sessionId === sessionId,
+          ).length,
+        SESSION_ID,
+      );
+      stableChecks = currentTraceLength === previousTraceLength ? stableChecks + 1 : 0;
+      previousTraceLength = currentTraceLength;
+      return stableChecks;
+    }, { timeout: 10000, intervals: [250, 250, 250] })
+    .toBeGreaterThanOrEqual(2);
+}
+
+/** Drops whatever __resizeCalls has accumulated so far. Used AFTER
+ *  waitForTerminalTraceQuiescence, right before a test fires the echo it
+ *  actually means to pin: the window manager's own layout-settle flush
+ *  (scheduleWindowTerminalResize -> flushResize, origin 'flush') can land
+ *  after openDetailAndCaptureOwnerDims's own clear but before quiescence is
+ *  reached, at the SAME dims as ownerDims - benign window housekeeping, not a
+ *  corrective re-assert, but indistinguishable from one by dims alone.
+ *  Clearing again here (post-quiescence, so no further window-layout resize
+ *  is expected) means the only calls left by the time a test asserts are the
+ *  ones it is actually pinning. */
+async function clearResizeCalls(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const testWindow = window as unknown as TestWindow;
+    if (testWindow.electronAPI) testWindow.electronAPI.sessions.__resizeCalls.length = 0;
+  });
+}
+
+test.describe('Terminal width-drift echo re-assert', () => {
+  test('a disagreeing echo makes the mounted owner re-assert its grid once and repair the frame', async () => {
+    const { browser, page } = await launchWithState(preConfig);
+    try {
+      const ownerDims = await openDetailAndCaptureOwnerDims(page);
+      const dialog = page.locator('[data-testid="task-detail-dialog"]');
+      const rogueCols = ownerDims.cols + 80;
+
+      // Quiescence gate before the incident is provoked: a still-pending
+      // replay or window-entrance-driven layout resize (see
+      // waitForTerminalTraceQuiescence) would otherwise let the TRIGGERING
+      // echo below land while resolvePtyEchoReassert still sees
+      // 'replay-in-flight' or 'own-resize-pending', silently skipping the
+      // re-assert this test means to pin and leaving the torn frame
+      // unrepaired.
+      await waitForTerminalTraceQuiescence(page);
+      await clearResizeCalls(page);
+
+      // The incident, reproduced: the PTY (simulated by the fired data) draws
+      // a ruler exactly rogueCols wide while the xterm sits at ownerDims. The
+      // line must wrap - the staircase positive control: #END lands on a row
+      // of its own, torn off the RULER- prefix. Fired inside the poll: a byte
+      // swallowed by a still-in-flight mount replay (held, then superseded by
+      // its sample) is simply re-fired until one lands live.
+      await expect
+        .poll(async () => {
+          await page.evaluate(
+            ({ sessionId, cols }) => {
+              const ruler = (`RULER-${cols}-`).padEnd(cols - 4, '.') + '#END';
+              (window as unknown as TestWindow).__mockFireSessionData?.(sessionId, `${ruler}\r\n`);
+            },
+            { sessionId: SESSION_ID, cols: rogueCols },
+          );
+          const text = await dialog.locator('.xterm').first().innerText();
+          const endRow = text.split('\n').find((row) => row.includes('#END'));
+          return endRow !== undefined && !endRow.includes('RULER-');
+        }, { timeout: 10000, intervals: [250] })
+        .toBe(true);
+
+      // The repair replay will fetch this frame (main's parsed grid, drawn at
+      // the corrected width).
+      await page.evaluate((repaired) => {
+        (window as unknown as TestWindow).__scrollbackValue = `${repaired}\r\n`;
+      }, REPAIRED_CONTENT);
+
+      // The echo: main announces the PTY moved to the rogue grid.
+      await page.evaluate(
+        ({ sessionId, cols }) => {
+          (window as unknown as TestWindow).__mockFirePtyResized?.(sessionId, cols, 15, 'desktop');
+        },
+        { sessionId: SESSION_ID, cols: rogueCols },
+      );
+
+      // The heal: exactly one corrective resize, at the OWNER's dims - not the
+      // rogue ones (a bad fix that refits the xterm to the echoed grid would
+      // send rogueCols here), and not more than one (ownership gating: no
+      // second surface re-asserts).
+      await expect
+        .poll(
+          async () => page.evaluate(() => (window as unknown as TestWindow).electronAPI?.sessions.__resizeCalls ?? []),
+          { timeout: 10000 },
+        )
+        .toEqual([{ sessionId: SESSION_ID, cols: ownerDims.cols, rows: ownerDims.rows }]);
+
+      // The repair replay replaced the torn frame (xterm.reset before the
+      // write), so the staircased ruler is gone and the repaired frame shows.
+      await expect
+        .poll(async () => dialog.locator('.xterm').first().innerText(), { timeout: 10000 })
+        .toContain(REPAIRED_CONTENT);
+      const repairedText = await dialog.locator('.xterm').first().innerText();
+      expect(repairedText).not.toContain('#END');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('the echo of the terminal own grid is skipped in-sync: no resize, no replay', async () => {
+    const { browser, page } = await launchWithState(preConfig);
+    try {
+      const ownerDims = await openDetailAndCaptureOwnerDims(page);
+
+      const scrollbackReadsBefore = await page.evaluate(
+        () => (window as unknown as TestWindow).__scrollbackReads ?? 0,
+      );
+
+      // An echo carrying the terminal's own dims - what its own resize (or a
+      // remount re-send) reflects back.
+      await page.evaluate(
+        ({ sessionId, cols, rows }) => {
+          (window as unknown as TestWindow).__mockFirePtyResized?.(sessionId, cols, rows, 'desktop');
+        },
+        { sessionId: SESSION_ID, cols: ownerDims.cols, rows: ownerDims.rows },
+      );
+
+      // Deterministic "the echo was processed" signal: the listener traces
+      // every echo with its decision. This is the positive control that makes
+      // the negative assertions below meaningful without a bare timeout.
+      await expect
+        .poll(async () => readEchoTraceEvents(page), { timeout: 5000 })
+        .toEqual([
+          expect.objectContaining({ action: 'skip', reason: 'in-sync', cols: ownerDims.cols, rows: ownerDims.rows }),
+        ]);
+
+      const resizeCalls = await page.evaluate(
+        () => (window as unknown as TestWindow).electronAPI?.sessions.__resizeCalls ?? [],
+      );
+      expect(resizeCalls).toEqual([]);
+      const scrollbackReadsAfter = await page.evaluate(
+        () => (window as unknown as TestWindow).__scrollbackReads ?? 0,
+      );
+      expect(scrollbackReadsAfter).toBe(scrollbackReadsBefore);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('repeated echoes of one divergence are bounded by the re-assert budget', async () => {
+    const { browser, page } = await launchWithState(preConfig);
+    try {
+      const ownerDims = await openDetailAndCaptureOwnerDims(page);
+      const rogueCols = ownerDims.cols + 80;
+
+      // Quiescence gate: without this, the FIRST of the four echoes fired
+      // below can legitimately skip as 'replay-in-flight' (a StrictMode
+      // second mount's replay still in flight) or 'own-resize-pending' (the
+      // window's own entrance-driven layout resize still debouncing), and the
+      // test never reaches the cap it means to pin - the exact flake this
+      // test hit under worker contention (all four decisions read 'skip'
+      // instead of ['reassert', 'reassert', 'skip', 'skip']).
+      await waitForTerminalTraceQuiescence(page);
+      await clearResizeCalls(page);
+
+      // Fire the SAME rogue echo four times in ONE synchronous evaluate: the
+      // 150ms re-assert debounce cannot fire inside a single JS turn, so the
+      // decisions are fully deterministic - reassert (count 1), reassert
+      // (count 2, timer rescheduled), attempt-cap, attempt-cap - and the two
+      // scheduled re-asserts coalesce into exactly one corrective send.
+      await page.evaluate(
+        ({ sessionId, cols }) => {
+          for (let fired = 0; fired < 4; fired += 1) {
+            (window as unknown as TestWindow).__mockFirePtyResized?.(sessionId, cols, 15, 'desktop');
+          }
+        },
+        { sessionId: SESSION_ID, cols: rogueCols },
+      );
+
+      await expect
+        .poll(async () => (await readEchoTraceEvents(page)).map((event) => event.action), { timeout: 5000 })
+        .toEqual(['reassert', 'reassert', 'skip', 'skip']);
+      const echoEvents = await readEchoTraceEvents(page);
+      expect(echoEvents.filter((event) => event.reason === 'attempt-cap')).toHaveLength(2);
+
+      // The coalesced debounced pass sends exactly one corrective resize, at
+      // the OWNER's dims.
+      await expect
+        .poll(
+          async () => page.evaluate(() => (window as unknown as TestWindow).electronAPI?.sessions.__resizeCalls ?? []),
+          { timeout: 5000 },
+        )
+        .toEqual([{ sessionId: SESSION_ID, cols: ownerDims.cols, rows: ownerDims.rows }]);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('main refusing a re-assert arms a time-stamped hold that skips every later echo', async () => {
+    const { browser, page } = await launchWithState(preConfig);
+    try {
+      const ownerDims = await openDetailAndCaptureOwnerDims(page);
+      const rogueCols = ownerDims.cols + 80;
+
+      // Quiescence gate before the triggering echo, so it is never skipped as
+      // 'replay-in-flight' or 'own-resize-pending' (see
+      // waitForTerminalTraceQuiescence). Re-clear __resizeCalls afterward: the
+      // window manager's own layout-settle flush can land in the same window
+      // (see clearResizeCalls) and would otherwise contaminate the
+      // exactly-one-call assertion below.
+      await waitForTerminalTraceQuiescence(page);
+      await clearResizeCalls(page);
+
+      // Force the corrective re-assert's resize IPC to come back refused (the
+      // mobile sub-floor hold). Set only AFTER the mount replay has settled -
+      // the mock returns __mockResizeResult for EVERY resize call, including
+      // the mount-time fit, so setting this earlier would corrupt
+      // openDetailAndCaptureOwnerDims's own resize call and its ownerDims read.
+      await page.evaluate(() => {
+        (window as unknown as TestWindow).__mockResizeResult = { colsChanged: false, refused: true };
+      });
+
+      const scrollbackReadsBefore = await page.evaluate(
+        () => (window as unknown as TestWindow).__scrollbackReads ?? 0,
+      );
+
+      // The disagreeing echo: main announces the PTY moved to a rogue grid.
+      await page.evaluate(
+        ({ sessionId, cols }) => {
+          (window as unknown as TestWindow).__mockFirePtyResized?.(sessionId, cols, 15, 'desktop');
+        },
+        { sessionId: SESSION_ID, cols: rogueCols },
+      );
+
+      // Deterministic "the refusal was processed" signal, so the negative
+      // assertions below aren't racing the debounce + async resize round trip.
+      await expect
+        .poll(async () => (await readRefusedTraceEvents(page)).length, { timeout: 5000 })
+        .toBe(1);
+
+      // Exactly one corrective re-assert landed, at the OWNER's width (not the
+      // rogue one echoed) - the send main refused.
+      const resizeCallsAfterFirstEcho = await page.evaluate(
+        () => (window as unknown as TestWindow).electronAPI?.sessions.__resizeCalls ?? [],
+      );
+      expect(resizeCallsAfterFirstEcho).toEqual([
+        { sessionId: SESSION_ID, cols: ownerDims.cols, rows: ownerDims.rows },
+      ]);
+
+      // The refused trace's dims are read from the exact same re-fit as the
+      // resize call above (reassertOwnGrid reads `{ cols, rows }` once and
+      // uses it for both), so they must agree with each other.
+      const refusedEvents = await readRefusedTraceEvents(page);
+      expect(refusedEvents).toEqual([
+        { cols: resizeCallsAfterFirstEcho[0].cols, rows: resizeCallsAfterFirstEcho[0].rows },
+      ]);
+
+      // No repair replay ran: a refused result returns before
+      // reloadScrollbackRef is ever called.
+      const scrollbackReadsAfter = await page.evaluate(
+        () => (window as unknown as TestWindow).__scrollbackReads ?? 0,
+      );
+      expect(scrollbackReadsAfter).toBe(scrollbackReadsBefore);
+
+      // A SECOND disagreeing echo, with a DIFFERENT cols value, is skipped
+      // too: the refusal hold is time-stamped, not signature-keyed (see
+      // ECHO_REASSERT_BUDGET_WINDOW_MS in useTerminal.ts), so a fresh
+      // divergence signature does not reopen healing during the hold window.
+      const secondRogueCols = ownerDims.cols + 40;
+      await page.evaluate(
+        ({ sessionId, cols }) => {
+          (window as unknown as TestWindow).__mockFirePtyResized?.(sessionId, cols, 15, 'desktop');
+        },
+        { sessionId: SESSION_ID, cols: secondRogueCols },
+      );
+
+      await expect
+        .poll(async () => readEchoTraceEvents(page), { timeout: 5000 })
+        .toEqual([
+          expect.objectContaining({ action: 'reassert' }),
+          expect.objectContaining({
+            action: 'skip', reason: 'refused-hold', cols: secondRogueCols, rows: 15,
+          }),
+        ]);
+
+      // No further resize call: the second echo never scheduled a re-assert.
+      const resizeCallsFinal = await page.evaluate(
+        () => (window as unknown as TestWindow).electronAPI?.sessions.__resizeCalls ?? [],
+      );
+      expect(resizeCallsFinal).toHaveLength(1);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/unit/pop-out.test.ts
+++ b/tests/unit/pop-out.test.ts
@@ -40,8 +40,8 @@ describe('POP_OUT_SURFACES fan-out declarations', () => {
   /**
    * A channel a surface subscribes to but does not declare here is dropped
    * SILENTLY for pop-out windows (windowsForChannel filters on this list), so the
-   * detached surface just never updates. These pin the monitor's three live
-   * wires - MONITOR_PEEK included, even though (unlike the other two) it is
+   * detached surface just never updates. These pin the monitor's live
+   * wires - MONITOR_PEEK included, even though (unlike the others) it is
    * subscribe-gated rather than an unconditional push: the detached window
    * subscribes on its own behalf, so main is already fanning to it by the time
    * rows exist, and dropping this line would silently freeze every card's
@@ -53,6 +53,21 @@ describe('POP_OUT_SURFACES fan-out declarations', () => {
     expect(channels).toContain(IPC.SESSION_ACTIVITY);
     expect(channels).toContain(IPC.MONITOR_PEEK);
     expect(channels).toContain(IPC.CONFIG_CHANGED);
+  });
+
+  /**
+   * The monitor is currently the ONLY pop-out surface that can host a task
+   * detail (and therefore a live terminal) for a project the board is not on
+   * (see the channels comment in src/shared/pop-out.ts). Without this channel
+   * declared, a PTY reshaped under that detached terminal would never receive
+   * the width-drift self-heal's echo (windowsForChannel filters the broadcast
+   * on this list) and the divergence would never recover in that window -
+   * silently, since nothing else observes the drop. If a future surface also
+   * hosts a terminal, extend this assertion to it too.
+   */
+  it('the monitor declares the PTY-dims echo so a hosted terminal can self-heal a width divergence', () => {
+    const channels = POP_OUT_SURFACES.monitor.channels;
+    expect(channels).toContain(IPC.SESSION_PTY_RESIZED);
   });
 
   it('the monitor is a global surface with no task params', () => {

--- a/tests/unit/pty-resize-echo-reassert.test.ts
+++ b/tests/unit/pty-resize-echo-reassert.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit coverage for `resolvePtyEchoReassert`, the pure guard matrix of the
+ * terminal width-drift self-heal (useTerminal's SESSION_PTY_RESIZED listener).
+ *
+ * The scenario it exists for: a PTY reshaped under a mounted xterm (a lost
+ * resize, another surface's late write, a respawn) has NO recovery path on its
+ * own - xterm re-sends dimensions only when its own size changes - so live
+ * absolute-positioned TUI output wraps into a staircase until the window is
+ * resized by hand. The echo listener re-asserts the mounted owner's fitted
+ * grid; this function decides when that is safe.
+ *
+ * The budget is deliberately time-windowed rather than reset-on-heal: in a
+ * two-surface fight each side's successful re-assert lands an in-sync echo at
+ * the OTHER side, so a budget reset by in-sync echoes never binds in exactly
+ * the livelock it exists to bound. The sequence tests below pin that.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  resolvePtyEchoReassert,
+  type PtyEchoReassertAttempts,
+  type PtyEchoReassertInput,
+} from '../../src/renderer/hooks/useTerminal';
+
+const NOW = 1_000_000;
+
+function makeInput(overrides: Partial<PtyEchoReassertInput> = {}): PtyEchoReassertInput {
+  return {
+    // The incident geometry: PTY reshaped to the bottom panel's strip while
+    // the board window's xterm sits at the detail fit.
+    echoedCols: 306,
+    echoedRows: 15,
+    ownCols: 210,
+    ownRows: 48,
+    origin: 'desktop',
+    replayPending: false,
+    parked: false,
+    ownResizePending: false,
+    previousAttempts: null,
+    lastRefusalAt: null,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe('resolvePtyEchoReassert', () => {
+  it('re-asserts on a disagreeing desktop-origin echo with all guards clear', () => {
+    const decision = resolvePtyEchoReassert(makeInput());
+    expect(decision).toEqual({
+      action: 'reassert',
+      signature: '306x15<-210x48',
+      nextAttempts: { signature: '306x15<-210x48', count: 1, lastScheduledAt: NOW },
+    });
+  });
+
+  it('re-asserts on a cols-only and on a rows-only mismatch (rows drift staircases too)', () => {
+    const colsOnly = resolvePtyEchoReassert(makeInput({ echoedCols: 306, echoedRows: 48 }));
+    expect(colsOnly.action).toBe('reassert');
+    const rowsOnly = resolvePtyEchoReassert(makeInput({ echoedCols: 210, echoedRows: 15 }));
+    expect(rowsOnly.action).toBe('reassert');
+  });
+
+  it('treats a spawn-origin echo like desktop (a respawn under a mounted xterm is healable)', () => {
+    const decision = resolvePtyEchoReassert(makeInput({ origin: 'spawn', echoedCols: 120, echoedRows: 30 }));
+    expect(decision.action).toBe('reassert');
+  });
+
+  it('skips in-sync: the echo of this terminal own resize self-filters', () => {
+    const decision = resolvePtyEchoReassert(makeInput({ echoedCols: 210, echoedRows: 48 }));
+    expect(decision).toEqual({ action: 'skip', reason: 'in-sync', signature: '210x48<-210x48' });
+  });
+
+  it('skips foreign-hold for mobile- and park-origin echoes (a phone or the park legitimately holds the grid)', () => {
+    expect(resolvePtyEchoReassert(makeInput({ origin: 'mobile' }))).toMatchObject({ action: 'skip', reason: 'foreign-hold' });
+    expect(resolvePtyEchoReassert(makeInput({ origin: 'park' }))).toMatchObject({ action: 'skip', reason: 'foreign-hold' });
+  });
+
+  it('skips while parked (must not reshape a grid it is not showing)', () => {
+    expect(resolvePtyEchoReassert(makeInput({ parked: true }))).toMatchObject({ action: 'skip', reason: 'parked' });
+  });
+
+  describe('the refusal hold (main deliberately holding the grid)', () => {
+    it('skips refused-hold while a refusal is fresh', () => {
+      const decision = resolvePtyEchoReassert(makeInput({ lastRefusalAt: NOW - 500 }));
+      expect(decision).toMatchObject({ action: 'skip', reason: 'refused-hold' });
+    });
+
+    it('holds across changed own dims (time-stamped, not signature-keyed)', () => {
+      // The pre-send fit can move this terminal's own dims during the
+      // debounce, changing every future signature. The hold must still bind,
+      // or a container drag while a phone holds the floor retries a refused
+      // IPC per fresh signature.
+      const decision = resolvePtyEchoReassert(makeInput({ lastRefusalAt: NOW - 500, ownCols: 190, ownRows: 40 }));
+      expect(decision).toMatchObject({ action: 'skip', reason: 'refused-hold' });
+    });
+
+    it('a lapsed refusal no longer blocks (the holder may have let go)', () => {
+      const decision = resolvePtyEchoReassert(makeInput({ lastRefusalAt: NOW - 60_000 }));
+      expect(decision.action).toBe('reassert');
+    });
+  });
+
+  it('skips while a replay is in flight (the replay own fit and resize settle the dims)', () => {
+    expect(resolvePtyEchoReassert(makeInput({ replayPending: true }))).toMatchObject({ action: 'skip', reason: 'replay-in-flight' });
+  });
+
+  it('skips while its own debounced resize is pending (those dims are about to be asserted anyway)', () => {
+    expect(resolvePtyEchoReassert(makeInput({ ownResizePending: true }))).toMatchObject({ action: 'skip', reason: 'own-resize-pending' });
+  });
+
+  describe('guard ordering (the trace must name the REAL reason)', () => {
+    it('in-sync wins over every hold and mechanical guard', () => {
+      const decision = resolvePtyEchoReassert(makeInput({
+        echoedCols: 210, echoedRows: 48,
+        origin: 'park', parked: true, replayPending: true, ownResizePending: true,
+        lastRefusalAt: NOW - 500,
+      }));
+      expect(decision).toMatchObject({ action: 'skip', reason: 'in-sync' });
+    });
+
+    it('foreign-hold wins over the refusal hold, the mechanical guards, and the cap', () => {
+      const spent: PtyEchoReassertAttempts = { signature: '306x15<-210x48', count: 99, lastScheduledAt: NOW };
+      const decision = resolvePtyEchoReassert(makeInput({
+        origin: 'mobile', parked: true, replayPending: true, previousAttempts: spent,
+        lastRefusalAt: NOW - 500,
+      }));
+      expect(decision).toMatchObject({ action: 'skip', reason: 'foreign-hold' });
+    });
+
+    it('refused-hold wins over parked and the cap', () => {
+      const spent: PtyEchoReassertAttempts = { signature: '306x15<-210x48', count: 99, lastScheduledAt: NOW };
+      const decision = resolvePtyEchoReassert(makeInput({
+        parked: true, previousAttempts: spent, lastRefusalAt: NOW - 500,
+      }));
+      expect(decision).toMatchObject({ action: 'skip', reason: 'refused-hold' });
+    });
+
+    it('the cap is judged last, so a capped-but-parked echo reports parked', () => {
+      const spent: PtyEchoReassertAttempts = { signature: '306x15<-210x48', count: 99, lastScheduledAt: NOW };
+      const decision = resolvePtyEchoReassert(makeInput({ parked: true, previousAttempts: spent }));
+      expect(decision).toMatchObject({ action: 'skip', reason: 'parked' });
+    });
+  });
+
+  describe('the time-windowed budget', () => {
+    it('caps the same signature after two re-asserts inside the window', () => {
+      const first = resolvePtyEchoReassert(makeInput());
+      expect(first.action).toBe('reassert');
+      const firstAttempts = first.action === 'reassert' ? first.nextAttempts : null;
+
+      const second = resolvePtyEchoReassert(makeInput({ previousAttempts: firstAttempts, now: NOW + 500 }));
+      expect(second.action).toBe('reassert');
+      const secondAttempts = second.action === 'reassert' ? second.nextAttempts : null;
+      expect(secondAttempts).toEqual({ signature: '306x15<-210x48', count: 2, lastScheduledAt: NOW + 500 });
+
+      const third = resolvePtyEchoReassert(makeInput({ previousAttempts: secondAttempts, now: NOW + 1_000 }));
+      expect(third).toMatchObject({ action: 'skip', reason: 'attempt-cap' });
+    });
+
+    it('a lapsed window grants a fresh budget for the same signature', () => {
+      const spent: PtyEchoReassertAttempts = { signature: '306x15<-210x48', count: 2, lastScheduledAt: NOW };
+      const decision = resolvePtyEchoReassert(makeInput({ previousAttempts: spent, now: NOW + 60_000 }));
+      expect(decision).toMatchObject({
+        action: 'reassert',
+        nextAttempts: { signature: '306x15<-210x48', count: 1, lastScheduledAt: NOW + 60_000 },
+      });
+    });
+
+    it('a new signature (different echoed or own dims) gets a fresh budget immediately', () => {
+      const spent: PtyEchoReassertAttempts = { signature: '306x15<-210x48', count: 2, lastScheduledAt: NOW };
+      const differentEcho = resolvePtyEchoReassert(makeInput({ echoedCols: 320, previousAttempts: spent, now: NOW + 100 }));
+      expect(differentEcho).toMatchObject({ action: 'reassert', nextAttempts: { count: 1 } });
+      const differentOwn = resolvePtyEchoReassert(makeInput({ ownCols: 190, previousAttempts: spent, now: NOW + 100 }));
+      expect(differentOwn).toMatchObject({ action: 'reassert', nextAttempts: { count: 1 } });
+    });
+
+    it('an intervening in-sync echo does NOT refresh the budget (the two-surface livelock bound)', () => {
+      // Surface A at 306x15 and surface B at 210x48 fighting over one PTY:
+      // every successful re-assert by one side lands an in-sync echo at that
+      // side and a disagreeing echo at the other. The caller stores attempts
+      // only on a reassert decision, so B's view of the fight is: rogue echo
+      // (count 1), own in-sync echo (no change), rogue echo (count 2), own
+      // in-sync echo (no change), rogue echo -> CAP. Three rounds, then quiet
+      // for the rest of the window, whatever the other side does.
+      let attempts: PtyEchoReassertAttempts | null = null;
+      const rounds: string[] = [];
+      for (let round = 0; round < 4; round += 1) {
+        const timestamp = NOW + round * 400;
+        const rogue = resolvePtyEchoReassert(makeInput({ previousAttempts: attempts, now: timestamp }));
+        rounds.push(rogue.action === 'skip' ? rogue.reason : rogue.action);
+        if (rogue.action === 'reassert') attempts = rogue.nextAttempts;
+        // The echo of this side's own successful re-assert: in-sync, and the
+        // caller leaves the stored attempts untouched on any skip.
+        const own = resolvePtyEchoReassert(makeInput({
+          echoedCols: 210, echoedRows: 48, previousAttempts: attempts, now: timestamp + 200,
+        }));
+        expect(own).toMatchObject({ action: 'skip', reason: 'in-sync' });
+      }
+      expect(rounds).toEqual(['reassert', 'reassert', 'attempt-cap', 'attempt-cap']);
+    });
+  });
+});

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -1214,16 +1214,36 @@ describe('Dimension tracking', () => {
     expect(manager.getDimensions('nonexistent')).toBeNull();
   });
 
-  it('every grid-changing resize emits pty-resize with the clamped grid', async () => {
+  it('every grid-changing resize emits pty-resize with the clamped grid and its origin', async () => {
     const mock = createMockPty();
     vi.mocked(pty.spawn).mockReturnValue(mock.mockPty as unknown as pty.IPty);
     const session = await manager.spawn({ taskId: 'task-dims-emit', command: '', cwd: tmpDir });
 
-    const resizes: Array<[string, number, number]> = [];
-    manager.on('pty-resize', (sessionId: string, cols: number, rows: number) => resizes.push([sessionId, cols, rows]));
+    const resizes: Array<[string, number, number, string]> = [];
+    manager.on('pty-resize', (sessionId: string, cols: number, rows: number, origin: string) => resizes.push([sessionId, cols, rows, origin]));
 
     manager.resize(session.id, 80.7, 0);
-    expect(resizes).toEqual([[session.id, 80, 1]]);
+    expect(resizes).toEqual([[session.id, 80, 1, 'desktop']]);
+
+    // Explicit origins ride the emit unchanged, so the renderer's echo
+    // listener can leave phone- and park-held grids alone (foreign-hold).
+    manager.resize(session.id, 90, 20, 'mobile');
+    manager.resize(session.id, 210, 48, 'park');
+    expect(resizes.slice(1)).toEqual([
+      [session.id, 90, 20, 'mobile'],
+      [session.id, 210, 48, 'park'],
+    ]);
+  });
+
+  it('the spawn announces its grid with the spawn origin', async () => {
+    const mock = createMockPty();
+    vi.mocked(pty.spawn).mockReturnValue(mock.mockPty as unknown as pty.IPty);
+
+    const resizes: Array<[number, number, string]> = [];
+    manager.on('pty-resize', (_sessionId: string, cols: number, rows: number, origin: string) => resizes.push([cols, rows, origin]));
+
+    await manager.spawn({ taskId: 'task-dims-spawn-origin', command: '', cwd: tmpDir });
+    expect(resizes).toEqual([[120, 30, 'spawn']]);
   });
 
   it('a resize to the current grid neither reshapes the PTY nor emits pty-resize', async () => {
@@ -3144,7 +3164,11 @@ describe('Resting grid restore', () => {
 
     const result = manager.resize(session.id, PANEL_COLS, PANEL_ROWS);
 
-    expect(result).toEqual({ colsChanged: false });
+    // `refused` marks the one outcome where main deliberately HOLDS the grid
+    // against the caller. The echo re-assert (width-drift self-heal) reads it
+    // to stop after a single refused IPC instead of retrying to its cap; every
+    // other early return stays the bare { colsChanged: false }.
+    expect(result).toEqual({ colsChanged: false, refused: true });
     expect(mockPty.resize).not.toHaveBeenCalled();
     expect(resizes).toEqual([]);
     expect([mockPty.cols, mockPty.rows]).toEqual([120, 30]);
@@ -3216,6 +3240,57 @@ describe('Resting grid restore', () => {
 
     manager.resize(session.id, PANEL_COLS, PANEL_ROWS);
 
+    expect(manager.getDimensions(session.id)).toEqual({ cols: PANEL_COLS, rows: PANEL_ROWS });
+  });
+
+  /**
+   * The pre-spawn stash is a deferral, not a refusal: the PTY does not exist,
+   * so nothing was held AGAINST the caller and nothing changed that could
+   * echo. `refused` must stay reserved for the floor's deliberate hold, or the
+   * echo re-assert would burn its budget on a session that is merely
+   * mid-respawn.
+   */
+  it('a stashed resize neither emits pty-resize nor reports refused', async () => {
+    const { session } = await spawnSession('task-floor-stash-shape');
+    await manager.suspend(session.id);
+    mobileStreamWatchers = new Set();
+
+    const resizes: Array<[number, number]> = [];
+    manager.on('pty-resize', (_sessionId: string, cols: number, rows: number) => resizes.push([cols, rows]));
+
+    const result = manager.resize(session.id, PANEL_COLS, PANEL_ROWS);
+
+    expect(result).toEqual({ colsChanged: false });
+    expect(resizes).toEqual([]);
+  });
+
+  /**
+   * suspend() marks the record 'suspended' BEFORE gracefulPtyShutdown
+   * resolves, so the PTY stays non-null for up to ~3s of teardown. A resize
+   * landing in that window must stash like any suspended-session resize:
+   * reshaping the dying PTY would SIGWINCH a mid-exit agent and re-broadcast
+   * a pty-resize echo that arms re-asserts on other mounted terminals during
+   * teardown.
+   */
+  it('a resize in suspend\'s marked-but-alive window stashes instead of reshaping the dying PTY', async () => {
+    const { session, mockPty } = await spawnSession('task-floor-suspend-window');
+    mobileStreamWatchers = new Set();
+
+    const resizes: Array<[number, number]> = [];
+    manager.on('pty-resize', (_sessionId: string, cols: number, rows: number) => resizes.push([cols, rows]));
+    mockPty.resize.mockClear();
+
+    // Deliberately not awaited yet: the status flip is synchronous, the PTY
+    // teardown is not - this is the marked-but-alive window.
+    const suspendPromise = manager.suspend(session.id);
+    const result = manager.resize(session.id, PANEL_COLS, PANEL_ROWS);
+
+    expect(result).toEqual({ colsChanged: false });
+    expect(mockPty.resize).not.toHaveBeenCalled();
+    expect(resizes).toEqual([]);
+
+    await suspendPromise;
+    // The stash recorded the intent, so the respawn lands at the real size.
     expect(manager.getDimensions(session.id)).toEqual({ cols: PANEL_COLS, rows: PANEL_ROWS });
   });
 });


### PR DESCRIPTION
## What

A self-heal for terminal width drift: when the PTY's grid is reshaped under a mounted xterm (a lost or overridden resize on a surface flip, a respawn, any last-writer-wins race), the mounted owner now detects the divergence and recovers it automatically. Touches the IPC bridge (new `session:ptyResized` push channel through all 7 layers), `SessionManager.resize` (origin on the emit, `refused: true` from the mobile sub-floor branch, full outcome tracing), `useTerminal` (the echo listener, the pure `resolvePtyEchoReassert` guard matrix, the corrective re-assert + repair replay), and the pop-out monitor surface's channel list.

## Why

A task-detail window intermittently painted its whole terminal as a staircase: rows shifted progressively right, labels clipped at the left edge, border fragments drifting. Captured live: main's headless parsed grid held the frame perfectly while the window's pixels tore, meaning the mounted xterm was at one width (~210 cols) while the PTY drew at another (~306, the bottom panel's strip). xterm re-sends its dimensions only when its OWN size changes, so this divergence had no recovery path - documented in five places in the codebase as "the unrecoverable divergence" - and `CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT=1` (the Windows default) garbles the entire viewport on every frame once it happens.

## How

Main already short-circuits same-dims resizes, so its `pty-resize` emit fires only on real grid changes; this PR forwards that emit to renderers as a broadcast (`session:ptyResized`, carrying cols/rows and the resize origin: `desktop`/`mobile`/`park`/`spawn`). The mounted owner compares the echo to its own grid and, on disagreement, re-fits, re-sends its dims after a 150ms coalescing debounce, and repairs the already-garbled frame with the existing `reloadScrollback` replay (generation-guarded, held-byte-dropping, veil-free).

The guard matrix keeps the heal from fighting anything legitimate, in trace-naming order: in-sync self-filter (the echo of your own resize), foreign-hold (phone- and park-held grids are never fought), a time-stamped refused-hold (one refused IPC stops all healing for the window when main deliberately holds the grid for a streaming phone), parked, replay-in-flight, own-resize-pending, and a time-windowed budget (2 re-asserts per divergence signature per 10s - deliberately not reset by in-sync echoes, because in a two-surface fight each side's successful re-assert lands an in-sync echo at the other, so a reset-on-heal budget never binds in exactly the livelock it exists to bound).

Trade-offs: the repair replay repaints without the veil, so a heal can show one sub-300ms frame-replace (measured live: the garbled bytes were dropped before ever painting); steady-state cost is zero (no echo without a real grid change, all new traces compiled out of production).

Includes the Code Review pass's interleaved hardening (suspend-window resize stash, post-await re-checks before the repair, session-change budget reset, shared E2E echo-recorder helpers).

## Breaking changes

None. The `sessions.resize` return widens compatibly (`refused?: true`); the mobile wire payload is untouched.

## Tests

- Unit: `pty-resize-echo-reassert.test.ts` (19 guard-matrix cases incl. refusal-hold semantics and the two-surface livelock bound), `session-manager.test.ts` (emit origins, refusal shape, stash pins, suspend-window stash), `pop-out.test.ts` (monitor surface must declare the echo channel).
- UI: `terminal-resize-echo-reassert.spec.ts` - real mounted xterm: re-assert + frame repair, self-echo no-op, budget bound, refusal hold.
- E2E: `terminal-width-drift-selfheal.spec.ts` injects the exact incident (rogue `sessions.resize` under an open window) against a live PTY with positive controls and Linux-gated TUI ruler oracles, and asserts the heal; `terminal-fit-invariant.spec.ts` gained an end-state PTY-agreement epilogue on its 8-cycle churn loop.
- Live drive-tested in a preview against a real Claude TUI: three injections healed in ~260ms each, organic surface flips and window drags produced zero spurious re-asserts.

Generated with [Claude Code](https://claude.com/claude-code)
