### PR TITLE
feat(announcements): megaphone access point, unread badge, browsable history

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -423,11 +423,13 @@ Detach a registered UI surface (usage stats, git changes, the task Browser pane,
 | `updater:install` | invoke | Install downloaded update (quit and install) |
 | `updater:downloaded` | on | Event: update has been downloaded and is ready to install |
 
-### Announcements (2 channels)
+### Announcements (4 channels)
 | Channel | Pattern | Purpose |
 |---------|---------|---------|
 | `announcements:get` | invoke | Current active announcements (remote feed, already filtered for this client's version/platform in main) |
-| `announcements:changed` | on | Event: the filtered active announcement list changed since the last poll |
+| `announcements:getHistory` | invoke | The local announcement archive (every announcement ever active for this client, plus read-state) |
+| `announcements:markRead` | invoke | Stamp `readAt` on one archive entry, clearing it from the megaphone's unread badge |
+| `announcements:changed` | on | Event: the filtered active announcement list changed since the last poll. Carries `{ active, history }`, since both derive from the same poll |
 
 ### Search (1 channel)
 | Channel | Pattern | Purpose |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,7 +98,7 @@ These settings appear in both App Settings (as defaults) and Project Settings (a
 | `hasCompletedFirstRun` | boolean | `false` | Legacy: set true on first task creation, kept for schema/fixture compatibility. No onboarding UI reads it, and it is not the walkthrough gate: creating a task is step 3 of the walkthrough, so this flips mid-flow. The walkthrough is suppressed once `onboardedProjectIds` is non-empty. Auto-set, not shown in UI. |
 | `lastSeenReleaseNotesVersion` | string | `''` | The version whose release-notes modal has already been auto-shown (see [Auto-Update Behavior](deployment.md#auto-update-behavior)), so it does not reopen on every relaunch after "Later". Auto-set, not shown in UI. |
 | `lastWhatsNewShownVersion` | string | `''` | The version whose post-update ["What's New" dialog](deployment.md#auto-update-behavior) has already been shown. Deliberately separate from `lastSeenReleaseNotesVersion`, which records the PENDING version when the pre-restart modal is dismissed: a user who clicks "Later" and then quits normally has the update installed by `autoInstallOnAppQuit`, and would relaunch with the new version already marked seen and the notes never read. Written when the dialog OPENS, not when it closes, so quitting with it open does not re-arm it. Seeded to the running version on a fresh install (no `config.json` existed at launch), so a first-time user is not shown notes for software they have never run. Auto-set, not shown in UI. |
-| `dismissedAnnouncementIds` | string[] | `[]` | Ids of [in-app announcements](#in-app-announcements) dismissed from the banner. Pruned on write to ids still present in the active feed, so the array stays bounded with no separate cleanup. Auto-set, not shown in UI. |
+| `dismissedAnnouncementIds` | string[] | `[]` | Ids of [in-app announcements](#in-app-announcements) dismissed from the banner. Pruned on write to ids still present in the active feed, so the array stays bounded with no separate cleanup. That prune is also why READ-state is not stored here: it would drain as soon as an announcement expired. Read-state lives on the [local archive](#the-local-archive) entry instead. Auto-set, not shown in UI. |
 | `onboardedProjectIds` | string[] \| undefined | `undefined` | Project ids whose onboarding checklist the user has dismissed. `undefined` means the one-time upgrade backfill (on first app hydration) has not run yet; `[]` means it has run and nothing is dismissed. Global, keyed by project id like `lastActiveTaskByProject`. **Emptiness, not membership, gates the walkthrough:** the checklist auto-opens only while this list is empty, because the walkthrough teaches the app rather than a repo and must not replay on every newly added project. It becomes non-empty by three routes, all meaning "not a first run": the backfill finding an existing project, a real dismissal, or all five steps completed. A fourth, dev-only route SHRINKS it: the Developer settings tab's "Restart checklist" trigger (`resetOnboarding` in `config-store.ts`) removes one project's id, and if that was the only entry the list is empty again, re-arming the persisted install-scoped auto-open gate until the next dismissal or completion. A per-session latch still applies, so a project already auto-opened this session waits for the next launch; the trigger itself opens the checklist directly rather than relying on auto-open. That trigger is excluded from production builds. Auto-set, not shown in UI. |
 | `onboardingBaseline` | Record\<string, object\> \| undefined | `undefined` | Per-project snapshot of the settings the onboarding checklist watches (`defaultAgent`, `defaultModel`, `defaultEffort`, `permissionMode`, and a `swimlaneSignature` string encoding of the board's shape), captured on first checklist open. Adding a project does not capture one by itself. While `onboardedProjectIds` is still empty, arriving at a project earns one auto-open per session, so a second project added during that first-run window does get a baseline. Once the list is non-empty the install-scoped gate is closed for good, so a project added later has no baseline until the Developer settings tab's dev-only trigger opens the checklist there, and that trigger is not reachable in a production build. Checklist steps 1 and 2 tick when live state DIFFERS from this, so opening a settings screen and closing it unchanged earns no checkmark. Both are guarded on the baseline existing, so a baseline-less project reports them un-ticked rather than complete. Keyed by project id; replaced wholesale on write (a `CONFIG_DICTIONARY_PATHS` entry). That replace semantics is what lets the same dev-only trigger DROP one project's entry so the checklist re-baselines on the next open; the first-write-wins capture never re-baselines on an ordinary reopen. Auto-set, not shown in UI. |
 | `windowBounds` | object \| null | `null` | Persisted window bounds `{x, y, width, height}`. Auto-saved, not shown in UI. |
@@ -642,6 +642,11 @@ unreachable, malformed, or empty feed simply means no banner (offline and self-h
 lose nothing). The poll runs 10 seconds after launch and every 4 hours (`src/main/announcements.ts`),
 is skipped entirely under `NODE_ENV=test`, and never emits error telemetry.
 
+The banner is not the only way in. A **megaphone button in the title bar** (always present, at the
+right end of the icon row just before Settings, beside the update-available indicator) opens the
+announcement history and carries a badge counting unread announcements. Rows open the same
+"Learn more" dialog, so a dismissed or expired announcement stays re-readable.
+
 Feed schema (`src/shared/announcements.ts`): each entry carries `id`, `title` (banner line),
 `body` (markdown intro), `links` (label + https URL; a link flagged `qr: true` renders a large
 scannable QR code above its button, for phone-destined links like store opt-in pages), optional
@@ -659,6 +664,40 @@ cache). Set targeting fields conservatively and put an `expiresAt` on every entr
 parser on every push, so a typo'd entry (which production would silently drop) fails CI on the
 content PR instead of shipping invisible.
 
+**Deleting an expired entry is allowed.** Clients keep their own archive (below), so removing a
+long-expired entry from the feed no longer takes it away from anyone who already saw it. Deleting
+an entry that has NOT expired still retracts it: it leaves the active list, the banner clears, and
+an open banner dialog closes. It stays in the archive of every client that already saw it, and
+never enters the archive of one that did not.
+
+### The local archive
+
+Each client keeps `<configDir>/announcements-archive.json`: every announcement that was ever
+active **for that client**, most recently seen first, capped at 50 entries with the oldest pruned
+on write. Ordering is by when this client first saw an entry, not by the announcement's own
+`publishedAt`, so a high-priority older announcement that arrives on a later poll sorts above
+entries published after it.
+It is written from the same filtered list the banner uses, so targeting is inherited for free (an
+announcement that never matched this client never enters its history), and it is what makes the
+megaphone useful in the three cases the live feed cannot cover: the ~10 seconds before the first
+poll, an offline launch, and an entry deleted upstream. An entry's stored copy is refreshed when
+the feed edits it in place, but its `firstSeenAt` and read-state are not.
+
+**Dismissed and read are different states, stored apart:**
+
+| Concept | Stored where | Effect |
+|---------|--------------|--------|
+| Dismissed | `dismissedAnnouncementIds` in config | hides that announcement's banner strip |
+| Read | `readAt` on its archive entry | stops the megaphone badge counting it |
+
+Opening the dialog from either entry point (the banner's "Learn more" or a history row) marks it
+read. Dismissing the banner does not: a dismissed-but-unread announcement still lights the badge,
+because the megaphone means "there is something you have not read", not "there is a banner". The
+badge counts every unread entry, expired ones included.
+
+Read-state cannot live in `dismissedAnnouncementIds` because that list prunes itself to ids still
+in the active feed on every write, so it would forget an announcement the moment it expired.
+
 **Authoring contract - no scrolling:** an announcement must fit its dialog without a scrollbar
 on a typical desktop window (QR links lay out side by side to help; the dialog's scroll is a
 safety valve for very small windows only, and a UI test pins the contract for a realistic
@@ -666,7 +705,7 @@ two-QR announcement). Keep bodies to a few short paragraphs and QR links to two 
 message wants more, it should be a link to a page, not a longer announcement.
 
 Dismissals persist per-announcement-id in `dismissedAnnouncementIds` (see the
-[Top-Level reference](#top-level)).
+[Top-Level reference](#top-level)). Read-state does not: it lives on the archive entry.
 
 ## Environment Variables
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -592,9 +592,17 @@ The Settings > Notifications panel exposes four configurable events: **Agent Idl
 
 Occasionally Kangentic shows a product announcement (for example, a call for mobile-app beta
 testers) as a slim banner above the board. **Learn more** opens the full message with links and
-a QR code; the **X** dismisses that announcement permanently on this machine. Announcements are
-fetched from a static file on the public GitHub repo - no account, no tracking, and if the feed
-is unreachable (offline or self-hosted setups) the banner simply never appears. See
+a QR code; the **X** hides that banner for good on this machine.
+
+Dismissing does not lose the announcement. The **megaphone** in the title bar is always there and
+opens the full history, newest first, so anything you dismissed or that has since expired stays
+readable. Its badge counts announcements you have not opened yet, and reading one clears it.
+Dismissing is not reading, so an announcement you waved away still shows in the count until you
+open it.
+
+Announcements are fetched from a static file on the public GitHub repo - no account, no tracking,
+and if the feed is unreachable (offline or self-hosted setups) no new ones appear, though your
+history stays available. See
 [Configuration - In-App Announcements](configuration.md#in-app-announcements) for the feed
 mechanics.
 
@@ -675,7 +683,7 @@ The viewer opens positioned at the latest message, or centered on the turn match
 
 The Command Terminal provides quick, ephemeral access to Claude Code without creating a task on the board. Useful for one-off actions like creating releases, running queries, or any ad-hoc interaction.
 
-**Opening:** Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS), or click the terminal icon in the title bar (next to the settings gear). The same button **toggles** the layer closed again, so there is always a one-click way to hide it, even when a window is maximized. The terminal icon reflects activity across your open terminals: its prompt blinks in green while an agent is working, it holds a steady warm amber when one needs your input, and it stays plain when idle.
+**Opening:** Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS), or click the terminal icon in the title bar (the left-most icon in its right-hand button row). The same button **toggles** the layer closed again, so there is always a one-click way to hide it, even when a window is maximized. The terminal icon reflects activity across your open terminals: its prompt blinks in green while an agent is working, it holds a steady warm amber when one needs your input, and it stays plain when idle.
 
 **Behavior:**
 - Spawns Claude Code at the project root on the configured default base branch

--- a/src/devtools/renderer/DevToolsSections.tsx
+++ b/src/devtools/renderer/DevToolsSections.tsx
@@ -1,10 +1,12 @@
-import { Network, Code2, Compass, Sparkles, Rocket } from 'lucide-react';
+import { Network, Code2, Compass, Megaphone, Sparkles, Rocket } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import type { AppConfig } from '../../shared/types';
+import type { Announcement, AnnouncementArchiveEntry } from '../../shared/announcements';
 import { useScopedUpdate } from '../../renderer/components/settings/shared';
 import { useConfigStore } from '../../renderer/stores/config-store';
 import { useProjectStore } from '../../renderer/stores/project-store';
 import { useUpdaterStore } from '../../renderer/stores/updater-store';
+import { useAnnouncementsStore } from '../../renderer/stores/announcements-store';
 import {
   Code,
   Description,
@@ -22,6 +24,71 @@ const FIXTURE_RELEASE_NOTES = `## What's New
 - Fixed a crash when opening an empty board.
 - \`Escape\` now closes the release-notes modal like every other dialog.
 `;
+
+function isoDaysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+/**
+ * A feed and archive shaped like a real poll's output, exercising every
+ * announcement surface at once: the banner takes the highest-priority active
+ * entry, the badge counts the two unread, and history additionally carries an
+ * entry that is NO LONGER active, which is the case only the local archive can
+ * produce.
+ *
+ * Ids are stamped per click rather than fixed. Dismissal persists per id in
+ * `dismissedAnnouncementIds`, so a fixed id would hide the banner permanently
+ * after the first dismissal with no UI to undo it. Stale fixture ids drain
+ * themselves on the next dismissal (computeDismissedIdsAfterDismiss prunes to
+ * ids still in the active feed).
+ */
+function buildAnnouncementFixture(): {
+  active: Announcement[];
+  history: AnnouncementArchiveEntry[];
+} {
+  const stamp = Date.now();
+  const headline: Announcement = {
+    id: `dev-fixture-headline-${stamp}`,
+    title: 'Kangentic Mobile is almost here - iOS in review, Android in beta',
+    body: 'The mobile companion app is on its way to **both stores**. Here is where each platform stands.',
+    links: [],
+    sections: [
+      { heading: 'iOS: in App Store review', body: 'Submitted and waiting on Apple. Nothing to do yet.' },
+      {
+        heading: 'Android: open for beta testers',
+        body: 'Two steps: join the group, then become a tester.',
+        links: [
+          { label: 'Join the testers Google Group', url: 'https://groups.google.com/g/kangentic-testers', qr: true },
+        ],
+      },
+    ],
+    publishedAt: isoDaysAgo(2),
+    priority: 5,
+  };
+  const secondary: Announcement = {
+    id: `dev-fixture-secondary-${stamp}`,
+    title: 'Agent Monitor now spans every project',
+    body: 'One view over every running agent on this machine, not just the open project.',
+    links: [{ label: 'Read the docs', url: 'https://kangentic.com/docs/' }],
+    publishedAt: isoDaysAgo(16),
+  };
+  const retired: Announcement = {
+    id: `dev-fixture-retired-${stamp}`,
+    title: 'Command Terminal: multiple terminals, tiled and persistent',
+    body: 'Expired upstream, kept by the local archive. Proves history outlives the feed.',
+    links: [],
+    publishedAt: isoDaysAgo(120),
+  };
+
+  return {
+    active: [headline, secondary],
+    history: [
+      { announcement: headline, firstSeenAt: isoDaysAgo(2), readAt: null },
+      { announcement: secondary, firstSeenAt: isoDaysAgo(16), readAt: null },
+      { announcement: retired, firstSeenAt: isoDaysAgo(120), readAt: isoDaysAgo(119) },
+    ],
+  };
+}
 
 /**
  * A dev-only trigger row: what it opens on the left, the button that opens it
@@ -180,6 +247,32 @@ export function DevToolsSections({ globalConfig }: { globalConfig: AppConfig }) 
         testId="dev-trigger-whats-new-dialog"
         onClick={() => {
           useUpdaterStore.getState().openWhatsNew({ autoOpened: false });
+        }}
+      />
+
+      {/* The announcements poll runs 10s after launch and then every 4 hours
+          against the live feed on `main`, so in dev you wait on the network to
+          see one, and the feed usually holds a single entry - which is not
+          enough to exercise the badge count, the multi-row history, or a
+          history entry that has left the active set.
+
+          This pushes the same two store actions the announcements:changed IPC
+          push calls, exactly as the release-notes trigger above reuses
+          receiveUpdate. It is store-only: the real poll ALSO writes the archive
+          sidecar, so this does not survive an HMR resync or the next real poll,
+          both of which re-read main's copy. Use KANGENTIC_ANNOUNCEMENTS_URL
+          against a local fixture file when you need the persistent path. */}
+      <ActionRow
+        icon={Megaphone}
+        title="Announcements Feed"
+        description="Push two active announcements plus an expired one, so the banner, the megaphone badge, and a multi-row history all have something to show without waiting on the 4-hour poll. Not persisted: a resync or the next real poll replaces it."
+        label="Seed feed"
+        testId="dev-trigger-announcements-feed"
+        onClick={() => {
+          const { active, history } = buildAnnouncementFixture();
+          const store = useAnnouncementsStore.getState();
+          store.receiveActive(active);
+          store.receiveHistory(history);
         }}
       />
 

--- a/src/main/announcements-archive.ts
+++ b/src/main/announcements-archive.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { atomicWriteJson } from './config/board-config/atomic-write';
+import { PATHS } from './config/paths';
+import { parseAnnouncement, type AnnouncementArchiveEntry } from '../shared/announcements';
+
+/**
+ * The local announcements archive: this client's own copy of every
+ * announcement that was ever active for it, plus per-entry read-state.
+ *
+ * It exists for three reasons the live feed cannot cover:
+ *   1. `cachedActive` in announcements.ts is in-memory and empty for the first
+ *      10 seconds of every launch, and stays empty offline. A permanent
+ *      megaphone backed by the feed alone would show an empty history on every
+ *      boot.
+ *   2. Read-state needs somewhere durable that is NOT
+ *      config.dismissedAnnouncementIds, which prunes itself to ids still in the
+ *      active feed on every write (see computeDismissedIdsAfterDismiss).
+ *   3. Announcements can be deleted from the feed upstream once expired.
+ *
+ * A sidecar under configDir rather than a config.json key: entries carry full
+ * markdown bodies, which do not belong in the blob that dismissAnnouncement
+ * rewrites fire-and-forget.
+ *
+ * EVERY archive mutation goes through this module. The poll's append and a
+ * mark-read both do read-mutate-write on one file, so a second writer
+ * elsewhere would clobber. Paths are injected (like resolveClientId's
+ * cacheFilePath) so unit tests can point at a temp dir.
+ */
+
+/** True for a value shaped like a stored entry, with a parseable announcement. */
+function parseEntry(raw: unknown): AnnouncementArchiveEntry | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const candidate = raw as Record<string, unknown>;
+  // Reuse the feed parser so the archive can never hold something the live
+  // feed itself would have rejected.
+  const announcement = parseAnnouncement(candidate.announcement);
+  if (announcement === null) return null;
+  if (typeof candidate.firstSeenAt !== 'string' || candidate.firstSeenAt.length === 0) return null;
+  // An absent key reads as unread, the same as an explicit null: `readAt` is
+  // `string | null`, so a writer that omits null-valued keys still produced a
+  // valid entry, and dropping it would lose the announcement rather than just
+  // its read-state. Only a present-but-wrong-typed value is malformed.
+  const readAt = candidate.readAt === undefined ? null : candidate.readAt;
+  if (readAt !== null && typeof readAt !== 'string') return null;
+  return {
+    announcement,
+    firstSeenAt: candidate.firstSeenAt,
+    readAt: readAt === null || readAt.length === 0 ? null : readAt,
+  };
+}
+
+/**
+ * Read the archive. A missing, unreadable, or corrupt file loads as empty, and
+ * individual malformed entries are dropped while their siblings survive, the
+ * same tolerant posture the feed parser takes.
+ */
+export function readArchive(filePath: string): AnnouncementArchiveEntry[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    const entries: AnnouncementArchiveEntry[] = [];
+    for (const item of parsed) {
+      const entry = parseEntry(item);
+      if (entry) entries.push(entry);
+    }
+    return entries;
+  } catch {
+    // Corrupt file -> treat as empty.
+    return [];
+  }
+}
+
+/**
+ * Write the archive atomically (tmp + rename, via the shared primitive so a
+ * crash mid-write cannot truncate it). Best-effort: a failed write is logged
+ * and swallowed, matching checkAnnouncements' documented silent-degrade
+ * posture. Losing the archive costs a badge count, never a user action.
+ */
+export function writeArchive(filePath: string, entries: AnnouncementArchiveEntry[]): void {
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    atomicWriteJson(filePath, entries);
+  } catch (error) {
+    console.log('[ANNOUNCEMENTS] archive write skipped:',
+      error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** Production read, bound to the configDir sidecar. */
+export function readAnnouncementArchive(): AnnouncementArchiveEntry[] {
+  return readArchive(PATHS.announcementsArchiveFile);
+}
+
+/** Production write, bound to the configDir sidecar. */
+export function writeAnnouncementArchive(entries: AnnouncementArchiveEntry[]): void {
+  writeArchive(PATHS.announcementsArchiveFile, entries);
+}

--- a/src/main/announcements.ts
+++ b/src/main/announcements.ts
@@ -2,10 +2,13 @@ import { app, BrowserWindow, ipcMain } from 'electron';
 import { IPC } from '../shared/ipc-channels';
 import {
   ANNOUNCEMENTS_URL,
+  appendToArchive,
+  markArchiveEntryRead,
   parseAnnouncementsFeed,
   selectActiveAnnouncements,
   type Announcement,
 } from '../shared/announcements';
+import { readAnnouncementArchive, writeAnnouncementArchive } from './announcements-archive';
 
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours, matching the updater cadence
 const INITIAL_DELAY_MS = 10_000; // after the updater's 5s first check
@@ -17,8 +20,9 @@ let announcementsWindow: BrowserWindow | null = null;
 let cachedActive: Announcement[] = [];
 
 /**
- * Fetch the announcements feed, filter it for this client, and push the
- * active list to the renderer when it changed. Never throws: every failure
+ * Fetch the announcements feed, filter it for this client, fold the result
+ * into the local archive, and push both to the renderer when the active list
+ * changed. Never throws: every failure
  * mode (offline, DNS, timeout, non-200, malformed JSON, unusable feed) is a
  * silent skip that keeps the last-known list, following the attempt/catch/
  * degrade convention (see the relay probe in ipc/handlers/mobile-bridge.ts).
@@ -61,23 +65,46 @@ export async function checkAnnouncements(): Promise<void> {
   // is a sound change check.
   if (JSON.stringify(active) === JSON.stringify(cachedActive)) return;
   cachedActive = active;
+
+  // Below the early return on purpose: an unchanged feed does no archive I/O.
+  // Above the isDestroyed guard, like cachedActive, so a destroyed window
+  // never leaves the archive behind the feed.
+  const history = appendToArchive(readAnnouncementArchive(), active, new Date());
+  writeAnnouncementArchive(history);
+
   if (announcementsWindow && !announcementsWindow.isDestroyed()) {
-    announcementsWindow.webContents.send(IPC.ANNOUNCEMENTS_CHANGED, active);
+    // One push carrying both: active and history derive from this same poll
+    // and change at the same instant, so two channels would only race.
+    announcementsWindow.webContents.send(IPC.ANNOUNCEMENTS_CHANGED, { active, history });
   }
 }
 
 /**
- * Register the announcements IPC handler and start the polling timers.
+ * Register the announcements IPC handlers and start the polling timers.
  *
- * The GET handler is registered before any bail-out so the renderer's invoke
+ * The handlers are registered before any bail-out so the renderer's invoke
  * never rejects with `No handler registered` (same reasoning as the updater's
- * no-op handlers). Unlike the updater there is no `app.isPackaged` gate: dev
+ * no-op handlers). They live here rather than under `src/main/ipc/handlers/`
+ * deliberately, mirroring the updater: this module owns the poll, the cache,
+ * and the archive, so co-locating keeps that ownership in one file.
+ *
+ * Unlike the updater there is no `app.isPackaged` gate: dev
  * builds poll too, so the team dogfoods the announcements surface from
  * `npm start`. Tests are the exception: under NODE_ENV=test (set by the E2E
  * helpers) nothing is scheduled, so no test run ever touches the network.
  */
 export function initAnnouncements(mainWindow: BrowserWindow): void {
   ipcMain.handle(IPC.ANNOUNCEMENTS_GET, () => cachedActive);
+  // Both archive handlers register above the test bail-out too, or every
+  // test-tier invoke would reject with "No handler registered".
+  ipcMain.handle(IPC.ANNOUNCEMENTS_GET_HISTORY, () => readAnnouncementArchive());
+  ipcMain.handle(IPC.ANNOUNCEMENTS_MARK_READ, (_event, announcementId: string) => {
+    const entries = readAnnouncementArchive();
+    const stamped = markArchiveEntryRead(entries, announcementId, new Date());
+    // markArchiveEntryRead returns the input unchanged for an unknown or
+    // already-read id, so identity is a sound "nothing to persist" check.
+    if (stamped !== entries) writeAnnouncementArchive(stamped);
+  });
 
   if (process.env.NODE_ENV === 'test') return;
 

--- a/src/main/config/paths.ts
+++ b/src/main/config/paths.ts
@@ -61,6 +61,11 @@ export const PATHS = {
   get globalDb() { return path.join(this.configDir, 'index.db'); },
   get configFile() { return path.join(this.configDir, 'config.json'); },
   get projectsDir() { return path.join(this.configDir, 'projects'); },
+  /** Local archive of announcements this client has seen, and their read-state.
+   *  A sidecar rather than a config.json key: it holds full markdown bodies,
+   *  and read-state must survive an announcement leaving the active feed (see
+   *  src/main/announcements-archive.ts). */
+  get announcementsArchiveFile() { return path.join(this.configDir, 'announcements-archive.json'); },
   projectDb(projectId: string) { return path.join(this.projectsDir, `${projectId}.db`); },
   /** Downloaded voice-dictation models, one subdirectory per model id (global cache). */
   get modelsDir() { return this.modelCacheDir; },

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,7 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import { IPC } from '../shared/ipc-channels';
 import type { ElectronAPI, NotificationInput, Project, PtyResizeOrigin, Session, SessionUsage, ActivityState, ActivityReason, SessionEvent, UpdateDownloadedInfo, UsageTimePeriod, UsageStatsScope, UsageDayDrill, UsageCustomWindow, TaskBulkDeleteProgress, ProjectMoveProgress, DictationModelProgress, MobilePairingSasPayload, MobilePairingConfirmedPayload, MobilePairingEndedPayload, MonitorSnapshot, TaskDetailHost, TaskDetailRemoteOwner, AutoCommandResultNotice } from '../shared/types';
-import type { Announcement } from '../shared/announcements';
+import type { AnnouncementsChangedPayload } from '../shared/announcements';
 import { POPOUT_ARG_PREFIX } from '../shared/pop-out';
 import type { PopOutDescriptor, PopOutKind, PopOutParamsByKind } from '../shared/pop-out';
 import { installConsoleCapture } from './diagnostics/console-capture';
@@ -484,8 +484,10 @@ const api: ElectronAPI = {
 
   announcements: {
     getActive: () => ipcRenderer.invoke(IPC.ANNOUNCEMENTS_GET),
+    getHistory: () => ipcRenderer.invoke(IPC.ANNOUNCEMENTS_GET_HISTORY),
+    markRead: (announcementId: string) => ipcRenderer.invoke(IPC.ANNOUNCEMENTS_MARK_READ, announcementId),
     onChanged: (callback) => {
-      const handler = (_event: Electron.IpcRendererEvent, active: Announcement[]) => callback(active);
+      const handler = (_event: Electron.IpcRendererEvent, payload: AnnouncementsChangedPayload) => callback(payload);
       ipcRenderer.on(IPC.ANNOUNCEMENTS_CHANGED, handler);
       return () => ipcRenderer.removeListener(IPC.ANNOUNCEMENTS_CHANGED, handler);
     },

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -128,11 +128,17 @@ export function App() {
     });
 
     // Announcements: hydrate the active list (the first poll may have landed
-    // before this renderer mounted), then stay live via the changed push.
+    // before this renderer mounted) and the local archive (which, unlike the
+    // in-memory active list, is non-empty before the first poll and offline),
+    // then stay live via the changed push.
     void useAnnouncementsStore.getState().loadActive();
-    const cleanupAnnouncementsChanged = window.electronAPI.announcements?.onChanged((active) => {
-      useAnnouncementsStore.getState().receiveActive(active);
-    });
+    void useAnnouncementsStore.getState().loadHistory();
+    const cleanupAnnouncementsChanged = window.electronAPI.announcements?.onChanged(
+      ({ active, history }) => {
+        useAnnouncementsStore.getState().receiveActive(active);
+        useAnnouncementsStore.getState().receiveHistory(history);
+      },
+    );
 
     return () => {
       if (mountTimerRafId !== undefined) cancelAnimationFrame(mountTimerRafId);
@@ -848,8 +854,11 @@ if (import.meta.hot) {
     }
     // Pop-out windows Pattern B: re-hydrate which surfaces are currently detached.
     usePopOutStore.getState().loadOpen();
-    // Announcements Pattern B: re-pull the active list from main-process truth.
+    // Announcements Pattern B: re-pull the active list and the archive from
+    // main-process truth. loadActive also re-runs the open-dialog
+    // reconciliation, which a history-opened dialog is exempt from.
     void useAnnouncementsStore.getState().loadActive();
+    void useAnnouncementsStore.getState().loadHistory();
     useSessionStore.getState().syncSessions().then((applied) => {
       if (!applied) return;
 

--- a/src/renderer/components/CountBadge.tsx
+++ b/src/renderer/components/CountBadge.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
 
 type CountBadgeVariant = 'muted' | 'accent' | 'solid';
-type CountBadgeSize = 'sm' | 'md';
+type CountBadgeSize = 'xs' | 'sm' | 'md';
 
 interface CountBadgeProps {
   count: number;
   /** Visual variant. 'muted' for subtle, 'accent' for highlighted, 'solid' for strong emphasis. */
   variant?: CountBadgeVariant;
-  /** Size. 'sm' = 18px circle, 'md' = 20px circle. */
+  /** Size. 'xs' = 14px circle (overlaid on an icon), 'sm' = 18px, 'md' = 20px. */
   size?: CountBadgeSize;
   className?: string;
 }
 
 const SIZE_CLASSES: Record<CountBadgeSize, string> = {
+  // 'xs' exists for badges OVERLAID on a title-bar icon button, where the glyph
+  // is 20px: an 18px badge is nearly icon-sized and buries whatever it sits on.
+  // Keeps the 10px text floor the badge family is grandfathered at, and pairs
+  // with a min-w so a 2-digit count widens into a pill instead of clipping.
+  xs: 'h-3.5 min-w-3.5 px-[3px] text-[10px]',
   sm: 'w-[18px] h-[18px] text-[10px]',
   md: 'w-5 h-5 text-[12px]',
 };
@@ -24,13 +29,15 @@ const VARIANT_CLASSES: Record<CountBadgeVariant, string> = {
 };
 
 /**
- * Circular count badge for displaying numeric counts.
- * Always renders as a perfect circle with centered text.
+ * Circular count badge for displaying numeric counts. 'sm' and 'md' are fixed
+ * circles; 'xs' is a circle at one digit that widens into a pill past that, so
+ * an overlay badge stays small without clipping a 2-digit count.
  *
  * Usage:
  *   <CountBadge count={3} />
  *   <CountBadge count={12} variant="accent" />
  *   <CountBadge count={5} variant="solid" size="sm" />
+ *   <CountBadge count={12} variant="solid" size="xs" />   // overlaid on an icon
  */
 export const CountBadge = React.memo(function CountBadge({
   count,

--- a/src/renderer/components/announcements/AnnouncementBanner.tsx
+++ b/src/renderer/components/announcements/AnnouncementBanner.tsx
@@ -34,7 +34,7 @@ export function AnnouncementBanner() {
       <button
         type="button"
         data-testid="announcement-learn-more"
-        onClick={() => openDialog(banner)}
+        onClick={() => openDialog(banner, 'banner')}
         className="flex-shrink-0 text-xs text-fg-secondary underline underline-offset-2 hover:text-fg transition-colors cursor-pointer"
       >
         Learn more

--- a/src/renderer/components/announcements/AnnouncementDialog.tsx
+++ b/src/renderer/components/announcements/AnnouncementDialog.tsx
@@ -50,16 +50,23 @@ function AnnouncementLinkList({ links }: { links: AnnouncementLink[] }) {
 /**
  * The "Learn more" dialog for an announcement: intro markdown, then any
  * titled sections (each its own message with scoped links), then the
- * announcement-level links. Only ever opens from a user click on the
- * banner's "Learn more", never on its own, so BaseDialog's default focus
- * trap is correct (the updater's autoOpened machinery exists only for
- * unbidden modals). Mounted in AppLayout beside the other app-level dialogs.
+ * announcement-level links.
+ *
+ * Two entry points, both a user click and neither unbidden: the banner's
+ * "Learn more" and a row in AnnouncementHistoryDialog. So BaseDialog's default
+ * focus behavior is correct (the updater's autoOpened machinery exists only for
+ * modals that open on their own), and the focus trap is added only for the
+ * history path, where this dialog is layered over another one. Mounted in
+ * AppLayout beside the other app-level dialogs.
  */
 export function AnnouncementDialog() {
   const announcement = useAnnouncementsStore((state) => state.dialogAnnouncement);
+  const dialogSource = useAnnouncementsStore((state) => state.dialogSource);
   const closeDialog = useAnnouncementsStore((state) => state.closeDialog);
 
   if (!announcement) return null;
+
+  const openedFromHistory = dialogSource === 'history';
 
   return (
     <BaseDialog
@@ -68,6 +75,15 @@ export function AnnouncementDialog() {
       icon={<Megaphone size={16} className="text-accent" />}
       backdropClassName="backdrop-blur-xs"
       className="w-[640px] max-w-[92vw] max-h-[85vh]"
+      // z-[60], not the z-50 default: opened from a history row this dialog
+      // layers OVER AnnouncementHistoryDialog, which is itself a z-50
+      // BaseDialog, so paint order would otherwise depend on JSX order in
+      // AppLayout. Same slot ConfirmDialog uses for the same reason.
+      zIndex="z-[60]"
+      // Only when layered, so the banner path keeps the default focus
+      // behavior its header comment reasons about. Without this, Tab from the
+      // top dialog wanders into the history list underneath.
+      trapFocus={openedFromHistory}
       testId="announcement-dialog"
       footer={
         <div className="flex items-center justify-end">

--- a/src/renderer/components/announcements/AnnouncementHistoryDialog.tsx
+++ b/src/renderer/components/announcements/AnnouncementHistoryDialog.tsx
@@ -1,0 +1,100 @@
+import { Megaphone } from 'lucide-react';
+import { BaseDialog } from '../dialogs/BaseDialog';
+import { useAnnouncementsStore } from '../../stores/announcements-store';
+import { formatRelativeTime } from '../../lib/datetime';
+import type { AnnouncementArchiveEntry } from '../../../shared/announcements';
+
+function AnnouncementHistoryRow({ entry }: { entry: AnnouncementArchiveEntry }) {
+  const openDialog = useAnnouncementsStore((state) => state.openDialog);
+  const unread = entry.readAt === null;
+
+  return (
+    <button
+      type="button"
+      data-testid="announcement-history-row"
+      data-announcement-id={entry.announcement.id}
+      data-unread={unread ? 'true' : 'false'}
+      onClick={() => openDialog(entry.announcement, 'history')}
+      className="w-full flex items-center gap-2.5 px-4 py-2.5 text-left border-b border-edge/50 hover:bg-surface-hover transition-colors cursor-pointer"
+    >
+      {/* Always drawn, never hover-only (ui-conventions.md): the unread state
+          is the reason the megaphone badge is lit, so it has to be readable
+          without pointing at the row. The read case keeps the same box so
+          titles stay on one left edge down the list. */}
+      <span
+        className={`flex-shrink-0 w-1.5 h-1.5 rounded-full ${unread ? 'bg-accent' : 'bg-transparent'}`}
+        aria-hidden="true"
+      />
+      <span
+        className={`flex-1 min-w-0 truncate text-xs ${unread ? 'text-fg font-medium' : 'text-fg-secondary'}`}
+        title={entry.announcement.title}
+      >
+        {entry.announcement.title}
+      </span>
+      {/* publishedAt is what the user thinks of as the announcement's date;
+          firstSeenAt is the fallback for an entry the feed published without
+          one. */}
+      <span className="flex-shrink-0 text-[11px] text-fg-faint tabular-nums">
+        {formatRelativeTime(entry.announcement.publishedAt ?? entry.firstSeenAt)}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * The megaphone's history list: every announcement this client has ever had
+ * active, most recently seen first, read and unread alike. Rows print the
+ * announcement's own publishedAt, so those dates need not descend in step with
+ * the archive's first-seen ordering.
+ *
+ * Rows open the EXISTING AnnouncementDialog for their content, so nothing about
+ * markdown / sections / QR rendering is duplicated here, and the list stays
+ * open underneath so closing an announcement returns to it.
+ *
+ * "Page through" is a scrollable capped list, not pagination controls: the
+ * archive is capped at ANNOUNCEMENT_ARCHIVE_CAP entries, so it can never grow
+ * into something that needs paging.
+ */
+export function AnnouncementHistoryDialog() {
+  const historyOpen = useAnnouncementsStore((state) => state.historyOpen);
+  const history = useAnnouncementsStore((state) => state.history);
+  const dialogAnnouncement = useAnnouncementsStore((state) => state.dialogAnnouncement);
+  const closeHistory = useAnnouncementsStore((state) => state.closeHistory);
+
+  if (!historyOpen) return null;
+
+  return (
+    <BaseDialog
+      onClose={closeHistory}
+      title="Announcements"
+      icon={<Megaphone size={16} className="text-accent" />}
+      // max-h, not a fixed h: the archive is usually one or two entries early
+      // on, and a fixed 60vh box left almost all of it empty. The list grows to
+      // its content and starts scrolling only once it reaches the cap.
+      className="w-[520px] max-w-[92vw] max-h-[60vh]"
+      rawBody
+      // A row opens AnnouncementDialog ON TOP of this one. Both Escape
+      // listeners are bubble-phase on `document`, so the one registered first
+      // (this dialog, mounted first) would otherwise win, dismissing the LIST
+      // and orphaning the announcement above it. Hand Escape to the top dialog
+      // while it is open.
+      suppressEscape={dialogAnnouncement !== null}
+      testId="announcement-history-dialog"
+    >
+      {history.length === 0 ? (
+        <div
+          className="flex-1 flex items-center justify-center px-6 py-10 text-center text-sm text-fg-muted"
+          data-testid="announcement-history-empty"
+        >
+          No announcements yet. Product news shows up here as it is published.
+        </div>
+      ) : (
+        <div className="flex-1 min-h-0 overflow-y-auto" data-testid="announcement-history-list">
+          {history.map((entry) => (
+            <AnnouncementHistoryRow key={entry.announcement.id} entry={entry} />
+          ))}
+        </div>
+      )}
+    </BaseDialog>
+  );
+}

--- a/src/renderer/components/layout/AppLayout.tsx
+++ b/src/renderer/components/layout/AppLayout.tsx
@@ -23,6 +23,7 @@ import { ReleaseNotesDialog } from '../dialogs/ReleaseNotesDialog';
 import { WhatsNewDialog } from '../dialogs/WhatsNewDialog';
 import { AnnouncementBanner } from '../announcements/AnnouncementBanner';
 import { AnnouncementDialog } from '../announcements/AnnouncementDialog';
+import { AnnouncementHistoryDialog } from '../announcements/AnnouncementHistoryDialog';
 import { useConfigStore } from '../../stores/config-store';
 import { useProjectStore } from '../../stores/project-store';
 import { useBoardStore } from '../../stores/board-store';
@@ -538,6 +539,10 @@ export function AppLayout() {
       <ProjectPathMissingDialog />
       <ReleaseNotesDialog />
       <WhatsNewDialog />
+      {/* History first, then the announcement dialog it can open on top. The
+          ordering is cosmetic only: AnnouncementDialog pins itself to z-[60]
+          rather than relying on being second here. */}
+      <AnnouncementHistoryDialog />
       <AnnouncementDialog />
       {onboardingChecklistOpen && <WelcomeChecklistDialog />}
       <WalkthroughLayer />

--- a/src/renderer/components/layout/TitleBar.tsx
+++ b/src/renderer/components/layout/TitleBar.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { ChartColumn, CloudDownload, Command, Minus, Settings, Square, SquareActivity, X } from 'lucide-react';
+import { ChartColumn, CloudDownload, Command, Megaphone, Minus, Settings, Square, SquareActivity, X } from 'lucide-react';
 import { useProjectStore } from '../../stores/project-store';
 import { useConfigStore } from '../../stores/config-store';
 import { useSessionStore } from '../../stores/session-store';
 import { useUpdaterStore } from '../../stores/updater-store';
 import { useUsageDashboardStore } from '../../stores/usage-dashboard-store';
 import { useMonitorStore } from '../../stores/monitor-store';
+import { useAnnouncementsStore, selectUnreadAnnouncementCount } from '../../stores/announcements-store';
+import { CountBadge } from '../CountBadge';
 import { warmStatsDashboard } from '../stats/LazyStatsDashboard';
 import { usePopOut } from '../../pop-out/usePopOut';
 import { selectCommandTerminalSummary } from '../../stores/session-store/transient-session-slice';
@@ -82,6 +84,15 @@ export function TitleBar({
   // toggling the (suppressed) in-app overlay.
   const monitorPopOut = usePopOut('monitor', {});
 
+  const announcementsOpen = useAnnouncementsStore((state) => state.historyOpen);
+  const openAnnouncements = useAnnouncementsStore((state) => state.openHistory);
+  const closeAnnouncements = useAnnouncementsStore((state) => state.closeHistory);
+  // Select the COUNT, not the history array, so Zustand's Object.is equality
+  // skips a re-render when a poll rewrites the array without changing it.
+  const unreadAnnouncements = useAnnouncementsStore(
+    (state) => selectUnreadAnnouncementCount(state.history),
+  );
+
   const isWorktree = currentProject?.path ? isWorktreePath(currentProject.path) : false;
 
   const handleGearClick = () => {
@@ -147,24 +158,6 @@ export function TitleBar({
       <div className="flex-1" />
 
       <div className="flex items-center gap-1" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
-        {/* Update-available indicator: LEFT-MOST of all conditionally-mounted
-            controls in this row, for the same reason "New terminal" is (see
-            the comment on that pair below) - this row is right-anchored, so
-            an element's on-screen position is fixed by what comes AFTER it.
-            Placing this first means it appearing/disappearing (when an
-            update lands / is installed) never shifts the "New terminal" /
-            Command Terminal pair or anything to their right. */}
-        {pendingUpdate && (
-          <button
-            onClick={openUpdateModal}
-            className="p-1.5 hover:bg-surface-hover rounded text-attention transition-colors"
-            title={`Version ${pendingUpdate.version} is ready to install`}
-            aria-label="Update available"
-            data-testid="update-available-button"
-          >
-            <CloudDownload size={20} />
-          </button>
-        )}
         {/* "New terminal" + the Command Terminal toggle are the LEFT-MOST icons
             in this row on purpose: this row is right-anchored (the flex-1
             spacer eats the space to its left), so an element's on-screen
@@ -251,9 +244,9 @@ export function TitleBar({
         </button>
         {/* Quick Find sits to the RIGHT of Usage Stats: it is the one control here
             that opens a transient overlay the user dismisses immediately, so it
-            reads as the last step out of the icon cluster before Settings, while
-            the monitor and stats buttons (both surfaces over running work) stay
-            adjacent to each other. */}
+            reads as the step out of the running-work cluster, while the monitor
+            and stats buttons (both surfaces over running work) stay adjacent to
+            each other. */}
         {onOpenSearch && (
           <button
             onClick={onOpenSearch}
@@ -264,6 +257,74 @@ export function TitleBar({
             data-testid="open-search-button"
           >
             <Command size={20} />
+          </button>
+        )}
+        {/* The two "news from upstream" controls, grouped at the right end just
+            before Settings: announcements (what the team is saying) and an
+            update waiting to install. Both are machine-global, both are things
+            the app is telling YOU rather than surfaces over your running work,
+            which is the cluster to their left.
+
+            Announcements mounts UNCONDITIONALLY - a permanent access point is
+            the whole point, since the banner strip is single-use and a
+            dismissed announcement used to be unreachable. Its badge is
+            absolutely positioned, so appearing or clearing moves nothing.
+
+            This is the one control in this row carrying a corner badge.
+            `quick-session-button` argues for "no separate corner badge to
+            clash or clutter" and `update-available-button` beside it tones
+            itself with no badge, but neither of those has a COUNT to state: a
+            tone can say "something is unread", it cannot say how many. Ship
+            the badge and tone the glyph too, muted at zero. */}
+        <button
+          onClick={() => (announcementsOpen ? closeAnnouncements() : openAnnouncements())}
+          className={`relative p-1.5 hover:bg-surface-hover rounded transition-colors ${
+            announcementsOpen
+              ? 'text-fg bg-surface-hover'
+              : unreadAnnouncements > 0
+                ? 'text-attention hover:text-fg'
+                : 'text-fg-muted hover:text-fg'
+          }`}
+          title={unreadAnnouncements > 0
+            ? `Announcements (${unreadAnnouncements} unread)`
+            : 'Announcements'}
+          aria-label="Announcements"
+          data-testid="announcements-button"
+        >
+          <Megaphone size={20} />
+          {unreadAnnouncements > 0 && (
+            // Sized and offset so the megaphone stays readable underneath. The
+            // glyph is 20px inside a 32px button, so barely any corner sits
+            // outside it and an 18px badge at a token offset buried the horn.
+            // The offsets are bounded on both axes and are not free to grow:
+            // the button sits 3.5px below the title bar's top edge, and the
+            // row's gap to its neighbour is 4px, so a larger pull clips
+            // off-screen or lands on that neighbour. `flex` shrink-wraps the
+            // badge, since a plain inline span's line box is taller than it.
+            <span
+              className="absolute -top-0.5 -right-1 flex pointer-events-none"
+              data-testid="announcements-unread-badge"
+            >
+              <CountBadge count={unreadAnnouncements} variant="solid" size="xs" />
+            </span>
+          )}
+        </button>
+        {/* Deliberately NOT left-most, unlike every other conditional control in
+            this row, because it belongs beside announcements. The row is
+            right-anchored, so a conditional mount shifts everything BEFORE it
+            and nothing after: an arriving update therefore leaves Settings and
+            the OS window controls untouched, but does nudge the icons to its
+            left by one slot. That is the accepted price of the grouping, and it
+            is a once-per-release event. */}
+        {pendingUpdate && (
+          <button
+            onClick={openUpdateModal}
+            className="p-1.5 hover:bg-surface-hover rounded text-attention transition-colors"
+            title={`Version ${pendingUpdate.version} is ready to install`}
+            aria-label="Update available"
+            data-testid="update-available-button"
+          >
+            <CloudDownload size={20} />
           </button>
         )}
         <button

--- a/src/renderer/stores/announcements-store.ts
+++ b/src/renderer/stores/announcements-store.ts
@@ -1,5 +1,12 @@
 import { create } from 'zustand';
-import type { Announcement } from '../../shared/announcements';
+import {
+  countUnreadAnnouncements,
+  markArchiveEntryRead,
+  reconcileOpenDialog,
+  type Announcement,
+  type AnnouncementArchiveEntry,
+  type AnnouncementDialogSource,
+} from '../../shared/announcements';
 
 interface AnnouncementsState {
   /** Active announcements for this client, filtered and sorted by the main
@@ -8,15 +15,35 @@ interface AnnouncementsState {
    *  selectBannerAnnouncement), so a dismissal is instant with no IPC
    *  round-trip and the dismissal prune can see the full active set. */
   active: Announcement[];
+  /** The local archive, most recently seen first: every announcement ever active
+   *  for this client, plus read-state. Backs the megaphone's history list and
+   *  its unread badge, and unlike `active` it is populated from disk at mount,
+   *  so it is non-empty during the 10s before the first poll and while
+   *  offline. */
+  history: AnnouncementArchiveEntry[];
   /** The announcement the "Learn more" dialog is showing; null = closed. */
   dialogAnnouncement: Announcement | null;
+  /** Where the open dialog was opened from. Load-bearing: receiveActive
+   *  reconciles a 'banner' dialog against the active list but must leave a
+   *  'history' one alone. */
+  dialogSource: AnnouncementDialogSource | null;
+  /** Whether the megaphone's history dialog is showing. */
+  historyOpen: boolean;
 
   /** Pull the current active list (app mount and HMR resync, Pattern B). */
   loadActive: () => Promise<void>;
+  /** Pull the archive (app mount and HMR resync, Pattern B). */
+  loadHistory: () => Promise<void>;
   /** Called from the announcements:changed IPC push. */
   receiveActive: (active: Announcement[]) => void;
-  openDialog: (announcement: Announcement) => void;
+  /** Called from the announcements:changed IPC push. */
+  receiveHistory: (history: AnnouncementArchiveEntry[]) => void;
+  openDialog: (announcement: Announcement, source: AnnouncementDialogSource) => void;
   closeDialog: () => void;
+  /** Stamp an archive entry read. Optimistic, then fire-and-forget over IPC. */
+  markRead: (announcementId: string) => void;
+  openHistory: () => void;
+  closeHistory: () => void;
 }
 
 /**
@@ -31,9 +58,23 @@ export function selectBannerAnnouncement(
   return active.find((announcement) => !dismissedIds.includes(announcement.id)) ?? null;
 }
 
+/**
+ * The megaphone badge count: unread archive entries.
+ *
+ * Deliberately NOT filtered by dismissal. Dismissed hides the banner; read
+ * silences the badge. A dismissed-but-unread announcement still counts, because
+ * the megaphone means "there is something you have not read".
+ */
+export function selectUnreadAnnouncementCount(history: AnnouncementArchiveEntry[]): number {
+  return countUnreadAnnouncements(history);
+}
+
 const createAnnouncementsStore = () => create<AnnouncementsState>((set, get) => ({
   active: [],
+  history: [],
   dialogAnnouncement: null,
+  dialogSource: null,
+  historyOpen: false,
 
   loadActive: async () => {
     // Optional chaining: during Vite HMR full reloads the preload bridge may
@@ -46,22 +87,60 @@ const createAnnouncementsStore = () => create<AnnouncementsState>((set, get) => 
     if (active) get().receiveActive(active);
   },
 
+  loadHistory: async () => {
+    const history = await window.electronAPI.announcements?.getHistory();
+    if (history) get().receiveHistory(history);
+  },
+
   receiveActive: (active) => {
-    const { dialogAnnouncement } = get();
+    const { dialogAnnouncement, dialogSource } = get();
+    // A banner-opened dialog for an announcement that just left the active set
+    // (expired or retracted upstream) closes rather than lingering over content
+    // the feed withdrew. A history-opened one survives: history exists to show
+    // announcements that are no longer active, and this path runs on every poll
+    // AND every HMR resync, so reconciling it would close the dialog out from
+    // under the user on every renderer edit in dev.
+    const keptDialog = reconcileOpenDialog(dialogAnnouncement, dialogSource, active);
     set({
       active,
-      // An open dialog for an announcement that just left the active set
-      // (expired or retracted upstream) closes rather than lingering over
-      // content the feed withdrew.
-      dialogAnnouncement: dialogAnnouncement
-        && active.some((announcement) => announcement.id === dialogAnnouncement.id)
-        ? dialogAnnouncement
-        : null,
+      dialogAnnouncement: keptDialog,
+      dialogSource: keptDialog ? dialogSource : null,
     });
   },
 
-  openDialog: (announcement) => set({ dialogAnnouncement: announcement }),
-  closeDialog: () => set({ dialogAnnouncement: null }),
+  receiveHistory: (history) => set({ history }),
+
+  openDialog: (announcement, source) => {
+    // Opening from ANY entry point marks it read: the badge tracks what the
+    // user has seen, and both the banner's "Learn more" and a history row show
+    // the same full content.
+    get().markRead(announcement.id);
+    set({ dialogAnnouncement: announcement, dialogSource: source });
+  },
+
+  closeDialog: () => set({ dialogAnnouncement: null, dialogSource: null }),
+
+  markRead: (announcementId) => {
+    const { history } = get();
+    const stamped = markArchiveEntryRead(history, announcementId, new Date());
+    // Update optimistically so the badge never lags a round-trip. Identity means
+    // the local copy had nothing to change, so skip the re-render only.
+    if (stamped !== history) set({ history: stamped });
+    // The IPC fires UNCONDITIONALLY, even when the local copy changed nothing.
+    // Main owns the durable archive, and this store's `history` can legitimately
+    // be behind it: mount fires loadActive() and loadHistory() together without
+    // awaiting, so after a renderer reload the banner (served from main's
+    // already-warm cachedActive) can render and be clicked while the archive's
+    // disk read is still in flight. Gating the write on the local copy would
+    // silently drop that read forever. Main's handler no-ops on an unknown or
+    // already-read id, so an extra call is free.
+    // Fire-and-forget: failing to persist must not break the UI (same shape as
+    // dismissAnnouncement in config-store.ts).
+    void window.electronAPI.announcements?.markRead(announcementId).catch(() => undefined);
+  },
+
+  openHistory: () => set({ historyOpen: true }),
+  closeHistory: () => set({ historyOpen: false }),
 }));
 
 // HMR instance pinning (Pattern E, see .claude/rules/hmr-patterns.md): this

--- a/src/shared/announcements.ts
+++ b/src/shared/announcements.ts
@@ -75,6 +75,51 @@ export interface AnnouncementTargetContext {
   now: Date;
 }
 
+/**
+ * One archived announcement. The archive is the client's own copy of every
+ * announcement that was ever active FOR THIS CLIENT, and it owns read-state.
+ *
+ * Read is not dismissed, and the two are stored apart on purpose:
+ *   - dismissed (config.dismissedAnnouncementIds) hides the banner strip;
+ *   - read (`readAt` here) stops the megaphone badge counting it.
+ * Dismissing leaves an announcement unread, so a dismissed-but-unread entry
+ * still lights the badge. The megaphone means "there is something you have not
+ * read", not "there is a banner".
+ *
+ * Read-state cannot live in `dismissedAnnouncementIds` because
+ * computeDismissedIdsAfterDismiss prunes that list to ids still in the ACTIVE
+ * feed on every write, so it would drain the moment an announcement expired.
+ *
+ * The announcement is NESTED rather than spread so a future feed field can
+ * never collide with `firstSeenAt` / `readAt`.
+ */
+export interface AnnouncementArchiveEntry {
+  announcement: Announcement;
+  /** ISO 8601 UTC: when this client first saw it in its targeted active set. */
+  firstSeenAt: string;
+  /** ISO 8601 UTC when its dialog was first opened; null = unread. */
+  readAt: string | null;
+}
+
+/**
+ * The `announcements:changed` push payload. Active and history both derive
+ * from the same poll and change at the same instant, so they travel together
+ * rather than on two channels that could race.
+ */
+export interface AnnouncementsChangedPayload {
+  active: Announcement[];
+  history: AnnouncementArchiveEntry[];
+}
+
+/** Where an open "Learn more" dialog was opened from; null = closed. */
+export type AnnouncementDialogSource = 'banner' | 'history';
+
+/**
+ * Archive size cap. Bounds the file and the badge count with no separate
+ * cleanup pass, the same self-maintaining shape as the dismissal prune.
+ */
+export const ANNOUNCEMENT_ARCHIVE_CAP = 50;
+
 const KNOWN_PLATFORMS: readonly AnnouncementPlatform[] = ['win32', 'darwin', 'linux'];
 
 function isNonEmptyString(value: unknown): value is string {
@@ -285,4 +330,105 @@ export function computeDismissedIdsAfterDismiss(
   const retained = existingDismissedIds.filter(
     (id) => id !== dismissedId && activeAnnouncementIds.includes(id));
   return [...retained, dismissedId];
+}
+
+/**
+ * Fold the current active set into the archive, newest-first.
+ *
+ * Fed from selectActiveAnnouncements output, so client targeting (version,
+ * platform, publish window) is free: an announcement that never matched this
+ * client never enters history.
+ *
+ * Ids not yet archived are prepended, and `active` is walked in REVERSE so the
+ * feed's own priority/publishedAt/id sort survives at the head. Ids already
+ * archived keep their position, `firstSeenAt`, and `readAt`, but their payload
+ * is refreshed so an edited announcement's content updates in place. The tail
+ * past `cap` is dropped.
+ *
+ * `now` is a parameter rather than read internally so callers and tests get a
+ * deterministic result.
+ */
+export function appendToArchive(
+  existing: AnnouncementArchiveEntry[],
+  active: Announcement[],
+  now: Date,
+  cap: number = ANNOUNCEMENT_ARCHIVE_CAP,
+): AnnouncementArchiveEntry[] {
+  const activeById = new Map(active.map((announcement) => [announcement.id, announcement]));
+  const archived = new Set(existing.map((entry) => entry.announcement.id));
+
+  const refreshed = existing.map((entry) => {
+    const current = activeById.get(entry.announcement.id);
+    return current ? { ...entry, announcement: current } : entry;
+  });
+
+  const firstSeenAt = now.toISOString();
+  const head: AnnouncementArchiveEntry[] = [];
+  for (let index = active.length - 1; index >= 0; index -= 1) {
+    const announcement = active[index];
+    if (archived.has(announcement.id)) continue;
+    // Track as we go, not just from `existing`: a feed that repeats an id
+    // within one batch would otherwise archive it twice, permanently (both
+    // copies then match on every later poll, and they collide on the history
+    // list's React key). The committed feed's unique-id check lives in
+    // announcements-json-valid.test.ts, but a self-hosted or overridden feed
+    // (KANGENTIC_ANNOUNCEMENTS_URL) never passes through it.
+    archived.add(announcement.id);
+    head.unshift({ announcement, firstSeenAt, readAt: null });
+  }
+
+  return [...head, ...refreshed].slice(0, Math.max(0, cap));
+}
+
+/**
+ * Stamp `readAt` on one entry. Idempotent: an already-read entry keeps its
+ * original timestamp, so re-opening a dialog never rewrites when it was first
+ * read. An unknown id returns the input untouched (the archive may have pruned
+ * it, and a mark-read is fire-and-forget).
+ */
+export function markArchiveEntryRead(
+  entries: AnnouncementArchiveEntry[],
+  announcementId: string,
+  now: Date,
+): AnnouncementArchiveEntry[] {
+  let changed = false;
+  const stamped = entries.map((entry) => {
+    if (entry.announcement.id !== announcementId || entry.readAt !== null) return entry;
+    changed = true;
+    return { ...entry, readAt: now.toISOString() };
+  });
+  return changed ? stamped : entries;
+}
+
+/**
+ * Badge count: every unread entry, expired ones included. Expiry is not the
+ * same as read, and the archive cap already bounds the number.
+ */
+export function countUnreadAnnouncements(entries: AnnouncementArchiveEntry[]): number {
+  return entries.reduce((total, entry) => (entry.readAt === null ? total + 1 : total), 0);
+}
+
+/**
+ * Which announcement an open dialog should still be showing after a new active
+ * list arrives. A BANNER-opened dialog closes when its announcement leaves the
+ * active set (expired or retracted upstream) rather than lingering over content
+ * the feed withdrew. A HISTORY-opened one is exempt: history exists precisely to
+ * show announcements that are no longer active, and every poll (plus every HMR
+ * resync, which routes through the same path) would otherwise close it out from
+ * under the user.
+ *
+ * Lives here rather than in the store so it is pure and directly unit-testable
+ * (tests/unit/announcements-archive.test.ts), alongside the archive helpers it
+ * reconciles against.
+ */
+export function reconcileOpenDialog(
+  dialogAnnouncement: Announcement | null,
+  dialogSource: AnnouncementDialogSource | null,
+  active: Announcement[],
+): Announcement | null {
+  if (dialogAnnouncement === null) return null;
+  if (dialogSource === 'history') return dialogAnnouncement;
+  return active.some((announcement) => announcement.id === dialogAnnouncement.id)
+    ? dialogAnnouncement
+    : null;
 }

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -381,6 +381,8 @@ export const IPC = {
 
   // Announcements (remote feed poll; see src/main/announcements.ts)
   ANNOUNCEMENTS_GET: 'announcements:get',
+  ANNOUNCEMENTS_GET_HISTORY: 'announcements:getHistory',
+  ANNOUNCEMENTS_MARK_READ: 'announcements:markRead',
   ANNOUNCEMENTS_CHANGED: 'announcements:changed',
 
   // Search

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,5 +1,9 @@
 import type { PopOutDescriptor, PopOutKind, PopOutParamsByKind } from './pop-out';
-import type { Announcement } from './announcements';
+import type {
+  Announcement,
+  AnnouncementArchiveEntry,
+  AnnouncementsChangedPayload,
+} from './announcements';
 
 // === Database Models ===
 
@@ -4817,10 +4821,13 @@ export interface ElectronAPI {
     onUpdateDownloaded: (callback: (info: UpdateDownloadedInfo) => void) => () => void;
   };
 
-  // Announcements (remote feed; active = filtered for this client in main)
+  // Announcements (remote feed; active = filtered for this client in main.
+  // history = the local archive sidecar, which also owns per-entry read-state)
   announcements: {
     getActive: () => Promise<Announcement[]>;
-    onChanged: (callback: (active: Announcement[]) => void) => () => void;
+    getHistory: () => Promise<AnnouncementArchiveEntry[]>;
+    markRead: (announcementId: string) => Promise<void>;
+    onChanged: (callback: (payload: AnnouncementsChangedPayload) => void) => () => void;
   };
 
   // Backlog Attachments

--- a/tests/ui/announcements.spec.ts
+++ b/tests/ui/announcements.spec.ts
@@ -48,21 +48,53 @@ function makeAnnouncement(overrides: Partial<Announcement> & { id: string }): An
   };
 }
 
+/** An archive entry as the mock stores it, mirroring AnnouncementArchiveEntry. */
+interface HistoryEntry {
+  announcement: Announcement;
+  firstSeenAt: string;
+  readAt: string | null;
+}
+
+function makeHistoryEntry(
+  announcement: Announcement,
+  overrides: Partial<Omit<HistoryEntry, 'announcement'>> = {},
+): HistoryEntry {
+  return {
+    announcement,
+    firstSeenAt: new Date().toISOString(),
+    readAt: null,
+    ...overrides,
+  };
+}
+
 /**
  * Fires the announcements-changed push once App.tsx's subscriber is attached.
  * Firing before the mount-effect subscription registers would be a silent
  * no-op (the eager mock hook tolerates zero listeners), so wait for it.
+ *
+ * The push carries `{ active, history }`. Omitting `history` lets the mock
+ * derive one unread entry per active announcement, which is what a real poll
+ * produces; pass it explicitly to model already-read or no-longer-active
+ * entries. Each fire REPLACES the history wholesale, so a test's badge count
+ * never inherits from an earlier test on the same worker page.
  */
-async function fireAnnouncements(active: Announcement[]): Promise<void> {
+async function fireAnnouncements(
+  active: Announcement[],
+  history?: HistoryEntry[],
+): Promise<void> {
   await expect
     .poll(() => page.evaluate(() =>
       (window as unknown as { __mockAnnouncementsChangedListeners: unknown[] })
         .__mockAnnouncementsChangedListeners.length))
     .toBeGreaterThan(0);
-  await page.evaluate((activeList) => {
-    (window as unknown as { __mockFireAnnouncementsChanged: (active: unknown[]) => void })
-      .__mockFireAnnouncementsChanged(activeList);
-  }, active as unknown as unknown[]);
+  await page.evaluate(({ activeList, historyList }) => {
+    (window as unknown as {
+      __mockFireAnnouncementsChanged: (active: unknown[], history?: unknown[]) => void;
+    }).__mockFireAnnouncementsChanged(activeList, historyList);
+  }, {
+    activeList: active as unknown as unknown[],
+    historyList: history as unknown as unknown[] | undefined,
+  });
 }
 
 async function getGlobalConfig(): Promise<AppConfig> {
@@ -237,6 +269,364 @@ test.describe('Announcements banner and dialog', () => {
   });
 });
 
+test.describe('Announcements megaphone and history', () => {
+  const megaphone = () => page.locator('[data-testid="announcements-button"]');
+  const badge = () => page.locator('[data-testid="announcements-unread-badge"]');
+  const historyDialog = () => page.locator('[data-testid="announcement-history-dialog"]');
+  const historyRows = () => page.locator('[data-testid="announcement-history-row"]');
+
+  test('the megaphone badges unread entries and clears as each is read', async () => {
+    const stamp = Date.now();
+    const unread = makeAnnouncement({ id: `badge-unread-${stamp}` });
+    const alsoUnread = makeAnnouncement({ id: `badge-unread-2-${stamp}` });
+    const alreadyRead = makeAnnouncement({ id: `badge-read-${stamp}` });
+    await fireAnnouncements([unread, alsoUnread, alreadyRead], [
+      makeHistoryEntry(unread),
+      makeHistoryEntry(alsoUnread),
+      makeHistoryEntry(alreadyRead, { readAt: new Date().toISOString() }),
+    ]);
+
+    // Two of three unread. The button itself is permanent, the badge is not.
+    await expect(megaphone()).toBeVisible();
+    await expect(badge()).toContainText('2');
+
+    await megaphone().click();
+    await expect(historyDialog()).toBeVisible();
+    await expect(historyRows()).toHaveCount(3);
+
+    // Reading one drops the count without waiting on an IPC round-trip.
+    await historyRows().first().click();
+    await expect(page.locator('[data-testid="announcement-dialog"]')).toBeVisible();
+    await expect(badge()).toContainText('1');
+
+    // The history list stays up underneath, so closing returns to it.
+    await page.locator('[data-testid="announcement-close"]').click();
+    await expect(historyDialog()).toBeVisible();
+    await expect(historyRows().first()).toHaveAttribute('data-unread', 'false');
+
+    await historyRows().nth(1).click();
+    await page.locator('[data-testid="announcement-close"]').click();
+    // Nothing unread left: the badge unmounts entirely rather than showing 0.
+    await expect(badge()).toHaveCount(0);
+    await expect(megaphone()).toBeVisible();
+
+    await historyDialog().locator('[aria-label="Close dialog"]').click();
+    await expect(historyDialog()).toHaveCount(0);
+    await fireAnnouncements([]);
+  });
+
+  test('history lists announcements that are no longer active, and the banner never showed', async () => {
+    const stamp = Date.now();
+    const retired = makeAnnouncement({ id: `history-retired-${stamp}`, title: 'Retired announcement' });
+    // Empty active list with a non-empty archive: exactly the state of a fresh
+    // launch before the first poll, and of an announcement deleted upstream.
+    await fireAnnouncements([], [makeHistoryEntry(retired, { readAt: new Date().toISOString() })]);
+
+    await expect(page.locator('[data-testid="announcement-banner"]')).toHaveCount(0);
+
+    await megaphone().click();
+    await expect(historyRows()).toHaveCount(1);
+    await expect(historyRows().first()).toContainText('Retired announcement');
+
+    await historyDialog().locator('[aria-label="Close dialog"]').click();
+    await fireAnnouncements([]);
+  });
+
+  test('an announcement opened from history survives a poll that drops it', async () => {
+    // The trap this feature had to design around: receiveActive closes an open
+    // dialog whose announcement left the active set, and loadActive routes
+    // through it too, so in dev this fires on EVERY renderer edit. A
+    // history-opened dialog must be exempt.
+    const stamp = Date.now();
+    const expired = makeAnnouncement({ id: `history-survives-${stamp}`, title: 'Opened from history' });
+    await fireAnnouncements([expired]);
+
+    await megaphone().click();
+    await historyRows().first().click();
+    const dialog = page.locator('[data-testid="announcement-dialog"]');
+    await expect(dialog).toBeVisible();
+
+    // The feed drops it entirely while the dialog is open.
+    await fireAnnouncements([], [makeHistoryEntry(expired, { readAt: new Date().toISOString() })]);
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Opened from history');
+
+    await page.locator('[data-testid="announcement-close"]').click();
+    await historyDialog().locator('[aria-label="Close dialog"]').click();
+    await fireAnnouncements([]);
+  });
+
+  test('Escape closes only the layered announcement dialog, leaving the history list up', async () => {
+    // Both dialogs register a bubble-phase Escape listener on `document`, and
+    // the first registered (the history list) would otherwise win, dismissing
+    // the LIST and orphaning the announcement on top of nothing.
+    const announcement = makeAnnouncement({ id: `history-escape-${Date.now()}` });
+    await fireAnnouncements([announcement]);
+
+    await megaphone().click();
+    await historyRows().first().click();
+    const dialog = page.locator('[data-testid="announcement-dialog"]');
+    await expect(dialog).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).toHaveCount(0);
+    await expect(historyDialog()).toBeVisible();
+
+    // A second Escape, now unsuppressed, closes the list.
+    await page.keyboard.press('Escape');
+    await expect(historyDialog()).toHaveCount(0);
+    await fireAnnouncements([]);
+  });
+
+  test('a dismissed announcement stays unread, so the badge keeps counting it', async () => {
+    // Dismissed hides the banner; read silences the badge. They are separate
+    // states in separate stores, and dismissing must not imply reading.
+    const stamp = Date.now();
+    const first = makeAnnouncement({ id: `badge-dismissed-${stamp}`, priority: 5 });
+    const second = makeAnnouncement({ id: `badge-dismissed-2-${stamp}` });
+    await fireAnnouncements([first, second]);
+    await expect(badge()).toContainText('2');
+
+    await page.locator('[data-testid="announcement-dismiss"]').click();
+    await expect(page.locator('[data-testid="announcement-banner"]')).toContainText(second.title);
+    // Banner moved on, badge did not: the first is dismissed but still unread.
+    await expect(badge()).toContainText('2');
+
+    await page.locator('[data-testid="announcement-dismiss"]').click();
+    await expect(page.locator('[data-testid="announcement-banner"]')).toHaveCount(0);
+    // Both dismissed, neither opened. The megaphone is now the ONLY way to
+    // reach them, and it still says there are two unread.
+    await expect(badge()).toContainText('2');
+
+    await megaphone().click();
+    await expect(historyRows()).toHaveCount(2);
+    await historyDialog().locator('[aria-label="Close dialog"]').click();
+    await fireAnnouncements([]);
+  });
+
+  test('the banner marks read durably even before the local archive has loaded', async () => {
+    // Mount fires loadActive() and loadHistory() together without awaiting, so
+    // after a renderer reload the banner (served from main's already-warm
+    // cachedActive) can render and be clicked while the archive read is still
+    // in flight. Modelled here as active-with-empty-history. The mark-read IPC
+    // must still go out, or that read is silently lost forever: main owns the
+    // durable archive and the renderer's copy is only a cache.
+    const announcement = makeAnnouncement({ id: `read-before-history-${Date.now()}` });
+    await page.evaluate(() => {
+      (window as unknown as { __mockAnnouncementMarkReadCalls: string[] })
+        .__mockAnnouncementMarkReadCalls = [];
+    });
+    await fireAnnouncements([announcement], []);
+    await expect(badge()).toHaveCount(0);
+
+    await page.locator('[data-testid="announcement-learn-more"]').click();
+    await expect(page.locator('[data-testid="announcement-dialog"]')).toBeVisible();
+
+    await expect
+      .poll(() => page.evaluate(() =>
+        (window as unknown as { __mockAnnouncementMarkReadCalls: string[] })
+          .__mockAnnouncementMarkReadCalls))
+      .toEqual([announcement.id]);
+
+    await page.locator('[data-testid="announcement-close"]').click();
+    await fireAnnouncements([]);
+  });
+
+  test('the badge stays clear of its neighbours and never clips a 2-digit count', async () => {
+    // The badge is overlaid on a 20px glyph inside a 32px button, so its size
+    // and offsets are bounded on every side: too big or pulled too far and it
+    // either buries the megaphone (the bug this replaced), clips off the top of
+    // the title bar, or lands on Quick Find.
+    const stamp = Date.now();
+    await fireAnnouncements([], Array.from({ length: 12 }, (_unused, index) =>
+      makeHistoryEntry(makeAnnouncement({ id: `badge-geometry-${stamp}-${index}` }))));
+    await expect(badge()).toContainText('12');
+
+    const boxes = await page.evaluate(() => {
+      const button = document.querySelector('[data-testid="announcements-button"]');
+      const badge = document.querySelector('[data-testid="announcements-unread-badge"]');
+      const badgeElement = badge?.querySelector('span');
+      // Read the neighbour off the DOM rather than naming it: this button has
+      // moved along the row before, and the invariant is about whatever
+      // actually sits to its right, not about one specific control.
+      const neighbour = button?.nextElementSibling ?? null;
+      return {
+        button: button ? button.getBoundingClientRect().toJSON() : null,
+        badge: badge ? badge.getBoundingClientRect().toJSON() : null,
+        neighbour: neighbour ? neighbour.getBoundingClientRect().toJSON() : null,
+        clipped: badgeElement
+          ? badgeElement.scrollWidth > badgeElement.clientWidth + 1
+          : true,
+      };
+    });
+
+    if (!boxes.button || !boxes.badge || !boxes.neighbour) throw new Error('missing element');
+    // A 2-digit count widens the pill rather than clipping its own text.
+    expect(boxes.clipped).toBe(false);
+    // Stays inside the title bar rather than being cut off at the top.
+    expect(boxes.badge.top).toBeGreaterThanOrEqual(0);
+    // Does not reach into whatever button sits to its right.
+    expect(boxes.badge.right).toBeLessThanOrEqual(boxes.neighbour.left);
+    // Still small relative to the glyph it sits on, so the megaphone reads.
+    expect(boxes.badge.height).toBeLessThanOrEqual(16);
+
+    await fireAnnouncements([]);
+  });
+
+  test('the history list grows to its content, then caps and scrolls', async () => {
+    // The dialog is max-h, not a fixed height, so a one-entry archive is a
+    // small box rather than a mostly-empty 60vh one. This pins both ends of
+    // that: it must still cap and scroll once the archive is long.
+    const stamp = Date.now();
+    const one = makeAnnouncement({ id: `scroll-one-${stamp}` });
+    await fireAnnouncements([], [makeHistoryEntry(one, { readAt: new Date().toISOString() })]);
+    await megaphone().click();
+
+    const viewportHeight = page.viewportSize()?.height ?? 0;
+    const dialogHeight = async () =>
+      (await historyDialog().boundingBox())?.height ?? 0;
+
+    const shortHeight = await dialogHeight();
+    expect(shortHeight).toBeLessThan(viewportHeight * 0.3);
+    // Nothing to scroll at one entry.
+    await expect
+      .poll(() => page.locator('[data-testid="announcement-history-list"]')
+        .evaluate((element) => element.scrollHeight - element.clientHeight))
+      .toBe(0);
+
+    // A full archive (the cap is 50) must not grow the dialog past 60vh.
+    await fireAnnouncements([], Array.from({ length: 50 }, (_unused, index) =>
+      makeHistoryEntry(makeAnnouncement({ id: `scroll-many-${stamp}-${index}` }))));
+    await expect(historyRows()).toHaveCount(50);
+
+    const tallHeight = await dialogHeight();
+    expect(tallHeight).toBeGreaterThan(shortHeight);
+    // +2 tolerates sub-pixel rounding between Windows and CI's headless Linux.
+    expect(tallHeight).toBeLessThanOrEqual(viewportHeight * 0.6 + 2);
+    await expect
+      .poll(() => page.locator('[data-testid="announcement-history-list"]')
+        .evaluate((element) => element.scrollHeight - element.clientHeight))
+      .toBeGreaterThan(0);
+
+    await historyDialog().locator('[aria-label="Close dialog"]').click();
+    await fireAnnouncements([]);
+  });
+
+  test('the Developer tab seed button fills every announcement surface at once', async () => {
+    // The dev trigger exists because the real poll needs the network and a
+    // 10-second wait, and the live feed usually holds a single entry - not
+    // enough to exercise a badge count, a multi-row history, or a history entry
+    // that has left the active set. It renders only under __KANGENTIC_DEV__,
+    // which the UI tier's Vite dev server sets.
+    await fireAnnouncements([], []);
+    await expect(badge()).toHaveCount(0);
+
+    await page.locator('[data-testid="settings-button"]').click();
+    await page.locator('h2:has-text("Settings")').waitFor({ state: 'visible', timeout: 3000 });
+    await page.getByRole('button', { name: 'Developer', exact: true }).click();
+    await page.locator('[data-testid="dev-trigger-announcements-feed"]').click();
+    await page.keyboard.press('Escape');
+    await page.locator('h2:has-text("Settings")').waitFor({ state: 'hidden', timeout: 3000 });
+
+    // Two active announcements: the banner takes the higher-priority one...
+    await expect(page.locator('[data-testid="announcement-banner"]'))
+      .toContainText('Kangentic Mobile is almost here');
+    // ...both are unread, so the badge counts exactly those two...
+    await expect(badge()).toContainText('2');
+
+    // ...and history carries a third that is NOT active, which only the local
+    // archive can produce.
+    await megaphone().click();
+    await expect(historyRows()).toHaveCount(3);
+    await expect(historyRows().nth(2)).toContainText('Command Terminal');
+    await expect(historyRows().nth(2)).toHaveAttribute('data-unread', 'false');
+    await expect(historyRows().nth(0)).toHaveAttribute('data-unread', 'true');
+
+    await historyDialog().locator('[aria-label="Close dialog"]').click();
+    await fireAnnouncements([]);
+  });
+
+  test('the megaphone button toggles its own history dialog closed on a second activation', async () => {
+    // Isolated page (own browser context), not the shared per-worker `page`
+    // above: `historyOpen` is a single global boolean, shared by every test
+    // this file's `mode: 'parallel'` may schedule concurrently against that
+    // shared page. Every OTHER test in this block closes the dialog through
+    // the deterministic `[aria-label="Close dialog"]` button, which always
+    // closes regardless of ambient state; re-pressing the SAME toggle control
+    // is not idempotent that way; its outcome depends on whatever the shared
+    // boolean happens to be at that instant. That is genuinely racy against a
+    // concurrently-scheduled sibling also opening/closing the dialog -
+    // confirmed empirically: a full-file run observed the dialog already open
+    // before this test's own first action. A dedicated page removes the
+    // shared boolean entirely, following the same isolation this file already
+    // uses for "Announcements mount-time pull" below.
+    //
+    // A real MOUSE click could not exercise the close path either way: once
+    // the history dialog is open, BaseDialog's own `fixed inset-0 z-50`
+    // backdrop covers the whole viewport, including the title bar, so a click
+    // at the megaphone's screen coordinates lands on the backdrop (confirmed
+    // via document.elementFromPoint), not the button, and would be swallowed
+    // by the backdrop's own click-to-close instead of ever reaching the
+    // button's onClick. A keyboard activation (Enter on the focused button)
+    // bypasses hit-testing entirely and reaches the button's handler directly
+    // - the only real-user-reachable path (a keyboard user tabbed here) that
+    // actually proves the button's own open-vs-close ternary, rather than
+    // merely observing the backdrop's independent dismissal.
+    const announcement = makeAnnouncement({ id: `toggle-${Date.now()}` });
+    const historyEntry = makeHistoryEntry(announcement, { readAt: new Date().toISOString() });
+
+    await waitForViteReady(VITE_URL);
+    const isolatedBrowser = await chromium.launch({ headless: true });
+    try {
+      const context = await isolatedBrowser.newContext({ viewport: { width: 1920, height: 1080 } });
+      const isolatedPage = await context.newPage();
+
+      await isolatedPage.addInitScript({ path: MOCK_SCRIPT });
+      await isolatedPage.goto(VITE_URL);
+      await isolatedPage.waitForLoadState('load');
+      await isolatedPage.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+      // Push the archive over the changed feed, same as fireAnnouncements()
+      // does for the shared page above, but scoped to isolatedPage: wait for
+      // App.tsx's mount-effect subscriber to attach before firing, since an
+      // earlier push is a silent no-op.
+      await expect
+        .poll(() => isolatedPage.evaluate(() =>
+          (window as unknown as { __mockAnnouncementsChangedListeners: unknown[] })
+            .__mockAnnouncementsChangedListeners.length))
+        .toBeGreaterThan(0);
+      await isolatedPage.evaluate((entry) => {
+        (window as unknown as {
+          __mockFireAnnouncementsChanged: (active: unknown[], history?: unknown[]) => void;
+        }).__mockFireAnnouncementsChanged([], [entry]);
+      }, historyEntry as unknown as Record<string, unknown>);
+
+      const isolatedMegaphone = isolatedPage.locator('[data-testid="announcements-button"]');
+      const isolatedHistoryDialog = isolatedPage.locator('[data-testid="announcement-history-dialog"]');
+
+      await isolatedMegaphone.press('Enter');
+      await expect(isolatedHistoryDialog).toBeVisible();
+
+      await isolatedMegaphone.press('Enter');
+      await expect(isolatedHistoryDialog).toHaveCount(0);
+    } finally {
+      await isolatedBrowser.close();
+    }
+  });
+
+  test('the megaphone shows an empty state when nothing has ever been archived', async () => {
+    await fireAnnouncements([], []);
+
+    await megaphone().click();
+    await expect(page.locator('[data-testid="announcement-history-empty"]')).toBeVisible();
+    await expect(historyRows()).toHaveCount(0);
+    await expect(badge()).toHaveCount(0);
+
+    await historyDialog().locator('[aria-label="Close dialog"]').click();
+    await expect(historyDialog()).toHaveCount(0);
+  });
+});
+
 test.describe('Announcements mount-time pull', () => {
   // This test manages its own browser/page (not the shared per-worker one
   // above): it needs window.__mockActiveAnnouncements seeded BEFORE React
@@ -268,6 +658,48 @@ test.describe('Announcements mount-time pull', () => {
       const banner = isolatedPage.locator('[data-testid="announcement-banner"]');
       await expect(banner).toBeVisible();
       await expect(banner).toContainText(announcement.title);
+    } finally {
+      await isolatedBrowser.close();
+    }
+  });
+
+  // Sibling to the banner test above, proving the OTHER half of mount-time
+  // Pattern B: the local ARCHIVE pull (loadHistory()), not the active-list pull
+  // (loadActive()). This is what keeps the megaphone badge correct at boot and
+  // while offline, before any poll (and therefore any announcements:changed
+  // push) has ever landed - seed window.__mockAnnouncementHistory only, never
+  // fire __mockFireAnnouncementsChanged, and confirm the badge still counts the
+  // seeded unread entries.
+  test('the megaphone badges an archive that was already recorded before the renderer mounted, with no push', async () => {
+    const stamp = Date.now();
+    const firstUnread = makeAnnouncement({ id: `mount-pull-history-1-${stamp}` });
+    const secondUnread = makeAnnouncement({ id: `mount-pull-history-2-${stamp}` });
+    const alreadyRead = makeAnnouncement({ id: `mount-pull-history-3-${stamp}` });
+    const seededHistory = [
+      makeHistoryEntry(firstUnread),
+      makeHistoryEntry(secondUnread),
+      makeHistoryEntry(alreadyRead, { readAt: new Date().toISOString() }),
+    ];
+
+    await waitForViteReady(VITE_URL);
+    const isolatedBrowser = await chromium.launch({ headless: true });
+    try {
+      const context = await isolatedBrowser.newContext({ viewport: { width: 1920, height: 1080 } });
+      const isolatedPage = await context.newPage();
+
+      await isolatedPage.addInitScript({ path: MOCK_SCRIPT });
+      await isolatedPage.addInitScript((seeded) => {
+        (window as unknown as { __mockAnnouncementHistory: unknown[] }).__mockAnnouncementHistory = seeded;
+      }, seededHistory as unknown as Record<string, unknown>[]);
+
+      await isolatedPage.goto(VITE_URL);
+      await isolatedPage.waitForLoadState('load');
+      await isolatedPage.waitForSelector('text=Kangentic', { timeout: 15000 });
+
+      const isolatedMegaphone = isolatedPage.locator('[data-testid="announcements-button"]');
+      await expect(isolatedMegaphone).toBeVisible();
+      const isolatedBadge = isolatedPage.locator('[data-testid="announcements-unread-badge"]');
+      await expect(isolatedBadge).toContainText('2');
     } finally {
       await isolatedBrowser.close();
     }

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -390,15 +390,30 @@
   };
 
   // Announcements test hooks: installed eagerly for the same reason as the
-  // update-downloaded hooks above. `__mockFireAnnouncementsChanged(active)`
-  // also updates `__mockActiveAnnouncements` so a later
-  // announcements.getActive() (e.g. an HMR resync) returns the same list.
+  // update-downloaded hooks above. `__mockFireAnnouncementsChanged(active,
+  // history)` also updates `__mockActiveAnnouncements` /
+  // `__mockAnnouncementHistory` so a later getActive() / getHistory() (e.g. an
+  // HMR resync) returns the same lists. History defaults to one unread archive
+  // entry per active announcement, which is what a real poll produces, so a
+  // spec only passes it explicitly to test expired or already-read entries.
   window.__mockActiveAnnouncements = [];
+  window.__mockAnnouncementHistory = [];
+  // Every announcements.markRead(id) call, in order. Lets a spec assert the
+  // durable write was attempted even when the renderer's local history copy
+  // had nothing to stamp.
+  window.__mockAnnouncementMarkReadCalls = [];
   window.__mockAnnouncementsChangedListeners = [];
-  window.__mockFireAnnouncementsChanged = function (active) {
+  window.__mockFireAnnouncementsChanged = function (active, history) {
     window.__mockActiveAnnouncements = active;
+    window.__mockAnnouncementHistory = history || active.map(function (announcement) {
+      return { announcement: announcement, firstSeenAt: new Date().toISOString(), readAt: null };
+    });
+    var payload = {
+      active: window.__mockActiveAnnouncements,
+      history: window.__mockAnnouncementHistory,
+    };
     var listeners = window.__mockAnnouncementsChangedListeners.slice();
-    listeners.forEach(function (fn) { fn(active); });
+    listeners.forEach(function (fn) { fn(payload); });
   };
 
   // Notification-click test hook (App.tsx's `notifications.onClicked` handler,
@@ -3345,11 +3360,30 @@
       getActive: async function () {
         return window.__mockActiveAnnouncements || [];
       },
+      getHistory: async function () {
+        return window.__mockAnnouncementHistory || [];
+      },
+      markRead: async function (announcementId) {
+        window.__mockAnnouncementMarkReadCalls.push(announcementId);
+        // Stamp the backing array too, not just the store's optimistic copy,
+        // so a later getHistory() (HMR resync) agrees with the badge.
+        window.__mockAnnouncementHistory = (window.__mockAnnouncementHistory || []).map(
+          function (entry) {
+            if (entry.announcement.id !== announcementId || entry.readAt !== null) return entry;
+            return {
+              announcement: entry.announcement,
+              firstSeenAt: entry.firstSeenAt,
+              readAt: new Date().toISOString(),
+            };
+          },
+        );
+      },
       onChanged: function (callback) {
         // Tests fire the changed push via
-        // `window.__mockFireAnnouncementsChanged([announcement, ...])`. The
-        // listener array and the fire hook itself are installed eagerly at
-        // mock-bootstrap time (see top of file), not lazily here.
+        // `window.__mockFireAnnouncementsChanged([announcement, ...])`, which
+        // delivers `{ active, history }`. The listener array and the fire hook
+        // itself are installed eagerly at mock-bootstrap time (see top of
+        // file), not lazily here.
         window.__mockAnnouncementsChangedListeners.push(callback);
         return function () {
           var listeners = window.__mockAnnouncementsChangedListeners || [];

--- a/tests/unit/announcements-archive.test.ts
+++ b/tests/unit/announcements-archive.test.ts
@@ -1,0 +1,301 @@
+/**
+ * The local announcements archive: the pure fold/stamp/count helpers in
+ * src/shared/announcements.ts, and the configDir sidecar reader/writer in
+ * src/main/announcements-archive.ts.
+ *
+ * The archive is what makes history survive a feed deletion, an offline
+ * launch, and the 10 seconds before the first poll, and it owns read-state
+ * (which cannot live in dismissedAnnouncementIds, since that list prunes
+ * itself to the active feed on every write).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  ANNOUNCEMENT_ARCHIVE_CAP,
+  appendToArchive,
+  countUnreadAnnouncements,
+  markArchiveEntryRead,
+  reconcileOpenDialog,
+  type Announcement,
+  type AnnouncementArchiveEntry,
+} from '../../src/shared/announcements';
+import { readArchive, writeArchive } from '../../src/main/announcements-archive';
+
+const NOW = new Date('2026-08-04T12:00:00Z');
+const LATER = new Date('2026-08-05T12:00:00Z');
+
+function makeAnnouncement(overrides: Partial<Announcement> & { id: string }): Announcement {
+  return {
+    title: `Title ${overrides.id}`,
+    body: `Body ${overrides.id}`,
+    links: [],
+    ...overrides,
+  };
+}
+
+function makeEntry(
+  id: string,
+  overrides: Partial<AnnouncementArchiveEntry> = {},
+): AnnouncementArchiveEntry {
+  return {
+    announcement: makeAnnouncement({ id }),
+    firstSeenAt: NOW.toISOString(),
+    readAt: null,
+    ...overrides,
+  };
+}
+
+describe('appendToArchive', () => {
+  it('adds unseen announcements newest-first, preserving the feed order', () => {
+    // selectActiveAnnouncements already sorted these (priority, then recency),
+    // so the archive head must come out in the same order.
+    const active = [makeAnnouncement({ id: 'high' }), makeAnnouncement({ id: 'low' })];
+
+    const archive = appendToArchive([], active, NOW);
+
+    expect(archive.map((entry) => entry.announcement.id)).toEqual(['high', 'low']);
+    expect(archive.every((entry) => entry.readAt === null)).toBe(true);
+    expect(archive.every((entry) => entry.firstSeenAt === NOW.toISOString())).toBe(true);
+  });
+
+  it('prepends genuinely new announcements above the existing archive', () => {
+    const existing = [makeEntry('old')];
+
+    const archive = appendToArchive(existing, [makeAnnouncement({ id: 'fresh' })], LATER);
+
+    expect(archive.map((entry) => entry.announcement.id)).toEqual(['fresh', 'old']);
+    expect(archive[0].firstSeenAt).toBe(LATER.toISOString());
+  });
+
+  it('dedupes by id: a still-active announcement is not archived twice', () => {
+    const existing = [makeEntry('a1')];
+
+    const archive = appendToArchive(existing, [makeAnnouncement({ id: 'a1' })], LATER);
+
+    expect(archive).toHaveLength(1);
+  });
+
+  it('dedupes a same-batch duplicate id: the feed itself repeating an id does not archive it twice', () => {
+    // A self-hosted or overridden feed (KANGENTIC_ANNOUNCEMENTS_URL) never
+    // passes through the committed feed's unique-id check, so a repeated id
+    // within one batch must not permanently double-archive: both copies
+    // would then match on every later poll and collide on the history
+    // list's React key.
+    const active = [makeAnnouncement({ id: 'dup' }), makeAnnouncement({ id: 'dup' })];
+
+    const archive = appendToArchive([], active, NOW);
+
+    expect(archive).toHaveLength(1);
+    expect(archive[0].announcement.id).toBe('dup');
+  });
+
+  it('keeps a re-seen entry in its original position among its siblings', () => {
+    // Every other test that touches an already-archived id uses an archive
+    // of exactly one entry, so surviving order among multiple entries is
+    // otherwise never asserted.
+    const existing = [makeEntry('a1'), makeEntry('a2')];
+
+    const archive = appendToArchive(existing, [makeAnnouncement({ id: 'a2' })], LATER);
+
+    expect(archive.map((entry) => entry.announcement.id)).toEqual(['a1', 'a2']);
+  });
+
+  it('keeps firstSeenAt and readAt on a re-seen entry but refreshes its payload', () => {
+    // An announcement edited in place upstream should show its new text, without
+    // resetting when this client first saw it or whether it was read.
+    const existing = [makeEntry('a1', { readAt: NOW.toISOString() })];
+    const edited = makeAnnouncement({ id: 'a1', title: 'Edited title' });
+
+    const [entry] = appendToArchive(existing, [edited], LATER);
+
+    expect(entry.announcement.title).toBe('Edited title');
+    expect(entry.firstSeenAt).toBe(NOW.toISOString());
+    expect(entry.readAt).toBe(NOW.toISOString());
+  });
+
+  it('leaves an archived announcement in place once it drops out of the feed', () => {
+    // The whole point: an expired or upstream-deleted announcement stays readable.
+    const existing = [makeEntry('gone')];
+
+    const archive = appendToArchive(existing, [], LATER);
+
+    expect(archive.map((entry) => entry.announcement.id)).toEqual(['gone']);
+  });
+
+  it('caps the archive, dropping the oldest from the tail', () => {
+    const existing = Array.from({ length: 5 }, (_unused, index) => makeEntry(`old-${index}`));
+
+    const archive = appendToArchive(existing, [makeAnnouncement({ id: 'fresh' })], LATER, 3);
+
+    expect(archive.map((entry) => entry.announcement.id)).toEqual(['fresh', 'old-0', 'old-1']);
+  });
+
+  it('defaults to the shared cap', () => {
+    const active = Array.from({ length: ANNOUNCEMENT_ARCHIVE_CAP + 10 }, (_unused, index) =>
+      makeAnnouncement({ id: `a${index}` }));
+
+    expect(appendToArchive([], active, NOW)).toHaveLength(ANNOUNCEMENT_ARCHIVE_CAP);
+  });
+});
+
+describe('markArchiveEntryRead', () => {
+  it('stamps readAt on the matching entry only', () => {
+    const entries = [makeEntry('a1'), makeEntry('a2')];
+
+    const stamped = markArchiveEntryRead(entries, 'a1', NOW);
+
+    expect(stamped[0].readAt).toBe(NOW.toISOString());
+    expect(stamped[1].readAt).toBeNull();
+  });
+
+  it('is idempotent: an already-read entry keeps its original timestamp', () => {
+    const entries = [makeEntry('a1', { readAt: NOW.toISOString() })];
+
+    const stamped = markArchiveEntryRead(entries, 'a1', LATER);
+
+    expect(stamped[0].readAt).toBe(NOW.toISOString());
+    // Returns the SAME array, which the store and the IPC handler both use as
+    // their "nothing to persist" check.
+    expect(stamped).toBe(entries);
+  });
+
+  it('returns the input untouched for an unknown id', () => {
+    const entries = [makeEntry('a1')];
+
+    expect(markArchiveEntryRead(entries, 'never-archived', NOW)).toBe(entries);
+  });
+});
+
+describe('countUnreadAnnouncements', () => {
+  it('counts only unread entries', () => {
+    const entries = [
+      makeEntry('a1'),
+      makeEntry('a2', { readAt: NOW.toISOString() }),
+      makeEntry('a3'),
+    ];
+
+    expect(countUnreadAnnouncements(entries)).toBe(2);
+  });
+
+  it('counts an expired-but-unread entry, since expiry is not read', () => {
+    const expired = makeEntry('old', {
+      announcement: makeAnnouncement({ id: 'old', expiresAt: '2020-01-01T00:00:00Z' }),
+    });
+
+    expect(countUnreadAnnouncements([expired])).toBe(1);
+  });
+
+  it('is zero for an empty archive', () => {
+    expect(countUnreadAnnouncements([])).toBe(0);
+  });
+});
+
+describe('reconcileOpenDialog', () => {
+  const open = makeAnnouncement({ id: 'a1' });
+
+  it('closes a banner-opened dialog whose announcement left the active set', () => {
+    expect(reconcileOpenDialog(open, 'banner', [])).toBeNull();
+  });
+
+  it('keeps a banner-opened dialog whose announcement is still active', () => {
+    expect(reconcileOpenDialog(open, 'banner', [open])).toBe(open);
+  });
+
+  it('keeps a history-opened dialog whose announcement is NOT active', () => {
+    // History exists to show announcements that are no longer active, and this
+    // path runs on every poll AND every HMR resync. Reconciling it would close
+    // the dialog out from under the user on every renderer edit in dev.
+    expect(reconcileOpenDialog(open, 'history', [])).toBe(open);
+  });
+
+  it('is null when no dialog is open', () => {
+    expect(reconcileOpenDialog(null, null, [open])).toBeNull();
+  });
+});
+
+describe('archive file store', () => {
+  let tempDir: string;
+  let archivePath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'announcements-archive-test-'));
+    archivePath = path.join(tempDir, 'announcements-archive.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('round-trips entries', () => {
+    const entries = [makeEntry('a1', { readAt: NOW.toISOString() }), makeEntry('a2')];
+
+    writeArchive(archivePath, entries);
+
+    expect(readArchive(archivePath)).toEqual(entries);
+  });
+
+  it('reads a missing file as empty', () => {
+    expect(readArchive(archivePath)).toEqual([]);
+  });
+
+  it('reads a corrupt file as empty rather than throwing', () => {
+    fs.writeFileSync(archivePath, '{ not json');
+
+    expect(readArchive(archivePath)).toEqual([]);
+  });
+
+  it('reads a non-array payload as empty', () => {
+    fs.writeFileSync(archivePath, JSON.stringify({ entries: [] }));
+
+    expect(readArchive(archivePath)).toEqual([]);
+  });
+
+  it('treats an absent readAt key as unread rather than malformed', () => {
+    // A stored entry can legitimately omit `readAt` (it is `string | null`),
+    // so an absent key must read as unread, the same as an explicit null.
+    const entry = { announcement: makeAnnouncement({ id: 'no-read-key' }), firstSeenAt: NOW.toISOString() };
+    fs.writeFileSync(archivePath, JSON.stringify([entry]));
+
+    const archive = readArchive(archivePath);
+
+    expect(archive).toHaveLength(1);
+    expect(archive[0].readAt).toBeNull();
+  });
+
+  it('still rejects a present but wrong-typed readAt, with its siblings surviving', () => {
+    // Guards against a permissive fix: only an ABSENT readAt key is unread.
+    // A present value of the wrong type is still a malformed entry.
+    fs.writeFileSync(archivePath, JSON.stringify([
+      makeEntry('good'),
+      { announcement: makeAnnouncement({ id: 'bad-read-type' }), firstSeenAt: NOW.toISOString(), readAt: 42 },
+    ]));
+
+    expect(readArchive(archivePath).map((entry) => entry.announcement.id)).toEqual(['good']);
+  });
+
+  it('drops malformed entries while their siblings survive', () => {
+    fs.writeFileSync(archivePath, JSON.stringify([
+      makeEntry('good'),
+      { announcement: { id: 'no-title' }, firstSeenAt: NOW.toISOString(), readAt: null },
+      { announcement: makeAnnouncement({ id: 'no-timestamp' }), readAt: null },
+    ]));
+
+    expect(readArchive(archivePath).map((entry) => entry.announcement.id)).toEqual(['good']);
+  });
+
+  it('creates the parent directory on write', () => {
+    const nested = path.join(tempDir, 'nested', 'announcements-archive.json');
+
+    writeArchive(nested, [makeEntry('a1')]);
+
+    expect(readArchive(nested)).toHaveLength(1);
+  });
+
+  it('leaves no temp file behind (the write is tmp + rename)', () => {
+    writeArchive(archivePath, [makeEntry('a1')]);
+
+    expect(fs.readdirSync(tempDir)).toEqual(['announcements-archive.json']);
+  });
+});

--- a/tests/unit/announcements-init-guard.test.ts
+++ b/tests/unit/announcements-init-guard.test.ts
@@ -2,17 +2,24 @@
  * Guards for the main-process announcements poller (src/main/announcements.ts),
  * mirroring updater-init-guard.test.ts:
  *
- * - initAnnouncements always registers the GET handler (invoke never rejects
+ * - initAnnouncements always registers its handlers (invoke never rejects
  *   with `No handler registered`), and under NODE_ENV=test schedules nothing,
  *   so no test run ever touches the network.
  * - checkAnnouncements degrades silently on every failure mode (network
  *   error, non-200, garbage JSON, unusable feed) and only pushes the changed
  *   event when the filtered active list actually changed.
+ * - the local archive persists across polls, so history outlives an
+ *   announcement leaving the feed, and mark-read stamps it idempotently.
  *
  * Module state (cachedActive, timers) is per-import, so each test re-imports
- * a fresh module via vi.resetModules() + dynamic import.
+ * a fresh module via vi.resetModules() + dynamic import. configDir is
+ * redirected to a temp dir per test, since a successful poll writes the
+ * archive sidecar.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 const mocks = vi.hoisted(() => ({
   electronMock: {
@@ -53,8 +60,16 @@ function okJsonResponse(payload: unknown): Response {
 }
 
 const originalNodeEnv = process.env.NODE_ENV;
+const originalDataDir = process.env.KANGENTIC_DATA_DIR;
+
+/** The archive sidecar inside the current temp data dir. */
+function archivePath(): string {
+  return path.join(process.env.KANGENTIC_DATA_DIR as string, 'announcements-archive.json');
+}
 
 describe('announcements poller', () => {
+  let tempDataDir: string;
+
   beforeEach(() => {
     vi.useFakeTimers();
     vi.stubGlobal('fetch', fetchMock);
@@ -62,12 +77,24 @@ describe('announcements poller', () => {
     mocks.electronMock.ipcMain.handle.mockReset();
     fakeWindowSend.mockReset();
     delete process.env.KANGENTIC_ANNOUNCEMENTS_URL;
+    // A successful poll now writes the announcements archive under configDir.
+    // Redirect configDir at a temp dir BEFORE importFreshModule so the
+    // vi.resetModules() re-import of src/main/config/paths picks it up, and no
+    // test ever writes into the developer's real %APPDATA%/kangentic.
+    tempDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'announcements-poller-test-'));
+    process.env.KANGENTIC_DATA_DIR = tempDataDir;
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     process.env.NODE_ENV = originalNodeEnv;
+    if (originalDataDir === undefined) {
+      delete process.env.KANGENTIC_DATA_DIR;
+    } else {
+      process.env.KANGENTIC_DATA_DIR = originalDataDir;
+    }
+    fs.rmSync(tempDataDir, { recursive: true, force: true });
   });
 
   it('registers the GET handler but schedules nothing under NODE_ENV=test', async () => {
@@ -153,10 +180,19 @@ describe('announcements poller', () => {
 
     await checkAnnouncements();
     expect(fakeWindowSend).toHaveBeenCalledTimes(1);
-    const [channel, active] = fakeWindowSend.mock.calls[0] as [string, unknown[]];
+    const [channel, payload] = fakeWindowSend.mock.calls[0] as [
+      string,
+      { active: Array<{ id: string }>; history: Array<{ announcement: { id: string } }> },
+    ];
     expect(channel).toBe(IPC.ANNOUNCEMENTS_CHANGED);
-    expect((active as Array<{ id: string }>).map((announcement) => announcement.id)).toEqual(['a1']);
-    expect(getHandlerResult()).toEqual(active);
+    // One push carries both halves, since they derive from this same poll.
+    expect(payload.active.map((announcement) => announcement.id)).toEqual(['a1']);
+    // History is fed from the FILTERED active list, so an announcement this
+    // client was never targeted by never enters its archive.
+    expect(payload.history.map((entry) => entry.announcement.id)).toEqual(['a1']);
+    // ANNOUNCEMENTS_GET stays the bare active array (a zero-I/O read of the
+    // in-memory cache); history has its own channel.
+    expect(getHandlerResult()).toEqual(payload.active);
 
     // Identical feed on the next poll: no second push.
     await checkAnnouncements();
@@ -165,7 +201,71 @@ describe('announcements poller', () => {
     // A failed poll keeps the last-known list rather than clearing it.
     fetchMock.mockRejectedValue(new Error('offline'));
     await checkAnnouncements();
-    expect(getHandlerResult()).toEqual(active);
+    expect(getHandlerResult()).toEqual(payload.active);
+  });
+
+  it('persists the archive so history survives a restart and an emptied feed', async () => {
+    process.env.NODE_ENV = 'test';
+    const { initAnnouncements, updateAnnouncementsWindow, checkAnnouncements } = await importFreshModule();
+    initAnnouncements(fakeWindow);
+    updateAnnouncementsWindow(fakeWindow);
+
+    fetchMock.mockResolvedValue(okJsonResponse({
+      announcements: [{ id: 'a1', title: 'T', body: 'B' }],
+    }));
+    await checkAnnouncements();
+
+    // Written to the configDir sidecar, unread.
+    const stored = JSON.parse(fs.readFileSync(archivePath(), 'utf-8')) as Array<{
+      announcement: { id: string };
+      firstSeenAt: string;
+      readAt: string | null;
+    }>;
+    expect(stored.map((entry) => entry.announcement.id)).toEqual(['a1']);
+    expect(stored[0].readAt).toBeNull();
+    expect(stored[0].firstSeenAt).toEqual(expect.any(String));
+
+    // The announcement is pulled upstream. The active list empties, but the
+    // archive keeps it, which is the whole reason history is a local file.
+    fetchMock.mockResolvedValue(okJsonResponse({ announcements: [] }));
+    await checkAnnouncements();
+
+    const [, secondPayload] = fakeWindowSend.mock.calls[1] as [
+      string,
+      { active: unknown[]; history: Array<{ announcement: { id: string } }> },
+    ];
+    expect(secondPayload.active).toEqual([]);
+    expect(secondPayload.history.map((entry) => entry.announcement.id)).toEqual(['a1']);
+  });
+
+  it('stamps readAt through the mark-read handler, idempotently', async () => {
+    process.env.NODE_ENV = 'test';
+    const { initAnnouncements, checkAnnouncements } = await importFreshModule();
+    initAnnouncements(fakeWindow);
+
+    fetchMock.mockResolvedValue(okJsonResponse({
+      announcements: [{ id: 'a1', title: 'T', body: 'B' }],
+    }));
+    await checkAnnouncements();
+
+    const markRead = mocks.electronMock.ipcMain.handle.mock.calls.find(
+      (candidate) => candidate[0] === IPC.ANNOUNCEMENTS_MARK_READ,
+    );
+    if (!markRead) throw new Error('ANNOUNCEMENTS_MARK_READ handler was not registered');
+    const invokeMarkRead = markRead[1] as (event: unknown, id: string) => void;
+
+    invokeMarkRead(null, 'a1');
+    const afterFirst = JSON.parse(fs.readFileSync(archivePath(), 'utf-8')) as Array<{ readAt: string | null }>;
+    expect(afterFirst[0].readAt).toEqual(expect.any(String));
+
+    // Re-reading an announcement must not rewrite when it was first read.
+    invokeMarkRead(null, 'a1');
+    const afterSecond = JSON.parse(fs.readFileSync(archivePath(), 'utf-8')) as Array<{ readAt: string | null }>;
+    expect(afterSecond[0].readAt).toBe(afterFirst[0].readAt);
+
+    // An unknown id is a no-op, not a throw: mark-read is fire-and-forget and
+    // the archive may have pruned the entry.
+    expect(() => invokeMarkRead(null, 'never-archived')).not.toThrow();
   });
 
   it('does not push to a destroyed window but still advances the cache for a later pull', async () => {
@@ -196,6 +296,34 @@ describe('announcements poller', () => {
     // inside the isDestroyed guard would leave this stale until the feed
     // changed again on a later poll.
     expect(getHandlerResult()).toEqual([{ id: 'a1', title: 'T', body: 'B', links: [] }]);
+  });
+
+  it('writes the archive even when the push window is destroyed', async () => {
+    // checkAnnouncements folds and writes the archive ABOVE the isDestroyed
+    // guard (like cachedActive), so a destroyed window never leaves the
+    // archive behind the feed. Nothing else pins that placement: moving the
+    // archive fold/write inside the isDestroyed guard passes every other
+    // test in this file.
+    process.env.NODE_ENV = 'test';
+    const { initAnnouncements, updateAnnouncementsWindow, checkAnnouncements } = await importFreshModule();
+    initAnnouncements(fakeWindow);
+
+    const destroyedWindow = {
+      isDestroyed: () => true,
+      webContents: { send: vi.fn() },
+    } as unknown as Electron.BrowserWindow;
+    updateAnnouncementsWindow(destroyedWindow);
+
+    const feed = { announcements: [{ id: 'a1', title: 'T', body: 'B' }] };
+    fetchMock.mockResolvedValue(okJsonResponse(feed));
+
+    await checkAnnouncements();
+
+    expect(fs.existsSync(archivePath())).toBe(true);
+    const stored = JSON.parse(fs.readFileSync(archivePath(), 'utf-8')) as Array<{
+      announcement: { id: string };
+    }>;
+    expect(stored.map((entry) => entry.announcement.id)).toEqual(['a1']);
   });
 
   it('honors the KANGENTIC_ANNOUNCEMENTS_URL override', async () => {

--- a/tests/unit/announcements-store.test.ts
+++ b/tests/unit/announcements-store.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for the announcements store (`src/renderer/stores/announcements-store.ts`).
+ *
+ * tests/ui/announcements.spec.ts already exercises this store end to end
+ * through the real TitleBar / AnnouncementBanner / AnnouncementDialog
+ * components and a headless mock-electron-api, including markRead firing
+ * over IPC and a banner-opened dialog closing when its announcement leaves
+ * the active set. Two things stay structurally unreachable from that tier,
+ * mirroring exactly why updater-store.test.ts exists for the sibling store:
+ *
+ *   - `markRead`'s `.catch(() => undefined)` swallow of a rejected IPC call.
+ *     The UI mock's markRead always resolves, so no UI assertion can tell
+ *     the difference between a present `.catch()` and a missing one - only
+ *     an ACTUALLY-rejecting promise plus an `unhandledRejection` listener
+ *     can observe that.
+ *   - `receiveActive`'s `dialogSource: keptDialog ? dialogSource : null`
+ *     line. `reconcileOpenDialog` itself (which announcement to keep) is
+ *     fully covered as a pure function in announcements-archive.test.ts, but
+ *     `dialogSource` is renderer store state Playwright cannot read
+ *     directly - only the visible dialogAnnouncement is observable through
+ *     the DOM.
+ *
+ * window.electronAPI.announcements is stubbed globally before importing the
+ * store (Node, non-jsdom unit tier), following the same
+ * stub-then-import-after pattern as updater-store.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Announcement, AnnouncementArchiveEntry } from '../../src/shared/announcements';
+
+const markReadMock = vi.fn();
+(globalThis as Record<string, unknown>).window = {
+  electronAPI: {
+    announcements: {
+      getActive: vi.fn(),
+      getHistory: vi.fn(),
+      markRead: markReadMock,
+    },
+  },
+};
+
+// Imported after the stub so the store module sees it.
+import { useAnnouncementsStore } from '../../src/renderer/stores/announcements-store';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeAnnouncement(overrides: Partial<Announcement> & { id: string }): Announcement {
+  return {
+    title: `Title ${overrides.id}`,
+    body: `Body ${overrides.id}`,
+    links: [],
+    ...overrides,
+  };
+}
+
+function makeEntry(
+  announcement: Announcement,
+  overrides: Partial<Omit<AnnouncementArchiveEntry, 'announcement'>> = {},
+): AnnouncementArchiveEntry {
+  return {
+    announcement,
+    firstSeenAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
+    readAt: null,
+    ...overrides,
+  };
+}
+
+function resetStore(): void {
+  useAnnouncementsStore.setState({
+    active: [],
+    history: [],
+    dialogAnnouncement: null,
+    dialogSource: null,
+    historyOpen: false,
+  });
+}
+
+beforeEach(() => {
+  resetStore();
+  // Restore a well-behaved markRead before every test, so a test that swaps
+  // in a rejecting implementation (below) never leaks into a sibling test.
+  markReadMock.mockReset().mockResolvedValue(undefined);
+  (window as unknown as {
+    electronAPI: { announcements: { markRead: (announcementId: string) => Promise<void> } };
+  }).electronAPI.announcements.markRead = markReadMock;
+});
+
+// ---------------------------------------------------------------------------
+// markRead() - the IPC failure path
+// ---------------------------------------------------------------------------
+
+describe('markRead()', () => {
+  it('swallows a rejected markRead IPC call instead of leaving it unhandled', async () => {
+    // A plain rejecting function, not `vi.fn().mockRejectedValue(...)`: a mock
+    // built that way instruments its own returned promise for mock.results
+    // tracking, which itself attaches a handler and would mask a missing
+    // `.catch()` in the store - the assertion below would pass either way.
+    const rejectingMarkRead = () => Promise.reject(new Error('disk full'));
+    (window as unknown as {
+      electronAPI: { announcements: { markRead: () => Promise<void> } };
+    }).electronAPI.announcements.markRead = rejectingMarkRead;
+    const announcement = makeAnnouncement({ id: 'a1' });
+    useAnnouncementsStore.setState({ history: [makeEntry(announcement)] });
+
+    // markRead() does not await the IPC call, so a synchronous
+    // throw/not-throw assertion here would pass whether or not the
+    // rejection is actually caught. Listen for Node's 'unhandledRejection'
+    // instead: it only fires if the store's `.catch(() => undefined)` is
+    // missing or broken, which is the real thing this test guards.
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason);
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      useAnnouncementsStore.getState().markRead('a1');
+
+      // Cross a macrotask boundary so Node's unhandled-rejection check
+      // (which runs after the microtask queue drains) has a chance to fire
+      // before we assert on it.
+      await new Promise((resolve) => setImmediate(resolve));
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+
+    expect(unhandledRejections).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// receiveActive() - dialogSource reconciliation
+// ---------------------------------------------------------------------------
+
+describe('receiveActive()', () => {
+  it('clears dialogSource when a banner-opened dialog is reconciled away', () => {
+    const announcement = makeAnnouncement({ id: 'a1' });
+    useAnnouncementsStore.setState({
+      dialogAnnouncement: announcement,
+      dialogSource: 'banner',
+    });
+
+    // The new active list no longer carries a1: reconcileOpenDialog closes a
+    // banner-opened dialog whose announcement left the feed.
+    useAnnouncementsStore.getState().receiveActive([]);
+
+    expect(useAnnouncementsStore.getState().dialogAnnouncement).toBeNull();
+    expect(useAnnouncementsStore.getState().dialogSource).toBeNull();
+  });
+
+  it('preserves dialogSource when a history-opened dialog survives the same reconciliation', () => {
+    const announcement = makeAnnouncement({ id: 'a1' });
+    useAnnouncementsStore.setState({
+      dialogAnnouncement: announcement,
+      dialogSource: 'history',
+    });
+
+    // Same input (a1 absent from the new active list) as the banner case
+    // above, but a history-opened dialog is exempt: it must survive with its
+    // source intact.
+    useAnnouncementsStore.getState().receiveActive([]);
+
+    expect(useAnnouncementsStore.getState().dialogAnnouncement).toEqual(announcement);
+    expect(useAnnouncementsStore.getState().dialogSource).toBe('history');
+  });
+});


### PR DESCRIPTION
## What

Adds a permanent title-bar **megaphone** with an unread badge, and a **browsable announcement history**, backed by a new local archive sidecar.

- `src/shared/announcements.ts` - `AnnouncementArchiveEntry` / `AnnouncementsChangedPayload` / `AnnouncementDialogSource`, `ANNOUNCEMENT_ARCHIVE_CAP`, and the pure `appendToArchive` / `markArchiveEntryRead` / `countUnreadAnnouncements` / `reconcileOpenDialog`.
- `src/main/announcements-archive.ts` (new) - the JSON sidecar at `<configDir>/announcements-archive.json`, tolerant parse, atomic write via the existing `atomicWriteJson`.
- `src/main/announcements.ts` - the poll now folds the active list into the archive, writes it, and pushes `{ active, history }`.
- `src/renderer/components/announcements/AnnouncementHistoryDialog.tsx` (new) - rows open the EXISTING announcement dialog, so nothing about markdown / sections / QR rendering is duplicated.
- `TitleBar.tsx`, `announcements-store.ts`, `CountBadge.tsx` (new `xs` size), plus a dev-only "Seed feed" trigger in the Developer tab.

## Why

Announcements ship often now, but the banner strip was the only way to see one and it was single-use: dismiss it and that announcement was unreachable forever. There was no count of what was unread and no way to re-read anything.

## How

Three properties of the existing code shaped the design.

**`receiveActive` closed the open dialog for anything absent from the active list**, and `loadActive` routes through it, so in dev that fired on every renderer edit. A history surface breaks on that immediately. The reconciliation is load-bearing for the live banner, so it gained a narrower gate rather than being deleted: `dialogSource` records where the dialog was opened from, and only a banner-sourced one reconciles.

**`dismissedAnnouncementIds` cannot carry read-state**, because `computeDismissedIdsAfterDismiss` prunes it to ids still in the ACTIVE feed on every write - read-state built on it would drain the moment an announcement expired. So read-state lives on the archive entry, and dismissed and read are now separate states: dismissing hides the banner but leaves the announcement unread, so the badge still counts it. The megaphone means "there is something you have not read", not "there is a banner". **No new `AppConfig` key.**

**`cachedActive` is in-memory and empty for the first 10 seconds of every launch**, and stays empty offline. A permanent access point backed by the live feed alone would show an empty history on every boot. The archive is fed from the already-targeted active list, so client targeting is inherited for free, and is capped at 50 with the oldest pruned on write.

### Three bugs found while building, each with a red-green proof

- **Layered Escape.** A history row opens the announcement dialog OVER the history list. Both Escape listeners are bubble-phase on `document`, so the list (registered first) won: one Escape dismissed the list and orphaned the dialog on top of nothing. Fixed with `suppressEscape` plus an explicit `z-[60]`.
- **Mark-read silently dropped.** `markRead` bailed when the local history copy had nothing to stamp. Mount fires `loadActive` and `loadHistory` together without awaiting, so after a renderer reload the banner renders from main's warm cache while the archive read is still in flight; clicking "Learn more" in that window sent no IPC at all and the read was lost permanently. The write is now unconditional; main's handler already no-ops on an unknown id.
- **Same-batch duplicate ids.** A feed repeating an id within one batch double-archived it permanently, and the two copies then collided on the history list's React key. The committed feed's unique-id check does not cover a self-hosted or `KANGENTIC_ANNOUNCEMENTS_URL`-overridden feed.

### Two decisions worth a reviewer's attention

**The title-bar row is reordered** so the megaphone and the update-available indicator sit together at its right end, just before Settings: both are the app relaying news from upstream, as against the cluster to their left, which are surfaces over running work. The update indicator therefore loses its shift-immunity - the row is right-anchored, so a conditional mount shifts what comes *before* it - but Settings and the OS window controls come after it and stay pinned, which is the part that matters for muscle memory. It is a once-per-release event.

**The badge is a deliberate exception to this row's convention.** `quick-session-button` argues for "no separate corner badge to clash or clutter" and `update-available-button` tones itself with no badge. Neither has a COUNT to state: a tone can say "something is unread", it cannot say how many. `CountBadge` gained an `xs` size because the existing 18px `sm` buried the 20px megaphone glyph underneath it.

## Breaking changes

None for users. Two internal contract changes:

- The `announcements:changed` push payload widens from `Announcement[]` to `{ active, history }`. Both derive from the same poll, so one push avoids two racing updates. `tests/ui/mock-electron-api.js` moves with it.
- **The publishing contract loosens:** authors MAY now delete an expired entry from `announcements.json`, because clients keep their own copy. Deleting a *non*-expired entry still retracts it as before.

**Expected one-time effect on upgrade:** every existing user's archive starts empty, so the currently active announcement enters as unread even for someone who dismissed it weeks ago - their megaphone lights up with a 1. That is the correct consequence of the dismissed-vs-read split (and doubles as discovery of the new button), not the badge miscounting. Seeding `readAt` from `dismissedAnnouncementIds` to avoid it would permanently conflate the two concepts for one launch's cosmetics.

## Tests

CI runs lint, typecheck, unit, build, and the sharded UI + Linux Electron E2E tiers.

Added in this PR:

- `tests/unit/announcements-archive.test.ts` (new, 28) - append / dedupe (including a same-batch duplicate id) / cap / prune / re-seen position, `markArchiveEntryRead` idempotence, unread count, `reconcileOpenDialog`'s four branches, and the file store's round-trip, missing, corrupt, non-array, malformed-entry, and absent-`readAt` paths.
- `tests/unit/announcements-store.test.ts` (new, 3) - the two store branches a UI test structurally cannot observe: `markRead`'s rejected-IPC swallow (the UI mock always resolves) and `receiveActive` clearing `dialogSource` (store-internal state Playwright cannot read).
- `tests/unit/announcements-init-guard.test.ts` - the new push payload shape, archive persistence across polls, and mark-read idempotence.
- `tests/ui/announcements.spec.ts` - grew to 19: badge counts and clears, dismissed-stays-unread, history listing an announcement that is no longer active, an announcement opened from history surviving a poll that drops it, the layered-Escape fix, mark-read before the archive loads, badge geometry (no clipping, no neighbour overlap, stays inside the bar), the list growing then capping and scrolling, the empty state, and the dev seed button.

Each of the three bugs above was verified falsifiable: the fix was reverted, the test confirmed red for the right reason, and the fix restored.

Generated with [Claude Code](https://claude.com/claude-code)
