### PR TITLE
fix(activity-marks): keep the indicators animating while the main thread is busy

### DIFF
--- a/.claude/rules/restore-no-animation-replay.md
+++ b/.claude/rules/restore-no-animation-replay.md
@@ -57,6 +57,8 @@ when the same UI is reconstructed or re-pointed by a restore.
 
 Renderer UI under `src/renderer/`. Governs motion that fires on mount or on a value change for
 surfaces reconstructed/re-pointed by a restore. Does not govern ongoing ambient motion
-(`animate-spin`, `animate-pulse-subtle`, and the activity marks' `.kng-march` from
+(`animate-spin`, `animate-pulse-subtle`, and the activity marks' `.kng-spin` / `.kng-blink` from
 `@kangentic/branding/assets/activity/activity.css`) or genuinely user-initiated open/close
-animations, which are intentional and stay.
+animations, which are intentional and stay. The activity marks are in fact the opposite case: they
+are anchored to the document timeline precisely so a restore or re-mount CANNOT replay them from
+phase zero.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,12 +138,14 @@ won't be found.
   settings, or the OS window controls - only this pair's own position moves. The toggle glyph's
   stroke color is the aggregate activity of the project's terminals (active-green working /
   attention-amber needs-you / muted rest, via the central `--kng-active` / `--kng-attention`
-  tokens) and the working border MARCHES (`.kng-march` + a `pathLength`-normalized stroke-dash,
-  both shipped with the mark). The glyph itself is no longer hand-authored: `CommandTerminalIcon`
-  is a thin wrapper over `components/ActivityMark.tsx`, which renders the `terminal-idle` /
-  `terminal-working` / `terminal-new` marks from `@kangentic/branding`. See the Activity marks
-  section below. The toggle reflects only the CURRENT project, so the same glyph is mirrored
-  per project in the sidebar (`SidebarCommandTerminalIndicator` in each `ProjectListItem` row,
+  tokens) and the working state BLINKS its whole prompt like a live shell cursor (`.kng-blink`,
+  shipped with the mark). It marched a travelling dash until 2026-08-07; a rounded rect cannot
+  carry a composited travelling dash, so the working chip was redesigned rather than left
+  stalling. The glyph itself is no longer hand-authored: `CommandTerminalIcon` is a thin wrapper
+  over `components/ActivityMark.tsx`, which renders the `terminal-idle` / `terminal-working` /
+  `terminal-new` marks from `@kangentic/branding`. See the Activity marks section below. The
+  toggle reflects only the CURRENT project, so the same glyph is mirrored per project in the
+  sidebar (`SidebarCommandTerminalIndicator` in each `ProjectListItem` row,
   plus a plain tone dot on `CollapsedRail`'s 28px buttons, where an arc-bearing glyph would read
   as broken). Both the toggle and the sidebar read one shared selector,
   `selectCommandTerminalSummary` (`transient-session-slice.ts`), which derives count + tone from
@@ -179,7 +181,34 @@ won't be found.
   `?raw`, strips the packaged `<svg>` wrapper, and injects the inner markup into a `<g>` under a
   React-authored root. That root shape is load-bearing and must not become `BrandMark`'s wrapper-
   `<span>` form: React forbids `children` next to `dangerouslySetInnerHTML` on one element, and
-  `TaskCard` passes a `<title>` child for its hover tooltip. Marks are `currentColor` only, so the
+  `TaskCard` passes a `<title>` child for its hover tooltip. MOTION is always on a COMPOSITED
+  property, because Chromium composites only `transform` / `opacity` and a non-composited
+  animation stops producing frames for exactly as long as the renderer's main thread is blocked
+  (measured: 194 stalls in 3.6h, worst 703ms, and the indicators visibly hitched). Which primitive
+  a mark gets is decided by its geometry, not by taste: to travel a dash along a perimeter a
+  transform must map the shape onto ITSELF while advancing arc length, which is the shape's
+  symmetry group. A circle's is continuous, so the three ROUND working marks rotate (`.kng-spin`)
+  and it is the SAME image the old march produced - `pathLength` 100 makes a dash shift of d
+  exactly a rotation of d percent of 360 degrees. A rounded square's is DISCRETE (four 90-degree
+  rotations, nothing between), so `terminal-working` cannot travel a dash at all; its working
+  state is instead a solid outline with a blinking PROMPT (`.kng-blink`, an `opacity`), and
+  its rest strategy is now `static` rather than `drop-dash` since there is no dash left to drop.
+  Which element blinks was settled at the 16px sidebar size, not at review size: 2.8.0 blinked
+  the 4-unit prompt BAR alone, which draws 2.7px there against the 15.6px of perimeter the march
+  put in motion, and read as no motion at all. The whole prompt is 7.9px. Blinking the outline
+  too moves more ink but fades the tone that carries working-vs-resting, so it stays solid.
+  `.kng-march` still ships but no mark uses it. Three things bite silently: `ActivityMark`'s
+  timeline anchor must select EVERY motion class (none of the primitives is phase-invariant - the
+  rotating arc is dashed and a restarted blink can land mid-off), any consumer that freezes motion
+  must too AND must do it with `!important` (`MonitorSummaryCards`' zero-state Active tile is the
+  only one; `ActivityMark` imports the packaged CSS from node_modules, so `.kng-spin` arrives
+  UNLAYERED and outranks every Tailwind utility, which compile into `@layer utilities` - an
+  un-important override loses the cascade outright and does nothing, which is what the tile did
+  from the day it adopted the shared marks until a rendered test caught it - the lucide era before
+  that just omitted `animate-spin` and never fought the cascade), and the packaged CSS must ship
+  no animation fill mode or a stopped blink rests at its 0.06 trough instead of visible.
+  The shared 1400ms period across all primitives is what keeps a rotating agent ring in lockstep
+  with a blinking chip in the same sidebar row. Marks are `currentColor` only, so the
   CALL SITE supplies `text-active` / `text-attention` / `text-fg-muted` - never hardcode a hex,
   since `--kng-active` / `--kng-attention` are desktop-only values that mobile and web
   deliberately diverge from. There is no `-rest` mark: rest is the `-idle` geometry in a muted

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -668,7 +668,7 @@ The viewer opens positioned at the latest message, or centered on the turn match
 
 The Command Terminal provides quick, ephemeral access to Claude Code without creating a task on the board. Useful for one-off actions like creating releases, running queries, or any ad-hoc interaction.
 
-**Opening:** Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS), or click the terminal icon in the title bar (next to the settings gear). The same button **toggles** the layer closed again, so there is always a one-click way to hide it, even when a window is maximized. The terminal icon's border reflects activity across your open terminals: it marches in green while an agent is working, holds a steady warm amber when one needs your input, and stays plain when idle.
+**Opening:** Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS), or click the terminal icon in the title bar (next to the settings gear). The same button **toggles** the layer closed again, so there is always a one-click way to hide it, even when a window is maximized. The terminal icon reflects activity across your open terminals: its prompt blinks in green while an agent is working, it holds a steady warm amber when one needs your input, and it stays plain when idle.
 
 **Behavior:**
 - Spawns Claude Code at the project root on the configured default base branch

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@electron/fuses": "^2.1.1",
         "@electron/notarize": "^3.1.1",
         "@eslint/js": "^9.39.4",
-        "@kangentic/branding": "^2.7.1",
+        "@kangentic/branding": "^2.8.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.3.0",
@@ -2502,9 +2502,9 @@
       }
     },
     "node_modules/@kangentic/branding": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@kangentic/branding/-/branding-2.7.1.tgz",
-      "integrity": "sha512-RrkOCYAed0mUUbqTmgRPnyCw+AbYhxaQB7forqjCAzAp+HRHrCMlyum8mW3Qd0DH7v1m1nzywAqF8fRMFfG5yg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@kangentic/branding/-/branding-2.8.1.tgz",
+      "integrity": "sha512-22LfIga6lffy6BOpnVwbk9FdOsgaCbv+vWSp2hWAS1/LyRtmu7nHrQ7BTQ0m8KWJxYCzrvPGw4MNS9kEZZM1vA==",
       "dev": true,
       "license": "AGPL-3.0-only"
     },
