### PR TITLE
fix(attachments): surface open failures and never leave attachment:open unanswered

### DIFF
--- a/src/main/db/repositories/attachment-repository.ts
+++ b/src/main/db/repositories/attachment-repository.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
 import type Database from 'better-sqlite3';
 import type { TaskAttachment } from '../../../shared/types';
+import { attachmentDiskName } from '../../../shared/attachment-filename';
 
 export class AttachmentRepository {
   constructor(private db: Database.Database) {}
@@ -29,9 +30,7 @@ export class AttachmentRepository {
     const id = uuidv4();
     const now = new Date().toISOString();
 
-    // Sanitize filename: keep only safe characters
-    const sanitized = filename.replace(/[^a-zA-Z0-9._-]/g, '_');
-    const diskName = `${id}_${sanitized}`;
+    const diskName = attachmentDiskName(id, filename);
 
     const attachDir = path.join(projectPath, '.kangentic', 'tasks', taskId, 'attachments');
     fs.mkdirSync(attachDir, { recursive: true });

--- a/src/main/db/repositories/backlog-attachment-repository.ts
+++ b/src/main/db/repositories/backlog-attachment-repository.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
 import type Database from 'better-sqlite3';
 import type { BacklogAttachment } from '../../../shared/types';
+import { attachmentDiskName } from '../../../shared/attachment-filename';
 
 export class BacklogAttachmentRepository {
   constructor(private db: Database.Database) {}
@@ -29,9 +30,7 @@ export class BacklogAttachmentRepository {
     const id = uuidv4();
     const now = new Date().toISOString();
 
-    // Sanitize filename: keep only safe characters
-    const sanitized = filename.replace(/[^a-zA-Z0-9._-]/g, '_');
-    const diskName = `${id}_${sanitized}`;
+    const diskName = attachmentDiskName(id, filename);
 
     const attachDir = path.join(projectPath, '.kangentic', 'backlog', backlogTaskId, 'attachments');
     fs.mkdirSync(attachDir, { recursive: true });

--- a/src/main/ipc/handlers/backlog.ts
+++ b/src/main/ipc/handlers/backlog.ts
@@ -1,7 +1,5 @@
 import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-import { ipcMain, shell } from 'electron';
+import { ipcMain } from 'electron';
 import { IPC } from '../../../shared/ipc-channels';
 import { getProjectDb } from '../../db/database';
 import { BacklogRepository } from '../../db/repositories/backlog-repository';
@@ -11,7 +9,7 @@ import { ActionRepository } from '../../db/repositories/action-repository';
 import { AttachmentRepository } from '../../db/repositories/attachment-repository';
 import { BacklogAttachmentRepository } from '../../db/repositories/backlog-attachment-repository';
 import { SessionRepository } from '../../db/repositories/session-repository';
-import { cleanupTaskResources, createTransitionEngine, getProjectRepos, ensureTaskWorktree, ensureTaskBranchCheckout, notifyBranchCheckoutBlocked, spawnAgent } from '../helpers';
+import { cleanupTaskResources, createTransitionEngine, getProjectRepos, ensureTaskWorktree, ensureTaskBranchCheckout, notifyBranchCheckoutBlocked, spawnAgent, openAttachmentFile } from '../helpers';
 import { isAbortError } from '../../../shared/abort-utils';
 import { withTaskLock } from '../task-lifecycle-lock';
 import type { IpcContext } from '../ipc-context';
@@ -347,16 +345,7 @@ export function registerBacklogHandlers(context: IpcContext): void {
     const db = getProjectDb(context.currentProjectId);
     const attachment = new BacklogAttachmentRepository(db).getById(id);
     if (!attachment) throw new Error(`Backlog attachment ${id} not found`);
-    const tempDir = path.join(os.tmpdir(), 'kangentic-attachments');
-    fs.mkdirSync(tempDir, { recursive: true });
-    const tempPath = path.join(tempDir, attachment.id + '_' + attachment.filename);
-    fs.copyFileSync(attachment.file_path, tempPath);
-    const errorMessage = await shell.openPath(tempPath);
-    if (errorMessage) {
-      // File format unsupported or no default app - fall back to showing in file explorer
-      shell.showItemInFolder(tempPath);
-    }
-    return errorMessage;
+    return openAttachmentFile(attachment);
   });
 
   // --- Import handlers ---

--- a/src/main/ipc/handlers/board.ts
+++ b/src/main/ipc/handlers/board.ts
@@ -1,9 +1,6 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-import { ipcMain, shell } from 'electron';
+import { ipcMain } from 'electron';
 import { IPC } from '../../../shared/ipc-channels';
-import { getProjectRepos } from '../helpers';
+import { getProjectRepos, openAttachmentFile } from '../helpers';
 import { pruneDeletedColumnFromProfiles } from '../../config/board-config/prune-profile-references';
 import { propagateStrategyToLiveSessions, propagateBoardProfileChange, buildColumnStrategyChanges } from './strategy-propagation';
 import { runWithProjectLogContext } from '../../diagnostics/project-log-context';
@@ -45,17 +42,11 @@ export function registerBoardHandlers(context: IpcContext): void {
     return attachments.getDataUrl(id);
   });
 
-  ipcMain.handle(IPC.ATTACHMENT_OPEN, (_, id: string) => {
+  ipcMain.handle(IPC.ATTACHMENT_OPEN, async (_, id: string) => {
     const { attachments } = getProjectRepos(context);
     const attachment = attachments.getById(id);
     if (!attachment) throw new Error(`Attachment ${id} not found`);
-    // Copy to temp dir with original filename to avoid long-path issues on Windows
-    // and ensure the OS opens it with the correct default app
-    const tempDir = path.join(os.tmpdir(), 'kangentic-attachments');
-    fs.mkdirSync(tempDir, { recursive: true });
-    const tempPath = path.join(tempDir, attachment.id + '_' + attachment.filename);
-    fs.copyFileSync(attachment.file_path, tempPath);
-    return shell.openPath(tempPath);
+    return openAttachmentFile(attachment);
   });
 
   // === Swimlanes ===

--- a/src/main/ipc/helpers/attachment-open.ts
+++ b/src/main/ipc/helpers/attachment-open.ts
@@ -1,0 +1,144 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { shell } from 'electron';
+import { attachmentDiskName } from '../../../shared/attachment-filename';
+
+export const OPEN_PATH_TIMEOUT_MS = 5000;
+
+export interface OpenableAttachment {
+  id: string;
+  filename: string;
+  file_path: string;
+}
+
+export interface OpenAttachmentOptions {
+  /** Defaults to process.platform. Injectable so the Windows-only temp-copy branch is testable on Linux CI. */
+  platform?: NodeJS.Platform;
+  /** Defaults to OPEN_PATH_TIMEOUT_MS. */
+  timeoutMs?: number;
+  /** Defaults to os.tmpdir(). Injectable so tests never write to a hardcoded absolute path. */
+  tempDirRoot?: string;
+}
+
+/**
+ * Open an attachment with the OS default app, and guarantee the IPC invoke
+ * that called this always gets a reply.
+ *
+ * shell.openPath() never rejects - it always resolves, with '' on success or
+ * a non-empty error string on failure (Electron's
+ * shell/common/api/electron_api_shell.cc). Nothing bounds how long that can
+ * take: on Linux, OpenPath shells out to xdg-open, which can wait on
+ * whatever viewer it launches. If that promise never settles, it can outlive
+ * the renderer's ipcRenderer.invoke() call, and the reply channel gets torn
+ * down without ever sending a reply - surfacing as "reply was never sent"
+ * (Electron's ReplyChannel::EnsureReplySent pre-finalizer). Racing openPath
+ * against a timeout does not un-stick that hang; it only guarantees this
+ * handler's own promise settles, so the invoke is always answered.
+ */
+export async function openAttachmentFile(
+  attachment: OpenableAttachment,
+  options?: OpenAttachmentOptions,
+): Promise<string> {
+  const platform = options?.platform ?? process.platform;
+  const timeoutMs = options?.timeoutMs ?? OPEN_PATH_TIMEOUT_MS;
+  const tempDirRoot = options?.tempDirRoot ?? os.tmpdir();
+
+  const targetPath = resolveOpenTarget(attachment, platform, tempDirRoot);
+
+  const openPromise = shell.openPath(targetPath);
+  const result = await raceWithTimeout(openPromise, timeoutMs);
+
+  if (result.timedOut) {
+    // The invoke is answered now. If openPath eventually does report an
+    // error, still reveal the file - the renderer has already been told
+    // this succeeded, so there is no toast for this late outcome.
+    void openPromise.then(
+      (lateError) => {
+        if (lateError) shell.showItemInFolder(targetPath);
+      },
+      () => {
+        // Nothing left to report: the invoke was answered at the timeout.
+      },
+    );
+    return '';
+  }
+
+  if (result.value) {
+    // Unsupported format or no default app - fall back to showing the file
+    // in the file manager so the user can act on it manually.
+    shell.showItemInFolder(targetPath);
+  }
+  return result.value;
+}
+
+/**
+ * Windows keeps the temp-copy workaround: the short temp path stays clear of
+ * MAX_PATH inside the LAUNCHED VIEWER, which may still use the legacy Win32
+ * path APIs (Kangentic's own write of the stored file already succeeded at
+ * the longer path, so the limit being dodged is never ours), and it lets the
+ * OS pick a default app off a filename we control. Every other platform opens
+ * the stored file directly - the stored path already keeps the sanitized
+ * filename's extension, and the copy only adds a failure surface with nothing
+ * to show for it off Windows.
+ */
+function resolveOpenTarget(
+  attachment: OpenableAttachment,
+  platform: NodeJS.Platform,
+  tempDirRoot: string,
+): string {
+  if (platform !== 'win32') return attachment.file_path;
+
+  const tempDir = path.join(tempDirRoot, 'kangentic-attachments');
+  fs.mkdirSync(tempDir, { recursive: true });
+  const tempPath = path.join(tempDir, attachmentDiskName(attachment.id, attachment.filename));
+
+  // An attachment's bytes never change once stored (the repositories only add
+  // and remove), so a same-size copy is already the file to open. Reusing it
+  // is not just cheaper: the temp name is deterministic, and on Windows a
+  // viewer still holding the previous copy open locks it, which would make
+  // every REopen of an attachment throw a sharing violation.
+  if (copyIsCurrent(attachment.file_path, tempPath)) return tempPath;
+
+  try {
+    fs.copyFileSync(attachment.file_path, tempPath);
+    return tempPath;
+  } catch {
+    // Locked or otherwise uncopyable. Opening the stored file directly is
+    // worse only in the MAX_PATH case above, and far better than failing.
+    return attachment.file_path;
+  }
+}
+
+/** True when `copyPath` already holds a same-size copy of `sourcePath`. */
+function copyIsCurrent(sourcePath: string, copyPath: string): boolean {
+  try {
+    return fs.statSync(copyPath).size === fs.statSync(sourcePath).size;
+  } catch {
+    return false;
+  }
+}
+
+type RaceResult = { timedOut: true } | { timedOut: false; value: string };
+
+function raceWithTimeout(promise: Promise<string>, timeoutMs: number): Promise<RaceResult> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve({ timedOut: true }), timeoutMs);
+    void promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve({ timedOut: false, value });
+      },
+      (error: unknown) => {
+        // openPath is documented never to reject, but this function exists to
+        // guarantee the invoke is answered - so it cannot depend on an
+        // upstream contract holding. Report a rejection as the failure it is
+        // instead of stalling until the timer and then claiming success.
+        clearTimeout(timer);
+        const message = error instanceof Error ? error.message : String(error);
+        // Never resolve '' here: '' is this function's success value.
+        resolve({ timedOut: false, value: message || 'The file could not be opened.' });
+      },
+    );
+  });
+}

