### PR TITLE
fix(terminal): arbitrate which terminal takes focus on arrival

### DIFF
--- a/.claude/rules/terminal-arrival-focus.md
+++ b/.claude/rules/terminal-arrival-focus.md
@@ -1,0 +1,74 @@
+---
+paths:
+  - "src/renderer/**"
+---
+# Rule: an arriving terminal never decides its own focus
+
+A terminal "arrives" when it finishes mounting or replaying: the deferred-init `focus()`, the
+mount-time scrollback replay, and any reload the caller did not opt out of. Several terminals can
+arrive within a few frames of each other, and their finish order is not knowable in advance:
+opening a task detail claims that task's session, which evicts the bottom panel's selection and
+makes it mount a terminal for a DIFFERENT session at the same moment; each then fetches
+scrollback, which main deliberately delays 150-400ms while the agent TUI's repaint settles.
+
+When every one of those paths ended in an unconditional `xterm.focus()`, whichever replay resolved
+last won. The user opened a task, started typing, and the keystrokes went to whatever agent the
+panel had fallen back to (the reported case typed `/compact` into the wrong session). It presented
+as intermittent, which was the mechanism, not flakiness. The same grab also silently re-pointed the
+dictation target, since `noteTerminalFocus` is wired to the textarea's `focus` event and cannot
+tell a programmatic focus from a user one.
+
+## The rule
+
+**Arrival focus is decided by user-intent state, never by replay order or rAF order.** Route every
+programmatic focus on an arriving terminal through `mayTakeArrivalFocus(sessionId)`
+(`src/renderer/utils/terminal-arrival-focus.ts`). Hosts own the policy and pass it to `useTerminal`
+as the `mayTakeArrivalFocus` option, so the hook stays surface-agnostic.
+
+- **Tiers are EXCLUSIVE.** A tier that resolves an answer decides: it allows a match and DENIES a
+  mismatch. It never falls through to a lower tier that might allow. A falling-through tier
+  degrades straight back into a race, because two terminals arriving in the same frame would both
+  find themselves permitted.
+- **Do not gate on `document.activeElement` alone.** Both terminals arrive with focus in the same
+  place, so an "is focus orphaned" test just converts "last replay wins" into "first rAF wins", and
+  it blocks the detail terminal outright whenever the clicked board card kept focus.
+- **A gesture that names a terminal which has not mounted yet must claim it**
+  (`claimArrivalFocus`). The bottom panel is not a window, so clicking its tab or expanding it
+  moves no layer's `focusedWindowId` and tier 2 would otherwise deny it forever.
+- **Genuinely user-initiated focus stays unconditional** and must NOT be routed through the
+  arbiter: pointer-down on a window frame, a file drop on a terminal, the maximize/restore
+  re-homing, and the imperative `focus()` those use.
+- **Do not reuse the word "focused" for this.** `focused-terminals.ts` already owns it for the
+  PTY-stream focused SET (which sessions main forwards bytes for). This is keyboard focus, and
+  exactly one terminal holds it.
+
+## Enforcement (self-maintaining)
+
+- **Test (sites):** `tests/unit/terminal-arrival-focus-sites.test.ts` scans the terminal-host files
+  under `src/renderer/**` (those that call `useTerminal(` or reference `.xterm-helper-textarea`)
+  and fails on any focus call that is neither guarded by `mayTakeArrivalFocus` nor carries an
+  `// arrival-focus-ok: <reason>` marker. It matches bare `focus()` as well as `.focus()`, because
+  three of the real sites call a destructured `focus` with no receiver and a `\.focus\(\)` pattern
+  would skip exactly the sites the rule exists to protect. Runs in CI via `npm run test:unit`.
+- **Test (policy):** `tests/unit/terminal-arrival-focus.test.ts` pins the tier order and, in
+  particular, that a `claim-mismatch` and a `window-mismatch` both DENY rather than fall through.
+  Every mismatch case is constructed so the next tier down would have allowed it.
+- **Test (behavior):** `tests/ui/terminal-arrival-focus.spec.ts` drives the real race with a
+  per-session replay delay and asserts focus stays in the just-opened detail, plus that a panel tab
+  click still focuses its own terminal.
+- **Review:** `/code-review` flags a new arrival path that focuses unconditionally.
+
+**Mechanical coverage is deliberately incomplete on the CLAIM side, and this is the gap:** the
+site scan can see a focus call that is not arbitrated, but it cannot see a user gesture that
+SHOULD have claimed and did not - that requires knowing the gesture names a terminal which has not
+mounted yet, which is not statically expressible. A new panel-side gesture that skips
+`claimArrivalFocus` therefore fails no unit test; its terminal simply mounts unfocused whenever a
+window holds window-layer focus. The behavior spec's second and third tests are the only guard, so
+extend them when a new claiming gesture is added.
+
+## Scope
+
+Programmatic focus on terminals under `src/renderer/`. Does not govern focus inside a terminal's
+own input handling, non-terminal focus (dialogs, form fields, menus), or the PTY-stream focused set
+in `focused-terminals.ts` / `focused-sessions.ts`, which is a different mechanism with a
+confusingly similar name.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,6 +388,7 @@ session; rules with one load when you touch matching files. Each rule names its 
 - `settings-tab-scope.md` - a setting's tab must match its persistence scope; a project-scoped setting in a system tab silently drops its write with no project open (`src/renderer/components/settings/settings-registry.ts`, `settings-tabs.ts`, `tabs/**`).
 - `derived-detail-ownership.md` - task-detail ownership is reported as a host's COMPLETE mounted set and reconciled, never accumulated from claim/release; the reporter mounts where it outlives the window store (`src/main/task-detail/**`, `src/renderer/window-manager/bridge/**`, `src/renderer/components/monitor/**`).
 - `retained-pane-never-remounts.md` - a task-detail window whose Browser pane is open is RETAINED across a project switch so its `<webview>` guest survives; never re-parent it, never change its tree shape above `BrowserPane`, and hide it with `opacity: 0` only (`src/renderer/window-manager/**`, `src/renderer/components/browser/**`).
+- `terminal-arrival-focus.md` - an arriving terminal never decides its own focus; route programmatic focus through `mayTakeArrivalFocus`, keep the tiers exclusive, and mark genuine user gestures `// arrival-focus-ok:` (`src/renderer/**`).
 
 **Local overrides:** there is no per-rule local file. Put machine-specific instruction
 overrides in a gitignored `CLAUDE.local.md` at the project root.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -668,11 +668,11 @@ State: `tasks`, `swimlanes`, `archivedTasks`, `loading`, `completingTask`, `comp
 
 ### SessionStore (`session-store.ts`)
 
-State: `sessions`, `activeSessionId`, `openTaskId`, `dialogSessionIds`, `sessionUsage`, `sessionActivity`, `sessionEvents`
+State: `sessions`, `activeSessionId`, `detailTaskId`, `dialogSessionIds`, `sessionUsage`, `sessionActivity`, `sessionEvents`
 
 - **Terminal ownership handoff** -- `dialogSessionIds` (a string array) lists every session owned by an open task-detail window, so the bottom panel never renders an xterm for a session a window already owns (one xterm per PTY). It replaced the scalar `dialogSessionId` once task detail became modeless and multiple windows can stack. When a window claims a session, the panel unmounts that session's xterm; on release, the panel recreates from scrollback. The array is renderer-GLOBAL, not per-layer: `useWindowSessionClaims` reconciles it across every window-manager instance in the renderer (`allWindowManagers` - board, Command Terminal, Agent Monitor), resolving each window's taskId through its manager's `anchorToTaskId` since the board anchors by taskId and the monitor by `projectId:taskId`. A reconciler that walked one layer would treat the other layers' claims as stale and erase them, putting a second xterm on a live PTY.
 - **HMR store re-sync** -- The `vite:afterUpdate` handler in `App.tsx` re-fetches all IPC-backed stores (project, config, board, session) after Vite HMR replaces modules, preventing stores from reverting to defaults. A unit test (`hmr-resync.test.ts`) enforces that new stores are included. Usage and events are scoped to the current project; activity is fetched unscoped so sidebar badges work across all projects.
-- **Project switch cleanup** -- On project switch, `activeSessionId`, `dialogSessionIds`, `openTaskId`, `sessionUsage`, and `sessionEvents` are cleared before re-syncing. A generation counter invalidates in-flight syncs from the previous project. `sessionActivity` and `sessions` are preserved for sidebar badge rendering. After sync completes, any `_pendingOpenTaskId` (set by notification click) is applied and cleared.
+- **Project switch cleanup** -- On project switch, `activeSessionId`, `dialogSessionIds`, `detailTaskId`, `sessionUsage`, and `sessionEvents` are cleared before re-syncing. A generation counter invalidates in-flight syncs from the previous project. `sessionActivity` and `sessions` are preserved for sidebar badge rendering. After sync completes, any `_pendingOpenTaskId` (set by notification click) is applied and cleared.
 - **Event capping** -- max 500 events per session to bound DOM size in ActivityLog.
 - **Queue position** -- `getQueuePosition()` returns 1-indexed position sorted by startedAt.
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -282,6 +282,30 @@ Sessions are resumable on next launch via `--resume <agent_session_id>` from the
 - When the window releases it: the tab returns, still selected, and the panel recreates xterm from the PTY scrollback buffer.
 - This prevents duplicate xterm instances from sending conflicting resize calls.
 - Both surfaces can therefore hold a live terminal at once, so `deriveFocusedSessionIds` focuses the window-owned sessions AND the panel's own session; anything with a mounted xterm must be in that set or the main process suppresses its PTY output.
+- **Which of those terminals takes KEYBOARD focus when it arrives is arbitrated, not raced**
+  (`src/renderer/utils/terminal-arrival-focus.ts`). The handoff above is exactly what creates the
+  race: opening a detail claims its session, so the panel drops that tab and mounts a terminal for a
+  DIFFERENT session at the same moment the window mounts its own. Both then fetch scrollback, which
+  main delays 150-400ms for the repaint settle, and every arrival path used to end in an
+  unconditional `xterm.focus()` - so whichever replay resolved LAST won, and a user who opened a
+  task and started typing could have the keystrokes land in whatever agent the panel fell back to.
+  `mayTakeArrivalFocus(sessionId)` decides from user-intent STATE instead, in three tiers:
+  a claim recorded by a gesture that named a terminal before it existed (a panel tab click, a panel
+  expand - the panel is not a window, so neither moves any layer's `focusedWindowId`); else the
+  terminal-hosting window holding window-layer focus, resolved by ANCHOR across all three layers
+  via `resolveFocusedWindowTerminal` in `dictation-target.ts`; else, when nothing owns the user's
+  attention, allow unless focus is in a typing surface. A claim is NOT consumed on grant, because
+  one arrival legitimately fires focus more than once (the deferred-init frame, then the mount
+  replay); a later window-focus change (the fingerprint) or the TTL is what ends it. Tiers 1 and 2
+  DENY a mismatch outright rather than falling through, which is what stops two terminals arriving
+  in one frame from both being permitted - including the case where the focused window has not
+  spawned a session yet, which still blocks everyone else. Tier 3 has no mismatch to deny, so its
+  own guard is a 500ms burst hold (`ARRIVAL_BURST_MS`): several terminals can reach it together on a
+  workspace restore that persisted no focused window, and only the first wins. Hosts own the policy
+  and pass it to `useTerminal` as an option, so the hook stays
+  surface-agnostic. Genuinely user-initiated focus (frame pointer-down, file drop, maximize
+  re-homing) is unconditional and marked `// arrival-focus-ok:`. See
+  `.claude/rules/terminal-arrival-focus.md`.
 - The converse also holds: anything with NO mounted xterm must be OUT of that set. A collapsed panel renders no `TerminalTab`, so `derivePanelSessionId` returns null for it (`panelShowsTerminal`, threaded from `useTerminalResize`'s `showContent`). Otherwise main streams bytes nothing can acknowledge, and a chatty agent eventually trips backpressure (`BACKPRESSURE_HIGH_WATER`) and has its PTY paused. Output produced while collapsed accumulates in main's scrollback ring and is replayed when the panel expands and the terminal remounts. A remount is not the only way back: a session that stays MOUNTED and merely leaves the focused union (a detail window a detached monitor owns, a hidden panel, a closed command bar over a transient) is repaired on the focus edge alone, without remounting. See the focus-edge catch-up bullet under Output Streaming.
 
 ## Project-Scoped Session State
@@ -638,7 +662,11 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   (main, `recomputeFocusedUnion`), `terminal-unfocus` / `terminal-refocus` (renderer,
   `focused-terminals.ts`), and `repaint-repaired` / `repaint-verified` (renderer,
   `repaint-nudge.ts`, the latter meaning the frame was already correct and the nudge cost one
-  render). All six merge into `kangentic_devtools_terminal_state`'s timeline alongside the
+  render). `arrival-focus` (renderer, `terminal-arrival-focus.ts`) joins them, carrying the
+  allow/deny plus the tier that decided it (`claim` / `claim-mismatch` / `window` /
+  `window-mismatch` / `occupied` / `burst-taken` / `unclaimed`) - the only record of WHY a terminal
+  did or did not take focus, which a "typed into the wrong terminal" report otherwise leaves to
+  guesswork. All seven merge into `kangentic_devtools_terminal_state`'s timeline alongside the
   resize and replay events above. `kangentic_devtools_terminal_forensics` is the session-scoped
   companion: renderer viewport rows, main's re-parsed grid, and the raw byte ring side by side,
   which is what separates "the agent never sent these rows" from "we lost them".

--- a/src/renderer/components/command-bar/CommandTerminalPane.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalPane.tsx
@@ -16,8 +16,9 @@
  * Gating means the pane only ever exists with a real session id, so
  * `sessionId` here is non-nullable.
  */
-import { useEffect, useRef, type RefObject } from 'react';
+import { useCallback, useEffect, useRef, type RefObject } from 'react';
 import { useTerminal } from '../../hooks/useTerminal';
+import { mayTakeArrivalFocus } from '../../utils/terminal-arrival-focus';
 import { useTerminalRefit } from '../../hooks/useTerminalRefit';
 import { useDeferredTerminalInit } from '../../hooks/useDeferredTerminalInit';
 import { useTerminalFileDrop } from '../../hooks/useTerminalFileDrop';
@@ -52,6 +53,12 @@ export function CommandTerminalPane({ sessionId, isMaximized, gridGetterRef }: C
     (s) => s.sessions.find((session) => session.id === sessionId)?.shell,
   );
 
+  // Arrival-focus policy, shared with TerminalTab. A Command Terminal window can
+  // be remounted by the project-switch reconcile rather than by a user gesture,
+  // so its arrivals are arbitrated like any other. A real Ctrl+Shift+P still
+  // focuses: opening the layer focuses its window, which the arbiter resolves.
+  const mayFocusOnArrival = useCallback(() => mayTakeArrivalFocus(sessionId), [sessionId]);
+
   const { terminalRef, initTerminal, fit, flushResize, focus, getDimensions } = useTerminal({
     sessionId,
     fontFamily: config.terminal.fontFamily,
@@ -61,6 +68,7 @@ export function CommandTerminalPane({ sessionId, isMaximized, gridGetterRef }: C
     shellName: commandTerminalShell ?? undefined,
     pasteImageTemplate,
     backspaceSendsCtrlH: config.terminal.backspaceSendsCtrlH,
+    mayTakeArrivalFocus: mayFocusOnArrival,
   });
 
   const fileDrop = useTerminalFileDrop(sessionId, focus, commandTerminalShell ?? undefined, pasteImageTemplate);
@@ -87,7 +95,7 @@ export function CommandTerminalPane({ sessionId, isMaximized, gridGetterRef }: C
     initTerminal,
     onInit: () => {
       fit();
-      focus();
+      if (mayFocusOnArrival()) focus();
     },
   });
 