@@ -14051,7 +14051,7 @@
     },
     "packages/protocol": {
       "name": "@kangentic/protocol",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@electron/fuses": "^2.1.1",
     "@electron/notarize": "^3.1.1",
     "@eslint/js": "^9.39.4",
-    "@kangentic/branding": "^2.7.1",
+    "@kangentic/branding": "^2.8.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.0",

--- a/src/renderer/components/ActivityMark.tsx
+++ b/src/renderer/components/ActivityMark.tsx
@@ -14,8 +14,26 @@ import terminalWorkingSvg from '@kangentic/branding/assets/activity/terminal-wor
 /**
  * The activity marks, owned upstream in `@kangentic/branding` (`assets/activity/`) and shared
  * with the website and the mobile app. Nine marks over five silhouettes (`activity.json` counts
- * `control-pause` and `control-stop` separately) on one 24 grid at stroke 2, `currentColor` only,
- * motion via a marching `stroke-dashoffset`.
+ * `control-pause` and `control-stop` separately) on one 24 grid at stroke 2, `currentColor` only.
+ *
+ * Motion is composited, always, because Chromium can only composite `transform` and `opacity` and
+ * a non-composited animation stops producing frames for exactly as long as THIS renderer's main
+ * thread is blocked - which is what made the indicators visibly hitch. Two primitives ship, and
+ * which one a mark gets is decided by its geometry:
+ *
+ *  - `.kng-spin` (a `transform`) on the ROUND working marks, riding a `pathLength`-normalized
+ *    dash on the outline. On a circle a rotation and a marching dash are the same image, so this
+ *    was a free swap.
+ *  - `.kng-blink` (an `opacity`) on the terminal chip's PROMPT, outline held solid. A rounded rect
+ *    has only a DISCRETE symmetry group, so no transform can travel a dash around it, and the
+ *    chip's working state was redesigned rather than left stalling. Which element blinks is a
+ *    legibility decision settled at the 16px sidebar size, not at review size: branding 2.8.0
+ *    blinked the 4-unit prompt BAR alone, which draws 2.7px there and was reported illegible
+ *    immediately. Blinking the outline too would move more ink but fade the tone that carries
+ *    working-vs-resting, so the outline stays at full strength.
+ *
+ * `.kng-march` (the original `stroke-dashoffset`) still ships in the packaged CSS but no mark
+ * uses it. Upstream holds every primitive to one period so marks stay in lockstep in a shared row.
  *
  * The grid is a WIDTH KEYLINE, not a square ink box: every mark fills its slot's width and
  * takes whatever height its form actually needs. Two keylines, one per role - 18 for
@@ -27,7 +45,7 @@ import terminalWorkingSvg from '@kangentic/branding/assets/activity/terminal-wor
  *
  * A deliberate inline-SVG exception to the lucide-only icon convention (`ui-conventions.md`),
  * and the third in that chain after `BrandMark.tsx` and `command-bar/CommandTerminalIcon.tsx`
- * (which is now a wrapper over this): no lucide glyph carries a marching activity border, and
+ * (which is now a wrapper over this): no lucide glyph carries a dashed activity border, and
  * these marks must stay byte-identical across three surfaces. The `?raw` sources are trusted
  * build-time package assets.
  *
@@ -106,36 +124,51 @@ const MARK_INNER: Record<ActivityMarkName, string> = Object.fromEntries(
 ) as Record<ActivityMarkName, string>;
 
 /**
- * Anchor every marching mark to the document timeline so the animation's phase is a
+ * Every class the packaged set uses to carry motion. ALL THREE must be listed.
+ *
+ * None of the three is phase-invariant, so every one of them needs the anchor:
+ * the set rotates a 75/25 DASHED arc, so a restart snaps its gap back to 12
+ * o'clock exactly as visibly as a restarted march did, and a restarted blink can
+ * land the cursor mid-off. (The lucide spinner these replaced was
+ * phase-invariant because it was one solid arc, which is why the restarts only
+ * became legible when the marks landed.) A selector that named only the classes
+ * in use at the time would silently un-anchor whatever upstream moved next -
+ * which is exactly what happened when the round marks went from march to spin.
+ * `.kng-march` is currently unused by the shipped set and is listed anyway.
+ */
+const MOTION_SELECTOR = '.kng-march, .kng-spin, .kng-blink';
+
+/**
+ * Anchor every animated mark to the document timeline so the animation's phase is a
  * pure function of time rather than of when its DOM node happened to be created.
  *
- * The march lives on a node inside `dangerouslySetInnerHTML`, so it has no React
+ * The motion lives on a node inside `dangerouslySetInnerHTML`, so it has no React
  * fiber: anything that rebuilds or re-inserts that node gives it a brand-new
  * animation starting at zero, and the 75/25 dashed ring snaps its gap back to 12
  * o'clock. That is highly legible - it reads as the indicator freezing or choking.
- * The lucide spinner this replaced never showed it, because a rotating circle looks
- * identical at every phase, which is why the restarts only became visible when the
- * marks landed.
  *
  * Setting `startTime = 0` re-bases the animation onto the document timeline origin,
  * making its phase `documentTime % period` for EVERY mark. Two consequences, both
  * wanted: a rebuilt node resumes exactly where the surviving ones are (so a restart
- * is undetectable), and all marks on screen march in lockstep, which reads as
- * deliberate rather than as N independent spinners.
+ * is undetectable), and all marks on screen move in lockstep, which reads as
+ * deliberate rather than as N independent spinners. Upstream deliberately holds
+ * every primitive to the same period so a rotating agent ring and a blinking
+ * terminal chip stay in lockstep in the same sidebar row.
  *
  * Idempotent by construction - re-applying always computes the same anchor - so it
  * is safe to run on any render.
  */
-function anchorMarchToTimeline(host: SVGGElement | null): void {
+function anchorMarkMotionToTimeline(host: SVGGElement | null): void {
   if (!host) return;
-  const marching = host.querySelector('.kng-march');
-  // `getAnimations` is unavailable in jsdom and absent under reduced motion (the
-  // packaged CSS drops the animation entirely), where there is nothing to anchor.
-  if (!marching || typeof marching.getAnimations !== 'function') return;
-  for (const animation of marching.getAnimations()) {
-    // Only write on drift: assigning startTime unconditionally on every render
-    // would be a needless style mutation on every card, every frame.
-    if (animation.startTime !== 0) animation.startTime = 0;
+  for (const animated of host.querySelectorAll(MOTION_SELECTOR)) {
+    // `getAnimations` is unavailable in jsdom and absent under reduced motion (the
+    // packaged CSS drops the animation entirely), where there is nothing to anchor.
+    if (typeof animated.getAnimations !== 'function') continue;
+    for (const animation of animated.getAnimations()) {
+      // Only write on drift: assigning startTime unconditionally on every render
+      // would be a needless style mutation on every card, every frame.
+      if (animation.startTime !== 0) animation.startTime = 0;
+    }
   }
 }
 
@@ -160,8 +193,10 @@ export interface ActivityMarkProps extends React.SVGProps<SVGSVGElement> {
  *  3. A wrapper `<span>` carrying the tone class would break the sidebar specs, which assert
  *     that `span.text-active` / `span.text-attention` resolve to the count digits alone.
  *
- * The extra `<g>` is harmless to the packaged CSS: `.kng-march` is a class selector and the
- * reduced-motion rule is `svg[data-rest="drop-dash"] *`, so both still match one level deeper.
+ * The extra `<g>` is harmless to the packaged CSS: every motion rule is a class selector and the
+ * reduced-motion dash rule is `svg[data-rest="drop-dash"] *`, so all of them still match one level
+ * deeper. It is also harmless to compositing: the animated element is the packaged inner `<g>`,
+ * and an extra static ancestor does not stop Blink from promoting it.
  */
 export function ActivityMark({
   mark,
@@ -179,9 +214,9 @@ export function ActivityMark({
   // BEFORE paint, so a rebuilt node is already in phase on the frame it appears and
   // the reset is never shown. No dependency array on purpose - a DOM move or a
   // re-injection can hand us a fresh animation without changing `mark`, and
-  // `anchorMarchToTimeline` no-ops when the anchor is already correct.
+  // `anchorMarkMotionToTimeline` no-ops when the anchor is already correct.
   React.useLayoutEffect(() => {
-    anchorMarchToTimeline(markGroupRef.current);
+    anchorMarkMotionToTimeline(markGroupRef.current);
   });
 
   return (

--- a/src/renderer/components/command-bar/CommandTerminalIcon.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalIcon.tsx
@@ -6,7 +6,7 @@ import type { CommandTerminalTone } from '../../stores/session-store/transient-s
  * The Command Terminal glyph: a terminal icon whose state lives IN the glyph rather than in a
  * separate corner badge. The stroke color is the aggregate activity of a project's terminals
  * (green while working / warm amber when one needs you / muted rest, via the --kng-active /
- * --kng-attention tokens), and the working border MARCHES (a dash flows around the perimeter).
+ * --kng-attention tokens), and the working state BLINKS its prompt like a live shell.
  * The center morphs from the shell prompt to a `+` when rendered for the "New terminal" button,
  * so that button reads as a terminal glyph (not a bare plus).
  *
@@ -14,9 +14,9 @@ import type { CommandTerminalTone } from '../../stores/session-store/transient-s
  * and the only one that holds the exemption second-hand: it draws nothing itself, it wraps
  * `ActivityMark`. The geometry comes from `@kangentic/branding`'s `terminal-*` marks.
  * It was previously hand-authored here and was byte-identical to the packaged art (same rect,
- * chevron, plus, and `65 35` dash), which is exactly the duplication the shared set exists to
- * remove. This component stays as the app-facing wrapper because it owns the tone -> mark
- * mapping and the `data-activity` / `data-plus` test contract.
+ * chevron, plus, and the working dash it carried then), which is exactly the duplication the
+ * shared set exists to remove. This component stays as the app-facing wrapper because it owns
+ * the tone -> mark mapping and the `data-activity` / `data-plus` test contract.
  *
  * Shared by the title bar (20px, the project-wide toggle) and the project sidebar (14px, per
  * project row). Callers outside the title bar MUST pass their own `testId`: the default belongs
@@ -40,7 +40,7 @@ export function CommandTerminalIcon({
   const needsAttention = tone === 'idle'; // activity-state-ok: presentational tone, not an ActivityState
   const colorClass = isWorking ? 'text-active' : needsAttention ? 'text-attention' : '';
 
-  // `showPlus` wins: the "New terminal" button is an ACTION, so it never marches. Rest and
+  // `showPlus` wins: the "New terminal" button is an ACTION, so it never animates. Rest and
   // needs-you share the `terminal-idle` geometry and differ only in tone, which is why the
   // packaged set ships no separate `-rest` mark.
   const mark: ActivityMarkName = showPlus

--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -57,7 +57,7 @@ const ChangesPanel = lazy(() => import('../dialogs/task-detail/changes/ChangesPa
  * The Stop button glyph, carrying the same activity ring the task-detail header folds into its
  * pause button (`PauseButtonIcon`), but with a STOP square centered instead of pause bars - the
  * command terminal stops (kills the PTY); it never pauses. Activity is encoded by the ring:
- *   - thinking (agent working): a marching active ring around the stop square.
+ *   - thinking (agent working): a rotating active ring around the stop square.
  *   - idle/permission (needs you): a static attention ring around the stop square.
  *   - not yet running / no activity: the plain red CircleStop (rest state).
  *

--- a/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
+++ b/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
@@ -50,7 +50,7 @@ function PauseButtonIcon({
   if (toggling) return <Loader2 size={18} className="animate-spin" />;
 
   // Active and idle/permission share one packaged mark, differing only by color and motion
-  // (a marching dash vs a static ring), so the two states read as one visual language.
+  // (a rotating dashed arc vs a static ring), so the two states read as one visual language.
   //
   // Rendered at 20 in a 20px box, which is a pixel-for-pixel match for the lucide Circle +
   // hand-drawn bars this replaced: the packaged control ring is r=10 on a 20-unit ink box, so
@@ -716,7 +716,7 @@ function TaskDetailKebabItems({
         />
       )}
 
-      {/* Commands -- searchable flyout (shares CommandSearchList with the header
+      {/* Commands - searchable flyout (shares CommandSearchList with the header
           pill). Hover to open / leave to close, like Move to: the flyout is a DOM
           child of this container, so moving the pointer INTO it (to type in the
           search) stays within the container and keeps it open; the search input
@@ -753,7 +753,7 @@ function TaskDetailKebabItems({
         </div>
       )}
 
-      {/* Move to -- flyout submenu */}
+      {/* Move to - flyout submenu */}
       {moveTargets.length > 0 && (
         <div
           ref={moveFlyoutTriggerRef}
@@ -834,7 +834,7 @@ function TaskDetailKebabItems({
         />
       )}
 
-      {/* Delete -- always available */}
+      {/* Delete - always available */}
       <KebabMenuItem
         icon={<Trash2 size={14} />}
         label="Delete"

--- a/src/renderer/components/monitor/MonitorSummaryCards.tsx
+++ b/src/renderer/components/monitor/MonitorSummaryCards.tsx
@@ -105,15 +105,33 @@ function MonitorSummaryCardsInner({ rows }: { rows: MonitorSessionRow[] }) {
       />
       <SummaryTile
         label="Active"
-        // The working mark marches by default (`.kng-march` in the branding CSS).
-        // At zero there is nothing in flight to animate, so freeze the dash rather
-        // than have an idle machine's chrome keep moving. Same conditional the
-        // lucide spinner this replaced used.
+        // The working mark animates by default. At zero there is nothing in flight
+        // to animate, so freeze it rather than have an idle machine's chrome keep
+        // moving. Same conditional the lucide spinner this replaced used.
+        //
+        // BOTH motion classes, deliberately. `agent-working` moved from `.kng-march`
+        // to `.kng-spin` upstream, so naming only one leaves the tile animating on
+        // an idle machine. Naming both means a future upstream flip in either
+        // direction stays frozen here. (The chip's `.kng-blink` is not listed
+        // because this tile only ever renders the ring.)
+        //
+        // The `!` is load-bearing, not defensive. `ActivityMark` imports the packaged
+        // `activity.css` straight from node_modules, so `.kng-spin { animation: ... }`
+        // lands UNLAYERED, while `@import "tailwindcss"` compiles every utility into
+        // `@layer utilities` - and an unlayered author rule beats a layered one at any
+        // specificity. Without `!important` this override loses the cascade outright
+        // and silently does nothing, which is how the tile spun at zero for both the
+        // `.kng-march` era and the first cut of this widening. Only importance, which
+        // outranks layering, wins here. Pinned red-green in tests/ui/agent-monitor.spec.ts.
         icon={(
           <ActivityMark
             mark="agent-working"
             size={15}
-            className={counts.working > 0 ? '' : '[&_.kng-march]:[animation:none]'}
+            className={
+              counts.working > 0
+                ? ''
+                : '[&_.kng-march]:[animation:none]! [&_.kng-spin]:[animation:none]!'
+            }
           />
         )}
         value={counts.working}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -393,11 +393,14 @@
   z-index: 0;
 }
 
-/* The activity marks' marching-border animation used to live here as
-   `@keyframes march-border` / `.animate-march-border`. It now ships with the marks themselves,
-   in `@kangentic/branding/assets/activity/activity.css` (`kng-activity-march` / `.kng-march`,
-   same 1.4s linear dashoffset), imported by `components/ActivityMark.tsx` - so the keyframe
-   and the geometry it animates can no longer drift apart. */
+/* The activity marks' motion used to live here as `@keyframes march-border` /
+   `.animate-march-border`. It now ships with the marks themselves, in
+   `@kangentic/branding/assets/activity/activity.css`, imported by `components/ActivityMark.tsx` -
+   so the keyframes and the geometry they animate can no longer drift apart. Every shipped
+   primitive is now on a composited property, all 1.4s linear so they stay in lockstep:
+   `.kng-spin` (a `transform`, on the round working marks) and `.kng-blink` (an `opacity`, on the
+   terminal chip's prompt, since a rounded rect cannot carry a travelling dash under any
+   transform). `.kng-march` still ships in the packaged CSS but no mark uses it. */
 
 /* xterm: fill parent height so scrollbar is flush with bottom edge.
    xterm.js creates a .xterm child div that is content-sized (rows * cellHeight)

--- a/tests/ui/activity-marks.spec.ts
+++ b/tests/ui/activity-marks.spec.ts
@@ -215,6 +215,71 @@ test.describe('Activity marks', () => {
     }
   });
 
+  test('a mark REBUILT after mount (idle -> working mid-session) re-anchors instead of keeping its own creation-time phase', async () => {
+    // Every anchor assertion above seeds the card as agent-working from the very first paint,
+    // so the only invocation of ActivityMark's layout effect they exercise is its FIRST one -
+    // which always runs, dependency array or not, and would still pass even if a future edit
+    // added one (e.g. `}, [mark])` still fires on this exact prop change; `}, [])` would not,
+    // but neither shape is what this test is pinning). The actual defect class the anchor
+    // exists to prevent is a SUBSEQUENT render swapping in fresh markup: `TaskCard` flips
+    // `mark` from 'agent-idle' to 'agent-working' via `dangerouslySetInnerHTML`, which builds
+    // a brand-new <g class="kng-spin"> with no React fiber and no animation history. This
+    // drives that exact transition mid-session, after the page has been running long enough
+    // that an unanchored animation could not land on startTime 0 by coincidence, and confirms
+    // the freshly created animation is actively RE-anchored - not merely correctly anchored
+    // because it happened to exist from the start.
+    const { browser, page } = await launch('idle');
+    try {
+      const idleMark = page.locator(`[data-task-id="${TASK_ID}"] [data-mark="agent-idle"]`);
+      await expect(idleMark).toBeVisible({ timeout: 15000 });
+      // agent-idle is static (see 'a static mark carries no motion group at all'), so nothing
+      // is animating yet - the interesting event is what the rebuild does a moment from now.
+      await expect(idleMark.locator('.kng-spin')).toHaveCount(0);
+
+      await page.evaluate((sessionId) => {
+        const stores = (window as unknown as {
+          __zustandStores: { session: { getState: () => { updateActivity: (id: string, state: string) => void } } };
+        }).__zustandStores;
+        stores.session.getState().updateActivity(sessionId, 'thinking');
+      }, SESSION_ID);
+
+      const workingMark = page.locator(`[data-task-id="${TASK_ID}"] [data-mark="agent-working"]`);
+      await expect(workingMark).toBeVisible({ timeout: 10000 });
+
+      await expect
+        .poll(
+          () => page.evaluate((taskId) => {
+            const node = document.querySelector(
+              `[data-task-id="${taskId}"] [data-mark="agent-working"] .kng-spin`,
+            );
+            if (!node) return null;
+            const animations = node.getAnimations();
+            return {
+              // Turns the "enough real time has passed" precondition into an assertion rather
+              // than a sleep-and-hope: a fresh, UNanchored animation's startTime is set to the
+              // document timeline's current time at creation, so it can only read exactly 0 by
+              // fluke if the timeline itself is still near its origin.
+              documentTimeWellPastOrigin: (document.timeline.currentTime ?? 0) > 200,
+              // Not just "no animation has drifted" - a mutation that dropped the motion group
+              // entirely would otherwise pass this vacuously, the same failure mode the
+              // sibling test above guards against with its `classes:` key.
+              animationCount: animations.length,
+              startTime: animations[0]?.startTime ?? null,
+            };
+          }, TASK_ID),
+          {
+            message:
+              'the rebuilt working mark kept its own creation-time phase instead of '
+              + 're-anchoring to the document timeline - it will visibly jump or restart '
+              + 'against every mark that was already on screen',
+          },
+        )
+        .toEqual({ documentTimeWellPastOrigin: true, animationCount: 1, startTime: 0 });
+    } finally {
+      await browser.close();
+    }
+  });
+
   test('marks render at their call site size, not the packaged 24px', async () => {
     // Computed style, not boundingBox: the task-detail window carries a scale transform, so
     // every measured rect inside it is uniformly smaller than its layout size.

--- a/tests/ui/activity-marks.spec.ts
+++ b/tests/ui/activity-marks.spec.ts
@@ -5,14 +5,19 @@
  * already assert WHICH mark each state renders. This file covers the three things that are
  * properties of the packaged set itself, and that fail silently everywhere else:
  *
- *  1. The packaged `activity.css` reaches the renderer's cascade. `.kng-march` is an unscoped
- *     global arriving from node_modules, so a mark can render perfectly and simply never move.
- *     No `data-mark` assertion catches that.
+ *  1. The packaged `activity.css` reaches the renderer's cascade, and each working mark is on
+ *     the primitive it is supposed to be on. `.kng-spin` / `.kng-march` are unscoped globals
+ *     arriving from node_modules, so a mark can render perfectly and simply never move, and no
+ *     `data-mark` assertion catches that. WHICH primitive matters too: only the rotation is
+ *     composited, so a silent revert to the march would still animate here and still stall
+ *     under load.
+ *  1b. Every mark on screen is anchored to the document timeline. Invisible when it works,
+ *     and when it breaks it looks exactly like the stall in (1).
  *  2. The marks render at the size their call site asked for. The packaged SVGs carry a
  *     hardcoded `width="24" height="24"`, so a regression in ActivityMark's root would silently
  *     paint every indicator at 24px.
- *  3. `prefers-reduced-motion` is honored, including the `drop-dash` strategy that needs
- *     `data-rest` to survive into the DOM.
+ *  3. `prefers-reduced-motion` is honored for every primitive, that a stopped mark comes to rest
+ *     in a readable state, and that `data-rest` survives into the DOM.
  */
 import { test, expect } from '@playwright/test';
 import { chromium, type Browser, type Page } from '@playwright/test';
@@ -108,34 +113,103 @@ async function launch(
  */
 
 test.describe('Activity marks', () => {
-  test('the packaged activity.css reaches the cascade and drives the march', async () => {
-    const { browser, page } = await launch('thinking');
+  test('the packaged activity.css reaches the cascade and drives a COMPOSITED rotation', async () => {
+    const { browser, page } = await launch('thinking', undefined, 'thinking');
     try {
+      const readAnimation = (locator: ReturnType<Page['locator']>): Promise<unknown> =>
+        locator.evaluate((node) => {
+          const style = getComputedStyle(node);
+          return {
+            name: style.animationName,
+            duration: style.animationDuration,
+            timing: style.animationTimingFunction,
+            iteration: style.animationIterationCount,
+          };
+        });
+
       const mark = page.locator(`[data-task-id="${TASK_ID}"] [data-mark="agent-working"]`);
       await expect(mark).toBeVisible({ timeout: 15000 });
 
+      // The round working mark ROTATES. `transform` is the only reason this test names a
+      // specific keyframe rather than just "something animates": Chromium composites transform
+      // animations and cannot composite `stroke-dashoffset`, so a silent revert to the march
+      // would keep this mark rendering and animating while reintroducing the stall it was
+      // moved to escape. Nothing else in the suite would notice.
       await expect
-        .poll(
-          () => mark.locator('.kng-march').evaluate((node) => {
-            const style = getComputedStyle(node);
-            return {
-              name: style.animationName,
-              duration: style.animationDuration,
-              timing: style.animationTimingFunction,
-              iteration: style.animationIterationCount,
-            };
-          }),
-          {
-            message:
-              'activity.css did not reach the cascade: .kng-march resolved to no animation, so every working mark is frozen',
-          },
-        )
+        .poll(() => readAnimation(mark.locator('.kng-spin')), {
+          message:
+            'activity.css did not reach the cascade, or agent-working reverted to the '
+            + 'non-composited march: the board indicator freezes whenever the renderer is busy',
+        })
         .toEqual({
-          name: 'kng-activity-march',
+          name: 'kng-activity-spin',
           duration: '1.4s',
           timing: 'linear',
           iteration: 'infinite',
         });
+
+      // The terminal chip is not radially symmetric, so it cannot rotate at all. Its working
+      // state is a solid outline with a blinking cursor, on `opacity`, which composites. The
+      // period must MATCH the rotation above: both are anchored to the document timeline, and a
+      // mismatch drifts the sidebar's agent ring out of lockstep with the chip beside it.
+      const terminalMark = page.getByTestId('quick-session-icon');
+      await expect(terminalMark).toHaveAttribute('data-mark', 'terminal-working', { timeout: 10000 });
+      await expect
+        .poll(() => readAnimation(terminalMark.locator('.kng-blink')), {
+          message: 'the terminal chip lost its blink, or its period drifted from the rotation',
+        })
+        .toEqual({
+          name: 'kng-activity-blink',
+          duration: '1.4s',
+          timing: 'linear',
+          iteration: 'infinite',
+        });
+
+      // The blink rides the WHOLE PROMPT and leaves the outline solid. Both halves matter and
+      // neither is caught anywhere else: blinking less (the bar alone, as 2.8.0 shipped) draws
+      // 2.7px at this size and is illegible, and blinking more (the outline, or the whole mark)
+      // fades the tone that carries working-vs-resting. Either mistake still animates, still
+      // composites, and sails past every other assertion in this file.
+      await expect(terminalMark.locator('.kng-blink > path')).toHaveCount(2);
+      await expect(terminalMark.locator('.kng-blink rect')).toHaveCount(0);
+      await expect
+        .poll(() => terminalMark.locator('rect').first().evaluate((node) => getComputedStyle(node).animationName), {
+          message: 'the chip outline must not blink - a whole-mark fade dims the state tone',
+        })
+        .toBe('none');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('every mark on screen is anchored to the document timeline, so none can restart', async () => {
+    // The anchor is what makes a rebuilt node resume where the survivors are. It is invisible
+    // when it works and indistinguishable from the compositing stall when it breaks, so assert
+    // it directly: startTime 0 on every animation, and one shared currentTime across all of
+    // them. This is the guard for the selector regression - anchoring only `.kng-march` would
+    // leave the rotating marks un-anchored, and everything else here would still pass.
+    const { browser, page } = await launch('thinking', undefined, 'thinking');
+    try {
+      const mark = page.locator(`[data-task-id="${TASK_ID}"] [data-mark="agent-working"]`);
+      await expect(mark).toBeVisible({ timeout: 15000 });
+      await expect(page.getByTestId('quick-session-icon'))
+        .toHaveAttribute('data-mark', 'terminal-working', { timeout: 10000 });
+
+      await expect
+        .poll(
+          () => page.evaluate(() => {
+            const animated = Array.from(document.querySelectorAll('.kng-spin, .kng-march, .kng-blink'));
+            const animations = animated.flatMap((node) => node.getAnimations());
+            return {
+              // Both shipped primitives must actually be on screen, or "all anchored" is vacuous.
+              classes: [...new Set(animated.map((node) => node.getAttribute('class')))].sort(),
+              unanchored: animations.filter((animation) => animation.startTime !== 0).length,
+              phases: new Set(animations.map((animation) => String(animation.currentTime))).size,
+            };
+          }),
+          { message: 'activity marks are not all anchored to the document timeline' },
+        )
+        .toEqual({ classes: ['kng-blink', 'kng-spin'], unanchored: 0, phases: 1 });
     } finally {
       await browser.close();
     }
@@ -183,13 +257,13 @@ test.describe('Activity marks', () => {
     }
   });
 
-  test('a static mark carries no marching group at all', async () => {
+  test('a static mark carries no motion group at all', async () => {
     const { browser, page } = await launch('idle');
     try {
       const mark = page.locator(`[data-task-id="${TASK_ID}"] [data-mark="agent-idle"]`);
       await expect(mark).toBeVisible({ timeout: 15000 });
       await expect(mark).toHaveAttribute('data-rest', 'static');
-      await expect(mark.locator('.kng-march')).toHaveCount(0);
+      await expect(mark.locator('.kng-march, .kng-spin')).toHaveCount(0);
       // The idle branch carries its own `size={16}` literal in TaskCard, separate from the
       // thinking branch the size test above measures, so it can regress on its own.
       await expect
@@ -200,35 +274,60 @@ test.describe('Activity marks', () => {
     }
   });
 
-  test('prefers-reduced-motion stops the march and drops the drop-dash dash', async () => {
-    // The transient terminal is seeded 'thinking' on purpose. `terminal-working` is the ONLY
-    // mark that declares `drop-dash`, and it renders only when a running transient PTY is
-    // active: `selectCommandTerminalSummary` counts `transient && running` sessions, so the
-    // task's own (non-transient) session never drives the toggle no matter what its activity
-    // is. Without this the toggle sits at `terminal-idle` / `static` and the dash assertion
-    // below has nothing to check.
+  test('prefers-reduced-motion stops every primitive and leaves both marks readable', async () => {
+    // The transient terminal is seeded 'thinking' on purpose: `terminal-working` renders only
+    // when a running transient PTY is active, because `selectCommandTerminalSummary` counts
+    // `transient && running` sessions, so the task's own (non-transient) session never drives
+    // the toggle no matter what its activity is. Without this the toggle sits at `terminal-idle`
+    // and the blink assertion below has nothing to check.
     const { browser, page } = await launch('thinking', 'reduce', 'thinking');
     try {
       const mark = page.locator(`[data-task-id="${TASK_ID}"] [data-mark="agent-working"]`);
       await expect(mark).toBeVisible({ timeout: 15000 });
+      // Each time upstream added a primitive, a reduced-motion rule still naming only the
+      // previous ones would have left the newest marks moving - silently, and only for the
+      // users who asked for no motion. Both shipped primitives are checked here for that reason.
       await expect
         .poll(
-          () => mark.locator('.kng-march').evaluate((node) => getComputedStyle(node).animationName),
-          { message: 'prefers-reduced-motion should disable the march' },
+          () => mark.locator('.kng-spin').evaluate((node) => getComputedStyle(node).animationName),
+          { message: 'prefers-reduced-motion should disable the rotation' },
         )
         .toBe('none');
 
-      // Under reduced motion a `drop-dash` mark must lose its dash outright, not merely freeze
-      // it mid-gap. That rule is `svg[data-rest="drop-dash"] *`, so it only fires if `data-rest`
-      // survives the packaged-wrapper strip into the React-authored root.
       const terminalMark = page.getByTestId('quick-session-icon');
       await expect(terminalMark).toHaveAttribute('data-mark', 'terminal-working', { timeout: 10000 });
-      await expect(terminalMark).toHaveAttribute('data-rest', 'drop-dash');
+      await expect
+        .poll(
+          () => terminalMark.locator('.kng-blink').evaluate((node) => getComputedStyle(node).animationName),
+          { message: 'prefers-reduced-motion should disable the blink' },
+        )
+        .toBe('none');
+
+      // And the prompt must come to rest VISIBLE, not stuck at the keyframe's 0.06 trough. The
+      // packaged CSS deliberately ships no animation fill mode for exactly this reason, so a
+      // stopped blink resolves to the element's own opacity rather than to its last keyframe.
+      // Without this the mark would rest looking like it had lost its prompt.
+      //
+      // Read the GROUP, not a child path. The animation is on `<g class="kng-blink">`, and a
+      // child <path> computes to opacity 1 no matter what the group is doing - so asserting on
+      // the path would pass even with the group stuck at 0.06, which is the whole failure.
+      await expect
+        .poll(
+          () => terminalMark.locator('.kng-blink').evaluate((node) => getComputedStyle(node).opacity),
+          { message: 'a stopped prompt must rest visible, not at the blink trough' },
+        )
+        .toBe('1');
+
+      // `data-rest` still has to survive the packaged-wrapper strip into the React-authored
+      // root: it is the hook the packaged `svg[data-rest="drop-dash"] *` rule keys off. No
+      // shipped mark declares drop-dash since the chip's dash was removed, so this asserts the
+      // attribute is plumbed and correct rather than exercising that rule.
+      await expect(terminalMark).toHaveAttribute('data-rest', 'static');
       await expect
         .poll(
           () => terminalMark.locator('rect').first()
             .evaluate((node) => getComputedStyle(node).strokeDasharray),
-          { message: 'a drop-dash mark should lose its dash under reduced motion' },
+          { message: 'the working chip outline must be solid' },
         )
         .toBe('none');
     } finally {

--- a/tests/ui/agent-monitor.spec.ts
+++ b/tests/ui/agent-monitor.spec.ts
@@ -1207,4 +1207,82 @@ test.describe('agent monitor', () => {
       await browser.close();
     }
   });
+
+  /**
+   * The Active tile freezes its own icon at `counts.working === 0`, so an idle machine's
+   * chrome stops moving. The only prior coverage was a source-text scan in
+   * tests/unit/activity-mark.test.ts that pins the literal override string, and it stayed
+   * green for the entire time the override did nothing at all: the packaged `activity.css`
+   * is imported unlayered from node_modules and outranks any Tailwind utility, which live
+   * in `@layer utilities`. A string scan cannot see a lost cascade. These two assert the
+   * EFFECT - the computed `animation-name` of the real `.kng-spin` node - on both sides of
+   * the ternary, so neither a dropped `!important` nor a permanently-frozen tile can ship.
+   */
+  test('the Active tile freezes its ring when no agent is working', async () => {
+    const { browser, page } = await launchWithState(`
+      ${monitorPreConfig()}
+      window.__mockMonitorRows = [
+        {
+          // Running but user-blocked, so it routes through requiresUserInteraction() into
+          // the needs-you bucket rather than the suspended short-circuit. That keeps the
+          // summary row mounted (it unmounts entirely with zero rows) while holding the
+          // working count at 0, which is the state under test.
+          sessionId: 'sess-idle-only', projectId: '${PROJECT_A}', projectName: 'Monitor Alpha',
+          taskId: 'task-a', taskTitle: 'Fix PTY capture race', outputPeek: [], displayId: 142,
+          columnName: 'Tests', commandTerminalBranch: null, labels: [], prUrl: null,
+          prNumber: null, prState: null, agentName: 'claude', modelDisplayName: 'Opus 5',
+          effort: 'xhigh', permissionMode: 'plan', startedAt: '2026-01-01T00:00:00.000Z',
+          exitedAt: null, status: 'running', activity: 'idle',
+          activityReason: { kind: 'idle', since: 0 }, lastEvent: null, contextPercent: 62,
+          isolated: false, isCommandTerminal: false
+        }
+      ];
+    `);
+    try {
+      // Reduced motion would strip the animation regardless of the override and pass this
+      // vacuously. Headless Chromium already defaults to no-preference; pinned so the
+      // precondition is explicit rather than incidental.
+      await page.emulateMedia({ reducedMotion: 'no-preference' });
+      await openMonitor(page);
+      await expect(page.locator('[data-testid="monitor-summary-working-value"]')).toHaveText('0');
+
+      const workingRing = page.locator(
+        '[data-testid="monitor-summary-working"] [data-mark="agent-working"] .kng-spin',
+      );
+      await workingRing.waitFor({ state: 'attached', timeout: 10000 });
+      await expect
+        .poll(() => workingRing.evaluate((node) => getComputedStyle(node).animationName), {
+          message: 'the Active tile kept rotating at zero: the freeze lost the cascade',
+        })
+        .toBe('none');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('the Active tile keeps its ring rotating while an agent is working', async () => {
+    // The other branch of the same ternary. Without it, an override that froze the tile
+    // unconditionally would still satisfy the zero-state test above.
+    const { browser, page } = await launchWithState(monitorPreConfig());
+    try {
+      await page.emulateMedia({ reducedMotion: 'no-preference' });
+      await openMonitor(page);
+      // The default fixture's three running+thinking rows. An exact count, so a fixture
+      // change that dropped it to zero fails here with a clear message instead of timing
+      // out confusingly on the animation assertion below.
+      await expect(page.locator('[data-testid="monitor-summary-working-value"]')).toHaveText('3');
+
+      const workingRing = page.locator(
+        '[data-testid="monitor-summary-working"] [data-mark="agent-working"] .kng-spin',
+      );
+      await workingRing.waitFor({ state: 'attached', timeout: 10000 });
+      await expect
+        .poll(() => workingRing.evaluate((node) => getComputedStyle(node).animationName), {
+          message: 'the Active tile stopped rotating while agents were working',
+        })
+        .toBe('kng-activity-spin');
+    } finally {
+      await browser.close();
+    }
+  });
 });

--- a/tests/ui/command-terminal.spec.ts
+++ b/tests/ui/command-terminal.spec.ts
@@ -2003,7 +2003,9 @@ test.describe('Command Terminal', () => {
   //
   // Ring and square are ONE packaged @kangentic/branding mark, so `data-mark` carries both
   // "a ring is showing" and "which state it is": there is no separate stop-square element to
-  // assert, and no animate-spin class (the working mark marches via .kng-march instead).
+  // assert, and no lucide `animate-spin` class - the working ring rotates via the packaged
+  // `.kng-spin`, whose own contract (period, composited property, reduced motion) is pinned in
+  // tests/ui/activity-marks.spec.ts rather than re-asserted here.
   //
   // Each test uses a deterministic spawnTransient override (known session id) so
   // page.evaluate can call updateActivity + markFirstOutput on that exact id
@@ -2091,7 +2093,7 @@ test.describe('Command Terminal', () => {
       // We assert the activity-specific state in each individual test instead.
     }
 
-    test('thinking activity shows the marching active stop ring', async () => {
+    test('thinking activity shows the rotating active stop ring', async () => {
       // Derives expected behavior from the contract in CommandTerminalWindow.tsx:
       //   isThinking = sessionRunning && isActive(activity)
       //   -> the control-stop-working mark, tinted text-active
@@ -2158,7 +2160,7 @@ test.describe('Command Terminal', () => {
         await expect(ring).toBeVisible({ timeout: 3000 });
         await expect(ring).toHaveClass(/text-attention/);
 
-        // Idle is static. The marching variant is a DIFFERENT mark, so its absence is the
+        // Idle is static. The animated variant is a DIFFERENT mark, so its absence is the
         // assertion - there is no motion class to check on the idle one.
         await expect(stopButton.locator('[data-mark="control-stop-working"]')).toHaveCount(0);
 
@@ -2195,7 +2197,7 @@ test.describe('Command Terminal', () => {
         const stopButton = page.getByTestId('command-bar-terminate-button');
 
         // Static attention ring - permission maps to the idle disposition, so it renders the
-        // SAME mark as idle, not the marching one.
+        // SAME mark as idle, not the animated one.
         const ring = stopButton.locator('[data-mark="control-stop-idle"]');
         await expect(ring).toBeVisible({ timeout: 3000 });
         await expect(ring).toHaveClass(/text-attention/);

--- a/tests/ui/task-activity-indicators.spec.ts
+++ b/tests/ui/task-activity-indicators.spec.ts
@@ -1355,7 +1355,7 @@ test.describe('Task Activity Indicators', () => {
 
         const pauseButton = dialog.locator('button[title="Pause session"]');
         await expect(pauseButton).toBeVisible({ timeout: 10000 });
-        // Active: the marching ring with the pause centered inside it. Ring and bars are one
+        // Active: the rotating ring with the pause centered inside it. Ring and bars are one
         // packaged mark now, so the mark's identity carries both facts.
         await expect(pauseButton.locator('[data-mark="control-pause-working"]')).toBeVisible();
         await expect(pauseButton.locator('[data-mark="control-pause-idle"]')).toHaveCount(0);
@@ -1374,7 +1374,7 @@ test.describe('Task Activity Indicators', () => {
 
         const pauseButton = dialog.locator('button[title="Pause session"]');
         await expect(pauseButton).toBeVisible({ timeout: 10000 });
-        // Idle: the static amber ring + the centered pause; the ring does not march.
+        // Idle: the static amber ring + the centered pause; the ring does not rotate.
         await expect(pauseButton.locator('[data-mark="control-pause-idle"]')).toBeVisible();
         await expect(pauseButton.locator('[data-mark="control-pause-working"]')).toHaveCount(0);
       } finally {
@@ -1392,11 +1392,11 @@ test.describe('Task Activity Indicators', () => {
 
         const pauseButton = dialog.locator('button[title="Pause session"]');
         await expect(pauseButton).toBeVisible({ timeout: 10000 });
-        // Permission maps to idle: the static amber ring, never the marching one.
+        // Permission maps to idle: the static amber ring, never the rotating one.
         await expect(pauseButton.locator('[data-mark="control-pause-idle"]')).toBeVisible();
         await expect(pauseButton.locator('[data-mark="control-pause-working"]')).toHaveCount(0);
 
-        // Drive permission -> thinking; the static ring becomes the marching ring.
+        // Drive permission -> thinking; the static ring becomes the rotating ring.
         await page.evaluate((sessionId) => {
           const stores = (window as unknown as {
             __zustandStores: { session: { getState: () => { updateActivity: (id: string, state: string) => void } } };

--- a/tests/unit/activity-mark-render.test.ts
+++ b/tests/unit/activity-mark-render.test.ts
@@ -18,8 +18,8 @@
  * (`{ type, props }`) is walked without a renderer.
  *
  * ActivityMark is no longer hookless. It takes a ref on the injected `<g>` and
- * runs a layout effect that anchors the marching dash to the document timeline,
- * so a re-injected or DOM-moved mark does not restart its animation mid-march.
+ * runs a layout effect that anchors the mark's motion to the document timeline,
+ * so a re-injected or DOM-moved mark does not restart its animation mid-cycle.
  * Calling a component as a plain function invokes hooks outside a render, where
  * React's dispatcher is null, so the two hooks are stubbed below.
  *

--- a/tests/unit/activity-mark.test.ts
+++ b/tests/unit/activity-mark.test.ts
@@ -29,16 +29,73 @@ describe('innerMarkup', () => {
     ).toEqual([]);
   });
 
-  it('keeps the marching group and its dash on the working marks', () => {
-    // The march is a <g class="kng-march"> wrapper plus a pathLength-normalized dash. Losing
-    // either leaves a working mark that renders but never animates.
+  it('gives every working mark a motion group', () => {
+    // A working mark that renders but never animates is the failure this catches, and nothing
+    // else would: `data-mark` is still right, the geometry is still right, it just sits there.
     const broken = ACTIVITY_MARK_NAMES.filter((markName) => markName.endsWith('-working')).filter(
-      (markName) => {
-        const inner = innerMarkup(readMark(markName));
-        return !inner.includes('class="kng-march"') || !inner.includes('stroke-dasharray');
-      },
+      (markName) => !/class="kng-(spin|march|blink)"/.test(innerMarkup(readMark(markName))),
     );
-    expect(broken, `working marks missing their march group or dash:\n${broken.join('\n')}`).toEqual([]);
+    expect(broken, `working marks with no motion group:\n${broken.join('\n')}`).toEqual([]);
+  });
+
+  it('pins WHICH primitive each working mark uses, and pairs each with what it needs', () => {
+    // The whole point of the 2026-08-07 change. Chromium can composite `transform` and `opacity`
+    // and nothing else that matters here, so a `stroke-dashoffset` march stops producing frames
+    // for exactly as long as this renderer's main thread is blocked. Measured in the shipping
+    // runtime (Electron 41, Chromium 146) against a 4000ms block via CDP Page.startScreencast:
+    // HTML rotation 349 distinct frames, SVG <g> rotation 355, dashoffset march 0.
+    //
+    // Geometry decides which primitive a mark can take, and it is a hard constraint rather than
+    // a preference. To travel a dash along a perimeter, a transform has to map the shape onto
+    // ITSELF while advancing arc length - that is the shape's symmetry group. A circle's is
+    // continuous, so the three ROUND marks rotate and it is the same image the march produced
+    // (pathLength 100 makes a dash shift of d exactly a rotation of d percent of 360 degrees;
+    // verified by pixel diff across eight phases). A rounded square's symmetry group is DISCRETE
+    // - four 90 degree rotations, nothing between - so the chip cannot travel a dash at all. Its
+    // working state was redesigned instead: a solid outline with a blinking cursor.
+    //
+    // Each primitive needs a specific companion, which is why they are asserted together:
+    // an outline primitive is invisible without a dash (a solid ring rotating shows nothing),
+    // and the blink needs its own element to ride or the whole mark would flash.
+    const primitive: Record<string, { motionClass: string; needs: RegExp; because: string }> = {
+      'agent-working': { motionClass: 'kng-spin', needs: /stroke-dasharray/, because: 'a solid rotating ring shows no motion' },
+      'control-pause-working': { motionClass: 'kng-spin', needs: /stroke-dasharray/, because: 'a solid rotating ring shows no motion' },
+      'control-stop-working': { motionClass: 'kng-spin', needs: /stroke-dasharray/, because: 'a solid rotating ring shows no motion' },
+      'terminal-working': {
+        motionClass: 'kng-blink',
+        // The blink wraps the WHOLE PROMPT and nothing else. Both bounds are load-bearing and
+        // both have been wrong once or nearly so:
+        //  - Too little. 2.8.0 blinked the prompt BAR alone, which is 4 units and draws 2.7px at
+        //    the 16px sidebar size, against the 15.6px of perimeter the march it replaced put in
+        //    motion. It was reported illegible immediately. The whole prompt is 11.8 units, 7.9px.
+        //  - Too much. Wrapping the outline, or the whole mark, moves more ink but fades the glyph
+        //    as a whole - and the app encodes state in TONE, `text-active` working against a muted
+        //    rest. A whole-mark fade makes a working terminal periodically read as a resting one.
+        needs: /<rect [^>]*\/><g class="kng-blink"><path d="M7\.5 9\.5 L10\.5 12 L7\.5 14\.5"\/><path d="M12\.5 14\.5 H16\.5"\/><\/g>$/,
+        because:
+          'the blink must ride the whole prompt and leave the outline solid - the bar alone is '
+          + 'illegible at 16px, and including the outline fades the tone that carries the state',
+      },
+    };
+    for (const [markName, { motionClass, needs, because }] of Object.entries(primitive)) {
+      const inner = innerMarkup(readMark(markName));
+      expect(
+        inner,
+        `${markName} should carry class="${motionClass}". A round mark on kng-march freezes under `
+        + 'renderer jank; the chip on kng-spin tilts. Neither is a silent upstream call.',
+      ).toContain(`class="${motionClass}"`);
+      expect(inner, `${markName}: ${because}`).toMatch(needs);
+    }
+  });
+
+  it('leaves the terminal chip outline solid, with no dash to freeze', () => {
+    // The chip's dash is gone entirely, which is what makes `static` the right rest strategy for
+    // it now: `drop-dash` existed because a STOPPED 65/35 ring reads as broken, and there is no
+    // longer a dash to stop. A dash left behind here would render as a permanently broken chip,
+    // since nothing animates the outline any more.
+    const inner = innerMarkup(readMark('terminal-working'));
+    expect(inner, 'the working chip outline must be solid').not.toContain('stroke-dasharray');
+    expect(inner).toContain('<rect x="3" y="3" width="18" height="18" rx="3" pathLength="100"/>');
   });
 
   it('keeps the control ring at r=10, which the size-20 call sites depend on', () => {
@@ -107,60 +164,81 @@ describe('innerMarkup', () => {
     ).toContain('d="M3 7 L12 12.1566 L21 7"');
   });
 
-  it('keeps the control glyph as a sibling of the marching group, not inside it', () => {
-    // The pause bars / stop square must NOT march with the ring. They are siblings of the
-    // <g class="kng-march"> in the packaged file; a strip that reordered or nested them would
-    // set the whole glyph spinning.
+  it('keeps the control glyph as a sibling of the motion group, not inside it', () => {
+    // The pause bars / stop square must NOT animate with the ring. They are siblings of the
+    // <g class="kng-spin"> in the packaged file; a strip that reordered or nested them would
+    // set the whole glyph moving.
+    //
+    // This got sharper when the controls moved from march to spin. Nesting them under a MARCHING
+    // group was invisible (a dashoffset only affects a dashed stroke, and these are filled), so
+    // the assertion was pure insurance. Nesting them under a ROTATING group visibly turns the
+    // pause bars and the stop square. It is now the thing that stands between a correct mark and
+    // an obviously broken one.
     for (const markName of ['control-stop-working', 'control-pause-working']) {
       const inner = innerMarkup(readMark(markName));
-      const marchEnd = inner.indexOf('</g>');
-      expect(marchEnd, `${markName} has no closing </g> for its march group`).toBeGreaterThan(-1);
+      const motionEnd = inner.indexOf('</g>');
+      expect(motionEnd, `${markName} has no closing </g> for its motion group`).toBeGreaterThan(-1);
       expect(
-        inner.slice(marchEnd).includes('fill="currentColor"'),
-        `${markName} should carry its filled glyph AFTER the march group, so it does not animate`,
+        inner.slice(motionEnd).includes('fill="currentColor"'),
+        `${markName} should carry its filled glyph AFTER the motion group, or the pause bars / `
+        + 'stop square rotate with the ring',
       ).toBe(true);
     }
   });
 
   it('keeps the terminal prompt paths the Command Terminal icon reads as a shell', () => {
-    const inner = innerMarkup(readMark('terminal-working'));
-    expect(inner).toContain('M7.5 9.5 L10.5 12 L7.5 14.5');
-    expect(inner).toContain('M12.5 14.5 H16.5');
-    expect(inner).toContain('stroke-dasharray="65 35"');
+    // Both terminal states carry both prompt paths. The working mark splitting the bar into its
+    // own <g> is what the blink rides; it must not lose or move either path in the process,
+    // because the chevron plus bar IS what makes this glyph read as a shell rather than a box.
+    for (const markName of ['terminal-idle', 'terminal-working']) {
+      const inner = innerMarkup(readMark(markName));
+      expect(inner, `${markName} lost its prompt chevron`).toContain('M7.5 9.5 L10.5 12 L7.5 14.5');
+      expect(inner, `${markName} lost its prompt bar`).toContain('M12.5 14.5 H16.5');
+    }
   });
 
   it('keeps the plus glyph on the new-terminal action mark', () => {
     const inner = innerMarkup(readMark('terminal-new'));
     expect(inner).toContain('M12 8.5 V15.5');
     expect(inner).toContain('M8.5 12 H15.5');
-    // The action mark never marches: it represents a spawn, not a running terminal.
-    expect(inner).not.toContain('kng-march');
+    // The action mark never animates: it represents a spawn, not a running terminal. Checked
+    // against EVERY primitive, not just the retired march - `terminal-new` does not end in
+    // `-working`, so the motion-group sweep above never reaches it, and a march-only guard would
+    // wave through an upstream release that attached `.kng-spin` or `.kng-blink` to it.
+    expect(inner).not.toMatch(/kng-(march|spin|blink)/);
   });
 });
 
 /**
- * The marching indicator must run smoothly for as long as an agent is working. It kept
- * visibly resetting, which read as the board freezing or choking.
- *
- * Two independent causes, each guarded below:
+ * The activity indicator must run smoothly for as long as an agent is working. Three
+ * independent defects have broken that, and all three are guarded below. The first two are
+ * RESTARTS (the mark jumps back to phase zero); the third is a STALL (the mark stops
+ * producing frames). They look identical to the eye and have nothing in common mechanically,
+ * which is why diagnosing one as the other wasted a pass.
  *
  *  1. `TaskCard` rendered the idle and working marks as two SIBLING conditional slots.
  *     React reconciles unkeyed children positionally, so an idle/thinking flip was a
  *     delete at one index plus a create at the other - unmounting the <svg>, re-injecting
- *     `MARK_INNER`, and restarting the dash from zero.
- *  2. `.kng-march` lives on a node inside `dangerouslySetInnerHTML`, so it has no React
+ *     `MARK_INNER`, and restarting from zero.
+ *  2. The motion class lives on a node inside `dangerouslySetInnerHTML`, so it has no React
  *     fiber. Anything that rebuilds or merely MOVES that node (Chromium restarts CSS
  *     animations on detach/reattach) hands it a fresh animation starting at zero.
+ *  3. `stroke-dashoffset` is a paint property, so Chromium cannot composite it. A marching
+ *     mark stops dead for exactly as long as the renderer's main thread is blocked, and the
+ *     desktop measured 194 such stalls in 3.6 hours, worst 703ms.
  *
  * (1) is fixed structurally. (2) cannot be, so the animation is anchored to the document
  * timeline, making its phase a pure function of time - a rebuilt node resumes where the
- * surviving ones are, and every mark marches in lockstep.
+ * surviving ones are, and every mark moves in lockstep. (3) is fixed upstream by putting every
+ * working mark on a composited property: `transform` where the geometry allows a rotation,
+ * `opacity` where it does not. See the primitive pin above.
  *
- * The lucide spinner these replaced hid this for free: a rotating circle looks identical at
- * every phase. The dashed ring does not, which is why the restarts only became visible when
- * the marks landed.
+ * Note that (3)'s fix does NOT retire (2)'s: the set rotates a DASHED arc, so a restarted
+ * rotation snaps its gap back to 12 o'clock just as visibly as a restarted march did, and a
+ * restarted blink can land the cursor mid-off. Only the solid lucide spinner these replaced was
+ * phase-invariant, which is why the restarts became legible when the marks landed.
  */
-describe('marching indicator smoothness', () => {
+describe('activity indicator smoothness', () => {
   // Strip comments: both files deliberately DESCRIBE the retired two-slot shape so the next
   // reader knows why it changed, and a naive scan would match that prose and fail.
   const readSource = (relativePath: string): string =>
@@ -174,23 +252,70 @@ describe('marching indicator smoothness', () => {
   const taskCard = readSource('src/renderer/components/board/TaskCard.tsx');
   const activityMark = readSource('src/renderer/components/ActivityMark.tsx');
 
-  it('the packaged march is an infinite linear loop', () => {
+  it('every packaged primitive is an infinite linear loop of the SAME period', () => {
     // Timeline anchoring only makes sense for a loop with a constant period. A finite or
-    // eased march would put anchored marks permanently out of phase with each other.
-    const march = /\.kng-march\s*\{\s*animation:\s*kng-activity-march\s+(\d+)ms\s+linear\s+infinite/
-      .exec(activityCss);
+    // eased animation would put anchored marks permanently out of phase with each other.
+    const durationOf = (motionClass: string, keyframes: string): number => {
+      const shorthand = new RegExp(
+        `\\.${motionClass}\\s*\\{\\s*animation:\\s*${keyframes}\\s+(\\d+)ms\\s+linear\\s+infinite`,
+      ).exec(activityCss);
+      expect(
+        shorthand,
+        `upstream changed the .${motionClass} animation shorthand. It must stay `
+        + '`<duration>ms linear infinite` for document-timeline anchoring to keep every mark in phase.',
+      ).not.toBeNull();
+      return Number(shorthand?.[1]);
+    };
+    const periods = {
+      march: durationOf('kng-march', 'kng-activity-march'),
+      spin: durationOf('kng-spin', 'kng-activity-spin'),
+      blink: durationOf('kng-blink', 'kng-activity-blink'),
+    };
+    expect(periods.march).toBeGreaterThan(0);
+    // The periods must MATCH across all three. A rotating agent ring and a blinking Command
+    // Terminal chip sit in the SAME sidebar row, and anchoring both to the document timeline
+    // only reads as deliberate if they share a period; different periods drift them apart into
+    // N independent indicators. It is also what made the march-to-spin swap a pure performance
+    // change rather than a visible speed change on the marks that moved.
     expect(
-      march,
-      'upstream changed the .kng-march animation shorthand. It must stay `<duration>ms linear '
-      + 'infinite` for document-timeline anchoring to keep every mark in phase.',
-    ).not.toBeNull();
-    expect(Number(march?.[1])).toBeGreaterThan(0);
+      [periods.spin, periods.blink],
+      'a primitive period diverged. All are anchored to the document timeline, so a mismatch '
+      + 'drifts a rotating ring out of lockstep with the blinking chip beside it.',
+    ).toEqual([periods.march, periods.march]);
   });
 
-  it('reduced motion drops the animation entirely, so there is nothing to anchor', () => {
-    // `anchorMarchToTimeline` relies on getAnimations() being empty here rather than on a
-    // reduced-motion branch of its own.
-    expect(activityCss).toMatch(/prefers-reduced-motion[\s\S]*\.kng-march[^}]*animation:\s*none/);
+  it('the cursor blink is a cursor, not a fade', () => {
+    // The ramps are short on purpose: a slow sinusoidal fade reads as "pulsing/attention", the
+    // vocabulary animate-pulse-subtle already owns elsewhere in the app, rather than as a shell
+    // cursor. And the off state is 0.06 rather than 0, because at the 12px indicator floor a
+    // fully absent bar reads as a mark that has lost a piece.
+    expect(
+      activityCss,
+      'the blink keyframes were reshaped. Ramps longer than a few percent of the period turn the '
+      + 'cursor into a pulse, and a 0 trough reads as a mark missing a piece at the 12px floor.',
+    ).toContain('@keyframes kng-activity-blink { 0%, 44% { opacity: 1; } 50%, 94% { opacity: 0.06; } 100% { opacity: 1; } }');
+  });
+
+  it('the rotation resolves its origin in viewBox units, not the arc bbox', () => {
+    // A dashed arc's own bbox is not the circle's centre, so a percentage or fill-box origin
+    // would wobble the ring instead of spinning it. `transform-box: view-box` is the CSS
+    // initial value, but it is written out upstream precisely so this does not depend on a
+    // UA default.
+    expect(activityCss).toMatch(/\.kng-spin[^}]*transform-origin:\s*12px 12px/);
+    expect(activityCss).toMatch(/\.kng-spin[^}]*transform-box:\s*view-box/);
+  });
+
+  it('reduced motion drops EVERY animation, so there is nothing to anchor', () => {
+    // `anchorMarkMotionToTimeline` relies on getAnimations() being empty here rather than on a
+    // reduced-motion branch of its own. The rule must name every class: each time a primitive
+    // was added, a rule naming only the previous ones would have left the newest marks moving
+    // for a user who asked for no motion, silently and only for that user.
+    const reduced = /@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{([\s\S]*?)\n\}/.exec(activityCss);
+    expect(reduced, 'the packaged CSS lost its prefers-reduced-motion block').not.toBeNull();
+    for (const motionClass of ['kng-march', 'kng-spin', 'kng-blink']) {
+      expect(reduced?.[1], `reduced motion does not silence .${motionClass}`)
+        .toMatch(new RegExp(`\\.${motionClass}[^}]*animation:\\s*none`));
+    }
   });
 
   it('TaskCard renders the activity mark in ONE slot, not two conditional siblings', () => {
@@ -208,19 +333,58 @@ describe('marching indicator smoothness', () => {
     expect(taskCard).toMatch(/mark=\{isThinking \? 'agent-working' : 'agent-idle'\}/);
   });
 
-  it('ActivityMark anchors the march to the document timeline before paint', () => {
+  it('ActivityMark anchors mark motion to the document timeline before paint', () => {
     expect(
       activityMark.includes('startTime = 0'),
-      'ActivityMark no longer re-bases the march onto the document timeline. Without it a '
-      + 'rebuilt or moved node starts its dash at zero and the indicator visibly resets.',
+      'ActivityMark no longer re-bases mark motion onto the document timeline. Without it a '
+      + 'rebuilt or moved node starts at phase zero and the indicator visibly resets.',
     ).toBe(true);
 
     // A layout effect, so the phase is corrected before the frame is painted; a plain effect
     // would show one frame of the reset.
-    expect(activityMark).toMatch(/useLayoutEffect\(\(\) => \{\s*anchorMarchToTimeline/);
+    expect(activityMark).toMatch(/useLayoutEffect\(\(\) => \{\s*anchorMarkMotionToTimeline/);
 
     // No dependency array: a DOM move or a re-injection can hand us a fresh animation
     // without `mark` changing, and the anchor is idempotent so running it is free.
-    expect(activityMark).not.toMatch(/anchorMarchToTimeline\(markGroupRef\.current\);\s*\}, \[/);
+    expect(activityMark).not.toMatch(/anchorMarkMotionToTimeline\(markGroupRef\.current\);\s*\}, \[/);
+  });
+
+  it('the anchor selector covers BOTH motion classes', () => {
+    // The regression this pins actually happened in review: the selector was
+    // `querySelector('.kng-march')`, so the moment upstream moved the round marks to
+    // `.kng-spin` they stopped being anchored - and because the set rotates a DASHED arc, that
+    // reintroduces the visible restart this whole describe block exists to prevent, on exactly
+    // the marks the composite fix was meant to help. Silent, and indistinguishable by eye from
+    // the stall being fixed.
+    for (const motionClass of ['.kng-march', '.kng-spin', '.kng-blink']) {
+      expect(
+        activityMark,
+        `ActivityMark's motion selector no longer covers ${motionClass}, so those marks lose `
+        + 'their timeline anchor and visibly restart on any DOM move.',
+      ).toContain(motionClass);
+    }
+    // querySelectorAll, not querySelector: a mark can only carry one primitive today, but a
+    // single-element query silently anchors the first match and leaves any sibling adrift.
+    expect(activityMark).toMatch(/querySelectorAll\(MOTION_SELECTOR\)/);
+  });
+
+  it('the Monitor Active tile freezes BOTH primitives at zero, importantly', () => {
+    // The one consumer-side motion override in the codebase, and it has to clear two separate
+    // bars. It must name BOTH classes, because it named only `.kng-march` and so matched nothing
+    // once `agent-working` moved to `.kng-spin`. And each must be `!important`: `ActivityMark`
+    // imports the packaged CSS straight from node_modules, so `.kng-spin` arrives UNLAYERED and
+    // outranks any Tailwind utility (those compile into `@layer utilities`) at every specificity.
+    // Dropping the `!` does not weaken the override, it deletes it.
+    //
+    // This is a SOURCE SCAN, so it cannot see a lost cascade at all: an override that wins
+    // nothing still reads perfectly correct here. The real guard is the rendered red-green pair
+    // in tests/ui/agent-monitor.spec.ts; this only pins the shape so the two cannot drift.
+    const summaryCards = readSource('src/renderer/components/monitor/MonitorSummaryCards.tsx');
+    for (const motionClass of ['kng-march', 'kng-spin']) {
+      expect(
+        summaryCards,
+        `the Active tile's zero-state freeze no longer covers .${motionClass} with !important`,
+      ).toContain(`[&_.${motionClass}]:[animation:none]!`);
+    }
   });
 });


### PR DESCRIPTION
## What

The activity indicators (board cards, sidebar counts, Monitor, task-detail pause, Command Terminal toggle) no longer freeze when the renderer is busy.

Adopts `@kangentic/branding` 2.8.1, which moves every working mark's motion onto a composited property, plus the two consumer-side changes that adoption requires.

- `src/renderer/components/ActivityMark.tsx` - `anchorMarchToTimeline` renamed `anchorMarkMotionToTimeline`; its selector is now a `MOTION_SELECTOR` covering all three motion classes via `querySelectorAll`.
- `src/renderer/components/monitor/MonitorSummaryCards.tsx` - the Active tile's zero-state freeze now names both motion classes.
- Comment-only wording updates in `CommandTerminalIcon.tsx`, `CommandTerminalWindow.tsx`, `TaskDetailHeader.tsx`, `index.css`.
- `package.json` - `@kangentic/branding` `^2.7.1` -> `^2.8.1`.

## Why

The marching indicators visibly stuttered whenever the renderer was busy. Two different defects read as "stutter" and only one is fixed by compositing, so both were discriminated against the live instance before any code moved:

- **Restart: ruled out.** All five on-screen marks reported `startTime: 0`, an identical `currentTime`, and `playState: running`. The existing timeline anchor was working; a re-mount would have been invisible.
- **Stall: confirmed.** `kangentic_devtools_event_loop_lag` reported **194 renderer main-thread spikes in 3.6 hours, worst 703ms**, routinely 150-320ms.

`stroke-dashoffset` is a paint property, so Chromium cannot composite the march. The mark stops producing frames for exactly as long as the main thread is blocked. On a 1400ms period, a 300ms stall is a fifth of a lap lost.

## How

Verified in the **shipping runtime** (Electron 41, Chromium 146) rather than inferred, via CDP `Page.startScreencast` (pushed from the compositor) against a 4000ms main-thread block, with a rAF witness confirming the block landed:

| | distinct frames during the block |
|---|---|
| HTML rotation (positive control) | 349 |
| SVG `<g>` rotation | 355 |
| dashoffset march (negative control) | **0** |

So SVG-level rotation composites, and no HTML wrapper is needed.

**Geometry decides which primitive a mark can take.** To travel a dash along a perimeter, a transform must map the shape onto *itself* while advancing arc length - the shape's symmetry group.

- The three **round** marks rotate. A circle's symmetry group is continuous, and with `pathLength` normalizing the perimeter to 100, a dash-offset shift of *d* is exactly a rotation of *d* percent of 360 degrees. This is the same image, not an approximation: confirmed by pixel diff across eight phases, 0 to 2.2 percent of ink differing once edge antialiasing is averaged out.
- The **terminal chip** blinks its prompt. A rounded square's symmetry group is discrete (four 90 degree rotations, nothing between), so no transform can travel a dash around it at all. Rejected before redesigning it: a rotating mask (the gap would stretch and shrink ~41% per lap, since the chip runs 9 units from centre at a side midpoint and 12.73 at a corner), N dash segments crossfading opacity (quantized, or a comet tail, and N composited layers per 16px glyph), and giving the chip the ring silhouette (collides with `agent-working`, which shares its sidebar row).

### Two traps worth a reviewer's attention

Both would have silently reintroduced the bug, and no existing test caught either:

1. **The timeline anchor** selected `.kng-march` alone. A rotating mark is *not* phase-invariant - the set rotates a **dashed** arc, and a restarted blink can land mid-off - so every mark upstream moved would have lost its anchor and visibly restarted. That is indistinguishable by eye from the stall being fixed.
2. **The Monitor Active tile** freezes its mark at a zero count with `[&_.kng-march]:[animation:none]`. It names the class, so after the swap it matched nothing and an idle machine's chrome spun forever.

### Honest ceiling

Compositing decouples the indicator from renderer main-thread jank. It does **not** survive a blocked main *process* or a GPU-side stall. Reducing the jank itself is filed separately, together with the `Opus 5 / 48%` progress bar, which animates a layout property and is the same class of problem one layer down.

## Breaking changes

None for this app. The upstream package change is visible, though:

- `terminal-working` is redrawn (solid outline + blinking prompt instead of a travelling `65 35` dash), and its `reducedMotion` moves `drop-dash` -> `static`. No behavior change at rest, because `drop-dash` already resolved it to byte-identical geometry with `terminal-idle`.
- `agent-working` and both control rings are visually unchanged.
- `kangentic-mobile` consumes the same package and pins `^2.7.1`. Its `syncBranding.mjs` hard-fails on the new motion by design, so it is unaffected until it upgrades deliberately; a task is filed there.

## Tests

CI runs the full unit, UI, and Electron E2E tiers. Locally verified against a real install (not a junctioned `node_modules`): typecheck, lint, 53 unit and 123 UI specs.

Tests widened rather than deleted, since each assertion was load-bearing:

- Which primitive each working mark uses is now pinned per mark, with the companion each needs (an outline primitive is invisible without a dash; the blink needs its own element to ride, and wrapping the outline would fade the tone that carries working-vs-resting).
- All three primitives are asserted to share one period, which is what keeps a rotating ring in lockstep with a blinking chip in the same sidebar row.
- Reduced motion is asserted for every primitive, plus that a stopped blink rests **visible** rather than at its 0.06 trough (the packaged CSS ships no animation fill mode precisely so it can).
- New: every mark on screen is anchored to the document timeline, and the Monitor freeze covers both classes. These are the two traps above.
- New (coverage pass): a mark **rebuilt after mount** re-anchors instead of keeping its own creation-time phase. Every prior anchor assertion seeded the mark as working from the first paint, so only the layout effect's first invocation was exercised - never the idle -> working flip that hands it a fresh node. Red-green: mutating the effect to `}, [])` fails with `startTime: 1611.08` instead of `0`.
- Fixed a weak assertion found while widening the reduced-motion test: it read a child `<path>`'s computed opacity, which resolves to `1` regardless of the group's fade, so it would have passed with the blink group stuck at its trough. It now reads the group.

### Note on the review commit

`test(review): pin the Monitor Active tile freeze, and resync the march prose` is a separate commit from the Code Review column's pass, left as-authored. Its finding is load-bearing and worth reading: widening the Monitor freeze to `.kng-spin` was **necessary but not sufficient**. `ActivityMark` imports the packaged `activity.css` from `node_modules`, so the rule arrives **unlayered** and outranks every Tailwind utility (which compile into `@layer utilities`); without the trailing `!` the override loses the cascade outright and does nothing. The tile had in fact been animating at a zero count since it adopted the shared marks. A source-scan test cannot see a lost cascade, which is why that pass added a rendered red-green pair in `agent-monitor.spec.ts`.

Generated with [Claude Code](https://claude.com/claude-code)