--- a/src/main/ipc/helpers/index.ts
+++ b/src/main/ipc/helpers/index.ts
@@ -15,3 +15,5 @@ export {
 export { createTransitionEngine, spawnAgent, autoSpawnForTask, resolveSpawnOverrides } from './agent-spawn';
 export type { AgentSpawnOptions } from './agent-spawn';
 export { cleanupTaskSession, cleanupTaskResources, deleteTaskWorktree } from './task-cleanup';
+export { openAttachmentFile, OPEN_PATH_TIMEOUT_MS } from './attachment-open';
+export type { OpenableAttachment, OpenAttachmentOptions } from './attachment-open';

--- a/src/renderer/components/backlog/NewBacklogTaskDialog.tsx
+++ b/src/renderer/components/backlog/NewBacklogTaskDialog.tsx
@@ -11,7 +11,7 @@ import { useToastStore } from '../../stores/toast-store';
 import { useKeybinding } from '../../hooks/useKeybinding';
 import { DescriptionEditor } from '../DescriptionEditor';
 import { AttachmentChipStrip } from '../dialogs/AttachmentChipStrip';
-import { MAX_ATTACHMENT_BYTES, MEDIA_TYPE_EXT, resolveMediaType, isImageMediaType, pastedAttachmentPrefix, reserveNextPastedIndex } from '../dialogs/attachment-utils';
+import { MAX_ATTACHMENT_BYTES, MEDIA_TYPE_EXT, resolveMediaType, isImageMediaType, pastedAttachmentPrefix, reserveNextPastedIndex, openAttachmentWithToast } from '../dialogs/attachment-utils';
 import { compressClipboardImage } from '../dialogs/image-compress';
 import type { BacklogTask, BacklogTaskCreateInput, BacklogTaskUpdateInput } from '../../../shared/types';
 
@@ -206,6 +206,17 @@ export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: 
     }
   }, [attachments]);
 
