### PR TITLE
feat: in-app announcements feed and Mobile Devices "Get the App" section

### DIFF
--- a/.claude/rules/hmr-patterns.md
+++ b/.claude/rules/hmr-patterns.md
@@ -18,7 +18,7 @@ front rather than reaching for ad-hoc fixes later.
 | **B. Re-sync** | Zustand stores whose truth lives in the main process (IPC-backed) | Add a `load*` / `sync*` call to the `vite:afterUpdate` handler in `App.tsx` | `loadBoard()`, `loadBacklog()`, `loadConfig()`, `loadProjects()`, `syncSessions()` |
 | **C. Re-key remount** | Stateful third-party React subtrees whose subscriptions go stale across Fast Refresh (every `<DndContext>`) | `const hmrGeneration = useHmrGeneration();` then `<DndContext key={hmrGeneration}>` | All 5 `<DndContext>` sites: `KanbanBoard`, `BacklogView`, `PrioritiesPopover`, `ProjectSidebar`, `ShortcutsTab` |
 | **D. Cleanup** | Imperative DOM or global state no React component owns | Add the clear to the top of the `vite:afterUpdate` handler | `.drop-highlight` class removal in `App.tsx` |
-| **E. Pin instance** | A Zustand store whose only runtime export is the non-component hook, so the module is not a Fast Refresh boundary and a re-eval can hand a SECOND store to part of the tree | `const make = () => create<T>(init); export const useX = import.meta.hot?.data?.x ?? make();` plus `import.meta.hot.data.x = useX; import.meta.hot.accept(() => import.meta.hot.invalidate())` | `board-store.ts`, `backlog-store.ts`, `project-store.ts` |
+| **E. Pin instance** | A Zustand store whose only runtime export is the non-component hook, so the module is not a Fast Refresh boundary and a re-eval can hand a SECOND store to part of the tree | `const make = () => create<T>(init); export const useX = import.meta.hot?.data?.x ?? make();` plus `import.meta.hot.data.x = useX; import.meta.hot.accept(() => import.meta.hot.invalidate())` | `board-store.ts`, `backlog-store.ts`, `announcements-store.ts`, and the rest of `PATTERN_E_STORES` in `tests/unit/hmr-resync.test.ts` (the authoritative list) |
 
 **Decision tree:**
 
@@ -49,8 +49,9 @@ already collapse to no-ops).
   `load*` / `sync*` is called in `App.tsx`'s `vite:afterUpdate` (B); every module-scope mutable
   declaration under the watched dirs has `import.meta.hot.dispose(` or a `// hmr-safe:` opt-out
   (A); every `<DndContext>` has `key={hmrGeneration}` (C); and each instance-pinned store
