### PR TITLE
fix(image-paste): cap at the measured clamp, prune the clipboard temp dir

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -399,7 +399,7 @@ Detach a registered UI surface (usage stats, git changes, the task Browser pane,
 ### Clipboard (2 channels)
 | Channel | Pattern | Purpose |
 |---------|---------|---------|
-| `clipboard:readImage` | invoke | Read the native clipboard image, save it to a temp file, returns file path or null |
+| `clipboard:readImage` | invoke | Read the native clipboard image, cap its long edge at `IMAGE_LONG_EDGE_CAP`, prune stale `pasted-image-*` files from the temp directory (24h age limit, 40-file cap), save it to a temp file, returns file path or null |
 | `clipboard:writeText` | invoke | Write text to the native clipboard (focus-independent; used by terminal copy and the OSC 52 handler) |
 
 ### Browser pane (10 channels)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -160,7 +160,7 @@ The leftmost tab shows an activity log - structured events from all sessions. Th
 
 ### Clipboard Paste
 
-Press **Ctrl+V** (Cmd+V on macOS) in the terminal to paste. Text on the clipboard is pasted directly. If the clipboard contains an image (and no text), the image is saved to a temporary file; the agent then reliably reads it as a vision input, since a bare file path alone is not recognized as an image by most CLIs. Claude Code receives an explicit "Read this image: ..." instruction pointing at the saved file (this is more reliable than the CLI's own clipboard reader, which can silently miss a Windows Snipping Tool image); other agents receive the bare file path today. Paths are automatically quoted for the active shell (PowerShell, bash, cmd, WSL, etc.).
+Press **Ctrl+V** (Cmd+V on macOS) in the terminal to paste. Text on the clipboard is pasted directly. If the clipboard contains an image (and no text), the image is saved to a temporary file, capped at a 2000px long edge so a 4K or 5K grab does not land on disk at full size; the agent then reliably reads it as a vision input, since a bare file path alone is not recognized as an image by most CLIs. The cap costs no detail - it sits at the point above which the extra pixels are discarded before an agent ever sees them. Saved pastes are pruned by age and count, so the temp directory no longer grows for the life of the install. Claude Code receives an explicit "Read this image: ..." instruction pointing at the saved file (this is more reliable than the CLI's own clipboard reader, which can silently miss a Windows Snipping Tool image); other agents receive the bare file path today. Paths are automatically quoted for the active shell (PowerShell, bash, cmd, WSL, etc.).
 
 ### File Drop to Terminal
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -32,7 +32,7 @@ New projects start with seven columns:
 
 Click the **+** button on any column header or use the "New Task" button. Enter a title and optional description. You can set a priority level, add labels, and attach files (images, documents, or any file type) by pasting from the clipboard or dragging files onto the dialog. Attachments are included in the agent's prompt.
 
-Pasted screenshots are automatically compressed to fit Claude's per-image budget. Kangentic resizes large pastes to a 1568px long edge (matching the API's own downscale) and re-encodes them as WebP, stepping quality down until each image lands under a ~1.5MB target, so a multi-monitor screen grab does not get rejected by the API. Small pastes (under 500KB), GIFs, and SVGs are attached as-is.
+Pasted screenshots are capped at a 2000px long edge, which bounds a multi-monitor grab without costing the detail an agent needs to read small text. Oversized pastes are re-encoded as WebP, stepping quality down until each image lands under a ~1.5MB target, so a large grab is not rejected by the API. Small pastes (under 500KB), GIFs, SVGs, and PNGs already inside the cap are attached as-is.
 
 In the description field, type `@` to trigger file autocomplete. A dropdown lists files and directories from the project root, which you can navigate with arrow keys and select with Enter to insert the path.
 

--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -17,6 +17,7 @@ import { agentRegistry } from '../../agent/agent-registry';
 import { broadcast } from '../../pop-out/window-broadcast';
 import { resolveRelayUrl } from '../../../shared/relay';
 import { EXTERNAL_OPEN_SCHEMES, isAllowedExternalUrl } from '../../../shared/external-url';
+import { capClipboardImage, pruneClipboardTempDir } from '../helpers/clipboard-image';
 import type {
   NotificationInput,
   AgentCommand,
@@ -635,14 +636,33 @@ export function registerSystemHandlers(context: IpcContext): void {
   // clipboard holds no image. Always PNG: a NativeImage is a still bitmap, so an
   // animated GIF copied from a browser is reduced to a single static frame, matching
   // how OS "copy screenshot" already populates the clipboard.
+  //
+  // The image is capped at IMAGE_LONG_EDGE_CAP before it is written, so a raw 4K
+  // or 5K grab does not land on disk and cross the bridge at full size. This
+  // costs no fidelity and saves no tokens: the cap sits at the knee where the
+  // chain normalizes anyway, so the dropped pixels are ones the model would
+  // never have seen. See `src/shared/image-fidelity.ts` for what was measured.
   ipcMain.handle(IPC.CLIPBOARD_READ_IMAGE, (): string | null => {
     const image = clipboard.readImage();
     if (image.isEmpty()) return null;
     const tempDir = path.join(os.tmpdir(), 'kangentic-clipboard');
-    fs.mkdirSync(tempDir, { recursive: true });
-    const filePath = path.join(tempDir, `pasted-image-${Date.now()}.png`);
-    fs.writeFileSync(filePath, image.toPNG());
-    return filePath;
+    try {
+      fs.mkdirSync(tempDir, { recursive: true });
+      // Nothing used to delete these, so the directory grew for the life of the
+      // install. Disk hygiene only - it does not change what an agent is billed.
+      pruneClipboardTempDir(tempDir);
+      const filePath = path.join(tempDir, `pasted-image-${Date.now()}.png`);
+      fs.writeFileSync(filePath, capClipboardImage(image).toPNG());
+      return filePath;
+    } catch (error) {
+      // Degrade to the same null an empty clipboard returns rather than
+      // rejecting the renderer's invoke. The disk can be full, a Windows
+      // antivirus scanner can hold a just-created temp file, and on a shared
+      // Linux /tmp the directory can already belong to another user. None of
+      // those should turn a Ctrl+V into an unhandled rejection.
+      console.error('[clipboard] Failed to save pasted image:', error);
+      return null;
+    }
   });
 
   // Write text to the clipboard natively in the main process rather than via the web

--- a/src/main/ipc/helpers/clipboard-image.ts
+++ b/src/main/ipc/helpers/clipboard-image.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { NativeImage } from 'electron';
+import { IMAGE_LONG_EDGE_CAP, resolveResizeTarget } from '../../../shared/image-fidelity';
+
+/**
+ * Clipboard-image handling for the terminal Ctrl+V paste path.
+ *
+ * Kept out of `handlers/system.ts` so the sizing and pruning rules can be tested
+ * directly rather than through `ipcMain`.
+ */
+
+/** Keep pasted images around long enough to survive a re-read or a slow agent,
+ *  but not forever. */
+export const CLIPBOARD_TEMP_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/** Ceiling regardless of age, so a burst of pastes in one session cannot leave
+ *  hundreds of multi-megabyte PNGs behind.
+ *
+ *  The prune runs BEFORE the current paste is written, so it trims what is
+ *  already there and the write then lands on top: the observed steady state is
+ *  this many plus the in-flight file, not exactly this many. */
+export const CLIPBOARD_TEMP_MAX_FILES = 40;
+
+const CLIPBOARD_TEMP_PREFIX = 'pasted-image-';
+
+/**
+ * Cap the long edge of a clipboard image before it is written to disk.
+ *
+ * This saves no tokens and is not meant to: the upstream clamp already charges
+ * the same for a 4K grab as for a 2000px one (see `image-fidelity.ts`). What it
+ * bounds is the temp file and the path handed across the bridge, so a 5K
+ * screenshot does not land on disk at full size on every paste.
+ *
+ * Returns the input untouched when it already fits, so an ordinary screenshot is
+ * never re-encoded for nothing.
+ */
+export function capClipboardImage(image: NativeImage, longEdge: number = IMAGE_LONG_EDGE_CAP): NativeImage {
+  const size = image.getSize();
+  const target = resolveResizeTarget(size.width, size.height, longEdge);
+  if (!target) return image;
+
+  // `quality: 'best'` is already Electron's default; it is passed explicitly
+  // because this is a downscale of small UI text, where the resampling filter is
+  // a legibility lever rather than a cosmetic one, and a future default change
+  // should not silently degrade it.
+  const resized = image.resize({ width: target.width, height: target.height, quality: 'best' });
+
+  // Never hand an empty image on to toPNG(): a paste that writes a zero-byte file
+  // is worse than a paste that costs a few extra bytes.
+  return resized.isEmpty() ? image : resized;
+}
+
+/**
+ * Delete stale pasted-image files from the clipboard temp directory.
+ *
+ * This is a DISK fix, not a token optimization. The obvious-looking alternative -
+ * naming the file by a hash of its contents so a repeated paste of the same
+ * screenshot reuses one path and is billed once - was measured and does not work.
+ * Two Read calls in a single turn cost the same whether they name the same path
+ * twice or two different paths holding identical bytes (measured 2026-08-10:
+ * 139,945 vs 139,914 total input tokens, a 31-token difference that is pure
+ * run-to-run noise). The billing unit is the image BLOCK in context, not the
+ * path, so a second paste is a second block no matter what it is called. Do not
+ * rebuild that idea on token grounds.
+ *
+ * Before this prune, every paste wrote a new file and nothing ever removed one,
+ * so the directory grew for the life of the install.
+ *
+ * Best-effort by design. It runs on the paste path, so a locked or vanished file
+ * must never turn into a failed paste.
+ */
+export function pruneClipboardTempDir(
+  tempDir: string,
+  options: { maxAgeMs?: number; maxFiles?: number; now?: number } = {},
+): void {
+  const maxAgeMs = options.maxAgeMs ?? CLIPBOARD_TEMP_MAX_AGE_MS;
+  const maxFiles = options.maxFiles ?? CLIPBOARD_TEMP_MAX_FILES;
+  const now = options.now ?? Date.now();
+
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(tempDir);
+  } catch {
+    return; // directory does not exist yet, or is unreadable
+  }
+
+  const files: { filePath: string; modifiedMs: number }[] = [];
+  for (const entry of entries) {
+    if (!entry.startsWith(CLIPBOARD_TEMP_PREFIX)) continue; // never touch a file we did not write
+    const filePath = path.join(tempDir, entry);
+    try {
+      const stats = fs.statSync(filePath);
+      if (!stats.isFile()) continue;
+      files.push({ filePath, modifiedMs: stats.mtimeMs });
+    } catch {
+      // Raced with another delete, or unreadable. Skip it.
+    }
+  }
+
+  // Newest first, so the count cap drops the oldest.
+  files.sort((left, right) => right.modifiedMs - left.modifiedMs);
+
+  for (let index = 0; index < files.length; index++) {
+    const isTooOld = now - files[index].modifiedMs > maxAgeMs;
+    const isOverCap = index >= maxFiles;
+    if (!isTooOld && !isOverCap) continue;
+    try {
+      // `force` suppresses ENOENT only, for a file a concurrent paste already
+      // removed. It does NOT suppress the EPERM/EBUSY Windows raises on a file
+      // held open by a reader - the catch below is what tolerates that, so do
+      // not drop it as redundant.
+      fs.rmSync(files[index].filePath, { force: true });
+    } catch {
+      // Best-effort: a file we cannot remove is retried on the next paste.
+    }
+  }
+}

--- a/src/renderer/components/dialogs/image-compress.ts
+++ b/src/renderer/components/dialogs/image-compress.ts
@@ -1,17 +1,30 @@
 import { useToastStore } from '../../stores/toast-store';
+import { IMAGE_LONG_EDGE_CAP, resolveResizeTarget } from '../../../shared/image-fidelity';
 import { isImageMediaType, resolveMediaType } from './attachment-utils';
 
 /**
  * Anthropic vision API budget:
  *   - 5MB hard cap per image (base64-encoded source bytes)
  *   - 8000x8000 absolute pixel cap, 2000x2000 when sending >20 images
- *   - Auto-downscales to ~1568px long edge, so larger uploads waste bandwidth
+ *
+ * WHAT ACTUALLY COSTS TOKENS: pixel AREA, and nothing else. Re-encoding an image
+ * (the WebP quality ladder below, grayscale, palette reduction, PNG optimization)
+ * shrinks the file and costs the model exactly the same. The ladder is kept for
+ * disk and IPC reasons - a pasted attachment is base64'd across the bridge and
+ * stored - and must not be described as a token optimization.
+ *
+ * ON THE LONG-EDGE CAP: this path shipped 1568px for a long time, on a comment
+ * claiming it matched "the API's own downscale". It did not, and 1568 was
+ * actively costing accuracy: with no option to decline, an agent reading a
+ * 1568px UI screenshot misread a branch hash in 6 of 7 attempts and named the
+ * wrong bar in a three-bar chart in 5 of 7, confidently and without ever
+ * flagging doubt. At the 2000px cap the same 84 probes produced zero errors, and
+ * cost no more, because the chain normalizes above ~2.25MP anyway. See
+ * `src/shared/image-fidelity.ts` for the measurements.
  *
  * We target a 1.5MB blob so the base64 payload (~2MB) fits with comfortable
- * headroom under the 5MB cap, and we resize to 1568px long edge to match
- * the API's own downscale and avoid sending pixels that get discarded.
+ * headroom under the 5MB cap.
  */
-export const LONG_EDGE_TARGET = 1568;
 export const MIN_COMPRESS_BYTES = 500 * 1024;
 export const TARGET_BYTES = 1.5 * 1024 * 1024;
 export const QUALITY_LADDER = [0.85, 0.75, 0.6] as const;
@@ -35,20 +48,34 @@ function renameToWebp(originalName: string): string {
 }
 
 /**
+ * Draw `bitmap` into a canvas at `target`, downscaling if needed.
+ *
+ * `imageSmoothingQuality` is set explicitly because the browser default is
+ * 'low', which is visibly destructive on a large downscale of small UI text -
+ * and reading small UI text is the case this whole pipeline exists to preserve.
+ */
+function renderToCanvas(bitmap: ImageBitmap, longEdge: number): OffscreenCanvas {
+  const target = resolveResizeTarget(bitmap.width, bitmap.height, longEdge)
+    ?? { width: bitmap.width, height: bitmap.height };
+
+  const canvas = new OffscreenCanvas(target.width, target.height);
+  const context = canvas.getContext('2d');
+  if (!context) throw new Error('OffscreenCanvas 2d context unavailable');
+
+  context.imageSmoothingEnabled = true;
+  context.imageSmoothingQuality = 'high';
+  context.drawImage(bitmap, 0, 0, target.width, target.height);
+  return canvas;
+}
+
+/**
  * Pure pipeline used by both the public helper and the calibration harness.
  * Takes an explicit long-edge target and quality so callers can sweep params.
  */
 export async function compressImage(input: File, options: CompressImageOptions): Promise<Blob> {
   const bitmap = await createImageBitmap(input);
   try {
-    const longEdge = Math.max(bitmap.width, bitmap.height);
-    const scale = Math.min(1, options.longEdge / longEdge);
-    const width = Math.max(1, Math.round(bitmap.width * scale));
-    const height = Math.max(1, Math.round(bitmap.height * scale));
-    const canvas = new OffscreenCanvas(width, height);
-    const ctx = canvas.getContext('2d');
-    if (!ctx) throw new Error('OffscreenCanvas 2d context unavailable');
-    ctx.drawImage(bitmap, 0, 0, width, height);
+    const canvas = renderToCanvas(bitmap, options.longEdge);
     return await canvas.convertToBlob({ type: 'image/webp', quality: options.quality });
   } finally {
     bitmap.close();
@@ -59,12 +86,14 @@ export async function compressImage(input: File, options: CompressImageOptions):
  * Compress a clipboard-pasted image to fit Anthropic's vision API budget.
  *
  * Skip rules: not an image, GIF/SVG (lossy re-encode would damage them), under
- * 500KB (already small), or PNG that already fits the long-edge target (preserves
- * alpha for icons/UI screenshots without an explicit alpha probe).
+ * 500KB (already small), or a PNG that already fits the long-edge cap (preserves
+ * alpha for icons/UI screenshots without an explicit alpha probe, and avoids a
+ * lossy round-trip for an image that is already within budget).
  *
- * Pipeline: createImageBitmap -> resize to LONG_EDGE_TARGET on the long edge ->
- * OffscreenCanvas -> WebP at quality 0.85, falling back to 0.75 then 0.6 if the
- * result still exceeds TARGET_BYTES.
+ * Pipeline: createImageBitmap -> resize to IMAGE_LONG_EDGE_CAP on the long edge
+ * at high resampling quality -> WebP at quality 0.85, falling back to 0.75 then
+ * 0.6 if the result still exceeds TARGET_BYTES. The ladder is a byte budget, not
+ * a token one.
  *
  * Failure handling: any thrown error toasts a single warning and returns the
  * original file. Pastes never silently disappear.
@@ -83,17 +112,11 @@ export async function compressClipboardImage(input: File): Promise<CompressResul
   try {
     const bitmap = await createImageBitmap(input);
     try {
-      const longEdge = Math.max(bitmap.width, bitmap.height);
-      const scale = Math.min(1, LONG_EDGE_TARGET / longEdge);
-      if (scale === 1 && mediaType === 'image/png') {
+      const needsResize = resolveResizeTarget(bitmap.width, bitmap.height, IMAGE_LONG_EDGE_CAP) !== null;
+      if (!needsResize && mediaType === 'image/png') {
         return { file: input, compressed: false };
       }
-      const width = Math.max(1, Math.round(bitmap.width * scale));
-      const height = Math.max(1, Math.round(bitmap.height * scale));
-      const canvas = new OffscreenCanvas(width, height);
-      const ctx = canvas.getContext('2d');
-      if (!ctx) throw new Error('OffscreenCanvas 2d context unavailable');
-      ctx.drawImage(bitmap, 0, 0, width, height);
+      const canvas = renderToCanvas(bitmap, IMAGE_LONG_EDGE_CAP);
 
       let blob: Blob | null = null;
       for (const quality of QUALITY_LADDER) {

--- a/src/shared/image-fidelity.ts
+++ b/src/shared/image-fidelity.ts
@@ -1,0 +1,116 @@
+/**
+ * Pixel budget for images handed to an agent, shared by the main process
+ * (terminal Ctrl+V paste) and the renderer (task/backlog attachment paste).
+ *
+ * Lives in `src/shared/` because main cannot import from `src/renderer/`, and both
+ * paths must cap by the same rule or a pasted screenshot would mean two different
+ * things depending on where it was dropped.
+ *
+ * ---------------------------------------------------------------------------
+ * THIS IS A FIDELITY FLOOR, NOT A TOKEN OPTIMIZATION
+ * ---------------------------------------------------------------------------
+ *
+ * Vision cost is a function of pixel AREA, not file bytes, so re-encoding (WebP or
+ * JPEG quality, grayscale, palette reduction, PNG optimization) shrinks the file
+ * and costs the model exactly the same. That makes downscaling look like the one
+ * real lever. It is not, and the reason is worth writing down, because the idea
+ * keeps looking attractive.
+ *
+ * FIRST: a clamp upstream is already doing the capping. One procedural scene
+ * emitted at eight resolutions, one `claude -p` run each, comparing TOTAL input
+ * tokens (`inputTokens + cacheCreation + cacheRead`; the individual cache buckets
+ * are useless alone, since a repeat flips a cacheCreation into a cacheRead and the
+ * delta inverts). "predicted" is area/750 relative to the 1000px row:
+ *
+ *   long edge   size        area     vs 1000px   predicted
+ *        1000   1000x563   0.56MP           -           -
+ *        1568   1568x882   1.38MP      +1,052      +1,093
+ *        1984   1984x1116  2.21MP      +2,113      +2,202
+ *        2100   2100x1181  2.48MP      +2,248      +2,556
+ *        2400   2400x1350  3.24MP      +2,266      +3,569
+ *        3400   3400x1913  6.50MP      +2,252      +7,922
+ *
+ * Cost tracks area/750 up through 1984px, then every rung from 2100 to 3400 lands
+ * on the same ~+2,250 plateau (the +-25 spread is run-to-run noise). Something
+ * normalizes above roughly 2.25MP, about 2000px on the long edge at 16:9. A 4K
+ * paste and a 2000px paste therefore cost the SAME. There is no token saving to be
+ * had above this line.
+ *
+ * SECOND: below it, the agent gets details wrong without ever saying so. A
+ * 2560x1440 dark UI was rendered at Kangentic's real type sizes (11px labels, 12px
+ * monospace) with twelve probes - six text, six non-text affordances at realistic
+ * sizes (a 6px status dot, a 12px checkbox, a 14px icon, a 1px underline, three bar
+ * heights, a diff gutter marker). It was downscaled and the agent asked to answer
+ * all twelve with NO option to decline, so every miss is a silent error - the
+ * failure that reaches users, not a refusal. 84 probes per rung:
+ *
+ *   long edge   silent-wrong   what actually broke
+ *        2000        0 / 84    nothing
+ *        1568       11 / 84    branch hash "feat/b6d09fa" read as "feat/b6dd9f6"
+ *                              (6 of 7 attempts); "which bar is tallest" answered
+ *                              right instead of middle (5 of 7)
+ *
+ * That second row is not low confidence and not a transcription wobble. It is a
+ * confident, specific, wrong answer about both text and non-text detail. An
+ * earlier version of this measurement scored 41/42 at 1568 - but it probed only
+ * text, and it told the model it could answer ILLEGIBLE. Both concessions hid the
+ * real failure.
+ *
+ * So the cap below is chosen to be free (the clamp discards everything above it)
+ * AND clean (0/84). Lowering it to buy tokens buys wrong answers instead, which is
+ * also why there is deliberately no user-facing setting: a dial here would only
+ * offer someone a way to make their own screenshots worse.
+ *
+ * This path shipped 1568 for a long time on a comment claiming it matched "the
+ * API's own downscale". It did not, and it was quietly costing accuracy.
+ */
+
+/**
+ * Long-edge cap, in pixels, for any image on its way to an agent.
+ *
+ * Sits at the knee: high enough that nothing the model would have used is
+ * discarded, low enough to bound the temp file and the base64 IPC payload a raw
+ * 4K or 5K screenshot would otherwise carry.
+ *
+ * Note what is and is not measured AT this number. The cost table brackets it
+ * rather than landing on it - 1984 still tracks area, 2100 is already on the
+ * plateau - so 2000 is interpolated between those two rungs, not a measured cost
+ * point. The ACCURACY probes below were run at exactly 2000 (0 of 84 silent
+ * errors), so the fidelity half of the choice is measured directly.
+ */
+export const IMAGE_LONG_EDGE_CAP = 2000;
+
+export interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+/**
+ * Target dimensions to fit `longEdge`, preserving aspect ratio.
+ *
+ * Returns null for BOTH of these, deliberately:
+ *   - the image already fits, so callers can skip the resize (and, on the
+ *     attachment path, skip a lossy re-encode) rather than paying a no-op scale
+ *     of 1;
+ *   - the dimensions are malformed (non-finite, zero, or negative).
+ *
+ * Every caller's correct response to either case is the same - leave the image
+ * alone - so they are one return value rather than two. A caller that needs to
+ * reject malformed input must probe the dimensions itself; do not read null as
+ * "already fits".
+ */
+export function resolveResizeTarget(
+  width: number,
+  height: number,
+  longEdge: number = IMAGE_LONG_EDGE_CAP,
+): ImageDimensions | null {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return null;
+  const currentLongEdge = Math.max(width, height);
+  if (currentLongEdge <= longEdge) return null;
+
+  const scale = longEdge / currentLongEdge;
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  };
+}

--- a/tests/ui/image-compress-calibration.spec.ts
+++ b/tests/ui/image-compress-calibration.spec.ts
@@ -3,8 +3,9 @@
  *
  * Sweeps long-edge target x quality across synthetic 1080p, 1440p (2K), and
  * 4K noise screenshots and prints a results table. Use this to re-tune
- * LONG_EDGE_TARGET / TARGET_BYTES / QUALITY_LADDER when monitor sizes shift
- * or the Anthropic vision API budget changes.
+ * IMAGE_LONG_EDGE_CAP (src/shared/image-fidelity.ts) / TARGET_BYTES /
+ * QUALITY_LADDER when monitor sizes shift or the Anthropic vision API budget
+ * changes.
  *
  * Skipped by default because it takes ~20s. Run with:
  *   CALIBRATE_IMAGE_COMPRESS=1 npx playwright test --project=ui tests/ui/image-compress-calibration.spec.ts
@@ -16,7 +17,9 @@
 import { test } from '@playwright/test';
 import { launchPage } from './helpers';
 
-const LONG_EDGES = [1280, 1568, 1920];
+// Brackets the shipped IMAGE_LONG_EDGE_CAP (2000) so a sweep can see one rung
+// either side of it, rather than topping out below the value it exists to tune.
+const LONG_EDGES = [1568, 2000, 2400];
 const QUALITIES = [0.85, 0.75, 0.6];
 const RESOLUTIONS = [
   { name: '1080p', width: 1920, height: 1080 },

--- a/tests/ui/image-compression.spec.ts
+++ b/tests/ui/image-compression.spec.ts
@@ -105,6 +105,38 @@ test.describe('Clipboard image compression', () => {
     expect(attachment.size_bytes).toBeLessThan(TARGET_BASE64_BYTES);
   });
 
+  test('an oversized paste is capped on the long edge', async () => {
+    // Real Chromium, because the unit tier stubs OffscreenCanvas and so never
+    // proves the actual draw. 2400x1200 fits 2000 on the long edge at scale
+    // 0.8333 -> 2000x1000.
+    const size = await page.evaluate(async () => {
+      const module = await import('/src/renderer/components/dialogs/image-compress.ts');
+
+      const canvas = new OffscreenCanvas(2400, 1200);
+      const context = canvas.getContext('2d');
+      if (!context) throw new Error('no 2d context');
+      const data = context.createImageData(2400, 1200);
+      for (let index = 0; index < data.data.length; index += 4) {
+        data.data[index] = Math.floor(Math.random() * 200);
+        data.data[index + 1] = Math.floor(Math.random() * 200);
+        data.data[index + 2] = Math.floor(Math.random() * 200);
+        data.data[index + 3] = 255;
+      }
+      context.putImageData(data, 0, 0);
+
+      const blob = await canvas.convertToBlob({ type: 'image/png' });
+      const file = new File([blob], 'wide.png', { type: 'image/png' });
+
+      const out = await module.compressImage(file, { longEdge: 2000, quality: 0.85 });
+      const bitmap = await createImageBitmap(out);
+      const measured = { width: bitmap.width, height: bitmap.height };
+      bitmap.close();
+      return measured;
+    });
+
+    expect(size).toEqual({ width: 2000, height: 1000 });
+  });
+
   test('small PNG paste is left untouched', async () => {
     await openNewTaskDialog();
 

--- a/tests/unit/clipboard-image.test.ts
+++ b/tests/unit/clipboard-image.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit coverage for the terminal Ctrl+V paste path's main-process helpers
+ * (`src/main/ipc/helpers/clipboard-image.ts`).
+ *
+ * `NativeImage` is faked rather than mocked wholesale: `capClipboardImage` only
+ * touches getSize / resize / isEmpty, so a small stand-in covers the real surface
+ * without needing Electron.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { NativeImage } from 'electron';
+import { capClipboardImage, pruneClipboardTempDir } from '../../src/main/ipc/helpers/clipboard-image';
+import { IMAGE_LONG_EDGE_CAP } from '../../src/shared/image-fidelity';
+
+// ---------------------------------------------------------------------------
+// capClipboardImage
+// ---------------------------------------------------------------------------
+
+class FakeImage {
+  resizeCalls: { width?: number; height?: number; quality?: string }[] = [];
+
+  constructor(
+    private readonly width: number,
+    private readonly height: number,
+    private readonly resizeEmpty = false,
+  ) {}
+
+  getSize(): { width: number; height: number } {
+    return { width: this.width, height: this.height };
+  }
+
+  isEmpty(): boolean { return false; }
+
+  resize(options: { width?: number; height?: number; quality?: string }): NativeImage {
+    this.resizeCalls.push(options);
+    if (this.resizeEmpty) return { isEmpty: () => true } as unknown as NativeImage;
+    const resized = new FakeImage(options.width ?? this.width, options.height ?? this.height);
+    resized.resizeCalls = this.resizeCalls;
+    return resized as unknown as NativeImage;
+  }
+}
+
+function cap(image: FakeImage): FakeImage {
+  return capClipboardImage(image as unknown as NativeImage) as unknown as FakeImage;
+}
+
+describe('capClipboardImage', () => {
+  it('caps an oversized grab at the long-edge cap', () => {
+    const image = new FakeImage(3840, 2160);
+
+    const result = cap(image);
+
+    expect(image.resizeCalls).toEqual([{ width: IMAGE_LONG_EDGE_CAP, height: 1125, quality: 'best' }]);
+    expect(result.getSize()).toEqual({ width: IMAGE_LONG_EDGE_CAP, height: 1125 });
+  });
+
+  it('caps by the long edge on a portrait grab', () => {
+    const image = new FakeImage(1500, 4000);
+
+    cap(image);
+
+    expect(image.resizeCalls).toEqual([{ width: 750, height: IMAGE_LONG_EDGE_CAP, quality: 'best' }]);
+  });
+
+  it('returns an already-small image untouched, without re-encoding it', () => {
+    const image = new FakeImage(1200, 800);
+
+    const result = cap(image);
+
+    expect(image.resizeCalls).toEqual([]);
+    expect(result).toBe(image);
+  });
+
+  it('falls back to the original when resize returns empty', () => {
+    // Never hand an empty image to toPNG(): a paste that writes a zero-byte file
+    // is worse than a paste that costs a few extra bytes.
+    const image = new FakeImage(3840, 2160, true);
+
+    const result = cap(image);
+
+    expect(result.isEmpty()).toBe(false);
+    expect(result.getSize()).toEqual({ width: 3840, height: 2160 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pruneClipboardTempDir
+// ---------------------------------------------------------------------------
+
+const HOUR_MS = 60 * 60 * 1000;
+const NOW = 1_800_000_000_000;
+
+let tempDir: string;
+
+/** Write a file and stamp its mtime to `ageMs` before NOW. */
+function writeAged(name: string, ageMs: number): void {
+  const filePath = path.join(tempDir, name);
+  fs.writeFileSync(filePath, 'png-bytes');
+  const seconds = (NOW - ageMs) / 1000;
+  fs.utimesSync(filePath, seconds, seconds);
+}
+
+function remaining(): string[] {
+  return fs.readdirSync(tempDir).sort();
+}
+
+beforeEach(() => {
+  // Under os.tmpdir(), never a hardcoded absolute root: the latter is writable on
+  // a developer's Windows drive and EACCES on the Linux CI runner.
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kangentic-prune-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('pruneClipboardTempDir', () => {
+  it('keeps recent pastes', () => {
+    writeAged('pasted-image-1.png', 1 * HOUR_MS);
+    writeAged('pasted-image-2.png', 5 * HOUR_MS);
+
+    pruneClipboardTempDir(tempDir, { now: NOW });
+
+    expect(remaining()).toEqual(['pasted-image-1.png', 'pasted-image-2.png']);
+  });
+
+  it('deletes pastes older than the age limit', () => {
+    writeAged('pasted-image-fresh.png', 1 * HOUR_MS);
+    writeAged('pasted-image-stale.png', 30 * HOUR_MS);
+
+    pruneClipboardTempDir(tempDir, { now: NOW });
+
+    expect(remaining()).toEqual(['pasted-image-fresh.png']);
+  });
+
+  it('enforces the count cap by dropping the oldest first', () => {
+    for (let index = 0; index < 6; index++) {
+      writeAged(`pasted-image-${index}.png`, index * HOUR_MS);
+    }
+
+    pruneClipboardTempDir(tempDir, { now: NOW, maxFiles: 3 });
+
+    expect(remaining()).toEqual(['pasted-image-0.png', 'pasted-image-1.png', 'pasted-image-2.png']);
+  });
+
+  it('never touches a file it did not write', () => {
+    // The temp directory is shared ground. Deleting by age alone would reach into
+    // whatever else happens to be sitting there.
+    writeAged('important-user-file.png', 100 * HOUR_MS);
+    writeAged('screenshot.png', 100 * HOUR_MS);
+    writeAged('pasted-image-old.png', 100 * HOUR_MS);
+
+    pruneClipboardTempDir(tempDir, { now: NOW });
+
+    expect(remaining()).toEqual(['important-user-file.png', 'screenshot.png']);
+  });
+
+  it('leaves directories alone', () => {
+    fs.mkdirSync(path.join(tempDir, 'pasted-image-dir'));
+    writeAged('pasted-image-old.png', 100 * HOUR_MS);
+
+    pruneClipboardTempDir(tempDir, { now: NOW });
+
+    expect(remaining()).toEqual(['pasted-image-dir']);
+  });
+
+  it('does not throw when the directory does not exist', () => {
+    expect(() => pruneClipboardTempDir(path.join(tempDir, 'nope'), { now: NOW })).not.toThrow();
+  });
+
+  it('applies the age limit and the count cap together', () => {
+    writeAged('pasted-image-a.png', 1 * HOUR_MS);
+    writeAged('pasted-image-b.png', 2 * HOUR_MS);
+    writeAged('pasted-image-c.png', 3 * HOUR_MS);
+    writeAged('pasted-image-d.png', 100 * HOUR_MS);
+
+    pruneClipboardTempDir(tempDir, { now: NOW, maxFiles: 2 });
+
+    expect(remaining()).toEqual(['pasted-image-a.png', 'pasted-image-b.png']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pruneClipboardTempDir - best-effort swallow around a single locked file
+//
+// This runs on the user-visible paste path, so a file held open by another
+// process (Windows EPERM/EBUSY on fs.statSync or fs.rmSync) must never turn
+// into a thrown error, and must never stop the OTHER stale files from being
+// cleaned up. Real files on disk are never locked in this test environment,
+// so the lock is simulated by spying on fs.statSync / fs.rmSync and throwing
+// for one specific file only, passing every other call through to the real
+// implementation.
+// ---------------------------------------------------------------------------
+
+describe('pruneClipboardTempDir - best-effort swallow of a locked file', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('skips a file whose statSync throws (EPERM/EBUSY) without aborting the scan of the rest', () => {
+    writeAged('pasted-image-a.png', 30 * HOUR_MS);
+    writeAged('pasted-image-locked.png', 30 * HOUR_MS);
+    writeAged('pasted-image-c.png', 30 * HOUR_MS);
+
+    const realStatSync = fs.statSync;
+    const statSyncSpy = vi.spyOn(fs, 'statSync').mockImplementation((...args: Parameters<typeof fs.statSync>) => {
+      const [target] = args;
+      if (String(target).endsWith('pasted-image-locked.png')) {
+        throw new Error('EBUSY: resource busy or locked, stat');
+      }
+      return realStatSync(...args);
+    });
+
+    expect(() => pruneClipboardTempDir(tempDir, { now: NOW })).not.toThrow();
+
+    // Proves the spy actually intercepted the locked file - without this, the
+    // assertions below would pass vacuously even if statSync was never called
+    // for it at all.
+    expect(
+      statSyncSpy.mock.calls.some((call) => String(call[0]).endsWith('pasted-image-locked.png')),
+    ).toBe(true);
+
+    // The locked file's stat threw, so its entry was skipped entirely and it
+    // is never considered for deletion. The other two files are equally
+    // stale (30h > the 24h default max age) and must still be deleted: one
+    // locked file failing to stat must not abort the scan of the rest.
+    expect(remaining()).toEqual(['pasted-image-locked.png']);
+  });
+
+  it('skips a file whose rmSync throws (EPERM/EBUSY) without aborting deletion of the rest', () => {
+    // Deletion iterates newest-first by mtime, so the locked file (30h old,
+    // the newest of this stale trio) is processed BEFORE the older two (40h,
+    // 50h). If the rmSync catch were ever removed, the thrown error would
+    // propagate straight out of pruneClipboardTempDir and the two files later
+    // in iteration order would never be reached - this ordering makes that
+    // failure mode observable.
+    writeAged('pasted-image-locked.png', 30 * HOUR_MS);
+    writeAged('pasted-image-mid.png', 40 * HOUR_MS);
+    writeAged('pasted-image-old.png', 50 * HOUR_MS);
+
+    const realRmSync = fs.rmSync;
+    const rmSyncSpy = vi.spyOn(fs, 'rmSync').mockImplementation((...args: Parameters<typeof fs.rmSync>) => {
+      const [target] = args;
+      if (String(target).endsWith('pasted-image-locked.png')) {
+        throw new Error('EPERM: operation not permitted, unlink');
+      }
+      return realRmSync(...args);
+    });
+
+    expect(() => pruneClipboardTempDir(tempDir, { now: NOW })).not.toThrow();
+
+    // Proves the spy actually intercepted the locked file's delete attempt.
+    expect(
+      rmSyncSpy.mock.calls.some((call) => String(call[0]).endsWith('pasted-image-locked.png')),
+    ).toBe(true);
+
+    // The locked file's delete failed and stays on disk; the two other stale
+    // files, later in iteration order, still got removed.
+    expect(remaining()).toEqual(['pasted-image-locked.png']);
+  });
+});

--- a/tests/unit/clipboard-write-text-handler.test.ts
+++ b/tests/unit/clipboard-write-text-handler.test.ts
@@ -1,10 +1,10 @@
 /**
- * Unit tests for the CLIPBOARD_WRITE_TEXT IPC handler in
- * src/main/ipc/handlers/system.ts.
+ * Unit tests for the clipboard IPC handlers in src/main/ipc/handlers/system.ts:
+ * CLIPBOARD_WRITE_TEXT and CLIPBOARD_READ_IMAGE.
  *
- * The handler writes text to the native clipboard via Electron's synchronous,
- * focus-independent `clipboard.writeText`, guarded against non-string and
- * empty-string input:
+ * CLIPBOARD_WRITE_TEXT writes text to the native clipboard via Electron's
+ * synchronous, focus-independent `clipboard.writeText`, guarded against
+ * non-string and empty-string input:
  *
  *   ipcMain.handle(IPC.CLIPBOARD_WRITE_TEXT, (_event, text: string): void => {
  *     if (typeof text !== 'string' || text.length === 0) return;
@@ -18,15 +18,28 @@
  * an empty write to the OS clipboard, and must not throw on a caller sending
  * an unexpected non-string.
  *
+ * CLIPBOARD_READ_IMAGE reads the clipboard's NativeImage, caps it via the real
+ * (unmocked) `capClipboardImage` before writing it to a temp file, and prunes
+ * the temp directory via the real (unmocked) `pruneClipboardTempDir` first.
+ * Those two helpers are unit-tested in isolation in clipboard-image.test.ts;
+ * the tests here cover the WIRING - that the handler actually calls them,
+ * rather than writing `image.toPNG()` straight to disk.
+ *
  * Strategy mirrors keybindings-probe-handler.test.ts: mock electron's ipcMain
- * to capture registered handlers, then invoke the CLIPBOARD_WRITE_TEXT
- * handler directly with controlled inputs and assert against a mocked
- * `clipboard.writeText`.
+ * to capture registered handlers, then invoke the handler directly with
+ * controlled inputs and assert against a mocked `clipboard.writeText` /
+ * `clipboard.readImage`. `os.tmpdir()` is spied so CLIPBOARD_READ_IMAGE writes
+ * under a throwaway test directory instead of the real
+ * `<tmpdir>/kangentic-clipboard` the dogfooding app's own pastes live in.
  *
  * Tier: Unit (vitest, no browser, no Electron).
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { IPC } from '../../src/shared/ipc-channels';
+import { IMAGE_LONG_EDGE_CAP, resolveResizeTarget } from '../../src/shared/image-fidelity';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks - must be declared before any imports that trigger them.
@@ -141,6 +154,49 @@ function invokeClipboardWriteTextHandler(text: unknown): void {
   handler(undefined, text);
 }
 
+function invokeClipboardReadImageHandler(): string | null {
+  const handler = capturedHandlers.get(IPC.CLIPBOARD_READ_IMAGE);
+  if (!handler) throw new Error(`Handler not registered for ${IPC.CLIPBOARD_READ_IMAGE}`);
+  return handler(undefined) as string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Fake NativeImage for CLIPBOARD_READ_IMAGE - exposes exactly the surface
+// capClipboardImage touches (getSize / resize / isEmpty) plus toPNG, with the
+// resized image carrying its OWN toPNG spy so a test can tell whether the
+// handler wrote the original or the resized bytes to disk.
+// ---------------------------------------------------------------------------
+
+interface FakeNativeImage {
+  getSize: ReturnType<typeof vi.fn>;
+  resize: ReturnType<typeof vi.fn>;
+  isEmpty: ReturnType<typeof vi.fn>;
+  toPNG: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeNativeImage(width: number, height: number): {
+  image: FakeNativeImage;
+  resizedToPng: ReturnType<typeof vi.fn>;
+} {
+  const resizedToPng = vi.fn(() => Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+  // getSize/resize are never called on the RESIZED image by capClipboardImage
+  // (only isEmpty/toPNG are); left unimplemented deliberately rather than
+  // faked, so an accidental call surfaces as a clear stub failure.
+  const resizedImage: FakeNativeImage = {
+    getSize: vi.fn(),
+    resize: vi.fn(),
+    isEmpty: vi.fn(() => false),
+    toPNG: resizedToPng,
+  };
+  const image: FakeNativeImage = {
+    getSize: vi.fn(() => ({ width, height })),
+    resize: vi.fn(() => resizedImage),
+    isEmpty: vi.fn(() => false),
+    toPNG: vi.fn(() => Buffer.from([0x89, 0x50, 0x4e, 0x47])),
+  };
+  return { image, resizedToPng };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -180,5 +236,88 @@ describe('CLIPBOARD_WRITE_TEXT IPC handler', () => {
     invokeClipboardWriteTextHandler(42);
 
     expect(mockClipboard.writeText).not.toHaveBeenCalled();
+  });
+});
+
+describe('CLIPBOARD_READ_IMAGE IPC handler', () => {
+  let testTmpRoot: string;
+  let clipboardTempDir: string;
+
+  beforeEach(() => {
+    // Capture the real tmpdir with the real os.tmpdir() BEFORE spying it, then
+    // redirect the handler's `path.join(os.tmpdir(), 'kangentic-clipboard')`
+    // write target at this throwaway root. Without this, the handler would
+    // write into (and this test's prune assertion would delete from) the same
+    // directory the dogfooding app's own terminal pastes live in.
+    testTmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kangentic-clipboard-handler-test-'));
+    vi.spyOn(os, 'tmpdir').mockReturnValue(testTmpRoot);
+    clipboardTempDir = path.join(testTmpRoot, 'kangentic-clipboard');
+
+    capturedHandlers.clear();
+    mockClipboard.readImage.mockReset();
+    registerSystemHandlers(makeContext() as Parameters<typeof registerSystemHandlers>[0]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(testTmpRoot, { recursive: true, force: true });
+  });
+
+  it('caps an oversized clipboard image and writes the RESIZED bytes, not the original', () => {
+    const { image, resizedToPng } = makeFakeNativeImage(4000, 2000);
+    mockClipboard.readImage.mockReturnValue(image);
+
+    const filePath = invokeClipboardReadImageHandler();
+
+    expect(filePath).toBeTruthy();
+    // Proves the write went through the throwaway test root, not the real
+    // clipboard temp directory the dogfooding app uses.
+    expect(filePath as string).toContain(testTmpRoot);
+
+    // Reverting the handler to its old `fs.writeFileSync(filePath,
+    // image.toPNG())` body would call the ORIGINAL image's toPNG, not the
+    // resized one - this is the discriminating assertion for that revert.
+    expect(image.toPNG).not.toHaveBeenCalled();
+    expect(resizedToPng).toHaveBeenCalledOnce();
+
+    // Resize target matches the shared long-edge cap resolver directly, so
+    // this pins the wiring rather than re-deriving the expected numbers.
+    const expectedTarget = resolveResizeTarget(4000, 2000, IMAGE_LONG_EDGE_CAP);
+    expect(image.resize).toHaveBeenCalledWith({ ...expectedTarget, quality: 'best' });
+
+    // The bytes actually on disk are the resized image's PNG output.
+    const writtenBytes = fs.readFileSync(filePath as string);
+    expect(writtenBytes).toEqual(resizedToPng.mock.results[0]?.value);
+  });
+
+  it('prunes stale pasted-image files from the temp dir before writing the new paste', () => {
+    fs.mkdirSync(clipboardTempDir, { recursive: true });
+    const staleFilePath = path.join(clipboardTempDir, 'pasted-image-old.png');
+    fs.writeFileSync(staleFilePath, 'stale-png-bytes');
+    // 48h old - past the 24h default max age pruneClipboardTempDir applies
+    // when the handler calls it with no options.
+    const fortyEightHoursAgoSeconds = (Date.now() - 48 * 60 * 60 * 1000) / 1000;
+    fs.utimesSync(staleFilePath, fortyEightHoursAgoSeconds, fortyEightHoursAgoSeconds);
+
+    const { image } = makeFakeNativeImage(800, 600); // already fits, no resize needed
+    mockClipboard.readImage.mockReturnValue(image);
+
+    const filePath = invokeClipboardReadImageHandler();
+
+    // Reverting the handler to skip pruneClipboardTempDir(tempDir) leaves this
+    // stale file in place - it is the discriminating assertion for that
+    // revert.
+    expect(fs.existsSync(staleFilePath)).toBe(false);
+    // The new paste itself must still have been written.
+    expect(filePath).toBeTruthy();
+    expect(fs.existsSync(filePath as string)).toBe(true);
+  });
+
+  it('returns null when the clipboard holds no image', () => {
+    mockClipboard.readImage.mockReturnValue({ isEmpty: () => true });
+
+    const filePath = invokeClipboardReadImageHandler();
+
+    expect(filePath).toBeNull();
   });
 });

--- a/tests/unit/clipboard-write-text-handler.test.ts
+++ b/tests/unit/clipboard-write-text-handler.test.ts
@@ -320,4 +320,34 @@ describe('CLIPBOARD_READ_IMAGE IPC handler', () => {
 
     expect(filePath).toBeNull();
   });
+
+  it('degrades to null instead of throwing when writing the capped image fails', () => {
+    // Pre-diff this handler had no try/catch at all: any fs failure (disk full,
+    // a Windows AV scanner holding the just-created temp file, a foreign-owned
+    // /tmp on shared Linux) became a rejected invoke in the renderer. The
+    // handler now wraps the write in try/catch and degrades to the same null an
+    // empty clipboard returns, logging a trace instead. That degrade branch has
+    // no other covering assertion - this pins it directly.
+    const { image } = makeFakeNativeImage(800, 600); // already fits, no resize needed
+    mockClipboard.readImage.mockReturnValue(image);
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+      throw new Error('ENOSPC: no space left on device, write');
+    });
+
+    let filePath: string | null = null;
+    expect(() => {
+      filePath = invokeClipboardReadImageHandler();
+    }).not.toThrow();
+
+    expect(filePath).toBeNull();
+    // The other half of the documented contract: degrade quietly to the
+    // renderer, but still leave a trace for whoever is debugging a paste that
+    // silently did nothing.
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[clipboard] Failed to save pasted image:',
+      expect.any(Error),
+    );
+  });
 });

--- a/tests/unit/image-compress.test.ts
+++ b/tests/unit/image-compress.test.ts
@@ -1,10 +1,13 @@
 /**
  * Unit tests for `compressClipboardImage` skip rules and failure path.
  *
- * Covers three gaps identified in the audit:
+ * Covers four gaps identified in the audit:
  *   1. Failure path - createImageBitmap rejects -> toast + original file returned.
  *   2. GIF passthrough - SKIP_RECOMPRESS_MEDIA_TYPES short-circuits before bitmap decode.
- *   3. PNG-already-fits skip - scale === 1 && mediaType === 'image/png' early return.
+ *   3. PNG-already-fits skip - resolveResizeTarget returns null && mediaType ===
+ *      'image/png' -> early return.
+ *   4. Long-edge cap - the size the pipeline actually draws at, read back off the
+ *      canvas the encoder was handed.
  *
  * The <500KB skip (MIN_COMPRESS_BYTES) is already covered transitively by the UI
  * tier "small PNG paste is left untouched" test in image-compression.spec.ts.
@@ -12,11 +15,11 @@
  * Strategy: mock createImageBitmap, OffscreenCanvas, and the toast+config stores.
  * jsdom lacks both OffscreenCanvas.convertToBlob and createImageBitmap, so we
  * install globals before the module loads via vi.hoisted + beforeEach assignments.
- * The test never reaches the encoding pipeline - we only exercise the skip/catch
- * branches, so OffscreenCanvas only needs to be constructable, not fully functional.
+ * The cap tests DO run the encoding pipeline, so the stub records every canvas it
+ * constructs; only the drawn dimensions are asserted, never blob contents.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Hoisted store mocks - must be declared before any import that transitively
@@ -51,23 +54,62 @@ function makeImageBitmap(width: number, height: number): ImageBitmap {
   } as unknown as ImageBitmap;
 }
 
-/** Minimal OffscreenCanvas stub. convertToBlob is never called by the paths we test. */
+/**
+ * Every canvas the pipeline constructs, in order, so a test can assert the size
+ * the image was actually drawn at.
+ */
+const constructedCanvases: StubOffscreenCanvas[] = [];
+
+/** The subset of CanvasRenderingContext2D the stub retains and a test can read back. */
+interface StubCanvasContext {
+  drawImage: ReturnType<typeof vi.fn>;
+  imageSmoothingEnabled: boolean;
+  imageSmoothingQuality: ImageSmoothingQuality;
+}
+
+/** Minimal OffscreenCanvas stub. */
 class StubOffscreenCanvas {
+  /**
+   * Retained (not recreated per getContext() call) so a test can read back
+   * what renderToCanvas assigned onto it. Seeded with the browser's actual
+   * destructive defaults - smoothing off, 'low' quality - so an assertion
+   * that these were overridden is meaningful rather than vacuously true.
+   */
+  readonly context: StubCanvasContext = {
+    drawImage: vi.fn(),
+    imageSmoothingEnabled: false,
+    imageSmoothingQuality: 'low',
+  };
+
   constructor(
     public readonly width: number,
     public readonly height: number,
-  ) {}
+  ) {
+    constructedCanvases.push(this);
+  }
 
   getContext(): CanvasRenderingContext2D {
-    return {
-      drawImage: vi.fn(),
-    } as unknown as CanvasRenderingContext2D;
+    return this.context as unknown as CanvasRenderingContext2D;
   }
 
   convertToBlob(): Promise<Blob> {
-    // Not reached by any skip path; the catch path never constructs a canvas.
     return Promise.resolve(new Blob([], { type: 'image/webp' }));
   }
+}
+
+/** Pristine encoder, restored after every test so a per-test override cannot leak. */
+const originalConvertToBlob = StubOffscreenCanvas.prototype.convertToBlob;
+
+/** Size of the canvas the pipeline encoded from. */
+function renderedSize(): { width: number; height: number } {
+  const target = constructedCanvases[constructedCanvases.length - 1];
+  return { width: target.width, height: target.height };
+}
+
+/** The stub 2d context of the last canvas the pipeline constructed. */
+function renderedContext(): StubCanvasContext {
+  const target = constructedCanvases[constructedCanvases.length - 1];
+  return target.context;
 }
 
 // ---------------------------------------------------------------------------
@@ -75,6 +117,7 @@ class StubOffscreenCanvas {
 // ---------------------------------------------------------------------------
 
 import { compressClipboardImage, MIN_COMPRESS_BYTES } from '../../src/renderer/components/dialogs/image-compress';
+import { IMAGE_LONG_EDGE_CAP } from '../../src/shared/image-fidelity';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -108,6 +151,7 @@ describe('compressClipboardImage', () => {
   beforeEach(() => {
     // Reset the toast spy between tests.
     addToastMock = vi.fn();
+    constructedCanvases.length = 0;
     storeMocks.useToastStore.getState.mockReturnValue({ addToast: addToastMock });
     storeMocks.useConfigStore.getState.mockReturnValue(TOAST_CONFIG);
 
@@ -118,6 +162,14 @@ describe('compressClipboardImage', () => {
 
     // Cast via `unknown` to satisfy TypeScript without the full constructor signature.
     globalThis.OffscreenCanvas = StubOffscreenCanvas as unknown as typeof OffscreenCanvas;
+  });
+
+  afterEach(() => {
+    // One test swaps convertToBlob on the shared prototype to force a specific
+    // blob size. Without this restore that override leaks into every test
+    // declared after it, which is how a later assertion silently starts reading
+    // the wrong encoder output.
+    StubOffscreenCanvas.prototype.convertToBlob = originalConvertToBlob;
   });
 
   describe('GIF passthrough (SKIP_RECOMPRESS_MEDIA_TYPES)', () => {
@@ -143,10 +195,10 @@ describe('compressClipboardImage', () => {
     });
   });
 
-  describe('PNG-already-fits skip (scale === 1 && mediaType === image/png)', () => {
-    it('returns the original PNG when long edge is under LONG_EDGE_TARGET', async () => {
-      // Bitmap dimensions 1000x800 -> long edge 1000 < 1568 -> scale === 1.
-      // mediaType === 'image/png' -> early return without encoding.
+  describe('PNG-already-fits skip (resolveResizeTarget returns null && mediaType === image/png)', () => {
+    it('returns the original PNG when the long edge is inside IMAGE_LONG_EDGE_CAP', async () => {
+      // Bitmap dimensions 1000x800 -> long edge 1000 <= 2000 -> resolveResizeTarget
+      // returns null. mediaType === 'image/png' -> early return without encoding.
       const pngFile = makeLargeFile('image/png', 'screenshot.png');
 
       const result = await compressClipboardImage(pngFile);
@@ -175,6 +227,62 @@ describe('compressClipboardImage', () => {
     });
   });
 
+  describe('long-edge cap', () => {
+    /** Point createImageBitmap at a source of the given size. */
+    function sourceSize(width: number, height: number): void {
+      globalThis.createImageBitmap = vi.fn().mockResolvedValue(makeImageBitmap(width, height));
+    }
+
+    it('caps an oversized image at IMAGE_LONG_EDGE_CAP', async () => {
+      sourceSize(4000, 2000);
+
+      const result = await compressClipboardImage(makeLargeFile('image/jpeg', 'wide.jpg'));
+
+      expect(result.compressed).toBe(true);
+      expect(renderedSize()).toEqual({ width: IMAGE_LONG_EDGE_CAP, height: 1000 });
+    });
+
+    it('sets high-quality image smoothing before drawing the resized image onto the canvas', async () => {
+      // Oversized so the resize path (renderToCanvas) actually runs - a
+      // PNG that already fits the cap returns before ever reaching a canvas.
+      sourceSize(4000, 2000);
+
+      await compressClipboardImage(makeLargeFile('image/jpeg', 'wide.jpg'));
+
+      const context = renderedContext();
+      // The browser default ('low' quality, smoothing untouched) is visibly
+      // destructive on a downscale of small UI text, which is the case this
+      // whole pipeline exists to preserve. The stub is seeded with that
+      // default, so this assertion is meaningful rather than vacuous.
+      expect(context.imageSmoothingEnabled).toBe(true);
+      expect(context.imageSmoothingQuality).toBe('high');
+      // Proves the retained context is the SAME object renderToCanvas drew
+      // onto, not an unrelated sibling.
+      expect(context.drawImage).toHaveBeenCalled();
+    });
+
+    it('caps by the long edge on a portrait image', async () => {
+      sourceSize(1500, 4000);
+
+      await compressClipboardImage(makeLargeFile('image/jpeg', 'tall.jpg'));
+
+      expect(renderedSize()).toEqual({ width: 750, height: IMAGE_LONG_EDGE_CAP });
+    });
+
+    it('leaves a PNG that is already inside the cap exactly as pasted', async () => {
+      // At the old 1568 cap this image was re-encoded to lossy WebP. It is now
+      // passed through untouched: no lossy round trip, alpha intact. That is the
+      // fidelity regression the cap change fixes, expressed as behaviour.
+      sourceSize(1800, 900);
+      const png = makeLargeFile('image/png', 'screenshot.png');
+
+      const result = await compressClipboardImage(png);
+
+      expect(result.compressed).toBe(false);
+      expect(result.file).toBe(png);
+    });
+  });
+
   describe('failure path (createImageBitmap rejects)', () => {
     it('returns the original file and emits the warning toast', async () => {
       const decodeError = new Error('GPU process crashed');
@@ -183,10 +291,9 @@ describe('compressClipboardImage', () => {
       );
 
       const pngFile = makeLargeFile('image/png', 'corrupt.png');
-      // Use a PNG with long edge > LONG_EDGE_TARGET so we do not hit the
-      // PNG-already-fits skip before createImageBitmap is invoked.
-      // We achieve this by mocking createImageBitmap to reject -- the mock
-      // is already set up to reject, so the PNG dimensions never matter.
+      // createImageBitmap rejects before any dimension is read, so the decode
+      // failure is reached ahead of the PNG-already-fits skip and the bitmap
+      // size never matters here.
 
       const result = await compressClipboardImage(pngFile);
 

--- a/tests/unit/image-fidelity.test.ts
+++ b/tests/unit/image-fidelity.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit coverage for the shared image pixel budget
+ * (`src/shared/image-fidelity.ts`), which both the main-process terminal paste
+ * path and the renderer attachment path size by.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IMAGE_LONG_EDGE_CAP, resolveResizeTarget } from '../../src/shared/image-fidelity';
+
+describe('IMAGE_LONG_EDGE_CAP', () => {
+  it('sits at the measured clamp, not below it', () => {
+    // This number is load-bearing in a way a round constant usually is not.
+    // Measured: cost stops tracking pixel area above ~2.25MP (about 2000px on the
+    // long edge at 16:9), so capping here discards nothing the model would have
+    // used. Measured separately: at 1568px an agent misreads small text and
+    // non-text detail with full confidence and no warning (11 silent errors in 84
+    // probes, against 0 at this cap). Lowering it to buy tokens buys wrong answers
+    // instead - the upstream clamp was already doing the saving.
+    expect(IMAGE_LONG_EDGE_CAP).toBe(2000);
+  });
+
+  it('is the default for resolveResizeTarget, so the two paths cannot drift', () => {
+    expect(resolveResizeTarget(4000, 2000)).toEqual(
+      resolveResizeTarget(4000, 2000, IMAGE_LONG_EDGE_CAP),
+    );
+  });
+});
+
+describe('resolveResizeTarget', () => {
+  it('scales a landscape image by its width and preserves aspect ratio', () => {
+    expect(resolveResizeTarget(3840, 2160, 1568)).toEqual({ width: 1568, height: 882 });
+  });
+
+  it('scales a portrait image by its height', () => {
+    expect(resolveResizeTarget(1080, 2400, 1024)).toEqual({ width: 461, height: 1024 });
+  });
+
+  it('returns null when the image already fits, so callers skip the resize', () => {
+    expect(resolveResizeTarget(1200, 800, 1568)).toBeNull();
+  });
+
+  it('returns null at exactly the cap rather than emitting a no-op scale', () => {
+    expect(resolveResizeTarget(1568, 882, 1568)).toBeNull();
+  });
+
+  it('never rounds an edge down to zero on an extreme aspect ratio', () => {
+    const target = resolveResizeTarget(10000, 3, 1024);
+    expect(target).not.toBeNull();
+    expect(target?.height).toBeGreaterThanOrEqual(1);
+  });
+
+  it('returns null for malformed dimensions', () => {
+    expect(resolveResizeTarget(0, 100, 1568)).toBeNull();
+    expect(resolveResizeTarget(100, -5, 1568)).toBeNull();
+    expect(resolveResizeTarget(Number.NaN, 100, 1568)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Caps every image handed to an agent at a 2000px long edge, via a single shared
`IMAGE_LONG_EDGE_CAP` (`src/shared/image-fidelity.ts`), and prunes the clipboard temp directory.

- **Terminal Ctrl+V paste** (`clipboard:readImage` in `handlers/system.ts`) did not resize at all
  before. It now caps via `capClipboardImage`, and prunes stale files from the temp directory.
- **Task / backlog attachment paste** (`image-compress.ts`) was capped at **1568**. That value was
  measurably corrupting screenshots, so it moves to 2000. It also now sets
  `imageSmoothingQuality = 'high'`, having silently used the browser default of `low`.

No new IPC channel, no new config key, no settings surface, no migration.

## Why

**This PR started life as "cut image tokens" and the premise did not survive measurement.** There
are no tokens to reclaim on the paste path. What the investigation found instead was a live
fidelity bug and a 388 MB disk leak.

**1. An upstream clamp already caps the cost.** One procedural scene at eight resolutions, one
`claude -p` run each, comparing total input tokens (`predicted` = area/750 vs the 1000px row):

| long edge | area | vs 1000px | predicted |
|---|---|---|---|
| 1568 | 1.38MP | +1,052 | +1,093 |
| 1984 | 2.21MP | +2,113 | +2,202 |
| 2100 | 2.48MP | +2,248 | +2,556 |
| 2400 | 3.24MP | +2,266 | +3,569 |
| 3400 | 6.50MP | +2,252 | +7,922 |

Cost tracks pixel area up through 1984px, then every rung from 2100 to 3400 lands on the same
~+2,250 plateau. A 4K paste and a 2000px paste cost the same. Downscaling below the clamp is the
only thing that saves anything, and that is exactly what turns out to be unsafe.

**2. Below the clamp the agent is confidently wrong, not hesitant.** A 2560x1440 UI at real type
sizes (11px labels, 12px monospace) carrying twelve probes: six text, six non-text affordances at
realistic sizes (6px status dot, 12px checkbox, 14px icon, 1px underline, three bar heights, diff
gutter marker). Downscaled through the real pipeline, then answered with **no option to decline**,
so every miss is a silent error rather than a refusal:

| long edge | silent-wrong |
|---|---|
| 2000 | **0 / 84** |
| 1568 | **11 / 84** |

At 1568 it read the branch hash `feat/b6d09fa` as `feat/b6dd9f6` in 6 of 7 attempts, and named the
wrong bar in a three-bar chart in 5 of 7. It never flagged doubt. The attachment path had shipped
1568 for a long time on a comment claiming it matched "the API's own downscale" - which it did not.

**3. The clipboard temp directory never pruned.** Measured on a real machine: 3,553 files,
387.8 MB, oldest four months old.

## How

`IMAGE_LONG_EDGE_CAP` lives in `src/shared/` because main cannot import from `src/renderer/`, and
both paste paths must cap by the same rule or a pasted screenshot would mean two different things
depending on where it was dropped. The module carries both measurement tables, so the number is
justified in place rather than asserted.

The prune only touches `pasted-image-*`, is best-effort (a locked file must never fail a paste), and
combines an age limit with a count cap.

**Trade-off worth a reviewer's attention:** token spend goes **up** roughly 1,200 per attachment
image, because 1568 was corrupting them. That is deliberate. An agent misreading the screenshot you
pasted to explain a bug costs far more than 1,200 tokens in wasted turns.

**Deliberately not done**, each measured rather than assumed:

- **No fidelity dial.** A top tier would save zero tokens and a bottom tier sits below the measured
  floor - a dial whose two outer options are both wrong. There is no tradeoff left to expose.
- **No content-hash temp-path reuse.** Matched turn structure: same path read twice = 139,945
  tokens, two paths holding identical bytes = 139,914. A 31-token difference. The billing unit is
  the image block in context, not the path.
- **No border cropping.** Built, tested, then cut: 0% on edge-to-edge screenshots (what this app
  actually sees), and it was the only part of the change with a silent-failure mode.
- **No quality / grayscale / palette tuning.** Bytes only, zero tokens.

## Breaking changes

None. No config key, no IPC signature change, no migration. The only user-visible behavior change is
that pasted screenshots keep more detail than before.

## Tests

- `tests/unit/image-fidelity.test.ts` (new) - pins the cap and `resolveResizeTarget`, including its
  deliberate dual-null contract.
- `tests/unit/clipboard-image.test.ts` (new) - `capClipboardImage` against a faked `NativeImage`
  (oversize, portrait, already-small passthrough, empty-resize fallback) and `pruneClipboardTempDir`
  (age, count cap, never touching files it did not write, directories, missing dir, and a simulated
  locked file that must not abort the scan).
- `tests/unit/clipboard-write-text-handler.test.ts` - covers the `CLIPBOARD_READ_IMAGE` handler
  itself. Both helpers were fully unit-tested in isolation, so deleting either call site from the
  handler left every test green; this closes that.
- `tests/ui/image-compression.spec.ts` - adds a real-Chromium assertion that an oversized paste is
  capped on the long edge, since the unit tier stubs `OffscreenCanvas` and never proves the draw.
- `tests/unit/image-compress.test.ts` - reworked for the cap, including that a PNG already inside it
  is passed through byte-identical rather than re-encoded.

Verified live against the real IPC path with a real clipboard image: a 4K grab capped to 2000x1125,
an under-cap 1200x800 passed through unresized, a real 2560-wide screenshot capped to 2000x1085 with
11px sidebar text, ticket numbers and `751.5k / 1M`-class numerics all still legible, and the prune
reclaiming 387 MB on the first paste.

Generated with [Claude Code](https://claude.com/claude-code)