+  const handleOpenAttachment = useCallback(async (attachment: DisplayAttachment) => {
+    if (isImageMediaType(attachment.media_type)) {
+      setPreviewAttachment(attachment);
+      return;
+    }
+    if (!isSavedAttachment(attachment)) return;
+    await openAttachmentWithToast(attachment.filename, () =>
+      window.electronAPI.backlogAttachments.open(attachment.id),
+    );
+  }, []);
+
   const handlePaste = useCallback((event: React.ClipboardEvent) => {
     const items = event.clipboardData?.items;
     if (!items) return;
@@ -359,13 +370,7 @@ export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: 
 
             <AttachmentChipStrip
               attachments={attachments}
-              onOpen={(attachment) => {
-                if (isImageMediaType(attachment.media_type)) {
-                  setPreviewAttachment(attachment);
-                } else if (isSavedAttachment(attachment)) {
-                  window.electronAPI.backlogAttachments.open(attachment.id);
-                }
-              }}
+              onOpen={(attachment) => { void handleOpenAttachment(attachment); }}
               onRemove={removeAttachment}
             />
 
@@ -405,6 +410,7 @@ export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: 
       {/* Full-size preview overlay (images only) */}
       {previewAttachment && isImageMediaType(previewAttachment.media_type) && (
         <div
+          data-testid="attachment-preview-overlay"
           className="fixed inset-0 bg-black/80 flex flex-col items-center justify-center z-[60]"
           onClick={() => setPreviewAttachment(null)}
         >

--- a/src/renderer/components/dialogs/attachment-utils.ts
+++ b/src/renderer/components/dialogs/attachment-utils.ts
@@ -1,5 +1,6 @@
 import { Image as ImageIcon, FileText, FileCode, File as FileIcon } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+import { useToastStore } from '../../stores/toast-store';
 
 export const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024; // 10MB
 
@@ -59,6 +60,39 @@ export function reserveNextPastedIndex(
   issuedHighest: number,
 ): number {
   return Math.max(highestPastedIndex(prefix, existingFilenames), issuedHighest) + 1;
+}
+
+/**
+ * Hand an attachment to the OS default app, reporting any failure as a toast.
+ *
+ * Both the task-detail dialog and the backlog dialog open attachments through
+ * their own IPC namespace but owe the user the same thing when it fails, so
+ * the invoke is passed in as a thunk and the failure contract lives here once.
+ *
+ * The main-process handler resolves '' on success and a non-empty error string
+ * when it could not open the file, in which case it has ALREADY revealed the
+ * file in the OS file manager - which is why only that branch says so. A
+ * thrown error means the open never got that far, so it makes no such claim.
+ */
+export async function openAttachmentWithToast(
+  filename: string,
+  invokeOpen: () => Promise<string>,
+): Promise<void> {
+  try {
+    const errorMessage = await invokeOpen();
+    if (errorMessage) {
+      useToastStore.getState().addToast({
+        message: `Couldn't open "${filename}": ${errorMessage}. Showing it in the file manager instead.`,
+        variant: 'warning',
+      });
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    useToastStore.getState().addToast({
+      message: `Couldn't open "${filename}": ${message}`,
+      variant: 'warning',
+    });
+  }
 }
 
 /** Return the appropriate Lucide icon for a given media type. */

--- a/src/renderer/components/dialogs/task-detail/TaskDetailBody.tsx
+++ b/src/renderer/components/dialogs/task-detail/TaskDetailBody.tsx
@@ -75,7 +75,7 @@ interface TaskDetailBodyProps {
   pendingCommandLabel: string | null;
   savedAttachments: AttachmentWithPreview[];
   handlePreview: (attachment: AttachmentWithPreview) => void;
-  handleOpenExternal: (attachment: AttachmentWithPreview) => void;
+  handleOpenExternal: (attachment: AttachmentWithPreview) => Promise<void>;
   handleToggle: () => void;
   changesOpen: boolean;
   projectPath: string;

--- a/src/renderer/components/dialogs/task-detail/useAttachments.ts
+++ b/src/renderer/components/dialogs/task-detail/useAttachments.ts
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useToastStore } from '../../../stores/toast-store';
-import { MAX_ATTACHMENT_BYTES, MEDIA_TYPE_EXT, resolveMediaType, isImageMediaType, pastedAttachmentPrefix, reserveNextPastedIndex } from '../attachment-utils';
+import { MAX_ATTACHMENT_BYTES, MEDIA_TYPE_EXT, resolveMediaType, isImageMediaType, pastedAttachmentPrefix, reserveNextPastedIndex, openAttachmentWithToast } from '../attachment-utils';
 import { compressClipboardImage } from '../image-compress';
 import type { TaskAttachment } from '../../../../shared/types';
 
@@ -167,8 +167,10 @@ export function useAttachments(taskId: string, updateAttachmentCount: (taskId: s
     }
   }, []);
 
-  const handleOpenExternal = useCallback((attachment: AttachmentWithPreview) => {
-    window.electronAPI.attachments.open(attachment.id);
+  const handleOpenExternal = useCallback(async (attachment: AttachmentWithPreview) => {
+    await openAttachmentWithToast(attachment.filename, () =>
+      window.electronAPI.attachments.open(attachment.id),
+    );
   }, []);
 
   const closePreview = useCallback(() => {

--- a/src/shared/attachment-filename.ts
+++ b/src/shared/attachment-filename.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared attachment on-disk naming.
+ *
+ * Both AttachmentRepository and BacklogAttachmentRepository write a file's
+ * disk name as `attachmentDiskName(id, filename)` while keeping the ORIGINAL
+ * (unsanitized) filename in the DB row for display. Reads go through the
+ * stored absolute `file_path`, so this is a NAME BUILDER, not a lookup key:
+ * its other caller, the attachment-open helper's Windows temp copy, uses it
+ * to name a fresh destination file. Keeping one builder is still what makes
+ * the temp copy carry the same extension the OS picks a default app from.
+ */
+
+/** Keep only characters safe across Windows/macOS/Linux filesystems. */
+export function sanitizeAttachmentFilename(filename: string): string {
+  return filename.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+/**
+ * Longest single path component NTFS, APFS, and ext4 all accept. Board
+ * imports name attachments from a remote URL path or issue alt text, neither
+ * of which is length-bounded, so an over-long name has to be trimmed here
+ * rather than thrown at `fs.writeFileSync`.
+ */
+const MAX_DISK_NAME_LENGTH = 255;
+
+/** The on-disk filename for an attachment: `${id}_${sanitized filename}`. */
+export function attachmentDiskName(id: string, filename: string): string {
+  const diskName = `${id}_${sanitizeAttachmentFilename(filename)}`;
+  if (diskName.length <= MAX_DISK_NAME_LENGTH) return diskName;
+
+  // Trim the middle, not the tail: the extension is what the OS reads to pick
+  // a default application, so it is the one part that has to survive.
+  const extension = trailingExtension(diskName);
+  return diskName.slice(0, MAX_DISK_NAME_LENGTH - extension.length) + extension;
+}
+
+/** The trailing `.ext` of a disk name, or '' when there is no usable one. */
+function trailingExtension(diskName: string): string {
+  const dotIndex = diskName.lastIndexOf('.');
+  if (dotIndex < 0) return '';
+  const extension = diskName.slice(dotIndex);
+  // An "extension" long enough to crowd out the name is not worth keeping.
+  return extension.length > 16 ? '' : extension;
+}

--- a/tests/ui/attachment-open-failure.spec.ts
+++ b/tests/ui/attachment-open-failure.spec.ts
@@ -1,0 +1,297 @@
+/**
+ * UI test for the attachment "Open" failure toast.
+ *
+ * ATTACHMENT_OPEN (src/main/ipc/handlers/board.ts) returns a resolved error
+ * string when shell.openPath can't open the file - it never rejects. Before
+ * this change, useAttachments.ts's handleOpenExternal fired the invoke and
+ * discarded the result, so a failed open produced no feedback at all. This
+ * spec drives that failure path by overriding the mock's attachments.open
+ * to resolve a non-empty error string (the app.spec.ts:64 override idiom)
+ * and asserts a warning toast names the file.
+ *
+ * The second describe block below covers the same failure contract for the
+ * backlog dialog's own IPC namespace (NewBacklogTaskDialog.tsx's
+ * handleOpenAttachment -> backlogAttachments.open), which shares the
+ * openAttachmentWithToast helper but is a separate call site with its own
+ * image-preview short-circuit that never touches IPC at all.
+ */
+import { test, expect } from '@playwright/test';
+import { launchPage, createProject, createTask, waitForBoard } from './helpers';
+import type { Browser, Page } from '@playwright/test';
+
+test.describe.configure({ mode: 'parallel' });
+
+const PROJECT_NAME = `Attachment Open Failure Test ${Date.now()}`;
+let browser: Browser;
+let page: Page;
+
+test.beforeAll(async () => {
+  const result = await launchPage();
+  browser = result.browser;
+  page = result.page;
+  await createProject(page, PROJECT_NAME);
+});
+
+test.afterAll(async () => {
+  await browser?.close();
+});
+
+/** Create a task via the UI and seed one saved, non-image attachment on it
+ *  directly through the attachments IPC, returning the new task's id. */
+async function createTaskWithAttachment(title: string, filename: string): Promise<string> {
+  await createTask(page, title);
+
+  const taskId = await page.evaluate(async (taskTitle) => {
+    const tasks = await window.electronAPI.tasks.list();
+    const task = tasks.find((candidate) => candidate.title === taskTitle);
+    if (!task) throw new Error(`Task "${taskTitle}" not found`);
+    return task.id;
+  }, title);
+
+  await page.evaluate(
+    async ({ id, name }) => {
+      await window.electronAPI.attachments.add({
+        task_id: id,
+        filename: name,
+        data: 'aGVsbG8=',
+        media_type: 'application/octet-stream',
+      });
+    },
+    { id: taskId, name: filename },
+  );
+
+  return taskId;
+}
+
+async function openTaskDetailInViewMode(taskId: string): Promise<void> {
+  await page.evaluate((id) => {
+    const stores = (window as unknown as {
+      __zustandStores?: { session?: { getState: () => { setDetailTaskId: (taskId: string | null) => void } } };
+    }).__zustandStores;
+    if (!stores?.session) throw new Error('session store not exposed on __zustandStores');
+    stores.session.getState().setDetailTaskId(id);
+  }, taskId);
+}
+
+test.describe('Attachment open failure', () => {
+  test('a non-empty error string from attachments.open surfaces a warning toast naming the file', async () => {
+    await page.evaluate(() => {
+      window.electronAPI.attachments.open = async () => 'No application is registered for this file type';
+    });
+
+    const taskId = await createTaskWithAttachment('Open Failure Task', 'archive.bin');
+    await openTaskDetailInViewMode(taskId);
+
+    const dialog = page.locator('[data-testid="task-detail-dialog"]');
+    await dialog.waitFor({ state: 'visible', timeout: 5000 });
+
+    const chip = dialog.locator('[data-testid="attachment-chip"]');
+    await expect(chip).toBeVisible({ timeout: 5000 });
+    await chip.locator('[data-testid="attachment-open"]').click();
+
+    const toast = page.locator('[data-testid="toast"]').filter({ hasText: 'archive.bin' });
+    await expect(toast).toBeVisible({ timeout: 5000 });
+    await expect(toast).toContainText("Couldn't open");
+    await expect(toast).toContainText('No application is registered for this file type');
+
+    await dialog.locator('[data-testid="task-detail-close"]').click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('a thrown error from attachments.open surfaces a warning toast with no reveal-fallback claim', async () => {
+    await page.evaluate(() => {
+      window.electronAPI.attachments.open = async () => { throw new Error('Attachment not found'); };
+    });
+
+    const taskId = await createTaskWithAttachment('Open Throw Task', 'notes.bin');
+    await openTaskDetailInViewMode(taskId);
+
+    const dialog = page.locator('[data-testid="task-detail-dialog"]');
+    await dialog.waitFor({ state: 'visible', timeout: 5000 });
+
+    const chip = dialog.locator('[data-testid="attachment-chip"]');
+    await expect(chip).toBeVisible({ timeout: 5000 });
+    await chip.locator('[data-testid="attachment-open"]').click();
+
+    const toast = page.locator('[data-testid="toast"]').filter({ hasText: 'notes.bin' });
+    await expect(toast).toBeVisible({ timeout: 5000 });
+    await expect(toast).toContainText('Attachment not found');
+    await expect(toast).not.toContainText('file manager');
+
+    await dialog.locator('[data-testid="task-detail-close"]').click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+});
+
+/**
+ * Open NewBacklogTaskDialog in edit mode against a synthetic backlog task,
+ * bypassing the row-click UI entirely. The dialog's saved-attachment list
+ * comes from `window.electronAPI.backlogAttachments.list`, which the caller
+ * overrides before calling this helper, so the object's id only needs to be
+ * unique enough to identify the dialog instance - the mock ignores it.
+ *
+ * BacklogDialogs only mounts alongside BacklogView (AppLayout.tsx), which
+ * itself only renders while the board's activeView is 'backlog', so a real
+ * board (not backlog) view switch is a required setup step before driving
+ * the store - setting editingItem while the board view is active sets state
+ * nothing is rendering.
+ */
+async function openBacklogEditDialog(taskTitle: string): Promise<void> {
+  await page.locator('[data-testid="view-toggle-backlog"]').click();
+  await page.locator('[data-testid="backlog-view"]').waitFor({ state: 'visible', timeout: 5000 });
+
+  await page.evaluate((title) => {
+    const stores = (window as unknown as {
+      __zustandStores?: { backlog?: { getState: () => { setEditingItem: (task: unknown) => void } } };
+    }).__zustandStores;
+    if (!stores?.backlog) throw new Error('backlog store not exposed on __zustandStores');
+    stores.backlog.getState().setEditingItem({
+      id: `backlog-attachment-open-${Date.now()}`,
+      title,
+      description: '',
+      priority: 0,
+      labels: [],
+      position: 0,
+      assignee: null,
+      due_date: null,
+      item_type: null,
+      external_id: null,
+      external_source: null,
+      external_url: null,
+      sync_status: null,
+      external_metadata: null,
+      attachment_count: 1,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+  }, taskTitle);
+
+  const dialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+  await dialog.waitFor({ state: 'visible', timeout: 5000 });
+}
+
+/**
+ * Close NewBacklogTaskDialog by driving the backlog store's editingItem
+ * slot directly (the same function BaseDialog's own X button calls), rather
+ * than clicking a close gesture. A saved attachment makes the edit form
+ * report dirty (NewBacklogTaskDialog.tsx's isDirty includes
+ * `attachments.length > 0` in edit mode), which would otherwise route any
+ * close gesture through the discard-changes ConfirmDialog.
+ *
+ * Also switches back to the board view, so a later test in this shared-page
+ * file (e.g. the task-detail describe above, which needs the "To Do" swimlane
+ * visible to create a task) never inherits the backlog view left active here.
+ */
+async function closeBacklogEditDialog(): Promise<void> {
+  await page.evaluate(() => {
+    const stores = (window as unknown as {
+      __zustandStores?: { backlog?: { getState: () => { setEditingItem: (task: unknown) => void } } };
+    }).__zustandStores;
+    stores?.backlog?.getState().setEditingItem(null);
+  });
+  const dialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+  await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+  await page.locator('[data-testid="view-toggle-board"]').click();
+  await waitForBoard(page);
+}
+
+test.describe('Backlog attachment open failure', () => {
+  test('a non-empty error string from backlogAttachments.open surfaces a warning toast naming the file', async () => {
+    await page.evaluate(() => {
+      window.electronAPI.backlogAttachments.list = async () => [{
+        id: 'ba-open-error',
+        backlog_task_id: 'unused',
+        filename: 'design-spec.bin',
+        file_path: '/mock/design-spec.bin',
+        media_type: 'application/octet-stream',
+        size_bytes: 10,
+        created_at: new Date().toISOString(),
+      }];
+      window.electronAPI.backlogAttachments.open = async () => 'No application is registered for this file type';
+    });
+
+    await openBacklogEditDialog('Backlog Open Failure Task');
+
+    const dialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    const chip = dialog.locator('[data-testid="attachment-chip"]');
+    await expect(chip).toBeVisible({ timeout: 5000 });
+    await chip.locator('[data-testid="attachment-open"]').click();
+
+    const toast = page.locator('[data-testid="toast"]').filter({ hasText: 'design-spec.bin' });
+    await expect(toast).toBeVisible({ timeout: 5000 });
+    await expect(toast).toContainText("Couldn't open");
+    await expect(toast).toContainText('No application is registered for this file type');
+    await expect(toast).toContainText('Showing it in the file manager instead.');
+
+    await closeBacklogEditDialog();
+  });
+
+  test('a thrown error from backlogAttachments.open surfaces a warning toast with no reveal-fallback claim', async () => {
+    await page.evaluate(() => {
+      window.electronAPI.backlogAttachments.list = async () => [{
+        id: 'ba-open-throw',
+        backlog_task_id: 'unused',
+        filename: 'notes-backlog.bin',
+        file_path: '/mock/notes-backlog.bin',
+        media_type: 'application/octet-stream',
+        size_bytes: 10,
+        created_at: new Date().toISOString(),
+      }];
+      window.electronAPI.backlogAttachments.open = async () => { throw new Error('Attachment not found'); };
+    });
+
+    await openBacklogEditDialog('Backlog Open Throw Task');
+
+    const dialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    const chip = dialog.locator('[data-testid="attachment-chip"]');
+    await expect(chip).toBeVisible({ timeout: 5000 });
+    await chip.locator('[data-testid="attachment-open"]').click();
+
+    const toast = page.locator('[data-testid="toast"]').filter({ hasText: 'notes-backlog.bin' });
+    await expect(toast).toBeVisible({ timeout: 5000 });
+    await expect(toast).toContainText('Attachment not found');
+    await expect(toast).not.toContainText('file manager');
+
+    await closeBacklogEditDialog();
+  });
+
+  test('clicking an image attachment chip opens the preview and never calls backlogAttachments.open', async () => {
+    await page.evaluate(() => {
+      (window as unknown as { __backlogAttachmentOpenCalls: number }).__backlogAttachmentOpenCalls = 0;
+      window.electronAPI.backlogAttachments.list = async () => [{
+        id: 'ba-image-preview',
+        backlog_task_id: 'unused',
+        filename: 'diagram-preview.png',
+        file_path: '/mock/diagram-preview.png',
+        media_type: 'image/png',
+        size_bytes: 10,
+        created_at: new Date().toISOString(),
+      }];
+      window.electronAPI.backlogAttachments.open = async () => {
+        (window as unknown as { __backlogAttachmentOpenCalls: number }).__backlogAttachmentOpenCalls += 1;
+        return '';
+      };
+    });
+
+    await openBacklogEditDialog('Backlog Image Preview Task');
+
+    const dialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    const chip = dialog.locator('[data-testid="attachment-chip"]');
+    await expect(chip).toBeVisible({ timeout: 5000 });
+    await chip.locator('[data-testid="attachment-open"]').click();
+
+    // The preview overlay renders as a sibling of the dialog content, not a
+    // descendant of the testid'd dialog node, so it is located from the page.
+    const previewOverlay = page.locator('[data-testid="attachment-preview-overlay"]');
+    await expect(previewOverlay).toBeVisible({ timeout: 5000 });
+    await expect(previewOverlay).toContainText('diagram-preview.png');
+
+    const openCalls = await page.evaluate(
+      () => (window as unknown as { __backlogAttachmentOpenCalls: number }).__backlogAttachmentOpenCalls,
+    );
+    expect(openCalls).toBe(0);
+
+    await closeBacklogEditDialog();
+  });
+});

--- a/tests/unit/attachment-filename.test.ts
+++ b/tests/unit/attachment-filename.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for the shared attachment on-disk naming helpers
+ * (src/shared/attachment-filename.ts).
+ *
+ * Both AttachmentRepository and BacklogAttachmentRepository derive an
+ * attachment's disk filename from `attachmentDiskName(id, filename)`, and
+ * the win32 branch of the attachment-open helper reuses the same builder to
+ * name its temp copy. Board imports name attachments from a remote URL path
+ * or issue alt text, neither of which is length-bounded, so the 255-char
+ * clamp and its extension-preserving truncation are pinned here.
+ *
+ * Tier: Unit (vitest, no browser, no Electron, no filesystem).
+ */
+import { describe, it, expect } from 'vitest';
+import { sanitizeAttachmentFilename, attachmentDiskName } from '../../src/shared/attachment-filename';
+
+describe('sanitizeAttachmentFilename', () => {
+  it('passes a safe name through unchanged', () => {
+    expect(sanitizeAttachmentFilename('report.pdf')).toBe('report.pdf');
+    expect(sanitizeAttachmentFilename('file-name_v2.1.tar.gz')).toBe('file-name_v2.1.tar.gz');
+  });
+
+  it('replaces reserved characters with an underscore', () => {
+    expect(sanitizeAttachmentFilename('a:b')).toBe('a_b');
+    expect(sanitizeAttachmentFilename('a/b\\c')).toBe('a_b_c');
+    expect(sanitizeAttachmentFilename('a*b?c"d<e>f|g')).toBe('a_b_c_d_e_f_g');
+  });
+
+  it('replaces spaces', () => {
+    expect(sanitizeAttachmentFilename('my report (v2).pdf')).toBe('my_report__v2_.pdf');
+  });
+
+  it('replaces unicode characters that fall outside the safe set', () => {
+    expect(sanitizeAttachmentFilename('café.png')).toBe('caf_.png');
+    expect(sanitizeAttachmentFilename('日本.txt')).toBe('__.txt');
+  });
+
+  it('returns an empty string for an empty input', () => {
+    expect(sanitizeAttachmentFilename('')).toBe('');
+  });
+});
+
+describe('attachmentDiskName', () => {
+  it('composes exactly `${id}_${sanitized filename}` for a normal name', () => {
+    expect(attachmentDiskName('a1', 'report.pdf')).toBe('a1_report.pdf');
+    expect(attachmentDiskName('task-99', 'My File (v2).png')).toBe('task-99_My_File__v2_.png');
+  });
+
+  it('returns a name that already fits within the limit untouched', () => {
+    const filename = 'report.pdf';
+    const diskName = attachmentDiskName('a1', filename);
+    expect(diskName.length).toBeLessThanOrEqual(255);
+    expect(diskName).toBe('a1_report.pdf');
+  });
+
+  it('caps an over-long name at exactly 255 characters', () => {
+    const longFilename = 'x'.repeat(300) + '.pdf';
+    const diskName = attachmentDiskName('a1', longFilename);
+
+    expect(diskName.length).toBe(255);
+  });
+
+  it('preserves the trailing extension when truncating', () => {
+    const longFilename = 'x'.repeat(300) + '.pdf';
+    const diskName = attachmentDiskName('a1', longFilename);
+
+    expect(diskName.endsWith('.pdf')).toBe(true);
+    expect(diskName.length).toBe(255);
+  });
+
+  it('treats an absurdly long "extension" (over 16 chars) as having none', () => {
+    const bogusExtension = '.' + 'y'.repeat(20); // 21 chars, over the 16-char cutoff
+    const longFilename = 'x'.repeat(300) + bogusExtension;
+    const diskName = attachmentDiskName('a1', longFilename);
+
+    expect(diskName.length).toBe(255);
+    // The 'y' run only appears past character 300, well beyond the clamp -
+    // if the bogus extension had been preserved, the result would end with
+    // it instead of being cut off mid-run of 'x' characters.
+    expect(diskName.includes('y')).toBe(false);
+    expect(diskName.endsWith('x')).toBe(true);
+  });
+});

--- a/tests/unit/attachment-open-helper.test.ts
+++ b/tests/unit/attachment-open-helper.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for the shared attachment-open helper
+ * (src/main/ipc/helpers/attachment-open.ts), used by both ATTACHMENT_OPEN
+ * (src/main/ipc/handlers/board.ts) and BACKLOG_ATTACHMENT_OPEN
+ * (src/main/ipc/handlers/backlog.ts).
+ *
+ * shell.openPath() never rejects (it always resolves - '' on success, a
+ * non-empty error string on failure), so the failure modes under test are
+ * a resolved error string, a resolved '' (success), and a promise that
+ * never settles (the shape behind the reported "reply was never sent"
+ * error: nothing previously bounded the wait on openPath).
+ *
+ * Tier: Unit (vitest, no browser, no Electron).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const { mockShell } = vi.hoisted(() => {
+  const mockShell = { openPath: vi.fn(), showItemInFolder: vi.fn() };
+  return { mockShell };
+});
+
+vi.mock('electron', () => ({ shell: mockShell }));
+
+import { openAttachmentFile, OPEN_PATH_TIMEOUT_MS } from '../../src/main/ipc/helpers/attachment-open';
+import { attachmentDiskName } from '../../src/shared/attachment-filename';
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'attachment-open-'));
+  mockShell.openPath.mockReset();
+  mockShell.showItemInFolder.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  vi.useRealTimers();
+});
+
+function makeAttachment(overrides?: Partial<{ id: string; filename: string; file_path: string }>) {
+  const filePath = path.join(tmpRoot, 'stored', 'a1_report.pdf');
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, 'contents');
+  return { id: 'a1', filename: 'report.pdf', file_path: filePath, ...overrides };
+}
+
+describe('openAttachmentFile', () => {
+  it('returns "" and does not fall back when openPath succeeds', async () => {
+    mockShell.openPath.mockResolvedValue('');
+
+    const result = await openAttachmentFile(makeAttachment(), { platform: 'linux', tempDirRoot: tmpRoot });
+
+    expect(result).toBe('');
+    expect(mockShell.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it('falls back to showItemInFolder and returns the error string on a resolved failure', async () => {
+    mockShell.openPath.mockResolvedValue('No application is registered for this file type');
+
+    const result = await openAttachmentFile(makeAttachment(), { platform: 'linux', tempDirRoot: tmpRoot });
+
+    expect(result).toBe('No application is registered for this file type');
+    expect(mockShell.showItemInFolder).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves "" when openPath never settles within the timeout (the reported-bug regression case)', async () => {
+    mockShell.openPath.mockReturnValue(new Promise<string>(() => { /* never settles */ }));
+
+    const result = await openAttachmentFile(makeAttachment(), {
+      platform: 'linux',
+      tempDirRoot: tmpRoot,
+      timeoutMs: 20,
+    });
+
+    expect(result).toBe('');
+  });
+
+  it('still reveals the file if openPath eventually reports an error after the timeout', async () => {
+    let resolveOpen: (value: string) => void = () => {};
+    mockShell.openPath.mockReturnValue(new Promise<string>((resolve) => { resolveOpen = resolve; }));
+
+    const resultPromise = openAttachmentFile(makeAttachment(), {
+      platform: 'linux',
+      tempDirRoot: tmpRoot,
+      timeoutMs: 20,
+    });
+
+    const result = await resultPromise;
+    expect(result).toBe('');
+    expect(mockShell.showItemInFolder).not.toHaveBeenCalled();
+
+    resolveOpen('late error after timeout');
+    // Let the late .then() microtask/macrotask run.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockShell.showItemInFolder).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not double-reveal when the late resolution after a timeout is also empty', async () => {
+    let resolveOpen: (value: string) => void = () => {};
+    mockShell.openPath.mockReturnValue(new Promise<string>((resolve) => { resolveOpen = resolve; }));
+
+    await openAttachmentFile(makeAttachment(), { platform: 'linux', tempDirRoot: tmpRoot, timeoutMs: 20 });
+
+    resolveOpen('');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockShell.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it('opens the stored file directly on linux/darwin, with no temp copy', async () => {
+    mockShell.openPath.mockResolvedValue('');
+    const attachment = makeAttachment();
+
+    await openAttachmentFile(attachment, { platform: 'linux', tempDirRoot: tmpRoot });
+
+    expect(mockShell.openPath).toHaveBeenCalledWith(attachment.file_path);
+    expect(fs.existsSync(path.join(tmpRoot, 'kangentic-attachments'))).toBe(false);
+  });
+
+  it('copies into a temp dir and opens the copy on win32', async () => {
+    mockShell.openPath.mockResolvedValue('');
+    const attachment = makeAttachment();
+
+    await openAttachmentFile(attachment, { platform: 'win32', tempDirRoot: tmpRoot });
+
+    const expectedTempPath = path.join(tmpRoot, 'kangentic-attachments', attachmentDiskName(attachment.id, attachment.filename));
+    expect(mockShell.openPath).toHaveBeenCalledWith(expectedTempPath);
+    expect(fs.existsSync(expectedTempPath)).toBe(true);
+  });
+
+  it('sanitizes a reserved character in the filename for the win32 temp copy name', async () => {
+    mockShell.openPath.mockResolvedValue('');
+    const attachment = makeAttachment({ filename: 'report:v2.pdf' });
+
+    await openAttachmentFile(attachment, { platform: 'win32', tempDirRoot: tmpRoot });
+
+    const expectedTempPath = path.join(tmpRoot, 'kangentic-attachments', `${attachment.id}_report_v2.pdf`);
+    expect(mockShell.openPath).toHaveBeenCalledWith(expectedTempPath);
+    expect(fs.existsSync(expectedTempPath)).toBe(true);
+  });
+
+  it('defaults the timeout to OPEN_PATH_TIMEOUT_MS when not overridden', async () => {
+    vi.useFakeTimers();
+    mockShell.openPath.mockReturnValue(new Promise<string>(() => { /* never settles */ }));
+
+    const resultPromise = openAttachmentFile(makeAttachment(), { platform: 'linux', tempDirRoot: tmpRoot });
+    let settled = false;
+    void resultPromise.then(() => { settled = true; });
+
+    // One tick short of the exported default: must still be pending.
+    await vi.advanceTimersByTimeAsync(OPEN_PATH_TIMEOUT_MS - 1);
+    expect(settled).toBe(false);
+
+    // The final tick: the helper's own timeout, not an override, fires.
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await resultPromise;
+
+    expect(settled).toBe(true);
+    expect(result).toBe('');
+  });
+
+  it('does not re-copy on win32 when a same-size temp copy already exists', async () => {
+    mockShell.openPath.mockResolvedValue('');
+    const attachment = makeAttachment();
+
+    const tempDir = path.join(tmpRoot, 'kangentic-attachments');
+    fs.mkdirSync(tempDir, { recursive: true });
+    const tempPath = path.join(tempDir, attachmentDiskName(attachment.id, attachment.filename));
+    // Same content (and therefore same size) as the stored file written by makeAttachment().
+    fs.writeFileSync(tempPath, 'contents');
+
+    const copyFileSyncSpy = vi.spyOn(fs, 'copyFileSync');
+
+    const result = await openAttachmentFile(attachment, { platform: 'win32', tempDirRoot: tmpRoot });
+
+    expect(result).toBe('');
+    expect(copyFileSyncSpy).not.toHaveBeenCalled();
+    expect(mockShell.openPath).toHaveBeenCalledWith(tempPath);
+
+    copyFileSyncSpy.mockRestore();
+  });
+
+  it('falls back to the stored file_path when the win32 temp copy fails (e.g. locked by a viewer)', async () => {
+    mockShell.openPath.mockResolvedValue('');
+    const attachment = makeAttachment();
+
+    const copyFileSyncSpy = vi.spyOn(fs, 'copyFileSync').mockImplementation(() => {
+      const busyError = new Error('EBUSY: resource busy or locked') as NodeJS.ErrnoException;
+      busyError.code = 'EBUSY';
+      throw busyError;
+    });
+
+    const result = await openAttachmentFile(attachment, { platform: 'win32', tempDirRoot: tmpRoot });
+
+    expect(result).toBe('');
+    expect(mockShell.openPath).toHaveBeenCalledWith(attachment.file_path);
+
+    copyFileSyncSpy.mockRestore();
+  });
+
+  it('resolves promptly with the rejection message when openPath rejects, instead of stalling until the timeout', async () => {
+    vi.useFakeTimers();
+    mockShell.openPath.mockReturnValue(Promise.reject(new Error('spawn xdg-open ENOENT')));
+
+    // A large timeoutMs with fake timers never advanced: if the rejection
+    // were not handled promptly, this await would hang until the test
+    // runner's own timeout instead of resolving here.
+    const result = await openAttachmentFile(makeAttachment(), {
+      platform: 'linux',
+      tempDirRoot: tmpRoot,
+      timeoutMs: 10000,
+    });
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toBe('spawn xdg-open ENOENT');
+    // A rejection takes the same fallback as a resolved error string, which is
+    // what makes the renderer's "Showing it in the file manager instead."
+    // wording true on this path too.
+    expect(mockShell.showItemInFolder).toHaveBeenCalledTimes(1);
+  });
+
+  it('yields a non-empty string even when the rejected Error has an empty message, since "" is the success value', async () => {
+    mockShell.openPath.mockReturnValue(Promise.reject(new Error('')));
+
+    const result = await openAttachmentFile(makeAttachment(), { platform: 'linux', tempDirRoot: tmpRoot });
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toBe('The file could not be opened.');
+  });
+});

--- a/tests/unit/attachment-open-with-toast.test.ts
+++ b/tests/unit/attachment-open-with-toast.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for openAttachmentWithToast
+ * (src/renderer/components/dialogs/attachment-utils.ts), the shared failure
+ * contract both the task-detail dialog (useAttachments.ts) and the backlog
+ * dialog (NewBacklogTaskDialog.tsx) route their attachments.open /
+ * backlogAttachments.open invoke through.
+ *
+ * tests/ui/attachment-open-failure.spec.ts already drives this function
+ * end-to-end through both call sites, but only exercises two of its four
+ * branches (resolved error string, and a thrown Error) via a full app boot.
+ * This file pins all four branches - including the success/no-toast path and
+ * the non-Error-thrown fallback, neither of which is covered anywhere else -
+ * as a fast, pure-logic unit test. Mirrors the mock scaffold in
+ * toast-store-hmr.test.ts: mock config-store (addToast reads
+ * config.notifications.toasts), use the real toast-store.
+ *
+ * Tier: Unit (vitest, no browser, no Electron, no IPC).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../src/renderer/stores/config-store', () => ({
+  useConfigStore: {
+    getState: () => ({
+      config: {
+        notifications: {
+          toasts: {
+            durationSeconds: 4,
+            maxCount: 5,
+          },
+        },
+      },
+    }),
+  },
+}));
+
+import { openAttachmentWithToast } from '../../src/renderer/components/dialogs/attachment-utils';
+import { useToastStore } from '../../src/renderer/stores/toast-store';
+
+/** Reset the store to empty toasts between tests without re-importing the module. */
+function clearToasts(): void {
+  const current = useToastStore.getState().toasts;
+  for (const toast of current) {
+    useToastStore.getState().dismissToast(toast.id);
+  }
+}
+
+describe('openAttachmentWithToast', () => {
+  beforeEach(() => {
+    clearToasts();
+  });
+
+  it('adds no toast when the invoke resolves "" (success)', async () => {
+    await openAttachmentWithToast('report.pdf', async () => '');
+
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('adds one warning toast naming the file, the error, and the reveal-fallback claim on a resolved error string', async () => {
+    await openAttachmentWithToast('archive.bin', async () => 'No application is registered for this file type');
+
+    const { toasts } = useToastStore.getState();
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].variant).toBe('warning');
+    expect(toasts[0].message).toContain('archive.bin');
+    expect(toasts[0].message).toContain('No application is registered for this file type');
+    expect(toasts[0].message).toContain('Showing it in the file manager instead.');
+  });
+
+  it('adds one warning toast with the Error message and no reveal-fallback claim on a thrown Error', async () => {
+    await openAttachmentWithToast('notes.bin', async () => {
+      throw new Error('Attachment not found');
+    });
+
+    const { toasts } = useToastStore.getState();
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].variant).toBe('warning');
+    expect(toasts[0].message).toContain('notes.bin');
+    expect(toasts[0].message).toContain('Attachment not found');
+    // Unlike the resolved-error-string branch, the open never got far enough
+    // for the main process to have called shell.showItemInFolder, so this
+    // path must not claim it did.
+    expect(toasts[0].message).not.toContain('file manager');
+  });
+
+  it('falls back to String(error) when a non-Error value is thrown', async () => {
+    await openAttachmentWithToast('diagram.png', async () => {
+      // Deliberately exercising the non-Error fallback branch (a real thunk
+      // could reject with a plain object, e.g. via an IPC serialization edge case).
+      throw { code: 'WEIRD_REJECTION' };
+    });
+
+    const { toasts } = useToastStore.getState();
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].variant).toBe('warning');
+    expect(toasts[0].message).toContain('diagram.png');
+    // String({ code: 'WEIRD_REJECTION' }) === '[object Object]' - distinct from
+    // any .message access, which would have thrown or produced 'undefined'.
+    expect(toasts[0].message).toContain('[object Object]');
+    expect(toasts[0].message).not.toContain('file manager');
+  });
+});


### PR DESCRIPTION
## What

Fixes attachment "Open" in two ways:

1. **Silent failures.** `shell.openPath()` never rejects - it resolves `''` on success or a non-empty error string on failure - but `ATTACHMENT_OPEN` returned that string unchanged and both renderer call sites (`useAttachments.ts`, `NewBacklogTaskDialog.tsx`) discarded it without awaiting or catching. A failed open produced no toast, no console line, no analytics event.
2. **The dangling IPC invoke.** Nothing bounded the wait on `shell.openPath`, so a promise that never settled (e.g. Linux's `OpenPath` shelling out to `xdg-open`) could outlive the invoke and surface as `Error invoking remote method 'attachment:open': reply was never sent` once the reply channel was torn down without a reply.

Also fixes a latent bug found while working on this: the Windows temp-copy destination filename was built from the raw, unsanitized attachment name while the on-disk file used a sanitized one, so a dragged-in file with a Windows-reserved character (`:` `*` `?` `"` `<` `>` `|`) would fail the copy.

## Why

Analytics recorded the `reply was never sent` error twice in one Ubuntu session. Investigation (verified against upstream Electron source, not assumed) showed `shell.openPath` cannot itself be the source of a rejection, and `reply was never sent` comes from Electron's `ReplyChannel::EnsureReplySent` pre-finalizer, which fires when the reply channel is garbage collected with its callback still unconsumed - meaning the handler never replied at all.

## How

- New `src/main/ipc/helpers/attachment-open.ts` (`openAttachmentFile`), delegated to by both `ATTACHMENT_OPEN` and `BACKLOG_ATTACHMENT_OPEN`, which previously had near-identical but already-drifted implementations. It races `shell.openPath` against a 5s timeout so the invoke always gets a reply (this does not unblock the underlying hang, it only guarantees an answer), falls back to `shell.showItemInFolder` on a reported failure, and gates the Windows long-path/default-app temp copy to `win32` only - every other platform now opens the stored file directly instead of paying for a copy that only adds a failure surface off Windows. Reuses an existing same-size temp copy instead of re-copying (avoids a Windows sharing-violation lock on reopen), and falls back to the stored path if the copy itself fails.
- New `src/shared/attachment-filename.ts` (`sanitizeAttachmentFilename`, `attachmentDiskName`), extracted out of both repositories' duplicated inline regex so the temp copy's destination name matches what was actually written to disk. Also clamps the composed disk name to 255 characters, extension-preserving, for board-imported attachments whose filenames come from unbounded remote URLs or issue text.
- Both renderer call sites now `await` the result and toast a failure through a shared `openAttachmentWithToast` helper (`attachment-utils.ts`): a resolved error string says the file was revealed in the file manager (the handler already attempted that fallback); a thrown error makes no such claim.

**Trade-off worth flagging:** opening the stored file directly (non-Windows) means the default app now edits the canonical attachment in place, rather than a throwaway temp copy. This is a deliberate simplification, not an oversight.

## Breaking changes

None.

## Tests

- Unit: `tests/unit/attachment-open-helper.test.ts` (the shared helper - including the never-settling-promise regression case for the reported bug, win32 temp-copy reuse/failure, and rejection handling), `tests/unit/attachment-filename.test.ts` (sanitizer + truncation), `tests/unit/attachment-open-with-toast.test.ts` (all four branches of the toast-dispatch helper).
- UI: `tests/ui/attachment-open-failure.spec.ts` covers both the task-detail dialog and the backlog dialog's failure-toast wiring, plus the backlog dialog's image-preview short-circuit (which never touches IPC).
- CI: typecheck, lint, unit, UI, and the sharded Linux Electron E2E tier.

Generated with [Claude Code](https://claude.com/claude-code)
