### PR TITLE
feat(onboarding): add a quiet mobile pairing link to the welcome screen footer

### DIFF
--- a/src/renderer/components/layout/WelcomeScreen.tsx
+++ b/src/renderer/components/layout/WelcomeScreen.tsx
@@ -13,6 +13,7 @@ import { OverseerMascot } from '../onboarding/OverseerMascot';
 import brandLogoUrl from '@kangentic/branding/assets/brandmark-small.svg?url';
 
 const SETUP_GUIDE_URL = 'https://www.kangentic.com/getting-started/';
+const MOBILE_PAIRING_URL = 'https://www.kangentic.com/mobile/pairing/';
 const CURATED_NOT_FOUND_LIMIT = 3;
 
 /** Reusable detection row used for both the Git and agent entries */
@@ -447,16 +448,25 @@ export function WelcomeScreen() {
           </div>
         </div>
 
-        {/* Footer link row: laid out to accept a second low-weight link later
-            (e.g. a Kangentic Mobile mention, tracked separately) without a relayout. */}
         <div className="mt-6 mb-8 flex items-center justify-center gap-4 text-sm">
           <button
             type="button"
             onClick={() => window.electronAPI.shell.openExternal(SETUP_GUIDE_URL)}
             className="inline-flex items-center gap-1 text-accent-fg underline underline-offset-2 hover:opacity-80 cursor-pointer"
             title={SETUP_GUIDE_URL}
+            data-testid="welcome-setup-guide"
           >
             Read the setup guide
+            <ExternalLink size={12} />
+          </button>
+          <button
+            type="button"
+            onClick={() => window.electronAPI.shell.openExternal(MOBILE_PAIRING_URL)}
+            className="inline-flex items-center gap-1 text-accent-fg underline underline-offset-2 hover:opacity-80 cursor-pointer"
+            title={MOBILE_PAIRING_URL}
+            data-testid="welcome-pair-phone"
+          >
+            Pair a phone
             <ExternalLink size={12} />
           </button>
         </div>

--- a/tests/ui/onboarding-welcome-screen.spec.ts
+++ b/tests/ui/onboarding-welcome-screen.spec.ts
@@ -277,6 +277,8 @@ test.describe('Welcome screen readiness', () => {
     const pairPhone = page.locator('[data-testid="welcome-pair-phone"]');
     await expect(setupGuide).toBeVisible();
     await expect(pairPhone).toBeVisible();
+    await expect(setupGuide).toHaveText(/Read the setup guide/);
+    await expect(pairPhone).toHaveText(/Pair a phone/);
 
     // Pinning the row's geometry mechanically, not by eye. The container is
     // `flex` with no `flex-wrap`, so it cannot break onto a second line: what

--- a/tests/ui/onboarding-welcome-screen.spec.ts
+++ b/tests/ui/onboarding-welcome-screen.spec.ts
@@ -269,4 +269,47 @@ test.describe('Welcome screen readiness', () => {
     await expect(page.locator('[data-testid="welcome-git-status"]')).toBeHidden();
     await expect(toggle).toHaveText(/Show setup/);
   });
+
+  test('the footer links sit on one row and each opens its own URL externally', async () => {
+    ({ browser, page } = await launchWithOverrides({}));
+
+    const setupGuide = page.locator('[data-testid="welcome-setup-guide"]');
+    const pairPhone = page.locator('[data-testid="welcome-pair-phone"]');
+    await expect(setupGuide).toBeVisible();
+    await expect(pairPhone).toBeVisible();
+
+    // Pinning the row's geometry mechanically, not by eye. The container is
+    // `flex` with no `flex-wrap`, so it cannot break onto a second line: what
+    // this actually guards is the row surviving as a row (a switch to
+    // flex-col, or the buttons going block-level, splits the y values by a
+    // full line box), and the two links staying side by side in order rather
+    // than overlapping or reordering.
+    // Compared with a tolerance rather than exactly: Blink lays out in 1/64px
+    // units and `items-center` halves the leftover cross-axis space, so two
+    // children whose heights ever diverge by an odd sub-pixel amount get y
+    // values differing in the last digit. Zero-tolerance geometry assertions
+    // are banned by .claude/rules/cross-platform-parity.md; a real break moves
+    // y far past 1px, so the guard keeps its teeth.
+    const [setupGuideBox, pairPhoneBox] = await Promise.all([
+      setupGuide.boundingBox(),
+      pairPhone.boundingBox(),
+    ]);
+    expect(setupGuideBox).not.toBeNull();
+    expect(pairPhoneBox).not.toBeNull();
+    expect(Math.abs(pairPhoneBox!.y - setupGuideBox!.y)).toBeLessThanOrEqual(1);
+    // gap-4 (16px) makes the ordering strict, so this needs no tolerance.
+    expect(pairPhoneBox!.x).toBeGreaterThan(setupGuideBox!.x + setupGuideBox!.width);
+
+    // Both links are clicked, so each one's URL is pinned to its own button.
+    // Asserting the accumulated array in order also catches a handler wired to
+    // the wrong constant, which asserting only the last call would miss.
+    await setupGuide.click();
+    await pairPhone.click();
+    await expect
+      .poll(() => page.evaluate(() => window.__openedExternalUrls ?? []))
+      .toEqual([
+        'https://www.kangentic.com/getting-started/',
+        'https://www.kangentic.com/mobile/pairing/',
+      ]);
+  });
 });


### PR DESCRIPTION
## What

Adds a second quiet footer link on the first-launch Welcome Screen: "Pair a phone", sibling to
the existing "Read the setup guide" link, opening `https://www.kangentic.com/mobile/pairing/`
via `window.electronAPI.shell.openExternal`. Both footer buttons now carry `data-testid`
attributes (`welcome-setup-guide`, `welcome-pair-phone`); the existing link had none before this
change.

Affected component: `src/renderer/components/layout/WelcomeScreen.tsx`.

## Why

#394's welcome-screen redesign deliberately left a placement open for a Kangentic Mobile
mention but did not build it, since the mobile bridge was still compiled out of production
builds. Closes #438.

## How

The footer row was already laid out to accept a second low-weight link without a relayout (see
the removed comment at the old `WelcomeScreen.tsx:450`), so this is additive: one new URL
constant, one new button mirroring the existing one's classes/pattern, two `data-testid`s.

Two decisions worth flagging to a reviewer:

- **No `__KANGENTIC_DEV__` gate.** The destination page already self-discloses ("Not yet enabled
  in released builds"), so a build-time gate would only suppress copy, not prevent a broken
  click, and would add a fifth paired gate for #409 to remove. **This PR must not merge before
  #409** (the mobile bridge production gate) merges. There is no mechanical enforcement of that
  order; it is a merge-time judgment call for whoever ships this.
- **No Settings deep-link.** The welcome screen only renders with zero projects registered
  (`AppLayout.tsx`), and the only tab-aware Settings opener requires a project path, so a docs
  URL is the correct destination regardless of build state, not a fallback.

## Breaking changes

None.

## Tests

- Extended `tests/ui/onboarding-welcome-screen.spec.ts` with one new test: both footer links are
  visible with their correct copy, share one row (bounding-box y within a 1px tolerance per
  `cross-platform-parity.md`, never zero-tolerance), sit in left-to-right order, and each opens
  its own URL (`window.__openedExternalUrls` accumulates both in order).
- `test-builder` ran a coverage audit against the full diff: confirmed via red-green mutation
  (wrong URL wired to the button, row forced to `flex-col`) that the new assertions actually
  catch those regressions, ran the new test 5x via `--repeat-each=5`, and ran the full spec file
  twice, all green. No additional test files were needed; it flagged one cheap gap (the new test
  located both links by `data-testid` without pinning their visible copy), which is included here.
- `npm run typecheck` and `npm run lint` both clean locally.

Generated with [Claude Code](https://claude.com/claude-code)
