### PR TITLE
fix(theme): give the control fill a visible step against its ground

### DIFF
--- a/src/renderer/components/DescriptionEditor.tsx
+++ b/src/renderer/components/DescriptionEditor.tsx
@@ -294,7 +294,7 @@ export function DescriptionEditor({
                 roughly half the box for a secondary hint. */}
             <div className="absolute inset-0 flex items-center justify-center">
               {/* `fg-muted`, not `fg-disabled`: this is an instruction, and at
-                  `fg-disabled` it sat at 1.58:1 on the control fill - the
+                  `fg-disabled` it sat at 1.48:1 on the control fill - the
                   weakest text in the app. Nothing here is disabled. */}
               <span className="inline-flex items-center gap-2 rounded-md border border-dashed border-edge px-3 py-1.5 text-xs text-fg-muted">
                 <Paperclip size={14} />
@@ -305,7 +305,7 @@ export function DescriptionEditor({
         )}
         {showPreview && (
           <div
-            className="absolute inset-0 bg-surface-control pl-3 pr-28 py-2 overflow-y-auto"
+            className="markdown-on-control absolute inset-0 bg-surface-control pl-3 pr-28 py-2 overflow-y-auto"
             data-testid="description-preview"
           >
             {value ? (

--- a/src/renderer/components/Field.tsx
+++ b/src/renderer/components/Field.tsx
@@ -14,15 +14,23 @@ import { Info } from 'lucide-react';
  * `--kng-surface-control` is a DEDICATED token, not a borrowed one, and that is
  * the point. Inputs, comboboxes, and `ToggleCard` all reference it, so a card
  * and the dropdown beside it read as one family - and re-tuning the control fill
- * is one value per theme rather than a sweep across ~19 files. It exists because
- * neither neighbouring token worked: `surface` is too dark (and nearly
- * theme-neutral, so every theme looked alike inside a dialog) while
- * `surface-hover` is too light, and there was nothing between them. Each theme's
- * value is 60% of the way from `surface-raised` to `surface-hover`.
+ * is one value per theme rather than a sweep across ~19 files. Each theme's
+ * value is tuned to a ~1.3:1 step against `surface-raised` (the ground under
+ * BaseDialog, the task-detail window, and the settings panel), extrapolated
+ * along the theme's own raised-to-hover hue ray. The first cut sat 60% of the
+ * way from `surface-raised` to `surface-hover` and did not register (1.09-1.22:1
+ * against that ground): the compressed themes' whole raised-to-hover span falls
+ * short of that same ~1.3:1 step, which is why the fill now sits at or PAST
+ * `surface-hover` where it must. That collapse is safe because nothing grounds a control on
+ * full-strength `surface-hover` - the fill's real neighbours are `surface-raised`
+ * and the segmented track's `surface`, and the fill carrying the separation also
+ * means `edge-input` is now redundant-by-design against the fill in the
+ * compressed themes (the border's job is the ground side, where it stays
+ * legible). `tests/unit/theme-contrast.test.ts` enforces the separation floors.
  *
  * Text ON this fill has to be chosen against the WHOLE theme set, not the
  * default one - that mistake cost several rounds. Worst-case ratios across all
- * 10 themes: `fg` 8.88:1, `fg-tertiary` 4.84:1, `fg-muted` 3.34:1. So anything a
+ * 10 themes: `fg` 8.49:1, `fg-tertiary` 4.63:1, `fg-muted` 3.19:1. So anything a
  * user must read stays at `fg-tertiary` or brighter; `fg-muted` and `fg-faint`
  * are for hint text and decoration. Value text is `fg-tertiary`, placeholders
  * are `fg-muted` (deliberately sub-AA: a placeholder must read dimmer than the

--- a/src/renderer/components/NameFromPromptButton.tsx
+++ b/src/renderer/components/NameFromPromptButton.tsx
@@ -95,7 +95,11 @@ export function NameFromPromptButton({ description, onTitle }: NameFromPromptBut
       data-testid="name-from-prompt-button"
       aria-label="Generate a title from the description"
       title="Generate a title from the description"
-      className="flex-shrink-0 inline-flex items-center justify-center w-9 h-9 text-fg-muted hover:text-accent-fg bg-surface hover:bg-surface-hover border border-edge-input hover:border-accent rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      // `surface-control`, matching the title input beside it (see
+      // FIELD_CONTROL_BASE in `Field.tsx` for why the token exists). Hover stays
+      // border + text only: the fill can sit at or past `surface-hover`, so a bg
+      // swap there would be invisible or inverted.
+      className="flex-shrink-0 inline-flex items-center justify-center w-9 h-9 text-fg-muted hover:text-accent-fg bg-surface-control border border-edge-input hover:border-accent rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
     >
       {isPending ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
     </button>

--- a/src/renderer/components/SegmentedControl.tsx
+++ b/src/renderer/components/SegmentedControl.tsx
@@ -18,16 +18,15 @@ interface SegmentedControlProps<T extends string> {
   onChange: (value: T) => void;
   /**
    * Which ground the control sits on. This is a real fork, not a style
-   * preference: the surface ramp INVERTS between themes. In dark themes
-   * `surface-hover` (#3f3f46) is the lightest of the three surface tokens, but in
-   * the light themes it is the DARKEST (#e7e5e4, against `surface-raised`
-   * #fafaf9). So one hardcoded thumb fill reads as "raised" in dark and
-   * "pressed" in light, and which of those is correct depends on the ground.
+   * preference: the surface ramp INVERTS between themes. In dark themes the
+   * control fill is LIGHTER than its ground; in the light themes it is DARKER.
+   * So one hardcoded thumb fill reads as "raised" in dark and "pressed" in
+   * light, and which of those is correct depends on the ground.
    *
    *   - `'control'` (default) - the control sits in a form row on a
    *     `surface-raised` ground, beside `Select` / `Combobox`. The thumb takes
-   *     `surface-hover`, the same fill those controls use, so a segmented control
-   *     and a select in one row read as the same species of control.
+   *     `surface-control`, the same fill those controls use, so a segmented
+   *     control and a select in one row read as the same species of control.
    *   - `'raised'` - the control sits on the app ground (the board toolbar). The
    *     thumb takes `surface-raised`, which stays lighter than its track in every
    *     theme.

--- a/src/renderer/components/ToggleCard.tsx
+++ b/src/renderer/components/ToggleCard.tsx
@@ -24,15 +24,15 @@ interface ToggleCardProps {
 }
 
 /**
- * `surface-hover` + `edge-input`, the same shell every input uses (see
+ * `surface-control` + `edge-input`, the same shell every input uses (see
  * `FIELD_CONTROL_BASE`), so a card and the dropdown beside it are one family.
  *
  * It was previously `surface/40`, a translucent value that composited to a
  * third dark matching nothing. The reason a card can share the input fill is
- * that its DESCRIPTION steps up to `fg-tertiary` (7.05:1 here, AAA). At
- * `fg-faint` the same line is 2.14:1 and effectively unreadable, which is what
- * made an earlier attempt at this fail - the fill was never the problem, the
- * faint text on it was.
+ * that its DESCRIPTION steps up to `fg-tertiary` (7.75:1 in the default theme,
+ * AAA). At `fg-faint` the same line is 2.37:1 and effectively unreadable, which
+ * is what made an earlier attempt at this fail - the fill was never the
+ * problem, the faint text on it was.
  */
 const TOGGLE_CARD_SURFACE = {
   enabled: 'bg-surface-control border-edge-input hover:border-fg-faint',

--- a/src/renderer/components/dialogs/Combobox.tsx
+++ b/src/renderer/components/dialogs/Combobox.tsx
@@ -214,7 +214,7 @@ export function Combobox({
 
   return (
     <div ref={containerRef} className={`relative ${className}${disabled ? ' opacity-60' : ''}`}>
-      {/* `surface-hover`, matching FIELD_CONTROL_BASE: this is an input, not a
+      {/* `surface-control`, matching FIELD_CONTROL_BASE: this is an input, not a
           text-bearing card. See the note there for the split. */}
       <div className="flex items-center gap-0 border border-edge-input rounded bg-surface-control">
         <input

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -29,7 +29,7 @@
   --kng-surface: #18181b;          /* zinc-900 */
   --kng-surface-raised: #27272a;   /* zinc-800 */
   --kng-surface-hover: #3f3f46;    /* zinc-700 */
-  --kng-surface-control: #35353b;
+  --kng-surface-control: #393940;
   --kng-surface-inset: #18181b;    /* zinc-900 */
 
   /* Foreground (text) */
@@ -82,7 +82,7 @@
   --kng-surface: #f5f5f4;          /* stone-100 */
   --kng-surface-raised: #fafaf9;   /* stone-50 */
   --kng-surface-hover: #e7e5e4;    /* stone-200 */
-  --kng-surface-control: #efedec;
+  --kng-surface-control: #e1dedd;
   --kng-surface-inset: #ffffff;
 
   /* Foreground (text) */
@@ -111,7 +111,7 @@
   --kng-surface: #1a1d2e;
   --kng-surface-raised: #232740;
   --kng-surface-hover: #2e3350;
-  --kng-surface-control: #2a2e4a;
+  --kng-surface-control: #333958;
   --kng-surface-inset: #141623;
   --kng-fg: #e0e2e8;
   --kng-fg-secondary: #c6c8d0;
@@ -132,7 +132,7 @@
   --kng-surface: #1a2318;
   --kng-surface-raised: #222e1f;
   --kng-surface-hover: #2e3e2a;
-  --kng-surface-control: #293826;
+  --kng-surface-control: #31412c;
   --kng-surface-inset: #151c13;
   --kng-fg: #e0e4de;
   --kng-fg-secondary: #c6cac4;
@@ -153,7 +153,7 @@
   --kng-surface: #0f1923;
   --kng-surface-raised: #162231;
   --kng-surface-hover: #1e2e42;
-  --kng-surface-control: #1b293b;
+  --kng-surface-control: #23364d;
   --kng-surface-inset: #0b1318;
   --kng-fg: #dae0e6;
   --kng-fg-secondary: #c0c6ce;
@@ -174,7 +174,7 @@
   --kng-surface: #1f1a17;
   --kng-surface-raised: #2a2320;
   --kng-surface-hover: #38302a;
-  --kng-surface-control: #322b26;
+  --kng-surface-control: #3e362e;
   --kng-surface-inset: #181412;
   --kng-fg: #e6e2de;
   --kng-fg-secondary: #ccc8c4;
@@ -197,7 +197,7 @@
   --kng-surface: #f5f0e8;
   --kng-surface-raised: #faf8f3;
   --kng-surface-hover: #e8e0d4;
-  --kng-surface-control: #efeae0;
+  --kng-surface-control: #e5dbce;
   --kng-surface-inset: #ffffff;
   --kng-fg: #2a2218;
   --kng-fg-secondary: #3d3228;
@@ -218,7 +218,7 @@
   --kng-surface: #eef5f0;
   --kng-surface-raised: #f7faf8;
   --kng-surface-hover: #d8e8dd;
-  --kng-surface-control: #e4efe8;
+  --kng-surface-control: #cfe3d6;
   --kng-surface-inset: #ffffff;
   --kng-fg: #142820;
   --kng-fg-secondary: #1e3028;
@@ -239,7 +239,7 @@
   --kng-surface: #edf3f8;
   --kng-surface-raised: #f6f9fc;
   --kng-surface-hover: #d6e4f0;
-  --kng-surface-control: #e3ecf5;
+  --kng-surface-control: #cfdfed;
   --kng-surface-inset: #ffffff;
   --kng-fg: #121e2e;
   --kng-fg-secondary: #1a2a3a;
@@ -260,7 +260,7 @@
   --kng-surface: #f8f0ec;
   --kng-surface-raised: #fcf8f6;
   --kng-surface-hover: #ecd8d0;
-  --kng-surface-control: #f2e5df;
+  --kng-surface-control: #edd9d2;
   --kng-surface-inset: #ffffff;
   --kng-fg: #2a1c18;
   --kng-fg-secondary: #3a2520;
@@ -697,6 +697,22 @@
   font-size: 0.875rem;
   line-height: 1.625;
   overflow-wrap: anywhere;
+}
+
+/* Markdown rendered ON the control fill (the description preview) steps its body
+   text up from `fg-muted` to `fg-tertiary`. `fg-muted` is the hint/decoration
+   tier: on this fill it reads 4.47:1 in the default theme, under AA, and 3.19:1
+   at worst, while a rendered description is content a user must read.
+   `fg-tertiary` clears AA on this fill in every theme (worst 4.63:1) and is what
+   the edit-mode textarea already uses, so Preview and Edit read at one tier.
+   Scoped rather than applied to `.markdown-body` itself because the other
+   markdown surfaces sit on grounds the control fill does not affect.
+
+   Unlayered on purpose, like `.markdown-body` above: a Tailwind utility compiles
+   into `@layer utilities`, which loses to an unlayered rule outright no matter
+   how specific the selector looks. */
+.markdown-on-control .markdown-body {
+  color: var(--kng-fg-tertiary);
 }
 
 .markdown-body > :first-child {

--- a/tests/unit/markdown-on-control-pairing.test.ts
+++ b/tests/unit/markdown-on-control-pairing.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Pairs `DescriptionEditor`'s `markdown-on-control` class with the CSS rule
+ * that consumes it. The two are wired together only by a bare string
+ * ("markdown-on-control") shared across two unrelated files, so neither side
+ * proves the pairing on its own: dropping the class from the preview div still
+ * compiles and still passes `tests/unit/theme-contrast.test.ts` (which checks
+ * token *values*, not which class applies which token), and so does deleting
+ * or renaming the CSS selector.
+ *
+ * Without the class, the preview's rendered markdown falls back to the base
+ * `.markdown-body` rule (`fg-muted`), which reads under WCAG AA against
+ * `surface-control` in every theme (see the comment above the CSS rule and
+ * `theme-contrast.test.ts`'s MUST_READ 'control value' entry for the same
+ * pairing at `fg-tertiary`, which does clear AA). This test is the only thing
+ * that would catch either half of the pairing silently breaking.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const DESCRIPTION_EDITOR_PATH = path.join(REPO_ROOT, 'src/renderer/components/DescriptionEditor.tsx');
+const INDEX_CSS_PATH = path.join(REPO_ROOT, 'src/renderer/index.css');
+const MARKDOWN_RENDERER_PATH = path.join(REPO_ROOT, 'src/renderer/components/MarkdownRenderer.tsx');
+
+describe('DescriptionEditor preview pane <-> .markdown-on-control CSS pairing', () => {
+  it('applies markdown-on-control to the preview pane alongside bg-surface-control', () => {
+    const source = fs.readFileSync(DESCRIPTION_EDITOR_PATH, 'utf-8');
+    const match = source.match(/<div\s+className="([^"]*)"\s+data-testid="description-preview"/);
+    expect(match, 'could not find the description-preview div in DescriptionEditor.tsx').not.toBeNull();
+
+    const classNames = (match?.[1] ?? '').split(/\s+/).filter(Boolean);
+    expect(classNames).toContain('markdown-on-control');
+    // The class is meaningless without the fill it steps the text up against;
+    // guard the pairing, not just the class's bare presence.
+    expect(classNames).toContain('bg-surface-control');
+  });
+
+  it('index.css steps .markdown-on-control .markdown-body up to fg-tertiary', () => {
+    const css = fs.readFileSync(INDEX_CSS_PATH, 'utf-8');
+    const normalized = css.replace(/\s+/g, ' ');
+    expect(normalized).toContain('.markdown-on-control .markdown-body { color: var(--kng-fg-tertiary); }');
+  });
+
+  it('the un-scoped .markdown-body rule this override steps up from is still fg-muted', () => {
+    // Anchors the "steps up FROM" half of the pairing: if the base rule ever
+    // changed to something already AA-safe on surface-control, the override
+    // (and this whole test) would no longer be guarding a real regression.
+    const css = fs.readFileSync(INDEX_CSS_PATH, 'utf-8');
+    const normalized = css.replace(/\s+/g, ' ');
+    expect(normalized).toContain('.markdown-body { color: var(--kng-fg-muted);');
+  });
+
+  it('MarkdownRenderer still renders its content inside a .markdown-body element', () => {
+    // The CSS rule is a DESCENDANT selector (`.markdown-on-control
+    // .markdown-body`), so the pairing also depends on MarkdownRenderer
+    // actually emitting `.markdown-body` under the preview div. Without this,
+    // the two assertions above could both stay green while the descendant
+    // selector matches nothing and the preview silently falls back to
+    // unstyled/inherited text color.
+    const source = fs.readFileSync(MARKDOWN_RENDERER_PATH, 'utf-8');
+    expect(source).toContain('className={`markdown-body');
+  });
+});

--- a/tests/unit/theme-contrast.test.ts
+++ b/tests/unit/theme-contrast.test.ts
@@ -15,6 +15,11 @@
  * exempt and listed explicitly, because it must stay dimmer than the value it
  * stands in for - if it matched, an empty field would be indistinguishable from
  * a filled one.
+ *
+ * It also guards SURFACE separation, for the same reason: the control fill
+ * shipped at 1.09-1.22:1 against the dialog ground because it was only ever
+ * eyeballed in the default theme, and an input that does not announce itself is
+ * invisible in exactly the themes nobody has open.
  */
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
@@ -81,12 +86,40 @@ const MUST_READ: { what: string; foreground: string; background: string }[] = [
   { what: 'control value', foreground: 'fg-tertiary', background: 'surface-control' },
 ];
 
+/**
+ * The grounds the control fill actually sits on, and the minimum separation
+ * that still reads at a glance. `surface-raised` is the ground under BaseDialog,
+ * the task-detail window, and the settings panel; `surface` is the
+ * SegmentedControl 'control' track.
+ *
+ * Both floors sit ~0.03 below the tightest theme, which is the margin a
+ * per-theme nudge needs before it fails. They are not the same KIND of number
+ * though: `surface-raised` is the tuning target, so its 1.25 tracks the ~1.3:1
+ * step the tokens are cut to (see FIELD_CONTROL_BASE in `Field.tsx`), while
+ * separation from `surface` is only a side effect of that tuning and ranges
+ * 1.21-1.55 across themes, so 1.17 is empirical rather than derived.
+ *
+ * There is deliberately NO floor against `surface-hover`: nothing grounds a
+ * control on it (hover appears near the control fill only as transient hover
+ * states and sub-50% tints), and the compressed themes' entire raised-to-hover
+ * span is smaller than any visible step, so the control fill legitimately sits
+ * at or past `surface-hover` in those themes.
+ */
+const CONTROL_SEPARATION_FLOORS: { ground: string; floor: number }[] = [
+  { ground: 'surface-raised', floor: 1.25 },
+  { ground: 'surface', floor: 1.17 },
+];
+
 describe('theme contrast (all themes, not just the default)', () => {
   const themes = parseThemes(CSS);
 
   it('parses every theme in index.css', () => {
     // Guards against the scan silently matching nothing and passing vacuously.
-    expect(themes.length).toBeGreaterThanOrEqual(8);
+    // Pinned to the CSS's own declaration count rather than a fixed floor: a
+    // theme the parser failed to match would still clear a floor, and would then
+    // exempt itself from every assertion below without failing anything.
+    const declaredControlFills = CSS.match(/--kng-surface-control\s*:/g) ?? [];
+    expect(themes.length).toBe(declaredControlFills.length);
     expect(themes.some((theme) => theme.name.includes(':root'))).toBe(true);
   });
 
@@ -101,6 +134,24 @@ describe('theme contrast (all themes, not just the default)', () => {
         if (ratio < AA_NORMAL_TEXT) {
           failures.push(
             `${theme.name}: ${pairing.what} (${pairing.foreground} on ${pairing.background}) = ${ratio.toFixed(2)}:1`,
+          );
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it('keeps the control fill visibly separated from every ground it sits on', () => {
+    const failures: string[] = [];
+    for (const theme of themes) {
+      const control = theme.vars['surface-control'];
+      for (const { ground, floor } of CONTROL_SEPARATION_FLOORS) {
+        const groundValue = theme.vars[ground];
+        if (!control || !groundValue) continue;
+        const ratio = contrastRatio(control, groundValue);
+        if (ratio < floor) {
+          failures.push(
+            `${theme.name}: surface-control on ${ground} = ${ratio.toFixed(3)}:1 (floor ${floor}:1)`,
           );
         }
       }


### PR DESCRIPTION
## What

Retunes `--kng-surface-control` in all 10 themes so a form control's fill actually reads as a distinct surface, adopts the token on the one control that never took it, and adds a mechanical floor so the separation cannot silently flatten again.

- `src/renderer/index.css` - a new per-theme value for `--kng-surface-control`, plus a `.markdown-on-control` rule.
- `src/renderer/components/NameFromPromptButton.tsx` - the sparkle "name from prompt" button adopts the shared control fill.
- `tests/unit/theme-contrast.test.ts` - separation floors against both grounds, and a vacuous-pass guard on the theme parser.
- `Field.tsx`, `ToggleCard.tsx`, `SegmentedControl.tsx`, `dialogs/Combobox.tsx` - comment-only corrections (three named `surface-hover` for a fill that is really `surface-control`).

## Why

Follow-up to `6adcd030`, which introduced `--kng-surface-control` so a control reads as a distinct fill rather than a hardcoded grey. The step it shipped with was too small to register: measured across the theme set, the fill sat 1.09 to 1.22:1 from `surface-raised`, the ground under BaseDialog, the task-detail window, and the settings panel. In practice the New Task title input was the same colour as the dialog it sat in and never announced itself as an editable field.

Separately, `NameFromPromptButton` still rendered `bg-surface hover:bg-surface-hover`, so the sparkle button was a visibly different surface from the input it is paired with.

## How

Each theme's value is extrapolated along its own raised-to-hover hue ray to roughly 1.3:1 against `surface-raised`, keeping direction per polarity: lighter than the ground in the dark themes, darker in the light ones.

Two things are worth a reviewer's attention:

**The fill now sits at or past `surface-hover` in the compressed themes.** That looks wrong at first glance, but no value inside the raised-to-hover span could have fixed this: moon's entire span is 1.19:1. The collapse is safe because nothing grounds a control on full-strength `surface-hover`. Near the control fill it appears only as a transient hover state and as sub-50% tints. For that same reason the button's background hover swap was dropped rather than kept, since past the retune it would be invisible or inverted depending on theme; hover feedback rides the border and text, as `ToggleCard` already does.

**Every foreground on that fill moved with it.** The `fix(review)` commit on this branch caught one that crossed below AA in three themes (the description preview's `.markdown-body`, which bases at `fg-muted`) and steps it to `fg-tertiary`. Its CSS rule lands in the following commit because `index.css` was already dirty when that pass ran; the class and its rule are useless apart. AA on the fill holds everywhere else, worst `fg-tertiary` 4.63:1 in forest.

The `theme-contrast` floors are deliberately asymmetric: 1.25 against `surface-raised` tracks the tuning target, while 1.17 against `surface` is empirical, since separation from `surface` is only a side effect of that tuning. There is no floor against `surface-hover`, for the reason above.

## Breaking changes

None. No token was added or removed, no theme was added, removed, or renamed, and no component API changed.

## Tests

- `tests/unit/theme-contrast.test.ts` gains the separation floors for both grounds, so a future per-theme edit that flattens a control fill fails in CI rather than shipping to a theme nobody has open. It also pins the theme-parse count to the CSS's own declaration count, closing a vacuous-pass hole where an unmatched theme would have exempted itself from every assertion.
- Verified visually rather than on hex values alone: the New Task dialog and the settings panel were rendered in all 10 themes through the UI harness and inspected, and the change was then re-checked live in a running dev instance, where the button and the input beside it compute an identical fill and border.
- Existing `tests/ui/auto-name-from-prompt.spec.ts` covers the changed button's gating and click-to-title flow.
- Full lint, typecheck, unit, UI, and Linux Electron E2E tiers run as the PR checks.

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] No em-dashes or `--` used as punctuation
- [x] Tests added or updated for this change
- [x] Docs updated if anchor source changed (types, IPC channels, migrations, adapters, settings) - audited, no anchor touched: no theme was added, removed, or renamed
- [x] Ran `npm run lint`, `npm run typecheck`, and the relevant tests locally
- [ ] Screenshot or clip included (UI changes) - rendered in all 10 themes and inspected, and re-checked live in a running instance, but the captures are not attached here
- [ ] CLA signed (or will sign on first PR)

Generated with [Claude Code](https://claude.com/claude-code)