@@ -117,6 +125,8 @@ export function CommandTerminalPane({ sessionId, isMaximized, gridGetterRef }: C
   useEffect(() => {
     if (wasMaximizedRef.current === isMaximized) return;
     wasMaximizedRef.current = isMaximized;
+    // arrival-focus-ok: follows the user's own maximize/restore toggle, and the ref
+    // above skips the initial mount, so this is never an arrival.
     if (initialized.current) focus();
     // `initialized` is the stable ref returned by useDeferredTerminalInit -
     // listed for exhaustive-deps (which cannot see through the hook), never

--- a/src/renderer/components/terminal/TerminalPanel.tsx
+++ b/src/renderer/components/terminal/TerminalPanel.tsx
@@ -313,6 +313,10 @@ export function TerminalPanel({ collapsed = false, showContent = true, onToggleC
                 <div
                   key={session.id}
                   data-testid="terminal-session-pane"
+                  // Which session this pane hosts. The panel swaps the mounted
+                  // pane when its selection changes, so a test that waits on the
+                  // bare testid can be satisfied by the OUTGOING pane.
+                  data-session-id={session.id}
                   className="absolute inset-0"
                   data-no-dismiss
                 >

--- a/src/renderer/components/terminal/TerminalTab.tsx
+++ b/src/renderer/components/terminal/TerminalTab.tsx
@@ -9,6 +9,7 @@ import { LaunchOverlay } from '../LaunchOverlay';
 import { useTerminalOverlay } from '../../utils/task-progress';
 import { useTerminalRefit } from '../../hooks/useTerminalRefit';
 import { useDeferredTerminalInit } from '../../hooks/useDeferredTerminalInit';
+import { mayTakeArrivalFocus } from '../../utils/terminal-arrival-focus';
 
 const FIT_DELAY_MS = 100;
 
@@ -95,6 +96,13 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
   const [replaySettled, setReplaySettled] = useState(false);
   const handleScrollbackSettled = useCallback(() => setReplaySettled(true), []);
 
+  // Arrival-focus policy for every programmatic focus this tab can produce. A
+  // TerminalTab mounts in the bottom panel AND in a task-detail window, and both
+  // pass `active` hardcoded true, so `active` carries no information about which
+  // surface the user is actually on - the arbiter answers that from user-intent
+  // state instead. See terminal-arrival-focus.ts.
+  const mayFocusOnArrival = useCallback(() => mayTakeArrivalFocus(sessionId), [sessionId]);
+
   const { terminalRef, initTerminal, fit, flushResize, focus, reloadScrollback, scrollbackPending, suppressDataRef } = useTerminal({
     sessionId,
     fontFamily: config.terminal.fontFamily,
@@ -106,6 +114,7 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
     pasteImageTemplate,
     backspaceSendsCtrlH: config.terminal.backspaceSendsCtrlH,
     onScrollbackSettled: handleScrollbackSettled,
+    mayTakeArrivalFocus: mayFocusOnArrival,
   });
 
   // Sync suppressDataRef with overlay state: suppress all PTY data while overlay is showing.
@@ -207,7 +216,11 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
       if (initialized.current && !scrollbackPending.current) {
         fit();
       }
-      if (initialized.current) {
+      // Arbitrated, not unconditional. On a SOLO mount this frame runs with
+      // `initialized` already true, so it focuses about one frame after mount -
+      // well before any replay settles. Gating only the replay would therefore
+      // leave the race intact, just decided earlier.
+      if (initialized.current && mayFocusOnArrival()) {
         focus();
       }
     });
@@ -228,7 +241,7 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
     // `initialized` is the stable ref returned by useDeferredTerminalInit -
     // listed for exhaustive-deps (which cannot see through the hook), never
     // a re-run trigger.
-  }, [active, fit, focus, scrollbackPending, initialized]);
+  }, [active, fit, focus, mayFocusOnArrival, scrollbackPending, initialized]);
 
   // Container refit while active: persistent gate-aware ResizeObserver plus the
   // terminal-panel-resize handling, shared with CommandTerminalWindow via

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -272,6 +272,19 @@ interface UseTerminalOptions {
    *  firing to lift its replay veil so only the settled frame is ever shown.
    *  Read live via a ref, so the callback never goes stale. */
   onScrollbackSettled?: () => void;
+  /** Host policy: may this terminal take keyboard focus on ARRIVAL (the mount
+   *  replay, or a reload the caller did not opt out of with `skipFocus`)?
+   *
+   *  Arrival focus is arbitrated because two terminals can mount together and
+   *  each finish its replay at an unpredictable moment, so an unconditional
+   *  focus makes the winner a coin toss (see `terminal-arrival-focus.ts`). The
+   *  policy lives in the HOST rather than here so this hook stays surface-
+   *  agnostic - it knows nothing about windows, panels, or layers.
+   *
+   *  Read live via a ref (same pattern as onScrollbackSettled) and evaluated
+   *  INSIDE the focus frame, so the answer is the one at focus time rather than
+   *  at render time. Absent means allow; both live hosts pass it. */
+  mayTakeArrivalFocus?: () => boolean;
 }
 
 /** Restore a saved scroll position (from HMR) or pin to the bottom.
@@ -588,6 +601,10 @@ export function useTerminal(options: UseTerminalOptions) {
    *  current callback. */
   const onScrollbackSettledRef = useRef(options.onScrollbackSettled);
   onScrollbackSettledRef.current = options.onScrollbackSettled;