-  (`board-store.ts`, `backlog-store.ts`, `project-store.ts`) reads and writes its instance in
-  `import.meta.hot.data` and self-accepts (E). Runs in CI via `npm run test:unit`.
+  (the test's `PATTERN_E_STORES` array - extend it whenever a store adopts the pin) reads and
+  writes its instance in `import.meta.hot.data` and self-accepts (E). Runs in CI via
+  `npm run test:unit`.
 - **Review:** the `hmr-parity` agent audits all five patterns; `hmr-integrity` is the narrow
   Pattern B store-registration check.
 

--- a/announcements.json
+++ b/announcements.json
@@ -1,0 +1,33 @@
+{
+  "announcements": [
+    {
+      "id": "mobile-launch-status-2026-08",
+      "title": "Kangentic Mobile is almost here - iOS in review, Android in beta",
+      "body": "The mobile companion app is on its way to both stores. Here is where each platform stands, and how you can help.",
+      "sections": [
+        {
+          "heading": "iOS: in App Store review",
+          "body": "The iOS app has been submitted and is with Apple for review. Nothing to do yet - we'll post a new announcement here the moment it's live on the App Store."
+        },
+        {
+          "heading": "Android: open for beta testers",
+          "body": "Help us test on Android - two steps:\n\n1. **Join the testers group**\n2. **Become a tester**, then install the app\n\nUse the Google account your phone's Play Store is signed into.",
+          "links": [
+            { "label": "Join the testers Google Group", "url": "https://groups.google.com/g/kangentic-testers", "qr": true },
+            { "label": "Become a tester on Google Play", "url": "https://play.google.com/apps/testing/com.kangentic.mobile", "qr": true }
+          ]
+        },
+        {
+          "heading": "After installing: pair your desktop",
+          "body": "Enable **Mobile Bridge** in Settings > Mobile Devices and click **Pair a Device**, then scan the QR with the app.",
+          "links": [
+            { "label": "Kangentic Mobile docs", "url": "https://kangentic.com/mobile/" }
+          ]
+        }
+      ],
+      "publishedAt": "2026-08-05T00:00:00Z",
+      "expiresAt": "2026-09-30T00:00:00Z",
+      "priority": 0
+    }
+  ]
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -420,6 +420,12 @@ Detach a registered UI surface (usage stats, git changes, the task Browser pane,
 | `updater:install` | invoke | Install downloaded update (quit and install) |
 | `updater:downloaded` | on | Event: update has been downloaded and is ready to install |
 
+### Announcements (2 channels)
+| Channel | Pattern | Purpose |
+|---------|---------|---------|
+| `announcements:get` | invoke | Current active announcements (remote feed, already filtered for this client's version/platform in main) |
+| `announcements:changed` | on | Event: the filtered active announcement list changed since the last poll |
+
 ### Search (1 channel)
 | Channel | Pattern | Purpose |
 |---------|---------|---------|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,6 +97,7 @@ These settings appear in both App Settings (as defaults) and Project Settings (a
 | `hasCompletedFirstRun` | boolean | `false` | Legacy: set true on first task creation, kept for schema/fixture compatibility. No onboarding UI reads it, and it is not the walkthrough gate: creating a task is step 3 of the walkthrough, so this flips mid-flow. The walkthrough is suppressed once `onboardedProjectIds` is non-empty. Auto-set, not shown in UI. |
 | `lastSeenReleaseNotesVersion` | string | `''` | The version whose release-notes modal has already been auto-shown (see [Auto-Update Behavior](deployment.md#auto-update-behavior)), so it does not reopen on every relaunch after "Later". Auto-set, not shown in UI. |
 | `lastWhatsNewShownVersion` | string | `''` | The version whose post-update ["What's New" dialog](deployment.md#auto-update-behavior) has already been shown. Deliberately separate from `lastSeenReleaseNotesVersion`, which records the PENDING version when the pre-restart modal is dismissed: a user who clicks "Later" and then quits normally has the update installed by `autoInstallOnAppQuit`, and would relaunch with the new version already marked seen and the notes never read. Written when the dialog OPENS, not when it closes, so quitting with it open does not re-arm it. Seeded to the running version on a fresh install (no `config.json` existed at launch), so a first-time user is not shown notes for software they have never run. Auto-set, not shown in UI. |
+| `dismissedAnnouncementIds` | string[] | `[]` | Ids of [in-app announcements](#in-app-announcements) dismissed from the banner. Pruned on write to ids still present in the active feed, so the array stays bounded with no separate cleanup. Auto-set, not shown in UI. |
 | `onboardedProjectIds` | string[] \| undefined | `undefined` | Project ids whose onboarding checklist the user has dismissed. `undefined` means the one-time upgrade backfill (on first app hydration) has not run yet; `[]` means it has run and nothing is dismissed. Global, keyed by project id like `lastActiveTaskByProject`. **Emptiness, not membership, gates the walkthrough:** the checklist auto-opens only while this list is empty, because the walkthrough teaches the app rather than a repo and must not replay on every newly added project. It becomes non-empty by three routes, all meaning "not a first run": the backfill finding an existing project, a real dismissal, or all five steps completed. Auto-set, not shown in UI. |
 | `onboardingBaseline` | Record\<string, object\> \| undefined | `undefined` | Per-project snapshot of the settings the onboarding checklist watches (`defaultAgent`, `defaultModel`, `defaultEffort`, `permissionMode`, and a `swimlaneSignature` string encoding of the board's shape), captured on first checklist open. Adding a project does not capture one: the auto-open gate is install-scoped, so a second project has no baseline until the checklist is opened there by hand. Checklist steps 1 and 2 tick when live state DIFFERS from this, so opening a settings screen and closing it unchanged earns no checkmark. Both are guarded on the baseline existing, so a baseline-less project reports them un-ticked rather than complete. Keyed by project id; replaced wholesale on write (a `CONFIG_DICTIONARY_PATHS` entry). Auto-set, not shown in UI. |
 | `windowBounds` | object \| null | `null` | Persisted window bounds `{x, y, width, height}`. Auto-saved, not shown in UI. |
@@ -402,7 +403,7 @@ The Mobile Devices tab hosts the desktop half of the mobile companion app's pair
 | `mobileBridge.relayMode` | `'hosted' \| 'local' \| 'custom'` | `'hosted'` | `'hosted'` always dials the Kangentic-hosted relay (`wss://relay.kangentic.com`), in every build. `'local'` is a dev-only mode: the Select only offers it in a dev build, and `resolveRelayMode()` itself gates the mode on `__KANGENTIC_DEV__` - a dev build dials `ws://127.0.0.1:8080` (`src/shared/relay.ts`'s `LOCAL_DEV_RELAY_URL`), while a production build reports and dials `'hosted'` even if a persisted `relayMode: 'local'` reaches it (e.g. carried over from a dev build's config in the same shared configDir). Both `resolveRelayUrl()` and the settings Select read `resolveRelayMode()`, so the mode shown and the URL dialed cannot disagree. `'custom'` dials `relayUrl` instead, for self-hosters. |
 | `mobileBridge.relayUrl` | string | `''` | The self-hosted relay to dial. Only consulted when `relayMode === 'custom'`; resolve the actual dial address through `resolveRelayUrl()` rather than reading this key directly - it normalizes the value and falls back to the hosted relay if this is empty or fails validation, so it never resolves to `''`. |
 
-**Actions (not config keys):** the Mobile Devices tab also exposes two settings-registry entries that are UI surfaces, not `AppConfig` keys: **Pair a Device** (registry id `mobileBridge.pairing`) starts the QR pairing ceremony described in [Mobile Bridge](mobile-bridge.md#pairing-ceremony), and **Paired Devices** (registry id `mobileBridge.devices`) lists currently paired phones, identified by key fingerprint, with rename and revoke actions - pairing grants all ten capability verbs uniformly, so there is no per-device capability control. Both are backed by the `mobile:*` IPC channels and the signed device roster (`src/main/mobile-bridge/roster-store.ts`), not persisted in `AppConfig`.
+**Actions (not config keys):** the Mobile Devices tab also exposes three settings-registry entries that are UI surfaces, not `AppConfig` keys: **Pair a Device** (registry id `mobileBridge.pairing`) starts the QR pairing ceremony described in [Mobile Bridge](mobile-bridge.md#pairing-ceremony), **Paired Devices** (registry id `mobileBridge.devices`) lists currently paired phones, identified by key fingerprint, with rename and revoke actions - pairing grants all ten capability verbs uniformly, so there is no per-device capability control - and **Get the App** (registry id `mobileBridge.getApp`) shows the Android closed-test signup steps (testers Google Group + Play opt-in page, each with a QR code and link), deliberately rendered OUTSIDE the bridge-enabled gating so it stays usable with the bridge off. The first two are backed by the `mobile:*` IPC channels and the signed device roster (`src/main/mobile-bridge/roster-store.ts`), not persisted in `AppConfig`; Get the App is purely informational.
 
 ### Privacy
 
@@ -626,11 +627,48 @@ Config files written by hand (without `id` fields on columns) are treated as add
 | `boardConfig:shortcutsChanged` | Event: shortcuts file changed |
 | `boardConfig:setDefaultBaseBranch` | Update the default base branch in `kangentic.json` |
 
+## In-App Announcements
+
+The desktop app periodically fetches a static JSON feed, `announcements.json` on this repo's
+`main` branch (served via `raw.githubusercontent.com`), and shows the highest-priority active
+announcement as a dismissible banner above the board content; "Learn more" opens a dialog with
+the markdown body, external links, and a QR code. There is no backend and no account: an
+unreachable, malformed, or empty feed simply means no banner (offline and self-hosted setups
+lose nothing). The poll runs 10 seconds after launch and every 4 hours (`src/main/announcements.ts`),
+is skipped entirely under `NODE_ENV=test`, and never emits error telemetry.
+
+Feed schema (`src/shared/announcements.ts`): each entry carries `id`, `title` (banner line),
+`body` (markdown intro), `links` (label + https URL; a link flagged `qr: true` renders a large
+scannable QR code above its button, for phone-destined links like store opt-in pages), optional
+`sections` (titled sub-messages, each `{ heading?, body?, links? }`, for one announcement that
+carries several messages such as per-platform statuses), `minVersion` / `maxVersion` (inclusive
+version window), `platforms` (`win32` / `darwin` / `linux`; omitted = all - note this targets
+the DESKTOP OS, not the user's phone), `publishedAt` / `expiresAt` (ISO 8601), and `priority`.
+Unknown fields and malformed entries are ignored, so the feed can grow without breaking released
+clients; an entry needing new client behavior sets `minVersion` instead.
+
+**Publishing warning:** an edit to `announcements.json` on `main` is a production push - it
+reaches every released client within one poll cycle (about 4 hours, plus ~5 minutes of CDN
+cache). Set targeting fields conservatively and put an `expiresAt` on every entry.
+`tests/unit/announcements-json-valid.test.ts` validates the committed file through the real
+parser on every push, so a typo'd entry (which production would silently drop) fails CI on the
+content PR instead of shipping invisible.
+
+**Authoring contract - no scrolling:** an announcement must fit its dialog without a scrollbar
+on a typical desktop window (QR links lay out side by side to help; the dialog's scroll is a
+safety valve for very small windows only, and a UI test pins the contract for a realistic
+two-QR announcement). Keep bodies to a few short paragraphs and QR links to two or three; if a
+message wants more, it should be a link to a page, not a longer announcement.
+
+Dismissals persist per-announcement-id in `dismissedAnnouncementIds` (see the
+[Top-Level reference](#top-level)).
+
 ## Environment Variables
 
 | Variable | Purpose |
 |----------|---------|
 | `KANGENTIC_DATA_DIR` | Override the config/data directory path |
+| `KANGENTIC_ANNOUNCEMENTS_URL` | Override the announcements feed URL (for testing against a local fixture) |
 
 ## Legacy Migration
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -581,6 +581,16 @@ Desktop and toast notifications fire when an agent needs attention and the user 
 
 The Settings > Notifications panel exposes four configurable events: **Agent Idle**, **Agent Crash** (session exit; desktop alerts on error exits only, toasts also cover clean exits), **Plan Complete**, and **Spawn Stalled** (a task spawn that waits too long on the git queue while preparing). Each can be set to Off, Desktop only, Toast only, or Both. Toast duration and max visible count are also configurable.
 
+### Announcements
+
+Occasionally Kangentic shows a product announcement (for example, a call for mobile-app beta
+testers) as a slim banner above the board. **Learn more** opens the full message with links and
+a QR code; the **X** dismisses that announcement permanently on this machine. Announcements are
+fetched from a static file on the public GitHub repo - no account, no tracking, and if the feed
+is unreachable (offline or self-hosted setups) the banner simply never appears. See
+[Configuration - In-App Announcements](configuration.md#in-app-announcements) for the feed
+mechanics.
+
 ### Mobile Devices
 
 The Mobile Devices tab is the desktop half of the mobile companion app's pairing link - global (applies to this desktop installation, not any one project) and off by default. Enable the **Mobile Bridge** toggle, then pick a **Relay**: *Kangentic Cloud* (the default hosted relay) or *Custom Relay* (your own self-hosted address, entered in the field that appears below). Dev builds also offer a *Local* option pointing at a relay on localhost. The address actually being dialed is shown beneath the picker, and **Test connection** probes it for reachability before you pair. The relay only ever sees encrypted traffic. A custom address must use `wss://`, or `ws://` for localhost only, since the phone refuses to pair over an untrusted transport.
@@ -588,6 +598,8 @@ The Mobile Devices tab is the desktop half of the mobile companion app's pairing
 Click **Pair a Device** to display a QR code; scanning it with the Kangentic mobile app starts an end-to-end encrypted pairing handshake. Once the handshake completes, both the desktop and the phone show the same short code - compare them, then tap **Confirm** on the phone. The desktop auto-enrolls the device as soon as it hears back; there is no second confirmation to make on the desktop. This catches a photographed or relayed QR, since an attacker cannot make both sides show the same code. To back out, cancel on the phone (or close the desktop's pairing panel) before confirming.
 
 The phone is treated as an extension of your own desktop, not a separate integration to configure: pairing grants it full access to the same ten capabilities the protocol defines (there is no shell, file, or arbitrary-command access in the protocol at all). Paired devices appear in a list below, identified by a key fingerprint you can compare against the phone's own Settings > Devices screen, along with their connection status and paired date. Rename a device from that list, or revoke it - revoking removes it from the desktop's signed roster immediately, and a revoked phone must be paired again from scratch to reconnect. See [Mobile Bridge](mobile-bridge.md) for the underlying protocol, pairing ceremony, and security design.
+
+Don't have the app yet? The **Get the App** section at the bottom of the tab stays usable even with the bridge toggle off. Kangentic Mobile for Android is currently in closed testing, and joining is two steps, each with a QR code to scan from your phone plus a clickable link: join the testers Google Group, then open the Google Play opt-in page and tap **Become a tester**. Use the same Google account your phone's Play Store is signed into, and stay opted in while the test is running.
 
 ### Privacy
 

--- a/src/devtools/renderer/state-mirror.ts
+++ b/src/devtools/renderer/state-mirror.ts
@@ -1,3 +1,4 @@
+import { useAnnouncementsStore } from '../../renderer/stores/announcements-store';
 import { useBacklogStore } from '../../renderer/stores/backlog-store';
 import { useBoardStore } from '../../renderer/stores/board-store';
 import { useConfigStore } from '../../renderer/stores/config-store';
@@ -67,6 +68,7 @@ export function buildPreviewSnapshot(): RendererStateSnapshot {
  * fails CI instead of silently being unreadable.
  */
 const PREVIEW_STORES: Record<string, ReadableStore> = {
+  announcements: useAnnouncementsStore,
   backlog: useBacklogStore,
   board: useBoardStore,
   config: useConfigStore,

--- a/src/main/announcements.ts
+++ b/src/main/announcements.ts
@@ -1,0 +1,118 @@
+import { app, BrowserWindow, ipcMain } from 'electron';
+import { IPC } from '../shared/ipc-channels';
+import {
+  ANNOUNCEMENTS_URL,
+  parseAnnouncementsFeed,
+  selectActiveAnnouncements,
+  type Announcement,
+} from '../shared/announcements';
+
+const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours, matching the updater cadence
+const INITIAL_DELAY_MS = 10_000; // after the updater's 5s first check
+const FETCH_TIMEOUT_MS = 10_000;
+
+let checkTimeout: ReturnType<typeof setTimeout> | null = null;
+let checkInterval: ReturnType<typeof setInterval> | null = null;
+let announcementsWindow: BrowserWindow | null = null;
+let cachedActive: Announcement[] = [];
+
+/**
+ * Fetch the announcements feed, filter it for this client, and push the
+ * active list to the renderer when it changed. Never throws: every failure
+ * mode (offline, DNS, timeout, non-200, malformed JSON, unusable feed) is a
+ * silent skip that keeps the last-known list, following the attempt/catch/
+ * degrade convention (see the relay probe in ipc/handlers/mobile-bridge.ts).
+ *
+ * Deliberately NO trackEvent here, not even for structural failures: unlike
+ * an updater download, a failed feed fetch has no user-visible consequence,
+ * and most failures are offline machines. The updater's
+ * isTransientUpdaterError classifier exists to separate blips from real bugs
+ * in app_error telemetry; with nothing worth alerting on, the simpler
+ * equivalent is to emit nothing at all.
+ *
+ * @internal Exported for testing.
+ */
+export async function checkAnnouncements(): Promise<void> {
+  const url = process.env.KANGENTIC_ANNOUNCEMENTS_URL ?? ANNOUNCEMENTS_URL;
+  let feed: Announcement[] | null = null;
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    if (!response.ok) {
+      console.log(`[ANNOUNCEMENTS] fetch skipped: HTTP ${response.status}`);
+      return;
+    }
+    feed = parseAnnouncementsFeed(await response.json());
+  } catch (error) {
+    console.log('[ANNOUNCEMENTS] fetch skipped:',
+      error instanceof Error ? error.message : String(error));
+    return;
+  }
+  if (feed === null) {
+    console.log('[ANNOUNCEMENTS] fetch skipped: unusable feed');
+    return;
+  }
+
+  const active = selectActiveAnnouncements(feed, {
+    appVersion: app.getVersion(),
+    platform: process.platform,
+    now: new Date(),
+  });
+  // selectActiveAnnouncements sorts deterministically, so serialized equality
+  // is a sound change check.
+  if (JSON.stringify(active) === JSON.stringify(cachedActive)) return;
+  cachedActive = active;
+  if (announcementsWindow && !announcementsWindow.isDestroyed()) {
+    announcementsWindow.webContents.send(IPC.ANNOUNCEMENTS_CHANGED, active);
+  }
+}
+
+/**
+ * Register the announcements IPC handler and start the polling timers.
+ *
+ * The GET handler is registered before any bail-out so the renderer's invoke
+ * never rejects with `No handler registered` (same reasoning as the updater's
+ * no-op handlers). Unlike the updater there is no `app.isPackaged` gate: dev
+ * builds poll too, so the team dogfoods the announcements surface from
+ * `npm start`. Tests are the exception: under NODE_ENV=test (set by the E2E
+ * helpers) nothing is scheduled, so no test run ever touches the network.
+ */
+export function initAnnouncements(mainWindow: BrowserWindow): void {
+  ipcMain.handle(IPC.ANNOUNCEMENTS_GET, () => cachedActive);
+
+  if (process.env.NODE_ENV === 'test') return;
+
+  announcementsWindow = mainWindow;
+
+  // .unref() both timers so a 4-hour interval never keeps the event loop
+  // alive past a clean quit (the pr-refresh-scheduler timer-leak rules).
+  checkTimeout = setTimeout(() => {
+    void checkAnnouncements();
+    checkInterval = setInterval(() => {
+      void checkAnnouncements();
+    }, CHECK_INTERVAL_MS);
+    checkInterval.unref();
+  }, INITIAL_DELAY_MS);
+  checkTimeout.unref();
+}
+
+/**
+ * Update the window reference used for the changed-push. Called when macOS
+ * recreates the window after all windows were closed (dock icon click).
+ */
+export function updateAnnouncementsWindow(mainWindow: BrowserWindow): void {
+  announcementsWindow = mainWindow;
+}
+
+/**
+ * Synchronously clear announcement timers. Called from syncShutdownCleanup().
+ */
+export function stopAnnouncementTimers(): void {
+  if (checkTimeout) {
+    clearTimeout(checkTimeout);
+    checkTimeout = null;
+  }
+  if (checkInterval) {
+    clearInterval(checkInterval);
+    checkInterval = null;
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -184,6 +184,7 @@ process.on('unhandledRejection', (reason) => {
 });
 
 import { initUpdater, updateUpdaterWindow, stopUpdaterTimers } from './updater';
+import { initAnnouncements, updateAnnouncementsWindow, stopAnnouncementTimers } from './announcements';
 import { ensureSpawnHelperPermissions } from './pty/spawn/spawn-helper-permissions';
 
 // Initialize anonymous analytics BEFORE app.whenReady() -- the SDK requires this
@@ -943,6 +944,7 @@ app.whenReady().then(async () => {
 
   createWindow();
   initUpdater(mainWindow!);
+  initAnnouncements(mainWindow!);
 
   // Windows has no powerMonitor 'shutdown' event (Linux/macOS only). An OS
   // shutdown/restart/log-off there is signaled via this BrowserWindow event
@@ -1056,6 +1058,7 @@ app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) {
     createWindow();
     updateUpdaterWindow(mainWindow!);
+    updateAnnouncementsWindow(mainWindow!);
   }
 });
 
@@ -1104,6 +1107,7 @@ function getShutdownDependencies() {
     getCurrentProjectId,
     deleteProjectFromIndex,
     stopUpdaterTimers,
+    stopAnnouncementTimers,
     clearPendingTimers: () => {
       if (activateAllProjectsTimer) {
         clearTimeout(activateAllProjectsTimer);

--- a/src/main/shutdown.ts
+++ b/src/main/shutdown.ts
@@ -20,6 +20,7 @@ interface ShutdownDependencies {
   getCurrentProjectId: () => string | null;
   deleteProjectFromIndex: (projectId: string) => void;
   stopUpdaterTimers: () => void;
+  stopAnnouncementTimers: () => void;
   clearPendingTimers: () => void;
   isEphemeral: boolean;
 }
@@ -42,6 +43,7 @@ export function syncShutdownCleanup(dependencies: ShutdownDependencies): void {
   // Clear pending timers that could fire during shutdown
   dependencies.clearPendingTimers();
   dependencies.stopUpdaterTimers();
+  dependencies.stopAnnouncementTimers();
   // Stop the periodic metrics snapshot so no tick races the sync shutdown writes.
   stopMetricsSnapshotTimer();
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import { IPC } from '../shared/ipc-channels';
 import type { ElectronAPI, NotificationInput, Project, PtyResizeOrigin, Session, SessionUsage, ActivityState, ActivityReason, SessionEvent, UpdateDownloadedInfo, UsageTimePeriod, UsageStatsScope, UsageDayDrill, UsageCustomWindow, TaskBulkDeleteProgress, ProjectMoveProgress, DictationModelProgress, MobilePairingSasPayload, MobilePairingConfirmedPayload, MobilePairingEndedPayload, MonitorSnapshot, TaskDetailHost, TaskDetailRemoteOwner } from '../shared/types';
+import type { Announcement } from '../shared/announcements';
 import { POPOUT_ARG_PREFIX } from '../shared/pop-out';
 import type { PopOutDescriptor, PopOutKind, PopOutParamsByKind } from '../shared/pop-out';
 import { installConsoleCapture } from './diagnostics/console-capture';
@@ -473,6 +474,15 @@ const api: ElectronAPI = {
       const handler = (_event: Electron.IpcRendererEvent, info: UpdateDownloadedInfo) => callback(info);
       ipcRenderer.on(IPC.UPDATE_DOWNLOADED, handler);
       return () => ipcRenderer.removeListener(IPC.UPDATE_DOWNLOADED, handler);
+    },
+  },
+
+  announcements: {
+    getActive: () => ipcRenderer.invoke(IPC.ANNOUNCEMENTS_GET),
+    onChanged: (callback) => {
+      const handler = (_event: Electron.IpcRendererEvent, active: Announcement[]) => callback(active);
+      ipcRenderer.on(IPC.ANNOUNCEMENTS_CHANGED, handler);
+      return () => ipcRenderer.removeListener(IPC.ANNOUNCEMENTS_CHANGED, handler);
     },
   },
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -11,6 +11,7 @@ import { useSessionStore } from './stores/session-store';
 import { useBacklogStore } from './stores/backlog-store';
 import { useToastStore } from './stores/toast-store';
 import { useUpdaterStore } from './stores/updater-store';
+import { useAnnouncementsStore } from './stores/announcements-store';
 import { useUsageDashboardStore } from './stores/usage-dashboard-store';
 import { useMonitorStore } from './stores/monitor-store';
 import { usePopOutStore } from './stores/pop-out-store';
@@ -126,12 +127,20 @@ export function App() {
       useUpdaterStore.getState().receiveUpdate(info);
     });
 
+    // Announcements: hydrate the active list (the first poll may have landed
+    // before this renderer mounted), then stay live via the changed push.
+    void useAnnouncementsStore.getState().loadActive();
+    const cleanupAnnouncementsChanged = window.electronAPI.announcements?.onChanged((active) => {
+      useAnnouncementsStore.getState().receiveActive(active);
+    });
+
     return () => {
       if (mountTimerRafId !== undefined) cancelAnimationFrame(mountTimerRafId);
       cleanupAutoOpen();
       cleanupPathMissing?.();
       cleanupPopOutChanged?.();
       cleanupUpdateListener?.();
+      cleanupAnnouncementsChanged?.();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only bootstrap: every callee is a stable Zustand action or an IPC listener registered exactly once
   }, []);
@@ -803,6 +812,8 @@ if (import.meta.hot) {
     }
     // Pop-out windows Pattern B: re-hydrate which surfaces are currently detached.
     usePopOutStore.getState().loadOpen();
+    // Announcements Pattern B: re-pull the active list from main-process truth.
+    void useAnnouncementsStore.getState().loadActive();
     useSessionStore.getState().syncSessions().then((applied) => {
       if (!applied) return;
 
@@ -834,5 +845,6 @@ if (import.meta.env.DEV) {
     usageDashboard: useUsageDashboardStore,
     popOut: usePopOutStore,
     dictation: useDictationStore,
+    announcements: useAnnouncementsStore,
   };
 }

--- a/src/renderer/components/ExternalLinkButton.tsx
+++ b/src/renderer/components/ExternalLinkButton.tsx
@@ -1,0 +1,30 @@
+import { ExternalLink } from 'lucide-react';
+
+interface ExternalLinkButtonProps {
+  label: string;
+  /** Opened via shell.openExternal; the main process allowlists schemes. */
+  url: string;
+  /** Stretch to the container width (the announcement dialog's link list). */
+  fullWidth?: boolean;
+  testId?: string;
+}
+
+/**
+ * A slim pill button that opens an external URL in the OS browser: truncating
+ * label, trailing ExternalLink glyph. Shared by the announcement dialog's
+ * link list and the Mobile Devices "Get the App" steps so the external-link
+ * affordance reads identically everywhere.
+ */
+export function ExternalLinkButton({ label, url, fullWidth, testId }: ExternalLinkButtonProps) {
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      onClick={() => void window.electronAPI.shell.openExternal(url)}
+      className={`${fullWidth ? 'w-full ' : ''}flex items-center gap-1 rounded-md border border-edge/50 bg-surface-hover/30 px-2.5 py-1.5 text-xs text-fg-secondary hover:bg-surface-hover hover:text-fg hover:border-edge transition-colors cursor-pointer`}
+    >
+      <span className="truncate">{label}</span>
+      <ExternalLink size={11} className="ml-auto shrink-0 opacity-60" />
+    </button>
+  );
+}

--- a/src/renderer/components/QrImage.tsx
+++ b/src/renderer/components/QrImage.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import QRCode from 'qrcode';
+
+interface QrImageProps {
+  /** The string to encode (any URL or URI). */
+  value: string;
+  /** Accessible description of what scanning the code reaches. */
+  alt: string;
+  /** Rendered square size in px. */
+  size?: number;
+  testId?: string;
+}
+
+/**
+ * A QR code rendered as a data-URL <img>, for links meant to be scanned with
+ * a phone (mobile pairing, store opt-in pages, announcement links). Renders
+ * nothing until the encode resolves, so callers never see a broken image.
+ */
+export function QrImage({ value, alt, size = 220, testId }: QrImageProps) {
+  const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setQrDataUrl(null);
+    QRCode.toDataURL(value, { margin: 1, width: size })
+      .then((dataUrl) => {
+        if (!cancelled) setQrDataUrl(dataUrl);
+      })
+      .catch((error: unknown) => {
+        // Fail closed to "no image": a value that exceeds QR capacity (e.g. an
+        // over-long feed URL) must not surface as an unhandled rejection, and
+        // every caller renders a labeled link beside the QR, so the
+        // destination stays reachable without it.
+        console.warn('[QrImage] encode failed:', error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [value, size]);
+
+  if (!qrDataUrl) return null;
+  return (
+    <img
+      src={qrDataUrl}
+      alt={alt}
+      width={size}
+      height={size}
+      className="rounded-md border border-edge"
+      data-testid={testId}
+    />
+  );
+}

--- a/src/renderer/components/announcements/AnnouncementBanner.tsx
+++ b/src/renderer/components/announcements/AnnouncementBanner.tsx
@@ -1,0 +1,53 @@
+import { Megaphone, X } from 'lucide-react';
+import { useAnnouncementsStore, selectBannerAnnouncement } from '../../stores/announcements-store';
+import { useConfigStore } from '../../stores/config-store';
+
+/**
+ * Slim dismissible strip above the board content for the highest-priority
+ * active announcement (remote feed, src/shared/announcements.ts). One
+ * announcement at a time; dismissing reveals the next non-dismissed one, if
+ * any. Mounted as the first child of AppLayout's content column so it spans
+ * the area right of the sidebar in every view (board, backlog, welcome).
+ *
+ * Deliberately no entrance animation: the strip can (re)mount on project
+ * switch and restore paths, which must paint flat
+ * (.claude/rules/restore-no-animation-replay.md).
+ */
+export function AnnouncementBanner() {
+  const active = useAnnouncementsStore((state) => state.active);
+  const openDialog = useAnnouncementsStore((state) => state.openDialog);
+  const dismissedIds = useConfigStore((state) => state.config.dismissedAnnouncementIds);
+  const dismissAnnouncement = useConfigStore((state) => state.dismissAnnouncement);
+
+  const banner = selectBannerAnnouncement(active, dismissedIds ?? []);
+  if (!banner) return null;
+
+  return (
+    <div
+      data-testid="announcement-banner"
+      className="flex-shrink-0 flex items-center gap-2.5 border-b border-edge bg-surface-raised px-3 py-1.5"
+    >
+      <Megaphone size={14} className="text-accent flex-shrink-0" aria-hidden="true" />
+      {/* title attr: the strip truncates on narrow windows and the full text
+          should still be reachable without opening the dialog. */}
+      <span className="flex-1 min-w-0 truncate text-xs text-fg-secondary" title={banner.title}>{banner.title}</span>
+      <button
+        type="button"
+        data-testid="announcement-learn-more"
+        onClick={() => openDialog(banner)}
+        className="flex-shrink-0 text-xs text-fg-secondary underline underline-offset-2 hover:text-fg transition-colors cursor-pointer"
+      >
+        Learn more
+      </button>
+      <button
+        type="button"
+        data-testid="announcement-dismiss"
+        aria-label="Dismiss announcement"
+        onClick={() => dismissAnnouncement(banner.id)}
+        className="flex-shrink-0 rounded p-1 text-fg-faint hover:text-fg hover:bg-surface-hover transition-colors"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/renderer/components/announcements/AnnouncementDialog.tsx
+++ b/src/renderer/components/announcements/AnnouncementDialog.tsx
@@ -1,0 +1,108 @@
+import { Megaphone } from 'lucide-react';
+import { BaseDialog } from '../dialogs/BaseDialog';
+import { MarkdownRenderer } from '../MarkdownRenderer';
+import { QrImage } from '../QrImage';
+import { ExternalLinkButton } from '../ExternalLinkButton';
+import { useAnnouncementsStore } from '../../stores/announcements-store';
+import type { AnnouncementLink } from '../../../shared/announcements';
+
+function AnnouncementLinkButton({ link }: { link: AnnouncementLink }) {
+  return (
+    <ExternalLinkButton label={link.label} url={link.url} fullWidth testId="announcement-link" />
+  );
+}
+
+/**
+ * QR-flagged links lay out SIDE BY SIDE in a grid (each a scannable QR with
+ * its labeling button beneath), plain links stack full-width below. The
+ * horizontal grid is what keeps a multi-QR announcement inside the dialog
+ * without a scrollbar - stacking two large QRs vertically cannot fit any
+ * reasonable window height. 180px scans reliably for the short URLs
+ * announcements carry (the 220px pairing QR is sized for far denser payloads).
+ */
+function AnnouncementLinkList({ links }: { links: AnnouncementLink[] }) {
+  if (links.length === 0) return null;
+  const qrLinks = links.filter((link) => link.qr);
+  const plainLinks = links.filter((link) => !link.qr);
+  return (
+    <div className="space-y-3">
+      {qrLinks.length > 0 && (
+        <div className="grid grid-cols-[repeat(auto-fit,minmax(13rem,1fr))] gap-3 justify-items-center">
+          {qrLinks.map((link) => (
+            <div key={link.url} className="w-full max-w-[15rem] flex flex-col items-center gap-2" data-testid="announcement-qr-block">
+              <QrImage value={link.url} size={180} alt={`QR code: ${link.label}`} testId="announcement-qr" />
+              <AnnouncementLinkButton link={link} />
+            </div>
+          ))}
+        </div>
+      )}
+      {plainLinks.length > 0 && (
+        <div className="flex flex-col items-stretch gap-1.5">
+          {plainLinks.map((link) => (
+            <AnnouncementLinkButton key={link.url} link={link} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The "Learn more" dialog for an announcement: intro markdown, then any
+ * titled sections (each its own message with scoped links), then the
+ * announcement-level links. Only ever opens from a user click on the
+ * banner's "Learn more", never on its own, so BaseDialog's default focus
+ * trap is correct (the updater's autoOpened machinery exists only for
+ * unbidden modals). Mounted in AppLayout beside the other app-level dialogs.
+ */
+export function AnnouncementDialog() {
+  const announcement = useAnnouncementsStore((state) => state.dialogAnnouncement);
+  const closeDialog = useAnnouncementsStore((state) => state.closeDialog);
+
+  if (!announcement) return null;
+
+  return (
+    <BaseDialog
+      onClose={closeDialog}
+      title={announcement.title}
+      icon={<Megaphone size={16} className="text-accent" />}
+      backdropClassName="backdrop-blur-xs"
+      className="w-[640px] max-w-[92vw] max-h-[85vh]"
+      testId="announcement-dialog"
+      footer={
+        <div className="flex items-center justify-end">
+          <button
+            onClick={closeDialog}
+            data-testid="announcement-close"
+            className="px-4 py-1.5 text-xs rounded transition-colors bg-accent-emphasis hover:bg-accent text-accent-on"
+          >
+            Close
+          </button>
+        </div>
+      }
+    >
+      {/* An announcement must fit WITHOUT scrolling (authoring contract, see
+          docs/configuration.md); the cap here is the dialog's height minus
+          header + footer chrome, and overflow-y-auto is only a safety valve
+          for very small windows, never a layout feature. Pinned by the
+          no-scrollbar assertion in tests/ui/announcements.spec.ts. */}
+      <div className="overflow-y-auto max-h-[calc(85vh-9rem)] space-y-4" data-testid="announcement-dialog-content">
+        <MarkdownRenderer content={announcement.body} />
+        {announcement.sections?.map((section, sectionIndex) => (
+          <div
+            key={sectionIndex}
+            className="border-t border-edge pt-3 space-y-3"
+            data-testid="announcement-section"
+          >
+            {section.heading && (
+              <h4 className="text-sm font-semibold text-fg">{section.heading}</h4>
+            )}
+            {section.body && <MarkdownRenderer content={section.body} />}
+            {section.links && <AnnouncementLinkList links={section.links} />}
+          </div>
+        ))}
+        <AnnouncementLinkList links={announcement.links} />
+      </div>
+    </BaseDialog>
+  );
+}

--- a/src/renderer/components/layout/AppLayout.tsx
+++ b/src/renderer/components/layout/AppLayout.tsx
@@ -21,6 +21,8 @@ import { useOnboardingProgress } from '../../hooks/useOnboardingProgress';
 import { ProjectPathMissingDialog } from '../dialogs/ProjectPathMissingDialog';
 import { ReleaseNotesDialog } from '../dialogs/ReleaseNotesDialog';
 import { WhatsNewDialog } from '../dialogs/WhatsNewDialog';
+import { AnnouncementBanner } from '../announcements/AnnouncementBanner';
+import { AnnouncementDialog } from '../announcements/AnnouncementDialog';
 import { useConfigStore } from '../../stores/config-store';
 import { useProjectStore } from '../../stores/project-store';
 import { useBoardStore } from '../../stores/board-store';
@@ -433,6 +435,7 @@ export function AppLayout() {
         )}
 
         <div className="flex-1 flex flex-col min-w-0" ref={terminal.contentColRef}>
+          <AnnouncementBanner />
           {currentProject ? (
             <>
               <ViewToggle />
@@ -510,6 +513,7 @@ export function AppLayout() {
       <ProjectPathMissingDialog />
       <ReleaseNotesDialog />
       <WhatsNewDialog />
+      <AnnouncementDialog />
       {onboardingChecklistOpen && <WelcomeChecklistDialog />}
       <WalkthroughLayer />
       <ToastContainer />

--- a/src/renderer/components/settings/settings-registry.ts
+++ b/src/renderer/components/settings/settings-registry.ts
@@ -173,6 +173,7 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
   { id: 'mobileBridge.relayUrl', tabId: 'mobile', label: 'Custom Relay Address', description: 'The self-hosted relay to dial when Relay above is set to Custom Relay.', scope: 'global', keywords: ['relay', 'server', 'url', 'address', 'self-host', 'websocket', 'mobile', 'custom'] },
   { id: 'mobileBridge.pairing', tabId: 'mobile', label: 'Pair a Device', description: 'Scan a QR code with the Kangentic mobile app to pair a new phone.', scope: 'global', keywords: ['pair', 'pairing', 'qr', 'scan', 'phone', 'mobile', 'sas', 'code'] },
   { id: 'mobileBridge.devices', tabId: 'mobile', label: 'Paired Devices', description: 'Phones paired to this desktop, identified by key fingerprint. Rename or revoke a device here.', scope: 'global', keywords: ['paired', 'devices', 'phone', 'revoke', 'rename', 'fingerprint', 'mobile'] },
+  { id: 'mobileBridge.getApp', tabId: 'mobile', label: 'Get the App', description: 'Join the Kangentic Mobile closed test on Android: join the testers group, then opt in on Google Play.', scope: 'global', keywords: ['android', 'play', 'store', 'closed test', 'beta', 'tester', 'opt in', 'install', 'download', 'app', 'mobile'] },
 ];
 
 /** Lookup by ID for O(1) access. */

--- a/src/renderer/components/settings/tabs/MobileDevicesTab.tsx
+++ b/src/renderer/components/settings/tabs/MobileDevicesTab.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { Check, CircleAlert, Copy, Loader2, Pencil, QrCode, Server, Smartphone, Trash2, WifiOff, X } from 'lucide-react';
-import QRCode from 'qrcode';
 import { formatKeyFingerprint } from '@kangentic/protocol/roster/fingerprint';
 import type { AppConfig, MobileDeviceConnectionState, MobilePairedDevice, RemoteServerStatus } from '../../../../shared/types';
 import { resolveRelayMode, resolveRelayUrl, validateRelayUrl } from '../../../../shared/relay';
@@ -9,7 +8,17 @@ import { INPUT_CLASS, SectionHeader, Select, SettingRow, SettingToggleRow, useSc
 import { Pill } from '../../Pill';
 import { settingProps } from '../settings-registry';
 import { ConfirmDialog } from '../../dialogs/ConfirmDialog';
+import { QrImage } from '../../QrImage';
+import { ExternalLinkButton } from '../../ExternalLinkButton';
 import { useMobileStore } from '../../../stores/mobile-store';
+
+/** The anyone-can-join Google Group that authorizes Play closed-test access
+ *  (its members are the track's tester list in the Play Console). Also
+ *  referenced by the mobile-launch announcement in announcements.json. */
+const ANDROID_TESTERS_GROUP_URL = 'https://groups.google.com/g/kangentic-testers';
+/** Deterministic from the Android applicationId (com.kangentic.mobile);
+ *  resolves once the closed testing track is published in the Play Console. */
+const ANDROID_CLOSED_TEST_OPT_IN_URL = 'https://play.google.com/apps/testing/com.kangentic.mobile';
 
 /**
  * 'idle' means this device has no session open yet (nothing to report), so it
@@ -79,7 +88,6 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
   const clearPairingEnded = useMobileStore((state) => state.clearPairingEnded);
 
   const [qrUri, setQrUri] = useState<string | null>(null);
-  const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [linkCopied, setLinkCopied] = useState(false);
   const [revokeTarget, setRevokeTarget] = useState<{ deviceId: string; displayName: string } | null>(null);
   const [renamingDeviceId, setRenamingDeviceId] = useState<string | null>(null);
@@ -97,7 +105,6 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
     const unsubscribeConfirmed = window.electronAPI.mobile.onPairingConfirmed((payload) => {
       setPairingConfirmed(payload);
       setQrUri(null);
-      setQrDataUrl(null);
     });
     const unsubscribeEnded = window.electronAPI.mobile.onPairingEnded((payload) => {
       // A plain cancel (Cancel button, or the panel closing mid-ceremony) is
@@ -106,7 +113,6 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
       // surfacing as a message.
       if (payload.kind === 'failed') setPairingEnded(payload.reason);
       setQrUri(null);
-      setQrDataUrl(null);
     });
     const unsubscribeState = window.electronAPI.mobile.onStateChanged(() => {
       void loadStatus();
@@ -151,20 +157,6 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
   }, [pairingConfirmed, clearPairingConfirmed]);
 
   useEffect(() => {
-    if (!qrUri) {
-      setQrDataUrl(null);
-      return;
-    }
-    let cancelled = false;
-    QRCode.toDataURL(qrUri, { margin: 1, width: 220 }).then((dataUrl) => {
-      if (!cancelled) setQrDataUrl(dataUrl);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [qrUri]);
-
-  useEffect(() => {
     if (!linkCopied) return;
     const timer = setTimeout(() => setLinkCopied(false), 2000);
     return () => clearTimeout(timer);
@@ -191,7 +183,6 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
   const handleCancelPairing = async () => {
     await cancelPairing();
     setQrUri(null);
-    setQrDataUrl(null);
   };
 
   const startRename = (device: MobilePairedDevice) => {
@@ -394,9 +385,7 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
         ) : (
           <div className="space-y-3 rounded-md border border-edge bg-surface-hover/40 p-4" data-testid="mobile-pair-qr">
             <p className="text-sm text-fg-secondary">Scan this code with the Kangentic app on your phone.</p>
-            {qrDataUrl && (
-              <img src={qrDataUrl} alt="Pairing QR code" className="rounded-md border border-edge" width={220} height={220} />
-            )}
+            {qrUri && <QrImage value={qrUri} alt="Pairing QR code" />}
             <div className="flex gap-2">
               <button
                 type="button"
@@ -522,6 +511,45 @@ export function MobileDevicesTab({ globalConfig }: { globalConfig: AppConfig }) 
             })}
           </ul>
         )}
+      </div>
+
+      {/* Outside the enabled-gated wrapper above: getting the app is exactly
+          what a user with the bridge still off needs, so this section stays
+          fully interactive regardless of the toggle. */}
+      <SectionHeader label="Get the App" searchIds={['mobileBridge.getApp']} />
+      <div className="space-y-3" data-testid="mobile-get-app">
+        <p className="text-sm text-fg-muted">
+          Kangentic Mobile for Android is in closed testing. Two steps to join:
+        </p>
+        <div className="rounded-md border border-edge bg-surface-hover/40 p-4 space-y-2" data-testid="mobile-get-app-step-group">
+          <p className="text-sm text-fg">1. Join the testers Google Group</p>
+          <QrImage
+            value={ANDROID_TESTERS_GROUP_URL}
+            alt="QR code for the Kangentic testers Google Group"
+            testId="mobile-get-app-group-qr"
+          />
+          <ExternalLinkButton
+            label="Join the testers Google Group"
+            url={ANDROID_TESTERS_GROUP_URL}
+            testId="mobile-get-app-group-link"
+          />
+        </div>
+        <div className="rounded-md border border-edge bg-surface-hover/40 p-4 space-y-2" data-testid="mobile-get-app-step-optin">
+          <p className="text-sm text-fg">2. Become a tester</p>
+          <QrImage
+            value={ANDROID_CLOSED_TEST_OPT_IN_URL}
+            alt="QR code for the Play Store tester opt-in page"
+            testId="mobile-get-app-optin-qr"
+          />
+          <ExternalLinkButton
+            label="Become a tester on Google Play"
+            url={ANDROID_CLOSED_TEST_OPT_IN_URL}
+            testId="mobile-get-app-optin-link"
+          />
+        </div>
+        <p className="text-xs text-fg-faint">
+          Use the same Google account you use in the Play Store, and stay opted in while the test is running.
+        </p>
       </div>
 
       {revokeTarget && (

--- a/src/renderer/stores/announcements-store.ts
+++ b/src/renderer/stores/announcements-store.ts
@@ -1,0 +1,86 @@
+import { create } from 'zustand';
+import type { Announcement } from '../../shared/announcements';
+
+interface AnnouncementsState {
+  /** Active announcements for this client, filtered and sorted by the main
+   *  process (targeting + expiry). Still CONTAINS dismissed items: dismissal
+   *  is applied renderer-side against config.dismissedAnnouncementIds (see
+   *  selectBannerAnnouncement), so a dismissal is instant with no IPC
+   *  round-trip and the dismissal prune can see the full active set. */
+  active: Announcement[];
+  /** The announcement the "Learn more" dialog is showing; null = closed. */
+  dialogAnnouncement: Announcement | null;
+
+  /** Pull the current active list (app mount and HMR resync, Pattern B). */
+  loadActive: () => Promise<void>;
+  /** Called from the announcements:changed IPC push. */
+  receiveActive: (active: Announcement[]) => void;
+  openDialog: (announcement: Announcement) => void;
+  closeDialog: () => void;
+}
+
+/**
+ * The announcement the banner shows: the first active entry the user has not
+ * dismissed (main pre-sorted by priority, then recency). One at a time, no
+ * stacking. Pure so the banner component and tests share it.
+ */
+export function selectBannerAnnouncement(
+  active: Announcement[],
+  dismissedIds: string[],
+): Announcement | null {
+  return active.find((announcement) => !dismissedIds.includes(announcement.id)) ?? null;
+}
+
+const createAnnouncementsStore = () => create<AnnouncementsState>((set, get) => ({
+  active: [],
+  dialogAnnouncement: null,
+
+  loadActive: async () => {
+    // Optional chaining: during Vite HMR full reloads the preload bridge may
+    // predate this namespace (see the onPathMissing note in App.tsx).
+    const active = await window.electronAPI.announcements?.getActive();
+    // Route through receiveActive so BOTH entry points apply the same
+    // dialog reconciliation: an HMR resync re-pull (Pattern B) that finds the
+    // open dialog's announcement gone must close it exactly like the push
+    // path does, not leave it rendering withdrawn content.
+    if (active) get().receiveActive(active);
+  },
+
+  receiveActive: (active) => {
+    const { dialogAnnouncement } = get();
+    set({
+      active,
+      // An open dialog for an announcement that just left the active set
+      // (expired or retracted upstream) closes rather than lingering over
+      // content the feed withdrew.
+      dialogAnnouncement: dialogAnnouncement
+        && active.some((announcement) => announcement.id === dialogAnnouncement.id)
+        ? dialogAnnouncement
+        : null,
+    });
+  },
+
+  openDialog: (announcement) => set({ dialogAnnouncement: announcement }),
+  closeDialog: () => set({ dialogAnnouncement: null }),
+}));
+
+// HMR instance pinning (Pattern E, see .claude/rules/hmr-patterns.md): this
+// module's only runtime export is the non-component hook, so it is not a
+// React Fast Refresh boundary. Pin the instance in `import.meta.hot.data` so
+// a Fast Refresh cannot hand a second store to the banner while the dialog
+// stays subscribed to the first.
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+const preservedAnnouncementsStore: ReturnType<typeof createAnnouncementsStore> | undefined = import.meta.hot?.data?.announcementsStore;
+
+export const useAnnouncementsStore = preservedAnnouncementsStore ?? createAnnouncementsStore();
+
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+if (import.meta.hot) {
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.data.announcementsStore = useAnnouncementsStore;
+  // Editing this module's OWN code would leave the pinned instance running
+  // stale closures; force a clean full reload instead. Rare; prod is
+  // unaffected (import.meta.hot is undefined there, so this block is dropped).
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.accept(() => import.meta.hot.invalidate());
+}

--- a/src/renderer/stores/config-store.ts
+++ b/src/renderer/stores/config-store.ts
@@ -2,8 +2,10 @@ import { create } from 'zustand';
 import type { AppConfig, DeepPartial, AgentDetectionInfo, OnboardingBaseline, OnboardingStepKey, SerializedWorkspace } from '../../shared/types';
 import { DEFAULT_CONFIG } from '../../shared/types';
 import { deepMergeConfig } from '../../shared/object-utils';
+import { computeDismissedIdsAfterDismiss } from '../../shared/announcements';
 import { parseModelId } from '../../shared/model-id';
 import { invalidateAllProjects } from './project-cache';
+import { useAnnouncementsStore } from './announcements-store';
 
 /** Last-viewed settings tab, preserved across HMR (Pattern A) so the panel
  *  reopens to the same section during dogfooding instead of resetting to the
@@ -49,6 +51,9 @@ interface ConfigStore {
   updateConfig: (partial: DeepPartial<AppConfig>) => Promise<void>;
   /** Dismiss the onboarding checklist for a project (adds its id to `onboardedProjectIds`). */
   markProjectOnboarded: (projectId: string) => void;
+  /** Dismiss an in-app announcement (adds its id to `dismissedAnnouncementIds`,
+   *  pruned to ids still in the active feed so the array stays bounded). */
+  dismissAnnouncement: (announcementId: string) => void;
   /** Record what a project's watched settings looked like before the user touched them, so
    *  checklist steps 1 and 2 can tick on a real change rather than on a screen being opened.
    *  No-op when a baseline already exists, so re-opening the checklist never re-baselines
@@ -282,6 +287,21 @@ export const useConfigStore = create<ConfigStore>((set, get) => {
       const existing = get().config.onboardedProjectIds ?? [];
       if (existing.includes(projectId)) return;
       get().updateConfig({ onboardedProjectIds: [...existing, projectId] });
+    },
+
+    dismissAnnouncement: (announcementId) => {
+      const existing = get().config.dismissedAnnouncementIds ?? [];
+      if (existing.includes(announcementId)) return;
+      const activeIds = useAnnouncementsStore.getState().active
+        .map((announcement) => announcement.id);
+      // Fire-and-forget, matching the other incidental config writes here:
+      // failing to persist the dismissal must not break hiding the banner.
+      void get()
+        .updateConfig({
+          dismissedAnnouncementIds:
+            computeDismissedIdsAfterDismiss(existing, activeIds, announcementId),
+        })
+        .catch(() => undefined);
     },
 
     captureOnboardingBaseline: (projectId, baseline) => {

--- a/src/shared/announcements.ts
+++ b/src/shared/announcements.ts
@@ -1,0 +1,288 @@
+/**
+ * In-app announcements: schema, tolerant feed parsing, and targeting.
+ *
+ * The desktop app polls a static JSON feed on the public repo
+ * (`announcements.json` on `main`, served via raw.githubusercontent.com) and
+ * shows the highest-priority active announcement as a dismissible banner.
+ * There is no backend: an unreachable or malformed feed simply means no
+ * announcement is shown. Everything here is pure and shared so the main
+ * process (fetch + filter), the renderer (types + dismissal), and unit tests
+ * consume one definition.
+ *
+ * Publishing contract: edits to `announcements.json` on `main` reach every
+ * released client within one poll cycle (about 4 hours, plus ~5 minutes of
+ * raw.githubusercontent CDN cache). See docs/configuration.md.
+ */
+
+export const ANNOUNCEMENTS_URL =
+  'https://raw.githubusercontent.com/Kangentic/kangentic/main/announcements.json';
+
+export type AnnouncementPlatform = 'win32' | 'darwin' | 'linux';
+
+export interface AnnouncementLink {
+  label: string;
+  /** https:// only; the parser drops links with any other scheme. */
+  url: string;
+  /** Render a large scannable QR code for this link in the dialog. Opt-in
+   *  because it is the exception: most announcements carry desktop-destined
+   *  links where a QR is noise. Reserve it for links meant to be opened on a
+   *  phone (store opt-in pages, TestFlight invites). */
+  qr?: boolean;
+}
+
+/**
+ * One titled message inside an announcement, for announcements that carry
+ * several at once (e.g. an iOS status and an Android status, each with its
+ * own links). A section needs at least one of heading / body / links to
+ * survive parsing. Rendered after the announcement's intro `body`, in order.
+ */
+export interface AnnouncementSection {
+  heading?: string;
+  /** Markdown, like the announcement body. */
+  body?: string;
+  links?: AnnouncementLink[];
+}
+
+export interface Announcement {
+  /** Stable unique id, e.g. 'mobile-closed-test-2026-08'. Dismissal is keyed on this. */
+  id: string;
+  /** Banner strip text (one line). */
+  title: string;
+  /** Markdown body for the "Learn more" dialog. With sections present this
+   *  reads as the intro; sections follow it. */
+  body: string;
+  /** External links rendered as buttons at the end of the dialog (with a
+   *  large QR code above any link flagged `qr: true`). May be empty; a
+   *  sectioned announcement usually scopes its links to sections instead. */
+  links: AnnouncementLink[];
+  /** Optional titled sub-messages rendered between body and links. */
+  sections?: AnnouncementSection[];
+  /** Inclusive semver floor/ceiling on the running app version. Omitted = unbounded. */
+  minVersion?: string;
+  maxVersion?: string;
+  /** Electron process.platform values. Omitted = all platforms. */
+  platforms?: AnnouncementPlatform[];
+  /** ISO 8601 UTC. Omitted publishedAt = live immediately; omitted expiresAt = never expires. */
+  publishedAt?: string;
+  expiresAt?: string;
+  /** Higher wins when several are active. Default 0. Ties broken by newest publishedAt. */
+  priority?: number;
+}
+
+export interface AnnouncementTargetContext {
+  appVersion: string;
+  platform: NodeJS.Platform;
+  now: Date;
+}
+
+const KNOWN_PLATFORMS: readonly AnnouncementPlatform[] = ['win32', 'darwin', 'linux'];
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  return isNonEmptyString(value) ? value : undefined;
+}
+
+function isHttpsUrl(value: string): boolean {
+  return value.startsWith('https://');
+}
+
+function parseLinks(raw: unknown): AnnouncementLink[] {
+  if (!Array.isArray(raw)) return [];
+  const links: AnnouncementLink[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== 'object' || entry === null) continue;
+    const candidate = entry as Record<string, unknown>;
+    if (!isNonEmptyString(candidate.label) || !isNonEmptyString(candidate.url)) continue;
+    // https only: these URLs are handed to shell.openExternal on click, so the
+    // parser is the choke point that keeps non-web schemes out of the feed.
+    if (!isHttpsUrl(candidate.url)) continue;
+    const link: AnnouncementLink = { label: candidate.label, url: candidate.url };
+    if (candidate.qr === true) link.qr = true;
+    links.push(link);
+  }
+  return links;
+}
+
+function parseSections(raw: unknown): AnnouncementSection[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const sections: AnnouncementSection[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== 'object' || entry === null) continue;
+    const candidate = entry as Record<string, unknown>;
+    const section: AnnouncementSection = {};
+    const heading = asOptionalString(candidate.heading);
+    if (heading !== undefined) section.heading = heading;
+    const body = asOptionalString(candidate.body);
+    if (body !== undefined) section.body = body;
+    const links = parseLinks(candidate.links);
+    if (links.length > 0) section.links = links;
+    // An empty section renders nothing; drop it rather than emit a blank gap.
+    if (section.heading !== undefined || section.body !== undefined || section.links !== undefined) {
+      sections.push(section);
+    }
+  }
+  return sections.length > 0 ? sections : undefined;
+}
+
+function parsePlatforms(raw: unknown): AnnouncementPlatform[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  // Unknown platform strings are dropped. An announcement targeting ONLY
+  // unknown platforms ends up with an empty array, which matches nothing:
+  // fail closed rather than showing it everywhere.
+  return raw.filter((entry): entry is AnnouncementPlatform =>
+    typeof entry === 'string' && (KNOWN_PLATFORMS as readonly string[]).includes(entry));
+}
+
+/**
+ * Parse one feed item. Returns null for a malformed item, which the caller
+ * skips without poisoning its siblings. Unknown fields are ignored so future
+ * feed additions never break released clients; a future item type that needs
+ * new client behavior sets `minVersion` to the first version that understands
+ * it instead of bumping a schema version.
+ */
+export function parseAnnouncement(raw: unknown): Announcement | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const candidate = raw as Record<string, unknown>;
+  if (!isNonEmptyString(candidate.id)) return null;
+  if (!isNonEmptyString(candidate.title)) return null;
+  if (!isNonEmptyString(candidate.body)) return null;
+
+  const announcement: Announcement = {
+    id: candidate.id,
+    title: candidate.title,
+    body: candidate.body,
+    links: parseLinks(candidate.links),
+  };
+  const sections = parseSections(candidate.sections);
+  if (sections !== undefined) announcement.sections = sections;
+  const minVersion = asOptionalString(candidate.minVersion);
+  if (minVersion !== undefined) announcement.minVersion = minVersion;
+  const maxVersion = asOptionalString(candidate.maxVersion);
+  if (maxVersion !== undefined) announcement.maxVersion = maxVersion;
+  const platforms = parsePlatforms(candidate.platforms);
+  if (platforms !== undefined) announcement.platforms = platforms;
+  const publishedAt = asOptionalString(candidate.publishedAt);
+  if (publishedAt !== undefined) announcement.publishedAt = publishedAt;
+  const expiresAt = asOptionalString(candidate.expiresAt);
+  if (expiresAt !== undefined) announcement.expiresAt = expiresAt;
+  if (typeof candidate.priority === 'number' && Number.isFinite(candidate.priority)) {
+    announcement.priority = candidate.priority;
+  }
+  return announcement;
+}
+
+/**
+ * Parse the whole feed (`{ "announcements": [...] }`). Returns null only when
+ * the feed is structurally unusable, which callers treat exactly like a
+ * network failure: silent, no banner, no telemetry.
+ */
+export function parseAnnouncementsFeed(raw: unknown): Announcement[] | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const feed = (raw as Record<string, unknown>).announcements;
+  if (!Array.isArray(feed)) return null;
+  const parsed: Announcement[] = [];
+  for (const item of feed) {
+    const announcement = parseAnnouncement(item);
+    if (announcement) parsed.push(announcement);
+  }
+  return parsed;
+}
+
+/**
+ * Numeric dotted-part version compare; pre-release/build suffixes after '-'
+ * or '+' are stripped (0.4.0-beta.1 compares as 0.4.0), missing parts are 0.
+ * Local because the only existing helper (`isVersionAtLeast` in
+ * src/main/git/git-detector.ts) lives in the main process and shared code
+ * cannot import it.
+ */
+export function compareVersions(a: string, b: string): -1 | 0 | 1 {
+  const numericParts = (version: string): number[] =>
+    version.split(/[-+]/, 1)[0].split('.').map((part) => {
+      const parsed = Number.parseInt(part, 10);
+      return Number.isFinite(parsed) ? parsed : 0;
+    });
+  const partsA = numericParts(a);
+  const partsB = numericParts(b);
+  const length = Math.max(partsA.length, partsB.length);
+  for (let index = 0; index < length; index += 1) {
+    const partA = partsA[index] ?? 0;
+    const partB = partsB[index] ?? 0;
+    if (partA < partB) return -1;
+    if (partA > partB) return 1;
+  }
+  return 0;
+}
+
+/** Epoch millis for an ISO string; null when missing or unparseable. */
+function parseTimestamp(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * Filter the feed to announcements active for this client: inside the
+ * inclusive min/max version window, matching the platform, already published,
+ * and not expired. An item with an unparseable date string is disabled (fail
+ * closed) rather than shown. The result is sorted priority desc, then
+ * publishedAt desc, then id, and the sort lives HERE deliberately: the main
+ * poller's change detection compares serialized lists, so ordering must be
+ * deterministic for identical inputs.
+ */
+export function selectActiveAnnouncements(
+  feed: Announcement[],
+  context: AnnouncementTargetContext,
+): Announcement[] {
+  const nowMs = context.now.getTime();
+  const active = feed.filter((announcement) => {
+    if (announcement.minVersion !== undefined
+        && compareVersions(context.appVersion, announcement.minVersion) < 0) {
+      return false;
+    }
+    if (announcement.maxVersion !== undefined
+        && compareVersions(context.appVersion, announcement.maxVersion) > 0) {
+      return false;
+    }
+    if (announcement.platforms !== undefined
+        && !(announcement.platforms as readonly string[]).includes(context.platform)) {
+      return false;
+    }
+    if (announcement.publishedAt !== undefined) {
+      const publishedMs = parseTimestamp(announcement.publishedAt);
+      if (publishedMs === null || publishedMs > nowMs) return false;
+    }
+    if (announcement.expiresAt !== undefined) {
+      const expiresMs = parseTimestamp(announcement.expiresAt);
+      if (expiresMs === null || expiresMs <= nowMs) return false;
+    }
+    return true;
+  });
+  return active.sort((first, second) => {
+    const priorityDelta = (second.priority ?? 0) - (first.priority ?? 0);
+    if (priorityDelta !== 0) return priorityDelta;
+    const publishedDelta =
+      (parseTimestamp(second.publishedAt) ?? 0) - (parseTimestamp(first.publishedAt) ?? 0);
+    if (publishedDelta !== 0) return publishedDelta;
+    return first.id.localeCompare(second.id);
+  });
+}
+
+/**
+ * Prune-on-write dismissal: the stored list keeps only ids still present in
+ * the active feed, plus the newly dismissed id, so stale ids from expired or
+ * removed announcements drain out on the next dismissal and the config array
+ * stays bounded with no separate cleanup pass. Accepted edge: an announcement
+ * whose expiry is later extended re-appears if its id was pruned meanwhile.
+ */
+export function computeDismissedIdsAfterDismiss(
+  existingDismissedIds: string[],
+  activeAnnouncementIds: string[],
+  dismissedId: string,
+): string[] {
+  const retained = existingDismissedIds.filter(
+    (id) => id !== dismissedId && activeAnnouncementIds.includes(id));
+  return [...retained, dismissedId];
+}

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -366,6 +366,10 @@ export const IPC = {
   UPDATE_INSTALL: 'updater:install',
   UPDATE_DOWNLOADED: 'updater:downloaded',
 
+  // Announcements (remote feed poll; see src/main/announcements.ts)
+  ANNOUNCEMENTS_GET: 'announcements:get',
+  ANNOUNCEMENTS_CHANGED: 'announcements:changed',
+
   // Search
   SEARCH_EVERYTHING: 'search:everything',
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,5 @@
 import type { PopOutDescriptor, PopOutKind, PopOutParamsByKind } from './pop-out';
+import type { Announcement } from './announcements';
 
 // === Database Models ===
 
@@ -2577,6 +2578,13 @@ export interface AppConfig {
    *  Empty string on an existing install that has not yet upgraded past the
    *  release this key was added in. */
   lastWhatsNewShownVersion: string;
+  /** Ids of in-app announcements the user has dismissed from the banner
+   *  (src/shared/announcements.ts). Auto-set on dismissal, not shown in the
+   *  settings UI. Pruned on write to ids still present in the active feed so
+   *  the array stays bounded (computeDismissedIdsAfterDismiss). Optional
+   *  because configs written before this key existed lack it until their next
+   *  save; readers guard with `?? []`. */
+  dismissedAnnouncementIds?: string[];
   /** Project ids whose onboarding checklist the user has dismissed. Global (per-machine)
    *  memory keyed by project id, like `lastActiveTaskByProject`. `undefined` means the
    *  one-time upgrade backfill (App.tsx, on first hydration) has not run yet; `[]` means
@@ -2853,6 +2861,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   hasCompletedFirstRun: false,
   lastSeenReleaseNotesVersion: '',
   lastWhatsNewShownVersion: '',
+  dismissedAnnouncementIds: [],
   skipDeleteConfirm: false,
   skipBoardConfigConfirm: false,
   autoFocusIdleSession: false,
@@ -4663,6 +4672,12 @@ export interface ElectronAPI {
     checkForUpdate: () => Promise<void>;
     installUpdate: () => Promise<void>;
     onUpdateDownloaded: (callback: (info: UpdateDownloadedInfo) => void) => () => void;
+  };
+
+  // Announcements (remote feed; active = filtered for this client in main)
+  announcements: {
+    getActive: () => Promise<Announcement[]>;
+    onChanged: (callback: (active: Announcement[]) => void) => () => void;
   };
 
   // Backlog Attachments

--- a/tests/ui/announcements.spec.ts
+++ b/tests/ui/announcements.spec.ts
@@ -1,0 +1,275 @@
+/**
+ * UI tests for the in-app announcements surface: the dismissible banner strip
+ * above the board content, the "Learn more" dialog (markdown body, QR image,
+ * external-link buttons), and dismissal persistence into global config
+ * (dismissedAnnouncementIds).
+ *
+ * The active list is driven through the mock's eager
+ * `__mockFireAnnouncementsChanged(active)` hook, which feeds the same
+ * `announcements.onChanged` push App.tsx subscribes to at mount. Each test
+ * seeds its own announcements with UNIQUE ids: dismissals persist in the
+ * mock's global config for the life of the worker's page, so reusing an id
+ * across tests would leak a dismissal into a later test.
+ */
+import { test, expect, chromium } from '@playwright/test';
+import path from 'node:path';
+import { launchPage, createProject, waitForViteReady } from './helpers';
+import type { Browser, Page } from '@playwright/test';
+import type { AppConfig } from '../../src/shared/types';
+import type { Announcement } from '../../src/shared/announcements';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+// Each describe is isolated per worker (separate process; per-test page launch / goto reset),
+// so the file's tests can fan out across the UI workers safely.
+test.describe.configure({ mode: 'parallel' });
+
+let browser: Browser;
+let page: Page;
+
+test.beforeAll(async () => {
+  const result = await launchPage();
+  browser = result.browser;
+  page = result.page;
+  await createProject(page, `Announcements Test ${Date.now()}`);
+});
+
+test.afterAll(async () => {
+  await browser?.close();
+});
+
+function makeAnnouncement(overrides: Partial<Announcement> & { id: string }): Announcement {
+  return {
+    title: `Title for ${overrides.id}`,
+    body: `Body for ${overrides.id}`,
+    links: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Fires the announcements-changed push once App.tsx's subscriber is attached.
+ * Firing before the mount-effect subscription registers would be a silent
+ * no-op (the eager mock hook tolerates zero listeners), so wait for it.
+ */
+async function fireAnnouncements(active: Announcement[]): Promise<void> {
+  await expect
+    .poll(() => page.evaluate(() =>
+      (window as unknown as { __mockAnnouncementsChangedListeners: unknown[] })
+        .__mockAnnouncementsChangedListeners.length))
+    .toBeGreaterThan(0);
+  await page.evaluate((activeList) => {
+    (window as unknown as { __mockFireAnnouncementsChanged: (active: unknown[]) => void })
+      .__mockFireAnnouncementsChanged(activeList);
+  }, active as unknown as unknown[]);
+}
+
+async function getGlobalConfig(): Promise<AppConfig> {
+  return page.evaluate(async () => window.electronAPI.config.getGlobal());
+}
+
+test.describe('Announcements banner and dialog', () => {
+  test('banner shows the pushed announcement title and clears when the feed empties', async () => {
+    const announcement = makeAnnouncement({ id: `banner-basic-${Date.now()}` });
+    await fireAnnouncements([announcement]);
+
+    const banner = page.locator('[data-testid="announcement-banner"]');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText(announcement.title);
+
+    // A retracted feed (announcement removed or expired upstream) clears the
+    // banner without any user action.
+    await fireAnnouncements([]);
+    await expect(banner).toHaveCount(0);
+  });
+
+  test('Learn more opens the dialog with markdown, sections, per-link QR, and recorded external link', async () => {
+    const id = `dialog-${Date.now()}`;
+    const announcement = makeAnnouncement({
+      id,
+      title: 'Kangentic Mobile status',
+      body: 'Status of **both platforms** below.',
+      sections: [
+        { heading: 'iOS: in App Store review', body: 'Nothing to do yet.' },
+        {
+          heading: 'Android: closed testing',
+          body: 'Two steps to join.',
+          links: [{ label: 'Become a tester', url: 'https://play.google.com/apps/testing/com.kangentic.mobile', qr: true }],
+        },
+      ],
+      links: [{ label: 'Read the blog post', url: 'https://kangentic.com/blog' }],
+    });
+    await fireAnnouncements([announcement]);
+
+    await page.locator('[data-testid="announcement-learn-more"]').click();
+    const dialog = page.locator('[data-testid="announcement-dialog"]');
+    await expect(dialog).toBeVisible();
+
+    // MarkdownRenderer output, not raw markdown: the ** delimiters became a tag.
+    await expect(dialog.locator('strong', { hasText: 'both platforms' })).toBeVisible();
+
+    // Both sections render with their headings, in authored order.
+    const sections = dialog.locator('[data-testid="announcement-section"]');
+    await expect(sections).toHaveCount(2);
+    await expect(sections.nth(0)).toContainText('iOS: in App Store review');
+    await expect(sections.nth(1)).toContainText('Android: closed testing');
+
+    // Exactly ONE QR: the qr-flagged section link. The plain announcement-level
+    // link renders as a pill only - QR is per-link opt-in, not a default.
+    const qrImages = dialog.locator('[data-testid="announcement-qr"]');
+    await expect(qrImages).toHaveCount(1);
+    await expect(qrImages).toHaveAttribute('src', /^data:/);
+    await expect(dialog.locator('[data-testid="announcement-link"]')).toHaveCount(2);
+
+    await page.evaluate(() => {
+      window.__openedExternalUrls = [];
+    });
+    await sections.nth(1).locator('[data-testid="announcement-link"]').click();
+    await expect
+      .poll(() => page.evaluate(() => window.__openedExternalUrls))
+      .toEqual(['https://play.google.com/apps/testing/com.kangentic.mobile']);
+
+    await dialog.locator('[data-testid="announcement-close"]').click();
+    await expect(dialog).toHaveCount(0);
+
+    // Leave no banner behind for tests sharing this worker's page.
+    await fireAnnouncements([]);
+  });
+
+  test('the dialog auto-closes when its announcement leaves the active set, with no Close click', async () => {
+    const announcement = makeAnnouncement({ id: `dialog-retract-${Date.now()}` });
+    await fireAnnouncements([announcement]);
+
+    await page.locator('[data-testid="announcement-learn-more"]').click();
+    const dialog = page.locator('[data-testid="announcement-dialog"]');
+    await expect(dialog).toBeVisible();
+
+    // The feed retracts the announcement (expired or withdrawn upstream)
+    // without the user ever clicking Close. receiveActive must reconcile the
+    // open dialog against the new active set and close it.
+    await fireAnnouncements([]);
+    await expect(dialog).toHaveCount(0);
+  });
+
+  test('a realistic multi-QR sectioned announcement fits the dialog without a scrollbar', async () => {
+    // Authoring contract: an announcement must never scroll. The QR grid lays
+    // multiple QRs side by side precisely so this holds; this assertion is the
+    // tripwire against a layout change quietly re-stacking them. Asserted at a
+    // common desktop size, since the safety-valve scroll is still allowed on
+    // very small windows.
+    const originalViewport = page.viewportSize();
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    try {
+      const announcement = makeAnnouncement({
+        id: `no-scroll-${Date.now()}`,
+        title: 'Kangentic Mobile is almost here - iOS in review, Android in beta',
+        body: 'The mobile companion app is on its way to both stores. Here is where each platform stands, and how you can help.',
+        sections: [
+          {
+            heading: 'iOS: in App Store review',
+            body: 'The iOS app has been submitted and is with Apple for review. Nothing to do yet - we will post a new announcement here the moment it is live on the App Store.',
+          },
+          {
+            heading: 'Android: open for beta testers',
+            body: 'Help us test on Android - two steps: join the testers group, then become a tester and install the app. Use the Google account your phone Play Store is signed into.',
+            links: [
+              { label: 'Join the testers Google Group', url: 'https://groups.google.com/g/kangentic-testers', qr: true },
+              { label: 'Become a tester on Google Play', url: 'https://play.google.com/apps/testing/com.kangentic.mobile', qr: true },
+            ],
+          },
+          {
+            heading: 'After installing: pair your desktop',
+            body: 'Enable Mobile Bridge in Settings and click Pair a Device, then scan the QR with the app.',
+            links: [{ label: 'Kangentic Mobile docs', url: 'https://kangentic.com/mobile/' }],
+          },
+        ],
+      });
+      await fireAnnouncements([announcement]);
+
+      await page.locator('[data-testid="announcement-learn-more"]').click();
+      const content = page.locator('[data-testid="announcement-dialog-content"]');
+      await expect(content).toBeVisible();
+      // Both QRs render side by side (the grid), and the content area does not
+      // overflow its box. +1 tolerates sub-pixel rounding differences between
+      // Windows and CI's headless Linux.
+      await expect(page.locator('[data-testid="announcement-qr"]')).toHaveCount(2);
+      await expect
+        .poll(() => content.evaluate((element) => element.scrollHeight - element.clientHeight))
+        .toBeLessThanOrEqual(1);
+
+      await page.locator('[data-testid="announcement-close"]').click();
+      await fireAnnouncements([]);
+    } finally {
+      if (originalViewport) await page.setViewportSize(originalViewport);
+    }
+  });
+
+  test('dismiss persists the id to global config and promotes the next announcement', async () => {
+    const stamp = Date.now();
+    const first = makeAnnouncement({ id: `dismiss-first-${stamp}`, priority: 5 });
+    const second = makeAnnouncement({ id: `dismiss-second-${stamp}` });
+    await fireAnnouncements([first, second]);
+
+    const banner = page.locator('[data-testid="announcement-banner"]');
+    await expect(banner).toContainText(first.title);
+
+    await page.locator('[data-testid="announcement-dismiss"]').click();
+
+    // The next non-dismissed announcement takes the single banner slot.
+    await expect(banner).toContainText(second.title);
+    await expect
+      .poll(async () => (await getGlobalConfig()).dismissedAnnouncementIds)
+      .toContain(first.id);
+
+    await page.locator('[data-testid="announcement-dismiss"]').click();
+    await expect(banner).toHaveCount(0);
+    await expect
+      .poll(async () => (await getGlobalConfig()).dismissedAnnouncementIds)
+      .toContain(second.id);
+
+    // The prune-on-write in computeDismissedIdsAfterDismiss must RETAIN a
+    // previously-dismissed id whose announcement is still in the active set
+    // (only ids that dropped out of the active feed get pruned). Both `first`
+    // and `second` are still active, so both dismissed ids should survive
+    // the second dismissal's write.
+    expect((await getGlobalConfig()).dismissedAnnouncementIds).toContain(first.id);
+  });
+});
+
+test.describe('Announcements mount-time pull', () => {
+  // This test manages its own browser/page (not the shared per-worker one
+  // above): it needs window.__mockActiveAnnouncements seeded BEFORE React
+  // mounts, which requires a SECOND addInitScript registered after the
+  // mock's own (the mock sets __mockActiveAnnouncements = [] eagerly at
+  // bootstrap; addInitScript calls run in registration order, so registering
+  // the seed after the mock script lets it overwrite that default before
+  // page.goto ever runs the app bundle). Never fires
+  // __mockFireAnnouncementsChanged: the whole point is proving the PULL path
+  // (App.tsx's mount-effect loadActive()) works with no push at all.
+  test('the banner shows an announcement that was already active before the renderer mounted, with no push', async () => {
+    const announcement = makeAnnouncement({ id: `mount-pull-${Date.now()}`, title: 'Seeded before mount' });
+
+    await waitForViteReady(VITE_URL);
+    const isolatedBrowser = await chromium.launch({ headless: true });
+    try {
+      const context = await isolatedBrowser.newContext({ viewport: { width: 1920, height: 1080 } });
+      const isolatedPage = await context.newPage();
+
+      await isolatedPage.addInitScript({ path: MOCK_SCRIPT });
+      await isolatedPage.addInitScript((seeded) => {
+        (window as unknown as { __mockActiveAnnouncements: unknown[] }).__mockActiveAnnouncements = [seeded];
+      }, announcement as unknown as Record<string, unknown>);
+
+      await isolatedPage.goto(VITE_URL);
+      await isolatedPage.waitForLoadState('load');
+      await isolatedPage.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+      const banner = isolatedPage.locator('[data-testid="announcement-banner"]');
+      await expect(banner).toBeVisible();
+      await expect(banner).toContainText(announcement.title);
+    } finally {
+      await isolatedBrowser.close();
+    }
+  });
+});

--- a/tests/ui/mobile-devices-settings.spec.ts
+++ b/tests/ui/mobile-devices-settings.spec.ts
@@ -167,6 +167,39 @@ test.describe('Mobile Devices settings tab', () => {
     }
   });
 
+  test('Get the App section stays interactive with the bridge off and opens both signup links', async () => {
+    // Bridge OFF is the interesting case: the section sits OUTSIDE the
+    // enabled-gated wrapper (opacity-40 pointer-events-none when disabled),
+    // because a user who has not installed the app yet is exactly the user
+    // who has not enabled the bridge. Clicks succeeding proves the escape.
+    await setMobileBridgeConfig({ enabled: false, relayMode: 'hosted', relayUrl: '' });
+    await openMobileTab();
+
+    const section = page.locator('[data-testid="mobile-get-app"]');
+    await expect(section).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Get the App' })).toBeVisible();
+
+    // Both step QRs resolve to encoded data URLs.
+    await expect(page.locator('[data-testid="mobile-get-app-group-qr"]')).toHaveAttribute('src', /^data:/);
+    await expect(page.locator('[data-testid="mobile-get-app-optin-qr"]')).toHaveAttribute('src', /^data:/);
+
+    await page.evaluate(() => {
+      window.__openedExternalUrls = [];
+    });
+    await page.locator('[data-testid="mobile-get-app-group-link"]').click();
+    await page.locator('[data-testid="mobile-get-app-optin-link"]').click();
+    await expect
+      .poll(() => page.evaluate(() => window.__openedExternalUrls))
+      .toEqual([
+        'https://groups.google.com/g/kangentic-testers',
+        // Deterministic from the Android applicationId; must match the Play
+        // Console closed-test opt-in URL exactly.
+        'https://play.google.com/apps/testing/com.kangentic.mobile',
+      ]);
+
+    await closeSettings();
+  });
+
   test('hosted mode renders the enable toggle, relay mode select, resolved URL, and section headers', async () => {
     await openMobileTab();
     await expect(page.getByRole('switch')).toBeVisible();

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -377,6 +377,18 @@
     listeners.forEach(function (fn) { fn(info); });
   };
 
+  // Announcements test hooks: installed eagerly for the same reason as the
+  // update-downloaded hooks above. `__mockFireAnnouncementsChanged(active)`
+  // also updates `__mockActiveAnnouncements` so a later
+  // announcements.getActive() (e.g. an HMR resync) returns the same list.
+  window.__mockActiveAnnouncements = [];
+  window.__mockAnnouncementsChangedListeners = [];
+  window.__mockFireAnnouncementsChanged = function (active) {
+    window.__mockActiveAnnouncements = active;
+    var listeners = window.__mockAnnouncementsChangedListeners.slice();
+    listeners.forEach(function (fn) { fn(active); });
+  };
+
   // Notification-click test hook (App.tsx's `notifications.onClicked` handler,
   // including the isCommandTerminal branch). Installed eagerly for the same
   // reason as the update-downloaded hooks above. Unlike that hook, this one
@@ -3268,6 +3280,24 @@
         window.__mockUpdateDownloadedListeners.push(callback);
         return function () {
           var listeners = window.__mockUpdateDownloadedListeners || [];
+          var idx = listeners.indexOf(callback);
+          if (idx >= 0) listeners.splice(idx, 1);
+        };
+      },
+    },
+
+    announcements: {
+      getActive: async function () {
+        return window.__mockActiveAnnouncements || [];
+      },
+      onChanged: function (callback) {
+        // Tests fire the changed push via
+        // `window.__mockFireAnnouncementsChanged([announcement, ...])`. The
+        // listener array and the fire hook itself are installed eagerly at
+        // mock-bootstrap time (see top of file), not lazily here.
+        window.__mockAnnouncementsChangedListeners.push(callback);
+        return function () {
+          var listeners = window.__mockAnnouncementsChangedListeners || [];
           var idx = listeners.indexOf(callback);
           if (idx >= 0) listeners.splice(idx, 1);
         };

--- a/tests/unit/announcements-feed.test.ts
+++ b/tests/unit/announcements-feed.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Pure-function tests for the announcements feed (src/shared/announcements.ts):
+ * tolerant parsing (malformed items skipped without poisoning siblings,
+ * unknown fields ignored for forward compat, https-only links), the dotted
+ * version comparator, active-selection targeting (version window, platform,
+ * publish/expiry with fail-closed dates, deterministic ordering), and the
+ * prune-on-write dismissal helper.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  parseAnnouncement,
+  parseAnnouncementsFeed,
+  compareVersions,
+  selectActiveAnnouncements,
+  computeDismissedIdsAfterDismiss,
+  type Announcement,
+} from '../../src/shared/announcements';
+
+const NOW = new Date('2026-08-04T12:00:00Z');
+
+function makeAnnouncement(overrides: Partial<Announcement> = {}): Announcement {
+  return {
+    id: 'a1',
+    title: 'Title',
+    body: 'Body',
+    links: [],
+    ...overrides,
+  };
+}
+
+function contextFor(overrides: Partial<{ appVersion: string; platform: NodeJS.Platform; now: Date }> = {}) {
+  return {
+    appVersion: '0.32.1',
+    platform: 'win32' as NodeJS.Platform,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe('parseAnnouncementsFeed', () => {
+  it('round-trips a valid feed', () => {
+    const feed = parseAnnouncementsFeed({
+      announcements: [{
+        id: 'mobile-launch-status-2026-08',
+        title: 'Try Kangentic Mobile',
+        body: 'Status of both platforms.',
+        links: [{ label: 'Blog post', url: 'https://kangentic.com/blog' }],
+        sections: [
+          { heading: 'iOS', body: 'In **review**.' },
+          {
+            heading: 'Android',
+            body: 'Closed testing.',
+            links: [{ label: 'Become a tester', url: 'https://play.google.com/apps/testing/com.kangentic.mobile', qr: true }],
+          },
+        ],
+        minVersion: '0.30.0',
+        platforms: ['win32', 'darwin'],
+        publishedAt: '2026-08-01T00:00:00Z',
+        expiresAt: '2026-09-15T00:00:00Z',
+        priority: 5,
+      }],
+    });
+    expect(feed).toEqual([{
+      id: 'mobile-launch-status-2026-08',
+      title: 'Try Kangentic Mobile',
+      body: 'Status of both platforms.',
+      links: [{ label: 'Blog post', url: 'https://kangentic.com/blog' }],
+      sections: [
+        { heading: 'iOS', body: 'In **review**.' },
+        {
+          heading: 'Android',
+          body: 'Closed testing.',
+          links: [{ label: 'Become a tester', url: 'https://play.google.com/apps/testing/com.kangentic.mobile', qr: true }],
+        },
+      ],
+      minVersion: '0.30.0',
+      platforms: ['win32', 'darwin'],
+      publishedAt: '2026-08-01T00:00:00Z',
+      expiresAt: '2026-09-15T00:00:00Z',
+      priority: 5,
+    }]);
+  });
+
+  it('ignores unknown top-level and per-item fields (forward compat)', () => {
+    const feed = parseAnnouncementsFeed({
+      schemaVersion: 99,
+      futureTopLevelField: { nested: true },
+      announcements: [{
+        id: 'a1', title: 'T', body: 'B',
+        futureItemField: 'ignored',
+        style: 'takeover',
+      }],
+    });
+    expect(feed).toEqual([{ id: 'a1', title: 'T', body: 'B', links: [] }]);
+  });
+
+  it('skips a malformed item while its siblings survive', () => {
+    const feed = parseAnnouncementsFeed({
+      announcements: [
+        { id: 'good-1', title: 'T', body: 'B' },
+        { id: 'missing-body', title: 'T' },
+        { id: '', title: 'T', body: 'B' },
+        'not-an-object',
+        null,
+        { id: 'good-2', title: 'T', body: 'B' },
+      ],
+    });
+    expect(feed?.map((announcement) => announcement.id)).toEqual(['good-1', 'good-2']);
+  });
+
+  it('returns null for a structurally unusable feed', () => {
+    expect(parseAnnouncementsFeed(null)).toBeNull();
+    expect(parseAnnouncementsFeed('nonsense')).toBeNull();
+    expect(parseAnnouncementsFeed([])).toBeNull();
+    expect(parseAnnouncementsFeed({})).toBeNull();
+    expect(parseAnnouncementsFeed({ announcements: 'not-an-array' })).toBeNull();
+  });
+
+  it('drops non-https links but keeps the item', () => {
+    const announcement = parseAnnouncement({
+      id: 'a1', title: 'T', body: 'B',
+      links: [
+        { label: 'Ok', url: 'https://example.com' },
+        { label: 'Http', url: 'http://example.com' },
+        { label: 'File', url: 'file:///etc/passwd' },
+        { label: 'NoUrl' },
+      ],
+    });
+    expect(announcement).toEqual({
+      id: 'a1', title: 'T', body: 'B',
+      links: [{ label: 'Ok', url: 'https://example.com' }],
+    });
+  });
+
+  it('carries the qr flag only when it is literally true', () => {
+    const announcement = parseAnnouncement({
+      id: 'a1', title: 'T', body: 'B',
+      links: [
+        { label: 'Scannable', url: 'https://example.com/a', qr: true },
+        { label: 'StringTruthy', url: 'https://example.com/b', qr: 'yes' },
+        { label: 'Plain', url: 'https://example.com/c' },
+      ],
+    });
+    expect(announcement?.links).toEqual([
+      { label: 'Scannable', url: 'https://example.com/a', qr: true },
+      { label: 'StringTruthy', url: 'https://example.com/b' },
+      { label: 'Plain', url: 'https://example.com/c' },
+    ]);
+  });
+
+  it('skips malformed and empty sections while keeping real ones', () => {
+    const announcement = parseAnnouncement({
+      id: 'a1', title: 'T', body: 'B',
+      sections: [
+        { heading: 'Real', body: 'content' },
+        {},
+        'not-an-object',
+        null,
+        { links: [{ label: 'Only link', url: 'https://example.com' }] },
+        { heading: '', body: '   ' },
+      ],
+    });
+    expect(announcement?.sections).toEqual([
+      { heading: 'Real', body: 'content' },
+      { links: [{ label: 'Only link', url: 'https://example.com' }] },
+    ]);
+  });
+
+  it('omits sections entirely when absent or all-empty', () => {
+    expect(parseAnnouncement({ id: 'a1', title: 'T', body: 'B' })?.sections).toBeUndefined();
+    expect(parseAnnouncement({ id: 'a2', title: 'T', body: 'B', sections: [{}] })?.sections).toBeUndefined();
+    expect(parseAnnouncement({ id: 'a3', title: 'T', body: 'B', sections: 'nope' })?.sections).toBeUndefined();
+  });
+
+  it('drops unknown platform strings, failing closed when none remain', () => {
+    const known = parseAnnouncement({ id: 'a1', title: 'T', body: 'B', platforms: ['win32', 'fuchsia'] });
+    expect(known?.platforms).toEqual(['win32']);
+    const allUnknown = parseAnnouncement({ id: 'a2', title: 'T', body: 'B', platforms: ['fuchsia'] });
+    // Empty (not undefined): matches no platform, rather than all of them.
+    expect(allUnknown?.platforms).toEqual([]);
+  });
+});
+
+describe('compareVersions', () => {
+  it('compares numerically per dotted part, not lexically', () => {
+    expect(compareVersions('1.2.3', '1.10.0')).toBe(-1);
+    expect(compareVersions('1.10.0', '1.2.3')).toBe(1);
+    expect(compareVersions('0.32.1', '0.32.1')).toBe(0);
+  });
+
+  it('treats missing parts as zero', () => {
+    expect(compareVersions('1.2', '1.2.0')).toBe(0);
+    expect(compareVersions('1.2', '1.2.1')).toBe(-1);
+  });
+
+  it('strips pre-release and build suffixes', () => {
+    expect(compareVersions('0.4.0-beta.1', '0.4.0')).toBe(0);
+    expect(compareVersions('0.4.0+build.7', '0.4.0')).toBe(0);
+  });
+});
+
+describe('selectActiveAnnouncements', () => {
+  it('applies the version window inclusively', () => {
+    const feed = [
+      makeAnnouncement({ id: 'below-min', minVersion: '0.33.0' }),
+      makeAnnouncement({ id: 'at-min', minVersion: '0.32.1' }),
+      makeAnnouncement({ id: 'at-max', maxVersion: '0.32.1' }),
+      makeAnnouncement({ id: 'above-max', maxVersion: '0.32.0' }),
+      makeAnnouncement({ id: 'unbounded' }),
+    ];
+    const active = selectActiveAnnouncements(feed, contextFor());
+    expect(active.map((announcement) => announcement.id).sort()).toEqual(['at-max', 'at-min', 'unbounded']);
+  });
+
+  it('filters by platform, with omitted platforms matching everywhere', () => {
+    const feed = [
+      makeAnnouncement({ id: 'win-only', platforms: ['win32'] }),
+      makeAnnouncement({ id: 'mac-only', platforms: ['darwin'] }),
+      makeAnnouncement({ id: 'everywhere' }),
+    ];
+    const active = selectActiveAnnouncements(feed, contextFor({ platform: 'win32' }));
+    expect(active.map((announcement) => announcement.id).sort()).toEqual(['everywhere', 'win-only']);
+  });
+
+  it('fails closed for a client platform outside the known trio: matches only untargeted announcements', () => {
+    // NodeJS.Platform includes values beyond win32/darwin/linux (aix, freebsd,
+    // openbsd, sunos, ...); AnnouncementPlatform only declares the three
+    // Kangentic ships on. A client running on one of those other platforms
+    // must never match a `platforms`-targeted announcement, only an
+    // untargeted (omitted platforms) one.
+    const feed = [
+      makeAnnouncement({ id: 'win-targeted', platforms: ['win32'] }),
+      makeAnnouncement({ id: 'untargeted' }),
+    ];
+    const active = selectActiveAnnouncements(
+      feed,
+      contextFor({ platform: 'freebsd' as NodeJS.Platform }),
+    );
+    expect(active.map((announcement) => announcement.id)).toEqual(['untargeted']);
+  });
+
+  it('excludes future publishedAt and past expiresAt', () => {
+    const feed = [
+      makeAnnouncement({ id: 'not-yet', publishedAt: '2026-08-05T00:00:00Z' }),
+      makeAnnouncement({ id: 'expired', expiresAt: '2026-08-01T00:00:00Z' }),
+      makeAnnouncement({ id: 'live', publishedAt: '2026-08-01T00:00:00Z', expiresAt: '2026-09-01T00:00:00Z' }),
+    ];
+    const active = selectActiveAnnouncements(feed, contextFor());
+    expect(active.map((announcement) => announcement.id)).toEqual(['live']);
+  });
+
+  it('fails closed on unparseable date strings', () => {
+    const feed = [
+      makeAnnouncement({ id: 'bad-published', publishedAt: 'not-a-date' }),
+      makeAnnouncement({ id: 'bad-expires', expiresAt: 'not-a-date' }),
+    ];
+    expect(selectActiveAnnouncements(feed, contextFor())).toEqual([]);
+  });
+
+  it('orders by priority desc, then publishedAt desc, then id (deterministic)', () => {
+    const feed = [
+      makeAnnouncement({ id: 'old-high', priority: 5, publishedAt: '2026-07-01T00:00:00Z' }),
+      makeAnnouncement({ id: 'new-low', publishedAt: '2026-08-02T00:00:00Z' }),
+      makeAnnouncement({ id: 'newer-low', publishedAt: '2026-08-03T00:00:00Z' }),
+      makeAnnouncement({ id: 'tie-b' }),
+      makeAnnouncement({ id: 'tie-a' }),
+    ];
+    const active = selectActiveAnnouncements(feed, contextFor());
+    expect(active.map((announcement) => announcement.id)).toEqual([
+      'old-high', 'newer-low', 'new-low', 'tie-a', 'tie-b',
+    ]);
+  });
+});
+
+describe('computeDismissedIdsAfterDismiss', () => {
+  it('appends the dismissed id', () => {
+    expect(computeDismissedIdsAfterDismiss([], ['a1'], 'a1')).toEqual(['a1']);
+  });
+
+  it('prunes stored ids no longer in the active feed', () => {
+    expect(computeDismissedIdsAfterDismiss(
+      ['gone-1', 'still-active', 'gone-2'],
+      ['still-active', 'a2'],
+      'a2',
+    )).toEqual(['still-active', 'a2']);
+  });
+
+  it('does not duplicate an already-dismissed id', () => {
+    expect(computeDismissedIdsAfterDismiss(['a1', 'a2'], ['a1', 'a2'], 'a2')).toEqual(['a1', 'a2']);
+  });
+});

--- a/tests/unit/announcements-init-guard.test.ts
+++ b/tests/unit/announcements-init-guard.test.ts
@@ -168,6 +168,36 @@ describe('announcements poller', () => {
     expect(getHandlerResult()).toEqual(active);
   });
 
+  it('does not push to a destroyed window but still advances the cache for a later pull', async () => {
+    process.env.NODE_ENV = 'test';
+    const { initAnnouncements, updateAnnouncementsWindow, checkAnnouncements } = await importFreshModule();
+    initAnnouncements(fakeWindow);
+
+    // A window can be destroyed between poll cycles (e.g. macOS closed the
+    // last window and the dock icon hasn't recreated one yet). Give this
+    // fake its own send spy so it can't be confused with fakeWindow's.
+    const destroyedSend = vi.fn();
+    const destroyedWindow = {
+      isDestroyed: () => true,
+      webContents: { send: destroyedSend },
+    } as unknown as Electron.BrowserWindow;
+    updateAnnouncementsWindow(destroyedWindow);
+
+    const feed = { announcements: [{ id: 'a1', title: 'T', body: 'B' }] };
+    fetchMock.mockResolvedValue(okJsonResponse(feed));
+
+    await checkAnnouncements();
+
+    // No push to a destroyed window's webContents.
+    expect(destroyedSend).not.toHaveBeenCalled();
+    // But the cache still advances, so ANNOUNCEMENTS_GET reflects the fresh
+    // list the moment a new renderer mounts and pulls it (the "mount-time
+    // pull" UI spec's path). A change that moved `cachedActive = active`
+    // inside the isDestroyed guard would leave this stale until the feed
+    // changed again on a later poll.
+    expect(getHandlerResult()).toEqual([{ id: 'a1', title: 'T', body: 'B', links: [] }]);
+  });
+
   it('honors the KANGENTIC_ANNOUNCEMENTS_URL override', async () => {
     const { checkAnnouncements } = await importFreshModule();
     process.env.KANGENTIC_ANNOUNCEMENTS_URL = 'https://localhost:9999/fixture.json';

--- a/tests/unit/announcements-init-guard.test.ts
+++ b/tests/unit/announcements-init-guard.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Guards for the main-process announcements poller (src/main/announcements.ts),
+ * mirroring updater-init-guard.test.ts:
+ *
+ * - initAnnouncements always registers the GET handler (invoke never rejects
+ *   with `No handler registered`), and under NODE_ENV=test schedules nothing,
+ *   so no test run ever touches the network.
+ * - checkAnnouncements degrades silently on every failure mode (network
+ *   error, non-200, garbage JSON, unusable feed) and only pushes the changed
+ *   event when the filtered active list actually changed.
+ *
+ * Module state (cachedActive, timers) is per-import, so each test re-imports
+ * a fresh module via vi.resetModules() + dynamic import.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  electronMock: {
+    app: { getVersion: () => '0.32.1' },
+    BrowserWindow: class {},
+    ipcMain: { handle: vi.fn() },
+  },
+}));
+
+vi.mock('electron', () => mocks.electronMock);
+
+import { IPC } from '../../src/shared/ipc-channels';
+
+const fakeWindowSend = vi.fn();
+const fakeWindow = {
+  isDestroyed: () => false,
+  webContents: { send: fakeWindowSend },
+} as unknown as Electron.BrowserWindow;
+
+const fetchMock = vi.fn();
+
+async function importFreshModule() {
+  vi.resetModules();
+  return import('../../src/main/announcements');
+}
+
+/** The registered ANNOUNCEMENTS_GET handler's current return value. */
+function getHandlerResult(): unknown {
+  const call = mocks.electronMock.ipcMain.handle.mock.calls.find(
+    (candidate) => candidate[0] === IPC.ANNOUNCEMENTS_GET,
+  );
+  if (!call) throw new Error('ANNOUNCEMENTS_GET handler was not registered');
+  return (call[1] as () => unknown)();
+}
+
+function okJsonResponse(payload: unknown): Response {
+  return { ok: true, status: 200, json: async () => payload } as unknown as Response;
+}
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+describe('announcements poller', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+    mocks.electronMock.ipcMain.handle.mockReset();
+    fakeWindowSend.mockReset();
+    delete process.env.KANGENTIC_ANNOUNCEMENTS_URL;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('registers the GET handler but schedules nothing under NODE_ENV=test', async () => {
+    process.env.NODE_ENV = 'test';
+    const { initAnnouncements } = await importFreshModule();
+
+    initAnnouncements(fakeWindow);
+
+    expect(getHandlerResult()).toEqual([]);
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('schedules the initial check outside test env', async () => {
+    process.env.NODE_ENV = 'development';
+    fetchMock.mockResolvedValue(okJsonResponse({ announcements: [] }));
+    const { initAnnouncements, stopAnnouncementTimers } = await importFreshModule();
+
+    initAnnouncements(fakeWindow);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(10_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // The recurring 4-hour interval is created INSIDE the initial setTimeout
+    // callback (checkInterval, src/main/announcements.ts), so it only exists
+    // after the advance above fires that callback. stopAnnouncementTimers must
+    // clear checkInterval too, not just the already-fired checkTimeout: advance
+    // past a full interval and confirm no second fetch happened.
+    stopAnnouncementTimers();
+    const FOUR_HOURS_MS = 4 * 60 * 60 * 1000; // mirrors CHECK_INTERVAL_MS
+    vi.advanceTimersByTime(FOUR_HOURS_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves silently on a network error and pushes nothing', async () => {
+    const { checkAnnouncements } = await importFreshModule();
+    fetchMock.mockRejectedValue(new Error('getaddrinfo ENOTFOUND raw.githubusercontent.com'));
+
+    await expect(checkAnnouncements()).resolves.toBeUndefined();
+    expect(fakeWindowSend).not.toHaveBeenCalled();
+  });
+
+  it('resolves silently on a non-200 response', async () => {
+    const { checkAnnouncements } = await importFreshModule();
+    fetchMock.mockResolvedValue({ ok: false, status: 404 } as unknown as Response);
+
+    await expect(checkAnnouncements()).resolves.toBeUndefined();
+    expect(fakeWindowSend).not.toHaveBeenCalled();
+  });
+
+  it('treats garbage JSON and an unusable feed like a network failure', async () => {
+    const { checkAnnouncements } = await importFreshModule();
+
+    fetchMock.mockResolvedValue({
+      ok: true, status: 200,
+      json: async () => { throw new SyntaxError('Unexpected token'); },
+    } as unknown as Response);
+    await expect(checkAnnouncements()).resolves.toBeUndefined();
+
+    fetchMock.mockResolvedValue(okJsonResponse(['bare', 'array']));
+    await expect(checkAnnouncements()).resolves.toBeUndefined();
+
+    expect(fakeWindowSend).not.toHaveBeenCalled();
+  });
+
+  it('caches the filtered active list and pushes only on change', async () => {
+    process.env.NODE_ENV = 'test';
+    const { initAnnouncements, updateAnnouncementsWindow, checkAnnouncements } = await importFreshModule();
+    initAnnouncements(fakeWindow);
+    // The test-env init path registers the handler but never wires the push
+    // window; attach it explicitly so the change-push is observable.
+    updateAnnouncementsWindow(fakeWindow);
+
+    const feed = {
+      announcements: [
+        { id: 'a1', title: 'T', body: 'B' },
+        // Filtered out for this client: version floor above the mocked 0.32.1.
+        { id: 'future-only', title: 'T', body: 'B', minVersion: '99.0.0' },
+      ],
+    };
+    fetchMock.mockResolvedValue(okJsonResponse(feed));
+
+    await checkAnnouncements();
+    expect(fakeWindowSend).toHaveBeenCalledTimes(1);
+    const [channel, active] = fakeWindowSend.mock.calls[0] as [string, unknown[]];
+    expect(channel).toBe(IPC.ANNOUNCEMENTS_CHANGED);
+    expect((active as Array<{ id: string }>).map((announcement) => announcement.id)).toEqual(['a1']);
+    expect(getHandlerResult()).toEqual(active);
+
+    // Identical feed on the next poll: no second push.
+    await checkAnnouncements();
+    expect(fakeWindowSend).toHaveBeenCalledTimes(1);
+
+    // A failed poll keeps the last-known list rather than clearing it.
+    fetchMock.mockRejectedValue(new Error('offline'));
+    await checkAnnouncements();
+    expect(getHandlerResult()).toEqual(active);
+  });
+
+  it('honors the KANGENTIC_ANNOUNCEMENTS_URL override', async () => {
+    const { checkAnnouncements } = await importFreshModule();
+    process.env.KANGENTIC_ANNOUNCEMENTS_URL = 'https://localhost:9999/fixture.json';
+    fetchMock.mockResolvedValue(okJsonResponse({ announcements: [] }));
+
+    await checkAnnouncements();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://localhost:9999/fixture.json',
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+  });
+});

--- a/tests/unit/announcements-json-valid.test.ts
+++ b/tests/unit/announcements-json-valid.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Validates the COMMITTED announcements feed (announcements.json at the repo
+ * root) through the real parser. The feed's tolerant parsing is a feature in
+ * production (a malformed entry is silently dropped rather than breaking the
+ * app) but a trap at authoring time: a typo'd entry would ship, drop, and
+ * show nothing, with no error anywhere. This test makes that failure loud on
+ * the PR that introduces it - every content-only announcement PR runs it via
+ * the unit tier in CI.
+ *
+ * Publishing contract reminder (docs/configuration.md): edits to this file on
+ * main reach every released client within one poll cycle. Ids are dismissal
+ * keys - never reuse or rename one.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseAnnouncementsFeed } from '../../src/shared/announcements';
+
+const FEED_PATH = path.join(__dirname, '..', '..', 'announcements.json');
+
+function readRawFeed(): { raw: unknown; rawEntries: unknown[] } {
+  const raw: unknown = JSON.parse(fs.readFileSync(FEED_PATH, 'utf-8'));
+  const rawEntries = (raw as { announcements?: unknown[] }).announcements ?? [];
+  return { raw, rawEntries };
+}
+
+function readRawFeedText(): string {
+  return fs.readFileSync(FEED_PATH, 'utf-8');
+}
+
+describe('committed announcements.json', () => {
+  it('is a structurally valid feed', () => {
+    const { raw } = readRawFeed();
+    expect(parseAnnouncementsFeed(raw)).not.toBeNull();
+  });
+
+  it('loses NOTHING to tolerant parsing: every authored entry and link survives', () => {
+    const { raw, rawEntries } = readRawFeed();
+    const parsed = parseAnnouncementsFeed(raw)!;
+
+    // Entry count: a malformed entry (missing id/title/body) would be dropped
+    // silently in production; here it fails the build instead.
+    expect(parsed.length).toBe(rawEntries.length);
+
+    // Link count, including section links: a non-https URL or missing label
+    // would silently drop just that link.
+    const countRawLinks = (entry: unknown): number => {
+      const candidate = entry as { links?: unknown[]; sections?: Array<{ links?: unknown[] }> };
+      return (candidate.links?.length ?? 0)
+        + (candidate.sections ?? []).reduce((sum, section) => sum + (section.links?.length ?? 0), 0);
+    };
+    const countParsedLinks = (entry: (typeof parsed)[number]): number =>
+      entry.links.length
+      + (entry.sections ?? []).reduce((sum, section) => sum + (section.links?.length ?? 0), 0);
+
+    for (let index = 0; index < parsed.length; index += 1) {
+      expect(countParsedLinks(parsed[index])).toBe(countRawLinks(rawEntries[index]));
+    }
+
+    // Section count: an all-empty section would be dropped silently.
+    for (let index = 0; index < parsed.length; index += 1) {
+      const rawSections = (rawEntries[index] as { sections?: unknown[] }).sections?.length ?? 0;
+      expect(parsed[index].sections?.length ?? 0).toBe(rawSections);
+    }
+  });
+
+  it('follows the authoring contract: unique ids, expiry on every entry, parseable dates', () => {
+    const { raw } = readRawFeed();
+    const parsed = parseAnnouncementsFeed(raw)!;
+
+    const ids = parsed.map((announcement) => announcement.id);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    for (const announcement of parsed) {
+      // Every entry carries an expiry (docs/configuration.md): a forgotten
+      // announcement must age out on its own, not linger for years.
+      expect(announcement.expiresAt, `announcement "${announcement.id}" needs expiresAt`).toBeDefined();
+      // Unparseable dates fail closed (the entry never shows); catch at author time.
+      expect(Number.isNaN(Date.parse(announcement.expiresAt!))).toBe(false);
+      if (announcement.publishedAt !== undefined) {
+        expect(Number.isNaN(Date.parse(announcement.publishedAt))).toBe(false);
+      }
+    }
+  });
+
+  it('follows house style: no em-dash and no " -- " separator in authored copy', () => {
+    // Content-only PRs (announcements.json is the one file non-engineering
+    // contributors edit directly) can ship house-style violations that no
+    // lint rule catches. .claude/rules/text-formatting.md's em-dash scan only
+    // covers src/ and scripts/. The character renders as mojibake on Windows
+    // console code pages, which the team dogfoods on. The escape below keeps
+    // this authored assertion itself free of a literal em-dash character.
+    const EM_DASH = String.fromCharCode(0x2014);
+    const rawText = readRawFeedText();
+    expect(rawText.includes(EM_DASH)).toBe(false);
+    expect(rawText.includes(' -- ')).toBe(false);
+  });
+});

--- a/tests/unit/hmr-resync.test.ts
+++ b/tests/unit/hmr-resync.test.ts
@@ -260,7 +260,7 @@ describe('HMR store re-sync', () => {
   // back, and self-accept so editing the store's own code forces a clean reload
   // instead of running stale closures. See .claude/rules/hmr-patterns.md.
   it('instance-pinned stores read, write, and self-accept across HMR (Pattern E)', () => {
-    const PATTERN_E_STORES = ['board-store.ts', 'backlog-store.ts', 'project-store.ts', 'dictation-store.ts', 'usage-dashboard-store.ts', 'pop-out-store.ts', 'updater-store.ts', 'monitor-store.ts'];
+    const PATTERN_E_STORES = ['board-store.ts', 'backlog-store.ts', 'project-store.ts', 'dictation-store.ts', 'usage-dashboard-store.ts', 'pop-out-store.ts', 'updater-store.ts', 'monitor-store.ts', 'announcements-store.ts'];
     const violations: string[] = [];
     for (const fileName of PATTERN_E_STORES) {
       const source = fs.readFileSync(path.join(STORES_DIR, fileName), 'utf-8');

--- a/tests/unit/session-auto-resume-on-restart.test.ts
+++ b/tests/unit/session-auto-resume-on-restart.test.ts
@@ -73,6 +73,7 @@ function makeDeps(options: { sessionStatus?: 'running' | 'queued' } = {}) {
     getCurrentProjectId: () => null,
     deleteProjectFromIndex: vi.fn(),
     stopUpdaterTimers: vi.fn(),
+    stopAnnouncementTimers: vi.fn(),
     clearPendingTimers: vi.fn(),
     isEphemeral: false,
   };

--- a/tests/unit/settings-tab-scope-parity.test.ts
+++ b/tests/unit/settings-tab-scope-parity.test.ts
@@ -443,11 +443,12 @@ describe('settings tab/scope parity: mobile bridge ships in production', () => {
     expect(mobileTab?.category).toBe('system');
   });
 
-  it('all five mobileBridge.* registry entries are present', () => {
+  it('all six mobileBridge.* registry entries are present', () => {
     const mobileIds = SETTINGS_REGISTRY.filter((entry) => entry.tabId === 'mobile').map((entry) => entry.id).sort();
     expect(mobileIds).toEqual([
       'mobileBridge.devices',
       'mobileBridge.enabled',
+      'mobileBridge.getApp',
       'mobileBridge.pairing',
       'mobileBridge.relayMode',
       'mobileBridge.relayUrl',

--- a/tests/unit/shutdown-history-wiring.test.ts
+++ b/tests/unit/shutdown-history-wiring.test.ts
@@ -123,6 +123,7 @@ function buildMockDependencies(sessions: Session[]) {
     getCurrentProjectId: vi.fn(() => null),
     deleteProjectFromIndex: vi.fn(),
     stopUpdaterTimers: vi.fn(),
+    stopAnnouncementTimers: vi.fn(),
     clearPendingTimers: vi.fn(),
     isEphemeral: false,
   };
@@ -176,6 +177,12 @@ describe('syncShutdownCleanup history wire-up', () => {
     // getDiffWatcher returns the same stub on every call, so reading it here
     // gives the instance the cleanup path acted on.
     expect(dependencies.getDiffWatcher().closeAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops the announcement poll timers so the 4-hour interval cannot fire during shutdown', () => {
+    const dependencies = buildMockDependencies([]);
+    syncShutdownCleanup(dependencies);
+    expect(dependencies.stopAnnouncementTimers).toHaveBeenCalledTimes(1);
   });
 
   it('does NOT call captureSessionMetrics for queued sessions (never spawned - nothing to capture)', () => {


### PR DESCRIPTION
## What

A serverless in-app announcements surface, plus a "Get the App" section on Settings > Mobile Devices, plus the first announcement's content:

- **Feed + poller** (`src/shared/announcements.ts`, `src/main/announcements.ts`): the app fetches `announcements.json` from this repo's `main` via raw.githubusercontent.com 10 seconds after launch and every 4 hours, filters entries by version window / platform / publish / expiry in the main process, and pushes the active list to the renderer. `KANGENTIC_ANNOUNCEMENTS_URL` overrides the URL for local testing; polling is disabled entirely under `NODE_ENV=test`.
- **Banner + dialog** (`src/renderer/components/announcements/`): the top active announcement renders as a slim dismissible strip above the board; "Learn more" opens a dialog with a markdown intro, titled sections, large per-link QR codes laid out side by side (opt-in via `"qr": true` per link), and external-link pills. An announcement must fit without a scrollbar (authoring contract, pinned by a UI test).
- **Dismissal**: persists per-announcement id in `AppConfig.dismissedAnnouncementIds`, pruned on write to ids still in the active feed. Dismissal is final by design; re-reaching everyone means republishing under a new id.
- **Get the App** (`MobileDevicesTab.tsx`): Android closed-test signup steps (join the testers Google Group, then the Play opt-in page), each with a QR + link, rendered outside the bridge-enabled gating so it works with the bridge off.
- **Content**: `announcements.json` ships the mobile launch announcement (iOS in review; Android open for beta testers; pairing pointer to the kangentic.com/mobile docs). It sits invisibly on `main` until the next release ships the poller.

## Why

Kangentic Mobile's Play closed test needs testers, and there was no channel to reach existing desktop users. Announcements are reusable for any future product message (the iOS-launch follow-up is already planned as a content-only PR). Serverless by design: an unreachable or malformed feed means no banner, so fully offline and self-hosted setups lose nothing.

## How

- The poller mirrors the updater's shape: module-scope `.unref()` timers, `stopAnnouncementTimers` wired into `ShutdownDependencies`, attempt/catch/degrade with no error telemetry, and the GET handler registered before any bail so `invoke` never rejects. Unlike the updater it polls in dev too (dogfooding), gated off only under tests.
- Parsing is tolerant per entry (malformed items and non-https links are dropped silently; unknown fields ignored for forward compat), which makes authoring the trap - so `tests/unit/announcements-json-valid.test.ts` runs the committed feed through the real parser and fails the PR that introduces a typo production would swallow.
- The renderer store follows HMR Patterns B and E; dismissal filtering stays renderer-side so a dismissal is instant and the prune sees the full active set.
- Rebased over the mobile-bridge un-gate: the `mobileBridge.getApp` registry entry now ships un-gated with the rest of the tab, and main's new registry parity guard was extended to count it.

## Breaking changes

None. New `AppConfig` key defaults to `[]`; new IPC channels are additive.

## Tests

- Unit: feed parsing/targeting/version-compare/prune (17), poller init + silent-failure + destroyed-window guards (8), committed-feed validity + house style (4), registry/HMR/shutdown parity extensions.
- UI: banner render/clear, dialog with sections + per-link QR + recorded `openExternal`, no-scrollbar contract, dismissal persistence + promotion, dialog auto-close on retraction, mount-time pull, and the Get the App section with the bridge off.
- Manually verified end to end in a worktree preview against a local feed server: real fetch -> banner -> dialog -> dismissal persisted to disk, plus graceful 404 behavior against the not-yet-published production URL.

Generated with [Claude Code](https://claude.com/claude-code)