+  /** Updated every render (same pattern as onScrollbackSettledRef) so the two
+   *  arrival-focus frames below ask the host's CURRENT policy. */
+  const mayTakeArrivalFocusRef = useRef(options.mayTakeArrivalFocus);
+  mayTakeArrivalFocusRef.current = options.mayTakeArrivalFocus;
 
   /** Single chokepoint for "a scrollback operation has settled". Ordering is
    *  load-bearing: pending must clear BEFORE the kick (the incoming queue's
@@ -934,12 +951,21 @@ export function useTerminal(options: UseTerminalOptions) {
             // (see shouldHold in the queue effect below) now that the replay
             // frame is fully painted, so they apply strictly after it.
             settleScrollback(true);
-            // Focus the terminal after the full init chain completes. No
+            // Focus the terminal after the full init chain completes, if the host
+            // says this arrival may take focus - a background terminal finishing
+            // its replay must not pull focus off the surface the user opened. No
             // corrective resize: main already sampled the settled frame at the
             // fitted width, and a same-dims resize is a documented no-op (POSIX
             // sends SIGWINCH only on a real size change; ConPTY likewise).
             requestAnimationFrame(() => {
-              xtermRef.current?.focus();
+              // Terminal first: the policy is not a pure query (it records the
+              // grant that suppresses a competing tier-3 arrival), so asking it
+              // for a host that unmounted between the settle and this frame
+              // would deny a live terminal on behalf of a disposed one.
+              const terminal = xtermRef.current;
+              if (!terminal) return;
+              if (mayTakeArrivalFocusRef.current?.() === false) return;
+              terminal.focus();
             });
           };
           if (scrollback && xtermRef.current) {
@@ -1591,12 +1617,21 @@ export function useTerminal(options: UseTerminalOptions) {
             return;
           }
           if (widthDecision.refundBudget) replayWidthAttemptsRef.current = 0;
-          // Focus after the reload completes (unless the caller opted out).
+          // Focus after the reload completes, unless the caller opted out or the
+          // host's arrival policy declines. The two gates are separate on
+          // purpose: `skipFocus` is a CALLER saying "this reload is a repair, not
+          // an arrival", while the policy is the HOST arbitrating between
+          // terminals that all believe they are arriving.
           // No corrective resize: when a resize was sent above, main sampled
           // the settled frame; a same-dims resize is a no-op either way.
           if (!skipFocus) {
             requestAnimationFrame(() => {
-              xtermRef.current?.focus();
+              // Terminal first, for the same reason as the mount-replay frame:
+              // the policy records a grant, so a disposed host must not consult it.
+              const terminal = xtermRef.current;
+              if (!terminal) return;
+              if (mayTakeArrivalFocusRef.current?.() === false) return;
+              terminal.focus();
             });
           }
         };
@@ -1705,6 +1740,9 @@ export function useTerminal(options: UseTerminalOptions) {
   }, [options.sessionId, reloadScrollback]);
 
   const focus = useCallback(() => {
+    // arrival-focus-ok: the imperative handle its callers use after a real gesture
+    // (frame pointer-down, file drop, maximize re-homing). The ARRIVAL paths that
+    // must be arbitrated are the two rAF frames above, not this.
     xtermRef.current?.focus();
   }, []);
 

--- a/src/renderer/hooks/useTerminalFileDrop.ts
+++ b/src/renderer/hooks/useTerminalFileDrop.ts
@@ -112,6 +112,8 @@ export function useTerminalFileDrop(
     }
     if (paths.length > 0) {
       window.electronAPI.sessions.write(sessionId, paths.join(' '));
+      // arrival-focus-ok: the user just dropped files on THIS terminal and its paths
+      // were written to that PTY, so focus belongs here.
       focusTerminal();
     }
   }, [sessionId, focusTerminal, shellName, pasteImageTemplate]);

--- a/src/renderer/hooks/useTerminalResize.ts
+++ b/src/renderer/hooks/useTerminalResize.ts
@@ -1,6 +1,11 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import type { AppConfig } from '../../shared/types';
 import { startPanelDrag } from './panel-drag';
+import { claimArrivalFocus } from '../utils/terminal-arrival-focus';
+import { derivePanelSessions } from '../utils/panel-sessions';
+import { derivePanelSessionId } from '../utils/focused-sessions';
+import { useSessionStore } from '../stores/session-store';
+import { useProjectStore } from '../stores/project-store';
 
 const MIN_HEIGHT = 100;
 export const COLLAPSED_HEIGHT = 36;
@@ -56,6 +61,31 @@ export interface TerminalResizeState {
   handleTransitionEnd: () => void;
 }
 
+/**
+ * The session the bottom panel is about to mount a terminal for, read from the
+ * live stores. Runs the same two derivations the panel itself renders from, so a
+ * claim can never name a session the panel is not going to show. `panelShowsTerminal`
+ * is deliberately left at its default: the caller is in the act of showing it.
+ */
+function panelArrivalSessionId(): string | null {
+  const sessionState = useSessionStore.getState();
+  const currentProjectId = useProjectStore.getState().currentProject?.id ?? null;
+  const { owned } = derivePanelSessions({
+    sessions: sessionState.sessions,
+    currentProjectId,
+    dialogSessionIds: sessionState.dialogSessionIds,
+    remoteDetailTaskIds: sessionState.remoteDetailTaskIds,
+    mobileTerminalStreamedSessionIds: sessionState.mobileTerminalStreamedSessionIds,
+  });
+  return derivePanelSessionId({
+    activeSessionId: sessionState.activeSessionId,
+    sessions: sessionState.sessions,
+    currentProjectId,
+    sessionActivity: sessionState.sessionActivity,
+    ownedSessionIds: owned,
+  });
+}
+
 /** `switchKey` is the current project id; a change to it triggers the snap-across-switch
  *  behavior (suppress the height transition for one settle window). */
 export function useTerminalResize(
@@ -88,6 +118,11 @@ export function useTerminalResize(
   const terminalConfigRef = useRef(config.terminal);
   terminalConfigRef.current = config.terminal;
   const effectiveCollapsedRef = useRef(effectiveCollapsed);
+  // Mirrored for `onToggleCollapse`, which has no deps and would otherwise close
+  // over a stale value. A toggle while `forceCollapsed` holds flips only the
+  // user's preference, so no terminal mounts and nothing arrives.
+  const forceCollapsedRef = useRef(forceCollapsed);
+  forceCollapsedRef.current = forceCollapsed;
   const availableHeightRef = useRef(0);
   const contentColRef = useRef<HTMLDivElement>(null);
   const contentTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -208,6 +243,23 @@ export function useTerminalResize(
   }, [clampHeight]);
 
   const onToggleCollapse = useCallback(() => {
+    // Expanding REMOUNTS the panel's TerminalTab (`showContent` gates whether it
+    // renders one at all), which is an arrival. Claim focus for it, because the
+    // bottom panel is not a window: expanding moves no layer's `focusedWindowId`,
+    // so with a detail window open the arbiter would otherwise leave focus there
+    // and the freshly expanded terminal would need a click before it could be
+    // typed into. Read from the ref rather than `collapsed`, which this callback
+    // closes over stale (it has no deps, by design). A claim whose session never
+    // mounts simply expires.
+    // Only when the toggle will actually un-collapse. While `forceCollapsed`
+    // holds (a project switch with detail windows still restoring), the panel
+    // stays collapsed and mounts nothing, so a claim here would name a terminal
+    // that never arrives - and tier 1 is EXCLUSIVE, so that dangling claim would
+    // deny the restoring windows' own terminals for the full TTL.
+    if (effectiveCollapsedRef.current && !forceCollapsedRef.current) {
+      claimArrivalFocus(panelArrivalSessionId());
+    }
+
     // Only the user's preference flips here; the showContent timing is driven by
     // the effectiveCollapsed effect above (which also reacts to windows opening).
     setCollapsed((prev) => {

--- a/src/renderer/stores/session-store.ts
+++ b/src/renderer/stores/session-store.ts
@@ -8,6 +8,7 @@ import { buildSessionByTaskId } from './session-store/session-index';
 import { createTaskChangesPanelSlice } from './session-store/task-changes-panel-slice';
 import { createTransientSessionSlice, transientKey, type TransientSessionEntry } from './session-store/transient-session-slice';
 import { mergeRateLimitSnapshot } from '../utils/rate-limit-window';
+import { claimArrivalFocus } from '../utils/terminal-arrival-focus';
 
 const MAX_EVENTS_PER_SESSION = 500;
 
@@ -560,6 +561,13 @@ export const useSessionStore = create<SessionStore>((set, get, api) => ({
   setActiveSession: (id) => set({ activeSessionId: id }),
 
   selectActiveSession: (id) => {
+    // A tab click is a user gesture naming a terminal that has not mounted yet,
+    // so it claims arrival focus. The bottom panel is not a window: clicking its
+    // tab moves no layer's `focusedWindowId`, so without this claim the arbiter
+    // would keep handing focus to an open detail window and the newly selected
+    // tab would mount unfocused. ACTIVITY_TAB names no session, and passing null
+    // clears any standing claim.
+    claimArrivalFocus(id === ACTIVITY_TAB ? null : id);
     set({ activeSessionId: id });
     // Persist the user's tab choice to AppConfig so it survives project switch
     // and app restart. Skip non-persistable selections: null, the activity tab

--- a/src/renderer/stores/session-store/types.ts
+++ b/src/renderer/stores/session-store/types.ts
@@ -169,11 +169,13 @@ export interface CoreSessionSlice {
    */
   reconcileSession: (taskId: string) => Promise<Session | null>;
   setActiveSession: (id: string | null) => void;
-  /** User-gesture variant of setActiveSession. Updates state AND persists the
+  /** User-gesture variant of setActiveSession. Updates state, persists the
    *  selection to AppConfig.lastActiveTaskByProject so it survives app restart
-   *  and project switch. Used by tab-click handlers; the auto-select fallback
-   *  in TerminalPanel uses setActiveSession directly so default picks don't
-   *  overwrite the remembered value. */
+   *  and project switch, AND claims arrival focus for the chosen session (see
+   *  utils/terminal-arrival-focus.ts) so the tab the user just clicked is the
+   *  terminal that takes focus when it mounts. Used by tab-click handlers; the
+   *  auto-select fallback in TerminalPanel uses setActiveSession directly so
+   *  default picks neither overwrite the remembered value nor claim focus. */
   selectActiveSession: (id: string | null) => void;
   /** A task-detail window claims its session (one xterm per PTY: the panel drops
    *  it while a window owns it). Idempotent. */

--- a/src/renderer/utils/dictation-target.ts
+++ b/src/renderer/utils/dictation-target.ts
@@ -1,4 +1,12 @@
-import { boardWindowManager, commandWindowManager } from '../window-manager';
+// The managers come from the deep path, not the `../window-manager` barrel: the
+// barrel also re-exports the layer COMPONENTS, which reach the task-detail tree
+// and back to session-store. Since session-store now imports the arrival-focus
+// arbiter, which imports this module, going through the barrel would put that
+// whole component tree in the store's import graph - and neither module
+// self-accepts, so a Fast Refresh anywhere in it would re-evaluate the store and
+// hand a second instance to a mounted tree (hmr-patterns Pattern E).
+import { boardWindowManager, commandWindowManager, monitorWindowManager } from '../window-manager/store/window-store';
+import { isLayerMounted } from '../window-manager/store/layer-mount-registry';
 import { useSessionStore } from '../stores/session-store';
 import { useProjectStore } from '../stores/project-store';
 import { derivePanelSessionId } from './focused-sessions';
@@ -10,6 +18,13 @@ import { transientKey, type TransientSessionEntry } from '../stores/session-stor
  * panel, task-detail windows, and Command Terminal windows); the main process
  * only tracks a focused SET. So we resolve here and pass the chosen session id
  * explicitly on the commit IPC, and refuse to guess when nothing resolves.
+ *
+ * `resolveFocusedWindowTerminal` is the shared half of that question ("which
+ * terminal-hosting window holds window-layer focus"), also consumed by the
+ * arrival-focus arbiter in `terminal-arrival-focus.ts`. The two differ in POLICY,
+ * not in the resolution: dictation must resolve something and so falls through to a
+ * wider chain, while arrival focus must abstain and so stops there. Keeping one
+ * resolver is what stops those two answers drifting apart.
  */
 
 // Last terminal whose xterm gained focus, across all layers. The window-manager
@@ -39,16 +54,71 @@ function isRunningSession(sessionId: string | null): sessionId is string {
     .sessions.some((session) => session.id === sessionId && session.status === 'running');
 }
 
-/** The session id owned by a window layer's currently focused window, if any.
- *  Conversation windows are read-only transcript viewers with no input surface,
- *  so their anchored session id must never become a dictation injection target. */
-function focusedWindowSessionId(manager: typeof boardWindowManager): string | null {
-  const state = manager.store.getState();
-  const focusedId = state.focusedWindowId;
-  if (!focusedId) return null;
-  const focusedWindow = state.windows[focusedId];
-  if (!focusedWindow || focusedWindow.kind === 'conversation') return null;
-  return focusedWindow.sessionId ?? null;
+/** A terminal-hosting window holding window-layer focus. `sessionId` is null when
+ *  that window's task has not spawned a session yet, which is NOT the same as
+ *  "no window is focused" - the window still owns the user's attention. */
+export interface FocusedWindowTerminal {
+  sessionId: string | null;
+}
+
+/** Layers in paint order, front-most first: the Command Terminal layer renders
+ *  over the Agent Monitor, which renders over the board. */
+const TERMINAL_WINDOW_LAYERS = [commandWindowManager, monitorWindowManager, boardWindowManager];
+
+/**
+ * The terminal-hosting window that currently holds window-layer focus, across
+ * EVERY layer. Returns null when no layer has one; that is the "nothing
+ * resolves" signal, and each caller applies its own policy to it - dictation
+ * falls through to a wider chain, arrival focus abstains.
+ *
+ * `sessionId` is resolved by ANCHOR, never read from `ManagedWindow.sessionId`.
+ * That field is captured at open time and is never written back on spawn or
+ * respawn, so a window opened on a task with no session keeps `null` forever and
+ * a respawned session leaves it stale. Same resolution `useWindowSessionClaims`
+ * uses, for the same reason.
+ *
+ * Exclusions: conversation windows (read-only transcript, no input surface),
+ * unmounted layers (the stores deliberately outlive their subtrees, and an
+ * unmounted layer hosts no xterm), and a hidden Command Terminal layer (hiding
+ * keeps its windows, focus pointer, and PTYs alive, but a terminal nobody can
+ * see must never win).
+ */
+export function resolveFocusedWindowTerminal(): FocusedWindowTerminal | null {
+  for (const manager of TERMINAL_WINDOW_LAYERS) {
+    if (!isLayerMounted(manager)) continue;
+    const state = manager.store.getState();
+    const focusedId = state.focusedWindowId;
+    if (!focusedId) continue;
+    const focusedWindow = state.windows[focusedId];
+    if (!focusedWindow || focusedWindow.kind === 'conversation') continue;
+    // Defensive: `retainWindows` already clears `focusedWindowId` when the focused
+    // window becomes retained, so a retained window cannot be focused today.
+    if (focusedWindow.retainedProjectId !== undefined) continue;
+
+    if (focusedWindow.kind === 'command-terminal') {
+      const sessionState = useSessionStore.getState();
+      // Not visible means this layer is not the user's surface at all, so fall
+      // through to the layers beneath rather than resolving it to null (which
+      // would wrongly claim the user's attention for a hidden terminal).
+      if (!sessionState.commandBarVisible) continue;
+      return {
+        sessionId: resolveFocusedCommandSessionId({
+          commandBarVisible: sessionState.commandBarVisible,
+          focusedCommandAnchor: focusedWindow.anchor,
+          currentProjectId: useProjectStore.getState().currentProject?.id ?? null,
+          transientSessions: sessionState.transientSessions,
+        }),
+      };
+    }
+
+    const toTaskId = manager.options.anchorToTaskId;
+    const taskId = toTaskId ? toTaskId(focusedWindow.anchor) : focusedWindow.anchor;
+    const session = useSessionStore
+      .getState()
+      .sessions.find((candidate) => candidate.taskId === taskId);
+    return { sessionId: session?.id ?? null };
+  }
+  return null;
 }
 
 /** Resolve the focused Command Terminal window's live session by its durable slot
@@ -69,37 +139,22 @@ export function resolveFocusedCommandSessionId(input: {
   return entry?.sessionId ?? null;
 }
 
-function focusedCommandSessionId(): string | null {
-  const windowState = commandWindowManager.store.getState();
-  const focusedId = windowState.focusedWindowId;
-  const focusedWindow = focusedId ? windowState.windows[focusedId] : null;
-  const sessionState = useSessionStore.getState();
-  return resolveFocusedCommandSessionId({
-    commandBarVisible: sessionState.commandBarVisible,
-    focusedCommandAnchor: focusedWindow?.anchor ?? null,
-    currentProjectId: useProjectStore.getState().currentProject?.id ?? null,
-    transientSessions: sessionState.transientSessions,
-  });
-}
-
 /**
  * Resolve the single injection target via a priority chain. Returns null when
  * no live terminal can be determined, so the caller can refuse to commit rather
  * than inject into the wrong terminal.
  */
 export function resolveDictationTarget(): string | null {
-  // 1. The focused Command Terminal window.
-  const commandTarget = focusedCommandSessionId();
-  if (isRunningSession(commandTarget)) return commandTarget;
+  // 1. The focused terminal-hosting window, in any layer (Command Terminal,
+  //    Agent Monitor, or board). Falls through when it names no running session,
+  //    which covers both "no focused window" and "focused window, no session yet".
+  const focusedWindowSessionId = resolveFocusedWindowTerminal()?.sessionId ?? null;
+  if (isRunningSession(focusedWindowSessionId)) return focusedWindowSessionId;
 
-  // 2. The focused task-detail (board) window.
-  const boardTarget = focusedWindowSessionId(boardWindowManager);
-  if (isRunningSession(boardTarget)) return boardTarget;
-
-  // 3. The last terminal the user focused anywhere.
+  // 2. The last terminal the user focused anywhere.
   if (isRunningSession(lastFocusedTerminalSessionId)) return lastFocusedTerminalSessionId;
 
-  // 4. The bottom panel's derived session.
+  // 3. The bottom panel's derived session.
   const currentProjectId = useProjectStore.getState().currentProject?.id ?? null;
   const sessionState = useSessionStore.getState();
   const panelSessionId = derivePanelSessionId({

--- a/src/renderer/utils/terminal-arrival-focus.ts
+++ b/src/renderer/utils/terminal-arrival-focus.ts
@@ -1,0 +1,228 @@
+/**
+ * Who may take keyboard focus when a terminal ARRIVES.
+ *
+ * A terminal "arrives" when it finishes mounting or replaying: the deferred-init
+ * `focus()`, the mount-time scrollback replay, and any reload the host did not opt
+ * out of. Those are programmatic events, not user gestures, and more than one can
+ * land in the same handful of frames - opening a task detail evicts the bottom
+ * panel's selected session, so the panel mounts a fresh terminal for a DIFFERENT
+ * session at the same moment the detail window mounts its own. Both then fetch
+ * scrollback, which main delays 150-400ms while the agent's TUI repaint settles.
+ * Every one of those paths used to end in an unconditional `xterm.focus()`, so
+ * whichever replay resolved LAST won, and the user's keystrokes went to whichever
+ * agent that happened to be.
+ *
+ * THE INVARIANT: at most one terminal takes focus on arrival, and which one is
+ * decided by user-intent STATE, never by replay order or rAF order. Each tier
+ * below is EXCLUSIVE - a tier that resolves an answer decides, allowing if it
+ * matches and DENYING if it does not. It never falls through to a lower tier.
+ * Non-exclusive tiers degrade straight back into a race, because two terminals
+ * arriving in the same frame would both find themselves permitted.
+ *
+ * Genuinely user-initiated focus does NOT come through here and stays
+ * unconditional: pointer-down on a window frame, a file drop on a terminal, the
+ * maximize/restore re-homing, and the imperative `focus()` those use.
+ *
+ * Naming note: "focused" is already taken in this codebase. `focused-terminals.ts`
+ * owns the PTY-STREAM focused set (which sessions main forwards bytes for, several
+ * at once), and `focused-sessions.ts` derives it. This module is about KEYBOARD
+ * focus, and exactly one terminal can hold that, so it uses its own vocabulary.
+ *
+ * Known boundary, deliberately not closed: click into the bottom panel's xterm
+ * body (rather than its tab) while a detail window still holds `focusedWindowId`,
+ * and that window's terminal then arrives - tier 2 allows the steal. It is narrow,
+ * because the window must have just opened for its terminal to still be arriving,
+ * which means the user just clicked it. Closing it would need a claim on
+ * panel-pane pointer-down, which brings a stale-claim edge of its own.
+ */
+
+import { allWindowManagers } from '../window-manager/store/window-store';
+import { resolveFocusedWindowTerminal, type FocusedWindowTerminal } from './dictation-target';
+import { traceTerminalRenderer } from './terminal-grid-registry';
+
+/** Backstop only. The fingerprint below is what actually supersedes a claim; this
+ *  bounds the case where a claim is set and its terminal never mounts at all. */
+export const ARRIVAL_CLAIM_TTL_MS = 4000;
+
+/** How long one granted arrival suppresses a DIFFERENT session's arrival while
+ *  nothing else resolves. Only reachable in tier 3. */
+export const ARRIVAL_BURST_MS = 500;
+
+/** A user gesture that named a session before its terminal existed. */
+export interface ArrivalFocusClaim {
+  sessionId: string;
+  /** Window-layer focus identity at gesture time, so any later window
+   *  open/focus/close supersedes this claim with no subscription. */
+  fingerprint: string;
+  at: number;
+}
+
+export type ArrivalFocusReason =
+  | 'claim'
+  | 'claim-mismatch'
+  | 'window'
+  | 'window-mismatch'
+  | 'occupied'
+  | 'burst-taken'
+  | 'unclaimed';
+
+export interface ArrivalFocusInput {
+  sessionId: string;
+  claim: ArrivalFocusClaim | null;
+  now: number;
+  windowFocusFingerprint: string;
+  /** Null when NO terminal-hosting window is focused in any layer. A non-null
+   *  entry whose `sessionId` is null means a window owns the user's attention but
+   *  has not spawned a session yet, which still denies everyone else. */
+  focusedWindowTerminal: FocusedWindowTerminal | null;
+  focusIsInTypingSurface: boolean;
+  lastGrant: { sessionId: string; at: number } | null;
+}
+
+export interface ArrivalFocusDecision {
+  allow: boolean;
+  reason: ArrivalFocusReason;
+}
+
+/**
+ * PURE. The whole decision, with no store or DOM reads, so every tier and every
+ * exclusivity edge is testable directly.
+ */
+export function resolveArrivalFocus(input: ArrivalFocusInput): ArrivalFocusDecision {
+  // Tier 1: a user gesture named a session. Still live only while the window
+  // layers have not moved focus since (a later open/focus/close changes the
+  // fingerprint) and the backstop TTL has not lapsed.
+  const { claim } = input;
+  if (
+    claim
+    && claim.fingerprint === input.windowFocusFingerprint
+    && input.now - claim.at <= ARRIVAL_CLAIM_TTL_MS
+  ) {
+    return claim.sessionId === input.sessionId
+      ? { allow: true, reason: 'claim' }
+      : { allow: false, reason: 'claim-mismatch' };
+  }
+
+  // Tier 2: a terminal-hosting window holds window-layer focus. That window is
+  // where the user is working, so only its terminal may arrive into focus.
+  if (input.focusedWindowTerminal) {
+    return input.focusedWindowTerminal.sessionId === input.sessionId
+      ? { allow: true, reason: 'window' }
+      : { allow: false, reason: 'window-mismatch' };
+  }
+
+  // Tier 3: nothing owns the user's attention. Cold start, a hard reload, and the
+  // bottom panel with no windows open all land here.
+  //
+  // The test is "is focus in a typing surface", NOT "is focus orphaned". After
+  // clicking a panel tab or the collapse chevron, `document.activeElement` is that
+  // <button>, so an orphan test would deny the most common interaction in the app.
+  // A <button> is not a typing surface; `.xterm-helper-textarea` is a <textarea>,
+  // so an arriving terminal still never yanks focus out of one being typed in.
+  if (input.focusIsInTypingSurface) return { allow: false, reason: 'occupied' };
+
+  // Several terminals can reach tier 3 together (a workspace restore that
+  // persisted no focused window). One winner, rather than last-rAF-wins.
+  if (
+    input.lastGrant
+    && input.lastGrant.sessionId !== input.sessionId
+    && input.now - input.lastGrant.at <= ARRIVAL_BURST_MS
+  ) {
+    return { allow: false, reason: 'burst-taken' };
+  }
+
+  return { allow: true, reason: 'unclaimed' };
+}
+
+// hmr-safe is NOT enough here: a Fast Refresh mid-gesture would drop a live claim
+// and let the wrong terminal win, so both are preserved (hmr-patterns Pattern A).
+// @ts-expect-error -- Vite handles import.meta.hot; tsc's "module": "commonjs" doesn't support it
+let arrivalClaim: ArrivalFocusClaim | null = import.meta.hot?.data?.arrivalClaim ?? null;
+// @ts-expect-error -- Vite handles import.meta.hot
+let lastArrivalGrant: { sessionId: string; at: number } | null = import.meta.hot?.data?.lastArrivalGrant ?? null;
+
+// @ts-expect-error -- Vite handles import.meta.hot
+if (import.meta.hot) {
+  // @ts-expect-error -- Vite handles import.meta.hot
+  import.meta.hot.dispose((data: Record<string, unknown>) => {
+    data.arrivalClaim = arrivalClaim;
+    data.lastArrivalGrant = lastArrivalGrant;
+  });
+}
+
+/**
+ * Window-layer focus identity across every layer. Opening, focusing, or closing
+ * any window moves it, which is exactly when a pending claim should stop applying:
+ * a TTL alone would reintroduce the bug in reverse (click a panel tab, open a
+ * detail inside the TTL, and focus would stay on the panel).
+ */
+export function windowFocusFingerprint(): string {
+  const parts: string[] = [];
+  for (const manager of allWindowManagers) {
+    parts.push(`${manager.options.idPrefix}:${manager.store.getState().focusedWindowId ?? ''}`);
+  }
+  return parts.join('|');
+}
+
+/**
+ * Record that a user gesture named this session's terminal before it existed.
+ *
+ * Needed because the bottom panel is not a window: clicking its tab does not move
+ * any layer's `focusedWindowId`, so tier 2 would deny it forever while a detail
+ * window is open. Passing null clears any standing claim.
+ *
+ * Deliberately NOT consumed on grant. One arrival legitimately fires focus more
+ * than once (the deferred-init rAF, then the mount replay), and those are all the
+ * same user intent; the fingerprint and the TTL are what end a claim.
+ */
+export function claimArrivalFocus(sessionId: string | null): void {
+  if (!sessionId) {
+    arrivalClaim = null;
+    return;
+  }
+  arrivalClaim = { sessionId, fingerprint: windowFocusFingerprint(), at: Date.now() };
+}
+
+/** True while focus sits in something the user could be typing into. */
+function focusIsInTypingSurface(): boolean {
+  const active = document.activeElement;
+  if (!active || active === document.body) return false;
+  return active.matches('input, textarea, select, [contenteditable="true"]');
+}
+
+/**
+ * The live gate. Hosts pass this down to `useTerminal` as a predicate, so the hook
+ * itself stays surface-agnostic and never imports this module.
+ *
+ * A null `sessionId` cannot arrive (both hosts require one before they mount a
+ * terminal), so it is permitted rather than given a policy of its own.
+ */
+export function mayTakeArrivalFocus(sessionId: string | null): boolean {
+  if (!sessionId) return true;
+  const now = Date.now();
+  const decision = resolveArrivalFocus({
+    sessionId,
+    claim: arrivalClaim,
+    now,
+    windowFocusFingerprint: windowFocusFingerprint(),
+    focusedWindowTerminal: resolveFocusedWindowTerminal(),
+    focusIsInTypingSurface: focusIsInTypingSurface(),
+    lastGrant: lastArrivalGrant,
+  });
+  // Dev-only ring (see traceTerminalRenderer), so this costs nothing shipped. The
+  // decision is the only record of WHY a terminal did or did not take focus, and
+  // the next "typed into the wrong terminal" report needs it.
+  traceTerminalRenderer(sessionId, 'arrival-focus', () => ({
+    allow: decision.allow,
+    reason: decision.reason,
+  }));
+  // Only a TIER-3 grant is recorded, because only tier 3 reads it. Tiers 1 and 2
+  // are already exclusive - they deny a mismatch outright - so a burst hold adds
+  // nothing there and actively misfires: a window that won tier 2 and then closed
+  // would leave an unrelated tier-3 arrival denied as `burst-taken` for up to
+  // ARRIVAL_BURST_MS with nothing actually contending for focus.
+  if (decision.allow && decision.reason === 'unclaimed') {
+    lastArrivalGrant = { sessionId, at: now };
+  }
+  return decision.allow;
+}

--- a/src/renderer/window-manager/bridge/useWindowFocusReconcile.ts
+++ b/src/renderer/window-manager/bridge/useWindowFocusReconcile.ts
@@ -33,6 +33,8 @@ export function useWindowFocusReconcile(): void {
     const next = entries.reduce((top, candidate) => (candidate.zIndex > top.zIndex ? candidate : top));
     const frame = document.querySelector(`[data-testid="window-frame-${next.id}"]`);
     const textarea = frame?.querySelector('.xterm-helper-textarea');
+    // arrival-focus-ok: repairs focus a window CLOSE orphaned, and the guard above
+    // already abstains unless activeElement fell back to <body>.
     if (textarea instanceof HTMLElement) textarea.focus();
   }, [windows]);
 }

--- a/src/renderer/window-manager/components/TaskDetailWindow.tsx
+++ b/src/renderer/window-manager/components/TaskDetailWindow.tsx
@@ -566,6 +566,8 @@ export function TaskDetailWindow({
     wasMaximizedRef.current = isMaximized;
     const frame = document.querySelector(`[data-testid="window-frame-${windowId}"]`);
     const textarea = frame?.querySelector('.xterm-helper-textarea');
+    // arrival-focus-ok: follows the user's own maximize/restore toggle, and the ref
+    // above skips the initial mount, so this is never an arrival.
     if (textarea instanceof HTMLElement) textarea.focus();
   }, [isMaximized, windowId]);
 

--- a/src/renderer/window-manager/components/WindowFrame.tsx
+++ b/src/renderer/window-manager/components/WindowFrame.tsx
@@ -121,6 +121,7 @@ function WindowFrameInner({ managedWindow, containerSize, overlayRef, tiledRect 
         if (target.closest('.xterm')) return;
         if (target.closest('[data-testid="conversation-view"]')) return;
         event.preventDefault();
+        // arrival-focus-ok: a literal pointer-down on THIS window's chrome.
         frameRef.current?.querySelector<HTMLElement>('.xterm-helper-textarea')?.focus();
       }}
       onPointerMove={handleFramePointerMove}

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -1620,7 +1620,17 @@
       list: async function () {
         return sessions;
       },
-      getScrollback: async function () {
+      // Per-session replay delay, in ms, via window.__mockScrollbackDelayMs
+      // keyed by session id. Real main deliberately waits 150-400ms here while
+      // the agent TUI's repaint settles (see pty-buffer-manager.ts), and that
+      // wait is what makes the ORDER in which two concurrently mounting
+      // terminals finish replaying nondeterministic. Without a way to control
+      // that order a spec cannot reproduce the arrival-focus race at all.
+      getScrollback: async function (sessionId) {
+        var delay = (window.__mockScrollbackDelayMs || {})[sessionId] || 0;
+        if (delay > 0) {
+          await new Promise(function (resolve) { setTimeout(resolve, delay); });
+        }
         return '';
       },
       getFirstOutput: async function () {

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -1626,8 +1626,18 @@
       // wait is what makes the ORDER in which two concurrently mounting
       // terminals finish replaying nondeterministic. Without a way to control
       // that order a spec cannot reproduce the arrival-focus race at all.
+      // Every call is logged to window.__mockScrollbackCalls as
+      // { sessionId, delay }, so a spec can prove AFTER the fact that a replay
+      // it meant to delay actually took the delayed path. That matters because
+      // the assertions a delay enables ("the late terminal did not steal
+      // focus") all still pass if the delay silently stops applying - a renamed
+      // session id, a changed mock - leaving the race unexercised and the spec
+      // vacuously green. Checking the log is deterministic; watching for the
+      // transient replay veil to prove the same thing is not, and fails on CI.
       getScrollback: async function (sessionId) {
         var delay = (window.__mockScrollbackDelayMs || {})[sessionId] || 0;
+        window.__mockScrollbackCalls = window.__mockScrollbackCalls || [];
+        window.__mockScrollbackCalls.push({ sessionId: sessionId, delay: delay });
         if (delay > 0) {
           await new Promise(function (resolve) { setTimeout(resolve, delay); });
         }

--- a/tests/ui/terminal-arrival-focus.spec.ts
+++ b/tests/ui/terminal-arrival-focus.spec.ts
@@ -244,15 +244,6 @@ test('a delayed background replay does not steal focus from a just-opened task d
     // pass simply because no competing terminal ever existed.
     await fallbackTextarea.waitFor({ state: 'attached', timeout: STEP_TIMEOUT_MS });
 
-    // ...and its replay is genuinely still IN FLIGHT. This is the spec's own
-    // self-defense: `toHaveCount(0)` below is also satisfied by a veil that was
-    // never there, so if the forced delay ever stopped applying (a mock-API
-    // change, a renamed session id) the race would go unexercised while every
-    // assertion still passed. Checked here, at the earliest moment the pane
-    // exists and before any wait on the detail's own replay, so the delay window
-    // is barely consumed.
-    await fallbackVeil.waitFor({ state: 'attached', timeout: STEP_TIMEOUT_MS });
-
     // The detail's replay settles first (the fallback's is delayed).
     await expect(frame.locator('[data-testid="terminal-replay-veil"]')).toHaveCount(0, { timeout: STEP_TIMEOUT_MS });
 
@@ -267,6 +258,21 @@ test('a delayed background replay does not steal focus from a just-opened task d
 
     await expect(detailTextarea).toBeFocused();
     await expect(fallbackTextarea).not.toBeFocused();
+
+    // Anti-vacuity, checked from the mock's own call log rather than by racing
+    // the transient replay veil. Every assertion above still passes if the
+    // forced delay silently stops applying (a renamed session id, a changed
+    // mock), which would leave the losing order unexercised and this spec green
+    // for the wrong reason. The log proves the fallback's replay really did take
+    // the delayed path, so it really did resolve after the detail's.
+    const delayedCalls = await page.evaluate((sessionId) => {
+      const calls = (window as unknown as {
+        __mockScrollbackCalls?: { sessionId: string; delay: number }[];
+      }).__mockScrollbackCalls ?? [];
+      return calls.filter((call) => call.sessionId === sessionId).map((call) => call.delay);
+    }, SESSION_FALLBACK);
+    expect(delayedCalls.length).toBeGreaterThan(0);
+    expect(Math.max(...delayedCalls)).toBe(FALLBACK_REPLAY_DELAY_MS);
   } finally {
     await browser.close();
   }

--- a/tests/ui/terminal-arrival-focus.spec.ts
+++ b/tests/ui/terminal-arrival-focus.spec.ts
@@ -1,0 +1,342 @@
+/**
+ * Regression spec: a background terminal must not steal keyboard focus from a
+ * just-opened task detail.
+ *
+ * The bug. Opening a task detail claims that task's session, so the bottom panel
+ * drops its tab and falls back to a DIFFERENT running session, mounting a fresh
+ * terminal for it moments after the detail window mounts its own. Both then fetch
+ * scrollback, which real main delays 150-400ms while the agent TUI's repaint
+ * settles, and both used to end in an unconditional `xterm.focus()`. Whichever
+ * replay resolved LAST won, so the user opened a task, started typing, and the
+ * keystrokes went to whatever agent the panel happened to fall back to. The
+ * reported case typed `/compact` into the wrong session.
+ *
+ * Why the ordering has to be forced. The defect only appears when the background
+ * terminal's replay resolves AFTER the detail's, which in production is a genuine
+ * race. `window.__mockScrollbackDelayMs` (see `getScrollback` in
+ * mock-electron-api.js) pins that order so the spec tests the losing case every
+ * run rather than half the time.
+ *
+ * Why the waits are causal, not timed. `TerminalTab` renders
+ * `data-testid="terminal-replay-veil"` until its scrollback settles, so a pane's
+ * veil disappearing IS that pane's replay resolving. `settleScrollback` runs one
+ * frame before the focus call it guards, so waiting for the veil to clear lands
+ * exactly where the steal used to happen. No `waitForTimeout` anywhere
+ * (.claude/rules/cross-platform-parity.md).
+ *
+ * How to verify RED / GREEN:
+ *  - Spec 1: drop either arrival gate - the `mayTakeArrivalFocusRef` check in
+ *    `useTerminal.ts`'s mount-replay frame, or the `mayFocusOnArrival()` check in
+ *    `TerminalTab.tsx`'s active effect - and the delayed panel replay takes focus,
+ *    failing the final two assertions.
+ *  - Spec 2: remove the `claimArrivalFocus` call from `selectActiveSession` in
+ *    `session-store.ts` and the clicked tab's terminal never gets focus, because
+ *    the arbiter resolves the still-focused detail window instead.
+ *  - Spec 3: remove the `claimArrivalFocus` call from `onToggleCollapse` in
+ *    `useTerminalResize.ts` and the re-expanded panel's terminal never gets focus,
+ *    for the same reason. That claim looks redundant until you notice `showContent`
+ *    gates whether the panel mounts a `TerminalTab` at all, so an expand IS an
+ *    arrival.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const RUN_ID = Math.random().toString(36).slice(2, 8);
+const PROJECT_ID = `proj-arrival-${RUN_ID}`;
+
+/** The task whose detail is opened. Its session starts as the panel's selection,
+ *  so opening it is what evicts the panel and forces the fallback mount. */
+const TASK_DETAIL = `task-arrival-detail-${RUN_ID}`;
+const SESSION_DETAIL = `sess-arrival-detail-${RUN_ID}`;
+/** The session the panel falls back to. Delayed, so it replays LAST. */
+const TASK_FALLBACK = `task-arrival-fallback-${RUN_ID}`;
+const SESSION_FALLBACK = `sess-arrival-fallback-${RUN_ID}`;
+/** A third session, so spec 2 has a tab to click that is not already selected. */
+const TASK_OTHER = `task-arrival-other-${RUN_ID}`;
+const SESSION_OTHER = `sess-arrival-other-${RUN_ID}`;
+
+const FALLBACK_REPLAY_DELAY_MS = 250;
+
+/**
+ * Viewport and panel height are chosen together so a default-placed detail window
+ * cannot cover the bottom panel's tab bar. A window occupies the middle 70% of the
+ * overlay (`defaultWindowGeometry`), so its lower edge sits at 85% of the overlay
+ * height; the panel needs to be shorter than the remaining 15% to stay clear.
+ * At 1500px tall the overlay is ~1424px, so 15% is ~213px against this 150px
+ * panel - about 60px of clearance.
+ */
+const VIEWPORT = { width: 1600, height: 1500 };
+const PANEL_HEIGHT_PX = 150;
+
+/** Comfortably under the tier's 15s per-test timeout, so a failing wait reports
+ *  its own error instead of being swallowed by the test cap. */
+const STEP_TIMEOUT_MS = 8000;
+
+function preConfig(): string {
+  return `
+    // Force the losing order: the panel's fallback terminal resolves its replay
+    // after the detail window's, which is the arrangement that used to steal focus.
+    window.__mockScrollbackDelayMs = { '${SESSION_FALLBACK}': ${FALLBACK_REPLAY_DELAY_MS} };
+
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+
+      // A detail window is always 70% of the overlay's height, centered, so with
+      // the default 250px panel it lands on top of the panel's tab bar and the
+      // tab click below can never reach it. Shrinking the panel puts the tab bar
+      // clear of the window's lower edge at this spec's viewport height. See
+      // PANEL_HEIGHT_PX / the viewport in launch().
+      state.config.terminal.panelHeight = ${PANEL_HEIGHT_PX};
+      state.projects.push({
+        id: '${PROJECT_ID}',
+        name: 'Arrival Focus ${RUN_ID}',
+        path: '/mock/arrival-focus-${RUN_ID}',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+
+      var executingLaneId = null;
+      state.DEFAULT_SWIMLANES.forEach(function (template, index) {
+        var laneId = 'lane-af-${RUN_ID}-' + index;
+        if (template.name === 'Executing') executingLaneId = laneId;
+        state.swimlanes.push(Object.assign({}, template, {
+          id: laneId, position: index, created_at: ts,
+        }));
+      });
+
+      function addTask(taskId, sessionId, title, pid, position) {
+        state.sessions.push({
+          id: sessionId,
+          taskId: taskId,
+          projectId: '${PROJECT_ID}',
+          pid: pid,
+          status: 'running',
+          shell: 'bash',
+          cwd: '/mock/arrival-focus-${RUN_ID}',
+          startedAt: ts,
+          exitCode: null,
+          resuming: false,
+        });
+        state.tasks.push({
+          id: taskId,
+          display_id: position + 1,
+          title: title,
+          description: '',
+          swimlane_id: executingLaneId,
+          position: position,
+          agent: 'claude',
+          session_id: sessionId,
+          worktree_path: null,
+          branch_name: null,
+          pr_number: null,
+          pr_url: null,
+          base_branch: null,
+          archived_at: null,
+          created_at: ts,
+          updated_at: ts,
+        });
+      }
+
+      // Pushed first, so it is the panel's initial selection: the only IDLE one
+      // wins derivePanelSessionId's "prefer an idle visible session" rule.
+      addTask('${TASK_DETAIL}', '${SESSION_DETAIL}', 'Arrival Detail ${RUN_ID}', 7200, 0);
+      addTask('${TASK_FALLBACK}', '${SESSION_FALLBACK}', 'Arrival Fallback ${RUN_ID}', 7201, 1);
+      addTask('${TASK_OTHER}', '${SESSION_OTHER}', 'Arrival Other ${RUN_ID}', 7202, 2);
+
+      // Both remaining sessions are 'thinking', so once the detail's session is
+      // evicted the fallback is the FIRST visible one - deterministic, rather than
+      // depending on which of two idle candidates is picked.
+      state.activityCache['${SESSION_DETAIL}'] = 'idle';
+      state.activityCache['${SESSION_FALLBACK}'] = 'thinking';
+      state.activityCache['${SESSION_OTHER}'] = 'thinking';
+
+      return { currentProjectId: '${PROJECT_ID}' };
+    });
+  `;
+}
+
+async function launch(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: VIEWPORT });
+  const page = await context.newPage();
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(preConfig());
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 10000 });
+  await page.locator('[data-swimlane-name="Executing"]').waitFor({ state: 'visible', timeout: 10000 });
+  return { browser, page };
+}
+
+/**
+ * Lift each session's launch overlay so `TerminalTab` mounts a real xterm.
+ *
+ * Called BEFORE the detail is opened, deliberately. Lifting the overlay on an
+ * already-mounted terminal triggers a second, later arrival (the overlay-lift
+ * reload), which would land after the mount replay this spec is timing against
+ * and make the veil an unreliable marker for "the steal has now had its chance".
+ * Marking first, as a long-running session would already be, leaves each freshly
+ * mounted terminal with exactly one arrival.
+ */
+async function markFirstOutput(page: Page, sessionIds: string[]): Promise<void> {
+  await page.evaluate((ids) => {
+    const stores = (window as unknown as {
+      __zustandStores?: {
+        session?: { getState: () => { markFirstOutput: (id: string) => void } };
+      };
+    }).__zustandStores;
+    for (const id of ids) stores?.session?.getState().markFirstOutput(id);
+  }, sessionIds);
+}
+
+/**
+ * Let the frame that a settled replay schedules its focus on actually run.
+ *
+ * `settleScrollback` (which clears the veil) and the `requestAnimationFrame` that
+ * calls `focus()` are one beat apart, so observing the veil gone in the DOM does
+ * not guarantee the focus call has happened yet. Asserting in that gap would let a
+ * broken build pass. Two frames is a causal wait on the browser's own scheduler,
+ * not a wall-clock sleep, so it stays within cross-platform-parity's ban on
+ * `waitForTimeout`.
+ */
+async function settleFocusFrames(page: Page): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    }),
+  );
+}
+
+test('a delayed background replay does not steal focus from a just-opened task detail', async () => {
+  const { browser, page } = await launch();
+  try {
+    // The panel starts on the detail task's session (the only idle one).
+    await page.locator('[data-testid="terminal-session-pane"]').waitFor({ state: 'visible', timeout: STEP_TIMEOUT_MS });
+    await markFirstOutput(page, [SESSION_DETAIL, SESSION_FALLBACK]);
+
+    // Open the detail. This claims its session, so the panel drops that tab and
+    // mounts a fresh terminal for the fallback session.
+    await page.locator(`text=Arrival Detail ${RUN_ID}`).first().click();
+    const dialog = page.locator('[data-testid="task-detail-dialog"]');
+    await dialog.waitFor({ state: 'visible', timeout: STEP_TIMEOUT_MS });
+
+    const frame = page.locator('[data-testid^="window-frame-"]').filter({ has: dialog });
+    const detailTextarea = frame.locator('.xterm-helper-textarea').first();
+    // Addressed by session, not by the bare testid: the panel swaps its mounted
+    // pane during the eviction, and the OUTGOING pane has already settled - so a
+    // bare-testid wait would resolve before the fallback terminal even mounts,
+    // long before the steal it is supposed to be timing against.
+    const fallbackPane = page.locator(
+      `[data-testid="terminal-session-pane"][data-session-id="${SESSION_FALLBACK}"]`,
+    );
+    const fallbackTextarea = fallbackPane.locator('.xterm-helper-textarea').first();
+    const fallbackVeil = fallbackPane.locator('[data-testid="terminal-replay-veil"]');
+
+    // The fallback terminal really did mount. Without this the whole spec could
+    // pass simply because no competing terminal ever existed.
+    await fallbackTextarea.waitFor({ state: 'attached', timeout: STEP_TIMEOUT_MS });
+
+    // ...and its replay is genuinely still IN FLIGHT. This is the spec's own
+    // self-defense: `toHaveCount(0)` below is also satisfied by a veil that was
+    // never there, so if the forced delay ever stopped applying (a mock-API
+    // change, a renamed session id) the race would go unexercised while every
+    // assertion still passed. Checked here, at the earliest moment the pane
+    // exists and before any wait on the detail's own replay, so the delay window
+    // is barely consumed.
+    await fallbackVeil.waitFor({ state: 'attached', timeout: STEP_TIMEOUT_MS });
+
+    // The detail's replay settles first (the fallback's is delayed).
+    await expect(frame.locator('[data-testid="terminal-replay-veil"]')).toHaveCount(0, { timeout: STEP_TIMEOUT_MS });
+
+    // Checkpoint BEFORE the delayed replay lands. Separates "the gate focused the
+    // right terminal" from "the gate focused nothing", which the final assertion
+    // alone cannot distinguish without burning its full retry budget.
+    await expect(detailTextarea).toBeFocused({ timeout: STEP_TIMEOUT_MS });
+
+    // Now let the delayed replay finish. This is the moment of the steal.
+    await expect(fallbackVeil).toHaveCount(0, { timeout: STEP_TIMEOUT_MS });
+    await settleFocusFrames(page);
+
+    await expect(detailTextarea).toBeFocused();
+    await expect(fallbackTextarea).not.toBeFocused();
+  } finally {
+    await browser.close();
+  }
+});
+
+test('clicking a bottom-panel tab still focuses its terminal while a detail window is open', async () => {
+  const { browser, page } = await launch();
+  try {
+    await page.locator('[data-testid="terminal-session-pane"]').waitFor({ state: 'visible', timeout: STEP_TIMEOUT_MS });
+
+    await page.locator(`text=Arrival Detail ${RUN_ID}`).first().click();
+    const dialog = page.locator('[data-testid="task-detail-dialog"]');
+    await dialog.waitFor({ state: 'visible', timeout: STEP_TIMEOUT_MS });
+
+    await markFirstOutput(page, [SESSION_DETAIL, SESSION_FALLBACK, SESSION_OTHER]);
+
+    const frame = page.locator('[data-testid^="window-frame-"]').filter({ has: dialog });
+    await expect(frame.locator('[data-testid="terminal-replay-veil"]')).toHaveCount(0, { timeout: STEP_TIMEOUT_MS });
+
+    // Click a tab the panel is NOT already showing, so its terminal genuinely
+    // mounts and arrives. The detail window still holds window-layer focus, so
+    // without the tab-click claim the arbiter would resolve to it and deny this.
+    // The explicit timeout matters: if a geometry change ever puts the detail
+    // window back over the tab bar, this reports "intercepts pointer events"
+    // instead of silently hanging until the test cap.
+    await page
+      .locator(`[data-testid="terminal-session-tab"][data-session-id="${SESSION_OTHER}"]`)
+      .click({ timeout: STEP_TIMEOUT_MS });
+
+    // Scoped by session, so this cannot be satisfied by the outgoing pane.
+    const otherPane = page.locator(
+      `[data-testid="terminal-session-pane"][data-session-id="${SESSION_OTHER}"]`,
+    );
+    await expect(otherPane.locator('[data-testid="terminal-replay-veil"]')).toHaveCount(0, { timeout: STEP_TIMEOUT_MS });
+
+    await expect(otherPane.locator('.xterm-helper-textarea').first()).toBeFocused({ timeout: STEP_TIMEOUT_MS });
+  } finally {
+    await browser.close();
+  }
+});
+
+test('re-expanding the bottom panel focuses its terminal while a detail window is open', async () => {
+  const { browser, page } = await launch();
+  try {
+    await page.locator('[data-testid="terminal-session-pane"]').waitFor({ state: 'visible', timeout: STEP_TIMEOUT_MS });
+    await markFirstOutput(page, [SESSION_DETAIL, SESSION_FALLBACK]);
+
+    await page.locator(`text=Arrival Detail ${RUN_ID}`).first().click();
+    const dialog = page.locator('[data-testid="task-detail-dialog"]');
+    await dialog.waitFor({ state: 'visible', timeout: STEP_TIMEOUT_MS });
+
+    const frame = page.locator('[data-testid^="window-frame-"]').filter({ has: dialog });
+    await expect(frame.locator('[data-testid="terminal-replay-veil"]')).toHaveCount(0, { timeout: STEP_TIMEOUT_MS });
+    await expect(frame.locator('.xterm-helper-textarea').first()).toBeFocused({ timeout: STEP_TIMEOUT_MS });
+
+    // Collapsing UNMOUNTS the panel's TerminalTab (`showContent`), so expanding
+    // mounts a fresh one - an arrival, competing with a detail window that still
+    // holds window-layer focus.
+    await page.locator('button[title^="Collapse terminal panel"]').click({ timeout: STEP_TIMEOUT_MS });
+    await page.locator('[data-testid="terminal-session-pane"]').waitFor({ state: 'hidden', timeout: STEP_TIMEOUT_MS });
+
+    await page.locator('button[title^="Expand terminal panel"]').click({ timeout: STEP_TIMEOUT_MS });
+
+    const fallbackPane = page.locator(
+      `[data-testid="terminal-session-pane"][data-session-id="${SESSION_FALLBACK}"]`,
+    );
+    await expect(fallbackPane.locator('[data-testid="terminal-replay-veil"]')).toHaveCount(0, { timeout: STEP_TIMEOUT_MS });
+
+    await expect(fallbackPane.locator('.xterm-helper-textarea').first()).toBeFocused({ timeout: STEP_TIMEOUT_MS });
+  } finally {
+    await browser.close();
+  }
+});

--- a/tests/unit/dictation-target.test.ts
+++ b/tests/unit/dictation-target.test.ts
@@ -1,5 +1,7 @@
 /**
- * Unit tests for `resolveFocusedCommandSessionId` in dictation-target.ts.
+ * Unit tests for dictation-target.ts: `resolveFocusedCommandSessionId`, the
+ * `resolveDictationTarget` priority chain, and the shared
+ * `resolveFocusedWindowTerminal` resolver the arrival-focus arbiter also consumes.
  *
  * Covers the fix for "Command Terminal voice dictation doesn't work": priority 1
  * of `resolveDictationTarget()` used to read `focusedWindow.sessionId` from the
@@ -11,9 +13,14 @@
  * focusedWindowId alive, so an unguarded resolve would let a hidden terminal
  * steal dictation from a visible board window).
  */
-import { describe, it, expect, beforeEach, afterAll } from 'vitest';
-import { resolveFocusedCommandSessionId, resolveDictationTarget } from '../../src/renderer/utils/dictation-target';
-import { boardWindowManager, commandWindowManager } from '../../src/renderer/window-manager';
+import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
+import {
+  resolveFocusedCommandSessionId,
+  resolveDictationTarget,
+  resolveFocusedWindowTerminal,
+} from '../../src/renderer/utils/dictation-target';
+import { boardWindowManager, commandWindowManager, monitorWindowManager } from '../../src/renderer/window-manager';
+import { markLayerMounted } from '../../src/renderer/window-manager/store/layer-mount-registry';
 import { useSessionStore } from '../../src/renderer/stores/session-store';
 import { useProjectStore } from '../../src/renderer/stores/project-store';
 import { transientKey, type TransientSessionEntry } from '../../src/renderer/stores/session-store/transient-session-slice';
@@ -89,6 +96,14 @@ function resetIntegrationStores(): void {
     tileTree: null,
     tileTreeRect: { x: 0, y: 0, w: 1, h: 1 },
   });
+  monitorWindowManager.store.setState({
+    windows: {},
+    order: [],
+    focusedWindowId: null,
+    zCounter: 0,
+    tileTree: null,
+    tileTreeRect: { x: 0, y: 0, w: 1, h: 1 },
+  });
   useSessionStore.setState({
     sessions: [],
     commandBarVisible: false,
@@ -96,6 +111,25 @@ function resetIntegrationStores(): void {
     activeSessionId: null,
   });
   useProjectStore.setState({ currentProject: null });
+}
+
+/**
+ * Mark the window layers mounted, the way `WindowManagerLayer` does whenever its
+ * surface is on screen. `resolveFocusedWindowTerminal` SKIPS an unmounted layer:
+ * a layer's store deliberately outlives its React subtree, and a layer with no
+ * subtree hosts no xterm, so a stale `focusedWindowId` there must not resolve.
+ * Without this, the integration tests below would model a state that cannot occur
+ * while a window is actually on screen.
+ */
+let unmountLayers: Array<() => void> = [];
+
+function mountAllLayers(): void {
+  unmountLayers = [boardWindowManager, commandWindowManager, monitorWindowManager].map(markLayerMounted);
+}
+
+function unmountAllLayers(): void {
+  for (const unmount of unmountLayers) unmount();
+  unmountLayers = [];
 }
 
 describe('resolveFocusedCommandSessionId', () => {
@@ -183,10 +217,10 @@ describe('resolveFocusedCommandSessionId', () => {
 
 /**
  * Integration coverage for `resolveDictationTarget()`'s priority-1 leg
- * (the private `focusedCommandSessionId()` wrapper), exercised against the
+ * (the shared `resolveFocusedWindowTerminal()` resolver), exercised against the
  * REAL Zustand stores rather than a hand-built input object. This is the part
  * `resolveFocusedCommandSessionId`'s unit tests above cannot reach: the
- * wrapper's own store reads (`commandWindowManager.store.getState().windows[
+ * resolver's own store reads (`commandWindowManager.store.getState().windows[
  * focusedWindowId].anchor`, `useSessionStore.getState().commandBarVisible` /
  * `.transientSessions`, `useProjectStore.getState().currentProject?.id`) and
  * the fact that `resolveDictationTarget()` actually calls this wrapper FIRST
@@ -199,7 +233,11 @@ describe('resolveFocusedCommandSessionId', () => {
  * null instead of the seeded command session id.
  */
 describe('resolveDictationTarget - Command Terminal priority (real stores)', () => {
-  beforeEach(resetIntegrationStores);
+  beforeEach(() => {
+    resetIntegrationStores();
+    mountAllLayers();
+  });
+  afterEach(unmountAllLayers);
   afterAll(resetIntegrationStores);
 
   it('resolves the focused command-terminal window session when the command layer is visible', () => {
@@ -350,5 +388,186 @@ describe('resolveDictationTarget - Command Terminal priority (real stores)', () 
     });
 
     expect(resolveDictationTarget()).toBe(commandSessionId);
+  });
+});
+
+/**
+ * `resolveFocusedWindowTerminal()` is the shared answer to "which terminal-hosting
+ * window holds window-layer focus", used by BOTH `resolveDictationTarget()` (which
+ * falls through when it names no running session) and the terminal arrival-focus
+ * arbiter (which abstains instead). The two policies differ, so the resolver is
+ * pinned here on its own rather than only through dictation's chain.
+ *
+ * Red conditions this guards:
+ *  - Read `ManagedWindow.sessionId` instead of resolving by anchor, and the
+ *    "no session at open" and "respawned" cases below both return null.
+ *  - Walk only `boardWindowManager` (the pre-extraction behavior) and the monitor
+ *    case below returns null, so a focused monitor detail window is invisible.
+ *  - Drop the `isLayerMounted` gate and the unmounted-layer case below resolves a
+ *    window with no xterm on screen.
+ */
+describe('resolveFocusedWindowTerminal (real stores)', () => {
+  beforeEach(() => {
+    resetIntegrationStores();
+    mountAllLayers();
+  });
+  afterEach(unmountAllLayers);
+  afterAll(resetIntegrationStores);
+
+  it('resolves a board window by ANCHOR, not the stored sessionId', () => {
+    // The window was opened before the task had a session, so its stored
+    // `sessionId` is null forever - the store never writes it back on spawn.
+    // Anchor resolution still finds the session that spawned afterwards.
+    boardWindowManager.store.getState().openWindow({
+      anchor: 'task-1',
+      sessionId: null,
+      title: 'Task One',
+    });
+    useSessionStore.setState({
+      sessions: [makeSession({ id: 'sess-spawned-later', taskId: 'task-1', status: 'running' })],
+    });
+
+    expect(resolveFocusedWindowTerminal()).toEqual({ sessionId: 'sess-spawned-later' });
+  });
+
+  it('resolves the live session when the stored sessionId went stale after a respawn', () => {
+    boardWindowManager.store.getState().openWindow({
+      anchor: 'task-1',
+      sessionId: 'sess-old',
+      title: 'Task One',
+    });
+    useSessionStore.setState({
+      sessions: [makeSession({ id: 'sess-respawned', taskId: 'task-1', status: 'running' })],
+    });
+
+    expect(resolveFocusedWindowTerminal()).toEqual({ sessionId: 'sess-respawned' });
+  });
+
+  it('reports a focused window whose task has no session as sessionId null, NOT as "no window"', () => {
+    // The distinction is load-bearing for the arbiter: a window owning the
+    // user's attention with no terminal yet must still deny other terminals,
+    // which a null return would not do.
+    boardWindowManager.store.getState().openWindow({
+      anchor: 'task-unspawned',
+      sessionId: null,
+      title: 'Task Unspawned',
+    });
+
+    expect(resolveFocusedWindowTerminal()).toEqual({ sessionId: null });
+  });
+
+  it('resolves a focused monitor detail window', () => {
+    monitorWindowManager.store.getState().openWindow({
+      anchor: 'proj-1:task-mon',
+      sessionId: null,
+      title: 'Monitor Task',
+    });
+    useSessionStore.setState({
+      sessions: [makeSession({ id: 'sess-mon', taskId: 'task-mon', status: 'running' })],
+    });
+
+    expect(resolveFocusedWindowTerminal()).toEqual({ sessionId: 'sess-mon' });
+  });
+
+  it('returns null when no layer has a focused window', () => {
+    expect(resolveFocusedWindowTerminal()).toBeNull();
+  });
+
+  it('skips an UNMOUNTED layer even though its store still names a focused window', () => {
+    monitorWindowManager.store.getState().openWindow({
+      anchor: 'proj-1:task-mon',
+      sessionId: null,
+      title: 'Monitor Task',
+    });
+    useSessionStore.setState({
+      sessions: [makeSession({ id: 'sess-mon', taskId: 'task-mon', status: 'running' })],
+    });
+    // Closing the Agent Monitor unmounts its layer but keeps its windows and
+    // focus pointer. Without the mount gate that stale pointer would resolve
+    // forever, and for the arbiter it would deny every other terminal focus.
+    unmountAllLayers();
+    unmountLayers = [boardWindowManager, commandWindowManager].map(markLayerMounted);
+
+    expect(resolveFocusedWindowTerminal()).toBeNull();
+  });
+
+  it('skips a focused conversation window (read-only transcript, no input surface)', () => {
+    boardWindowManager.store.getState().openWindow({
+      kind: 'conversation',
+      anchor: 'sess-conv',
+      sessionId: 'sess-conv',
+      title: 'Conversation',
+    });
+    useSessionStore.setState({
+      sessions: [makeSession({ id: 'sess-conv', taskId: 'task-conv', status: 'running' })],
+    });
+
+    expect(resolveFocusedWindowTerminal()).toBeNull();
+  });
+
+  it('prefers the visible command layer over a focused monitor and board window', () => {
+    const projectId = 'proj-priority';
+    useProjectStore.setState({ currentProject: makeProject(projectId) });
+
+    boardWindowManager.store.getState().openWindow({
+      anchor: 'task-board',
+      sessionId: null,
+      title: 'Board Task',
+    });
+    monitorWindowManager.store.getState().openWindow({
+      anchor: `${projectId}:task-mon`,
+      sessionId: null,
+      title: 'Monitor Task',
+    });
+    commandWindowManager.store.getState().openWindow({
+      anchor: 'slot-1',
+      sessionId: null,
+      title: 'Command Terminal',
+    });
+
+    useSessionStore.setState({
+      commandBarVisible: true,
+      transientSessions: {
+        [transientKey(projectId, 'slot-1')]: {
+          projectId,
+          slot: 'slot-1',
+          sessionId: 'sess-cmd',
+          branch: 'main',
+        },
+      },
+      sessions: [
+        makeSession({ id: 'sess-cmd', projectId, transient: true, status: 'running' }),
+        makeSession({ id: 'sess-mon', projectId, taskId: 'task-mon', status: 'running' }),
+        makeSession({ id: 'sess-board', projectId, taskId: 'task-board', status: 'running' }),
+      ],
+    });
+
+    expect(resolveFocusedWindowTerminal()).toEqual({ sessionId: 'sess-cmd' });
+  });
+
+  it('falls past a HIDDEN command layer to the monitor, rather than resolving it to null', () => {
+    // Resolving a hidden command layer to `{ sessionId: null }` would wrongly
+    // claim the user's attention for a terminal nobody can see, and would starve
+    // every layer beneath it.
+    const projectId = 'proj-hidden-cmd';
+    useProjectStore.setState({ currentProject: makeProject(projectId) });
+
+    monitorWindowManager.store.getState().openWindow({
+      anchor: `${projectId}:task-mon`,
+      sessionId: null,
+      title: 'Monitor Task',
+    });
+    commandWindowManager.store.getState().openWindow({
+      anchor: 'slot-1',
+      sessionId: null,
+      title: 'Command Terminal',
+    });
+
+    useSessionStore.setState({
+      commandBarVisible: false,
+      sessions: [makeSession({ id: 'sess-mon', projectId, taskId: 'task-mon', status: 'running' })],
+    });
+
+    expect(resolveFocusedWindowTerminal()).toEqual({ sessionId: 'sess-mon' });
   });
 });

--- a/tests/unit/select-active-session.test.ts
+++ b/tests/unit/select-active-session.test.ts
@@ -6,6 +6,11 @@
  *   - happy path: updates activeSessionId AND persists to configStore + fires config.set
  *   - no-op guard: same taskId already stored -- must NOT call config.set again
  *   - skip cases: null, ACTIVITY_TAB, transient session, session in another project
+ *   - claimArrivalFocus wiring: a tab click claims arrival focus for the clicked
+ *     session (see .claude/rules/terminal-arrival-focus.md); ACTIVITY_TAB and null
+ *     must translate to a clearing `null` claim rather than naming the sentinel
+ *     itself, which can never mount and would deny every real terminal for the
+ *     arbiter's tier-1 TTL.
  *
  * deleteProject cleanup (project-store.ts):
  *   - entry exists: strips from both config/globalConfig and fires config.set
@@ -20,6 +25,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ACTIVITY_TAB } from '../../src/shared/types';
 import { DEFAULT_CONFIG } from '../../src/shared/types';
 import type { Session } from '../../src/shared/types';
+
+// Mocked so this file's assertions land on the WIRING (selectActiveSession calls
+// claimArrivalFocus with the right argument) rather than on the arbiter's own
+// decision table, which terminal-arrival-focus.test.ts already owns. A minimal
+// factory - session-store.ts imports nothing else from this module - also keeps
+// the window-manager / dictation-target import graph out of this file.
+// vi.mock is hoisted above the imports below by vitest's transform, so this
+// composes fine with the pre-import `globalThis.window` stub further down.
+const { claimArrivalFocusSpy } = vi.hoisted(() => ({ claimArrivalFocusSpy: vi.fn() }));
+vi.mock('../../src/renderer/utils/terminal-arrival-focus', () => ({
+  claimArrivalFocus: claimArrivalFocusSpy,
+}));
 
 // ---------------------------------------------------------------------------
 // Stub window.electronAPI before importing any store that touches it.
@@ -343,6 +360,48 @@ describe('selectActiveSession - skip cases', () => {
     useSessionStore.getState().selectActiveSession('sess-unknown');
 
     expect(configSetSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectActiveSession - claimArrivalFocus wiring
+// ---------------------------------------------------------------------------
+
+describe('selectActiveSession - claimArrivalFocus wiring', () => {
+  beforeEach(() => {
+    configSetSpy.mockClear();
+    claimArrivalFocusSpy.mockClear();
+    resetStores({ currentProjectId: 'proj-alpha' });
+  });
+
+  it('claims arrival focus for the clicked session id', () => {
+    const session = makeSession({ id: 'sess-1', taskId: 'task-1', projectId: 'proj-alpha' });
+    useSessionStore.setState({
+      sessions: [session],
+      _sessionByTaskId: buildSessionByTaskId([session]),
+    });
+
+    useSessionStore.getState().selectActiveSession('sess-1');
+
+    expect(claimArrivalFocusSpy).toHaveBeenCalledOnce();
+    expect(claimArrivalFocusSpy).toHaveBeenCalledWith('sess-1');
+  });
+
+  it('claims null (clearing the claim) for the ACTIVITY_TAB sentinel, not the sentinel itself', () => {
+    // ACTIVITY_TAB names no session and can never mount a terminal. Claiming it
+    // literally would set a live tier-1 claim that DENIES every real terminal's
+    // arrival for the arbiter's TTL, since tier 1 is exclusive.
+    useSessionStore.getState().selectActiveSession(ACTIVITY_TAB);
+
+    expect(claimArrivalFocusSpy).toHaveBeenCalledOnce();
+    expect(claimArrivalFocusSpy).toHaveBeenCalledWith(null);
+  });
+
+  it('claims null for a null selection', () => {
+    useSessionStore.getState().selectActiveSession(null);
+
+    expect(claimArrivalFocusSpy).toHaveBeenCalledOnce();
+    expect(claimArrivalFocusSpy).toHaveBeenCalledWith(null);
   });
 });
 

--- a/tests/unit/terminal-arrival-focus-sites.test.ts
+++ b/tests/unit/terminal-arrival-focus-sites.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Enforces .claude/rules/terminal-arrival-focus.md. Every programmatic focus on an ARRIVING
+// terminal (deferred init, mount replay, a reload the caller did not opt out of) must be
+// arbitrated, or two terminals mounting together race and whichever replay settles last takes the
+// user's keystrokes. Genuinely user-initiated focus stays unconditional and opts out with a
+// `// arrival-focus-ok: <reason>` marker on the call line or the line above.
+//
+// Scope is the terminal HOSTS: files that call `useTerminal(` or reach for an xterm textarea
+// directly. A focus call anywhere else in the renderer (form fields, dialogs, menus) is unrelated
+// to this rule and is not scanned.
+//
+// The pattern deliberately matches a BARE `focus()` as well as `.focus()`. Three real sites call a
+// destructured `focus` with no receiver (`TerminalTab`'s active effect, `CommandTerminalPane`'s
+// onInit, `useTerminalFileDrop`'s `focusTerminal()`), so a `\.focus\(\)`-only scan would pass
+// vacuously over exactly the sites this rule exists to protect.
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const SCAN_DIR = 'src/renderer';
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);
+const OK_MARKER = /arrival-focus-ok/;
+const ARBITER_GUARD = /mayTakeArrivalFocus|mayFocusOnArrival/;
+
+/** The arbiter itself, and the hook option's own plumbing, are not call sites. */
+const EXEMPT_FILES = new Set([
+  'src/renderer/utils/terminal-arrival-focus.ts',
+]);
+
+/** A file is a terminal host if it constructs a terminal, reaches for its textarea, or is handed
+ *  a terminal's focus function to call. */
+function isTerminalHost(source: string): boolean {
+  return source.includes('useTerminal(')
+    || source.includes('.xterm-helper-textarea')
+    || source.includes('focusTerminal');
+}
+
+/** `focus()` / `focusTerminal()` / `something.focus()`, but not `onFocus(` or `focusWindow(`. */
+const FOCUS_CALL = /\b(?:focus|focusTerminal)\s*\(\s*\)/g;
+
+/** Prose mentioning `focus()` is not a call site. Strips line comments and skips block-comment
+ *  bodies, so only real code is matched. The `arrival-focus-ok` marker is still read from the
+ *  ORIGINAL line, since it lives in exactly the comment this removes. */
+function codeOnly(line: string): string {
+  const trimmed = line.trim();
+  if (trimmed.startsWith('*') || trimmed.startsWith('/*') || trimmed.startsWith('//')) return '';
+  const commentIndex = line.indexOf('//');
+  return commentIndex >= 0 ? line.slice(0, commentIndex) : line;
+}
+
+function collectSourceFiles(directory: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath));
+    } else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function toPosix(relativePath: string): string {
+  return relativePath.replace(/\\/g, '/');
+}
+
+describe('every arrival focus in a terminal host is arbitrated', () => {
+  it('no unguarded, unmarked focus call in a terminal-host file', () => {
+    const offenders: string[] = [];
+
+    for (const filePath of collectSourceFiles(path.join(REPO_ROOT, SCAN_DIR))) {
+      const relative = toPosix(path.relative(REPO_ROOT, filePath));
+      if (EXEMPT_FILES.has(relative)) continue;
+
+      const source = fs.readFileSync(filePath, 'utf8');
+      if (!isTerminalHost(source)) continue;
+
+      const lines = source.split('\n');
+      lines.forEach((line, index) => {
+        FOCUS_CALL.lastIndex = 0;
+        if (!FOCUS_CALL.test(codeOnly(line))) return;
+
+        // The guard may sit on the same line (`if (initialized.current && mayFocusOnArrival())`)
+        // or on the line just above (the ref check inside a requestAnimationFrame body). An
+        // opt-out marker may sit anywhere in the contiguous comment block directly above, since a
+        // one-line reason is rarely enough to say WHY a focus is user-initiated.
+        const context = [line];
+        for (let above = index - 1; above >= 0; above--) {
+          const trimmed = lines[above].trim();
+          const isComment = trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*');
+          if (!isComment && context.length > 1) break;
+          context.unshift(lines[above]);
+          if (!isComment) break;
+        }
+        const block = context.join('\n');
+        if (ARBITER_GUARD.test(block)) return;
+        if (OK_MARKER.test(block)) return;
+
+        offenders.push(`${relative}:${index + 1}  ${line.trim()}`);
+      });
+    }
+
+    expect(
+      offenders,
+      'Arrival focus must route through mayTakeArrivalFocus (see .claude/rules/terminal-arrival-focus.md).\n'
+        + 'If this focus follows a real user gesture, mark it `// arrival-focus-ok: <reason>`.\n'
+        + `Unguarded:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('every useTerminal host passes the arrival-focus policy', () => {
+    // The focus-call scan above cannot see this gap. `useTerminal` owns two arrival
+    // frames of its own (the mount replay and the reload), and both read the option
+    // as `mayTakeArrivalFocusRef.current?.() === false` - so an ABSENT option is
+    // `undefined === false`, i.e. allow. A new host that mounts useTerminal and never
+    // calls the returned `focus` itself would therefore contain no focus call to
+    // flag, pass the scan vacuously, and still take arrival focus unconditionally.
+    const offenders: string[] = [];
+
+    for (const filePath of collectSourceFiles(path.join(REPO_ROOT, SCAN_DIR))) {
+      const relative = toPosix(path.relative(REPO_ROOT, filePath));
+      // The hook itself declares the option; it does not pass one.
+      if (relative === 'src/renderer/hooks/useTerminal.ts') continue;
+
+      const source = fs.readFileSync(filePath, 'utf8');
+      if (!source.includes('useTerminal(')) continue;
+      if (source.includes('mayTakeArrivalFocus')) continue;
+
+      offenders.push(relative);
+    }
+
+    expect(
+      offenders,
+      'A useTerminal() host must pass the `mayTakeArrivalFocus` option (see '
+      + '.claude/rules/terminal-arrival-focus.md). Omitting it silently restores the '
+      + `unconditional arrival focus this rule exists to prevent.\nMissing:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('scans the terminal hosts it is meant to cover', () => {
+    // The scan is a no-op if `isTerminalHost` stops matching (a renamed hook, a moved file), and a
+    // no-op scan passes silently. Pin the hosts so that failure is loud.
+    const expectedHosts = [
+      'src/renderer/hooks/useTerminal.ts',
+      'src/renderer/hooks/useTerminalFileDrop.ts',
+      'src/renderer/components/terminal/TerminalTab.tsx',
+      'src/renderer/components/command-bar/CommandTerminalPane.tsx',
+      'src/renderer/window-manager/components/WindowFrame.tsx',
+      'src/renderer/window-manager/components/TaskDetailWindow.tsx',
+      'src/renderer/window-manager/bridge/useWindowFocusReconcile.ts',
+    ];
+
+    const scanned = new Set(
+      collectSourceFiles(path.join(REPO_ROOT, SCAN_DIR))
+        .filter((filePath) => isTerminalHost(fs.readFileSync(filePath, 'utf8')))
+        .map((filePath) => toPosix(path.relative(REPO_ROOT, filePath))),
+    );
+
+    const missing = expectedHosts.filter((host) => !scanned.has(host));
+    expect(missing, `These terminal hosts are no longer being scanned: ${missing.join(', ')}`).toEqual([]);
+  });
+});

--- a/tests/unit/terminal-arrival-focus.test.ts
+++ b/tests/unit/terminal-arrival-focus.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Unit tests for the terminal arrival-focus arbiter.
+ *
+ * The bug: opening a task detail evicts the bottom panel's selected session, so
+ * the panel mounts a terminal for a DIFFERENT session at the same moment the
+ * detail window mounts its own. Both replays end in `xterm.focus()`, and whichever
+ * resolves last wins - so keystrokes intended for the task you just opened land in
+ * whatever agent the panel happened to fall back to.
+ *
+ * The property under test is EXCLUSIVITY. Each tier that resolves an answer
+ * decides outright: it allows a match and DENIES a mismatch, and never falls
+ * through to a lower tier that might allow. A tier that fell through would let two
+ * terminals arriving in the same frame both find themselves permitted, which is
+ * the race all over again. Every mismatch case below is therefore constructed so
+ * that the NEXT tier down would have allowed it.
+ */
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import {
+  resolveArrivalFocus,
+  windowFocusFingerprint,
+  mayTakeArrivalFocus,
+  claimArrivalFocus,
+  ARRIVAL_CLAIM_TTL_MS,
+  ARRIVAL_BURST_MS,
+  type ArrivalFocusInput,
+} from '../../src/renderer/utils/terminal-arrival-focus';
+import {
+  boardWindowManager,
+  commandWindowManager,
+  monitorWindowManager,
+} from '../../src/renderer/window-manager';
+
+const NOW = 1_000_000;
+
+/**
+ * Shared by EVERY block below that calls the real `mayTakeArrivalFocus`, and
+ * deliberately module-scope rather than one `let` per describe.
+ *
+ * `lastArrivalGrant` is module state inside the arbiter with no exported reset,
+ * so the only way to neutralize a grant an earlier test armed is for every later
+ * test to run at a strictly later timestamp. A per-describe clock breaks that:
+ * the second block restarts at NOW, which is EARLIER than the grants the first
+ * block advanced past, so `now - lastGrant.at` goes negative - and a negative age
+ * still satisfies `<= ARRIVAL_BURST_MS`, denying an unrelated session as
+ * `burst-taken`. One monotonic clock across all blocks makes that unrepresentable
+ * regardless of the order vitest runs them in.
+ */
+let monotonicClock = NOW;
+
+/** Advance past any grant a previous test could have armed, then pin fake time there. */
+function advanceToFreshInstant(): void {
+  monotonicClock += ARRIVAL_BURST_MS * 10;
+  vi.setSystemTime(monotonicClock);
+}
+
+/**
+ * A single monotonic fake-time cursor shared by every `beforeEach` below that
+ * uses `vi.useFakeTimers()` (the two "real wrapper" describe blocks further
+ * down). `lastArrivalGrant` (module state in the source, no exported reset)
+ * persists across tests and across describe blocks within this file, so two
+ * INDEPENDENT cursors that each restart at `NOW` can go backwards relative to
+ * a grant a block collected earlier - which reads as a negative age, which is
+ * always `<= ARRIVAL_BURST_MS`, which spuriously denies the next block's
+ * first case. One shared, always-advancing cursor keeps every test strictly
+ * later than any grant any earlier test in the file could have recorded.
+ */
+let arrivalFocusFakeClock = NOW;
+
+/** Tier 3, allowing: no claim, no focused window, focus not in a typing surface. */
+function baseInput(overrides: Partial<ArrivalFocusInput> = {}): ArrivalFocusInput {
+  return {
+    sessionId: 'sess-arriving',
+    claim: null,
+    now: NOW,
+    windowFocusFingerprint: 'board:|cmd:|mon:',
+    focusedWindowTerminal: null,
+    focusIsInTypingSurface: false,
+    lastGrant: null,
+    ...overrides,
+  };
+}
+
+describe('resolveArrivalFocus - tier 1, the user-gesture claim', () => {
+  it('allows the claimed session', () => {
+    const result = resolveArrivalFocus(baseInput({
+      sessionId: 'sess-clicked',
+      claim: { sessionId: 'sess-clicked', fingerprint: 'board:|cmd:|mon:', at: NOW },
+    }));
+    expect(result).toEqual({ allow: true, reason: 'claim' });
+  });
+
+  it('DENIES an unclaimed session even when tier 2 would have allowed it', () => {
+    // Exclusivity. The user clicked panel tab `sess-clicked`, so the detail
+    // window's terminal must not take focus just because its window is focused.
+    const result = resolveArrivalFocus(baseInput({
+      sessionId: 'sess-detail',
+      claim: { sessionId: 'sess-clicked', fingerprint: 'board:|cmd:|mon:', at: NOW },
+      focusedWindowTerminal: { sessionId: 'sess-detail' },
+    }));
+    expect(result).toEqual({ allow: false, reason: 'claim-mismatch' });
+  });
+
+  it('stops applying once the window layers move focus (fingerprint supersession)', () => {
+    // The reverse bug a TTL alone would create: click a panel tab, then open a
+    // detail window inside the TTL, and focus would stay stuck on the panel.
+    const result = resolveArrivalFocus(baseInput({
+      sessionId: 'sess-detail',
+      claim: { sessionId: 'sess-clicked', fingerprint: 'board:|cmd:|mon:', at: NOW },
+      windowFocusFingerprint: 'board:board-window-1|cmd:|mon:',
+      focusedWindowTerminal: { sessionId: 'sess-detail' },
+    }));
+    expect(result).toEqual({ allow: true, reason: 'window' });
+  });
+
+  it('stops applying after the backstop TTL lapses', () => {
+    const result = resolveArrivalFocus(baseInput({
+      sessionId: 'sess-detail',
+      claim: {
+        sessionId: 'sess-clicked',
+        fingerprint: 'board:|cmd:|mon:',
+        at: NOW - ARRIVAL_CLAIM_TTL_MS - 1,
+      },
+      focusedWindowTerminal: { sessionId: 'sess-detail' },
+    }));
+    expect(result).toEqual({ allow: true, reason: 'window' });
+  });
+
+  it('still applies at exactly the TTL boundary', () => {
+    const result = resolveArrivalFocus(baseInput({
+      sessionId: 'sess-clicked',
+      claim: {
+        sessionId: 'sess-clicked',
+        fingerprint: 'board:|cmd:|mon:',
+        at: NOW - ARRIVAL_CLAIM_TTL_MS,
+      },
+    }));
+    expect(result).toEqual({ allow: true, reason: 'claim' });
+  });
+});
+
+describe('resolveArrivalFocus - tier 2, the focused window', () => {
+  it('allows the focused window\'s own terminal', () => {
+    const result = resolveArrivalFocus(baseInput({
+      sessionId: 'sess-detail',
+      focusedWindowTerminal: { sessionId: 'sess-detail' },
+    }));
+    expect(result).toEqual({ allow: true, reason: 'window' });
+  });
+
+  it('DENIES the bottom panel\'s evicted-fallback terminal - the reported bug', () => {
+    // Exclusivity again: tier 3 would have allowed this (focus is not in a typing
+    // surface), which is exactly how the panel used to win the race.
+    const result = resolveArrivalFocus(baseInput({
+      sessionId: 'sess-panel-fallback',
+      focusedWindowTerminal: { sessionId: 'sess-detail' },
+    }));
+    expect(result).toEqual({ allow: false, reason: 'window-mismatch' });
+  });
+
+  it('DENIES everyone while a focused window has not spawned its session yet', () => {
+    // A window with no session still owns the user's attention, so it must not
+    // read as "no window focused" and let some other terminal grab focus.
+    const result = resolveArrivalFocus(baseInput({
+      sessionId: 'sess-panel-fallback',
+      focusedWindowTerminal: { sessionId: null },
+    }));
+    expect(result).toEqual({ allow: false, reason: 'window-mismatch' });
+  });
+});
+
+describe('resolveArrivalFocus - tier 3, nothing owns the user\'s attention', () => {
+  it('allows an arrival on a cold start', () => {
+    expect(resolveArrivalFocus(baseInput())).toEqual({ allow: true, reason: 'unclaimed' });
+  });
+
+  it('denies while focus sits in a typing surface', () => {
+    // `.xterm-helper-textarea` is a <textarea>, so this is also what stops an
+    // arriving terminal yanking focus out of one being typed into.
+    const result = resolveArrivalFocus(baseInput({ focusIsInTypingSurface: true }));
+    expect(result).toEqual({ allow: false, reason: 'occupied' });
+  });
+
+  it('lets one winner through when several terminals arrive together', () => {
+    // A workspace restore that persisted no focused window puts every restored
+    // terminal plus the panel in tier 3 at once.
+    const result = resolveArrivalFocus(baseInput({
+      sessionId: 'sess-second',
+      lastGrant: { sessionId: 'sess-first', at: NOW - 10 },
+    }));
+    expect(result).toEqual({ allow: false, reason: 'burst-taken' });
+  });
+
+  it('does not block the SAME session re-arriving inside the burst window', () => {
+    // One arrival legitimately fires focus more than once (the deferred-init rAF,
+    // then the mount replay). Those must not fight each other.
+    const result = resolveArrivalFocus(baseInput({
+      sessionId: 'sess-first',
+      lastGrant: { sessionId: 'sess-first', at: NOW - 10 },
+    }));
+    expect(result).toEqual({ allow: true, reason: 'unclaimed' });
+  });
+
+  it('releases the burst hold once it lapses', () => {
+    const result = resolveArrivalFocus(baseInput({
+      sessionId: 'sess-second',
+      lastGrant: { sessionId: 'sess-first', at: NOW - ARRIVAL_BURST_MS - 1 },
+    }));
+    expect(result).toEqual({ allow: true, reason: 'unclaimed' });
+  });
+});
+
+/** Shared by the fingerprint describe below and by the impure-wrapper describe
+ *  further down, which also needs a known "no window focused" starting point. */
+function resetWindowStores(): void {
+  for (const manager of [boardWindowManager, commandWindowManager, monitorWindowManager]) {
+    manager.store.setState({
+      windows: {},
+      order: [],
+      focusedWindowId: null,
+      zCounter: 0,
+      tileTree: null,
+      tileTreeRect: { x: 0, y: 0, w: 1, h: 1 },
+    });
+  }
+}
+
+/**
+ * The fingerprint is what supersedes a stale claim without any subscription, so
+ * it must actually move on every window-focus transition. If it stopped changing,
+ * tier 1 would keep applying after the user moved to a window and the arbiter
+ * would hold focus on the panel.
+ */
+describe('windowFocusFingerprint (real window stores)', () => {
+  beforeEach(resetWindowStores);
+  afterAll(resetWindowStores);
+
+  it('changes when a window opens, when focus moves, and when a window closes', () => {
+    const empty = windowFocusFingerprint();
+
+    const firstId = boardWindowManager.store.getState().openWindow({
+      anchor: 'task-1',
+      sessionId: null,
+      title: 'Task One',
+    });
+    const afterOpen = windowFocusFingerprint();
+    expect(afterOpen).not.toBe(empty);
+
+    boardWindowManager.store.getState().openWindow({
+      anchor: 'task-2',
+      sessionId: null,
+      title: 'Task Two',
+    });
+    const afterSecondOpen = windowFocusFingerprint();
+    expect(afterSecondOpen).not.toBe(afterOpen);
+
+    boardWindowManager.store.getState().focusWindow(firstId);
+    expect(windowFocusFingerprint()).toBe(afterOpen);
+
+    boardWindowManager.store.getState().closeWindow(firstId);
+    expect(windowFocusFingerprint()).not.toBe(afterOpen);
+  });
+
+  it('distinguishes the layer a window belongs to', () => {
+    boardWindowManager.store.getState().openWindow({
+      anchor: 'task-1',
+      sessionId: null,
+      title: 'Task One',
+    });
+    const boardFocused = windowFocusFingerprint();
+
+    resetWindowStores();
+    monitorWindowManager.store.getState().openWindow({
+      anchor: 'proj-1:task-1',
+      sessionId: null,
+      title: 'Task One',
+    });
+
+    // Both layers issue ids from their own sequence, so a fingerprint that did not
+    // carry the layer prefix could collide across layers.
+    expect(windowFocusFingerprint()).not.toBe(boardFocused);
+  });
+});
+
+/**
+ * `resolveArrivalFocus` above is the pure decision table, exercised with
+ * injected inputs. These tests instead call the REAL exported wrapper -
+ * `mayTakeArrivalFocus` / `claimArrivalFocus` - so a bug in the module-scope
+ * `arrivalClaim` / `lastArrivalGrant` plumbing itself (not just the pure
+ * decision table) fails red. Nothing here duplicates the pure-function tiers;
+ * every case below is chosen because it can only be observed through the real
+ * wrapper's module state.
+ *
+ * This project deliberately runs its unit tier without jsdom (see
+ * use-terminal-font-race.test.ts), so `document` does not exist as a runtime
+ * global here. `mayTakeArrivalFocus` reaches `document.activeElement` only via
+ * the private `focusIsInTypingSurface()`, so a minimal stub - not a full DOM -
+ * is enough: `activeElement: null` makes that check false unconditionally,
+ * which is all tier 1 and tier 3 below need. `vi.stubGlobal` mirrors the same
+ * pattern `terminal-mount-registry.test.ts` uses for `window`.
+ *
+ * `lastArrivalGrant` has no exported reset, so a fixed `vi.setSystemTime(NOW)`
+ * per test would let a grant armed by an earlier test still read as "0ms old"
+ * in a later one. `advanceToFreshInstant()` steps the SHARED monotonic clock
+ * instead, so every test starts strictly later than any grant armed anywhere in
+ * this file and residual state never has to be tracked by hand.
+ */
+describe('mayTakeArrivalFocus / claimArrivalFocus (the real, impure wrapper)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    advanceToFreshInstant();
+    resetWindowStores();
+    claimArrivalFocus(null);
+    vi.stubGlobal('document', { activeElement: null });
+  });
+
+  afterEach(() => {
+    claimArrivalFocus(null);
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('claimArrivalFocus(null) clears a standing claim', () => {
+    claimArrivalFocus('sess-a');
+    claimArrivalFocus(null);
+
+    // A DIFFERENT session must now be granted through tier 3 rather than
+    // denied as a claim-mismatch against the session cleared above. If the
+    // null branch became a no-op, the stale claim on 'sess-a' would still be
+    // live and would deny 'sess-b'.
+    expect(mayTakeArrivalFocus('sess-b')).toBe(true);
+  });
+
+  it('claims tier-1 exclusivity through the real wrapper: the claimed session is allowed, any other is denied', () => {
+    claimArrivalFocus('sess-a');
+    expect(mayTakeArrivalFocus('sess-a')).toBe(true);
+
+    // Step past the tier-3 burst window (well inside the tier-1 claim's own
+    // TTL) before the second check. Without this, a wrapper that silently
+    // stopped threading the real `arrivalClaim` into tier 1 would fall
+    // through to tier 3, which would ALSO deny 'sess-b' immediately after
+    // granting 'sess-a' - but for the wrong reason (a fresh burst hold, not a
+    // live claim mismatch), making the assertion below pass vacuously.
+    // Stepping past the burst window removes that false-pass path.
+    vi.advanceTimersByTime(ARRIVAL_BURST_MS + 1);
+
+    expect(mayTakeArrivalFocus('sess-b')).toBe(false);
+  });
+
+  it('records lastArrivalGrant only for a tier-3 (unclaimed) grant, never for a tier-1 (claim) grant', () => {
+    claimArrivalFocus('sess-claimed');
+    // Tier-1 grant. If this incorrectly armed the burst hold, the very next
+    // check below (an unrelated session, checked at the SAME instant, well
+    // inside ARRIVAL_BURST_MS) would be denied as burst-taken instead of
+    // reaching tier 3 on its own.
+    expect(mayTakeArrivalFocus('sess-claimed')).toBe(true);
+    claimArrivalFocus(null);
+
+    expect(mayTakeArrivalFocus('sess-unrelated')).toBe(true);
+  });
+});
+
+/**
+ * `focusIsInTypingSurface` is private, with no exported test seam, so this
+ * block reaches it the only way anything can: through `mayTakeArrivalFocus`'s
+ * real tier-3 branch. A stub `document.activeElement` with a SPIED `matches`
+ * stands in for jsdom, which this tier deliberately does not have (see the
+ * block above). That means these tests can only pin the CONTRACT - which
+ * exact selector string gets asked, and the `document.body` short-circuit -
+ * rather than real `Element.matches` CSS-matching semantics. That is a
+ * narrower claim than a real browser DOM would give, and is a deliberate
+ * tradeoff: a UI-tier version was considered and rejected, because every
+ * user gesture that causes an arrival in the real running app (a panel tab
+ * click, the collapse/expand toggle) ALSO calls `claimArrivalFocus` - so a
+ * genuinely unclaimed arrival with a controlled focus target cannot be
+ * manufactured through the app's real mounted flows without mutating
+ * session activity mid-test through the mock IPC layer, which is not
+ * available at this tier either.
+ */
+describe('focusIsInTypingSurface (through mayTakeArrivalFocus, its only entry point)', () => {
+  // Shares the file-level monotonic clock with the block above, which is the
+  // whole point: a per-block clock restarting at NOW would run EARLIER than the
+  // grants that block already armed, and a negative grant age still reads as
+  // inside ARRIVAL_BURST_MS, denying these sessions as `burst-taken`.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    advanceToFreshInstant();
+    resetWindowStores();
+    claimArrivalFocus(null);
+  });
+
+  afterEach(() => {
+    claimArrivalFocus(null);
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('does not read a non-matching element (e.g. a <button>) as a typing surface, and asks the exact selector list', () => {
+    const matchesSpy = vi.fn(() => false);
+    vi.stubGlobal('document', { body: {}, activeElement: { matches: matchesSpy } });
+
+    expect(mayTakeArrivalFocus('sess-button-focus')).toBe(true);
+    // The load-bearing assertion: this is what fails if `button` (or anything
+    // else) is ever added to the selector list. The return-value assertion
+    // above cannot see that change, because the stub returns whatever this
+    // test told it to regardless of which selector string was actually
+    // passed in.
+    expect(matchesSpy).toHaveBeenCalledWith('input, textarea, select, [contenteditable="true"]');
+  });
+
+  it('reads a matching element (e.g. a <textarea>) as a typing surface and denies the arrival', () => {
+    const matchesSpy = vi.fn(() => true);
+    vi.stubGlobal('document', { body: {}, activeElement: { matches: matchesSpy } });
+
+    expect(mayTakeArrivalFocus('sess-textarea-focus')).toBe(false);
+  });
+
+  it('short-circuits on activeElement === document.body without calling matches', () => {
+    const matchesSpy = vi.fn(() => true);
+    const bodySentinel = { matches: matchesSpy };
+    vi.stubGlobal('document', { body: bodySentinel, activeElement: bodySentinel });
+
+    expect(mayTakeArrivalFocus('sess-body-focus')).toBe(true);
+    // The load-bearing assertion for the second red condition: dropping the
+    // `active === document.body` guard would route this call into
+    // `active.matches(...)` instead of short-circuiting. A real
+    // `document.body` never matches the selector list either, so a
+    // return-value-only assertion cannot see the guard's removal - only the
+    // call count can.
+    expect(matchesSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/window-layer-isolation.test.ts
+++ b/tests/unit/window-layer-isolation.test.ts
@@ -88,6 +88,44 @@ describe('window-manager layer isolation', () => {
       }
     });
 
+    it('TERMINAL_WINDOW_LAYERS covers every manager in allWindowManagers', () => {
+      // `dictation-target.ts` keeps its OWN ordered list rather than iterating
+      // allWindowManagers, because the order is load-bearing there: it resolves
+      // the front-most focused layer first (command over monitor over board),
+      // while allWindowManagers is an unordered set. The ORDER may differ; the
+      // MEMBERSHIP may not. A manager missing from the terminal list makes
+      // `resolveFocusedWindowTerminal()` blind to that layer, which costs twice:
+      // dictation's priority 1 skips it, and the arrival-focus arbiter's tier 2
+      // reports "no focused window" for a window the user is actually working
+      // in, falls through to tier 3, and lets an unrelated arriving terminal
+      // steal focus - the exact race terminal-arrival-focus.ts exists to close.
+      const windowStore = read('src/renderer/window-manager/store/window-store.ts');
+      const dictationTarget = read('src/renderer/utils/dictation-target.ts');
+
+      // Same extraction as the membership test above: the exported instance
+      // names, not a loose scan of the list body (which also matches the bare
+      // `WindowManager` type annotation and would pass vacuously).
+      const exportedManagers = [...windowStore.matchAll(/^export const (\w*[Ww]indowManager) =/gm)]
+        .map((match) => match[1]);
+      expect(exportedManagers.length).toBeGreaterThanOrEqual(3);
+
+      const terminalListBody = dictationTarget.split('const TERMINAL_WINDOW_LAYERS')[1]?.split('];')[0] ?? '';
+      expect(
+        terminalListBody,
+        'TERMINAL_WINDOW_LAYERS is missing or malformed in dictation-target.ts',
+      ).not.toBe('');
+
+      for (const manager of exportedManagers) {
+        expect(
+          terminalListBody,
+          `${manager} is in allWindowManagers but not in TERMINAL_WINDOW_LAYERS `
+          + '(src/renderer/utils/dictation-target.ts). resolveFocusedWindowTerminal() would not '
+          + 'walk that layer, so a focused window there is invisible to BOTH voice dictation and '
+          + 'the arrival-focus arbiter, and an unrelated terminal can steal its keyboard focus.',
+        ).toContain(manager);
+      }
+    });
+
     it('useWindowSessionClaims reconciles across all managers, not one store', () => {
       const source = stripComments(read('src/renderer/window-manager/bridge/useWindowSessionClaims.ts'));
 


### PR DESCRIPTION
## What

Adds an arbiter that decides which terminal may take keyboard focus when it *arrives* (finishes
mounting or replaying), and routes every programmatic arrival-focus path through it.

- New `src/renderer/utils/terminal-arrival-focus.ts` (`resolveArrivalFocus`, `mayTakeArrivalFocus`,
  `claimArrivalFocus`, `windowFocusFingerprint`).
- `useTerminal` gains a `mayTakeArrivalFocus` option, consulted inside its two focus frames.
- `TerminalTab` and `CommandTerminalPane` supply the policy and gate their own focus calls.
- `selectActiveSession` and the panel's expand edge record a claim.
- New `.claude/rules/terminal-arrival-focus.md` plus a marker scan.

## Why

Opening a task detail claims that task's session, which evicts the bottom panel's selection and
makes the panel mount a terminal for a **different** session at the same moment. Both then fetch
scrollback, which main deliberately delays 150-400ms while the agent TUI's repaint settles, and
every arrival path ended in an unconditional `xterm.focus()`.

Whichever replay resolved **last** won. So a user could open a task, start typing, and have the
keystrokes land in whatever agent the panel had fallen back to. The reported case typed `/compact`
into the wrong session. It presented as intermittent, which was the mechanism, not flakiness.

The same unconditional grab also silently re-pointed the dictation target, since
`noteTerminalFocus` is wired to the textarea's `focus` event and cannot tell a programmatic focus
from a user one. One fix, two symptoms.

## How

`mayTakeArrivalFocus` decides from user-intent **state** in three tiers: a claim recorded by a
gesture that named a terminal before it existed, else the terminal-hosting window holding
window-layer focus, else allow unless focus sits in a typing surface.

Two things worth a reviewer's attention:

- **Tiers 1 and 2 DENY a mismatch rather than falling through.** A falling-through tier degrades
  straight back into a race, because two terminals arriving in the same frame would both find
  themselves permitted. Tier 3 has no mismatch to deny, so its guard is a 500ms burst hold.
- **A `document.activeElement` gate does not fix this**, and is the obvious wrong answer. Both
  terminals arrive with focus in the same place, so it only converts "last replay wins" into
  "first rAF wins", and it blocks the detail terminal outright whenever the clicked board card
  kept focus. `skipEnterAnimation` looks like a user-open-vs-restore signal but is not, since
  terminal-hosting windows set it on every open.

Hosts own the policy and pass it to `useTerminal`, so the hook stays surface-agnostic and never
imports the arbiter. Genuinely user-initiated focus (frame pointer-down, file drop, maximize
re-homing) stays unconditional and carries an `// arrival-focus-ok:` marker.

Extracting the shared `resolveFocusedWindowTerminal` into `dictation-target.ts` fixed two latent
bugs in dictation targeting: the focused window's session is now resolved by **anchor** (because
`ManagedWindow.sessionId` is captured at open and never written back on spawn or respawn), and it
now walks all three window layers instead of only the board. It also skips unmounted layers,
without which a closed Agent Monitor's stale `focusedWindowId` would deny every terminal focus
indefinitely.

## Breaking changes

None. Dictation targeting changes behavior (anchor resolution, all three layers, unmounted-layer
skip), but only to resolve cases it previously got wrong; no API, config, or user action changes.

## Tests

- `tests/unit/terminal-arrival-focus.test.ts` - the pure resolver's tier matrix plus the live
  wrapper. Every mismatch case is constructed so the next tier down would have allowed it, so the
  exclusivity property is what is actually pinned.
- `tests/unit/terminal-arrival-focus-sites.test.ts` - scans terminal-host files and fails on any
  focus call that is neither arbitrated nor marked. Matches bare `focus()` as well as `.focus()`,
  since three real sites call a destructured `focus` with no receiver.
- `tests/unit/dictation-target.test.ts` - extended for the shared resolver (anchor resolution,
  stale/absent session, monitor layer, unmounted-layer skip, layer priority).
- `tests/ui/terminal-arrival-focus.spec.ts` - three specs driving the real race through a new
  per-session scrollback delay in the mock, which is what makes the losing order reproducible
  rather than a coin toss.

Red-green confirmed on each UI spec: removing the arrival gates, the tab-click claim, or the
panel-expand claim each fails its own spec. The fix was additionally verified by hand in a preview
against live PTYs, in the forced losing order.

Known gap, documented in the rule: the site scan can see a focus call that is not arbitrated, but
it cannot see a user gesture that *should* have claimed and did not. The behavior specs are the
only guard there, so extend them when a new claiming gesture is added.

Generated with [Claude Code](https://claude.com/claude-code)
