### PR TITLE
feat(agents): add Grok Build (xAI) as the thirteenth agent adapter

### DIFF
--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -267,7 +267,7 @@ Each entry has a one-line rationale so future edits know what the entry was prot
   WHY: every CREATE TABLE column, ALTER TABLE, and seed data block is enumerated in database.md schema tables and migration history. Glob covers global-schema.ts, project-schema.ts, default-data.ts, spawn-agent-config-migration.ts, and any future migration file. (Note: `src/main/db/migrations.ts` is a 2-line re-export shim — do not rely on it.)
 
 - `src/main/agent/adapters/**`
-  WHY: per-adapter capability declarations (claude-adapter.ts, codex-adapter.ts, etc.), command-builders, capability-discovery.ts, detectors, hook-managers, trust-managers, transcript-cleanup.ts all drive per-adapter tables in agent-integration.md, adapter-session-history.md, command-injection.md, and handoff.md. Glob covers all 11 adapters and all their internal files.
+  WHY: per-adapter capability declarations (claude-adapter.ts, codex-adapter.ts, etc.), command-builders, capability-discovery.ts, detectors, hook-managers, trust-managers, transcript-cleanup.ts all drive per-adapter tables in agent-integration.md, adapter-session-history.md, command-injection.md, and handoff.md. Glob covers all 13 adapters and all their internal files.
 
 - `src/main/agent/handoff/**`
   WHY: handoff orchestration (session-history-reference.ts, transcript-cleanup.ts) backs handoff.md sections. Small directory; safe to glob.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ---
 
-<p align="center">A Kanban board for AI coding agents. Spawn, suspend, and resume sessions across twelve agent CLIs from one board, with your own backlog. Local, free, open source. One board shows every agent's status, output, and progress: respond when needed, and let them work autonomously the rest of the time.</p>
+<p align="center">A Kanban board for AI coding agents. Spawn, suspend, and resume sessions across thirteen agent CLIs from one board, with your own backlog. Local, free, open source. One board shows every agent's status, output, and progress: respond when needed, and let them work autonomously the rest of the time.</p>
 
 <p align="center">
   <a href="https://www.kangentic.com"><img src="https://raw.githubusercontent.com/Kangentic/branding/main/resources/mobile/android-feature-graphic-1024x500.png" alt="Kangentic: Kanban board for AI coding agents" width="800" /></a>
@@ -35,7 +35,7 @@
 - **Usage & cost analytics** - tokens, cost, and burn rate by project, agent, model, and effort, over any time range, down to a per-project ledger with cost share and dollars per million tokens.
 - **Git worktrees & review** - each agent runs in its own worktree, so parallel work never collides. The built-in Changes panel opens a split or inline diff with file tree and commit graph, one click from the card.
 - **Session persistence** - session data is written incrementally, so even a hard crash loses nothing. On relaunch running agents auto-resume with full context, and sessions you paused stay paused.
-- **Handoff context** - move a card from a Claude plan column to a Codex execute column and the next agent starts with the full history. Both directions for Claude, Codex, Gemini, Qwen, Kimi, and OpenCode.
+- **Handoff context** - move a card from a Claude plan column to a Codex execute column and the next agent starts with the full history. Both directions for Claude, Codex, Gemini, Qwen, Kimi, Grok, and OpenCode.
 - **Model & effort routing** - Opus at xhigh for Planning, Sonnet for Executing, another agent for review. Save ladders as named Board Profiles; Kangentic applies them live as cards cross columns.
 - **Project & global settings** - every project carries its own agent, model, effort, permission mode, base branch, and worktree defaults, separate from machine-wide ones, in a searchable settings panel.
 - **Backlog, labels & priorities** - stage work before it hits the board, tag it with custom labels and a fully-customizable priority scale, and batch-promote in one move. The tags keep working as board filters afterward.
@@ -56,13 +56,14 @@
 
 ## Supported Agents
 
-Twelve coding-agent CLIs, all first-class, on one Kanban board. Mix agents per column and hand off context between them:
+Thirteen coding-agent CLIs, all first-class, on one Kanban board. Mix agents per column and hand off context between them:
 
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (Anthropic)
 - [Codex CLI](https://developers.openai.com/codex/cli) (OpenAI)
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) (Google)
 - [Qwen Code](https://github.com/QwenLM/qwen-code) (Alibaba)
 - [Kimi Code](https://github.com/MoonshotAI/kimi-cli) (Moonshot AI)
+- [Grok Build](https://github.com/xai-org/grok-build) (xAI)
 - [OpenCode](https://opencode.ai/docs) (sst)
 - [Droid](https://docs.factory.ai/cli/getting-started/overview) (Factory)
 - [Cursor CLI](https://cursor.com/docs/cli/overview)

--- a/docs/activity-detection.md
+++ b/docs/activity-detection.md
@@ -79,7 +79,7 @@ Surrounding infrastructure:
 | `src/main/activity-engine/background-shell/process-tree.ts` | Cross-platform descendant enumeration; `listAllProcesses` shared once per cycle |
 | `src/main/activity-engine/background-shell/resume.ts` | Resume-time orphan adoption |
 | `src/main/activity-engine/background-shell/looks-like-shell-id.ts` | Shell-id shape gate |
-| `src/main/agent/event-bridge.js` | Generic hook-to-JSONL bridge; decodes typed `<kind>:<base64(JSON)>` directives (extractTool, extractDetail, setTypeWhen, ...) built by `src/main/agent/shared/directive-builders.ts` |
+| `src/main/agent/event-bridge.js` | Generic hook-to-JSONL bridge; decodes typed `<kind>:<base64(JSON)>` directives (extractTool, extractDetail, setTypeWhen, ...) built by `src/main/agent/shared/directive-builders.ts`. The events-path argument is either a literal path or the sentinel `env:<NAME>`, resolved from the hook process environment at run time - used by adapters whose CLI has no per-session settings mechanism (Grok): one static per-cwd hook file routes each session's events via that session's own spawn env, and a session without the variable (the user's own manual CLI run) is a silent no-op |
 | `src/main/agent/adapters/claude/hook-manager.ts` | Claude Code hook configuration |
 | `src/shared/types.ts` | `ActivityState`, `ActivityReason`, `EventType`, `SessionEvent.toolId` |
 
@@ -233,7 +233,7 @@ Each adapter declares one strategy via its `runtime.activity` field (constructed
 |------|-------------|---------------|---------|-----------|
 | `hooks` | Yes (sole source of truth) | No | Claude Code | Activity state is driven exclusively by hook deliveries. PTY traffic is ignored for state transitions. |
 | `pty` | No | Yes | Aider, Cursor, Warp, Droid, Codex, Kimi, Ollama (today) | No hook protocol available. The PTY tracker emits `forceIdle` after a silence window, optionally short-circuited by an adapter-supplied `detectIdle(data)` regex that matches the agent's input prompt. Kimi gets authoritative `TurnBegin`/`TurnEnd` transitions from `runtime.sessionHistory` (wire.jsonl), not the hook pipeline. |
-| `hooks_and_pty` | Yes (primary) | Yes (fallback) | Gemini, Qwen, OpenCode, Copilot | Hooks are authoritative when they fire; the PTY tracker is auto-suppressed on the first hook event and re-engages only if hooks stop arriving. |
+| `hooks_and_pty` | Yes (primary) | Yes (fallback) | Gemini, Qwen, OpenCode, Copilot, Grok | Hooks are authoritative when they fire; the PTY tracker is auto-suppressed on the first hook event and re-engages only if hooks stop arriving. For Grok the fallback is load-bearing by design: its project hooks are folder-trust-gated and silently skipped in an untrusted directory, so the PTY tracker carries activity until trust lands. |
 
 Both `pty` and `hooks_and_pty` may pass an optional `detectIdle(data: string) => boolean` for instant idle detection from the input-prompt regex. Without it, idle is inferred from a silence timer.
 

--- a/docs/adapter-session-history.md
+++ b/docs/adapter-session-history.md
@@ -22,7 +22,7 @@ Runtime flow:
 1. An agent adapter declares a `sessionHistory` block in its `runtime` strategy (`src/shared/types.ts` - `AdapterRuntimeStrategy.sessionHistory`).
 2. On PTY spawn, the adapter's full runtime strategy is stored on `ManagedSession.agentParser` - SessionManager does nothing session-history-specific.
 3. The agent's session ID is captured via one of four paths (whichever fires first):
-   - **Spawn-time short-circuit** (caller-owned IDs): when the adapter declares `supportsCallerSessionId = true`, the spawn pipeline pre-generates a UUID and passes it via `SpawnSessionInput.agentSessionId`. `session-spawn-flow.ts` calls `sessionHistoryReader.attach(...)` directly during spawn. Used by Claude (when `runtime.sessionHistory` is wired), Qwen, and Kimi.
+   - **Spawn-time short-circuit** (caller-owned IDs): when the adapter declares `supportsCallerSessionId = true`, the spawn pipeline pre-generates a UUID and passes it via `SpawnSessionInput.agentSessionId`. `session-spawn-flow.ts` calls `sessionHistoryReader.attach(...)` directly during spawn. Used by Claude (when `runtime.sessionHistory` is wired), Qwen, Kimi, and Grok.
    - `runtime.sessionId.fromHook` (Gemini hook stdin)
    - `runtime.sessionId.fromOutput` (PTY scraper)
    - `runtime.sessionId.fromFilesystem` (Codex rollout directory scan)
@@ -309,13 +309,14 @@ behavior below is the resume contract.
 | Cursor | `agent --resume=<id>` | `~/.cursor/chats/<chat-id-hash>/` | chat id (global) | no | **no** (locator returns null) |
 | Aider | `aider --restore-chat-history` | `<cwd>/.aider.chat.history.md` | cwd file (no session id) | yes | n/a (no per-session file) |
 | Warp | (no resume) | none | n/a | n/a | n/a |
+| Grok Build | `grok --resume <id>` | `~/.grok/sessions/<encodeURIComponent(cwd)>/<id>/` (updates.jsonl + chat_history.jsonl) | URL-encoded cwd + id | yes | yes |
 
 Reading the table by class:
 
-- **cwd-keyed per-session file that `--resume` reads (Claude-like):** Gemini, Qwen, Kimi, Droid
-  (and Claude). The resume target is a file under a directory derived from the cwd (basename,
-  slug, or `md5`), so moving the project to a path with a different cwd-derived key, or deleting
-  that file, makes the stored id unresolvable.
+- **cwd-keyed per-session file that `--resume` reads (Claude-like):** Gemini, Qwen, Kimi, Droid,
+  Grok (and Claude). The resume target is a file under a directory derived from the cwd
+  (basename, slug, `md5`, or Grok's `encodeURIComponent`), so moving the project to a path with
+  a different cwd-derived key, or deleting that file, makes the stored id unresolvable.
 - **id-keyed / global store (cwd-independent):** Codex, OpenCode, Copilot, Cursor. Resume
   resolves by session id against a global location, so the working directory does not gate it.
   Codex scans `~/.codex/sessions/` by id (`codex-rs find_thread_path_by_id_str`; the per-rollout
@@ -426,7 +427,9 @@ and a 1,557-session-dir scan across versions v2.1.187-v2.1.220):
   from stored id" cleanly means a fork, never routine resume noise.
 
 Kangentic tracks the fork at two layers, neither of which is agent-name-branched (both ride the
-generic `runtime.statusFile` capability, which only Claude implements today):
+generic `runtime.statusFile` capability's status channel - i.e. a `parseStatus` that returns a
+live payload, which only Claude's does today; Copilot's and Grok's `statusFile` declarations
+carry only the events channel):
 
 1. **Live reconcile.** `SessionTelemetry.processStatusUpdate`'s agent-session-id capture is
    **change-sensitive on the status-file channel**: it re-fires `onAgentSessionId` whenever the

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -1,6 +1,6 @@
 # Agent Integration
 
-Kangentic supports twelve AI coding agents: Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cursor CLI, GitHub Copilot CLI, OpenCode, Aider, Oz CLI (Warp), Kimi Code, Droid, and Ollama. Each agent is wrapped behind a common `AgentAdapter` interface that handles CLI detection, command building, permission mapping, session lifecycle hooks, and cross-agent handoff. This doc covers the adapter system, agent-specific details, and shared infrastructure.
+Kangentic supports thirteen AI coding agents: Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cursor CLI, GitHub Copilot CLI, OpenCode, Aider, Oz CLI (Warp), Kimi Code, Droid, Ollama, and Grok Build. Each agent is wrapped behind a common `AgentAdapter` interface that handles CLI detection, command building, permission mapping, session lifecycle hooks, and cross-agent handoff. This doc covers the adapter system, agent-specific details, and shared infrastructure.
 
 ## Agent Adapter Interface
 
@@ -13,7 +13,7 @@ Every agent implements the `AgentAdapter` interface. Each adapter lives in `src/
 | `detect(overridePath?)` | Locate the CLI binary and return path + version |
 | `invalidateDetectionCache()` | Reset cached detection (e.g. after user changes CLI path) |
 | `ensureTrust(workingDirectory)` | Pre-approve a directory so the agent doesn't prompt for trust |
-| `probeAuth?()` | Optional. Check whether the agent is authenticated. Returns `true` (logged in), `false` (installed but not authenticated), or `null` (probe unavailable / I/O error). Only called by IPC after `detect()` reports `found: true`. Must never throw. Currently implemented only by Kimi (see [Kimi Code -> Authentication](#authentication)). |
+| `probeAuth?()` | Optional. Check whether the agent is authenticated. Returns `true` (logged in), `false` (installed but not authenticated), or `null` (probe unavailable / I/O error). Only called by IPC after `detect()` reports `found: true`. Must never throw. Currently implemented by Kimi (see [Kimi Code -> Authentication](#authentication)) and Grok (`grok models`, whose output says "not authenticated" from local state). |
 | `buildCommand(options)` | Build the shell command string to spawn the agent |
 | `interpolateTemplate(template, variables)` | Replace `{{key}}` placeholders in prompt templates |
 | `runtime` | `AdapterRuntimeStrategy` declaring activity detection + session ID capture (see below) |
@@ -27,7 +27,7 @@ Every agent implements the `AgentAdapter` interface. Each adapter lives in `src/
 
 | Property | Type | Purpose |
 |----------|------|---------|
-| `name` | `string` | Unique identifier (`'claude'`, `'codex'`, `'gemini'`, `'qwen'`, `'cursor'`, `'copilot'`, `'opencode'`, `'aider'`, `'warp'`, `'kimi'`, `'droid'`, `'ollama'`) |
+| `name` | `string` | Unique identifier (`'claude'`, `'codex'`, `'gemini'`, `'qwen'`, `'cursor'`, `'copilot'`, `'opencode'`, `'aider'`, `'warp'`, `'kimi'`, `'droid'`, `'ollama'`, `'grok'`) |
 | `displayName` | `string` | Human-readable product name |
 | `sessionType` | `SessionRecord['session_type']` | Value stored in the sessions DB table |
 | `supportsCallerSessionId` | `boolean` | True when the CLI accepts a caller-supplied session ID via `--session-id` (Claude). When false, Kangentic captures the agent's own ID via `runtime.sessionId` for `--resume`. |
@@ -39,28 +39,28 @@ Every agent implements the `AgentAdapter` interface. Each adapter lives in `src/
 
 | Property | Type | Purpose |
 |----------|------|---------|
-| `getSubmissionVerifier?(contextType)` | `(SubmissionContextType) => SubmissionVerifier \| null` | Returns a context-specific verification callback used in two flows: `'paste'` (post-`\r` confirmation in `TerminalSubmit.submitContent`) and `'command-injection'` (per-command confirmation in `TerminalSubmit.submitKeystrokes`, scheduled by `TerminalSubmitScheduler.scheduleKeystrokes`). The callback receives a `SubmissionContext` and returns `Promise<boolean>`. Adapters return `null` for contexts they cannot verify; every adapter returns `null` for `'paste'` today, falling back to the activity + data-floor backstops. Seven return a `'command-injection'` verifier: Claude (JSONL slash-invocation matching) and Codex, both VERIFIED and allowed to escalate; plus Copilot, OpenCode (via a read-only SQL query rather than a file read), Qwen, Kimi, and Aider, all CONFIRM-ONLY - they confirm and drive retry-on-Enter but are barred from escalation via `canEscalateOnVerificationFailure`. A verifier must only be added for an agent whose history is MEASURED to flush on submit; see [command-injection.md](command-injection.md) and [Embedded Browser - Paste Engine](embedded-browser.md#paste-engine). |
+| `getSubmissionVerifier?(contextType)` | `(SubmissionContextType) => SubmissionVerifier \| null` | Returns a context-specific verification callback used in two flows: `'paste'` (post-`\r` confirmation in `TerminalSubmit.submitContent`) and `'command-injection'` (per-command confirmation in `TerminalSubmit.submitKeystrokes`, scheduled by `TerminalSubmitScheduler.scheduleKeystrokes`). The callback receives a `SubmissionContext` and returns `Promise<boolean>`. Adapters return `null` for contexts they cannot verify; every adapter returns `null` for `'paste'` today, falling back to the activity + data-floor backstops. Eight return a `'command-injection'` verifier: Claude (JSONL slash-invocation matching) and Codex, both VERIFIED and allowed to escalate; plus Copilot, OpenCode (via a read-only SQL query rather than a file read), Qwen, Kimi, Aider, and Grok, all CONFIRM-ONLY - they confirm and drive retry-on-Enter but are barred from escalation via `canEscalateOnVerificationFailure`. A verifier must only be added for an agent whose history is MEASURED to flush on submit; see [command-injection.md](command-injection.md) and [Embedded Browser - Paste Engine](embedded-browser.md#paste-engine). |
 | `liveTelemetryUnsupported?` | `AgentLiveTelemetryUnsupported` | Set when the agent CLI has no per-session telemetry channel (no status file, session history, or stream output integration is possible). Carries the renderer-facing label and tooltip so all agent-specific copy lives with the adapter. Currently used by Droid. |
 | `reportsRateLimits?` | `boolean` | Set by adapters whose CLI streams account-wide rate-limit windows (plan-usage quotas). The renderer ContextBar shows its rate-limit pill for any session of such an agent, sourced from a shared global snapshot that is merged monotonically per window across sessions (within a fixed window used-percentage only rises, so a session carrying a stale cached report never regresses the displayed values, and a genuine window rollover is taken wholesale). A freshly spawned terminal shows the same limits as its siblings before it has emitted its own status line. Omit (falsy) for adapters with no rate-limit telemetry. Currently set only by Claude. |
 | `pastedImageReferenceTemplate?` | `string` | Set by adapters whose CLI does not reliably auto-attach an image from a bare file path (a typed/pasted path is read as inert text, not auto-recognized as an image). Kangentic saves a pasted-clipboard or dropped image to a temp PNG (reliable even where the CLI's own clipboard reader silently fails, e.g. Claude Code on Windows with Snipping Tool images - claude-code#26679) and injects this template instead of the bare path, so the agent reliably reads the file as an image. `{path}` is replaced with the shell-quoted absolute path; a template lacking `{path}` has the quoted path appended. Omit to inject the bare quoted path (legacy). Currently set only by Claude. |
-| `buildEnv?(options)` | `(SpawnCommandOptions) => Record<string, string> \| null` | Adapter-specific environment variables to inject into the PTY spawn. Used for MCP config an adapter cannot pass on the command line: either because the CLI has no MCP flag at all (OpenCode's `OPENCODE_CONFIG_CONTENT`, carrying the whole config), or because the value is a secret that must not land in argv or in a repo file (Codex and Droid both pass only `KANGENTIC_MCP_TOKEN`, referenced by name from their config). |
+| `buildEnv?(options)` | `(SpawnCommandOptions) => Record<string, string> \| null` | Adapter-specific environment variables to inject into the PTY spawn. Used for MCP config an adapter cannot pass on the command line: either because the CLI has no MCP flag at all (OpenCode's `OPENCODE_CONFIG_CONTENT`, carrying the whole config), or because the value is a secret that must not land in argv or in a repo file (Codex and Droid both pass only `KANGENTIC_MCP_TOKEN`, referenced by name from their config). Grok extends the pattern furthest: its env carries the MCP URL and token (`KANGENTIC_MCP_URL` / `KANGENTIC_MCP_TOKEN`, dereferenced by grok's `${VAR}` expansion so its `.grok/config.toml` block stays fully static) plus `KANGENTIC_EVENTS_PATH` for the hook bridge's `env:` sentinel. |
 | `getExitSequence?()` | `() => string[]` | Sequence of strings to write to the PTY for a graceful exit. Default is `['\x03']` (Ctrl+C only). Claude overrides with `['\x03', '/exit\r']` to flush conversation state. |
 | `attachSession?(context)` | `(SessionContext) => SessionAttachment \| void` | Per-session lifecycle hook for adapters that need work outside the declarative `runtime` strategy (out-of-band CLI queries, file watchers, etc.). The returned `dispose` is called on session end. |
 | `summarize?(prompt, cliPath, cwd)` | `(string, string, string) => Promise<string>` | One-shot summarization for the auto-name-tasks-from-prompt feature. Spawns the CLI in non-interactive `--print` mode. Adapters without a clean headless mode (Aider, Warp) omit this, as does Ollama (its headless mode is not yet wired). |
-| `parseTranscript?(agentSessionId, cwd)` | `(string, string) => Promise<ParsedTranscript>` | Parse the agent's native session history into agent-agnostic `TranscriptEntry[]` for the MCP `get_transcript` structured format. The adapter owns all format/location knowledge (JSONL file, chat JSONL, SQLite DB), so `handleGetTranscript` never branches on agent name. Must not throw; returns `{ entries: [], sourcePath }` on missing/corrupt history. Implemented by Claude, Droid, Codex, Gemini, Qwen, Kimi, and OpenCode; Aider/Warp/Cursor/Copilot/Ollama omit it (raw format only). See [MCP server - get_transcript](mcp-server.md#kangentic_get_transcript). |
-| `onProjectRelocated?(oldPath, newPath)` | `(string, string) => Promise<void>` | Migrate per-cwd data the agent keeps OUTSIDE the working directory, keyed by the absolute path, when that path changes. Invoked for two relocations with the same (oldPath, newPath) contract: a whole-project move (the `project:relocate` IPC handler, reached via Locate Folder / Change or the one-step "Move..." flow), and a single worktree-cwd rename on the first resume after a task's worktree was recreated at a new path (`migrateResumeCwdIfRenamed` in `src/main/transition-engine/resume-cwd-migration.ts`, which passes one worktree's old/new path so only that cwd's data moves). Called best-effort after the stored paths are settled and the new location exists. Implemented by Claude, Codex, Gemini, Qwen, Copilot, OpenCode, Kimi, and Droid (per-agent details in [Project relocation](#project-relocation) below); the shared mechanics (path-pair collection, directory rename/merge, backup + atomic write, serial lock) live in `src/main/agent/shared/relocation-utils.ts`. Implementations must be non-destructive and never block the caller. Aider, Cursor, Warp, and Ollama omit this (their resumable state is in-project or absent). |
-| `onWorktreeRemoved?(worktreePath)` | `(string) => Promise<void>` | Drop per-directory state the adapter recorded in a GLOBAL config file for a worktree Kangentic has just deleted. Kangentic creates a worktree per task, so an adapter keyed by absolute path accumulates one dead entry per task forever with nothing to clean it up (one machine reached 473). Dispatched from the single chokepoint inside `WorktreeManager.removeWorktree`, via a listener the main process registers at startup (`setWorktreeRemovedListener` -> `notifyAdaptersWorktreeRemoved`), so the git module never imports the agent registry and no removal path can run un-notified. Generic over `agentRegistry.list()` - no agent-name branching. Best-effort and never fatal: the worktree is already gone. Implemented by Codex (`~/.codex/config.toml` directory trust) and Gemini (`~/.gemini/trustedFolders.json`), the two adapters that key trust by absolute path in a global file. Both remove only an entry they could have written themselves, never a user decision. Every other adapter's per-directory state lives inside the worktree and disappears with it. |
+| `parseTranscript?(agentSessionId, cwd)` | `(string, string) => Promise<ParsedTranscript>` | Parse the agent's native session history into agent-agnostic `TranscriptEntry[]` for the MCP `get_transcript` structured format. The adapter owns all format/location knowledge (JSONL file, chat JSONL, SQLite DB), so `handleGetTranscript` never branches on agent name. Must not throw; returns `{ entries: [], sourcePath }` on missing/corrupt history. Implemented by Claude, Droid, Codex, Gemini, Qwen, Kimi, OpenCode, and Grok; Aider/Warp/Cursor/Copilot/Ollama omit it (raw format only). See [MCP server - get_transcript](mcp-server.md#kangentic_get_transcript). |
+| `onProjectRelocated?(oldPath, newPath)` | `(string, string) => Promise<void>` | Migrate per-cwd data the agent keeps OUTSIDE the working directory, keyed by the absolute path, when that path changes. Invoked for two relocations with the same (oldPath, newPath) contract: a whole-project move (the `project:relocate` IPC handler, reached via Locate Folder / Change or the one-step "Move..." flow), and a single worktree-cwd rename on the first resume after a task's worktree was recreated at a new path (`migrateResumeCwdIfRenamed` in `src/main/transition-engine/resume-cwd-migration.ts`, which passes one worktree's old/new path so only that cwd's data moves). Called best-effort after the stored paths are settled and the new location exists. Implemented by Claude, Codex, Gemini, Qwen, Copilot, OpenCode, Kimi, Droid, and Grok (per-agent details in [Project relocation](#project-relocation) below); the shared mechanics (path-pair collection, directory rename/merge, backup + atomic write, serial lock) live in `src/main/agent/shared/relocation-utils.ts`. Implementations must be non-destructive and never block the caller. Aider, Cursor, Warp, and Ollama omit this (their resumable state is in-project or absent). |
+| `onWorktreeRemoved?(worktreePath)` | `(string) => Promise<void>` | Drop per-directory state the adapter recorded in a GLOBAL config file for a worktree Kangentic has just deleted. Kangentic creates a worktree per task, so an adapter keyed by absolute path accumulates one dead entry per task forever with nothing to clean it up (one machine reached 473). Dispatched from the single chokepoint inside `WorktreeManager.removeWorktree`, via a listener the main process registers at startup (`setWorktreeRemovedListener` -> `notifyAdaptersWorktreeRemoved`), so the git module never imports the agent registry and no removal path can run un-notified. Generic over `agentRegistry.list()` - no agent-name branching. Best-effort and never fatal: the worktree is already gone. Implemented by Codex (`~/.codex/config.toml` directory trust), Gemini (`~/.gemini/trustedFolders.json`), and Grok (`~/.grok/trusted_folders.toml`), the three adapters that key trust by absolute path in a global file. All three remove only an entry they could have written themselves, never a user decision. Every other adapter's per-directory state lives inside the worktree and disappears with it. |
 | `probeAuth?()` | `() => Promise<boolean \| null>` | See the methods table above. |
 | `remoteExecution?` | `{ info: AgentRemoteExecutionInfo; probeServer(server): Promise<RemoteServerStatus> }` | Declared by adapters whose CLI can attach to an already-running server the user operates, instead of always spawning a local process (e.g. OpenCode's `opencode attach <url> --dir <serverPath>`). `info` (`urlPlaceholder`, `authKind`, `workingDirectoryScope`, `remoteModeCaveat?`) is surfaced to the renderer via `AgentDetectionInfo.remoteExecution` so the Agent settings tab renders remote-mode rows (right after the CLI Path row) only for capability-declaring agents - no agent-name branching, including for the adapter-authored caveat text. `probeServer` replaces `probeAuth` as the reachability check when a project's mode for this agent is `remote`: it must hit the server directly and never throw. Implemented today only by OpenCode. See [configuration.md - Remote Execution](configuration.md#remote-execution). |
 | `launchOptions?` | `readonly AgentLaunchOptionInfo[]` | Declared by adapters whose CLI exposes optional boolean startup toggles (id, label, description, default). Surfaced to the renderer via `AgentDetectionInfo.launchOptions` so the Agent settings tab renders one toggle row per declared option, only for capability-declaring agents. Values are resolved by `resolveLaunchOptions` (`src/main/agent/shared/launch-options.ts`) from `agent.launchOptions[agentName]` (falling back to each option's `default`) and threaded through as `CommandOptions.launchOptions`; only the adapter's own command builder interprets an `id` into a concrete CLI flag - no agent-name branching outside the adapter. Implemented today only by Codex, which declares `disableApps` (maps to `--disable apps`, skipping the optional cloud ChatGPT Apps MCP connector that can hang startup at "Booting MCP server: codex_apps" - openai/codex#20167). See [configuration.md - agent.*](configuration.md#agent) for the config shape. |
 | `discoverCapabilities?(cliPath, forceRefresh?)` | `(string, boolean?) => Promise<AgentCapabilities>` | Probe the live CLI for adapter-specific knobs (e.g. parsing `--help` for valid effort levels and the presence of a `--model` flag). Result is attached to `AgentDetectionInfo.capabilities` and read by the renderer to gate optional UI controls (Model and Effort dropdowns on `EditColumnDialog`). `forceRefresh` (set when a model dropdown opens) bypasses any adapter-internal capability caches - notably Claude's 12h `/model` picker probe - so a newly shipped model surfaces without a restart; adapters with no cache to bypass ignore it. Implementations must never throw - return an empty object on parse failure so the rest of detection still succeeds. |
 | `getInjectionSequence?(spec)` | `(SettingsChangeSpec) => string[]` | Translate a column-level settings change (model / effort) into the writes the `TerminalSubmitScheduler` should push onto the live PTY. Sibling of `getExitSequence` - both return `string[]` of writes. Claude returns `['/model X', '/effort Y']` for changed fields. Adapters with no live-swap slash return `[]` and the caller falls back to suspend+respawn. |
-| `canVerifySlashSubmission?()` | `() => boolean` | Whether a SLASH-prefixed `auto_command` can be verified in this agent's history. Omitted or `true` means yes. Declaring `false` makes `prepareInjectionPlan` tag that command `verify: 'none'`, so it is neither retried nor escalated and the outcome stays `unconfirmed`. Exists because absence from the history file is AMBIGUOUS for agents that handle slash input in the TUI - it cannot distinguish "the CLI rejected it" from "the CLI ran it client-side" - and treating the second as a failure escalates a command that actually worked into a session restart. Declared `false` by Codex, which prints "Unrecognized command" and writes no record. See [command-injection.md](command-injection.md). |
-| `canEscalateOnVerificationFailure?()` | `() => boolean` | Whether a verification FAILURE may escalate to a restart-with-prompt. Omitted or `true` means yes. Declaring `false` marks the verifier CONFIRM-ONLY: it still confirms and still drives retry-on-Enter (rung 2, where nearly all the delivery win lives), but is barred from rung 3, because a false negative from an unproven verifier is a guess and escalation acts on that guess by destroying live work. Escalation takes TWO proofs: flush latency measured live (`scripts/measure-injection-flush.mjs`), AND the adapter's own verifier watched confirming a real submission inside a running app. The second is separate because the harness reads the history with its OWN file reader, so it cannot catch a resolver pointing at the wrong path, an uncaptured session id, or a CLI that wraps the stored text - each a PERMANENT false negative that would escalate every delivery. Declared `false` today by Copilot, OpenCode, Qwen, Kimi, and Aider; only Claude and Codex escalate. Graduation recipe: [command-injection.md](command-injection.md). |
+| `canVerifySlashSubmission?()` | `() => boolean` | Whether a SLASH-prefixed `auto_command` can be verified in this agent's history. Omitted or `true` means yes. Declaring `false` makes `prepareInjectionPlan` tag that command `verify: 'none'`, so it is neither retried nor escalated and the outcome stays `unconfirmed`. Exists because absence from the history file is AMBIGUOUS for agents that handle slash input in the TUI - it cannot distinguish "the CLI rejected it" from "the CLI ran it client-side" - and treating the second as a failure escalates a command that actually worked into a session restart. Declared `false` by Codex, which prints "Unrecognized command" and writes no record, and by Grok, whose slash input runs in the TUI palette and never becomes a chat_history turn. See [command-injection.md](command-injection.md). |
+| `canEscalateOnVerificationFailure?()` | `() => boolean` | Whether a verification FAILURE may escalate to a restart-with-prompt. Omitted or `true` means yes. Declaring `false` marks the verifier CONFIRM-ONLY: it still confirms and still drives retry-on-Enter (rung 2, where nearly all the delivery win lives), but is barred from rung 3, because a false negative from an unproven verifier is a guess and escalation acts on that guess by destroying live work. Escalation takes TWO proofs: flush latency measured live (`scripts/measure-injection-flush.mjs`), AND the adapter's own verifier watched confirming a real submission inside a running app. The second is separate because the harness reads the history with its OWN file reader, so it cannot catch a resolver pointing at the wrong path, an uncaptured session id, or a CLI that wraps the stored text - each a PERMANENT false negative that would escalate every delivery. Declared `false` today by Copilot, OpenCode, Qwen, Kimi, Aider, and Grok; only Claude and Codex escalate. Graduation recipe: [command-injection.md](command-injection.md). |
 | `requiresAgentSessionIdForVerification?()` | `() => boolean` | Whether this adapter's verifier needs a captured `agent_session_id` to locate its history. Omitted or `true` means it does, which is the norm. Declared `false` by Aider and Copilot, for different reasons. Aider has NO session id at all (no `sessionIdCapture` in its `runtime`) because it keeps one `.aider.chat.history.md` per project directory, so `cwd` alone identifies its history. Copilot HAS a session id, but its prompt history is a single GLOBAL `~/.copilot/command-history-state.json` shared across every session and project, so neither the id nor `cwd` plays any part in locating it. Without the opt-out `buildCommandInjectionVerifier` short-circuits on the missing id and the verifier can never confirm - worse than having none, since the burst still retries and then reports `failed` instead of staying silently `unconfirmed`. |
-| `transcriptUsage?(input)` | `({ transcriptPath?, agentSessionId?, cwd? }) => Promise<TranscriptUsage \| null>` | Parse CUMULATIVE lifetime token usage for a session from the agent's own transcript - the authoritative source for the per-task lifetime-stats rollup, since the live statusLine token counts are a current-context snapshot (Claude Code 2.1.132+). Prefers the explicit `transcriptPath`, else derives it from `agentSessionId` + `cwd`. Must not throw; returns `null` when the transcript is missing/unparseable so the caller falls back to the snapshot. Implemented today only by the Claude adapter. |
-| `transcriptToolCounts?(input)` | `({ transcriptPath?, agentSessionId?, cwd? }) => Promise<TranscriptToolCounts \| null>` | Sibling of `transcriptUsage`: parse a cumulative tool-call count + callCount-only per-tool breakdown from the agent's own transcript. Backfills the live `UsageAccumulator` count for sessions whose ToolStart/ToolEnd hook events never reached it (e.g. a parked/suspended session that reports 0 despite real cost/tokens). Counts DISTINCT `tool_use` ids (parallel tool calls in one message count separately; a streamed re-emission of the same message does not double-count). Same location contract as `transcriptUsage`; must not throw, returns `null` on a missing/tool-less transcript so the caller keeps the live count. Implemented today only by the Claude adapter. |
-| `configuredModelFromCommand?(command)` | `(string) => { id: string; displayName: string } \| null` | Extract the configured model from a spawned command so the board card can show a friendly model name IMMEDIATELY, before the agent reports its own via status.json / stream telemetry. Returns `{ id, displayName }` (e.g. `claude-opus-4-8` -> "Opus 4.8"), or `null` when the command encodes no explicit model. The seeded value is a placeholder: the agent's own live telemetry overrides it once reported (full usage replace), so a later in-session `/model` change stays accurate. Each adapter owns its own command syntax and model-naming scheme. Implemented today only by the Claude adapter (`adapters/claude/model-display-name.ts`). |
+| `transcriptUsage?(input)` | `({ transcriptPath?, agentSessionId?, cwd? }) => Promise<TranscriptUsage \| null>` | Parse CUMULATIVE lifetime token usage for a session from the agent's own transcript - the authoritative source for the per-task lifetime-stats rollup, since the live statusLine token counts are a current-context snapshot (Claude Code 2.1.132+). Prefers the explicit `transcriptPath`, else derives it from `agentSessionId` + `cwd`. Must not throw; returns `null` when the transcript is missing/unparseable so the caller falls back to the snapshot. Implemented by Claude and Grok (Grok reads the last cumulative `turn_completed.usage` from `updates.jsonl`). |
+| `transcriptToolCounts?(input)` | `({ transcriptPath?, agentSessionId?, cwd? }) => Promise<TranscriptToolCounts \| null>` | Sibling of `transcriptUsage`: parse a cumulative tool-call count + callCount-only per-tool breakdown from the agent's own transcript. Backfills the live `UsageAccumulator` count for sessions whose ToolStart/ToolEnd hook events never reached it (e.g. a parked/suspended session that reports 0 despite real cost/tokens). Counts DISTINCT `tool_use` ids (parallel tool calls in one message count separately; a streamed re-emission of the same message does not double-count). Same location contract as `transcriptUsage`; must not throw, returns `null` on a missing/tool-less transcript so the caller keeps the live count. Implemented by Claude and Grok (Grok counts distinct `tool_call` ids in `updates.jsonl`). |
+| `configuredModelFromCommand?(command)` | `(string) => { id: string; displayName: string } \| null` | Extract the configured model from a spawned command so the board card can show a friendly model name IMMEDIATELY, before the agent reports its own via status.json / stream telemetry. Returns `{ id, displayName }` (e.g. `claude-opus-4-8` -> "Opus 4.8"), or `null` when the command encodes no explicit model. The seeded value is a placeholder: the agent's own live telemetry overrides it once reported (full usage replace), so a later in-session `/model` change stays accurate. Each adapter owns its own command syntax and model-naming scheme. Implemented by Claude (`adapters/claude/model-display-name.ts`) and Grok (`--model` extraction with display names from `~/.grok/models_cache.json`). |
 
 ### `AgentCapabilities`
 
@@ -79,13 +79,13 @@ Adapter-discovered capabilities surfaced to the renderer (returned by `discoverC
 
 ### Per-Adapter Capability Discovery
 
-Beyond Claude (detailed above) and Ollama (which lists installed models via `ollama list`, see [Ollama](#ollama)), eight adapters each ship their own `src/main/agent/adapters/<name>/capability-discovery.ts`. The seven that probe the CLI share a common shape built on the bounded session-history scan helpers in `src/main/agent/shared/history-scan.ts` (`listMostRecentDirs` / `listMostRecentFiles` / `readHeadBytes` / `readTailBytes` / `parseJsonlRecords`, all capped so discovery stays fast on a heavily-used install):
+Beyond Claude (detailed above) and Ollama (which lists installed models via `ollama list`, see [Ollama](#ollama)), nine adapters each ship their own `src/main/agent/adapters/<name>/capability-discovery.ts`. The seven that probe the CLI's session history share a common shape built on the bounded scan helpers in `src/main/agent/shared/history-scan.ts` (`listMostRecentDirs` / `listMostRecentFiles` / `readHeadBytes` / `readTailBytes` / `parseJsonlRecords`, all capped so discovery stays fast on a heavily-used install):
 
 1. **Model-override flag** - run `<cli> --help` and regex for a `--model` / `-m` flag to set `supportsModelOverride`.
 2. **Model list** - when that flag is present, scan the agent's own on-disk session history for the distinct model ids the user has actually used, sorted ascending so families cluster. An empty result leaves `models` undefined and the renderer falls back to a free-form text input.
-3. **Effort levels** - only Copilot parses these from `--help`; every other non-Claude adapter reports `effortLevels: []` (no CLI effort concept).
+3. **Effort levels** - Copilot parses these from `--help`, and Grok reads a real ladder (`low`..`xhigh`) from its models cache; every other non-Claude adapter reports `effortLevels: []` (no CLI effort concept).
 
-All implementations are best-effort and never throw: a help-read or history-scan failure yields conservative defaults so the rest of detection still succeeds. Droid is the one exception to the probe shape - it discovers nothing and hardcodes `supportsModelOverride: false` by design.
+All implementations are best-effort and never throw: a help-read or history-scan failure yields conservative defaults so the rest of detection still succeeds. Two adapters deviate from the probe shape, for opposite reasons: Droid discovers nothing and hardcodes `supportsModelOverride: false` by design, while Grok discovers everything (models, display names, effort ladders) from `~/.grok/models_cache.json` - the CLI's own maintained cache - rather than scanning session history, with a `--help` parse as its fresh-install fallback.
 
 | Adapter | `--model`? | Effort levels | Model list source | Notes |
 |---------|-----------|---------------|-------------------|-------|
@@ -97,6 +97,7 @@ All implementations are best-effort and never throw: a help-read or history-scan
 | Cursor | `--help` (`--model` only, no `-m`) | None | `~/.cursor/sessions/<dated>/*.jsonl` NDJSON `system` / `init` events' `model`, merged with a hardcoded `CURSOR_COMMON_MODELS` fallback | Model entries are display names (e.g. "Claude 4.1 Sonnet"), not ids; the fallback list runs unconditionally so `models` is always populated. Reasoning is encoded in model names, not a separate flag. |
 | OpenCode | `--help` best-effort, defaults false | None | (no history scan) | Model selection is intentionally left to the TUI / `opencode.json` per `cli-features-over-custom-layers.md`; no curated model list. |
 | Droid | No (hardcoded false, no probe) | None | (no history scan) | Intentional: `discoverDroidCapabilities` ignores `cliPath` and returns `supportsModelOverride: false` so the Model / Effort dropdowns stay hidden. TUI-first per `cli-features-over-custom-layers.md`. |
+| Grok Build | `~/.grok/models_cache.json` (fallback: `--help` `-m, --model`) | `models_cache.json` `reasoning_efforts[].id` per model (`low`..`xhigh`) | `~/.grok/models_cache.json` `models.<id>.info` (the CLI's own `/model` picker source; `hidden: true` entries skipped) | The cache carries ids, display names (`info.name`), context windows, AND effort ladders in one file grok itself maintains, so nothing is scraped from sessions. |
 
 ### `CommandOptions` - new spawn knobs
 
@@ -135,14 +136,14 @@ One scannable block per adapter for activity-state derivation and session ID cap
 | `backgroundShells?.resolveOutputFile({cwd, shellId})` | `(options) => string \| null` | Locate the agent's on-disk output file for a NAMED background shell, or `null` when it has none. The bg-shell process-tree watcher stats this file each poll cycle; file growth is ground-truth liveness that keeps a genuinely-running shell from being reclaimed at the 5-min named cap when no OS PID could be captured (see [Activity Detection](activity-detection.md), Output-file liveness). Today only Claude implements this (its temp `tasks/<shellId>.output` files). |
 | `backgroundShells?.reportTerminatedShells?({cwd, agentSessionId, shellIds})` | `(options) => string[]` | Report which of `shellIds` have a TERMINAL notification in the agent's durable session transcript - definitive proof of completion (task #386), independent of process-tree/output state. Reads only new transcript bytes since the previous call. Today only Claude implements this (its native transcript carries the holder's terminal `<task-notification>`; when the CLI is mid-turn it delivers that notification as a `queued_command` attachment which fires no hook, and mid-turn is exactly when a drain matters - see [Activity Detection](activity-detection.md), Transcript drain). Covers both backgrounded Bash shells and `Monitor` waits, which share the same id space, output store, and notification wrapper. |
 
-Omit `sessionId` entirely for agents that use caller-owned IDs (Claude via `--session-id`) or that have no resume mechanism (Aider). Omit `sessionHistory` for agents without a native session log file. Omit `statusFile` for agents that don't emit hook-driven `status.json` / `events.jsonl` (only Claude and Copilot use this pipeline today). Omit `streamOutput` for agents that don't emit machine-readable NDJSON to PTY stdout (everyone except Cursor today). Omit `backgroundShells` for agents that don't write a per-shell output file or expose a transcript-based termination signal (everyone except Claude today).
+Omit `sessionId` entirely for agents that use caller-owned IDs (Claude and Grok via `--session-id`) or that have no resume mechanism (Aider). Omit `sessionHistory` for agents without a native session log file. Omit `statusFile` for agents that don't emit hook-driven `status.json` / `events.jsonl` (Claude, Copilot, and Grok use this pipeline today; Grok's `parseStatus` is null because it has no statusline, but its hook-driven `parseEvent` is live). Omit `streamOutput` for agents that don't emit machine-readable NDJSON to PTY stdout (everyone except Cursor today). Omit `backgroundShells` for agents that don't write a per-shell output file or expose a transcript-based termination signal (everyone except Claude today).
 
 ### `SpawnSessionInput` extras
 
 | Field | Type | Purpose |
 |-------|------|---------|
 | `agentName?` | `string` | Human-readable agent name (`'claude'`, `'gemini'`, etc.) captured at spawn time. Used in diagnostic logs - survives production minification unlike `agentParser.constructor.name`. |
-| `agentSessionId?` | `string \| null` | Caller-owned agent session UUID. Set when the adapter declares `supportsCallerSessionId = true` and the spawn pipeline pre-generates a UUID before invoking the CLI (Claude `--session-id`, Qwen `--session-id`, Kimi `--session`). Lets `session-spawn-flow.ts` call `sessionHistoryReader.attach()` immediately at spawn time without waiting for capture pathways to round-trip, and skips the 30s "session ID not captured" diagnostic timer. Null/undefined for adapters that auto-generate IDs (Codex, Gemini, Droid). |
+| `agentSessionId?` | `string \| null` | Caller-owned agent session UUID. Set when the adapter declares `supportsCallerSessionId = true` and the spawn pipeline pre-generates a UUID before invoking the CLI (Claude `--session-id`, Qwen `--session-id`, Kimi `--session`, Grok `-s`). Lets `session-spawn-flow.ts` call `sessionHistoryReader.attach()` immediately at spawn time without waiting for capture pathways to round-trip, and skips the 30s "session ID not captured" diagnostic timer. Null/undefined for adapters that auto-generate IDs (Codex, Gemini, Droid). |
 
 ## Supported Agents
 
@@ -160,6 +161,7 @@ Omit `sessionId` entirely for agents that use caller-owned IDs (Claude via `--se
 | Droid | `droid-adapter.ts` | `droid` | `--resume <uuid>` | No (PTY-only) | No (use Droid's TUI: `/model` + Ctrl+D, shift+tab) | `<cwd>/.factory/mcp.json` + `buildEnv` token | No |
 | OpenCode | `opencode-adapter.ts` | `opencode` | Plugin/PTY-captured `ses_<id>` (auto-generated) | Yes (plugin JSONL via `tool.execute.before/after` + `event` `session.*`) | No (`opencode.json` + `OPENCODE_CONFIG_CONTENT` env) | `OPENCODE_CONFIG_CONTENT` (local spawns only) | No (auth via `opencode auth login` -> `~/.local/share/opencode/auth.json`) |
 | Ollama | `ollama-adapter.ts` | `ollama` | No | No | No | Not possible (CLI has no MCP client) | No |
+| Grok Build | `grok-adapter.ts` | `grok` | `--session-id <uuid>` (caller-owned) / `--resume <id>` | Yes (events.jsonl via Claude-compatible hooks; usage from `updates.jsonl` tail) | No (wholly-owned `.grok/hooks/kangentic.json` + `.grok/config.toml` sentinel block) | `[mcp_servers.kangentic]` block in `<cwd>/.grok/config.toml` with `${VAR}` env refs + `buildEnv` URL/token | Yes (`~/.grok/trusted_folders.toml`, cascades from project root) |
 
 ## Agent Resolution
 
@@ -194,6 +196,7 @@ Each adapter implements `detectFirstOutput(data)` to signal when the agent's TUI
 | Droid | `\x1b[?25l` (cursor hide) | Ink-based TUI, same pattern as Claude (verified empirically) |
 | OpenCode | `\x1b[?25l` (cursor hide) | Full-screen TUI initializes alternate screen buffer with cursor hide on first frame |
 | Ollama | `data.length > 0` | Ollama streams output immediately (no alternate screen buffer) |
+| Grok Build | `\x1b[?25l` (cursor hide) | Rust alt-screen TUI; the cursor-hide arrives in the very first output chunk, before the alt-screen switch (verified via node-pty against grok 1.0.0) |
 
 The `\x1b[?25l` (ANSI cursor hide) sequence fires after the shell prompt noise but before the TUI draws its startup banner. This keeps the shell command hidden behind the shimmer overlay.
 
@@ -215,6 +218,7 @@ Graceful exit sequences written to the PTY during `SessionManager.suspend()`:
 | Droid | `Ctrl+C`, `/quit` | Triggers clean shutdown of the Ink TUI |
 | OpenCode | `Ctrl+C` | Verified 2026-04-28: PTY exits in ~1s. `/exit` and `/quit` are not recognized slash commands. |
 | Ollama | `Ctrl+C`, `/bye` | `/bye` exits the interactive REPL; harmless after a one-shot run has already exited |
+| Grok Build | `Ctrl+C`, `/quit` | `/quit` exits cleanly (probe-verified exit 0) and prints the conversation dump that transcript cleanup anchors on |
 
 ## Session History File Location
 
@@ -234,6 +238,7 @@ During cross-agent handoff, each adapter's `locateSessionHistoryFile()` finds th
 | OpenCode | `~/.local/share/opencode/opencode.db` (SQLite `session` table) | Read-only WAL handle; match `directory == cwd` and `time_created` within spawn window |
 | Droid | N/A | Returns null (no native session history file; activity flows through PTY-only detection) |
 | Ollama | N/A | Returns null (no CLI-accessible session history) |
+| Grok Build | `~/.grok/sessions/<encodeURIComponent(cwd)>/<sessionId>/updates.jsonl` | Deterministic path construction (session id is caller-owned via `-s`) plus a strict existence check, scoped to the given cwd (the `resume-cwd-migration` reachability gate depends on a cross-cwd match NOT counting). The attach-time `runtime.sessionHistory.locate` additionally polls ~60s and falls back to a sessions-root scan for encoding mismatches |
 
 ## Auto-Name (Summarize)
 
@@ -259,6 +264,7 @@ Implementations live next to each adapter and call the shared `runCliPrintSummar
 | Cursor | `agent --output-format text -p "<prompt>"` | positional arg |
 | Droid | `droid exec -o text "<prompt>"` | positional arg |
 | Copilot | `copilot --silent -p "<prompt>"` | positional arg |
+| Grok Build | `grok --output-format plain -p "<prompt>"` | positional arg |
 | Aider, Warp | (no clean plain-text headless mode yet) | n/a |
 | Ollama | (summarize not yet wired) | n/a |
 
@@ -950,7 +956,7 @@ The renderer surfaces the `false` state two ways: an amber `DetectionCard` varia
 
 Filesystem check chosen over a `kimi info` subprocess: the probe runs on every `AGENT_LIST` call alongside the existing `--version` probes, and a single sub-millisecond `fs.readdirSync` (with ENOENT mapped to `false`) keeps the refresh latency unchanged. An expired-token false-positive (credentials present but not valid) still falls through to today's behavior - the spawned session prints "LLM not set" and exits.
 
-`probeAuth?()` is an optional method on the `AgentAdapter` interface; only Kimi implements it today. Other adapters return `undefined` for the `authenticated` field, which the renderer treats as "not applicable".
+`probeAuth?()` is an optional method on the `AgentAdapter` interface; Kimi and Grok implement it today (Grok via `grok models` output, see [Grok Build](#grok-build)). Other adapters return `undefined` for the `authenticated` field, which the renderer treats as "not applicable".
 
 ### Limitations
 
@@ -1073,6 +1079,113 @@ Runtime activity is PTY-only. A one-shot `ollama run` streams output then exits,
 - No `transcript-cleanup.ts` (streams plain text output, not a TUI alternate screen)
 - `locateSessionHistoryFile` returns null - `ollama run` has no native session history files
 
+## Grok Build
+
+`src/main/agent/adapters/grok/`
+
+xAI's terminal coding agent (repo: `xai-org/grok-build`, binary `grok`, a Rust alt-screen
+TUI). Grok deliberately clones Claude Code's surface - Claude-compatible hooks, the same
+`--session-id` / `--resume` split, the same `--permission-mode` vocabulary - which is what
+makes this the second full-harness adapter after Claude. Every empirical claim below was
+verified against grok 1.0.0 (3cd0d0cbce) on Windows and is re-checkable with
+`node scripts/probe-grok.js` (headless checks spend a few tiny free-tier turns; add
+`--skip-pty` to skip the interactive leg).
+
+**Sessions (caller-owned ids).** `-s/--session-id <uuid>` names a NEW session only (reusing
+an existing uuid errors with "Session ID ... is already in use"); `--resume <uuid>` resumes.
+The store lives at `~/.grok/sessions/<encodeURIComponent(cwd)>/<sessionId>/` (the raw
+absolute cwd, backslashes intact on Windows, URL-encoded byte-for-byte) with
+`updates.jsonl` (append-only ACP `session/update` JSON-RPC log, the authoritative record),
+`chat_history.jsonl` (raw model messages), and `summary.json` (metadata). `GROK_HOME`
+overrides `~/.grok`. Because the id is caller-owned, `locate` is a deterministic path build
+plus an existence poll, with a sessions-root scan fallback keyed on the uuid for encoding
+mismatches. The command builder deliberately emits NO `--cwd`: grok keys the store by
+process cwd, and a normalized `--cwd` value could key it under a different encoding than
+`session-paths.ts` computes.
+
+**Hooks (the activity pipeline).** Grok fires the full Claude-compatible hook set -
+including in headless mode - with camelCase payloads (`toolName`, `toolUseId`, `toolInput`,
+`toolResult`, `reason`, `stopHookActive`). `Stop` fires only for the main agent (subagents
+fire `SubagentStop` in the subagent), so Claude's subagent-depth gating is unnecessary.
+Grok has no per-session settings flag, so the hook file is per-cwd:
+`<cwd>/.grok/hooks/kangentic.json`, a wholly-Kangentic-owned file (grok merges every
+`*.json` in that directory, so user hook files are never read, merged, or swept). The
+per-session events path rides the spawn environment instead of the file: hook commands name
+`env:KANGENTIC_EVENTS_PATH`, which `event-bridge.js` resolves from its own process env at
+run time - hook processes inherit the grok process env (probe-verified). One static file is
+therefore correct for concurrent sessions in one cwd, and a session without the variable
+(the user's own manual `grok` run there) makes the bridge a silent no-op. Hooks load from
+the project root grok discovers by walking up to the first `.git`; every Kangentic spawn cwd
+is a git root, so writing at cwd is writing at the root. Runtime is
+`ActivityDetection.hooksAndPty()`: untrusted folders skip project hooks silently
+(fail-open), and the PTY silence timer carries activity until trust lands. No `detectIdle`
+regex - grok's `❯` prompt stays visible during active work, the same always-visible-prompt
+trap as Codex's `›`.
+
+**Telemetry (`updates.jsonl` tail, no statusline).** Grok has no statusline, so
+`parseStatus` is null and usage comes from `runtime.sessionHistory` tailing `updates.jsonl`.
+Three measured semantics are load-bearing: `params._meta.totalTokens` on streaming/tool
+updates is the RUNNING context total (the ContextBar occupancy number);
+`turn_completed.usage` is CUMULATIVE across the session (observed `numTurns: 8`,
+`inputTokens: 541k` - using it for occupancy is the Codex `total_token_usage` trap; it feeds
+`transcriptUsage` instead); and `costUsdTicks` is 1e-10 USD (pinned by a headless json run
+reporting `total_cost_usd` and `total_cost_usd_ticks` side by side, re-checked by the
+probe). Context window sizes and model display names come from `~/.grok/models_cache.json`.
+The parser emits NO tool events - hooks own those, and a second emitter would double-count
+ToolStart/ToolEnd pairs - only usage plus idempotent activity hints (`turn_completed` ->
+Idle, chunks -> Thinking, non-terminal `retry_state` -> Thinking) as a hook backstop.
+
+**Kangentic MCP.** Project-scoped `<cwd>/.grok/config.toml` carries a sentinel-delimited
+`[mcp_servers.kangentic]` block whose every value is an env reference
+(`url = "${KANGENTIC_MCP_URL}"`, token header `${KANGENTIC_MCP_TOKEN}`); grok's documented
+`${VAR}` expansion resolves them at load time. The block is fully static - the per-session
+URL (which carries the caller-session id) and per-launch token ride `buildEnv` - so
+concurrent sessions in one cwd each expand their own environment, no secret ever reaches
+disk or argv, and removal (refcounted, shared with the hooks file) is a surgical strip of
+the sentinel block that never reserializes the user's TOML. The builder also passes
+`--allow "MCPTool(kangentic__*)"` (grok's native permission-rules mechanism,
+session-scoped, deny still wins) so a board-driven session never stalls on the interactive
+approval prompt for Kangentic's own tools - verified live without it,
+`kangentic__kangentic_get_current_task` sat on the approval dialog with nobody there to
+answer. This is Claude's `mcp__kangentic` allow-rule injection, in grok's dialect.
+
+**Trust.** Folder trust (`~/.grok/trusted_folders.toml`, entries
+`[folders.'<path>'] / trusted = true / decided_at = <unix>`) gates project hooks and
+project MCP together, and CASCADES to subdirectories - verified live: a Kangentic worktree
+under a trusted project root reports `projectTrusted: true` with only the root in the store.
+`ensureTrust` therefore pre-approves ONLY a Kangentic worktree with no covering decision
+(one entry per task, dropped by `onWorktreeRemoved` - the Codex dead-entries lesson), never
+overrules an explicit ancestor deny, and never auto-trusts a plain project root: an
+undecided root runs untrusted (PTY fallback carries activity) until the user's own first
+interactive grok session decides it once, which then cascades to every future worktree.
+
+**Verification tier: confirm-only.** `chat_history.jsonl` flushes the typed user turn on
+SUBMIT (measured 313ms and 32ms across two runs, against a ~2s turn), so a
+`command-injection` verifier is wired against it (genuine turns have no `synthetic_reason`
+and wrap the text in `<user_query>` tags, which the extractor strips). But records carry no
+timestamps to bound the match window and the resolver has never been proven in-app, so
+`canEscalateOnVerificationFailure` is false. `canVerifySlashSubmission` is false (slash
+input runs in the TUI palette and never becomes a chat_history turn - the Codex verdict),
+which is also why `getInjectionSequence` returns `[]` despite grok having native `/model`
+and `/effort` commands: an unconfirmable injection could land as literal prompt text, while
+the suspend + respawn fallback applies `--model` / `--reasoning-effort` deterministically.
+
+**Other capabilities.** `parseTranscript` reads `chat_history.jsonl`
+(`system`/`user`/`assistant`/`reasoning`/`tool_result` records; assistant tool calls in
+`tool_calls[]` with JSON-string `arguments`; no timestamps, so entries get a parse-time
+stamp and synthesized uuids). `transcriptUsage`/`transcriptToolCounts` read `updates.jsonl`
+(Claude-parity lifetime rollup). `summarize` uses the verified headless mode
+(`--output-format plain -p`). `probeAuth` runs `grok models` and checks for "not
+authenticated" - note grok currently serves a free tier without login, so false means "not
+signed in", not "unusable"; a subscription-less account that hits a limit gets an explicit
+403 rendered as a failed turn in the TUI, not a hang. Auth is browser OAuth through the PTY
+(`grok login`, device-code fallback `--device-auth`, `XAI_API_KEY` env for CI).
+
+**Detector.** `binaryName: 'grok'` with NO `agent` alias - grok's installer also publishes
+a generic `agent` shim that collides with Cursor's (see the collision guard below), and
+`parseVersion` requires the `grok ` banner prefix so a foreign binary answering on a shared
+name is rejected. `tests/unit/cursor-grok-binary-collision.test.ts` pins both directions.
+
 ## Project relocation
 
 A Kangentic project relocates in one of two ways, both handled by the `project:relocate` IPC
@@ -1111,6 +1224,7 @@ same caveat the Claude adapter documents).
 | Cursor | None. | No cwd-keyed external session store Kangentic depends on. |
 | Oz (Warp) | None. | No resumable on-disk session state. |
 | Ollama | None. | No resumable external session state; `onProjectRelocated` omitted. |
+| Grok Build | `~/.grok/sessions/<encodeURIComponent(cwd)>/` session dirs and `[folders.'<path>']` headers in `~/.grok/trusted_folders.toml`. | Encoded-dir rename mirrors Droid's slug rename; the trust rewrite mirrors Codex's header rewrite (backup + atomic write). |
 
 ## Prompt Templates
 
@@ -1153,7 +1267,7 @@ Two standalone Node.js scripts in `src/main/agent/`:
 - **Output:** `events.jsonl` (append-only, one JSON line per event)
 - **Data:** Timestamps, event types, tool names, file paths
 - **Watched by:** SessionManager with 50ms debounce, incremental byte-offset reads
-- **Supported by:** Claude Code (18 hook points), Codex CLI (via config.toml hooks), Gemini CLI (via .gemini/settings.json hooks)
+- **Supported by:** Claude Code (18 hook points), Codex CLI (via config.toml hooks), Gemini CLI (via .gemini/settings.json hooks), Grok Build (via `.grok/hooks/kangentic.json`, with the events path resolved through the `env:KANGENTIC_EVENTS_PATH` sentinel - see [Grok Build](#grok-build))
 
 Both scripts are stateless (no persistent process), read JSON from stdin, write to their output file, and exit. All writes are try/catch wrapped for non-fatal failures.
 

--- a/docs/command-injection.md
+++ b/docs/command-injection.md
@@ -98,7 +98,7 @@ follows it.
 
 ## Claude's JSONL-polling implementation
 
-Claude's is the richest verifier, and the only one that matches on a structured slash-invocation record rather than on the submitted text. Seven adapters provide a `'command-injection'` verifier today (see the matrix below). Of the six besides Claude, three (Codex, Qwen, Kimi) reuse the shared submitted-text scan; Copilot, OpenCode, and Aider each ship a bespoke verifier, because their history formats cannot support that scan safely.
+Claude's is the richest verifier, and the only one that matches on a structured slash-invocation record rather than on the submitted text. Eight adapters provide a `'command-injection'` verifier today (see the matrix below). Of the seven besides Claude, four (Codex, Qwen, Kimi, Grok) reuse the shared submitted-text scan; Copilot, OpenCode, and Aider each ship a bespoke verifier, because their history formats cannot support that scan safely.
 
 Claude Code writes every successful slash invocation to its session JSONL transcript as a `local_command` system entry whose `<command-name>` matches the slash and whose `<command-args>` matches exactly what was sent. The verifier (`src/main/agent/adapters/claude/slash-command-verifier.ts`) tail-scans this file for an entry matching both fields exactly:
 
@@ -267,6 +267,14 @@ Live runs, 2026-08-08, Windows. "Worst" is the slowest observation across trials
 | Droid | 3202ms, 941ms | 661ms, 636ms (4.5s, 9.9s) | **3202ms** | yes (580ms, 564ms) | **stop** |
 | Cursor | login-gated | 5766ms, 5446ms (5.8s, 5.4s) | **5766ms** | yes (2614ms) | **stop** |
 | Gemini | 5504ms, never (>25s) | never (>25s), 6302ms (16.9s) | **>25s** | not reached | **stop** |
+| Grok Build | 313ms, 32ms (2.1s, ~4s turns) | (not yet paired-long measured) | **313ms** | n/a (slash never recorded, by design) | **implement (confirm-only)** |
+
+Grok's two numbers come from `scripts/probe-grok.js`'s interactive PTY leg (2026-08-16, grok
+1.0.0, Windows) rather than `measure-injection-flush.mjs` - a typed submit polled against
+`chat_history.jsonl` at 25ms cadence. Both landed well inside the single-attempt 400ms window
+and far below the turn end, which is the flush-on-submit signature; the formal paired
+short/long trial has not been run, which (together with the missing in-app proof and the
+records carrying no timestamps) is why its verifier ships confirm-only rather than verified.
 
 **The bar is the delivery BUDGET, not a margin.** `submitKeystrokes` retries up to 5 times polling 400ms each, so a submission has ~2000ms to become visible before the outcome is `failed`, and `sentAt` advances on every retry. Two earlier attempts to hold reserve (1000ms, then 1500ms) both failed the CLAUDE CONTROL - the reference implementation whose verifier ships and works. Any bar that rejects the known-good adapter is measuring the wrong thing.
 
@@ -304,6 +312,7 @@ There are three tiers, and the line between the first two is a safety property, 
 | OpenCode | `null` | verifier (SQL) | confirm-only | 95ms worst via a read-only query. Has a KNOWN wrong answer for remote sessions, below; declines SLASH commands, same as Codex |
 | Qwen | `null` | verifier | confirm-only | 696ms worst, slash included. Builds its path from a CAPTURED session id and has never run against a live Qwen session in-app |
 | Kimi | `null` | verifier | confirm-only | `wire.jsonl` shape pinned to real captures. Unmeasured: never reached a usable TUI |
+| Grok Build | `null` | verifier | confirm-only | 313ms/32ms flush-on-submit measured live; extractor unwraps the stored `<user_query>` wrapper and skips `synthetic_reason` records. Lacks the in-app proof, and `chat_history.jsonl` records carry NO timestamps so the scan cannot bound a `sentAt` window - a byte-identical PRIOR submission could false-confirm, harmless for confirm-only, disqualifying for escalation. Declines SLASH commands (TUI palette, never a recorded turn) |
 | Aider | `null` | verifier | confirm-only | markdown shape from a real fixture. Unmeasured: not installed on the measuring machine |
 | Gemini | `null` | `null` | none | measured turn-end flushed and highly variable |
 | Droid | `null` | `null` | none | measured unreliable: 564ms best, 3202ms worst |
@@ -325,7 +334,7 @@ The harness answers one question: *does the CLI write the record fast enough?* I
 
 Both of those produce a **permanent** false negative rather than an intermittent one, so they would escalate *every* auto_command the adapter ever receives. That is why the second proof is a run inside the app, and why an adapter stays confirm-only until it has one, even with a clean measurement.
 
-The wrapping half of that risk is partly mechanised: `tests/unit/command-injection-real-capture-extractors.test.ts` runs each extractor over a real captured history file committed under `tests/fixtures/` and asserts it hands back text that trim-equals what was typed. A hand-authored fixture cannot do this - it pins our belief about the shape rather than the shape itself. Codex, Qwen, Kimi, and Aider have such a capture; Copilot and OpenCode do not, and adding one is the cheapest single contribution toward graduating either.
+The wrapping half of that risk is partly mechanised: `tests/unit/command-injection-real-capture-extractors.test.ts` runs each extractor over a real captured history file committed under `tests/fixtures/` and asserts it hands back text that trim-equals what was typed. A hand-authored fixture cannot do this - it pins our belief about the shape rather than the shape itself. Codex, Qwen, Kimi, and Aider have such a capture; Copilot, OpenCode, and Grok do not, and adding one is the cheapest single contribution toward graduating any of them.
 
 Mechanically: `canEscalateOnVerificationFailure() === false` makes `prepareInjectionPlan` mark the auto_command `escalatable: false`, and `TerminalSubmitScheduler.escalate` filters it out. Worst case for a confirm-only adapter is a `failed` outcome and a notice, never a respawn. The tiers are pinned per adapter in `tests/unit/agent-submission-verifier-shape.test.ts`, so flipping one without recording the evidence fails CI.
 
@@ -466,11 +475,12 @@ Every "before" failure in the picker sweep fell in the 100-200ms band - exactly 
 - `src/main/pty/prompt-draft-ledger.ts` - unsent-user-text accounting.
 - `src/main/ipc/helpers/auto-command-outcome.ts` - persists the outcome and rations the notice.
 - `src/main/agent/adapters/claude/slash-command-verifier.ts` - Claude's JSONL-polling implementation, including the `submitted` exact-content scan.
-- `src/main/agent/shared/transcript-tail-cache.ts` - the bounded 256KB tail read and its LRU content-identity cache. Used by five of the seven verifiers: Claude and Aider import it directly, Codex/Qwen/Kimi reach it through the shared scan. Copilot and OpenCode do not read an appendable text file at all (a global JSON blob and a SQL query), so they bypass it. Must stay ONE module-global instance.
+- `src/main/agent/shared/transcript-tail-cache.ts` - the bounded 256KB tail read and its LRU content-identity cache. Used by six of the eight verifiers: Claude and Aider import it directly, Codex/Qwen/Kimi/Grok reach it through the shared scan. Copilot and OpenCode do not read an appendable text file at all (a global JSON blob and a SQL query), so they bypass it. Must stay ONE module-global instance.
 - `src/main/agent/shared/submitted-text-verifier.ts` - the shared backwards tail walk, `sentAt` watermark, and exact trim-equality. Adapters supply only a synchronous path resolver and a record-shape extractor.
 - `src/main/agent/adapters/codex/command-injection-verifier.ts` - Codex resolver (memoised readdir scan) and rollout record shape.
 - `src/main/agent/adapters/qwen-code/command-injection-verifier.ts` - Qwen resolver (direct path construction) and chats record shape.
 - `src/main/agent/adapters/kimi/command-injection-verifier.ts` - CONFIRM-ONLY. `wire.jsonl` resolver plus the unix-SECONDS timestamp conversion.
+- `src/main/agent/adapters/grok/command-injection-verifier.ts` - CONFIRM-ONLY. `chat_history.jsonl` resolver (deterministic path from the caller-owned session UUID) and the `<user_query>`-unwrapping extractor; records carry no timestamps, so `timestampMs` is null and the scan matches on text alone within the bounded tail.
 - `src/main/agent/adapters/aider/command-injection-verifier.ts` - CONFIRM-ONLY. One of the three bespoke verifiers that cannot use the shared scan (with OpenCode and Copilot): no per-entry timestamps, so it guards on file mtime and matches the LAST user block only.
 - `src/main/agent/adapters/opencode/command-injection-verifier.ts` - CONFIRM-ONLY, and the only SQL-backed verifier; a remote session has no local row and is reported `failed`.
 - `src/main/agent/adapters/copilot/command-injection-verifier.ts` - CONFIRM-ONLY. Reads the GLOBAL `command-history-state.json` newest-first, guarded by file mtime and a bounded recent-entry window.

--- a/docs/database.md
+++ b/docs/database.md
@@ -241,7 +241,7 @@ Index: `idx_transitions_from_to` on (from_swimlane_id, to_swimlane_id).
 | tool_breakdown | TEXT | | NULL |
 | compaction_count | INTEGER | NOT NULL | 0 |
 
-Valid session_type values: `claude_agent`, `codex_agent`, `gemini_agent`, `qwen_agent`, `aider_agent`, `cursor_agent`, `copilot_agent`, `warp_agent`, `kimi_agent`, `opencode_agent`, `droid_agent`, `ollama_agent`, `run_script`.
+Valid session_type values: `claude_agent`, `codex_agent`, `gemini_agent`, `qwen_agent`, `aider_agent`, `cursor_agent`, `copilot_agent`, `warp_agent`, `kimi_agent`, `opencode_agent`, `droid_agent`, `ollama_agent`, `grok_agent`, `run_script`.
 
 Valid status values: `running`, `queued`, `suspended`, `exited`, `orphaned`.
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -54,7 +54,7 @@ Post-spawn: handoff DB record updated with target session ID
 
 ## Session History File Locations
 
-Each agent adapter implements `locateSessionHistoryFile(agentSessionId, cwd)` to find the native session file. The full per-agent table (file patterns + lookup methods for all 12 supported adapters) lives in [Agent Integration > Session History File Location](agent-integration.md#session-history-file-location); maintained there as the single source of truth.
+Each agent adapter implements `locateSessionHistoryFile(agentSessionId, cwd)` to find the native session file. The full per-agent table (file patterns + lookup methods for all 13 supported adapters) lives in [Agent Integration > Session History File Location](agent-integration.md#session-history-file-location); maintained there as the single source of truth.
 
 ## Prompt Delivery
 
@@ -91,7 +91,7 @@ Handoff records are stored in the `handoffs` table for audit trail:
 
 ## MCP Access
 
-Claude Code sessions can access handoff metadata via the `kangentic_get_handoff_context` MCP tool, which returns the session history file path and handoff metadata. The `kangentic_get_transcript` tool provides structured access to session transcripts for Claude, Droid, Codex, Gemini, Qwen, Kimi, and OpenCode sessions (other agents fall back to raw scrollback). See [MCP Server](mcp-server.md) for details.
+Claude Code sessions can access handoff metadata via the `kangentic_get_handoff_context` MCP tool, which returns the session history file path and handoff metadata. The `kangentic_get_transcript` tool provides structured access to session transcripts for Claude, Droid, Codex, Gemini, Qwen, Kimi, OpenCode, and Grok sessions (other agents fall back to raw scrollback). See [MCP Server](mcp-server.md) for details.
 
 ## Disabling Session History Passthrough
 
@@ -103,7 +103,7 @@ The toggle is a per-column setting in the Edit Column dialog, under the Agent se
 
 ## Per-Agent Transcript Cleanup
 
-TUI agents (Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Kimi Code, Droid, OpenCode) produce raw PTY output with agent-specific rendering artifacts. Cleanup utilities in `src/main/agent/handoff/transcript-cleanup.ts` provide shared functions (`filterNoiseLines`, `finalizeTranscript`) used by per-adapter transcript cleanup files. Each agent's cleanup lives in its adapter folder: `src/main/agent/adapters/<name>/transcript-cleanup.ts`.
+TUI agents (Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Kimi Code, Droid, OpenCode, Grok Build) produce raw PTY output with agent-specific rendering artifacts. Cleanup utilities in `src/main/agent/handoff/transcript-cleanup.ts` provide shared functions (`filterNoiseLines`, `finalizeTranscript`) used by per-adapter transcript cleanup files. Each agent's cleanup lives in its adapter folder: `src/main/agent/adapters/<name>/transcript-cleanup.ts`.
 
 GitHub Copilot CLI is also a TUI agent but does not yet ship its own `transcript-cleanup.ts`, so its handoff transcripts may contain rendering artifacts until one is added. Cursor CLI, Oz CLI (Warp), and Ollama stream plain text output (no alternate screen buffer) and do not need per-adapter cleanup.
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -43,7 +43,7 @@ A Kangentic-spawned agent calls an MCP tool (e.g. kangentic_create_task)
 | Column Resolver | `src/main/agent/commands/column-resolver.ts` | Shared case-insensitive column name to swimlane lookup used by multiple handlers. |
 | Task Ordering | `src/main/agent/commands/task-ordering.ts` | Pure ordinal-slot arithmetic shared by `handleMoveTask`'s same-column reposition and `handleReorderTasks`: slot clamping, prefix-merge reordering, and ordinal-to-raw-position translation. |
 | MCP Config Delivery | Per-adapter, under `src/main/agent/adapters/<agent>/` | Each adapter delivers the per-launch URL + token through its own CLI's mechanism. See the [Discovery](#discovery) table. |
-| Trust Managers | `adapters/claude/trust-manager.ts`, `adapters/codex/trust-manager.ts`, `adapters/gemini/trust-manager.ts`, `adapters/qwen-code/trust-manager.ts` | Pre-approve the spawn directory so the session is not blocked at startup: Claude in `~/.claude.json`, Codex via `[projects.'<path>'] trust_level` in `~/.codex/config.toml`, Gemini and Qwen via `trustedFolders.json` (an untrusted folder disables every configured MCP server). All four leave an explicit user decision alone, in either direction. |
+| Trust Managers | `adapters/claude/trust-manager.ts`, `adapters/codex/trust-manager.ts`, `adapters/gemini/trust-manager.ts`, `adapters/qwen-code/trust-manager.ts`, `adapters/grok/trust-manager.ts` | Pre-approve the spawn directory so the session is not blocked at startup: Claude in `~/.claude.json`, Codex via `[projects.'<path>'] trust_level` in `~/.codex/config.toml`, Gemini and Qwen via `trustedFolders.json`, Grok via `[folders.'<path>']` in `~/.grok/trusted_folders.toml` (an untrusted folder disables every configured MCP server; Grok's trust cascades to subdirectories, so only worktrees under an undecided root get their own entry). All five leave an explicit user decision alone, in either direction. |
 | Board Refresh | `src/main/ipc/handlers/sessions.ts` | Forwards task-created/updated/backlog-changed events to renderer via IPC. |
 | Dev-only DevTools | `src/devtools/mcp/register.ts`, `src/devtools/mcp/preview-tools.ts` | Registers the `kangentic_devtools_*` tools when `__KANGENTIC_DEV__` is set. Excluded from production builds at compile time. |
 
@@ -60,6 +60,7 @@ Delivery is per-adapter, because no two of these CLIs accept MCP config the same
 | Gemini CLI | `mcpServers` in `<cwd>/.gemini/settings.json` (`httpUrl`) | project file, stripped on exit |
 | Qwen Code | `mcpServers` in `<cwd>/.qwen/settings.json` (`httpUrl`) | project file, stripped on exit |
 | Droid | `<cwd>/.factory/mcp.json` with `${KANGENTIC_MCP_TOKEN}` | process env (file holds only the var name) |
+| Grok Build | `[mcp_servers.kangentic]` sentinel block in `<cwd>/.grok/config.toml` with `${KANGENTIC_MCP_URL}` + `${KANGENTIC_MCP_TOKEN}`, plus `--allow "MCPTool(kangentic__*)"` pre-approval | process env (file holds only var names - the URL too, so the block is fully static) |
 | OpenCode | `OPENCODE_CONFIG_CONTENT` env var | process env (local spawns only) |
 | Cursor, Oz CLI | Not wired | n/a |
 | Aider, Ollama | Not possible - neither CLI is an MCP client | n/a |
@@ -697,7 +698,7 @@ Structured-format support by agent:
 
 | Agent | Structured | Raw |
 |-------|------------|-----|
-| Claude, Droid, Codex, Gemini, Qwen, Kimi, OpenCode | native parser | yes |
+| Claude, Droid, Codex, Gemini, Qwen, Kimi, OpenCode, Grok | native parser | yes |
 | Aider | no (no per-session native history) | yes |
 | Warp, Cursor, Copilot | no (history location unknown) | yes |
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,7 +2,7 @@
 
 ## What is Kangentic?
 
-Kangentic is a cross-platform desktop Kanban application purpose-built for orchestrating AI coding agents. It supports Claude Code, Codex CLI, Gemini CLI, Qwen Code, Kimi Code, OpenCode, Droid (Factory), Cursor CLI, GitHub Copilot CLI, Aider, Oz CLI (Warp), and Ollama. Dragging a task card between columns can spawn, suspend, resume, or terminate agent sessions - turning a familiar Kanban workflow into a powerful multi-agent control plane.
+Kangentic is a cross-platform desktop Kanban application purpose-built for orchestrating AI coding agents. It supports Claude Code, Codex CLI, Gemini CLI, Qwen Code, Kimi Code, OpenCode, Droid (Factory), Cursor CLI, GitHub Copilot CLI, Aider, Oz CLI (Warp), Ollama, and Grok Build (xAI). Dragging a task card between columns can spawn, suspend, resume, or terminate agent sessions - turning a familiar Kanban workflow into a powerful multi-agent control plane.
 
 ## The Problem
 
@@ -16,7 +16,7 @@ Kangentic replaces terminal tab chaos with a drag-and-drop board. Each task card
 
 ### Multi-Agent Support
 
-Orchestrate Claude Code, Codex CLI, Gemini CLI, Qwen Code, Kimi Code, OpenCode, Droid (Factory), Cursor CLI, GitHub Copilot CLI, Aider, Oz CLI (Warp), and Ollama from a single board. Set a default agent per project, or override it per column. When a task moves between columns with different agents, Kangentic automatically packages the outgoing agent's context (transcript, git changes, metrics) and hands it off to the incoming agent. No manual copy-paste between tools.
+Orchestrate Claude Code, Codex CLI, Gemini CLI, Qwen Code, Kimi Code, OpenCode, Droid (Factory), Cursor CLI, GitHub Copilot CLI, Aider, Oz CLI (Warp), Ollama, and Grok Build (xAI) from a single board. Set a default agent per project, or override it per column. When a task moves between columns with different agents, Kangentic automatically packages the outgoing agent's context (transcript, git changes, metrics) and hands it off to the incoming agent. No manual copy-paste between tools.
 
 ### Visual Agent Orchestration
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -449,7 +449,7 @@ The context bar is a status line displayed below the terminal showing session me
 
 | Setting | Description |
 |---------|-------------|
-| Default Agent | Which agent CLI to use for new sessions in this project. Supported agents: Claude Code, Codex CLI, Gemini CLI, Qwen Code, Kimi Code, OpenCode, Droid (Factory), Cursor CLI, GitHub Copilot CLI, Aider, Oz CLI (Warp), Ollama. Per-project setting. |
+| Default Agent | Which agent CLI to use for new sessions in this project. Supported agents: Claude Code, Codex CLI, Gemini CLI, Qwen Code, Kimi Code, OpenCode, Droid (Factory), Cursor CLI, GitHub Copilot CLI, Aider, Oz CLI (Warp), Ollama, Grok Build. Per-project setting. |
 | CLI Path | Path to agent CLI binary (auto-detected if empty) |
 | Execution (remote) | For agents that support it (today OpenCode), attach to a server you run instead of spawning a local process: server URL, authentication, and the server-side working directory. Shown only when the selected agent declares remote execution. |
 | Launch Options | Agent-specific startup toggles (today Codex's "Disable ChatGPT Apps", which skips the optional cloud ChatGPT Apps connector that can hang startup). Shown only for agents that declare options. |

--- a/docs/worktree-strategy.md
+++ b/docs/worktree-strategy.md
@@ -373,7 +373,7 @@ App reopened
 
 ### Adapter notification on removal
 
-Some agent CLIs record per-directory state in a GLOBAL config file, keyed by absolute path. That state outlives the worktree: Kangentic creates one worktree per task, so an adapter keyed this way accumulates a dead entry per task with nothing to clean it up. Codex is the case that forced this (its directory trust in `~/.codex/config.toml` reached 473 dead entries on one machine); Gemini's `trustedFolders.json` has the same shape.
+Some agent CLIs record per-directory state in a GLOBAL config file, keyed by absolute path. That state outlives the worktree: Kangentic creates one worktree per task, so an adapter keyed this way accumulates a dead entry per task with nothing to clean it up. Codex is the case that forced this (its directory trust in `~/.codex/config.toml` reached 473 dead entries on one machine); Gemini's `trustedFolders.json` and Grok's `~/.grok/trusted_folders.toml` have the same shape (Grok accumulates entries only for worktrees under an undecided project root, since its trust cascades from a decided ancestor).
 
 `WorktreeManager.removeWorktree` is therefore the single notification point: on a successful removal it calls the listener registered at startup (`setWorktreeRemovedListener` in `src/main/index.ts`), which fans out to every adapter's optional `onWorktreeRemoved` (see [Agent Integration](agent-integration.md)). The listener is registered rather than imported so this git module never reaches into the agent registry.
 

--- a/scripts/probe-grok.js
+++ b/scripts/probe-grok.js
@@ -1,0 +1,416 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-require-imports */
+/**
+ * Empirical probe for the Grok Build CLI (xAI).
+ *
+ * Validates every claim the Kangentic Grok adapter makes about the binary,
+ * with verbatim CLI evidence. Output is both human-readable and
+ * machine-parseable (a final verdict block). Re-runnable; safe to abort
+ * with Ctrl+C at any step. First validated against grok 1.0.0 (3cd0d0cbce)
+ * on Windows.
+ *
+ * What it checks
+ * --------------
+ *   1. Detection           - is `grok` on PATH? does the banner parse as
+ *                            `grok <version> ...`?
+ *   2. Headless new        - `grok -p --output-format json` returns a real
+ *                            sessionId, and total_cost_usd_ticks is exactly
+ *                            total_cost_usd * 1e10 (the tick unit the
+ *                            session-history parser depends on).
+ *   3. Session store       - the session lands at
+ *                            ~/.grok/sessions/<encodeURIComponent(cwd)>/<id>/
+ *                            with updates.jsonl + chat_history.jsonl +
+ *                            summary.json (the adapter's deterministic
+ *                            locate path).
+ *   4. Caller-owned id     - `-s <fresh uuid>` names the session dir with
+ *                            OUR uuid; re-using the same uuid errors
+ *                            (supportsCallerSessionId semantics).
+ *   5. Trust + hooks       - with the probe cwd seeded into
+ *                            ~/.grok/trusted_folders.toml (the same entry
+ *                            shape trust-manager.ts writes), project hooks
+ *                            in <cwd>/.grok/hooks/*.json fire in HEADLESS
+ *                            mode, the hook process inherits the spawn env
+ *                            (KANGENTIC_EVENTS_PATH), the stdin payload
+ *                            carries the camelCase fields the hook-manager
+ *                            extracts (toolName, toolUseId, toolInput,
+ *                            reason), and the REAL event-bridge.js resolves
+ *                            its `env:` sentinel and appends to the
+ *                            per-session events.jsonl.
+ *   6. Interactive (PTY)   - spawns the TUI via node-pty: first-output is
+ *                            the cursor-hide marker, a typed submit lands
+ *                            in chat_history.jsonl within the delivery
+ *                            budget (flush-on-submit), and `/quit` exits
+ *                            cleanly with the conversation dump the
+ *                            transcript cleanup anchors on.
+ *
+ * Auth
+ * ----
+ * Grok currently serves a free tier without login, so the probe usually
+ * needs no auth. If your account/region requires it, run `grok login`
+ * first. Each full run spends a few tiny single-turn prompts.
+ *
+ * Usage
+ * -----
+ *   node scripts/probe-grok.js
+ *   node scripts/probe-grok.js --skip-pty       # only headless probes
+ *   node scripts/probe-grok.js --keep-tmp       # leave tmp dir on disk
+ *
+ * Exit codes
+ * ----------
+ *   0   = all probes passed
+ *   10  = grok not installed / banner did not parse
+ *   30  = headless new failed (auth? network?)
+ *   35  = cost tick unit drifted from 1e-10 USD
+ *   40  = session store not at the expected encoded path
+ *   45  = caller-owned -s semantics drifted
+ *   50  = hooks did not fire / payload shape drifted / env not inherited
+ *   55  = event-bridge env: sentinel did not append
+ *   60  = interactive PTY probe failed (first output / flush / quit)
+ *   99  = unexpected error
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const childProcess = require('node:child_process');
+
+const args = process.argv.slice(2);
+const SKIP_PTY = args.includes('--skip-pty');
+const KEEP_TMP = args.includes('--keep-tmp');
+
+const verdicts = [];
+function verdict(name, pass, evidence) {
+  verdicts.push({ name, pass, evidence });
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name}${evidence ? `  (${evidence})` : ''}`);
+}
+
+function fail(code, message) {
+  console.error(`\nPROBE FAILED: ${message}`);
+  printVerdicts();
+  process.exit(code);
+}
+
+function printVerdicts() {
+  console.log('\n=== VERDICTS ===');
+  for (const entry of verdicts) {
+    console.log(JSON.stringify(entry));
+  }
+}
+
+function run(command, commandArgs, options = {}) {
+  const result = childProcess.spawnSync(command, commandArgs, {
+    encoding: 'utf-8',
+    timeout: options.timeoutMs ?? 120_000,
+    windowsHide: true,
+    cwd: options.cwd,
+    env: { ...process.env, ...(options.env ?? {}) },
+    shell: false,
+  });
+  return {
+    status: result.status,
+    stdout: (result.stdout ?? '').toString(),
+    stderr: (result.stderr ?? '').toString(),
+  };
+}
+
+function grokHome() {
+  return process.env.GROK_HOME && process.env.GROK_HOME.trim().length > 0
+    ? process.env.GROK_HOME
+    : path.join(os.homedir(), '.grok');
+}
+
+/** Locate the grok binary the way the adapter's detector does. */
+function findGrok() {
+  const candidates = process.platform === 'win32'
+    ? [path.join(os.homedir(), '.grok', 'bin', 'grok.exe')]
+    : [path.join(os.homedir(), '.grok', 'bin', 'grok'), '/usr/local/bin/grok', '/opt/homebrew/bin/grok'];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  // Fall back to PATH resolution via the shell's own lookup.
+  const probe = run(process.platform === 'win32' ? 'where.exe' : 'which', ['grok'], { timeoutMs: 5000 });
+  const first = probe.stdout.split(/\r?\n/).find((line) => line.trim().length > 0);
+  return first ? first.trim() : null;
+}
+
+const TRUST_MARKER = '# kangentic-probe-grok (removed automatically)';
+
+/** Seed a trust entry for `dir` the way trust-manager.ts does; returns an undo fn. */
+function seedTrust(dir) {
+  const storePath = path.join(grokHome(), 'trusted_folders.toml');
+  let existing = '';
+  try { existing = fs.readFileSync(storePath, 'utf-8'); } catch { /* fresh */ }
+  const separator = existing.length === 0 || existing.endsWith('\n') ? '' : '\n';
+  const table = `${TRUST_MARKER}\n[folders.'${dir}']\ntrusted = true\ndecided_at = ${Math.floor(Date.now() / 1000)}\n`;
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+  fs.appendFileSync(storePath, `${separator}\n${table}`);
+  return () => {
+    try {
+      const content = fs.readFileSync(storePath, 'utf-8');
+      const markerIndex = content.indexOf(TRUST_MARKER);
+      if (markerIndex === -1) return;
+      // Our block is marker + 3 lines, appended at the tail.
+      const lines = content.slice(markerIndex).split('\n');
+      const remainder = lines.slice(4).join('\n');
+      fs.writeFileSync(storePath, content.slice(0, markerIndex).replace(/\n+$/, '\n') + remainder);
+    } catch (error) {
+      console.warn('could not undo trust seed:', error.message);
+    }
+  };
+}
+
+async function main() {
+  console.log('=== Grok Build CLI probe ===\n');
+
+  // ---- 1. Detection ----
+  const grokPath = findGrok();
+  if (!grokPath) fail(10, 'grok binary not found (install: https://github.com/xai-org/grok-build)');
+  const versionResult = run(grokPath, ['--version'], { timeoutMs: 10_000 });
+  const banner = (versionResult.stdout.trim() || versionResult.stderr.trim());
+  const versionMatch = banner.match(/^grok\s+(\d[\w.+-]*)/i);
+  verdict('detection: banner parses as grok', Boolean(versionMatch), banner);
+  if (!versionMatch) fail(10, `unexpected --version banner: ${banner}`);
+
+  // ---- Probe workspace ----
+  // A git repo, because grok discovers the project root (where `.grok/hooks`
+  // and `.grok/config.toml` load from) by walking up to the first `.git` -
+  // and every Kangentic spawn cwd (project root or worktree) is a git root.
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-probe-'));
+  run('git', ['init', '--quiet'], { cwd: tmpDir, timeoutMs: 15_000 });
+  console.log(`probe cwd: ${tmpDir}`);
+  const cleanupFns = [];
+  const cleanup = () => {
+    for (const fn of cleanupFns.reverse()) {
+      try { fn(); } catch { /* best effort */ }
+    }
+    if (!KEEP_TMP) {
+      try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* locked */ }
+    }
+    // Session dirs created under the user's real grok home for this tmp cwd.
+    if (!KEEP_TMP) {
+      try {
+        fs.rmSync(path.join(grokHome(), 'sessions', encodeURIComponent(tmpDir)), { recursive: true, force: true });
+      } catch { /* best effort */ }
+    }
+  };
+
+  try {
+    // ---- 2. Headless new + cost tick unit ----
+    const headless = run(grokPath, ['-p', 'Reply with exactly: OK', '--output-format', 'json'], { cwd: tmpDir });
+    let headlessJson = null;
+    try { headlessJson = JSON.parse(headless.stdout); } catch { /* handled below */ }
+    verdict('headless: -p returns JSON with sessionId', Boolean(headlessJson && headlessJson.sessionId),
+      headlessJson ? `sessionId=${headlessJson.sessionId}` : `exit=${headless.status} stderr=${headless.stderr.slice(0, 200)}`);
+    if (!headlessJson || !headlessJson.sessionId) fail(30, 'headless run failed - check auth (grok login) and network');
+
+    const ticks = headlessJson.total_cost_usd_ticks;
+    const usd = headlessJson.total_cost_usd;
+    const ticksMatch = typeof ticks === 'number' && typeof usd === 'number'
+      && Math.abs(ticks * 1e-10 - usd) < 1e-9;
+    verdict('cost: ticks are 1e-10 USD', ticksMatch, `ticks=${ticks} usd=${usd}`);
+    if (!ticksMatch) fail(35, 'total_cost_usd_ticks no longer equals total_cost_usd * 1e10 - update session-history-parser.ts');
+
+    // ---- 3. Session store keying ----
+    const sessionDir = path.join(grokHome(), 'sessions', encodeURIComponent(tmpDir), headlessJson.sessionId);
+    const storeFiles = ['updates.jsonl', 'chat_history.jsonl', 'summary.json'];
+    const missing = storeFiles.filter((name) => !fs.existsSync(path.join(sessionDir, name)));
+    verdict('store: encodeURIComponent(cwd)/<id>/ layout', missing.length === 0,
+      missing.length === 0 ? sessionDir : `missing ${missing.join(', ')} under ${sessionDir}`);
+    if (missing.length > 0) fail(40, 'session store not at the deterministic path session-paths.ts computes');
+
+    // ---- 4. Caller-owned -s semantics ----
+    const callerUuid = crypto.randomUUID();
+    const named = run(grokPath, ['-p', 'Reply with exactly: OK', '-s', callerUuid, '--output-format', 'json'], { cwd: tmpDir });
+    const namedDirExists = fs.existsSync(path.join(grokHome(), 'sessions', encodeURIComponent(tmpDir), callerUuid));
+    verdict('sessions: -s names a NEW session with our uuid', namedDirExists, callerUuid);
+    const duplicate = run(grokPath, ['-p', 'noop', '-s', callerUuid, '--output-format', 'json'], { cwd: tmpDir, timeoutMs: 30_000 });
+    const duplicateRejected = duplicate.status !== 0;
+    verdict('sessions: re-using an existing uuid with -s errors', duplicateRejected,
+      `exit=${duplicate.status} stderr=${(duplicate.stderr || duplicate.stdout).slice(0, 160).replace(/\s+/g, ' ')}`);
+    if (!namedDirExists || !duplicateRejected) fail(45, 'caller-owned session-id semantics drifted - revisit supportsCallerSessionId');
+
+    // ---- 5. Trust + hooks + env inheritance + event-bridge sentinel ----
+    const dumpPath = path.join(tmpDir, 'hook-dump.jsonl');
+    const dumpScript = path.join(tmpDir, 'hook-dump.js');
+    fs.writeFileSync(dumpScript, [
+      "const fs = require('fs');",
+      "let input = '';",
+      "process.stdin.setEncoding('utf8');",
+      "process.stdin.on('data', (chunk) => { input += chunk; });",
+      "process.stdin.on('end', () => {",
+      '  let stdin = null;',
+      '  try { stdin = JSON.parse(input); } catch { stdin = null; }',
+      '  const record = { env: { KANGENTIC_EVENTS_PATH: process.env.KANGENTIC_EVENTS_PATH || null }, stdin };',
+      `  fs.appendFileSync(${JSON.stringify(dumpPath)}, JSON.stringify(record) + '\\n');`,
+      '});',
+    ].join('\n'));
+
+    const eventBridge = path.join(__dirname, '..', 'src', 'main', 'agent', 'event-bridge.js');
+    const eventsPath = path.join(tmpDir, 'events.jsonl');
+    const toForward = (value) => value.replace(/\\/g, '/');
+    const hooksDir = path.join(tmpDir, '.grok', 'hooks');
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'kangentic-probe.json'), JSON.stringify({
+      hooks: {
+        PreToolUse: [{ hooks: [{ type: 'command', command: `node "${toForward(dumpScript)}"` }] }],
+        Stop: [{ hooks: [
+          { type: 'command', command: `node "${toForward(dumpScript)}"` },
+          { type: 'command', command: `node "${toForward(eventBridge)}" "env:KANGENTIC_EVENTS_PATH" idle` },
+        ] }],
+      },
+    }, null, 2));
+
+    // Project hooks are trust-gated; seed the same entry trust-manager.ts writes.
+    cleanupFns.push(seedTrust(tmpDir));
+
+    fs.writeFileSync(path.join(tmpDir, 'hello.txt'), 'Hello from the probe.\n');
+    const hookRun = run(grokPath, ['-p', 'Use your file reading tool to read hello.txt and reply with its contents.', '--output-format', 'plain'], {
+      cwd: tmpDir,
+      env: { KANGENTIC_EVENTS_PATH: eventsPath },
+    });
+    if (hookRun.status !== 0) {
+      console.warn(`hook run exited ${hookRun.status}: ${(hookRun.stderr || hookRun.stdout).slice(0, 200)}`);
+    }
+
+    let dumpRecords = [];
+    try {
+      dumpRecords = fs.readFileSync(dumpPath, 'utf-8').split('\n').filter(Boolean).map((line) => JSON.parse(line));
+    } catch { /* handled below */ }
+    const preToolRecord = dumpRecords.find((record) => record.stdin && record.stdin.hookEventName === 'pre_tool_use');
+    const stopRecord = dumpRecords.find((record) => record.stdin && record.stdin.hookEventName === 'stop');
+    verdict('hooks: project hooks fire under seeded trust (headless included)', dumpRecords.length > 0, `${dumpRecords.length} records`);
+    verdict('hooks: payload carries camelCase toolName/toolUseId/toolInput',
+      Boolean(preToolRecord && preToolRecord.stdin.toolName && preToolRecord.stdin.toolUseId && preToolRecord.stdin.toolInput),
+      preToolRecord ? `toolName=${preToolRecord.stdin.toolName}` : 'no pre_tool_use record');
+    verdict('hooks: Stop payload carries reason', Boolean(stopRecord && stopRecord.stdin.reason),
+      stopRecord ? `reason=${stopRecord.stdin.reason}` : 'no stop record');
+    verdict('hooks: process inherits the spawn env', Boolean(dumpRecords[0] && dumpRecords[0].env.KANGENTIC_EVENTS_PATH === eventsPath));
+    if (dumpRecords.length === 0 || !preToolRecord) {
+      fail(50, 'hooks did not fire or the payload shape drifted - re-verify hook-manager.ts field names');
+    }
+
+    let bridgeLines = [];
+    try {
+      bridgeLines = fs.readFileSync(eventsPath, 'utf-8').split('\n').filter(Boolean).map((line) => JSON.parse(line));
+    } catch { /* handled below */ }
+    const idleLanded = bridgeLines.some((event) => event.type === 'idle');
+    verdict('event-bridge: env: sentinel resolves and appends', idleLanded, `${bridgeLines.length} events`);
+    if (!idleLanded) fail(55, 'event-bridge env:KANGENTIC_EVENTS_PATH sentinel did not append - check event-bridge.js');
+
+    // ---- 6. Interactive PTY probe ----
+    if (!SKIP_PTY) {
+      await ptyProbe(grokPath, tmpDir);
+    } else {
+      console.log('skipping PTY probe (--skip-pty)');
+    }
+
+    printVerdicts();
+    const allPassed = verdicts.every((entry) => entry.pass);
+    console.log(allPassed ? '\nALL PROBES PASSED' : '\nSOME PROBES FAILED');
+    process.exit(allPassed ? 0 : 99);
+  } finally {
+    cleanup();
+  }
+}
+
+/** Interactive TUI probe: first-output marker, submit flush latency, /quit. */
+function ptyProbe(grokPath, baseDir) {
+  return new Promise((resolve) => {
+    let pty;
+    try {
+      pty = require(path.join(__dirname, '..', 'node_modules', 'node-pty'));
+    } catch {
+      console.warn('node-pty not available (run npm install); skipping PTY probe');
+      resolve();
+      return;
+    }
+
+    const cwd = fs.mkdtempSync(path.join(baseDir, 'pty-'));
+    const sessionsRoot = path.join(grokHome(), 'sessions', encodeURIComponent(cwd));
+    const MARKER = 'PONG';
+    const chunks = [];
+    let sentAt = 0;
+    let chatFlushMs = null;
+    let turnDone = false;
+    let exitCode = null;
+
+    const proc = pty.spawn(grokPath, [], {
+      name: 'xterm-256color', cols: 110, rows: 32, cwd, env: process.env,
+    });
+    proc.onData((data) => chunks.push(data));
+    proc.onExit(({ exitCode: code }) => { exitCode = code; });
+
+    const poll = setInterval(() => {
+      if (!sentAt) return;
+      let sessionDirs = [];
+      try { sessionDirs = fs.readdirSync(sessionsRoot); } catch { return; }
+      for (const dir of sessionDirs) {
+        if (chatFlushMs === null) {
+          try {
+            const content = fs.readFileSync(path.join(sessionsRoot, dir, 'chat_history.jsonl'), 'utf-8');
+            for (const line of content.split('\n')) {
+              if (!line) continue;
+              try {
+                const record = JSON.parse(line);
+                if (record.type === 'user' && !record.synthetic_reason && JSON.stringify(record.content).includes(MARKER)) {
+                  chatFlushMs = Date.now() - sentAt;
+                }
+              } catch { /* partial line */ }
+            }
+          } catch { /* not yet */ }
+        }
+        if (!turnDone) {
+          try {
+            if (fs.readFileSync(path.join(sessionsRoot, dir, 'updates.jsonl'), 'utf-8').includes('"turn_completed"')) {
+              turnDone = true;
+            }
+          } catch { /* not yet */ }
+        }
+      }
+    }, 25);
+
+    setTimeout(() => {
+      proc.write(`Reply with exactly: ${MARKER}`);
+      setTimeout(() => { sentAt = Date.now(); proc.write('\r'); }, 500);
+    }, 4000);
+
+    const quitCheck = setInterval(() => {
+      if (turnDone) {
+        clearInterval(quitCheck);
+        setTimeout(() => { proc.write('/quit'); setTimeout(() => proc.write('\r'), 400); }, 1500);
+        setTimeout(finish, 8000);
+      }
+    }, 500);
+    const hardStop = setTimeout(() => { try { proc.kill(); } catch { /* gone */ } finish(); }, 90_000);
+
+    let finished = false;
+    function finish() {
+      if (finished) return;
+      finished = true;
+      clearInterval(poll);
+      clearInterval(quitCheck);
+      clearTimeout(hardStop);
+      try { proc.kill(); } catch { /* gone */ }
+
+      const all = chunks.join('');
+      verdict('pty: first output hides the cursor (ESC[?25l)', all.includes('[?25l'));
+      verdict('pty: typed submit flushes to chat_history within 2s',
+        chatFlushMs !== null && chatFlushMs < 2000,
+        chatFlushMs === null ? 'never flushed' : `${chatFlushMs}ms`);
+      verdict('pty: /quit exits cleanly', exitCode === 0, `exit=${exitCode}`);
+      verdict('pty: exit dump carries the conversation + resume hint',
+        all.includes('Resume this session with:'),
+        undefined);
+      if (!KEEP_TMP) {
+        try { fs.rmSync(sessionsRoot, { recursive: true, force: true }); } catch { /* best effort */ }
+      }
+      resolve();
+    }
+  });
+}
+
+main().catch((error) => {
+  console.error(error);
+  fail(99, error.message);
+});

--- a/src/main/agent/adapters/grok/capability-discovery.ts
+++ b/src/main/agent/adapters/grok/capability-discovery.ts
@@ -1,0 +1,146 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { exec, execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { grokHomeDir } from './session-paths';
+import type { AgentCapabilities } from '../../../../shared/types';
+
+const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+const HELP_TIMEOUT_MS = 5000;
+
+/**
+ * Grok Build capability discovery.
+ *
+ * Primary source: `~/.grok/models_cache.json`, the CLI's own cache of its
+ * `/v1/models` endpoint (written and refreshed by grok itself - the same
+ * source its in-TUI `/model` picker uses). Verified shape (grok 1.0.0):
+ *
+ *   { "models": { "<id>": { "info": {
+ *       "id", "name",                       // id + friendly display name
+ *       "context_window",                    // e.g. 500000
+ *       "supports_reasoning_effort",
+ *       "reasoning_efforts": [{"id": "xhigh"|"high"|"medium"|"low", ...}],
+ *       "hidden": bool } } } }
+ *
+ * Fallback when the cache is absent (fresh install, never launched):
+ * `grok --help` documents `-m/--model` and `--reasoning-effort`, so model
+ * override is reported as supported with a free-form input and the
+ * documented effort ladder is confirmed from the help text.
+ *
+ * Best-effort throughout: never throws, returns an empty object on total
+ * failure. `forceRefresh` bypasses the in-module memo (the underlying
+ * cache file is grok's own; Kangentic never refetches the model list
+ * itself - cli-features-over-custom-layers).
+ */
+let discoveryMemo: AgentCapabilities | null = null;
+
+export async function discoverGrokCapabilities(
+  cliPath: string,
+  forceRefresh?: boolean,
+): Promise<AgentCapabilities> {
+  if (discoveryMemo && !forceRefresh) return discoveryMemo;
+
+  const fromCache = readModelsCache();
+  if (fromCache) {
+    discoveryMemo = fromCache;
+    return fromCache;
+  }
+
+  const fromHelp = await readHelpCapabilities(cliPath);
+  discoveryMemo = fromHelp;
+  return fromHelp;
+}
+
+/** Test hook: reset the discovery memo. */
+export function clearGrokCapabilityMemo(): void {
+  discoveryMemo = null;
+}
+
+function readModelsCache(): AgentCapabilities | null {
+  const cachePath = path.join(grokHomeDir(), 'models_cache.json');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || !isRecord(parsed.models)) return null;
+
+  const models: string[] = [];
+  const modelDisplayNames: Record<string, string> = {};
+  const effortSet = new Set<string>();
+
+  for (const [modelId, entry] of Object.entries(parsed.models)) {
+    if (!isRecord(entry) || !isRecord(entry.info)) continue;
+    const info = entry.info;
+    if (info.hidden === true) continue;
+    models.push(modelId);
+    if (typeof info.name === 'string' && info.name.length > 0) {
+      modelDisplayNames[modelId] = info.name;
+    }
+    if (Array.isArray(info.reasoning_efforts)) {
+      for (const effort of info.reasoning_efforts) {
+        if (isRecord(effort) && typeof effort.id === 'string' && effort.id.length > 0) {
+          effortSet.add(effort.id);
+        }
+      }
+    }
+  }
+
+  if (models.length === 0) return null;
+  models.sort();
+
+  return {
+    supportsModelOverride: true,
+    models,
+    modelDisplayNames: Object.keys(modelDisplayNames).length > 0 ? modelDisplayNames : undefined,
+    effortLevels: orderEffortLevels(effortSet),
+  };
+}
+
+async function readHelpCapabilities(cliPath: string): Promise<AgentCapabilities> {
+  let helpText = '';
+  try {
+    if (process.platform === 'win32') {
+      const { stdout } = await execAsync(`"${cliPath}" --help`, {
+        timeout: HELP_TIMEOUT_MS,
+        windowsHide: true,
+        maxBuffer: 1024 * 1024,
+      });
+      helpText = stdout;
+    } else {
+      const { stdout } = await execFileAsync(cliPath, ['--help'], {
+        timeout: HELP_TIMEOUT_MS,
+        maxBuffer: 1024 * 1024,
+      });
+      helpText = stdout;
+    }
+  } catch {
+    return {};
+  }
+
+  const supportsModelOverride = /--model\s+<|-m,\s*--model/.test(helpText);
+  const supportsEffort = /--reasoning-effort\s+<|--effort/.test(helpText);
+  return {
+    supportsModelOverride,
+    // The documented ladder (17-sessions.md / `/effort`): low..xhigh. Only
+    // reported when the flag is present in this build's help.
+    effortLevels: supportsEffort ? ['low', 'medium', 'high', 'xhigh'] : [],
+  };
+}
+
+/** Stable low-to-high ordering for the effort dropdown. */
+function orderEffortLevels(effortSet: Set<string>): string[] {
+  const canonical = ['low', 'medium', 'high', 'xhigh'];
+  const ordered = canonical.filter((level) => effortSet.has(level));
+  for (const level of effortSet) {
+    if (!ordered.includes(level)) ordered.push(level);
+  }
+  return ordered;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/main/agent/adapters/grok/command-builder.ts
+++ b/src/main/agent/adapters/grok/command-builder.ts
@@ -1,0 +1,195 @@
+import { quoteArg, isUnixLikeShell } from '../../../../shared/paths';
+import { interpolateTemplate } from '../../shared/template-utils';
+import { writeHooksFile, KANGENTIC_EVENTS_PATH_ENV } from './hook-manager';
+import { writeMcpConfig, KANGENTIC_MCP_URL_ENV, KANGENTIC_MCP_TOKEN_ENV } from './mcp-config';
+import type { PermissionMode } from '../../../../shared/types';
+
+/**
+ * Grok Build CLI command builder.
+ *
+ * Empirically validated against grok 1.0.0 (3cd0d0cbce) via `grok --help`
+ * and the shipped user guide:
+ *
+ *   New session:    grok -s <uuid> --permission-mode <mode> [-m <model>]
+ *                        [--reasoning-effort <effort>] -- "<prompt>"
+ *   Resume session: grok --resume <uuid> --permission-mode <mode> [...]
+ *   Headless:       grok -p "<prompt>" --output-format plain [...]
+ *
+ * Design notes:
+ * - `-s/--session-id <uuid>` names a NEW session only (errors if the UUID
+ *   already exists); `--resume <uuid>` resumes an existing one. Identical
+ *   semantics to Claude's flags, so `supportsCallerSessionId = true` and
+ *   the spawn pipeline pre-generates the UUID.
+ * - `--permission-mode` accepts the exact PermissionMode vocabulary
+ *   Kangentic uses (`default | plan | acceptEdits | auto | dontAsk |
+ *   bypassPermissions`, verified in `grok --help`), so modes pass through
+ *   1:1 with no mapping table. (Internally grok normalizes
+ *   `acceptEdits`/`dontAsk` onto its own ladder - documented in
+ *   10-hooks.md - but the CLI accepts all six as compat values.)
+ * - NO `--cwd` flag is emitted. Grok keys its on-disk session store by the
+ *   process working directory, URL-encoded byte-for-byte
+ *   (`~/.grok/sessions/<encodeURIComponent(cwd)>/`), and the PTY already
+ *   spawns in `options.cwd`. Passing a normalized/forward-slashed `--cwd`
+ *   would risk keying the store under a DIFFERENT encoding than
+ *   `session-paths.ts` computes, silently breaking locate/telemetry.
+ * - NO screen-mode flags (`--fullscreen` / `--minimal` / `--no-alt-screen`)
+ *   and no `--always-approve`: session-scoped native TUI controls the user
+ *   owns (cli-features-over-custom-layers.md). The PTY probe shows grok
+ *   picks the fullscreen alt-screen TUI on its own in an embedded terminal.
+ * - The prompt is deliberately NOT re-sent on resume: the resumed
+ *   conversation already contains it (Claude/Codex convention).
+ *
+ * Side effects (mirroring Droid's builder): wires the per-cwd hook file and
+ * MCP config block before emitting the command - see hook-manager.ts and
+ * mcp-config.ts for why both files are static and env-routed.
+ */
+export interface GrokCommandOptions {
+  grokPath: string;
+  taskId: string;
+  prompt?: string;
+  cwd: string;
+  permissionMode: PermissionMode;
+  projectRoot?: string;
+  sessionId?: string;
+  resume?: boolean;
+  nonInteractive?: boolean;
+  /** Accepted for parity; grok has no statusline, so no status.json is wired. */
+  statusOutputPath?: string;
+  /** Per-session events.jsonl path, delivered to hooks via the PTY env. */
+  eventsOutputPath?: string;
+  shell?: string;
+  /**
+   * Whether to attach Kangentic's in-process MCP HTTP server. Default-on
+   * (matching Claude, Codex, and Droid): only an explicit `false`
+   * suppresses it.
+   */
+  mcpServerEnabled?: boolean;
+  /** Streamable-HTTP endpoint carrying the caller-session id. Delivered via env, never argv or file. */
+  mcpServerUrl?: string;
+  /** Per-launch MCP token. Delivered via env, never argv or file. */
+  mcpServerToken?: string;
+  model?: string;
+  effort?: string;
+}
+
+/**
+ * Single gate shared by the MCP config write and `buildGrokEnv`, so the
+ * file block and the env values it dereferences can never drift (the
+ * pattern `buildenv-adapter-interface-guard.test.ts` enforces across
+ * adapters). Default-on (`!== false`), matching Claude/Codex/Droid.
+ */
+export function grokMcpWiringEnabled(
+  options: GrokCommandOptions,
+): options is GrokCommandOptions & { mcpServerUrl: string; mcpServerToken: string } {
+  return (
+    options.mcpServerEnabled !== false
+    && Boolean(options.mcpServerUrl)
+    && Boolean(options.mcpServerToken)
+  );
+}
+
+export class GrokCommandBuilder {
+  buildGrokCommand(options: GrokCommandOptions): string {
+    const { shell } = options;
+
+    // Wire the per-cwd hook file (static, env-routed) whenever this spawn
+    // participates in the events pipeline, and the MCP config block
+    // whenever the server is attached. Both are idempotent rewrites.
+    if (options.eventsOutputPath) {
+      writeHooksFile(options.cwd);
+    }
+    if (grokMcpWiringEnabled(options)) {
+      writeMcpConfig(options.cwd);
+    }
+
+    const parts: string[] = [quoteArg(options.grokPath, shell)];
+    const isResume = Boolean(options.resume && options.sessionId);
+
+    if (isResume) {
+      parts.push('--resume', quoteArg(options.sessionId!, shell));
+    } else if (options.sessionId) {
+      parts.push('-s', quoteArg(options.sessionId, shell));
+    }
+
+    parts.push('--permission-mode', options.permissionMode);
+
+    // Pre-approve Kangentic's own MCP tools so a board-driven session never
+    // stalls on grok's interactive approval prompt for them (verified live:
+    // without this, `kangentic__kangentic_get_current_task` sat on the
+    // permission dialog with nobody present to answer). `--allow` with the
+    // documented `MCPTool(<server>__<tool>)` rule shape is grok's native
+    // permission-rules mechanism; an explicit user deny still wins (deny
+    // rules override allow rules). This is the Claude-parity move: Claude's
+    // builder injects the `mcp__kangentic` allow rule into its per-session
+    // settings for the same reason. Session-scoped (argv only), gated on
+    // the same predicate as the MCP wiring so it never fires when the
+    // server is not attached.
+    if (grokMcpWiringEnabled(options)) {
+      parts.push('--allow', quoteArg('MCPTool(kangentic__*)', shell));
+    }
+
+    if (options.model && options.model.trim().length > 0) {
+      parts.push('--model', quoteArg(options.model.trim(), shell));
+    }
+    if (options.effort && options.effort.trim().length > 0) {
+      parts.push('--reasoning-effort', quoteArg(options.effort.trim(), shell));
+    }
+
+    if (options.nonInteractive && !isResume && options.prompt) {
+      // Headless single-turn: prints the response and exits.
+      parts.push('-p', this.quotePrompt(options.prompt, shell), '--output-format', 'plain');
+      return parts.join(' ');
+    }
+
+    if (!isResume && options.prompt) {
+      // `--` (end-of-options) prevents prompt content like `--flag` from
+      // being parsed as a CLI option regardless of shell quoting behavior.
+      parts.push('--', this.quotePrompt(options.prompt, shell));
+    }
+
+    return parts.join(' ');
+  }
+
+  /**
+   * Environment injected into the grok PTY. Three per-session values ride
+   * here so that the two on-disk files stay static and shareable:
+   *
+   * - `KANGENTIC_EVENTS_PATH`: resolved by event-bridge.js's `env:` sentinel
+   *   in the hook commands, routing each session's hook events to its own
+   *   `events.jsonl` (and making the hooks a silent no-op in the user's own
+   *   grok sessions, which lack the variable).
+   * - `KANGENTIC_MCP_URL` / `KANGENTIC_MCP_TOKEN`: dereferenced by grok's
+   *   documented `${VAR}` expansion inside the `[mcp_servers.kangentic]`
+   *   block. The URL carries the caller-session id and the token rotates
+   *   per launch, so neither may be written to disk or argv.
+   */
+  buildGrokEnv(options: GrokCommandOptions): Record<string, string> | null {
+    const env: Record<string, string> = {};
+    if (options.eventsOutputPath) {
+      env[KANGENTIC_EVENTS_PATH_ENV] = options.eventsOutputPath;
+    }
+    if (grokMcpWiringEnabled(options)) {
+      env[KANGENTIC_MCP_URL_ENV] = options.mcpServerUrl;
+      env[KANGENTIC_MCP_TOKEN_ENV] = options.mcpServerToken;
+    }
+    return Object.keys(env).length > 0 ? env : null;
+  }
+
+  interpolateTemplate(template: string, variables: Record<string, string>): string {
+    return interpolateTemplate(template, variables);
+  }
+
+  private quotePrompt(prompt: string, shell: string | undefined): string {
+    // For double-quoted shells (PowerShell, cmd), replace double quotes with
+    // single quotes to prevent quoting breakage: quoteArg wraps in "..." and
+    // escapes " as \" which PowerShell misinterprets. Single-quoted shells
+    // (bash, zsh, WSL) preserve double quotes literally - no replacement.
+    const needsDoubleQuoteReplacement = shell
+      ? !isUnixLikeShell(shell)
+      : process.platform === 'win32';
+    const safePrompt = needsDoubleQuoteReplacement
+      ? prompt.replace(/"/g, "'")
+      : prompt;
+    return quoteArg(safePrompt, shell, { multiline: true });
+  }
+}

--- a/src/main/agent/adapters/grok/command-injection-verifier.ts
+++ b/src/main/agent/adapters/grok/command-injection-verifier.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs';
+import {
+  createSubmittedTextSubmissionVerifier,
+  type UserTurnRecord,
+} from '../../shared/submitted-text-verifier';
+import { grokChatHistoryPath } from './session-paths';
+import { extractTextContent, unwrapUserQuery } from './transcript-parser';
+import type { SubmissionVerifier } from '../../../../shared/types';
+
+/**
+ * Command-injection verifier for Grok Build, scanning `chat_history.jsonl`.
+ *
+ * MEASURED (grok 1.0.0, interactive TUI via node-pty on Windows): the user
+ * turn is appended to `chat_history.jsonl` 313ms after Enter - a
+ * flush-on-SUBMIT write that landed well before the turn finished (2.1s),
+ * comfortably inside the ~2s delivery budget. `updates.jsonl` flushed the
+ * same turn only at 1.7s, which is why the verifier reads chat_history and
+ * not the chunked updates stream (whose `user_message_chunk` records can
+ * also split a long message and would never trim-equal the submitted
+ * text).
+ *
+ * Record shape: `{ type: 'user', content: {type:'text',text} | string,
+ * synthetic_reason? }`. Genuine typed turns carry NO `synthetic_reason` and
+ * wrap the text in `<user_query>` tags, which the extractor strips before
+ * the exact-match comparison. Records carry NO timestamps, so
+ * `timestampMs` is null - the shared scan then matches on text alone
+ * within the bounded tail instead of stopping at a `sentAt` watermark.
+ *
+ * TIER: CONFIRM-ONLY (`canEscalateOnVerificationFailure -> false` on the
+ * adapter). Two reasons, per the escalation contract in agent-adapter.ts:
+ * (1) escalation additionally requires this adapter's own verifier proven
+ * end to end in a running app (the mock-CLI recipe), which has not been
+ * run; (2) with no record timestamps, a byte-identical PRIOR submission in
+ * the same session could false-confirm - harmless for confirm-only (a
+ * skipped retry), disqualifying for a restart authorization.
+ */
+export function extractGrokUserTurn(line: string): UserTurnRecord | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return null;
+  const record = raw as Record<string, unknown>;
+  if (record.type !== 'user') return null;
+  if (typeof record.synthetic_reason === 'string' && record.synthetic_reason.length > 0) return null;
+
+  // Shared with parseGrokTranscript so both readers of chat_history.jsonl
+  // accept the same content shapes (string / {text} block / block array,
+  // including plain-string array items).
+  const text = extractTextContent(record.content);
+  if (text === null) return null;
+
+  return { timestampMs: null, text: unwrapUserQuery(text) };
+}
+
+/**
+ * Build the verifier. `resolvePath` is synchronous deterministic
+ * construction (caller-owned session UUID + cwd), which trivially satisfies
+ * the shared wrapper's sync-resolve requirement; existence is probed so the
+ * first few hundred milliseconds after spawn read as "not yet seen" rather
+ * than an error.
+ */
+export function createGrokCommandInjectionVerifier(): SubmissionVerifier {
+  return createSubmittedTextSubmissionVerifier({
+    resolvePath: (agentSessionId, cwd) => {
+      const filePath = grokChatHistoryPath(cwd, agentSessionId);
+      try {
+        return fs.existsSync(filePath) ? filePath : null;
+      } catch {
+        return null;
+      }
+    },
+    extractUserTurn: extractGrokUserTurn,
+  });
+}

--- a/src/main/agent/adapters/grok/detector.ts
+++ b/src/main/agent/adapters/grok/detector.ts
@@ -1,0 +1,52 @@
+import os from 'node:os';
+import path from 'node:path';
+import { AgentDetector } from '../../shared/agent-detector';
+import { standardUnixFallbackPaths } from '../../shared/fallback-paths';
+
+/**
+ * Grok Build CLI detector.
+ *
+ * Version banner (verified against grok 1.0.0 on Windows):
+ *   `grok 1.0.0 (3cd0d0cbce) [stable]`
+ *
+ * COLLISION HAZARD - read before touching `binaryName` or `parseVersion`:
+ * xAI's installer publishes BOTH `grok` and a generic `agent` shim, and
+ * Cursor also publishes `agent` (with `cursor-agent`). On Windows, Grok's
+ * `agent.exe` beats Cursor's `agent.cmd` in PATHEXT order, which once made
+ * Cursor undetectable on any machine with Grok installed (see
+ * `tests/unit/cursor-grok-binary-collision.test.ts`). Two invariants keep
+ * both directions safe:
+ *
+ *   1. This detector probes ONLY `grok` - never the shared `agent` shim.
+ *   2. `parseVersion` REQUIRES the `grok ` product prefix, so if a foreign
+ *      binary ever answers (Cursor's `Cursor Agent 1.0.0` / bare
+ *      `2026.04.29-c83a488`, Codex's `codex-cli 0.128.0`), it is rejected
+ *      and detection keeps looking instead of mis-identifying it.
+ *
+ * The official installer puts the binary at `~/.grok/bin/grok` (grok.exe on
+ * Windows) and adds it to PATH. The explicit home fallback covers the macOS
+ * Finder/Dock launch case (no login-shell PATH) and any Windows session
+ * where the PATH edit has not propagated; note `standardUnixFallbackPaths`
+ * returns [] on win32, so the Windows install path must be listed here.
+ */
+export class GrokDetector extends AgentDetector {
+  constructor() {
+    super({
+      binaryName: 'grok',
+      fallbackPaths: [
+        ...standardUnixFallbackPaths('grok'),
+        path.join(os.homedir(), '.grok', 'bin', process.platform === 'win32' ? 'grok.exe' : 'grok'),
+      ],
+      parseVersion: parseGrokVersion,
+    });
+  }
+}
+
+/**
+ * Extract the version from `grok --version` output, or null when the banner
+ * is not Grok's. `grok 1.0.0 (3cd0d0cbce) [stable]` -> `1.0.0`.
+ */
+export function parseGrokVersion(raw: string): string | null {
+  const match = raw.trim().match(/^grok\s+(\d[\w.+-]*)/i);
+  return match ? match[1] : null;
+}

--- a/src/main/agent/adapters/grok/grok-adapter.ts
+++ b/src/main/agent/adapters/grok/grok-adapter.ts
@@ -1,0 +1,342 @@
+import fs from 'node:fs';
+import { exec, execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { GrokDetector } from './detector';
+import { GrokCommandBuilder, grokMcpWiringEnabled } from './command-builder';
+import { removeHooksFile } from './hook-manager';
+import { removeMcpConfig } from './mcp-config';
+import { GrokStatusParser } from './status-parser';
+import { GrokSessionHistoryParser, grokModelDisplayName } from './session-history-parser';
+import { parseGrokTranscript, grokTranscriptUsage, grokTranscriptToolCounts } from './transcript-parser';
+import { createGrokCommandInjectionVerifier } from './command-injection-verifier';
+import { discoverGrokCapabilities } from './capability-discovery';
+import { ensureWorktreeTrust, removeWorktreeTrust } from './trust-manager';
+import { migrateGrokProjectData } from './project-relocation';
+import { grokUpdatesJsonlPath } from './session-paths';
+import { runCliPrintSummarize, buildSummarizePrompt } from '../../shared/auto-name';
+import type { AgentAdapter, AgentInfo, SpawnCommandOptions, SettingsChangeSpec, ParsedTranscript } from '../../agent-adapter';
+import type {
+  AgentPermissionEntry,
+  PermissionMode,
+  AdapterRuntimeStrategy,
+  SubmissionContextType,
+  SubmissionVerifier,
+  AgentCapabilities,
+  TranscriptUsage,
+  TranscriptToolCounts,
+} from '../../../../shared/types';
+import { ActivityDetection } from '../../../../shared/types';
+
+const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+/**
+ * Grok Build (xAI) adapter - the full Claude-class harness.
+ *
+ * Everything empirical in this adapter was verified against grok 1.0.0
+ * (3cd0d0cbce) on Windows: flags via `grok --help`, the session store and
+ * event formats from real on-disk sessions, hook delivery (all events,
+ * including headless mode) via a live probe, and the TUI's first-output /
+ * exit behavior via node-pty captures. Grok deliberately clones Claude
+ * Code's surface - Claude-compatible hooks (10-hooks.md), the same
+ * `--session-id` / `--resume` split, the same `--permission-mode`
+ * vocabulary - which is what makes full parity reachable. The one
+ * structural divergence: no statusline, so usage telemetry tails the
+ * native `updates.jsonl` (Codex pattern) instead of a status bridge.
+ */
+export class GrokAdapter implements AgentAdapter {
+  readonly name = 'grok';
+  readonly displayName = 'Grok Build';
+  readonly sessionType = 'grok_agent';
+  readonly supportsCallerSessionId = true;
+  /**
+   * `--permission-mode` accepts Kangentic's exact PermissionMode names
+   * (verified in `grok --help`), so all six pass through 1:1. Internally
+   * grok normalizes `acceptEdits`/`dontAsk` onto its own ladder
+   * (`default | auto | plan | bypassPermissions`, per 10-hooks.md), with
+   * `auto` as the nearest neighbor - the labels below describe grok's
+   * behavior, not Claude's.
+   */
+  readonly permissions: AgentPermissionEntry[] = [
+    { mode: 'plan', label: 'Plan Mode (read-only)' },
+    { mode: 'default', label: 'Default (ask for approval)' },
+    { mode: 'acceptEdits', label: 'Accept Edits' },
+    { mode: 'auto', label: 'Auto (model decides when to ask)' },
+    { mode: 'dontAsk', label: 'Never Ask (auto-deny)' },
+    { mode: 'bypassPermissions', label: 'Dangerous Full Access' },
+  ];
+  readonly defaultPermission: PermissionMode = 'acceptEdits';
+
+  private readonly detector = new GrokDetector();
+  private readonly commandBuilder = new GrokCommandBuilder();
+  // Set of taskIds currently relying on the per-cwd `.grok/` wiring
+  // (hooks file + MCP config block), keyed by cwd. Both files are static
+  // and idempotently rewritten on every spawn; the refcount only guards
+  // REMOVAL, so concurrent sessions in one cwd do not strip each other's
+  // wiring (the Droid mcpHolders pattern).
+  private readonly wiringHolders = new Map<string, Set<string>>();
+
+  async detect(overridePath?: string | null): Promise<AgentInfo> {
+    return this.detector.detect(overridePath);
+  }
+
+  invalidateDetectionCache(): void {
+    this.detector.invalidateCache();
+  }
+
+  /**
+   * Pre-approve folder trust for Kangentic worktrees so project hooks and
+   * the MCP block load without the user re-answering per task. Grok trust
+   * cascades from the project root, so this is a no-op in the common
+   * steady state; see trust-manager.ts for the full policy.
+   */
+  async ensureTrust(workingDirectory: string): Promise<void> {
+    await ensureWorktreeTrust(workingDirectory);
+  }
+
+  buildCommand(options: SpawnCommandOptions): string {
+    const { agentPath, ...rest } = options;
+    const grokOptions = { grokPath: agentPath, ...rest };
+    const command = this.commandBuilder.buildGrokCommand(grokOptions);
+    if (options.eventsOutputPath || grokMcpWiringEnabled(grokOptions)) {
+      this.retainWiring(options.cwd, options.taskId);
+    }
+    return command;
+  }
+
+  /**
+   * Per-session values delivered through the PTY environment so the two
+   * per-cwd files stay static: the events.jsonl path for the hook bridge's
+   * `env:` sentinel, and the MCP URL + token that grok's documented
+   * `${VAR}` expansion dereferences inside the config block. The token and
+   * the caller-session URL never touch argv or disk.
+   */
+  buildEnv(options: SpawnCommandOptions): Record<string, string> | null {
+    const { agentPath, ...rest } = options;
+    return this.commandBuilder.buildGrokEnv({ grokPath: agentPath, ...rest });
+  }
+
+  private retainWiring(directory: string, taskId: string): void {
+    let holders = this.wiringHolders.get(directory);
+    if (!holders) {
+      holders = new Set<string>();
+      this.wiringHolders.set(directory, holders);
+    }
+    holders.add(taskId);
+  }
+
+  interpolateTemplate(template: string, variables: Record<string, string>): string {
+    return this.commandBuilder.interpolateTemplate(template, variables);
+  }
+
+  /**
+   * Runtime strategy.
+   *
+   * - Activity: hooks are the primary source (verified live: grok fires the
+   *   full Claude-compatible event set, headless included), with the PTY
+   *   silence timer as fallback for the cases where project hooks silently
+   *   do not load (an undecided/untrusted project root). No `detectIdle`
+   *   regex: grok's TUI keeps its `❯` prompt visible during active work,
+   *   the same always-visible-prompt trap that made Codex's `›` oscillate.
+   * - statusFile: no statusline (`parseStatus` -> null); `parseEvent`
+   *   decodes the live hook-driven events.jsonl.
+   * - sessionHistory: tails `updates.jsonl` for usage telemetry (model,
+   *   running context total, cumulative cost) plus idempotent activity
+   *   hints as a hook backstop. It deliberately emits NO tool events -
+   *   hooks own those, and a second emitter would double-count
+   *   ToolStart/ToolEnd pairs in the engine.
+   * - sessionId: omitted entirely - the UUID is caller-owned (`-s` at
+   *   spawn), so there is nothing to capture.
+   */
+  readonly runtime: AdapterRuntimeStrategy = {
+    activity: ActivityDetection.hooksAndPty(),
+    statusFile: {
+      parseStatus: GrokStatusParser.parseStatus,
+      parseEvent: GrokStatusParser.parseEvent,
+      isFullRewrite: false,
+    },
+    sessionHistory: {
+      locate: GrokSessionHistoryParser.locate,
+      parse: GrokSessionHistoryParser.parse,
+      isFullRewrite: false,
+    },
+  };
+
+  removeHooks(directory: string, taskId?: string): void {
+    const holders = this.wiringHolders.get(directory);
+    if (holders && taskId) {
+      holders.delete(taskId);
+      if (holders.size > 0) {
+        // Another session in this cwd still needs the wiring.
+        return;
+      }
+      this.wiringHolders.delete(directory);
+    }
+    removeHooksFile(directory);
+    removeMcpConfig(directory);
+  }
+
+  clearSettingsCache(): void {
+    // No settings cache: the hook file and MCP block are static content
+    // rewritten on every spawn.
+  }
+
+  detectFirstOutput(data: string): boolean {
+    // Grok hides the cursor in its very first output chunk (verified via
+    // node-pty: ESC[?25l arrives before the alt-screen switch and the
+    // banner), the same signature Codex and Droid key on.
+    return data.includes('\x1b[?25l');
+  }
+
+  getExitSequence(): string[] {
+    // Ctrl+C interrupts in-flight work; `/quit` exits cleanly (verified:
+    // exit code 0) and prints the conversation dump that transcript
+    // cleanup anchors on. Session state is flushed continuously to
+    // updates.jsonl either way.
+    return ['\x03', '/quit\r'];
+  }
+
+  /**
+   * Strictly cwd-scoped fast existence probe (the Claude pattern). This
+   * MUST NOT reuse `GrokSessionHistoryParser.locate`: that attach-time
+   * locator polls up to ~60s and falls back to a cross-cwd sessions-root
+   * scan, and callers of this method depend on both properties being
+   * absent - `resume-id-reconcile` documents it as "a fast existence
+   * probe", and `resume-cwd-migration` uses it as the "already reachable
+   * from the NEW cwd?" gate, where a cross-cwd match on the OLD cwd's
+   * store would falsely skip the migration and `--resume` would start
+   * empty.
+   */
+  async locateSessionHistoryFile(agentSessionId: string, cwd: string): Promise<string | null> {
+    const expectedPath = grokUpdatesJsonlPath(cwd, agentSessionId);
+    try {
+      fs.accessSync(expectedPath);
+      return expectedPath;
+    } catch {
+      return null;
+    }
+  }
+
+  async parseTranscript(agentSessionId: string, cwd: string): Promise<ParsedTranscript> {
+    return parseGrokTranscript(agentSessionId, cwd);
+  }
+
+  /**
+   * Lifetime token totals from the last `turn_completed.usage` in
+   * `updates.jsonl` - session-cumulative by measurement, exactly what the
+   * lifetime rollup wants (see transcript-parser.ts).
+   */
+  async transcriptUsage(input: {
+    transcriptPath?: string | null;
+    agentSessionId?: string | null;
+    cwd?: string | null;
+  }): Promise<TranscriptUsage | null> {
+    if (!input.agentSessionId || !input.cwd) return null;
+    return grokTranscriptUsage(input.agentSessionId, input.cwd);
+  }
+
+  async transcriptToolCounts(input: {
+    transcriptPath?: string | null;
+    agentSessionId?: string | null;
+    cwd?: string | null;
+  }): Promise<TranscriptToolCounts | null> {
+    if (!input.agentSessionId || !input.cwd) return null;
+    return grokTranscriptToolCounts(input.agentSessionId, input.cwd);
+  }
+
+  getSubmissionVerifier(contextType: SubmissionContextType): SubmissionVerifier | null {
+    if (contextType === 'command-injection') {
+      // chat_history.jsonl flushes the user turn on SUBMIT - measured at
+      // 313ms against a 2.1s turn (see command-injection-verifier.ts).
+      return createGrokCommandInjectionVerifier();
+    }
+    // 'paste': the hook pipeline's activity backstop covers it, matching
+    // Claude's reasoning.
+    return null;
+  }
+
+  /**
+   * Slash input is handled in the TUI (a `/quit` opens the command palette
+   * and never becomes a conversation turn - observed in the PTY capture),
+   * so absence from chat_history cannot distinguish "rejected" from "ran
+   * client-side". Same verdict as Codex; slash auto_commands stay
+   * unverified rather than risking a destructive escalation.
+   */
+  canVerifySlashSubmission(): boolean {
+    return false;
+  }
+
+  /**
+   * CONFIRM-ONLY: the verifier confirms deliveries and drives
+   * retry-on-Enter, but never authorizes a session restart. Escalation
+   * needs the mock-CLI end-to-end proof (docs/command-injection.md), and
+   * grok's history records carry no timestamps to bound the match window -
+   * see command-injection-verifier.ts.
+   */
+  canEscalateOnVerificationFailure(): boolean {
+    return false;
+  }
+
+  async discoverCapabilities(cliPath: string, forceRefresh?: boolean): Promise<AgentCapabilities> {
+    return discoverGrokCapabilities(cliPath, forceRefresh);
+  }
+
+  /**
+   * Grok has native `/model <id> [effort]` and `/effort <level>` slash
+   * commands, but slash submissions are unverifiable here (see
+   * `canVerifySlashSubmission`) - an unconfirmed injection that lands in
+   * the prompt box as literal text would pollute the conversation. The
+   * suspend + respawn fallback applies `--model` / `--reasoning-effort`
+   * deterministically instead.
+   */
+  getInjectionSequence(_spec: SettingsChangeSpec): string[] {
+    return [];
+  }
+
+  configuredModelFromCommand(command: string): { id: string; displayName: string } | null {
+    const match = command.match(/--model\s+"?([^\s"]+)"?/);
+    if (!match) return null;
+    const id = match[1];
+    return { id, displayName: grokModelDisplayName(id) };
+  }
+
+  /**
+   * Auth probe via `grok models`, which prints "You are not authenticated."
+   * from local state (no network round-trip observed; the model list comes
+   * from grok's cache). Note grok currently serves a free tier without
+   * login, so `false` here means "not signed in", not "unusable".
+   */
+  async probeAuth(): Promise<boolean | null> {
+    const info = await this.detector.detect();
+    if (!info.found || !info.path) return null;
+    try {
+      const output = process.platform === 'win32'
+        ? (await execAsync(`"${info.path}" models`, { timeout: 5000, windowsHide: true })).stdout
+        : (await execFileAsync(info.path, ['models'], { timeout: 5000 })).stdout;
+      return !/not authenticated/i.test(output);
+    } catch {
+      return null;
+    }
+  }
+
+  /** One-shot title generation via the verified headless mode. */
+  async summarize(prompt: string, cliPath: string, cwd: string): Promise<string> {
+    return runCliPrintSummarize({
+      cliPath,
+      args: ['--output-format', 'plain', '-p'],
+      prompt: buildSummarizePrompt(prompt),
+      cwd,
+      promptVia: 'arg',
+    });
+  }
+
+  /** Drop the per-worktree trust entry when Kangentic deletes the worktree. */
+  async onWorktreeRemoved(worktreePath: string): Promise<void> {
+    await removeWorktreeTrust(worktreePath);
+  }
+
+  /** Rename the encoded per-cwd session store and rewrite trust paths. */
+  async onProjectRelocated(oldPath: string, newPath: string): Promise<void> {
+    await migrateGrokProjectData(oldPath, newPath);
+  }
+}

--- a/src/main/agent/adapters/grok/hook-manager.ts
+++ b/src/main/agent/adapters/grok/hook-manager.ts
@@ -1,0 +1,194 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { EventType } from '../../../../shared/types';
+import { toForwardSlash } from '../../../../shared/paths';
+import { buildBridgeCommand } from '../../shared/hook-utils';
+import { resolveBridgeScript } from '../../shared/bridge-utils';
+import { extractTool, extractToolId, extractDetail } from '../../shared/directive-builders';
+import { setTypeWhenDetailContains } from '../../shared/directive-builders';
+
+/**
+ * Grok Build hook wiring.
+ *
+ * Grok's hook system is deliberately Claude Code-compatible (same event
+ * names, same `{"hooks": {Event: [{matcher, hooks: [{type, command}]}]}}`
+ * JSON shape, verified against the user guide shipped with grok 1.0.0,
+ * 10-hooks.md), and it merges EVERY `*.json` file found in
+ * `<project>/.grok/hooks/`. That last property is what makes this manager
+ * far simpler than Claude's: Kangentic writes its own wholly-owned file,
+ * `<cwd>/.grok/hooks/kangentic.json`, and never reads, merges, or sweeps
+ * the user's hook files at all. Removal is deleting our file.
+ *
+ * PER-SESSION EVENTS ROUTING (the `env:` sentinel). Grok has no per-session
+ * settings flag (`--settings` equivalent), so the hook file is per-cwd and
+ * must serve every session spawned there. Instead of baking one session's
+ * `events.jsonl` path into the command (last-writer-wins corruption for
+ * concurrent same-cwd sessions, and the user's own manual `grok` runs in
+ * that cwd would write into a task's activity log), the command names the
+ * events path indirectly: `env:KANGENTIC_EVENTS_PATH`. Hook processes
+ * inherit the grok process environment, and each Kangentic PTY spawn
+ * carries its own value via `buildEnv` - so one static file routes every
+ * session's events to that session's own log, and a session with no such
+ * env var (the user's own grok) makes the bridge exit as a silent no-op.
+ * See `event-bridge.js` for the sentinel resolution.
+ *
+ * TRUST: project-level hooks are gated by grok's folder-trust store
+ * (`~/.grok/trusted_folders.toml`), and trust CASCADES to subdirectories -
+ * verified live: a Kangentic worktree under a trusted project root reports
+ * `projectTrusted: true` in `grok inspect` with only the root in the store.
+ * An untrusted folder silently skips project hooks (fail-open), which the
+ * adapter's `hooksAndPty` activity strategy absorbs: the PTY silence timer
+ * carries activity until the user trusts the project once. See
+ * `trust-manager.ts` for the worktree pre-approval that keeps per-task
+ * worktrees from ever prompting.
+ *
+ * EVENT MAPPING NOTES (grok 1.0.0, shipped user guide):
+ * - Payloads are camelCase (`toolName`, `toolUseId`, `errorDetails`) where
+ *   Claude uses snake_case - the extraction directives below name grok's
+ *   fields.
+ * - `Stop` fires ONLY for the main agent and only on genuine completions
+ *   (interrupts skip it; API errors fire `StopFailure` instead), and a
+ *   subagent's turn end fires `SubagentStop` inside the subagent. This is
+ *   Claude's subagent-depth problem solved natively - no depth gating
+ *   needed.
+ * - An extra observe-only `Stop` fires at session end with
+ *   `reason: "channel_closed" | "shutdown"`; an Idle event then is
+ *   harmless (the session is terminating), so it is not filtered. The
+ *   reason is carried in `detail` for the activity log.
+ * - `StopFailure.error` uses Claude's vocabulary (`rate_limit`,
+ *   `server_error`, `authentication_failed`, `invalid_request`,
+ *   `max_output_tokens`, `unknown`; 503/529 capacity errors fold into
+ *   `rate_limit`). The transient classes remap to `turn_retrying` so the
+ *   engine holds the session thinking through a retry backoff instead of
+ *   false-idling it - mirroring Claude's StopFailure remaps.
+ * - Tool-scoped directives (`whenTool`, `setTypeWhen`) are deliberately
+ *   absent: the bridge's tool guard reads `ctx.tool_name` (Claude's field),
+ *   which grok payloads do not carry.
+ */
+
+/** The events-path sentinel the bridge resolves from the hook process env. */
+export const KANGENTIC_EVENTS_PATH_ENV = 'KANGENTIC_EVENTS_PATH';
+const EVENTS_PATH_SENTINEL = `env:${KANGENTIC_EVENTS_PATH_ENV}`;
+
+/** Grok hook event names (Claude-compatible, verified in 10-hooks.md). */
+const GrokHookEvent = {
+  PreToolUse: 'PreToolUse',
+  PostToolUse: 'PostToolUse',
+  PostToolUseFailure: 'PostToolUseFailure',
+  SessionStart: 'SessionStart',
+  SessionEnd: 'SessionEnd',
+  Stop: 'Stop',
+  StopFailure: 'StopFailure',
+  SubagentStart: 'SubagentStart',
+  SubagentStop: 'SubagentStop',
+  UserPromptSubmit: 'UserPromptSubmit',
+  PermissionDenied: 'PermissionDenied',
+  Notification: 'Notification',
+  PreCompact: 'PreCompact',
+} as const;
+
+interface GrokHookEntry {
+  matcher?: string;
+  hooks: Array<{ type: 'command'; command: string }>;
+}
+
+function commandEntry(command: string): GrokHookEntry {
+  return { hooks: [{ type: 'command', command }] };
+}
+
+/**
+ * Build the full Kangentic hook object for grok. Exported for tests; the
+ * production entry point is `writeHooksFile`.
+ */
+export function buildGrokHooks(eventBridge: string): Record<string, GrokHookEntry[]> {
+  const H = GrokHookEvent;
+  const E = EventType;
+  const bridge = (eventType: string, ...directives: string[]): string =>
+    buildBridgeCommand(eventBridge, EVENTS_PATH_SENTINEL, eventType, ...directives);
+
+  return {
+    [H.PreToolUse]: [commandEntry(bridge(E.ToolStart,
+      extractTool('toolName'),
+      extractToolId(['toolUseId']),
+      // Tool-specific context: grok's `toolInput` carries the tool's raw
+      // input (observed: `command` for run_terminal_command, `target_file`
+      // for read_file). First non-null wins.
+      extractDetail(['command', 'target_file', 'file_path', 'path', 'query', 'pattern', 'url', 'description'], { nested: 'toolInput' })))],
+    [H.PostToolUse]: [commandEntry(bridge(E.ToolEnd,
+      extractTool('toolName'),
+      extractToolId(['toolUseId'])))],
+    [H.PostToolUseFailure]: [commandEntry(bridge(E.ToolEnd,
+      extractTool('toolName'),
+      extractToolId(['toolUseId']),
+      extractDetail(['error', 'errorDetails'])))],
+    [H.UserPromptSubmit]: [commandEntry(bridge(E.Prompt))],
+    [H.Stop]: [commandEntry(bridge(E.Idle,
+      // `end_turn` for genuine completions; `channel_closed` / `shutdown`
+      // for the session-end observe fire. Carried for the activity log.
+      extractDetail(['reason'])))],
+    [H.StopFailure]: [commandEntry(bridge(E.TurnFailed,
+      extractDetail(['error', 'errorDetails']),
+      setTypeWhenDetailContains('rate_limit', E.TurnRetrying),
+      setTypeWhenDetailContains('server_error', E.TurnRetrying)))],
+    [H.SessionStart]: [commandEntry(bridge(E.SessionStart))],
+    [H.SessionEnd]: [commandEntry(bridge(E.SessionEnd))],
+    [H.SubagentStart]: [commandEntry(bridge(E.SubagentStart,
+      extractDetail(['subagentType', 'agentType'])))],
+    [H.SubagentStop]: [commandEntry(bridge(E.SubagentStop,
+      extractDetail(['subagentType', 'agentType'])))],
+    // Observation-only: a denied tool call and agent notifications are
+    // logged for the activity feed; neither changes activity state.
+    [H.PermissionDenied]: [commandEntry(bridge(E.Notification,
+      extractDetail(['toolName', 'message'])))],
+    [H.Notification]: [commandEntry(bridge(E.Notification,
+      extractDetail(['message', 'notification', 'text'])))],
+    [H.PreCompact]: [commandEntry(bridge(E.Compact))],
+  };
+}
+
+function hooksFilePath(directory: string): string {
+  return path.join(directory, '.grok', 'hooks', 'kangentic.json');
+}
+
+/**
+ * Write (or refresh) `<cwd>/.grok/hooks/kangentic.json`. Idempotent: the
+ * content is static per install (the only machine-varying piece is the
+ * bridge script's absolute path), so rewriting on every spawn also
+ * self-heals a stale path after an app update. Best-effort: a failure only
+ * costs hook-based activity, which `hooksAndPty` degrades around.
+ *
+ * Grok loads project hooks from the PROJECT ROOT it discovers by walking
+ * up from the session cwd to the first `.git` (probe-verified: hooks in a
+ * non-git directory never load). Every Kangentic spawn cwd is a git root
+ * (the project itself, or a worktree, which is its own git root), so
+ * writing at `cwd` IS writing at the discovered root.
+ */
+export function writeHooksFile(directory: string): void {
+  const filePath = hooksFilePath(directory);
+  try {
+    const eventBridge = toForwardSlash(resolveBridgeScript('event-bridge'));
+    const content = { hooks: buildGrokHooks(eventBridge) };
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(content, null, 2));
+  } catch (error) {
+    console.error(`[grok] Failed to write hooks file: ${filePath}`, error);
+  }
+}
+
+/**
+ * Delete Kangentic's hook file and prune the `.grok/hooks` / `.grok`
+ * directories when they end up empty (so a repo the user never configured
+ * grok in is left exactly as found). User hook files are never touched -
+ * Kangentic only ever owns `kangentic.json`.
+ */
+export function removeHooksFile(directory: string): void {
+  const filePath = hooksFilePath(directory);
+  try {
+    fs.rmSync(filePath, { force: true });
+    const hooksDir = path.dirname(filePath);
+    try { fs.rmdirSync(hooksDir); } catch { /* not empty or already gone */ }
+    try { fs.rmdirSync(path.dirname(hooksDir)); } catch { /* not empty or already gone */ }
+  } catch (error) {
+    console.error(`[grok] Failed to remove hooks file: ${filePath}`, error);
+  }
+}

--- a/src/main/agent/adapters/grok/index.ts
+++ b/src/main/agent/adapters/grok/index.ts
@@ -1,0 +1,6 @@
+export { GrokAdapter } from './grok-adapter';
+export { GrokDetector, parseGrokVersion } from './detector';
+export { GrokCommandBuilder, grokMcpWiringEnabled } from './command-builder';
+export { buildGrokHooks, writeHooksFile, removeHooksFile, KANGENTIC_EVENTS_PATH_ENV } from './hook-manager';
+export { writeMcpConfig, removeMcpConfig, KANGENTIC_MCP_URL_ENV, KANGENTIC_MCP_TOKEN_ENV } from './mcp-config';
+export { cleanGrokTranscript } from './transcript-cleanup';

--- a/src/main/agent/adapters/grok/mcp-config.ts
+++ b/src/main/agent/adapters/grok/mcp-config.ts
@@ -1,0 +1,123 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Kangentic MCP server wiring for Grok Build.
+ *
+ * Grok reads project-scoped MCP servers from `<cwd>/.grok/config.toml`
+ * (walked up to the git root; trust-gated by the folder-trust store, which
+ * a Kangentic worktree inherits from its trusted project root - see
+ * trust-manager.ts). There is no per-invocation config flag, so a file
+ * write is the delivery mechanism - the Droid `.factory/mcp.json`
+ * precedent.
+ *
+ * NO SECRET AND NO SESSION STATE EVER REACHES DISK. The shipped grok 1.0.0
+ * user guide (07-mcp-servers.md) documents that grok expands `${VAR}`
+ * references against the process environment in every string field of
+ * `[mcp_servers.*]` - `url`, `command`, `args`, and the values of `env` and
+ * `headers` - at load time, without rewriting the file. So the block below
+ * is fully STATIC: the per-session URL (which carries the caller-session
+ * id) and the per-launch token both arrive through the PTY environment via
+ * `buildEnv`. That also makes one file correct for CONCURRENT sessions in
+ * the same cwd - each grok process expands its own environment - which the
+ * Droid design (literal URL in the file, last-writer-wins) cannot do. A
+ * grok session without these env vars (the user's own manual run while a
+ * Kangentic session is live) merely shows a `kangentic` server that fails
+ * to connect; the block is removed when the last Kangentic session in the
+ * cwd releases it.
+ *
+ * `.grok/config.toml` is a USER-OWNED file that may carry their own
+ * project-scoped servers and settings, so edits are surgical: Kangentic
+ * only ever appends/removes its own sentinel-delimited block and never
+ * reserializes the user's TOML.
+ */
+
+export const KANGENTIC_MCP_URL_ENV = 'KANGENTIC_MCP_URL';
+export const KANGENTIC_MCP_TOKEN_ENV = 'KANGENTIC_MCP_TOKEN';
+export const KANGENTIC_MCP_TOKEN_HEADER = 'X-Kangentic-Token';
+
+const BLOCK_BEGIN = '# BEGIN KANGENTIC MANAGED BLOCK (written by Kangentic; removed automatically)';
+const BLOCK_END = '# END KANGENTIC MANAGED BLOCK';
+
+const MANAGED_BLOCK = [
+  BLOCK_BEGIN,
+  '[mcp_servers.kangentic]',
+  `url = "\${${KANGENTIC_MCP_URL_ENV}}"`,
+  `headers = { "${KANGENTIC_MCP_TOKEN_HEADER}" = "\${${KANGENTIC_MCP_TOKEN_ENV}}" }`,
+  BLOCK_END,
+  '',
+].join('\n');
+
+function configTomlPath(directory: string): string {
+  return path.join(directory, '.grok', 'config.toml');
+}
+
+/** Strip our sentinel-delimited block from the file content, if present. */
+function stripManagedBlock(content: string): string {
+  const beginIndex = content.indexOf(BLOCK_BEGIN);
+  if (beginIndex === -1) return content;
+  const endIndex = content.indexOf(BLOCK_END, beginIndex);
+  if (endIndex === -1) {
+    // A truncated block (crash mid-write). Drop from BEGIN to end of file -
+    // everything after our sentinel is ours by construction (we only ever
+    // append the block at the tail).
+    return content.slice(0, beginIndex);
+  }
+  const afterEnd = endIndex + BLOCK_END.length;
+  // Swallow the newline(s) that terminated our block.
+  const tail = content.slice(afterEnd).replace(/^\r?\n/, '');
+  return content.slice(0, beginIndex) + tail;
+}
+
+/**
+ * Ensure `<cwd>/.grok/config.toml` carries the Kangentic MCP block.
+ * Idempotent (any previous copy is replaced) and preserving: user content
+ * is untouched. Best-effort - a failure only costs MCP tools in the
+ * session, never the spawn.
+ */
+export function writeMcpConfig(directory: string): void {
+  const filePath = configTomlPath(directory);
+  try {
+    let existing = '';
+    try {
+      existing = fs.readFileSync(filePath, 'utf-8');
+    } catch {
+      // No existing config - start fresh.
+    }
+    const base = stripManagedBlock(existing);
+    const separator = base.length === 0 || base.endsWith('\n') ? '' : '\n';
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, `${base}${separator}${MANAGED_BLOCK}`);
+  } catch (error) {
+    console.error(`[grok] Failed to write MCP config: ${filePath}`, error);
+  }
+}
+
+/**
+ * Remove Kangentic's managed block, deleting the file when nothing else
+ * remains and pruning an empty `.grok/` directory - so a repo the user
+ * never configured grok in is left exactly as found.
+ */
+export function removeMcpConfig(directory: string): void {
+  const filePath = configTomlPath(directory);
+
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return;
+  }
+  if (!content.includes(BLOCK_BEGIN)) return;
+
+  const remaining = stripManagedBlock(content);
+  try {
+    if (remaining.trim().length === 0) {
+      fs.rmSync(filePath, { force: true });
+      try { fs.rmdirSync(path.dirname(filePath)); } catch { /* not empty or already gone */ }
+    } else {
+      fs.writeFileSync(filePath, remaining);
+    }
+  } catch (error) {
+    console.error(`[grok] Failed to clean up MCP config: ${filePath}`, error);
+  }
+}

--- a/src/main/agent/adapters/grok/project-relocation.ts
+++ b/src/main/agent/adapters/grok/project-relocation.ts
@@ -1,0 +1,88 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { collectRelocationPairs, renameOrMergeDirectory, atomicWriteFileWithBackup } from '../../shared/relocation-utils';
+import { grokHomeDir, cwdToSessionsDirName } from './session-paths';
+import { normalizeForCompare } from './trust-manager';
+
+/**
+ * Migrate Grok Build's per-project data when a Kangentic project (or a
+ * single task worktree) is relocated.
+ *
+ * Two path-keyed stores live OUTSIDE the project folder:
+ *
+ * 1. `~/.grok/sessions/<encodeURIComponent(cwd)>/` - the per-cwd session
+ *    store. Renaming the encoded directory keeps `--resume`, the telemetry
+ *    tail, and the transcript parser pointed at the moved data (the Droid
+ *    slug-rename precedent).
+ * 2. `~/.grok/trusted_folders.toml` - folder-trust entries keyed by the
+ *    absolute path. Header paths under the old location are rewritten so
+ *    the relocated project keeps its trust decision (the Codex
+ *    `[projects.'...']` precedent).
+ *
+ * Best-effort and non-destructive throughout: directories are renamed or
+ * merged (never deleted), the TOML rewrite goes through backup + rename,
+ * and every pair is guarded so a partial failure never blocks relocation.
+ */
+export async function migrateGrokProjectData(oldProjectPath: string, newProjectPath: string): Promise<void> {
+  const sessionsRoot = path.join(grokHomeDir(), 'sessions');
+  const pairs = collectRelocationPairs(oldProjectPath, newProjectPath);
+
+  for (const pair of pairs) {
+    try {
+      renameOrMergeDirectory(
+        path.join(sessionsRoot, cwdToSessionsDirName(pair.oldAbsolute)),
+        path.join(sessionsRoot, cwdToSessionsDirName(pair.newAbsolute)),
+      );
+    } catch (err) {
+      console.warn(`[GROK_RELOCATE] Failed to migrate sessions for ${pair.oldAbsolute}:`, err);
+    }
+  }
+
+  try {
+    rewriteTrustedFolderPaths(pairs);
+  } catch (err) {
+    console.warn('[GROK_RELOCATE] Failed to rewrite trusted_folders.toml:', err);
+  }
+}
+
+function rewriteTrustedFolderPaths(
+  pairs: Array<{ oldAbsolute: string; newAbsolute: string }>,
+): void {
+  const storePath = path.join(grokHomeDir(), 'trusted_folders.toml');
+  let content: string;
+  try {
+    content = fs.readFileSync(storePath, 'utf-8');
+  } catch {
+    return;
+  }
+
+  let changed = false;
+  const rewritten = content.split('\n').map((line) => {
+    // Accept BOTH TOML key quote styles, matching trust-manager.ts's
+    // parseHeaderLine - grok itself writes single-quoted literals, but a
+    // double-quoted entry is legal TOML and must not be silently left
+    // pointing at the old path.
+    const match = line.match(/^(\s*\[folders\.)(?:'([^']+)'|"([^"]+)")(\]\s*)$/);
+    if (!match) return line;
+    const headerPath = match[2] ?? match[3];
+    for (const pair of pairs) {
+      if (pathsEqual(headerPath, pair.oldAbsolute)) {
+        // A path containing a single quote cannot be a TOML literal key.
+        if (pair.newAbsolute.includes("'")) return line;
+        changed = true;
+        // Always rewrite as a single-quoted literal: the new path is
+        // emitted raw, and a basic (double-quoted) string would need
+        // backslash escaping on Windows paths.
+        return `${match[1]}'${path.resolve(pair.newAbsolute)}'${match[4]}`;
+      }
+    }
+    return line;
+  });
+
+  if (!changed) return;
+  atomicWriteFileWithBackup(storePath, rewritten.join('\n'), { logTag: '[GROK_RELOCATE]' });
+}
+
+function pathsEqual(a: string, b: string): boolean {
+  return normalizeForCompare(a) === normalizeForCompare(b);
+}

--- a/src/main/agent/adapters/grok/session-history-parser.ts
+++ b/src/main/agent/adapters/grok/session-history-parser.ts
@@ -1,0 +1,289 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  Activity,
+  type SessionHistoryParseResult,
+  type SessionUsage,
+} from '../../../../shared/types';
+import { grokHomeDir, locateGrokUpdatesFile } from './session-paths';
+
+/**
+ * Parser for Grok Build's native session history (`updates.jsonl`).
+ *
+ * File format (verified against grok 1.0.0 session files on disk):
+ * append-only JSONL of ACP JSON-RPC notifications:
+ *
+ *   {"timestamp":<unix-sec>,"method":"session/update"|"_x.ai/session/update",
+ *    "params":{"sessionId":"...","update":{"sessionUpdate":"<type>",...},
+ *              "_meta":{"totalTokens":N,"agentTimestampMs":...}}}
+ *
+ * Observed `sessionUpdate` types: `user_message_chunk`,
+ * `agent_message_chunk`, `agent_thought_chunk`, `tool_call`,
+ * `tool_call_update`, `turn_completed`, `retry_state`, `hook_execution`,
+ * `task_backgrounded`.
+ *
+ * WHAT THIS PARSER DELIBERATELY DOES NOT EMIT: SessionEvents. Grok's
+ * activity events flow through the hook pipeline (hook-manager.ts ->
+ * event-bridge -> events.jsonl), and the activity engine counts
+ * ToolStart/ToolEnd pairs - a second emitter for the same underlying tool
+ * calls would double-count starts and wedge the session at "thinking".
+ * This parser owns TELEMETRY (model, context occupancy, cost) plus
+ * idempotent ACTIVITY HINTS (`turn_completed` -> Idle, streaming chunks ->
+ * Thinking) that back up the hook pipeline if hooks fail to load (e.g. an
+ * untrusted folder silently skips project hooks).
+ *
+ * Token semantics (measured, and they differ by field - do not "simplify"):
+ * - `params._meta.totalTokens` on streaming/tool updates is the RUNNING
+ *   CONTEXT TOTAL (observed growing 49_869 -> 59_972 across one turn).
+ *   That is the context-occupancy number the ContextBar wants.
+ * - `turn_completed.usage.*` (`inputTokens`, `cachedReadTokens`, ...) is
+ *   CUMULATIVE across the whole session (observed `numTurns: 8`,
+ *   `inputTokens: 541_054`), the same trap Codex's `total_token_usage` set:
+ *   using it for occupancy sends the context bar past 100%. It feeds the
+ *   lifetime rollup via `transcriptUsage` (transcript-parser.ts), not this
+ *   snapshot - except `costUsdTicks` / `apiDurationMs`, which ARE the
+ *   session-cumulative cost figures `SessionUsage.cost` wants.
+ * - `costUsdTicks` unit: 1e-10 USD. Pinned empirically: a headless
+ *   `--output-format json` run reports both fields side by side
+ *   (`total_cost_usd: 0.023672`, `total_cost_usd_ticks: 236720000`).
+ *
+ * The model id rides `update._meta.modelId` on `user_message_chunk` (and
+ * the per-model breakdown keys of `turn_completed.usage.modelUsage`); the
+ * context window size is not in the stream at all, so it is resolved from
+ * grok's own `~/.grok/models_cache.json` (`context_window` per model id).
+ */
+export class GrokSessionHistoryParser {
+  static async locate(options: {
+    agentSessionId: string;
+    cwd: string;
+  }): Promise<string | null> {
+    return locateGrokUpdatesFile(options);
+  }
+
+  static parse(content: string, _mode: 'full' | 'append'): SessionHistoryParseResult {
+    let modelId: string | undefined;
+    let contextTotalTokens: number | undefined;
+    let cumulativeOutputTokens: number | undefined;
+    let costUsd: number | undefined;
+    let apiDurationMs: number | undefined;
+    let activity: Activity | null = null;
+
+    const lines = content.split(/\r?\n/).filter((line) => line.length > 0);
+
+    for (const line of lines) {
+      let entry: unknown;
+      try {
+        entry = JSON.parse(line);
+      } catch {
+        continue; // partial write mid-flush
+      }
+      if (!isRecord(entry)) continue;
+      const params = entry.params;
+      if (!isRecord(params)) continue;
+      const update = params.update;
+      if (!isRecord(update)) continue;
+      const rawType = update.sessionUpdate;
+      if (!isGrokDispatchType(rawType)) continue;
+      const updateType: GrokDispatchType = rawType;
+
+      // Running context total: present in `params._meta.totalTokens` on
+      // streaming and tool updates.
+      const paramsMeta = params._meta;
+      if (isRecord(paramsMeta) && typeof paramsMeta.totalTokens === 'number') {
+        contextTotalTokens = paramsMeta.totalTokens;
+      }
+
+      if (updateType === 'user_message_chunk') {
+        const updateMeta = update._meta;
+        if (isRecord(updateMeta) && typeof updateMeta.modelId === 'string' && updateMeta.modelId.length > 0) {
+          modelId = updateMeta.modelId;
+        }
+        activity = Activity.Thinking;
+      } else if (
+        updateType === 'agent_message_chunk'
+        || updateType === 'agent_thought_chunk'
+        || updateType === 'tool_call'
+        || updateType === 'tool_call_update'
+      ) {
+        activity = Activity.Thinking;
+      } else if (updateType === 'turn_completed') {
+        activity = Activity.Idle;
+        const usage = update.usage;
+        if (isRecord(usage)) {
+          if (typeof usage.outputTokens === 'number') {
+            cumulativeOutputTokens = usage.outputTokens;
+          }
+          if (typeof usage.costUsdTicks === 'number') {
+            // 1e-10 USD per tick, pinned by a headless json run that reports
+            // total_cost_usd and total_cost_usd_ticks side by side.
+            costUsd = usage.costUsdTicks * 1e-10;
+          }
+          if (typeof usage.apiDurationMs === 'number') {
+            apiDurationMs = usage.apiDurationMs;
+          }
+          const modelUsage = usage.modelUsage;
+          if (!modelId && isRecord(modelUsage)) {
+            const modelKeys = Object.keys(modelUsage);
+            if (modelKeys.length > 0) modelId = modelKeys[modelKeys.length - 1];
+          }
+        }
+      } else if (updateType === 'retry_state') {
+        // A live retry backoff means the turn is still alive - hold
+        // Thinking. A terminal `type: "failed"` is followed by its own
+        // `turn_completed` (observed with `stop_reason: "error"`), which
+        // settles the state; no transition is forced here.
+        if (update.type !== 'failed') {
+          activity = Activity.Thinking;
+        }
+      }
+    }
+
+    const usage = buildUsage({
+      modelId,
+      contextTotalTokens,
+      cumulativeOutputTokens,
+      costUsd,
+      apiDurationMs,
+    });
+
+    return { usage, events: [], activity };
+  }
+}
+
+/**
+ * Update types this parser dispatches on. Unknown types (hook_execution,
+ * task_backgrounded, future additions) are skipped silently, though their
+ * `params._meta.totalTokens` is still harvested above the dispatch.
+ */
+const GROK_DISPATCH_TYPES = [
+  'user_message_chunk',
+  'agent_message_chunk',
+  'agent_thought_chunk',
+  'tool_call',
+  'tool_call_update',
+  'turn_completed',
+  'retry_state',
+] as const;
+
+type GrokDispatchType = typeof GROK_DISPATCH_TYPES[number];
+
+function isGrokDispatchType(value: unknown): value is GrokDispatchType {
+  return typeof value === 'string'
+    && (GROK_DISPATCH_TYPES as readonly string[]).includes(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Resolve model metadata from grok's own models cache
+ * (`~/.grok/models_cache.json`, written by the CLI; carries
+ * `models.<id>.info.context_window` and `models.<id>.info.name`). Cached
+ * per (grokHome, mtime) so the common parse path costs one statSync -
+ * `buildUsage` runs on every session-history tail parse, so both lookups
+ * below MUST read through this memo, never re-read the file per call.
+ */
+let modelsCacheMemo: {
+  path: string;
+  mtimeMs: number;
+  windows: Map<string, number>;
+  displayNames: Map<string, string>;
+} | null = null;
+
+function loadModelsCacheMemo(): NonNullable<typeof modelsCacheMemo> | null {
+  const cachePath = path.join(grokHomeDir(), 'models_cache.json');
+  try {
+    const stat = fs.statSync(cachePath);
+    if (!modelsCacheMemo || modelsCacheMemo.path !== cachePath || modelsCacheMemo.mtimeMs !== stat.mtimeMs) {
+      const windows = new Map<string, number>();
+      const displayNames = new Map<string, string>();
+      const parsed: unknown = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+      if (isRecord(parsed) && isRecord(parsed.models)) {
+        for (const [id, entry] of Object.entries(parsed.models)) {
+          if (!isRecord(entry) || !isRecord(entry.info)) continue;
+          const window = entry.info.context_window;
+          if (typeof window === 'number' && window > 0) windows.set(id, window);
+          const name = entry.info.name;
+          if (typeof name === 'string' && name.length > 0) displayNames.set(id, name);
+        }
+      }
+      modelsCacheMemo = { path: cachePath, mtimeMs: stat.mtimeMs, windows, displayNames };
+    }
+    return modelsCacheMemo;
+  } catch {
+    return null;
+  }
+}
+
+export function grokModelContextWindow(modelId: string): number | undefined {
+  return loadModelsCacheMemo()?.windows.get(modelId);
+}
+
+/** Test hook: drop the models-cache memo so a redirected GROK_HOME is re-read. */
+export function clearGrokModelsCacheMemo(): void {
+  modelsCacheMemo = null;
+}
+
+/**
+ * Build a sparse SessionUsage from what this chunk actually carried.
+ * Uncaptured fields are omitted entirely (never defaulted to 0) so the
+ * shallow spread merge in `UsageAccumulator.setSessionUsage()` cannot
+ * overwrite good values from earlier chunks - the Codex parser's
+ * load-bearing sparse-merge rule.
+ */
+function buildUsage(captured: {
+  modelId: string | undefined;
+  contextTotalTokens: number | undefined;
+  cumulativeOutputTokens: number | undefined;
+  costUsd: number | undefined;
+  apiDurationMs: number | undefined;
+}): SessionUsage | null {
+  const { modelId, contextTotalTokens, cumulativeOutputTokens, costUsd, apiDurationMs } = captured;
+
+  if (
+    modelId === undefined
+    && contextTotalTokens === undefined
+    && costUsd === undefined
+  ) {
+    return null;
+  }
+
+  const contextWindow: Record<string, number> = {};
+  if (contextTotalTokens !== undefined) {
+    contextWindow.usedTokens = contextTotalTokens;
+    contextWindow.totalInputTokens = contextTotalTokens;
+  }
+  if (cumulativeOutputTokens !== undefined) {
+    contextWindow.totalOutputTokens = cumulativeOutputTokens;
+  }
+  const windowSize = modelId !== undefined ? grokModelContextWindow(modelId) : undefined;
+  if (windowSize !== undefined) {
+    contextWindow.contextWindowSize = windowSize;
+    if (contextTotalTokens !== undefined && windowSize > 0) {
+      contextWindow.usedPercentage = (contextTotalTokens / windowSize) * 100;
+    }
+  }
+
+  const cost: Record<string, number> = {};
+  if (costUsd !== undefined) cost.totalCostUsd = costUsd;
+  if (apiDurationMs !== undefined) cost.totalDurationMs = apiDurationMs;
+
+  const result: Record<string, unknown> = {};
+  if (Object.keys(contextWindow).length > 0) result.contextWindow = contextWindow;
+  if (Object.keys(cost).length > 0) result.cost = cost;
+  if (modelId !== undefined) {
+    result.model = { id: modelId, displayName: grokModelDisplayName(modelId), reportedByAgent: true };
+  }
+
+  return result as unknown as SessionUsage;
+}
+
+/**
+ * Friendly display name for a grok model id, from the models cache when
+ * available (`models.<id>.info.name`, e.g. `grok-4.6` -> "Grok 4.6"), else
+ * the raw id.
+ */
+export function grokModelDisplayName(modelId: string): string {
+  return loadModelsCacheMemo()?.displayNames.get(modelId) ?? modelId;
+}

--- a/src/main/agent/adapters/grok/session-paths.ts
+++ b/src/main/agent/adapters/grok/session-paths.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Single source of truth for Grok Build's on-disk layout.
+ *
+ * Empirically verified against grok 1.0.0 (3cd0d0cbce) on Windows:
+ *
+ *   ~/.grok/sessions/<encodeURIComponent(cwd)>/<session-uuid>/
+ *     updates.jsonl       - authoritative append-only ACP session/update log
+ *     chat_history.jsonl  - raw model messages (system/user/assistant/
+ *                           reasoning/tool_result records)
+ *     summary.json        - session metadata (id, cwd, timestamps, model,
+ *                           generated_title, reasoning_effort, git info)
+ *
+ * The directory key is the URL-encoded working directory exactly as
+ * `encodeURIComponent` produces it (observed on disk:
+ * `C%3A%5CUsers%5C...`), and `GROK_HOME` overrides `~/.grok` (documented in
+ * the shipped user guide, 17-sessions.md / 21-terminal-support.md).
+ *
+ * Because GrokAdapter declares `supportsCallerSessionId = true` (Kangentic
+ * generates the UUID and passes `-s <uuid>` at spawn), every path here is a
+ * deterministic construction - no filesystem scanning or capture race.
+ */
+
+/** Grok's config/data root: `$GROK_HOME` when set, else `~/.grok`. Read per-call so tests can redirect it. */
+export function grokHomeDir(): string {
+  const override = process.env.GROK_HOME;
+  if (override && override.trim().length > 0) return override;
+  return path.join(os.homedir(), '.grok');
+}
+
+/**
+ * The per-cwd sessions directory key. Grok URL-encodes the raw absolute
+ * cwd string (backslashes intact on Windows) with `encodeURIComponent`
+ * semantics - verified byte-for-byte against a real session directory.
+ */
+export function cwdToSessionsDirName(cwd: string): string {
+  return encodeURIComponent(cwd);
+}
+
+/** Absolute path to one session's directory. */
+export function grokSessionDir(cwd: string, agentSessionId: string): string {
+  return path.join(grokHomeDir(), 'sessions', cwdToSessionsDirName(cwd), agentSessionId);
+}
+
+export function grokUpdatesJsonlPath(cwd: string, agentSessionId: string): string {
+  return path.join(grokSessionDir(cwd, agentSessionId), 'updates.jsonl');
+}
+
+export function grokChatHistoryPath(cwd: string, agentSessionId: string): string {
+  return path.join(grokSessionDir(cwd, agentSessionId), 'chat_history.jsonl');
+}
+
+/**
+ * Locate the session's `updates.jsonl` by polling the deterministic path for
+ * existence. The budget mirrors Claude's (~60s): the caller-owned-session-id
+ * flow attaches the SessionHistoryReader at spawn, before the CLI has booted
+ * and written its first update, so the file legitimately does not exist for
+ * the first seconds. `locate` MUST confirm existence before returning -
+ * SessionHistoryReader treats ENOENT on the initial read as "file
+ * disappeared" and detaches.
+ */
+export async function locateGrokUpdatesFile(options: {
+  agentSessionId: string;
+  cwd: string;
+  maxAttempts?: number;
+}): Promise<string | null> {
+  const expected = grokUpdatesJsonlPath(options.cwd, options.agentSessionId);
+  const maxAttempts = options.maxAttempts ?? 120; // ~60s at 500ms cadence
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (fs.existsSync(expected)) return expected;
+    // Encoding-mismatch safety net: the session UUID is caller-generated
+    // and globally unique, so once the CLI has had a few seconds to write
+    // ANYTHING, a one-level scan of the sessions root finds our session
+    // even if the cwd key was encoded differently than we computed (e.g. a
+    // drive-letter casing difference on Windows). Checked every 10th
+    // attempt to keep the common path cheap.
+    if (attempt >= 10 && attempt % 10 === 0) {
+      const scanned = findSessionDirAcrossCwds(options.agentSessionId);
+      if (scanned) return scanned;
+    }
+    await sleep(500);
+  }
+  return findSessionDirAcrossCwds(options.agentSessionId);
+}
+
+/**
+ * Scan `~/.grok/sessions/<any-cwd-key>/<sessionId>/updates.jsonl` for a
+ * caller-owned session UUID. One readdir of the sessions root plus one
+ * existsSync per cwd key - cheap, and unambiguous because the UUID is ours.
+ */
+function findSessionDirAcrossCwds(agentSessionId: string): string | null {
+  const sessionsRoot = path.join(grokHomeDir(), 'sessions');
+  let cwdKeys: string[];
+  try {
+    cwdKeys = fs.readdirSync(sessionsRoot);
+  } catch {
+    return null;
+  }
+  for (const cwdKey of cwdKeys) {
+    const candidate = path.join(sessionsRoot, cwdKey, agentSessionId, 'updates.jsonl');
+    try {
+      if (fs.existsSync(candidate)) return candidate;
+    } catch {
+      // Unreadable entry (a file, a permissions issue) - skip.
+    }
+  }
+  return null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/main/agent/adapters/grok/status-parser.ts
+++ b/src/main/agent/adapters/grok/status-parser.ts
@@ -1,0 +1,28 @@
+import type { SessionUsage, SessionEvent } from '../../../../shared/types';
+
+/**
+ * Parses Grok Build status and event data.
+ *
+ * Grok has NO statusline mechanism (verified against the grok 1.0.0 user
+ * guide - the one structural divergence from Claude's harness), so
+ * `parseStatus` always returns null; live telemetry comes from tailing the
+ * native `updates.jsonl` instead (see GrokSessionHistoryParser).
+ *
+ * `parseEvent` decodes the agent-agnostic event-bridge JSONL that grok's
+ * hooks append (hook-manager.ts): this is the LIVE activity pipeline, not a
+ * dormant stub - grok fires the full Claude-compatible hook set, verified
+ * end to end against grok 1.0.0 including headless mode.
+ */
+export class GrokStatusParser {
+  static parseStatus(_raw: string): SessionUsage | null {
+    return null;
+  }
+
+  static parseEvent(line: string): SessionEvent | null {
+    try {
+      return JSON.parse(line) as SessionEvent;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/main/agent/adapters/grok/transcript-cleanup.ts
+++ b/src/main/agent/adapters/grok/transcript-cleanup.ts
@@ -1,0 +1,91 @@
+import { filterNoiseLines, finalizeTranscript } from '../../handoff/transcript-cleanup';
+
+/**
+ * Grok Build transcript cleanup for cross-agent handoff.
+ *
+ * Empirically derived from a captured grok 1.0.0 PTY session (interactive
+ * TUI probe, Windows). Grok runs a fullscreen alt-screen TUI, so the live
+ * frames never accumulate in the normal buffer; what the scrollback holds
+ * after a graceful exit (`/quit`, which `getExitSequence` sends) is grok's
+ * OWN clean conversation dump:
+ *
+ *   Reply with exactly: PONG        <- initial positional prompt echo
+ *   > Reply with exactly: PONG      <- user turns, `> ` prefixed
+ *     PONG                          <- response text
+ *   Resume this session with:
+ *     grok --resume <uuid>
+ *
+ * Strategy: filter TUI chrome that can leak into the buffer when the
+ * terminal lacks alt-screen support (welcome box, braille logo/spinners,
+ * status timers, upgrade banner, telemetry opt-in prose, key hints, the
+ * slash-command palette), strip the resume trailer, and anchor the last
+ * turn on the LAST `> ` user-prompt line when one exists.
+ */
+
+const GROK_NOISE_PATTERNS: RegExp[] = [
+  // Welcome banner and box chrome
+  /Grok Build\s+\d+\.\d+\.\d+/,
+  /Grok\s?[\d.]+\s?is\s?here/i,
+  /Click\s?here\s?to\s?Upgrade/i,
+  /Upgrade\s?for\s?more\s?usage/i,
+  /New worktree\s*ctrl\+w/i,
+  /Resume session\s*ctrl\+s/i,
+  /^\s*Changelog\s*$/,
+  /Quit\s*ctrl\+q/i,
+  // Braille logo art and spinner glyphs (U+2800 - U+28FF), possibly mixed
+  // with digits from the underlying frame
+  /^[\s\d]*[⠀-⣿]+[\s\d]*$/,
+  // Telemetry opt-in prose
+  /Help\s?improve\s?Grok/i,
+  /\[Opt\s?out\]\s?\[Opt\s?in\]/i,
+  /Opt-?in\s?to\s?allow\s?SpaceXAI/i,
+  /Read\s?Terms\s?and\s?Privacy\s?Policy/i,
+  // Status/timer chrome
+  /◆?\s*Thinking…/,
+  /Th\w*nking…\s*[\d.]+s/,
+  /Thought for\s+[\d.]+s/i,
+  /Responding…\s*[\d.]+s/,
+  /Worked for\s+[\d.]+s/i,
+  // Key hints and status bar
+  /Ctrl\+x\s*:\s*shortcuts/i,
+  /Enter\s*:\s*send/i,
+  /Shift\+Tab\s*:\s*mode/i,
+  /^\s*\[stable\]\s*$/,
+  // Slash-command palette entries ("/quit Quit the application", ...)
+  /^\s*\/\w[\w-]*\s+[A-Z]/,
+];
+
+/** User prompt marker in grok's exit dump: `> ` followed by the typed text. */
+const GROK_USER_PROMPT = /^\s*>\s+\S/;
+
+/** The resume trailer grok prints after the conversation dump. */
+const GROK_RESUME_TRAILER = /^\s*(Resume this session with:|grok\s+--resume\s+\S+)\s*$/;
+
+export function cleanGrokTranscript(rawText: string): string | null {
+  const lines = rawText.split('\n');
+
+  const filtered = filterNoiseLines(lines, GROK_NOISE_PATTERNS)
+    .filter((line) => !GROK_RESUME_TRAILER.test(line));
+  const text = filtered.join('\n').replace(/\n{3,}/g, '\n\n');
+  const cleanLines = text.split('\n');
+
+  // Anchor the last turn on the LAST `> ` user-prompt line. Everything from
+  // there onward is that turn's prompt + response in grok's own clean dump.
+  let lastPromptIndex = -1;
+  for (let index = cleanLines.length - 1; index >= 0; index--) {
+    if (GROK_USER_PROMPT.test(cleanLines[index])) {
+      lastPromptIndex = index;
+      break;
+    }
+  }
+
+  if (lastPromptIndex === -1) {
+    // No structural marker (e.g. the session was killed before the exit
+    // dump). Plain finalization keeps whatever prose survived filtering.
+    return finalizeTranscript(text);
+  }
+
+  const promptLine = cleanLines[lastPromptIndex].replace(/^\s*>\s+/, '');
+  const responseBlock = cleanLines.slice(lastPromptIndex + 1).join('\n');
+  return finalizeTranscript(`${promptLine}\n\n${responseBlock}`);
+}

--- a/src/main/agent/adapters/grok/transcript-parser.ts
+++ b/src/main/agent/adapters/grok/transcript-parser.ts
@@ -1,0 +1,272 @@
+import fs from 'node:fs/promises';
+import type {
+  TranscriptEntry,
+  TranscriptBlock,
+  TranscriptUsage,
+  TranscriptToolCounts,
+  PerToolStat,
+} from '../../../../shared/types';
+import { grokChatHistoryPath, grokUpdatesJsonlPath } from './session-paths';
+
+/**
+ * Parse Grok Build's native session files into agent-agnostic structures.
+ *
+ * Two source files, two jobs (both under
+ * `~/.grok/sessions/<encodeURIComponent(cwd)>/<sessionId>/`):
+ *
+ * - `chat_history.jsonl` -> `TranscriptEntry[]` for the Transcript tab and
+ *   the MCP `get_transcript` structured format. Record schema (verified
+ *   against real grok 1.0.0 sessions):
+ *     { type: 'system' | 'user' | 'assistant' | 'reasoning' | 'tool_result',
+ *       content: string | {type:'text',text} | blocks[],
+ *       synthetic_reason?, tool_calls?, tool_call_id?, model_id?,
+ *       reasoning_effort?, summary?, status? }
+ *   Genuine user turns have NO `synthetic_reason` (synthetic records carry
+ *   `project_instructions` / `system_reminder` and are injected context,
+ *   not conversation) and wrap the typed text in `<user_query>` tags.
+ *   Assistant tool calls ride `tool_calls: [{id, name, arguments}]` where
+ *   `arguments` is a JSON-encoded string. Records carry NO timestamps -
+ *   entries get a single parse-time stamp (the Droid fallback precedent)
+ *   and synthesized `<sessionId>:<line>` uuids.
+ *
+ * - `updates.jsonl` -> `TranscriptUsage` / `TranscriptToolCounts` for the
+ *   lifetime rollup (Claude-parity `transcriptUsage` /
+ *   `transcriptToolCounts`). `turn_completed.usage` is CUMULATIVE across
+ *   the session (verified: numTurns climbs, inputTokens climbs), which is
+ *   exactly what the lifetime rollup wants - the LAST turn_completed wins.
+ *   Tool calls are counted from distinct `tool_call` update ids.
+ */
+export async function parseGrokTranscript(
+  agentSessionId: string,
+  cwd: string,
+): Promise<{ entries: TranscriptEntry[]; sourcePath: string | null }> {
+  const filePath = grokChatHistoryPath(cwd, agentSessionId);
+  let content: string;
+  try {
+    content = await fs.readFile(filePath, 'utf-8');
+  } catch {
+    return { entries: [], sourcePath: null };
+  }
+
+  const entries: TranscriptEntry[] = [];
+  const parseTimeTs = Date.now();
+  const lines = content.split(/\r?\n/);
+  // Reasoning records precede the assistant record they belong to; buffer
+  // their summaries and attach as thinking blocks on the next assistant.
+  let pendingThinking: string[] = [];
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex];
+    if (line.length === 0) continue;
+    let raw: unknown;
+    try {
+      raw = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!isRecord(raw)) continue;
+    const uuid = `${agentSessionId}:${lineIndex}`;
+
+    if (raw.type === 'user') {
+      if (typeof raw.synthetic_reason === 'string' && raw.synthetic_reason.length > 0) continue;
+      const text = extractTextContent(raw.content);
+      if (!text) continue;
+      entries.push({ kind: 'user', uuid, ts: parseTimeTs, text: unwrapUserQuery(text) });
+    } else if (raw.type === 'reasoning') {
+      const summaryText = extractReasoningSummary(raw.summary);
+      if (summaryText) pendingThinking.push(summaryText);
+    } else if (raw.type === 'assistant') {
+      const blocks: TranscriptBlock[] = [];
+      for (const thinking of pendingThinking) {
+        blocks.push({ type: 'thinking', text: thinking });
+      }
+      pendingThinking = [];
+      const text = extractTextContent(raw.content);
+      if (text) blocks.push({ type: 'text', text });
+      if (Array.isArray(raw.tool_calls)) {
+        for (const call of raw.tool_calls) {
+          if (!isRecord(call)) continue;
+          blocks.push({
+            type: 'tool_use',
+            id: typeof call.id === 'string' ? call.id : '',
+            name: typeof call.name === 'string' ? call.name : 'tool',
+            input: parseToolArguments(call.arguments),
+          });
+        }
+      }
+      if (blocks.length === 0) continue;
+      const model = typeof raw.model_id === 'string' && raw.model_id.length > 0 ? raw.model_id : undefined;
+      entries.push({ kind: 'assistant', uuid, ts: parseTimeTs, model, blocks });
+    } else if (raw.type === 'tool_result') {
+      entries.push({
+        kind: 'tool_result',
+        uuid,
+        ts: parseTimeTs,
+        toolUseId: typeof raw.tool_call_id === 'string' ? raw.tool_call_id : '',
+        content: extractTextContent(raw.content) ?? '',
+      });
+    }
+    // 'system' (the system prompt) is deliberately skipped: TranscriptEntry
+    // has no system-prompt kind, and the viewer renders conversation.
+  }
+
+  return { entries, sourcePath: filePath };
+}
+
+/**
+ * Cumulative lifetime tokens from the LAST `turn_completed.usage` in
+ * `updates.jsonl` (session-cumulative by measurement). Null when no turn
+ * has completed yet or the file is missing/unreadable.
+ */
+export async function grokTranscriptUsage(
+  agentSessionId: string,
+  cwd: string,
+): Promise<TranscriptUsage | null> {
+  const records = await readUpdateRecords(agentSessionId, cwd);
+  if (!records) return null;
+
+  let latest: TranscriptUsage | null = null;
+  for (const update of records) {
+    if (update.sessionUpdate !== 'turn_completed') continue;
+    const usage = update.usage;
+    if (!isRecord(usage)) continue;
+    const inputTokens = usage.inputTokens;
+    const outputTokens = usage.outputTokens;
+    if (typeof inputTokens !== 'number' || typeof outputTokens !== 'number') continue;
+    latest = { inputTokens, outputTokens };
+  }
+  return latest;
+}
+
+/**
+ * Distinct tool-call count + per-tool breakdown from `updates.jsonl`
+ * `tool_call` events (each carries a unique `toolCallId` and the tool name
+ * in `title` / `_meta['x.ai/tool'].name`). callCount-only breakdown, per
+ * the TranscriptToolCounts contract.
+ */
+export async function grokTranscriptToolCounts(
+  agentSessionId: string,
+  cwd: string,
+): Promise<TranscriptToolCounts | null> {
+  const records = await readUpdateRecords(agentSessionId, cwd);
+  if (!records) return null;
+
+  const seenIds = new Set<string>();
+  const countsByTool = new Map<string, number>();
+  for (const update of records) {
+    if (update.sessionUpdate !== 'tool_call') continue;
+    const toolCallId = typeof update.toolCallId === 'string' ? update.toolCallId : null;
+    if (toolCallId) {
+      if (seenIds.has(toolCallId)) continue;
+      seenIds.add(toolCallId);
+    }
+    const toolName = grokToolCallName(update);
+    countsByTool.set(toolName, (countsByTool.get(toolName) ?? 0) + 1);
+  }
+
+  if (seenIds.size === 0 && countsByTool.size === 0) return null;
+
+  const toolBreakdown: PerToolStat[] = Array.from(countsByTool.entries())
+    .map(([toolName, callCount]) => ({ toolName, callCount, totalDurationMs: 0, interruptedCount: 0 }))
+    .sort((a, b) => b.callCount - a.callCount);
+  const toolCallCount = toolBreakdown.reduce((sum, stat) => sum + stat.callCount, 0);
+  return { toolCallCount, toolBreakdown };
+}
+
+// ---------- Internal helpers ----------
+
+async function readUpdateRecords(
+  agentSessionId: string,
+  cwd: string,
+): Promise<Array<Record<string, unknown>> | null> {
+  const filePath = grokUpdatesJsonlPath(cwd, agentSessionId);
+  let content: string;
+  try {
+    content = await fs.readFile(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+  const updates: Array<Record<string, unknown>> = [];
+  for (const line of content.split(/\r?\n/)) {
+    if (line.length === 0) continue;
+    let raw: unknown;
+    try {
+      raw = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!isRecord(raw) || !isRecord(raw.params) || !isRecord(raw.params.update)) continue;
+    updates.push(raw.params.update);
+  }
+  return updates;
+}
+
+function grokToolCallName(update: Record<string, unknown>): string {
+  const meta = update._meta;
+  if (isRecord(meta)) {
+    const toolMeta = meta['x.ai/tool'];
+    if (isRecord(toolMeta) && typeof toolMeta.name === 'string' && toolMeta.name.length > 0) {
+      return toolMeta.name;
+    }
+  }
+  return typeof update.title === 'string' && update.title.length > 0 ? update.title : 'tool';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Content is a plain string, a single `{type:'text',text}` block, or an
+ * array of blocks (whose items may themselves be plain strings). Exported
+ * so `command-injection-verifier.ts` parses the same `chat_history.jsonl`
+ * content shapes identically - a private copy there once diverged by
+ * silently dropping plain-string array items.
+ */
+export function extractTextContent(content: unknown): string | null {
+  if (typeof content === 'string') return content.length > 0 ? content : null;
+  if (isRecord(content)) {
+    return typeof content.text === 'string' && content.text.length > 0 ? content.text : null;
+  }
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const block of content) {
+      if (typeof block === 'string') parts.push(block);
+      else if (isRecord(block) && typeof block.text === 'string') parts.push(block.text);
+    }
+    const joined = parts.join('\n');
+    return joined.length > 0 ? joined : null;
+  }
+  return null;
+}
+
+/** Strip the `<user_query>` wrapper grok stores around the typed prompt. */
+export function unwrapUserQuery(text: string): string {
+  const match = text.match(/^\s*<user_query>\r?\n?([\s\S]*?)\r?\n?<\/user_query>\s*$/);
+  return match ? match[1] : text;
+}
+
+/** Reasoning `summary` is a string or an array of strings / text blocks. */
+function extractReasoningSummary(summary: unknown): string | null {
+  if (typeof summary === 'string') return summary.length > 0 ? summary : null;
+  if (Array.isArray(summary)) {
+    const parts: string[] = [];
+    for (const block of summary) {
+      if (typeof block === 'string') parts.push(block);
+      else if (isRecord(block) && typeof block.text === 'string') parts.push(block.text);
+    }
+    const joined = parts.join('\n');
+    return joined.length > 0 ? joined : null;
+  }
+  return null;
+}
+
+/** `tool_calls[].arguments` is a JSON-encoded string; fall back to the raw string. */
+function parseToolArguments(argumentsValue: unknown): unknown {
+  if (typeof argumentsValue !== 'string') return argumentsValue ?? {};
+  try {
+    return JSON.parse(argumentsValue);
+  } catch {
+    return argumentsValue;
+  }
+}

--- a/src/main/agent/adapters/grok/trust-manager.ts
+++ b/src/main/agent/adapters/grok/trust-manager.ts
@@ -1,0 +1,221 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createSerialLock, atomicWriteFileWithBackup } from '../../shared/relocation-utils';
+import { grokHomeDir } from './session-paths';
+
+/**
+ * Grok Build folder-trust pre-approval.
+ *
+ * Grok gates project-level hooks AND project-level `[mcp_servers]` behind
+ * its unified folder-trust store, `~/.grok/trusted_folders.toml`:
+ *
+ *   [folders.'C:\Users\dev\proj']
+ *   trusted = true
+ *   decided_at = 1786162868
+ *
+ * Untrusted folders do not prompt at spawn - project hooks and MCP are
+ * SILENTLY SKIPPED (fail-open, verified: a config-less fresh dir launches
+ * straight into the TUI). So without trust, a Kangentic-spawned session
+ * simply loses hook-based activity (the `hooksAndPty` PTY fallback covers
+ * it) and MCP tools.
+ *
+ * The load-bearing difference from Codex: grok trust CASCADES to
+ * subdirectories (documented in 10-hooks.md, and verified live - a
+ * Kangentic worktree under a trusted project root reports
+ * `projectTrusted: true` with only the root in the store). That shapes the
+ * policy here:
+ *
+ * - A worktree under an already-decided ancestor needs NOTHING (the
+ *   common steady state: one root entry covers every future worktree).
+ * - A worktree under an UNDECIDED project root gets its own entry
+ *   (scoped exactly like Codex's per-worktree approval: the trust
+ *   boundary is Kangentic itself - the user opened this project and the
+ *   directory being approved is a worktree Kangentic created from it).
+ *   `onWorktreeRemoved` drops that entry so the store tracks live
+ *   worktrees (Codex's 473-dead-entries lesson).
+ * - The PROJECT ROOT itself is never auto-trusted: an undecided root
+ *   spawn runs untrusted (hooks silently off, PTY fallback carries
+ *   activity), and the user's own first interactive grok session there
+ *   decides it once, cascading to everything after. Kangentic never
+ *   answers a trust question the user has not.
+ * - An explicit ancestor `trusted = false` is always respected.
+ */
+const withTrustStoreLock = createSerialLock();
+
+export async function ensureWorktreeTrust(workingDirectory: string): Promise<void> {
+  return withTrustStoreLock(() => ensureWorktreeTrustSync(workingDirectory));
+}
+
+export async function removeWorktreeTrust(worktreePath: string): Promise<void> {
+  return withTrustStoreLock(() => removeWorktreeTrustSync(worktreePath));
+}
+
+function trustStorePath(): string {
+  return path.join(grokHomeDir(), 'trusted_folders.toml');
+}
+
+/** Recover the owning project root from the `/.kangentic/worktrees/` marker. */
+function projectRootForWorktree(resolvedPath: string): string | null {
+  const marker = `${path.sep}.kangentic${path.sep}worktrees${path.sep}`;
+  const markerIndex = resolvedPath.indexOf(marker);
+  return markerIndex === -1 ? null : resolvedPath.substring(0, markerIndex);
+}
+
+/**
+ * Normalize for comparison: resolve, forward slashes, no trailing slash,
+ * casefold on win32. Exported for `project-relocation.ts`, which compares
+ * the same trust-store header paths (the Codex `config-toml.ts` precedent).
+ */
+export function normalizeForCompare(rawPath: string): string {
+  let normalized = path.resolve(rawPath).replace(/\\/g, '/');
+  normalized = normalized.replace(/\/+$/, '');
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
+interface TrustEntry {
+  folderPath: string;
+  trusted: boolean | null;
+}
+
+/** Parse `[folders.'<path>']` headers and their `trusted` values. */
+function parseTrustEntries(lines: string[]): TrustEntry[] {
+  const entries: TrustEntry[] = [];
+  let current: TrustEntry | null = null;
+  for (const line of lines) {
+    const header = parseHeaderLine(line);
+    if (header) {
+      current = { folderPath: header, trusted: null };
+      entries.push(current);
+      continue;
+    }
+    if (/^\s*\[/.test(line)) {
+      current = null;
+      continue;
+    }
+    if (current) {
+      const trustedMatch = line.match(/^\s*trusted\s*=\s*(true|false)\s*$/);
+      if (trustedMatch) current.trusted = trustedMatch[1] === 'true';
+    }
+  }
+  return entries;
+}
+
+/** Extract the quoted folder path from a `[folders.'...']` or `[folders."..."]` header line. */
+function parseHeaderLine(line: string): string | null {
+  const match = line.match(/^\s*\[folders\.(?:'([^']+)'|"([^"]+)")\]\s*$/);
+  if (!match) return null;
+  return match[1] ?? match[2] ?? null;
+}
+
+/** The decision covering `target`, honoring cascade (nearest decided ancestor wins). */
+function decisionFor(entries: TrustEntry[], target: string): boolean | null {
+  const normalizedTarget = normalizeForCompare(target);
+  let bestPathLength = -1;
+  let bestDecision: boolean | null = null;
+  for (const entry of entries) {
+    if (entry.trusted === null) continue;
+    const normalizedEntry = normalizeForCompare(entry.folderPath);
+    const covers = normalizedTarget === normalizedEntry
+      || normalizedTarget.startsWith(`${normalizedEntry}/`);
+    if (covers && normalizedEntry.length > bestPathLength) {
+      bestPathLength = normalizedEntry.length;
+      bestDecision = entry.trusted;
+    }
+  }
+  return bestDecision;
+}
+
+function ensureWorktreeTrustSync(workingDirectory: string): void {
+  const resolvedPath = path.resolve(workingDirectory);
+  const projectRoot = projectRootForWorktree(resolvedPath);
+  // Only a Kangentic worktree is ever pre-approved; a project root spawn
+  // runs with whatever the user decided (or undecided = untrusted).
+  if (!projectRoot) return;
+
+  const storePath = trustStorePath();
+  let content: string;
+  try {
+    content = fs.readFileSync(storePath, 'utf-8');
+  } catch {
+    content = '';
+  }
+  const entries = parseTrustEntries(content.split('\n'));
+
+  // Cascade already answers for this path (a decided ancestor, or a prior
+  // entry for the worktree itself, in either direction) - never overrule.
+  if (decisionFor(entries, resolvedPath) !== null) return;
+
+  // Single-quoted TOML literal keys cannot represent a path containing a
+  // single quote; reserializing the user's file to switch quote styles is
+  // not worth the risk (Codex precedent).
+  if (resolvedPath.includes("'")) return;
+
+  const decidedAt = Math.floor(Date.now() / 1000);
+  const table = `[folders.'${resolvedPath}']\ntrusted = true\ndecided_at = ${decidedAt}\n`;
+  const separator = content.length === 0 || content.endsWith('\n') ? '' : '\n';
+
+  try {
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.appendFileSync(storePath, `${separator}\n${table}`, 'utf-8');
+  } catch (error) {
+    // Best-effort: a failure only means project hooks/MCP stay silently
+    // gated for this session. Never block the spawn.
+    console.error('[grok] Failed to pre-approve folder trust', error);
+  }
+}
+
+function removeWorktreeTrustSync(worktreePath: string): void {
+  const storePath = trustStorePath();
+  const target = normalizeForCompare(worktreePath);
+
+  let content: string;
+  try {
+    content = fs.readFileSync(storePath, 'utf-8');
+  } catch {
+    return;
+  }
+
+  const lines = content.split('\n');
+  const kept: string[] = [];
+  let removed = false;
+  let index = 0;
+
+  while (index < lines.length) {
+    const headerPath = parseHeaderLine(lines[index]);
+    if (!headerPath || normalizeForCompare(headerPath) !== target) {
+      kept.push(lines[index]);
+      index += 1;
+      continue;
+    }
+
+    const body: string[] = [];
+    let cursor = index + 1;
+    while (cursor < lines.length && !/^\s*\[/.test(lines[cursor])) {
+      body.push(lines[cursor]);
+      cursor += 1;
+    }
+
+    // Only a table Kangentic could have written is removed: `trusted` and
+    // `decided_at` are also what grok's own prompt records, but anything
+    // BEYOND those keys is unmistakably not ours and survives.
+    const meaningful = body.filter((line) => line.trim().length > 0);
+    const removable = meaningful.length > 0 && meaningful.every(
+      (line) => /^\s*(trusted|decided_at)\s*=/.test(line),
+    );
+    if (!removable) {
+      kept.push(lines[index], ...body);
+    } else {
+      removed = true;
+      // Drop the blank separator line `ensureWorktreeTrustSync` wrote ahead
+      // of the table. Scoped to the single preceding line.
+      if (kept.length > 0 && kept[kept.length - 1].trim() === '') kept.pop();
+    }
+    index = cursor;
+  }
+
+  if (!removed) return;
+
+  // Full-file rewrite of a store the user owns - backup + temp + rename so
+  // an interrupted write can never truncate every project's trust.
+  atomicWriteFileWithBackup(storePath, kept.join('\n'), { logTag: '[GROK_TRUST]' });
+}

--- a/src/main/agent/agent-registry.ts
+++ b/src/main/agent/agent-registry.ts
@@ -11,6 +11,7 @@ import { QwenAdapter } from './adapters/qwen-code';
 import { KimiAdapter } from './adapters/kimi';
 import { DroidAdapter } from './adapters/droid';
 import { OllamaAdapter } from './adapters/ollama';
+import { GrokAdapter } from './adapters/grok';
 
 class AgentRegistry {
   private adapters = new Map<string, AgentAdapter>();
@@ -65,3 +66,4 @@ agentRegistry.register(new QwenAdapter());
 agentRegistry.register(new KimiAdapter());
 agentRegistry.register(new DroidAdapter());
 agentRegistry.register(new OllamaAdapter());
+agentRegistry.register(new GrokAdapter());

--- a/src/main/agent/event-bridge.js
+++ b/src/main/agent/event-bridge.js
@@ -57,7 +57,19 @@
 process.stdout.write = () => true;
 
 const fs = require('fs');
-const outputPath = process.argv[2];
+// The events path argument is either a literal path or the sentinel
+// `env:<NAME>`, which resolves the path from the hook process environment at
+// run time. Adapters whose CLI has no per-session settings mechanism (Grok)
+// write ONE static per-cwd hook file whose commands carry the sentinel; each
+// Kangentic PTY spawn supplies its own value, so concurrent sessions in the
+// same cwd route to their own events.jsonl - and a session WITHOUT the
+// variable (the user's own manual CLI run in that cwd) resolves to an empty
+// path, which the `if (!outputPath) return` below turns into a silent no-op
+// instead of writing into some task's activity log.
+const rawOutputPath = process.argv[2];
+const outputPath = rawOutputPath && rawOutputPath.startsWith('env:')
+  ? (process.env[rawOutputPath.slice(4)] || '')
+  : rawOutputPath;
 const eventType = process.argv[3] || 'idle';
 const directives = process.argv.slice(4);
 

--- a/src/main/agent/handoff/session-history-reference.ts
+++ b/src/main/agent/handoff/session-history-reference.ts
@@ -40,6 +40,7 @@ function agentDisplayLabel(agent: string): string {
     case 'aider': return 'Aider';
     case 'kimi': return 'Kimi Code';
     case 'droid': return 'Droid';
+    case 'grok': return 'Grok Build';
     default: return agent;
   }
 }

--- a/src/main/agent/handoff/transcript-cleanup.ts
+++ b/src/main/agent/handoff/transcript-cleanup.ts
@@ -10,6 +10,7 @@
  * - adapters/kimi/transcript-cleanup.ts
  * - adapters/droid/transcript-cleanup.ts
  * - adapters/opencode/transcript-cleanup.ts
+ * - adapters/grok/transcript-cleanup.ts
  *
  * This file provides:
  * 1. The dispatcher (cleanTranscriptForHandoff) that routes to the right adapter
@@ -24,6 +25,7 @@ import { cleanAiderTranscript } from '../adapters/aider/transcript-cleanup';
 import { cleanKimiTranscript } from '../adapters/kimi/transcript-cleanup';
 import { cleanDroidTranscript } from '../adapters/droid/transcript-cleanup';
 import { cleanOpenCodeTranscript } from '../adapters/opencode/transcript-cleanup';
+import { cleanGrokTranscript } from '../adapters/grok/transcript-cleanup';
 
 // ---------------------------------------------------------------------------
 // Shared utilities (exported for use by adapter transcript-cleanup files)
@@ -115,7 +117,7 @@ export function finalizeTranscript(text: string): string | null {
  * clean conversation from the raw PTY stream.
  *
  * @param rawTranscript - ANSI-stripped PTY output from TranscriptWriter
- * @param sourceAgent - Agent identifier: 'claude', 'codex', 'gemini', 'qwen', 'aider', 'kimi', 'droid', 'opencode'
+ * @param sourceAgent - Agent identifier: 'claude', 'codex', 'gemini', 'qwen', 'aider', 'kimi', 'droid', 'opencode', 'grok'
  * @returns Cleaned transcript text, or null if nothing meaningful remains.
  */
 export function cleanTranscriptForHandoff(
@@ -141,6 +143,8 @@ export function cleanTranscriptForHandoff(
       return cleanDroidTranscript(rawTranscript);
     case 'opencode':
       return cleanOpenCodeTranscript(rawTranscript);
+    case 'grok':
+      return cleanGrokTranscript(rawTranscript);
     default:
       // Unknown agents: no TUI-specific cleanup, just basic finalization
       return finalizeTranscript(rawTranscript);

--- a/src/renderer/utils/agent-display-name.ts
+++ b/src/renderer/utils/agent-display-name.ts
@@ -82,6 +82,12 @@ const AGENT_META: Record<string, AgentMeta> = {
     short: 'Cursor',
     installUrl: 'https://cursor.com/cli',
   },
+  grok: {
+    display: 'Grok Build',
+    short: 'Grok',
+    installUrl: 'https://github.com/xai-org/grok-build',
+    loginCommand: 'grok login',
+  },
 };
 
 /**

--- a/tests/e2e/grok-activity-detection.spec.ts
+++ b/tests/e2e/grok-activity-detection.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * E2E tests for Grok Build activity detection + the hook pipeline.
+ *
+ * Grok's runtime strategy is `ActivityDetection.hooksAndPty()`: Claude-
+ * compatible hooks are the primary activity source, delivered through a
+ * static per-cwd hook file (`<cwd>/.grok/hooks/kangentic.json`, written by
+ * GrokCommandBuilder at spawn) whose bridge commands resolve the per-session
+ * events path from the spawn env (`env:KANGENTIC_EVENTS_PATH`). The
+ * `updates.jsonl` tail provides usage telemetry and backstop activity hints.
+ *
+ * mock-grok.js emulates the real CLI end to end: it writes the real session
+ * store layout AND executes the hook file's commands with grok-shaped
+ * payloads (inheriting the PTY env), so these specs exercise the FULL
+ * production pipeline inside the app:
+ *
+ *  - Spawned Grok session appears in the activity IPC map and settles idle
+ *  - Hook-driven events (prompt, tool_start with the extracted grok fields,
+ *    idle with the Stop reason) land in the events cache - proving the hook
+ *    file content, the env routing, the event-bridge `env:` sentinel, and
+ *    GrokStatusParser.parseEvent as one chain
+ *  - With hooks suppressed (MOCK_GROK_NO_HOOKS=1, the untrusted-folder
+ *    path), activity still settles idle via the PTY fallback
+ */
+import { test, expect } from '@playwright/test';
+import {
+  launchApp,
+  createProject,
+  createTask,
+  createTempProject,
+  cleanupTempProject,
+  cleanupGrokSessionsForCwd,
+  getTestDataDir,
+  cleanupTestDataDir,
+  mockAgentPath,
+  setProjectDefaultAgent,
+  waitForScrollback,
+  getTaskIdByTitle,
+  getSwimlaneIds,
+  moveTaskIpc,
+  closeApp,
+} from './helpers';
+import type { ElectronApplication, Page } from '@playwright/test';
+import path from 'node:path';
+import fs from 'node:fs';
+import type { ActivityState, SessionEvent } from '../../src/shared/types';
+
+// Each describe block launches its own Electron app against its own isolated
+// KANGENTIC_DATA_DIR and tmpDir (unique TEST_NAME per block); mode:'parallel'
+// dispatches each to a separate worker process, so the MOCK_GROK_NO_HOOKS
+// process.env mutation in the second block is fully isolated.
+test.describe.configure({ mode: 'parallel' });
+
+const runId = Date.now();
+
+function writeAgentConfig(dataDir: string): void {
+  fs.writeFileSync(
+    path.join(dataDir, 'config.json'),
+    JSON.stringify({
+      agent: {
+        cliPaths: { grok: mockAgentPath('grok') },
+        permissionMode: 'acceptEdits',
+        maxConcurrentSessions: 5,
+        queueOverflow: 'queue',
+      },
+      git: { worktreesEnabled: false },
+    }),
+  );
+}
+
+test.describe('Grok Agent - hook-driven activity detection', () => {
+  const TEST_NAME = 'grok-activity-detection';
+  const PROJECT_NAME = `Grok Activity Test ${runId}`;
+
+  let app: ElectronApplication;
+  let page: Page;
+  let tmpDir: string;
+  let dataDir: string;
+
+  test.beforeAll(async () => {
+    tmpDir = createTempProject(TEST_NAME);
+    dataDir = getTestDataDir(TEST_NAME);
+    writeAgentConfig(dataDir);
+
+    const result = await launchApp({ dataDir });
+    app = result.app;
+    page = result.page;
+    await createProject(page, PROJECT_NAME, tmpDir);
+    await setProjectDefaultAgent(page, 'grok');
+  });
+
+  test.afterAll(async () => {
+    await closeApp(app);
+    cleanupGrokSessionsForCwd(tmpDir);
+    cleanupTempProject(TEST_NAME);
+    cleanupTestDataDir(TEST_NAME);
+  });
+
+  // ONE self-contained test: this file runs in mode:'parallel', where every
+  // test gets its own worker (and its own app via beforeAll), so a second
+  // test can never observe a spawn made by the first.
+  test('spawned Grok session settles idle and its hook events reach the events cache', async () => {
+    test.slow();
+    const title = `Grok Activity ${runId}`;
+    await createTask(page, title, 'Verify hook-driven activity detection');
+
+    const swimlaneIds = await getSwimlaneIds(page);
+    const taskId = await getTaskIdByTitle(page, title);
+
+    await moveTaskIpc(page, taskId, swimlaneIds.planning);
+    await waitForScrollback(page, 'MOCK_GROK_SESSION:');
+
+    // The mock fires the Stop hook (-> idle event via the events pipeline)
+    // and its updates.jsonl ends with turn_completed (-> Activity.Idle via
+    // the history tail); the PTY silence timer also lands idle. Any path
+    // satisfies the assertion within 15s.
+    await expect.poll(async () => {
+      const activity = await page.evaluate(() => window.electronAPI.sessions.getActivity());
+      return Object.values(activity as Record<string, ActivityState>);
+    }, { timeout: 15000 }).toContain('idle');
+
+    // Hook chain end to end: the mock executes the commands from the hook
+    // file GrokCommandBuilder wrote, those commands run the REAL
+    // event-bridge with the `env:KANGENTIC_EVENTS_PATH` sentinel resolved
+    // from the PTY env, and GrokStatusParser.parseEvent feeds the cache.
+    await expect.poll(async () => {
+      const eventsMap = await page.evaluate(() => window.electronAPI.sessions.getEventsCache());
+      const allEvents = Object.values(eventsMap as Record<string, SessionEvent[]>).flat();
+      const hasPrompt = allEvents.some((event) => event.type === 'prompt' && event.detail === undefined);
+      const hasToolStart = allEvents.some((event) =>
+        event.type === 'tool_start'
+        && event.tool === 'read_file'
+        && event.toolId === 'call-mock-1'
+        && event.detail === 'hello.txt');
+      const hasIdleWithReason = allEvents.some((event) => event.type === 'idle' && event.detail === 'end_turn');
+      return hasPrompt && hasToolStart && hasIdleWithReason;
+    }, {
+      timeout: 30000,
+      message: 'Expected prompt + tool_start(read_file/call-mock-1/hello.txt) + idle(end_turn) hook events in the cache',
+    }).toBe(true);
+  });
+});
+
+test.describe('Grok Agent - PTY fallback when hooks do not fire (MOCK_GROK_NO_HOOKS=1)', () => {
+  const TEST_NAME = 'grok-pty-fallback';
+  const PROJECT_NAME = `Grok Fallback Test ${runId}`;
+
+  let app: ElectronApplication;
+  let page: Page;
+  let tmpDir: string;
+  let dataDir: string;
+
+  test.beforeAll(async () => {
+    // The untrusted-folder path: real grok silently skips project hooks when
+    // the folder is not trusted, which is exactly "hooks never fire". The
+    // hooksAndPty strategy must settle activity via the PTY silence timer.
+    process.env.MOCK_GROK_NO_HOOKS = '1';
+
+    tmpDir = createTempProject(TEST_NAME);
+    dataDir = getTestDataDir(TEST_NAME);
+    writeAgentConfig(dataDir);
+
+    const result = await launchApp({ dataDir });
+    app = result.app;
+    page = result.page;
+    await createProject(page, PROJECT_NAME, tmpDir);
+    await setProjectDefaultAgent(page, 'grok');
+  });
+
+  test.afterAll(async () => {
+    delete process.env.MOCK_GROK_NO_HOOKS;
+    await closeApp(app);
+    cleanupGrokSessionsForCwd(tmpDir);
+    cleanupTempProject(TEST_NAME);
+    cleanupTestDataDir(TEST_NAME);
+  });
+
+  test('session settles to idle through the PTY silence fallback', async () => {
+    test.slow();
+    const title = `Grok Fallback ${runId}`;
+    await createTask(page, title, 'Verify PTY fallback when hooks are gated off');
+
+    const swimlaneIds = await getSwimlaneIds(page);
+    const taskId = await getTaskIdByTitle(page, title);
+
+    await moveTaskIpc(page, taskId, swimlaneIds.planning);
+    await waitForScrollback(page, 'MOCK_GROK_SESSION:');
+
+    // No hook events at all; the mock goes silent after its banner, so only
+    // the PTY silence timer (or the updates.jsonl turn_completed hint) can
+    // settle the session. The longer timeout covers the silence threshold.
+    await expect.poll(async () => {
+      const activity = await page.evaluate(() => window.electronAPI.sessions.getActivity());
+      return Object.values(activity as Record<string, ActivityState>);
+    }, { timeout: 30000 }).toContain('idle');
+  });
+});

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -6,7 +6,7 @@ import { createHash } from 'node:crypto';
 import { execSync, spawn } from 'node:child_process';
 import type { Session, Swimlane, Task } from '../../src/shared/types';
 
-export type AgentName = 'claude' | 'codex' | 'gemini' | 'cursor' | 'warp' | 'opencode' | 'kimi' | 'qwen' | 'droid';
+export type AgentName = 'claude' | 'codex' | 'gemini' | 'cursor' | 'warp' | 'opencode' | 'kimi' | 'qwen' | 'droid' | 'grok';
 
 // --- Test data isolation ---
 // Each test run uses its own data directory so E2E tests never pollute
@@ -492,6 +492,23 @@ export async function createTask(
 export function cleanupKimiSessionsForCwd(cwd: string): void {
   const hash = createHash('md5').update(path.resolve(cwd)).digest('hex');
   const target = path.join(os.homedir(), '.kimi', 'sessions', hash);
+  try { fs.rmSync(target, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+/**
+ * Remove the grok session store for a test cwd. mock-grok.js writes real
+ * session files under `$GROK_HOME/sessions/<encodeURIComponent(cwd)>/`
+ * (defaulting to `~/.grok`, the same resolution the real CLI uses), keyed
+ * by the test's temp project dir, so wiping that one encoded directory
+ * never touches user sessions. Honors GROK_HOME so a test that redirects
+ * the store cleans up the same root the mock wrote to.
+ */
+export function cleanupGrokSessionsForCwd(cwd: string): void {
+  const grokHomeOverride = process.env.GROK_HOME;
+  const grokHome = grokHomeOverride && grokHomeOverride.trim().length > 0
+    ? grokHomeOverride
+    : path.join(os.homedir(), '.grok');
+  const target = path.join(grokHome, 'sessions', encodeURIComponent(path.resolve(cwd)));
   try { fs.rmSync(target, { recursive: true, force: true }); } catch { /* ignore */ }
 }
 

--- a/tests/fixtures/mock-grok.cmd
+++ b/tests/fixtures/mock-grok.cmd
@@ -1,0 +1,2 @@
+@echo off
+node "%~dp0mock-grok.js" %*

--- a/tests/fixtures/mock-grok.js
+++ b/tests/fixtures/mock-grok.js
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+/**
+ * Mock Grok Build CLI for E2E tests.
+ *
+ * Real-CLI command shapes (see src/main/agent/adapters/grok/command-builder.ts,
+ * verified against grok 1.0.0):
+ *   grok --version                                        -> detector probe
+ *   grok -s <uuid> --permission-mode <mode> -- "<prompt>" -> new session
+ *   grok --resume <uuid> --permission-mode <mode>         -> resume
+ *   grok -p "<prompt>" --output-format plain              -> headless single turn
+ *
+ * Markers for test assertions (mirrors mock-kimi):
+ *   MOCK_GROK_SESSION:<id>   -> new session
+ *   MOCK_GROK_RESUMED:<id>   -> resumed session
+ *   MOCK_GROK_PROMPT:<text>  -> prompt text delivered (first line)
+ *   MOCK_GROK_CWD:<path>     -> the process cwd (grok has no --cwd flag)
+ *
+ * Writes the real on-disk session layout under
+ * `$GROK_HOME|~/.grok/sessions/<encodeURIComponent(cwd)>/<uuid>/`:
+ * `updates.jsonl` (user_message_chunk with `_meta.modelId`, chunks carrying
+ * `params._meta.totalTokens`, tool_call, turn_completed with the cumulative
+ * usage block incl. `costUsdTicks` at 1e-10 USD), `chat_history.jsonl`
+ * (user record wrapped in `<user_query>` tags), and `summary.json` - so the
+ * SessionHistoryReader locate -> parse pipeline and the transcript parser
+ * run against the exact shapes the adapter was built for.
+ *
+ * HOOK EMULATION: like the real grok, the mock loads
+ * `<cwd>/.grok/hooks/kangentic.json` (the file GrokCommandBuilder writes at
+ * spawn) and executes each entry's command for SessionStart,
+ * UserPromptSubmit, PreToolUse, PostToolUse, and Stop with grok-shaped
+ * camelCase stdin payloads. The commands inherit this process's env - which
+ * carries KANGENTIC_EVENTS_PATH from buildGrokEnv - so the E2E spec
+ * exercises the FULL production pipeline: static hook file -> env-routed
+ * event-bridge `env:` sentinel -> per-session events.jsonl -> parseEvent.
+ * (The real grok gates project hooks on folder trust; the mock does not
+ * model trust - the E2E spec covers the trusted path.)
+ *
+ * Env knobs:
+ *   MOCK_GROK_NO_HOOKS=1    -> skip hook execution (untrusted-folder path:
+ *                              activity must then settle via PTY silence).
+ *   MOCK_GROK_NO_SESSION=1  -> skip session-store writes.
+ */
+
+const { randomUUID } = require('node:crypto');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const args = process.argv.slice(2);
+
+if (args.includes('--version') || args.includes('-v')) {
+  console.log('grok 1.0.0-mock (deadbeef) [stable]');
+  process.exit(0);
+}
+
+// --- Argument parsing -------------------------------------------------------
+
+const FLAGS_WITH_VALUES = new Set([
+  '--permission-mode', '--model', '-m', '--reasoning-effort', '--effort',
+  '--output-format', '--sandbox', '--agent', '--agents', '--max-turns',
+  '--rules', '--prompt-file', '--prompt-json', '--cwd',
+]);
+
+let sessionId = null;
+let resume = false;
+let headless = false;
+let prompt = null;
+let afterDoubleDash = false;
+
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
+  if (afterDoubleDash) {
+    prompt = prompt === null ? arg : `${prompt} ${arg}`;
+    continue;
+  }
+  if (arg === '--') {
+    afterDoubleDash = true;
+  } else if (arg === '-s' || arg === '--session-id') {
+    sessionId = args[++i] ?? null;
+  } else if (arg === '-r' || arg === '--resume') {
+    // The real flag takes an optional value; the adapter always passes one.
+    const next = args[i + 1];
+    if (next && !next.startsWith('-')) { sessionId = next; i++; }
+    resume = true;
+  } else if (arg === '-p' || arg === '--single') {
+    headless = true;
+    const next = args[i + 1];
+    if (next && !next.startsWith('-')) { prompt = next; i++; }
+  } else if (FLAGS_WITH_VALUES.has(arg)) {
+    i++;
+  }
+  // booleans (--fullscreen, --minimal, --no-alt-screen, --always-approve,
+  // --fork-session, ...) intentionally fall through.
+}
+
+const cwd = path.resolve(process.cwd());
+
+// Real semantics: -s names a NEW session (errors if it exists); --resume
+// requires an existing one. The mock is forgiving about the error cases -
+// the specs never exercise them - but mirrors the create/resume split.
+if (!sessionId) sessionId = randomUUID();
+
+const grokHome = process.env.GROK_HOME && process.env.GROK_HOME.trim().length > 0
+  ? process.env.GROK_HOME
+  : path.join(os.homedir(), '.grok');
+const sessionDir = path.join(grokHome, 'sessions', encodeURIComponent(cwd), sessionId);
+const resumed = resume && fs.existsSync(path.join(sessionDir, 'updates.jsonl'));
+
+// --- Session store write ----------------------------------------------------
+
+function updateLine(update, paramsMeta) {
+  return JSON.stringify({
+    timestamp: Math.floor(Date.now() / 1000),
+    method: 'session/update',
+    params: {
+      sessionId,
+      update,
+      ...(paramsMeta ? { _meta: paramsMeta } : {}),
+    },
+  });
+}
+
+function writeSessionStore() {
+  if (process.env.MOCK_GROK_NO_SESSION) return;
+  fs.mkdirSync(sessionDir, { recursive: true });
+
+  const promptText = prompt ?? '';
+  const updates = [
+    updateLine({
+      sessionUpdate: 'user_message_chunk',
+      content: { type: 'text', text: promptText },
+      _meta: { modelId: 'grok-4.6', promptIndex: 0 },
+    }),
+    updateLine(
+      { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'Working on it.' } },
+      { totalTokens: 12000 },
+    ),
+    updateLine(
+      {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'call-mock-1',
+        title: 'read_file',
+        rawInput: { target_file: 'hello.txt' },
+        _meta: { 'x.ai/tool': { name: 'read_file', kind: 'read', label: 'Read' } },
+      },
+      { totalTokens: 12400 },
+    ),
+    updateLine({
+      sessionUpdate: 'turn_completed',
+      prompt_id: 'prompt-mock-1',
+      stop_reason: 'end_turn',
+      usage: {
+        inputTokens: 12400,
+        outputTokens: 180,
+        totalTokens: 12580,
+        cachedReadTokens: 512,
+        costUsdTicks: 236720000,
+        apiDurationMs: 1500,
+        modelCalls: 1,
+        numTurns: 1,
+        modelUsage: { 'grok-4.6': { inputTokens: 12400, outputTokens: 180 } },
+      },
+    }),
+  ];
+
+  const chatHistory = [
+    JSON.stringify({ type: 'system', content: 'You are mock Grok.' }),
+    JSON.stringify({
+      type: 'user',
+      content: { type: 'text', text: `<user_query>\n${promptText}\n</user_query>` },
+    }),
+    JSON.stringify({
+      type: 'assistant',
+      content: 'Done.',
+      model_id: 'grok-4.6',
+      reasoning_effort: 'high',
+      tool_calls: [{ id: 'call-mock-1', name: 'read_file', arguments: '{"target_file":"hello.txt"}' }],
+    }),
+    JSON.stringify({ type: 'tool_result', tool_call_id: 'call-mock-1', content: 'mock file contents' }),
+  ];
+
+  const flag = resumed ? 'a' : 'w';
+  fs.writeFileSync(path.join(sessionDir, 'updates.jsonl'), updates.join('\n') + '\n', { flag });
+  fs.writeFileSync(path.join(sessionDir, 'chat_history.jsonl'), chatHistory.join('\n') + '\n', { flag });
+  fs.writeFileSync(path.join(sessionDir, 'summary.json'), JSON.stringify({
+    info: { id: sessionId, cwd },
+    session_summary: 'mock session',
+    current_model_id: 'grok-4.6',
+    reasoning_effort: 'high',
+    num_messages: 3,
+  }, null, 2));
+}
+
+writeSessionStore();
+
+// --- Hook emulation ---------------------------------------------------------
+
+function runHooks() {
+  if (process.env.MOCK_GROK_NO_HOOKS) return;
+  const hooksPath = path.join(cwd, '.grok', 'hooks', 'kangentic.json');
+  let hooks;
+  try {
+    hooks = JSON.parse(fs.readFileSync(hooksPath, 'utf-8')).hooks;
+  } catch {
+    return; // No hook file - the adapter spawned without an events pipeline.
+  }
+  if (!hooks || typeof hooks !== 'object') return;
+
+  const common = {
+    sessionId,
+    cwd,
+    workspaceRoot: cwd.replace(/\\/g, '/') + '/',
+    timestamp: new Date().toISOString(),
+    permissionMode: 'auto',
+  };
+  const firings = [
+    ['SessionStart', { ...common, hookEventName: 'session_start', source: 'new' }],
+    ['UserPromptSubmit', { ...common, hookEventName: 'user_prompt_submit', prompt: `<user_query>\n${prompt ?? ''}\n</user_query>` }],
+    ['PreToolUse', { ...common, hookEventName: 'pre_tool_use', toolName: 'read_file', toolUseId: 'call-mock-1', toolInput: { target_file: 'hello.txt' } }],
+    ['PostToolUse', { ...common, hookEventName: 'post_tool_use', toolName: 'read_file', toolUseId: 'call-mock-1', toolInput: { target_file: 'hello.txt' }, toolResult: { type: 'ReadFile' } }],
+    ['Stop', { ...common, hookEventName: 'stop', reason: 'end_turn', stopHookActive: false, lastAssistantMessage: 'Done.', backgroundTasks: [], sessionCrons: [] }],
+  ];
+
+  for (const [eventName, payload] of firings) {
+    const entries = hooks[eventName];
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      if (!entry || !Array.isArray(entry.hooks)) continue;
+      for (const hook of entry.hooks) {
+        if (!hook || hook.type !== 'command' || typeof hook.command !== 'string') continue;
+        try {
+          // Shell exec like the real hook runner; env (incl. the adapter's
+          // KANGENTIC_EVENTS_PATH) is inherited from this process.
+          childProcess.execSync(hook.command, {
+            input: JSON.stringify(payload),
+            timeout: 10_000,
+            windowsHide: true,
+          });
+        } catch (error) {
+          console.error(`MOCK_GROK_HOOK_ERROR:${eventName}:${error.message}`);
+        }
+      }
+    }
+  }
+}
+
+// --- PTY output -------------------------------------------------------------
+
+// Hide-cursor escape first, so detectFirstOutput() returns true.
+process.stdout.write('\x1b[?25l');
+
+console.log('Grok Build  1.0.0-mock');
+console.log(`MOCK_GROK_${resumed ? 'RESUMED' : 'SESSION'}:${sessionId}`);
+console.log(`MOCK_GROK_CWD:${cwd}`);
+if (prompt) console.log(`MOCK_GROK_PROMPT:${prompt.split('\n')[0]}`);
+
+if (headless) {
+  runHooks();
+  console.log('OK');
+  process.exit(0);
+}
+
+// Fire hooks AFTER a short settle, modeling the real CLI (SessionStart
+// lands ~2s after launch, tool/Stop hooks over the following seconds).
+// Firing them synchronously at spawn raced the app's events.jsonl reader
+// attach, which deliberately skips bytes that predate the attach (stale-
+// replay protection) - a window the real grok never hits.
+const hooksTimer = setTimeout(() => { runHooks(); }, 1500);
+
+// Idle timeout - exits after 30s if not interrupted.
+const timeout = setTimeout(() => { process.exit(0); }, 30000);
+
+function shutdown(signal) {
+  clearTimeout(timeout);
+  clearTimeout(hooksTimer);
+  process.exit(signal === 'SIGINT' ? 130 : 0);
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
+
+process.stdin.resume();
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (data) => {
+  // Ctrl+C and the real exit sequence's "/quit\r" both trigger clean shutdown.
+  if (data.includes('\x03') || data.includes('/quit')) {
+    shutdown('STDIN');
+  }
+});

--- a/tests/integration/agent-cli-validation.test.ts
+++ b/tests/integration/agent-cli-validation.test.ts
@@ -39,6 +39,7 @@ import { OpenCodeAdapter } from '../../src/main/agent/adapters/opencode/opencode
 import { QwenAdapter } from '../../src/main/agent/adapters/qwen-code/qwen-adapter';
 import { KimiAdapter } from '../../src/main/agent/adapters/kimi/kimi-adapter';
 import { DroidAdapter } from '../../src/main/agent/adapters/droid/droid-adapter';
+import { GrokAdapter } from '../../src/main/agent/adapters/grok/grok-adapter';
 import type { AgentAdapter, SpawnCommandOptions } from '../../src/main/agent/agent-adapter';
 import type { PermissionMode } from '../../src/shared/types';
 
@@ -182,6 +183,7 @@ const ADAPTERS: ProbeAdapter[] = [
   { name: 'qwen', adapter: new QwenAdapter() },
   { name: 'kimi', adapter: new KimiAdapter() },
   { name: 'droid', adapter: new DroidAdapter() },
+  { name: 'grok', adapter: new GrokAdapter() },
 ];
 
 /**
@@ -234,7 +236,20 @@ const SESSIONS_ROOTS: Record<string, SessionRootSpec | undefined> = {
   droid: { root: path.join(os.homedir(), '.factory', 'sessions'), expectModels: true },
   aider: undefined, // .aider.chat.history.md lives per-project, not global
   warp: undefined, // no per-user session store
+  // Grok's model list comes from its own `~/.grok/models_cache.json` (the
+  // same source its /model picker uses), which the CLI writes on first use -
+  // so an install with sessions on disk reliably has a populated cache.
+  grok: { root: path.join(os.homedir(), '.grok', 'sessions'), expectModels: true },
 };
+
+/**
+ * Agents whose effort levels are documented OUTSIDE `--help` (grok's ladder
+ * comes from its own models cache metadata and the in-TUI `/effort` command;
+ * `grok --help` shows only `--reasoning-effort <EFFORT>` with no choice
+ * list). The effort-in-help assertion soft-passes for these; the source the
+ * adapter reads IS the CLI's own.
+ */
+const EFFORT_LEVELS_DOCUMENTED_OUTSIDE_HELP = new Set(['grok']);
 
 /**
  * Recursively check whether `root` (or any subdirectory up to depth 5)
@@ -384,6 +399,11 @@ describe('agent CLI validation (against live --help and disk state)', () => {
         const levels = capabilities.effortLevels;
         if (!levels || levels.length === 0) {
           // Soft pass: most adapters legitimately have no effort levels.
+          return;
+        }
+        if (EFFORT_LEVELS_DOCUMENTED_OUTSIDE_HELP.has(name)) {
+          // The ladder is real but documented in the CLI's own config/cache,
+          // not in --help - see the set's doc comment.
           return;
         }
         // Each declared level must appear somewhere in the help text.

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -2388,6 +2388,20 @@
             ],
             defaultPermission: 'default',
           },
+          {
+            name: 'grok', displayName: 'Grok Build', found: false, path: null, version: null,
+            // KEEP IN SYNC with GrokAdapter.permissions in src/main/agent/adapters/grok/grok-adapter.ts
+            permissions: [
+              { mode: 'plan', label: 'Plan Mode (read-only)' },
+              { mode: 'default', label: 'Default (ask for approval)' },
+              { mode: 'acceptEdits', label: 'Accept Edits' },
+              { mode: 'auto', label: 'Auto (model decides when to ask)' },
+              { mode: 'dontAsk', label: 'Never Ask (auto-deny)' },
+              { mode: 'bypassPermissions', label: 'Dangerous Full Access' },
+            ],
+            defaultPermission: 'acceptEdits',
+            supportsSummarize: true,
+          },
         ];
         return defaults.map(function (agent) {
           var override = overrides[agent.name];

--- a/tests/unit/adapter-multiline-prompt.test.ts
+++ b/tests/unit/adapter-multiline-prompt.test.ts
@@ -9,7 +9,7 @@
  * to multiline mode. Dropping the option from any adapter regresses prompt
  * delivery for tasks with multi-line descriptions.
  *
- * Coverage: codex, aider, opencode, kimi, droid, warp, ollama.
+ * Coverage: codex, aider, opencode, kimi, droid, warp, ollama, grok.
  * (claude, gemini, copilot, qwen-code are covered in their own test files.)
  *
  * Strategy: build the command with `shell: 'bash'` and a multi-line XML
@@ -57,6 +57,7 @@ import { KimiCommandBuilder } from '../../src/main/agent/adapters/kimi';
 import { DroidCommandBuilder } from '../../src/main/agent/adapters/droid';
 import { WarpAdapter } from '../../src/main/agent/adapters/warp';
 import { OllamaAdapter } from '../../src/main/agent/adapters/ollama';
+import { GrokCommandBuilder } from '../../src/main/agent/adapters/grok';
 
 // ---------------------------------------------------------------------------
 // Shared test data
@@ -160,6 +161,21 @@ describe('Adapter multiline prompt - regression guard for { multiline: true }', 
     const adapter = new OllamaAdapter();
     const command = adapter.buildCommand({
       agentPath: '/usr/bin/ollama',
+      taskId: 'task-1',
+      cwd: '/project',
+      permissionMode: 'default',
+      shell: 'bash',
+      prompt: MULTILINE_XML,
+    });
+    expect(command).toContain(EXPECTED_FRAGMENT);
+  });
+
+  it('GrokCommandBuilder preserves newlines in prompt under bash', () => {
+    // No eventsOutputPath / MCP options, so the builder's gated file writes
+    // (hooks file, config block) are never reached - no mocking needed.
+    const builder = new GrokCommandBuilder();
+    const command = builder.buildGrokCommand({
+      grokPath: '/usr/bin/grok',
       taskId: 'task-1',
       cwd: '/project',
       permissionMode: 'default',

--- a/tests/unit/agent-login-command.test.ts
+++ b/tests/unit/agent-login-command.test.ts
@@ -49,6 +49,10 @@ describe('agentLoginCommand', () => {
     expect(agentLoginCommand('ollama')).toBeUndefined();
   });
 
+  it('returns "grok login" for the grok agent', () => {
+    expect(agentLoginCommand('grok')).toBe('grok login');
+  });
+
   it('returns undefined for an unknown agent identifier', () => {
     expect(agentLoginCommand('unknown-agent-xyz')).toBeUndefined();
   });

--- a/tests/unit/agent-submission-verifier-shape.test.ts
+++ b/tests/unit/agent-submission-verifier-shape.test.ts
@@ -105,6 +105,12 @@ const ADAPTER_CLASSES = [
     verifiesSlashSubmission: true, requiresAgentSessionId: true,
     reason: '`ollama run` keeps no session history',
   },
+  {
+    name: 'grok', importPath: '../../src/main/agent/adapters/grok/grok-adapter', className: 'GrokAdapter',
+    commandInjection: 'verifier', escalates: false,
+    verifiesSlashSubmission: false, requiresAgentSessionId: true,
+    reason: 'measured 313ms flush-on-submit against a 2.1s turn (grok 1.0.0), but records carry no timestamps to bound the match window and the resolver has never been proven in-app; slash input runs in the TUI palette and never becomes a chat_history turn',
+  },
 ] as const;
 
 function reasonFor(name: string): string {

--- a/tests/unit/agent-summarize-shape.test.ts
+++ b/tests/unit/agent-summarize-shape.test.ts
@@ -98,6 +98,15 @@ describe('Adapter summarize() invocation shapes', () => {
     expect(call.promptVia).toBe('arg');
   });
 
+  it('Grok uses --output-format plain -p via positional arg', async () => {
+    const { GrokAdapter } = await import('../../src/main/agent/adapters/grok/grok-adapter');
+    const adapter = new GrokAdapter();
+    await adapter.summarize('triage crash report', '/usr/bin/grok', '/cwd');
+    const call = runCliPrintSummarizeMock.mock.calls[0][0];
+    expect(call.args).toEqual(['--output-format', 'plain', '-p']);
+    expect(call.promptVia).toBe('arg');
+  });
+
   it('Copilot uses --silent -p via positional arg', async () => {
     const { CopilotAdapter } = await import('../../src/main/agent/adapters/copilot/copilot-adapter');
     const adapter = new CopilotAdapter();

--- a/tests/unit/buildenv-adapter-interface-guard.test.ts
+++ b/tests/unit/buildenv-adapter-interface-guard.test.ts
@@ -10,6 +10,11 @@
  * Droid also delivers only the token: its project `.factory/mcp.json` holds
  * the literal `${KANGENTIC_MCP_TOKEN}`, which Droid expands at connect time,
  * keeping the secret out of a file that lives inside the user's repo.
+ * Grok goes one further than Droid: its project `.grok/config.toml` block is
+ * fully static (`${KANGENTIC_MCP_URL}` AND `${KANGENTIC_MCP_TOKEN}` are both
+ * env references grok expands at load time), and the same env channel also
+ * carries KANGENTIC_EVENTS_PATH for the hook bridge's `env:` sentinel - so
+ * neither the per-session URL, the token, nor the events path reaches disk.
  * Every other adapter passes its MCP config by flag or settings file, and
  * adding buildEnv to one of those by mistake would silently double-inject.
  * This test catches that regression by iterating all registered adapters.
@@ -25,7 +30,7 @@ import { agentRegistry } from '../../src/main/agent/agent-registry';
  * Exhaustive list of adapter names that are EXPECTED to implement buildEnv.
  * See the file docstring for why each one is here.
  */
-const ADAPTERS_WITH_BUILDENV: ReadonlySet<string> = new Set(['opencode', 'codex', 'droid']);
+const ADAPTERS_WITH_BUILDENV: ReadonlySet<string> = new Set(['opencode', 'codex', 'droid', 'grok']);
 
 describe('AgentAdapter.buildEnv interface guard', () => {
   it('exactly the adapters in ADAPTERS_WITH_BUILDENV implement buildEnv', () => {

--- a/tests/unit/context-packet.test.ts
+++ b/tests/unit/context-packet.test.ts
@@ -101,6 +101,7 @@ describe('buildSessionHistoryReference', () => {
       { name: 'aider', display: 'Aider' },
       { name: 'kimi', display: 'Kimi Code' },
       { name: 'droid', display: 'Droid' },
+      { name: 'grok', display: 'Grok Build' },
     ];
 
     for (const { name, display } of agents) {

--- a/tests/unit/cursor-grok-binary-collision.test.ts
+++ b/tests/unit/cursor-grok-binary-collision.test.ts
@@ -22,6 +22,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { CursorAdapter } from '../../src/main/agent/adapters/cursor/cursor-adapter';
+import { GrokDetector, parseGrokVersion } from '../../src/main/agent/adapters/grok/detector';
 
 /** Reach the detector config the adapter constructed. */
 function detectorConfig(): { binaryName: string; binaryAliases?: string[]; parseVersion(raw: string): string | null } {
@@ -63,6 +64,47 @@ describe('Cursor / Grok `agent` shim collision', () => {
     // stripped", so an unrelated tool that prints its own name is refused.
     for (const foreign of ['aider 0.9.1', 'codex-cli 0.128.0', 'some-tool v2', 'not a version']) {
       expect(parseVersion(foreign)).toBeNull();
+    }
+  });
+});
+
+/**
+ * The REVERSE direction, added with the Grok adapter itself: Grok's own
+ * detector must never resolve through the shared `agent` shim, and its
+ * parseVersion must reject every banner that is not Grok's - otherwise a
+ * machine where Cursor's `agent` wins the PATH race would mis-identify
+ * Cursor as Grok, the mirror image of the original defect.
+ */
+describe('Grok detector side of the `agent` shim collision', () => {
+  function grokConfig(): { binaryName: string; binaryAliases?: string[] } {
+    const detector = new GrokDetector() as unknown as {
+      config: { binaryName: string; binaryAliases?: string[] };
+    };
+    return detector.config;
+  }
+
+  it('probes only the unambiguous `grok` name, never the shared `agent` shim', () => {
+    const config = grokConfig();
+    expect(config.binaryName).toBe('grok');
+    expect(config.binaryAliases ?? []).not.toContain('agent');
+  });
+
+  it('accepts the real grok version banner', () => {
+    // The exact string a real `grok --version` returned (grok 1.0.0).
+    expect(parseGrokVersion('grok 1.0.0 (3cd0d0cbce) [stable]')).toBe('1.0.0');
+    expect(parseGrokVersion('grok 1.2.3')).toBe('1.2.3');
+  });
+
+  it("rejects Cursor's banners and every other foreign product", () => {
+    for (const foreign of [
+      '2026.04.29-c83a488',
+      'agent 1.0.0',
+      'Cursor Agent 1.0.0',
+      'codex-cli 0.128.0',
+      'aider 0.9.1',
+      'not a version',
+    ]) {
+      expect(parseGrokVersion(foreign)).toBeNull();
     }
   });
 });

--- a/tests/unit/event-bridge.test.ts
+++ b/tests/unit/event-bridge.test.ts
@@ -29,10 +29,11 @@ const BRIDGE = path.resolve(__dirname, '../../src/main/agent/event-bridge.js');
 let tmpDir: string;
 let outputFile: string;
 
-function runBridge(stdin: string, args: string[]): void {
+function runBridge(stdin: string, args: string[], env?: Record<string, string>): void {
   execFileSync(process.execPath, [BRIDGE, ...args], {
     input: stdin,
     timeout: 5000,
+    env: env ? { ...process.env, ...env } : process.env,
   });
 }
 
@@ -77,6 +78,31 @@ describe('event-bridge', () => {
 
   it('no output path does not crash', () => {
     runBridge('{}', []);
+    expect(fs.existsSync(outputFile)).toBe(false);
+  });
+
+  // --- env: sentinel (per-session routing for static per-cwd hook files) ---
+  // Adapters whose CLI has no per-session settings mechanism (Grok) write ONE
+  // static hook file whose commands carry `env:<NAME>`; each spawn supplies
+  // its own value through the PTY env, and a session without the variable
+  // (the user's own manual CLI run in that cwd) must be a silent no-op.
+
+  it('env: sentinel resolves the events path from the process environment', () => {
+    runBridge('{}', ['env:KANGENTIC_EVENTS_PATH_TEST', 'idle'], {
+      KANGENTIC_EVENTS_PATH_TEST: outputFile,
+    });
+    expect(readEvent().type).toBe('idle');
+  });
+
+  it('env: sentinel with the variable unset is a silent no-op', () => {
+    runBridge('{}', ['env:KANGENTIC_EVENTS_PATH_UNSET_TEST', 'idle']);
+    expect(fs.existsSync(outputFile)).toBe(false);
+  });
+
+  it('env: sentinel with an empty variable is a silent no-op', () => {
+    runBridge('{}', ['env:KANGENTIC_EVENTS_PATH_TEST', 'idle'], {
+      KANGENTIC_EVENTS_PATH_TEST: '',
+    });
     expect(fs.existsSync(outputFile)).toBe(false);
   });
 

--- a/tests/unit/grok-adapter.test.ts
+++ b/tests/unit/grok-adapter.test.ts
@@ -1,0 +1,1139 @@
+/**
+ * Grok Build adapter unit tests.
+ *
+ * Every empirical constant asserted here (version banner, session-store
+ * encoding, updates.jsonl shapes, cost tick unit, hook payload fields) was
+ * measured against grok 1.0.0 (3cd0d0cbce) - see the adapter files and
+ * scripts/probe-grok.js for the provenance.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { GrokAdapter } from '../../src/main/agent/adapters/grok/grok-adapter';
+import { GrokCommandBuilder, grokMcpWiringEnabled } from '../../src/main/agent/adapters/grok/command-builder';
+import { parseGrokVersion } from '../../src/main/agent/adapters/grok/detector';
+import { buildGrokHooks, writeHooksFile, removeHooksFile } from '../../src/main/agent/adapters/grok/hook-manager';
+import { writeMcpConfig, removeMcpConfig } from '../../src/main/agent/adapters/grok/mcp-config';
+import {
+  grokSessionDir,
+  grokUpdatesJsonlPath,
+  cwdToSessionsDirName,
+  locateGrokUpdatesFile,
+} from '../../src/main/agent/adapters/grok/session-paths';
+import {
+  GrokSessionHistoryParser,
+  clearGrokModelsCacheMemo,
+} from '../../src/main/agent/adapters/grok/session-history-parser';
+import {
+  parseGrokTranscript,
+  unwrapUserQuery,
+  grokTranscriptUsage,
+  grokTranscriptToolCounts,
+} from '../../src/main/agent/adapters/grok/transcript-parser';
+import {
+  extractGrokUserTurn,
+  createGrokCommandInjectionVerifier,
+} from '../../src/main/agent/adapters/grok/command-injection-verifier';
+import { cleanGrokTranscript } from '../../src/main/agent/adapters/grok/transcript-cleanup';
+import { discoverGrokCapabilities, clearGrokCapabilityMemo } from '../../src/main/agent/adapters/grok/capability-discovery';
+import { ensureWorktreeTrust, removeWorktreeTrust } from '../../src/main/agent/adapters/grok/trust-manager';
+import { migrateGrokProjectData } from '../../src/main/agent/adapters/grok/project-relocation';
+import type { PermissionMode } from '../../src/shared/types';
+
+const SESSION_ID = '01a00b63-e666-71b3-8a30-a1829680cfdc';
+
+let tempGrokHome: string | null = null;
+const originalGrokHome = process.env.GROK_HOME;
+
+function useTempGrokHome(): string {
+  tempGrokHome = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-home-'));
+  process.env.GROK_HOME = tempGrokHome;
+  clearGrokModelsCacheMemo();
+  clearGrokCapabilityMemo();
+  return tempGrokHome;
+}
+
+afterEach(() => {
+  if (originalGrokHome === undefined) delete process.env.GROK_HOME;
+  else process.env.GROK_HOME = originalGrokHome;
+  if (tempGrokHome) {
+    fs.rmSync(tempGrokHome, { recursive: true, force: true });
+    tempGrokHome = null;
+  }
+  clearGrokModelsCacheMemo();
+  clearGrokCapabilityMemo();
+});
+
+// ---------------------------------------------------------------------------
+// Identity + registry
+// ---------------------------------------------------------------------------
+
+describe('GrokAdapter identity', () => {
+  const adapter = new GrokAdapter();
+
+  it('declares the expected identity', () => {
+    expect(adapter.name).toBe('grok');
+    expect(adapter.displayName).toBe('Grok Build');
+    expect(adapter.sessionType).toBe('grok_agent');
+    expect(adapter.supportsCallerSessionId).toBe(true);
+  });
+
+  it('offers all six permission modes (1:1 CLI passthrough) with acceptEdits default', () => {
+    const modes = adapter.permissions.map((entry) => entry.mode);
+    expect(modes).toEqual(['plan', 'default', 'acceptEdits', 'auto', 'dontAsk', 'bypassPermissions']);
+    expect(adapter.defaultPermission).toBe('acceptEdits');
+  });
+
+  it('declares the hooks-and-pty runtime with a live event parser and history tail', () => {
+    expect(adapter.runtime.activity.kind).toBe('hooks_and_pty');
+    expect(adapter.runtime.sessionId).toBeUndefined();
+    expect(adapter.runtime.statusFile?.isFullRewrite).toBe(false);
+    expect(adapter.runtime.statusFile?.parseStatus('{"anything": true}')).toBeNull();
+    expect(adapter.runtime.statusFile?.parseEvent('{"ts":1,"type":"idle"}')).toEqual({ ts: 1, type: 'idle' });
+    expect(adapter.runtime.sessionHistory?.isFullRewrite).toBe(false);
+  });
+
+  it('parseEvent returns null on malformed JSON rather than throwing', () => {
+    // status-parser.ts's parseEvent is a bare JSON.parse with a try/catch;
+    // pin the failure path so a future refactor cannot let a torn
+    // events.jsonl line crash the reader instead of being skipped.
+    expect(adapter.runtime.statusFile?.parseEvent('not json at all')).toBeNull();
+  });
+
+  it('is registered in the agent registry under name and session type', async () => {
+    const { agentRegistry } = await import('../../src/main/agent/agent-registry');
+    expect(agentRegistry.has('grok')).toBe(true);
+    expect(agentRegistry.list()).toContain('grok');
+    expect(agentRegistry.getBySessionType('grok_agent')?.name).toBe('grok');
+  });
+
+  it('has renderer display metadata', async () => {
+    const { agentDisplayName, agentShortName, agentInstallUrl } = await import('../../src/renderer/utils/agent-display-name');
+    expect(agentDisplayName('grok')).toBe('Grok Build');
+    expect(agentShortName('grok')).toBe('Grok');
+    expect(agentInstallUrl('grok')).toContain('grok-build');
+  });
+
+  it('detects first output on the cursor-hide sequence', () => {
+    expect(adapter.detectFirstOutput('\x1b[?9001h\x1b[?1004h\x1b[?25l\x1b[2J')).toBe(true);
+    expect(adapter.detectFirstOutput('plain shell noise')).toBe(false);
+  });
+
+  it('exits via Ctrl+C then /quit', () => {
+    expect(adapter.getExitSequence()).toEqual(['\x03', '/quit\r']);
+  });
+
+  it('declares the confirm-only verification tier and no slash verification', () => {
+    expect(adapter.canEscalateOnVerificationFailure()).toBe(false);
+    expect(adapter.canVerifySlashSubmission()).toBe(false);
+    expect(typeof adapter.getSubmissionVerifier('command-injection')).toBe('function');
+    expect(adapter.getSubmissionVerifier('paste')).toBeNull();
+  });
+
+  it('falls back to respawn for model/effort changes (no unverifiable live injection)', () => {
+    expect(adapter.getInjectionSequence({ model: 'grok-4.6', modelChanged: true, effort: 'high', effortChanged: true })).toEqual([]);
+  });
+
+  it('seeds the board card model from the built command', () => {
+    expect(adapter.configuredModelFromCommand('grok -s x --model grok-4.6 -- "hi"')?.id).toBe('grok-4.6');
+    expect(adapter.configuredModelFromCommand('grok -s x -- "hi"')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Detector
+// ---------------------------------------------------------------------------
+
+describe('parseGrokVersion', () => {
+  it('accepts the real banner and rejects foreign products', () => {
+    expect(parseGrokVersion('grok 1.0.0 (3cd0d0cbce) [stable]')).toBe('1.0.0');
+    expect(parseGrokVersion('Cursor Agent 1.0.0')).toBeNull();
+    expect(parseGrokVersion('2026.04.29-c83a488')).toBeNull();
+    expect(parseGrokVersion('codex-cli 0.128.0')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Command builder
+// ---------------------------------------------------------------------------
+
+describe('GrokCommandBuilder', () => {
+  const builder = new GrokCommandBuilder();
+  const baseOptions = {
+    grokPath: '/usr/bin/grok',
+    taskId: 'task-1',
+    cwd: '/project',
+    permissionMode: 'acceptEdits' as PermissionMode,
+    shell: 'bash',
+  };
+
+  it('builds a new session with -s, permission passthrough, and a guarded positional prompt', () => {
+    const command = builder.buildGrokCommand({
+      ...baseOptions,
+      sessionId: SESSION_ID,
+      prompt: 'fix the bug',
+    });
+    expect(command).toContain(`-s ${SESSION_ID}`);
+    expect(command).toContain('--permission-mode acceptEdits');
+    expect(command).toContain("-- 'fix the bug'");
+    expect(command).not.toContain('--resume');
+    expect(command).not.toContain('--cwd');
+    expect(command).not.toContain('--fullscreen');
+    expect(command).not.toContain('--minimal');
+    expect(command).not.toContain('--always-approve');
+  });
+
+  it('passes every permission mode through 1:1', () => {
+    const modes: PermissionMode[] = ['default', 'plan', 'acceptEdits', 'dontAsk', 'bypassPermissions', 'auto'];
+    for (const mode of modes) {
+      const command = builder.buildGrokCommand({ ...baseOptions, permissionMode: mode });
+      expect(command).toContain(`--permission-mode ${mode}`);
+    }
+  });
+
+  it('resumes with --resume and never re-sends the prompt', () => {
+    const command = builder.buildGrokCommand({
+      ...baseOptions,
+      sessionId: SESSION_ID,
+      resume: true,
+      prompt: 'fix the bug',
+    });
+    expect(command).toContain(`--resume ${SESSION_ID}`);
+    expect(command).not.toContain(`-s ${SESSION_ID}`);
+    expect(command).not.toContain('fix the bug');
+  });
+
+  it('emits model and effort flags only when set', () => {
+    const bare = builder.buildGrokCommand({ ...baseOptions });
+    expect(bare).not.toContain('--model');
+    expect(bare).not.toContain('--reasoning-effort');
+
+    const withOverrides = builder.buildGrokCommand({ ...baseOptions, model: 'grok-4.6', effort: 'xhigh' });
+    expect(withOverrides).toContain('--model grok-4.6');
+    expect(withOverrides).toContain('--reasoning-effort xhigh');
+  });
+
+  it('builds headless mode with -p and plain output', () => {
+    const command = builder.buildGrokCommand({ ...baseOptions, nonInteractive: true, prompt: 'summarize this' });
+    expect(command).toContain("-p 'summarize this'");
+    expect(command).toContain('--output-format plain');
+  });
+
+  it('swaps double quotes on PowerShell to survive quoteArg escaping', () => {
+    const command = builder.buildGrokCommand({
+      ...baseOptions,
+      shell: 'powershell',
+      prompt: 'say "hello"',
+    });
+    expect(command).not.toContain('\\"hello\\"');
+    expect(command).toContain("'hello'");
+  });
+
+  it('routes per-session values through env, never argv', () => {
+    const options = {
+      ...baseOptions,
+      eventsOutputPath: '/project/.kangentic/sessions/s1/events.jsonl',
+      mcpServerUrl: 'http://127.0.0.1:4100/mcp/p1/s1',
+      mcpServerToken: 'secret-token',
+    };
+    expect(grokMcpWiringEnabled(options)).toBe(true);
+    const env = builder.buildGrokEnv(options);
+    expect(env).toEqual({
+      KANGENTIC_EVENTS_PATH: '/project/.kangentic/sessions/s1/events.jsonl',
+      KANGENTIC_MCP_URL: 'http://127.0.0.1:4100/mcp/p1/s1',
+      KANGENTIC_MCP_TOKEN: 'secret-token',
+    });
+  });
+
+  it('never leaks the MCP URL or token into argv, and pre-approves kangentic MCP tools', () => {
+    const tempCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-cmd-'));
+    try {
+      const command = builder.buildGrokCommand({
+        ...baseOptions,
+        cwd: tempCwd,
+        sessionId: SESSION_ID,
+        prompt: 'go',
+        mcpServerUrl: 'http://127.0.0.1:4100/mcp/p1/s1',
+        mcpServerToken: 'secret-token',
+      });
+      expect(command).not.toContain('secret-token');
+      expect(command).not.toContain('127.0.0.1:4100');
+      // The Claude-parity allow rule: without it, a board-driven session
+      // stalls on grok's approval prompt for kangentic's own MCP tools.
+      expect(command).toContain("--allow 'MCPTool(kangentic__*)'");
+    } finally {
+      fs.rmSync(tempCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('emits no MCP allow rule when the server is not attached', () => {
+    const command = builder.buildGrokCommand({ ...baseOptions, sessionId: SESSION_ID, prompt: 'go' });
+    expect(command).not.toContain('--allow');
+  });
+
+  it('suppresses MCP env when disabled or incomplete', () => {
+    expect(builder.buildGrokEnv({ ...baseOptions })).toBeNull();
+    expect(builder.buildGrokEnv({
+      ...baseOptions,
+      mcpServerEnabled: false,
+      mcpServerUrl: 'http://x',
+      mcpServerToken: 't',
+    })).toBeNull();
+    expect(grokMcpWiringEnabled({ ...baseOptions, mcpServerUrl: 'http://x' })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hook manager + MCP config files
+// ---------------------------------------------------------------------------
+
+function decodeDirective(token: string): { kind: string; payload: unknown } {
+  const colonIndex = token.indexOf(':');
+  const kind = token.slice(0, colonIndex);
+  const payload = JSON.parse(Buffer.from(token.slice(colonIndex + 1), 'base64').toString('utf8'));
+  return { kind, payload };
+}
+
+describe('buildGrokHooks', () => {
+  const hooks = buildGrokHooks('/bridge/event-bridge.js');
+
+  it('wires every lifecycle event through the env-sentinel bridge command', () => {
+    const expectedEvents = [
+      'PreToolUse', 'PostToolUse', 'PostToolUseFailure', 'UserPromptSubmit', 'Stop',
+      'StopFailure', 'SessionStart', 'SessionEnd', 'SubagentStart', 'SubagentStop',
+      'PermissionDenied', 'Notification', 'PreCompact',
+    ];
+    expect(Object.keys(hooks).sort()).toEqual([...expectedEvents].sort());
+    for (const entries of Object.values(hooks)) {
+      for (const entry of entries) {
+        for (const hook of entry.hooks) {
+          expect(hook.command).toContain('"/bridge/event-bridge.js"');
+          expect(hook.command).toContain('"env:KANGENTIC_EVENTS_PATH"');
+        }
+      }
+    }
+  });
+
+  it("extracts grok's camelCase payload fields on tool events", () => {
+    // Command shape: node "<bridge>" "env:KANGENTIC_EVENTS_PATH" <type> <directives...>
+    const preToolCommand = hooks.PreToolUse[0].hooks[0].command;
+    const tokens = preToolCommand.split(' ');
+    expect(tokens[3]).toBe('tool_start');
+    const directives = tokens.slice(4).map(decodeDirective);
+    expect(directives[0]).toEqual({ kind: 'extractTool', payload: { field: 'toolName' } });
+    expect(directives[1]).toEqual({ kind: 'extractToolId', payload: { fields: ['toolUseId'] } });
+    expect(directives[2].kind).toBe('extractDetail');
+    expect(directives[2].payload).toMatchObject({ nested: 'toolInput' });
+  });
+
+  it('maps Stop to idle and remaps transient StopFailure classes to turn_retrying', () => {
+    expect(hooks.Stop[0].hooks[0].command.split(' ')[3]).toBe('idle');
+
+    const stopFailureTokens = hooks.StopFailure[0].hooks[0].command.split(' ');
+    expect(stopFailureTokens[3]).toBe('turn_failed');
+    const directives = stopFailureTokens.slice(4).map(decodeDirective);
+    const remaps = directives.filter((directive) => directive.kind === 'setTypeWhenDetailContains');
+    expect(remaps.map((directive) => (directive.payload as { contains: string }).contains).sort())
+      .toEqual(['rate_limit', 'server_error']);
+  });
+
+  it('decodes payload fields for PostToolUseFailure, SessionEnd, SubagentStart/Stop, PermissionDenied, Notification, and PreCompact', () => {
+    const postToolUseFailureTokens = hooks.PostToolUseFailure[0].hooks[0].command.split(' ');
+    expect(postToolUseFailureTokens[3]).toBe('tool_end');
+    const postFailureDirectives = postToolUseFailureTokens.slice(4).map(decodeDirective);
+    expect(postFailureDirectives[0]).toEqual({ kind: 'extractTool', payload: { field: 'toolName' } });
+    expect(postFailureDirectives[1]).toEqual({ kind: 'extractToolId', payload: { fields: ['toolUseId'] } });
+    expect(postFailureDirectives[2]).toEqual({ kind: 'extractDetail', payload: { fields: ['error', 'errorDetails'] } });
+
+    const sessionEndTokens = hooks.SessionEnd[0].hooks[0].command.split(' ');
+    expect(sessionEndTokens[3]).toBe('session_end');
+    expect(sessionEndTokens).toHaveLength(4);
+
+    const subagentStartTokens = hooks.SubagentStart[0].hooks[0].command.split(' ');
+    expect(subagentStartTokens[3]).toBe('subagent_start');
+    expect(decodeDirective(subagentStartTokens[4])).toEqual({
+      kind: 'extractDetail', payload: { fields: ['subagentType', 'agentType'] },
+    });
+
+    const subagentStopTokens = hooks.SubagentStop[0].hooks[0].command.split(' ');
+    expect(subagentStopTokens[3]).toBe('subagent_stop');
+    expect(decodeDirective(subagentStopTokens[4])).toEqual({
+      kind: 'extractDetail', payload: { fields: ['subagentType', 'agentType'] },
+    });
+
+    const permissionDeniedTokens = hooks.PermissionDenied[0].hooks[0].command.split(' ');
+    expect(permissionDeniedTokens[3]).toBe('notification');
+    expect(decodeDirective(permissionDeniedTokens[4])).toEqual({
+      kind: 'extractDetail', payload: { fields: ['toolName', 'message'] },
+    });
+
+    const notificationTokens = hooks.Notification[0].hooks[0].command.split(' ');
+    expect(notificationTokens[3]).toBe('notification');
+    expect(decodeDirective(notificationTokens[4])).toEqual({
+      kind: 'extractDetail', payload: { fields: ['message', 'notification', 'text'] },
+    });
+
+    const preCompactTokens = hooks.PreCompact[0].hooks[0].command.split(' ');
+    expect(preCompactTokens[3]).toBe('compact');
+    expect(preCompactTokens).toHaveLength(4);
+  });
+});
+
+describe('hooks file + MCP config lifecycle', () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-proj-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('writes a wholly-owned hooks file and prunes it (and empty dirs) on removal', () => {
+    writeHooksFile(projectDir);
+    const hooksPath = path.join(projectDir, '.grok', 'hooks', 'kangentic.json');
+    const parsed = JSON.parse(fs.readFileSync(hooksPath, 'utf-8'));
+    expect(Object.keys(parsed.hooks)).toContain('Stop');
+
+    removeHooksFile(projectDir);
+    expect(fs.existsSync(hooksPath)).toBe(false);
+    expect(fs.existsSync(path.join(projectDir, '.grok'))).toBe(false);
+  });
+
+  it('never deletes user hook files or a non-empty .grok directory', () => {
+    const userHookPath = path.join(projectDir, '.grok', 'hooks', 'my-hooks.json');
+    fs.mkdirSync(path.dirname(userHookPath), { recursive: true });
+    fs.writeFileSync(userHookPath, '{"hooks":{}}');
+
+    writeHooksFile(projectDir);
+    removeHooksFile(projectDir);
+    expect(fs.existsSync(userHookPath)).toBe(true);
+  });
+
+  it('writes a static env-referencing MCP block and strips only its own block', () => {
+    const configPath = path.join(projectDir, '.grok', 'config.toml');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    const userContent = '[mcp_servers.mine]\nurl = "https://example.com/mcp"\n';
+    fs.writeFileSync(configPath, userContent);
+
+    writeMcpConfig(projectDir);
+    const written = fs.readFileSync(configPath, 'utf-8');
+    expect(written).toContain(userContent.trim());
+    expect(written).toContain('[mcp_servers.kangentic]');
+    expect(written).toContain('url = "${KANGENTIC_MCP_URL}"');
+    expect(written).toContain('"X-Kangentic-Token" = "${KANGENTIC_MCP_TOKEN}"');
+
+    // Idempotent: a second write does not duplicate the block.
+    writeMcpConfig(projectDir);
+    const rewritten = fs.readFileSync(configPath, 'utf-8');
+    expect(rewritten.match(/\[mcp_servers\.kangentic\]/g)).toHaveLength(1);
+
+    removeMcpConfig(projectDir);
+    const remaining = fs.readFileSync(configPath, 'utf-8');
+    expect(remaining).toContain('[mcp_servers.mine]');
+    expect(remaining).not.toContain('kangentic');
+  });
+
+  it('deletes the config file (and empty .grok dir) when only our block existed', () => {
+    writeMcpConfig(projectDir);
+    const configPath = path.join(projectDir, '.grok', 'config.toml');
+    expect(fs.existsSync(configPath)).toBe(true);
+
+    removeMcpConfig(projectDir);
+    expect(fs.existsSync(configPath)).toBe(false);
+    expect(fs.existsSync(path.join(projectDir, '.grok'))).toBe(false);
+  });
+
+  it('refcounts wiring removal across concurrent sessions in one cwd', () => {
+    const adapter = new GrokAdapter();
+    const spawnOptions = {
+      agentPath: '/usr/bin/grok',
+      cwd: projectDir,
+      permissionMode: 'acceptEdits' as PermissionMode,
+      eventsOutputPath: path.join(projectDir, 'events.jsonl'),
+    };
+    adapter.buildCommand({ ...spawnOptions, taskId: 'task-a' });
+    adapter.buildCommand({ ...spawnOptions, taskId: 'task-b' });
+    const hooksPath = path.join(projectDir, '.grok', 'hooks', 'kangentic.json');
+    expect(fs.existsSync(hooksPath)).toBe(true);
+
+    adapter.removeHooks(projectDir, 'task-a');
+    expect(fs.existsSync(hooksPath)).toBe(true);
+
+    adapter.removeHooks(projectDir, 'task-b');
+    expect(fs.existsSync(hooksPath)).toBe(false);
+  });
+
+  it('writes the sentinel MCP block to disk for an MCP-only spawn and refcounts its removal', () => {
+    // No eventsOutputPath: this spawn participates ONLY in the MCP wiring,
+    // not the hooks-file wiring, so the hooks file must never appear while
+    // the config.toml block is written and refcounted exactly like the
+    // events-driven case above.
+    const adapter = new GrokAdapter();
+    const spawnOptions = {
+      agentPath: '/usr/bin/grok',
+      cwd: projectDir,
+      permissionMode: 'acceptEdits' as PermissionMode,
+      mcpServerUrl: 'http://127.0.0.1:4100/mcp/p1/s1',
+      mcpServerToken: 'secret-token',
+    };
+    adapter.buildCommand({ ...spawnOptions, taskId: 'task-a' });
+
+    const configPath = path.join(projectDir, '.grok', 'config.toml');
+    const hooksPath = path.join(projectDir, '.grok', 'hooks', 'kangentic.json');
+    expect(fs.existsSync(hooksPath)).toBe(false);
+    const written = fs.readFileSync(configPath, 'utf-8');
+    expect(written).toContain('[mcp_servers.kangentic]');
+    expect(written).toContain('url = "${KANGENTIC_MCP_URL}"');
+    expect(written).toContain('"X-Kangentic-Token" = "${KANGENTIC_MCP_TOKEN}"');
+
+    adapter.buildCommand({ ...spawnOptions, taskId: 'task-b' });
+    adapter.removeHooks(projectDir, 'task-a');
+    expect(fs.existsSync(configPath)).toBe(true);
+
+    adapter.removeHooks(projectDir, 'task-b');
+    expect(fs.existsSync(configPath)).toBe(false);
+  });
+
+  it('recovers from a truncated managed block (BEGIN present, END missing) by dropping to EOF', () => {
+    // Simulates a crash mid-flush: the sentinel BEGIN line landed on disk but
+    // the write was cut off before the END sentinel. removeMcpConfig must
+    // still drop the whole (partial) block rather than leaving a dangling
+    // fragment, while preserving whatever preceded it.
+    const configPath = path.join(projectDir, '.grok', 'config.toml');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    const userContent = '[mcp_servers.mine]\nurl = "https://example.com/mcp"\n';
+    fs.writeFileSync(configPath, userContent);
+
+    writeMcpConfig(projectDir);
+    const wellFormed = fs.readFileSync(configPath, 'utf-8');
+    const endSentinelIndex = wellFormed.indexOf('# END KANGENTIC MANAGED BLOCK');
+    expect(endSentinelIndex).toBeGreaterThan(-1);
+    const truncated = wellFormed.slice(0, endSentinelIndex);
+    fs.writeFileSync(configPath, truncated);
+
+    removeMcpConfig(projectDir);
+    const remaining = fs.readFileSync(configPath, 'utf-8');
+    expect(remaining).toContain(userContent.trim());
+    expect(remaining).not.toContain('kangentic');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session paths
+// ---------------------------------------------------------------------------
+
+describe('session paths', () => {
+  it('URL-encodes the raw cwd exactly as the CLI does', () => {
+    // Byte-for-byte against a real on-disk session directory name.
+    expect(cwdToSessionsDirName('C:\\Users\\dev\\Documents\\GitHub\\kangentic'))
+      .toBe('C%3A%5CUsers%5Cdev%5CDocuments%5CGitHub%5Ckangentic');
+    expect(cwdToSessionsDirName('/home/dev/project')).toBe('%2Fhome%2Fdev%2Fproject');
+  });
+
+  it('honors GROK_HOME for the session store root', () => {
+    const home = useTempGrokHome();
+    const dir = grokSessionDir('/home/dev/project', SESSION_ID);
+    expect(dir).toBe(path.join(home, 'sessions', '%2Fhome%2Fdev%2Fproject', SESSION_ID));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session history parser (updates.jsonl)
+// ---------------------------------------------------------------------------
+
+function updateLine(update: Record<string, unknown>, paramsMeta?: Record<string, unknown>): string {
+  return JSON.stringify({
+    timestamp: 1786162871,
+    method: 'session/update',
+    params: { sessionId: SESSION_ID, update, ...(paramsMeta ? { _meta: paramsMeta } : {}) },
+  });
+}
+
+describe('GrokSessionHistoryParser', () => {
+  it('maps turn_completed to Idle with cumulative cost at 1e-10 USD per tick', () => {
+    const home = useTempGrokHome();
+    fs.writeFileSync(path.join(home, 'models_cache.json'), JSON.stringify({
+      models: { 'grok-4.6': { info: { id: 'grok-4.6', name: 'Grok 4.6', context_window: 500000 } } },
+    }));
+
+    const content = [
+      updateLine({ sessionUpdate: 'user_message_chunk', content: { type: 'text', text: 'hi' }, _meta: { modelId: 'grok-4.6' } }),
+      updateLine({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'ok' } }, { totalTokens: 50000 }),
+      updateLine({
+        sessionUpdate: 'turn_completed',
+        stop_reason: 'end_turn',
+        usage: { inputTokens: 541054, outputTokens: 1222, costUsdTicks: 236720000, apiDurationMs: 5980 },
+      }),
+    ].join('\n');
+
+    const result = GrokSessionHistoryParser.parse(content, 'append');
+    expect(result.activity).toBe('idle');
+    expect(result.events).toEqual([]);
+    expect(result.usage?.model.id).toBe('grok-4.6');
+    expect(result.usage?.model.displayName).toBe('Grok 4.6');
+    // Context occupancy comes from the running _meta.totalTokens, NEVER the
+    // cumulative turn_completed inputTokens (541k would blow past the bar).
+    expect(result.usage?.contextWindow.usedTokens).toBe(50000);
+    expect(result.usage?.contextWindow.contextWindowSize).toBe(500000);
+    expect(result.usage?.contextWindow.usedPercentage).toBeCloseTo(10, 5);
+    // Pinned by a real headless run reporting both fields side by side.
+    expect(result.usage?.cost.totalCostUsd).toBeCloseTo(0.023672, 6);
+  });
+
+  it('maps streaming chunks and tool activity to Thinking and holds through retries', () => {
+    const thinking = GrokSessionHistoryParser.parse(
+      updateLine({ sessionUpdate: 'tool_call', toolCallId: 'call-1', title: 'read_file' }),
+      'append',
+    );
+    expect(thinking.activity).toBe('thinking');
+    expect(thinking.events).toEqual([]);
+
+    const retrying = GrokSessionHistoryParser.parse(
+      updateLine({ sessionUpdate: 'retry_state', type: 'retrying', message: 'server busy' }),
+      'append',
+    );
+    expect(retrying.activity).toBe('thinking');
+
+    const failed = GrokSessionHistoryParser.parse(
+      updateLine({ sessionUpdate: 'retry_state', type: 'failed', message: 'API error' }),
+      'append',
+    );
+    expect(failed.activity).toBeNull();
+  });
+
+  it('tolerates malformed lines and unknown update types', () => {
+    const content = [
+      'not json at all',
+      '{"params": "shape mismatch"}',
+      updateLine({ sessionUpdate: 'hook_execution', event_name: 'pre_tool_use' }),
+      updateLine({ sessionUpdate: 'some_future_type' }),
+    ].join('\n');
+    const result = GrokSessionHistoryParser.parse(content, 'append');
+    expect(result.activity).toBeNull();
+    expect(result.events).toEqual([]);
+  });
+
+  it('falls back to the LAST modelUsage key for the model id when no user_message_chunk carried one', () => {
+    const home = useTempGrokHome();
+    fs.writeFileSync(path.join(home, 'models_cache.json'), JSON.stringify({
+      models: { 'grok-4-fast': { info: { id: 'grok-4-fast', name: 'Grok 4 Fast', context_window: 128000 } } },
+    }));
+
+    // Only a turn_completed record - no user_message_chunk to carry
+    // update._meta.modelId, so the model id must be resolved from the
+    // modelUsage breakdown keys, taking the LAST one.
+    const content = updateLine({
+      sessionUpdate: 'turn_completed',
+      stop_reason: 'end_turn',
+      usage: {
+        inputTokens: 500,
+        outputTokens: 50,
+        modelUsage: { 'grok-4-mini': { inputTokens: 200 }, 'grok-4-fast': { inputTokens: 300 } },
+      },
+    });
+
+    const result = GrokSessionHistoryParser.parse(content, 'append');
+    expect(result.usage?.model.id).toBe('grok-4-fast');
+    expect(result.usage?.model.displayName).toBe('Grok 4 Fast');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transcript parser (chat_history.jsonl)
+// ---------------------------------------------------------------------------
+
+describe('parseGrokTranscript', () => {
+  it('parses user turns, reasoning, assistant tool calls, and tool results', async () => {
+    const home = useTempGrokHome();
+    const cwd = '/home/dev/project';
+    const sessionDir = path.join(home, 'sessions', cwdToSessionsDirName(cwd), SESSION_ID);
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const records = [
+      { type: 'system', content: 'You are Grok.' },
+      { type: 'user', synthetic_reason: 'system_reminder', content: { type: 'text', text: 'injected context' } },
+      { type: 'user', content: { type: 'text', text: '<user_query>\nfix the bug\n</user_query>' } },
+      { type: 'reasoning', content: null, summary: 'Considering the fix.' },
+      {
+        type: 'assistant',
+        content: 'On it.',
+        model_id: 'grok-4.6',
+        tool_calls: [{ id: 'call-1', name: 'read_file', arguments: '{"target_file":"a.ts"}' }],
+      },
+      { type: 'tool_result', tool_call_id: 'call-1', content: 'file contents' },
+    ];
+    fs.writeFileSync(
+      path.join(sessionDir, 'chat_history.jsonl'),
+      records.map((record) => JSON.stringify(record)).join('\n'),
+    );
+
+    const { entries, sourcePath } = await parseGrokTranscript(SESSION_ID, cwd);
+    expect(sourcePath).toContain('chat_history.jsonl');
+    expect(entries).toHaveLength(3);
+
+    expect(entries[0]).toMatchObject({ kind: 'user', text: 'fix the bug' });
+    expect(entries[1]).toMatchObject({ kind: 'assistant', model: 'grok-4.6' });
+    const assistantEntry = entries[1] as { blocks: Array<{ type: string }> };
+    expect(assistantEntry.blocks.map((block) => block.type)).toEqual(['thinking', 'text', 'tool_use']);
+    const toolUse = assistantEntry.blocks[2] as { type: string; name: string; input: unknown };
+    expect(toolUse.name).toBe('read_file');
+    expect(toolUse.input).toEqual({ target_file: 'a.ts' });
+    expect(entries[2]).toMatchObject({ kind: 'tool_result', toolUseId: 'call-1', content: 'file contents' });
+  });
+
+  it('returns empty on a missing file', async () => {
+    useTempGrokHome();
+    const { entries, sourcePath } = await parseGrokTranscript(SESSION_ID, '/nowhere');
+    expect(entries).toEqual([]);
+    expect(sourcePath).toBeNull();
+  });
+});
+
+describe('grokTranscriptUsage / grokTranscriptToolCounts', () => {
+  it('takes the LAST turn_completed.usage, not the first or a sum', async () => {
+    const home = useTempGrokHome();
+    const cwd = '/home/dev/usage-project';
+    const updatesPath = grokUpdatesJsonlPath(cwd, SESSION_ID);
+    fs.mkdirSync(path.dirname(updatesPath), { recursive: true });
+    const content = [
+      updateLine({ sessionUpdate: 'turn_completed', usage: { inputTokens: 100, outputTokens: 20 } }),
+      updateLine({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'more' } }),
+      updateLine({ sessionUpdate: 'turn_completed', usage: { inputTokens: 300, outputTokens: 75 } }),
+    ].join('\n');
+    fs.writeFileSync(updatesPath, content);
+
+    const usage = await grokTranscriptUsage(SESSION_ID, cwd);
+    expect(usage).toEqual({ inputTokens: 300, outputTokens: 75 });
+  });
+
+  it('returns null when the updates file is missing', async () => {
+    useTempGrokHome();
+    const usage = await grokTranscriptUsage(SESSION_ID, '/nowhere');
+    expect(usage).toBeNull();
+  });
+
+  it('dedupes tool calls by toolCallId, names from _meta with a title fallback, and sorts the breakdown by callCount', async () => {
+    const home = useTempGrokHome();
+    const cwd = '/home/dev/tool-counts-project';
+    const updatesPath = grokUpdatesJsonlPath(cwd, SESSION_ID);
+    fs.mkdirSync(path.dirname(updatesPath), { recursive: true });
+    const content = [
+      // Same toolCallId twice - the duplicate must not be double-counted.
+      updateLine({ sessionUpdate: 'tool_call', toolCallId: 'call-1', title: 'read_file' }),
+      updateLine({ sessionUpdate: 'tool_call', toolCallId: 'call-1', title: 'read_file' }),
+      // Name resolved from _meta['x.ai/tool'].name, ignoring the title.
+      updateLine({ sessionUpdate: 'tool_call', toolCallId: 'call-2', title: 'ignored', _meta: { 'x.ai/tool': { name: 'edit_file' } } }),
+      // No _meta - name falls back to title. Three distinct ids, all counted.
+      updateLine({ sessionUpdate: 'tool_call', toolCallId: 'call-3', title: 'grep' }),
+      updateLine({ sessionUpdate: 'tool_call', toolCallId: 'call-4', title: 'grep' }),
+      updateLine({ sessionUpdate: 'tool_call', toolCallId: 'call-5', title: 'grep' }),
+    ].join('\n');
+    fs.writeFileSync(updatesPath, content);
+
+    const counts = await grokTranscriptToolCounts(SESSION_ID, cwd);
+    expect(counts?.toolCallCount).toBe(5);
+    // The sort-by-callCount contract only orders by count, so only the top
+    // (unambiguous) entry is asserted by position; the two count-1 entries
+    // (an incidental tie) are asserted by membership, not position.
+    expect(counts?.toolBreakdown?.[0]).toEqual({ toolName: 'grep', callCount: 3, totalDurationMs: 0, interruptedCount: 0 });
+    expect(counts?.toolBreakdown).toEqual(expect.arrayContaining([
+      { toolName: 'read_file', callCount: 1, totalDurationMs: 0, interruptedCount: 0 },
+      { toolName: 'edit_file', callCount: 1, totalDurationMs: 0, interruptedCount: 0 },
+    ]));
+    expect(counts?.toolBreakdown).toHaveLength(3);
+  });
+
+  it('returns null when there are no tool calls', async () => {
+    const home = useTempGrokHome();
+    const cwd = '/home/dev/no-tools-project';
+    const updatesPath = grokUpdatesJsonlPath(cwd, SESSION_ID);
+    fs.mkdirSync(path.dirname(updatesPath), { recursive: true });
+    fs.writeFileSync(updatesPath, updateLine({ sessionUpdate: 'turn_completed', usage: { inputTokens: 1, outputTokens: 1 } }));
+
+    const counts = await grokTranscriptToolCounts(SESSION_ID, cwd);
+    expect(counts).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Command-injection extractor
+// ---------------------------------------------------------------------------
+
+describe('extractGrokUserTurn', () => {
+  it('extracts a genuine typed turn, unwrapping <user_query>', () => {
+    const line = JSON.stringify({ type: 'user', content: { type: 'text', text: '<user_query>\n/code-review\n</user_query>' } });
+    expect(extractGrokUserTurn(line)).toEqual({ timestampMs: null, text: '/code-review' });
+  });
+
+  it('rejects synthetic context records and non-user records', () => {
+    expect(extractGrokUserTurn(JSON.stringify({ type: 'user', synthetic_reason: 'system_reminder', content: { type: 'text', text: 'x' } }))).toBeNull();
+    expect(extractGrokUserTurn(JSON.stringify({ type: 'assistant', content: 'hello' }))).toBeNull();
+    expect(extractGrokUserTurn('not json')).toBeNull();
+  });
+
+  it('handles the wrapper edge cases via unwrapUserQuery', () => {
+    expect(unwrapUserQuery('<user_query>\nplain\n</user_query>')).toBe('plain');
+    expect(unwrapUserQuery('no wrapper at all')).toBe('no wrapper at all');
+  });
+
+  it('extracts text from a content array of plain strings, not just block objects', () => {
+    // extractGrokUserTurn now delegates to the shared extractTextContent
+    // (transcript-parser.ts), which accepts plain-string array items. The
+    // pre-fix inline copy silently dropped them and returned null.
+    const line = JSON.stringify({
+      type: 'user',
+      content: ['<user_query>\ntyped text\n</user_query>'],
+    });
+    expect(extractGrokUserTurn(line)).toEqual({ timestampMs: null, text: 'typed text' });
+  });
+});
+
+describe('createGrokCommandInjectionVerifier (wiring)', () => {
+  // Everything above exercises extractGrokUserTurn directly. This drives the
+  // real chain the injection burst uses: build the verifier via the actual
+  // production factory and confirm it reads a real chat_history.jsonl on
+  // disk - the precedent is codex-command-injection-verifier.test.ts's
+  // 'createSubmittedTextSubmissionVerifier (Codex wiring)' block.
+  it('confirms a matching typed submission and rejects one that never landed', async () => {
+    const home = useTempGrokHome();
+    const cwd = '/home/dev/verifier-project';
+    const sessionDir = path.join(home, 'sessions', cwdToSessionsDirName(cwd), SESSION_ID);
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sessionDir, 'chat_history.jsonl'),
+      `${JSON.stringify({ type: 'user', content: { type: 'text', text: '<user_query>\nrun the tests\n</user_query>' } })}\n`,
+    );
+
+    const verifier = createGrokCommandInjectionVerifier();
+    const sentAt = Date.now();
+
+    expect(await verifier({
+      type: 'command-injection',
+      text: 'run the tests',
+      agentSessionId: SESSION_ID,
+      cwd,
+      sentAt,
+      mode: 'submitted',
+    })).toBe(true);
+
+    expect(await verifier({
+      type: 'command-injection',
+      text: 'a command that was never submitted',
+      agentSessionId: SESSION_ID,
+      cwd,
+      sentAt,
+      mode: 'submitted',
+    })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transcript cleanup
+// ---------------------------------------------------------------------------
+
+describe('cleanGrokTranscript', () => {
+  it("extracts the last turn from grok's exit dump and strips the resume trailer", () => {
+    const raw = [
+      'Grok Build  1.0.0',
+      'Grok4.6ishere,tryitoutforfreeforalimitedtime!',
+      '[Click here to Upgrade]',
+      'Reply with exactly: PONG',
+      '> Reply with exactly: PONG',
+      '  PONG',
+      'Resume this session with:',
+      '  grok --resume 01a00b66-92e2-7812-a209-b80885090deb',
+    ].join('\n');
+    const cleaned = cleanGrokTranscript(raw);
+    expect(cleaned).toContain('Reply with exactly: PONG');
+    expect(cleaned).toContain('PONG');
+    expect(cleaned).not.toContain('--resume');
+    expect(cleaned).not.toContain('Upgrade');
+    expect(cleaned).not.toContain('Grok Build  1.0.0');
+  });
+
+  it('returns finalized prose when no structural marker exists', () => {
+    expect(cleanGrokTranscript('just some output\n\nwith prose')).toContain('just some output');
+    expect(cleanGrokTranscript('   \n  ')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Capability discovery
+// ---------------------------------------------------------------------------
+
+describe('discoverGrokCapabilities', () => {
+  it("reads models, display names, and effort levels from grok's models cache", async () => {
+    const home = useTempGrokHome();
+    fs.writeFileSync(path.join(home, 'models_cache.json'), JSON.stringify({
+      models: {
+        'grok-4.6': {
+          info: {
+            id: 'grok-4.6', name: 'Grok 4.6', context_window: 500000, hidden: false,
+            reasoning_efforts: [{ id: 'xhigh' }, { id: 'high' }, { id: 'medium' }, { id: 'low' }],
+          },
+        },
+        'grok-secret': { info: { id: 'grok-secret', name: 'Hidden', hidden: true } },
+      },
+    }));
+
+    const capabilities = await discoverGrokCapabilities('/usr/bin/grok');
+    expect(capabilities.supportsModelOverride).toBe(true);
+    expect(capabilities.models).toEqual(['grok-4.6']);
+    expect(capabilities.modelDisplayNames).toEqual({ 'grok-4.6': 'Grok 4.6' });
+    expect(capabilities.effortLevels).toEqual(['low', 'medium', 'high', 'xhigh']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trust manager
+// ---------------------------------------------------------------------------
+
+describe('trust manager', () => {
+  function worktreePathUnder(projectRoot: string): string {
+    return path.join(projectRoot, '.kangentic', 'worktrees', 'task-slug');
+  }
+
+  it('pre-approves a Kangentic worktree with no covering decision', async () => {
+    const home = useTempGrokHome();
+    const projectRoot = path.join(home, 'fake-project');
+    const worktree = worktreePathUnder(projectRoot);
+
+    await ensureWorktreeTrust(worktree);
+    const store = fs.readFileSync(path.join(home, 'trusted_folders.toml'), 'utf-8');
+    expect(store).toContain(`[folders.'${path.resolve(worktree)}']`);
+    expect(store).toContain('trusted = true');
+    expect(store).toMatch(/decided_at = \d+/);
+  });
+
+  it('does nothing when a trusted ancestor already cascades over the worktree', async () => {
+    const home = useTempGrokHome();
+    const projectRoot = path.join(home, 'fake-project');
+    const storePath = path.join(home, 'trusted_folders.toml');
+    fs.writeFileSync(storePath, `[folders.'${path.resolve(projectRoot)}']\ntrusted = true\ndecided_at = 1786162868\n`);
+
+    await ensureWorktreeTrust(worktreePathUnder(projectRoot));
+    const store = fs.readFileSync(storePath, 'utf-8');
+    expect(store).not.toContain('worktrees');
+  });
+
+  it('respects an explicit ancestor deny', async () => {
+    const home = useTempGrokHome();
+    const projectRoot = path.join(home, 'fake-project');
+    const storePath = path.join(home, 'trusted_folders.toml');
+    fs.writeFileSync(storePath, `[folders.'${path.resolve(projectRoot)}']\ntrusted = false\ndecided_at = 1786162868\n`);
+
+    await ensureWorktreeTrust(worktreePathUnder(projectRoot));
+    const store = fs.readFileSync(storePath, 'utf-8');
+    expect(store).not.toContain('worktrees');
+    expect(store).toContain('trusted = false');
+  });
+
+  it('never auto-trusts a plain project root', async () => {
+    const home = useTempGrokHome();
+    await ensureWorktreeTrust(path.join(home, 'fake-project'));
+    expect(fs.existsSync(path.join(home, 'trusted_folders.toml'))).toBe(false);
+  });
+
+  it('removes only tables Kangentic could have written, atomically', async () => {
+    const home = useTempGrokHome();
+    const projectRoot = path.join(home, 'fake-project');
+    const worktree = worktreePathUnder(projectRoot);
+    const storePath = path.join(home, 'trusted_folders.toml');
+    const userTable = `[folders.'${path.resolve(projectRoot)}']\ntrusted = true\ndecided_at = 1786162868\ncustom_key = "user data"\n`;
+    fs.writeFileSync(storePath, userTable);
+
+    await ensureWorktreeTrust(worktree);
+    await removeWorktreeTrust(worktree);
+    const store = fs.readFileSync(storePath, 'utf-8');
+    expect(store).not.toContain('worktrees');
+    expect(store).toContain('custom_key = "user data"');
+
+    // A table with foreign keys at the WORKTREE path itself survives too.
+    fs.writeFileSync(storePath, `[folders.'${path.resolve(worktree)}']\ntrusted = true\nother = 1\n`);
+    await removeWorktreeTrust(worktree);
+    expect(fs.readFileSync(storePath, 'utf-8')).toContain('other = 1');
+  });
+});
+
+describe('GrokAdapter.onWorktreeRemoved', () => {
+  // Everything above exercises removeWorktreeTrust directly. This proves the
+  // REAL adapter method is wired to it - nothing else in the suite calls
+  // onWorktreeRemoved through the adapter itself (the codex-adapter.test.ts
+  // 'onWorktreeRemoved' block is the precedent for this shape).
+  it('delegates to trust-manager removal for a real worktree entry', async () => {
+    const home = useTempGrokHome();
+    const adapter = new GrokAdapter();
+    const projectRoot = path.join(home, 'delegation-project');
+    const worktree = path.join(projectRoot, '.kangentic', 'worktrees', 'task-slug');
+    const storePath = path.join(home, 'trusted_folders.toml');
+
+    await adapter.ensureTrust(worktree);
+    expect(fs.readFileSync(storePath, 'utf-8')).toContain(`[folders.'${path.resolve(worktree)}']`);
+
+    await adapter.onWorktreeRemoved(worktree);
+
+    expect(fs.readFileSync(storePath, 'utf-8')).not.toContain(`[folders.'${path.resolve(worktree)}']`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Project relocation
+// ---------------------------------------------------------------------------
+
+describe('migrateGrokProjectData', () => {
+  it('renames the encoded session directory and rewrites trust paths', async () => {
+    const home = useTempGrokHome();
+    const oldProject = path.join(home, 'old-project');
+    const newProject = path.join(home, 'new-project');
+    const sessionsRoot = path.join(home, 'sessions');
+    const oldSessionDir = path.join(sessionsRoot, cwdToSessionsDirName(path.resolve(oldProject)), SESSION_ID);
+    fs.mkdirSync(oldSessionDir, { recursive: true });
+    fs.writeFileSync(path.join(oldSessionDir, 'updates.jsonl'), '');
+    fs.writeFileSync(
+      path.join(home, 'trusted_folders.toml'),
+      `[folders.'${path.resolve(oldProject)}']\ntrusted = true\ndecided_at = 1786162868\n`,
+    );
+
+    await migrateGrokProjectData(oldProject, newProject);
+
+    expect(fs.existsSync(path.join(sessionsRoot, cwdToSessionsDirName(path.resolve(newProject)), SESSION_ID))).toBe(true);
+    expect(fs.existsSync(oldSessionDir)).toBe(false);
+    const store = fs.readFileSync(path.join(home, 'trusted_folders.toml'), 'utf-8');
+    expect(store).toContain(`[folders.'${path.resolve(newProject)}']`);
+    expect(store).not.toContain(`[folders.'${path.resolve(oldProject)}']`);
+  });
+
+  it('rewrites a double-quoted trust header for the old path, leaving an unrelated header untouched', async () => {
+    // grok itself always writes single-quoted literals, but a double-quoted
+    // key is legal TOML and must not be silently left pointing at the old
+    // path. POSIX-style paths (no backslashes) keep the naive quote
+    // extraction exact - a Windows path would need backslash escaping to be
+    // a valid double-quoted TOML basic string.
+    const home = useTempGrokHome();
+    const oldProjectPath = '/old/project/path';
+    const newProjectPath = path.join(home, 'new-project');
+    const unrelatedPath = '/some/other/project';
+    const storePath = path.join(home, 'trusted_folders.toml');
+    fs.writeFileSync(
+      storePath,
+      `[folders."${oldProjectPath}"]\ntrusted = true\ndecided_at = 1786162868\n\n`
+      + `[folders."${unrelatedPath}"]\ntrusted = true\ndecided_at = 1786162868\n`,
+    );
+
+    await migrateGrokProjectData(oldProjectPath, newProjectPath);
+
+    const store = fs.readFileSync(storePath, 'utf-8');
+    expect(store).toContain(`[folders.'${path.resolve(newProjectPath)}']`);
+    expect(store).not.toContain(`[folders."${oldProjectPath}"]`);
+    expect(store).toContain(`[folders."${unrelatedPath}"]`);
+  });
+});
+
+describe('GrokAdapter.onProjectRelocated', () => {
+  // Everything above exercises migrateGrokProjectData directly. This proves
+  // the REAL adapter method is wired to it.
+  it('delegates to migrateGrokProjectData for the real session directory', async () => {
+    const home = useTempGrokHome();
+    const adapter = new GrokAdapter();
+    const oldProject = path.join(home, 'delegation-old');
+    const newProject = path.join(home, 'delegation-new');
+    const sessionsRoot = path.join(home, 'sessions');
+    const oldSessionDir = path.join(sessionsRoot, cwdToSessionsDirName(path.resolve(oldProject)), SESSION_ID);
+    fs.mkdirSync(oldSessionDir, { recursive: true });
+    fs.writeFileSync(path.join(oldSessionDir, 'updates.jsonl'), '');
+
+    await adapter.onProjectRelocated(oldProject, newProject);
+
+    expect(fs.existsSync(path.join(sessionsRoot, cwdToSessionsDirName(path.resolve(newProject)), SESSION_ID))).toBe(true);
+    expect(fs.existsSync(oldSessionDir)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// locate: caller-owned id, deterministic path
+// ---------------------------------------------------------------------------
+
+describe('session history locate', () => {
+  it('finds the updates file at the deterministic encoded path', async () => {
+    const home = useTempGrokHome();
+    const cwd = '/home/dev/project';
+    const updatesPath = grokUpdatesJsonlPath(cwd, SESSION_ID);
+    fs.mkdirSync(path.dirname(updatesPath), { recursive: true });
+    fs.writeFileSync(updatesPath, '');
+
+    const located = await GrokSessionHistoryParser.locate({ agentSessionId: SESSION_ID, cwd });
+    expect(located).toBe(updatesPath);
+    expect(located).toContain(home);
+  });
+
+  it('gives up (null) when nothing appears within the budget', async () => {
+    useTempGrokHome();
+    const located = await (await import('../../src/main/agent/adapters/grok/session-paths')).locateGrokUpdatesFile({
+      agentSessionId: SESSION_ID,
+      cwd: '/nowhere',
+      maxAttempts: 1,
+    });
+    expect(located).toBeNull();
+  });
+
+  it('recovers via a cross-cwd scan when the file lives under a differently-encoded cwd key', async () => {
+    // The caller-owned session UUID is globally unique, so once the CLI has
+    // written ANYTHING, a one-level scan of the sessions root finds it even
+    // when the cwd key was encoded differently than expected (e.g. a
+    // drive-letter casing difference). This is the attach-time locator's
+    // fallback, deliberately absent from GrokAdapter.locateSessionHistoryFile
+    // (see the "GrokAdapter.locateSessionHistoryFile" block below).
+    const home = useTempGrokHome();
+    const foreignCwdKey = encodeURIComponent('/some/other/machine-path');
+    const sessionDir = path.join(home, 'sessions', foreignCwdKey, SESSION_ID);
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const updatesPath = path.join(sessionDir, 'updates.jsonl');
+    fs.writeFileSync(updatesPath, '');
+
+    const located = await locateGrokUpdatesFile({
+      agentSessionId: SESSION_ID,
+      cwd: '/home/dev/project-not-matching',
+      maxAttempts: 1,
+    });
+    expect(located).toBe(updatesPath);
+  });
+});
+
+describe('GrokAdapter.locateSessionHistoryFile (strict cwd-scoped probe)', () => {
+  // This MUST NOT reuse GrokSessionHistoryParser.locate's cross-cwd scan
+  // (see the preceding "recovers via a cross-cwd scan" test): callers like
+  // resume-cwd-migration's reachability gate depend on this probe answering
+  // ONLY for the exact (cwd, sessionId) pair, never a scan hit under a
+  // different cwd's encoded directory.
+  it('returns the path when updates.jsonl exists at the cwd-scoped encoded path', async () => {
+    const home = useTempGrokHome();
+    const adapter = new GrokAdapter();
+    const cwd = '/home/dev/probe-project';
+    const updatesPath = grokUpdatesJsonlPath(cwd, SESSION_ID);
+    fs.mkdirSync(path.dirname(updatesPath), { recursive: true });
+    fs.writeFileSync(updatesPath, '');
+
+    const located = await adapter.locateSessionHistoryFile(SESSION_ID, cwd);
+    expect(located).toBe(updatesPath);
+    expect(located).toContain(home);
+  });
+
+  it('returns null when the session id exists ONLY under a different cwd\'s encoded directory', async () => {
+    // Red-green: the pre-fix implementation reused the cross-cwd scan and
+    // would have found this session under the foreign cwd, falsely
+    // reporting it reachable from the cwd under test - the exact bug that
+    // broke resume-cwd-migration's "already reachable from the NEW cwd?"
+    // gate.
+    const home = useTempGrokHome();
+    const adapter = new GrokAdapter();
+    const foreignCwd = '/home/dev/other-project';
+    const foreignUpdatesPath = grokUpdatesJsonlPath(foreignCwd, SESSION_ID);
+    fs.mkdirSync(path.dirname(foreignUpdatesPath), { recursive: true });
+    fs.writeFileSync(foreignUpdatesPath, '');
+
+    const located = await adapter.locateSessionHistoryFile(SESSION_ID, '/home/dev/probe-project');
+    expect(located).toBeNull();
+  });
+});

--- a/tests/unit/grok-capability-discovery-help-fallback.test.ts
+++ b/tests/unit/grok-capability-discovery-help-fallback.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Grok Build capability discovery's `--help` fallback path
+ * (`src/main/agent/adapters/grok/capability-discovery.ts`), exercised when
+ * `~/.grok/models_cache.json` is absent (a fresh install that has never
+ * launched grok interactively).
+ *
+ * `discoverGrokCapabilities` shells out via `exec` (win32) / `execFile`
+ * (POSIX), both wrapped in `promisify`. This mirrors the established mocking
+ * pattern from `cursor-capability-discovery.test.ts`: `node:child_process`
+ * and `node:util` are mocked so `promisify(exec)` resolves to the identity
+ * of the mocked `exec` itself, and both `exec`/`execFile` are stubbed
+ * identically so the test is correct on both win32 (CI-local) and POSIX
+ * (CI Linux) without branching on `process.platform`.
+ *
+ * Kept in its own file (rather than folded into grok-adapter.test.ts)
+ * because a module-level `vi.mock('node:child_process', ...)` is
+ * file-scoped and would otherwise shadow child_process for every other
+ * test in that shared file.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+  exec: vi.fn(),
+}));
+
+vi.mock('node:util', () => ({
+  promisify: (fn: unknown) => fn,
+}));
+
+import { execFile, exec } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  discoverGrokCapabilities,
+  clearGrokCapabilityMemo,
+} from '../../src/main/agent/adapters/grok/capability-discovery';
+
+const execMock = exec as unknown as ReturnType<typeof vi.fn>;
+const execFileMock = execFile as unknown as ReturnType<typeof vi.fn>;
+
+let tempGrokHome: string;
+const originalGrokHome = process.env.GROK_HOME;
+
+function setHelpOutput(stdout: string): void {
+  const result = Promise.resolve({ stdout, stderr: '' });
+  execMock.mockReturnValue(result);
+  execFileMock.mockReturnValue(result);
+}
+
+beforeEach(() => {
+  // A fresh, empty GROK_HOME has no models_cache.json, so
+  // discoverGrokCapabilities always falls through to readHelpCapabilities.
+  tempGrokHome = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-cap-help-'));
+  process.env.GROK_HOME = tempGrokHome;
+  execMock.mockReset();
+  execFileMock.mockReset();
+  clearGrokCapabilityMemo();
+});
+
+afterEach(() => {
+  if (originalGrokHome === undefined) delete process.env.GROK_HOME;
+  else process.env.GROK_HOME = originalGrokHome;
+  fs.rmSync(tempGrokHome, { recursive: true, force: true });
+  clearGrokCapabilityMemo();
+});
+
+describe('discoverGrokCapabilities --help fallback (models_cache.json absent)', () => {
+  it('reports supportsModelOverride and the hardcoded effort ladder when --help documents both flags', async () => {
+    setHelpOutput('Usage: grok\n  -m, --model <model>   Model to use\n  --reasoning-effort <level>   Reasoning effort\n');
+
+    const capabilities = await discoverGrokCapabilities('/usr/bin/grok');
+
+    expect(capabilities.supportsModelOverride).toBe(true);
+    // The documented ladder (17-sessions.md / `/effort`), only reported when
+    // the flag is present in this build's help text.
+    expect(capabilities.effortLevels).toEqual(['low', 'medium', 'high', 'xhigh']);
+  });
+
+  it('reports no model override and no effort ladder when --help omits both flags', async () => {
+    setHelpOutput('Usage: grok\n  -h, --help    Display help\n');
+
+    const capabilities = await discoverGrokCapabilities('/usr/bin/grok');
+
+    expect(capabilities.supportsModelOverride).toBe(false);
+    expect(capabilities.effortLevels).toEqual([]);
+  });
+
+  it('returns an empty capabilities object when --help itself fails', async () => {
+    const reject = (): Promise<{ stdout: string }> => {
+      const promise = Promise.reject(new Error('ENOENT')) as Promise<{ stdout: string }>;
+      promise.catch(() => {});
+      return promise;
+    };
+    execMock.mockImplementation(reject);
+    execFileMock.mockImplementation(reject);
+
+    const capabilities = await discoverGrokCapabilities('/missing/grok');
+
+    expect(capabilities).toEqual({});
+  });
+});

--- a/tests/unit/grok-probe-auth.test.ts
+++ b/tests/unit/grok-probe-auth.test.ts
@@ -1,0 +1,118 @@
+/**
+ * GrokAdapter.probeAuth() (src/main/agent/adapters/grok/grok-adapter.ts) -
+ * the `grok models` exec branch that drives the Settings amber "not
+ * authenticated" warning. Every existing cross-agent guard
+ * (agent-submission-verifier-shape, agent-summarize-shape, ...) only checks
+ * that GrokAdapter *implements* probeAuth with the right shape; none of
+ * them exercise the "not authenticated" string match or the exec-failure
+ * fallback, so those two branches were unguarded before this file.
+ *
+ * Kept in its own file (rather than folded into grok-adapter.test.ts)
+ * because a module-level `vi.mock('node:child_process', ...)` is
+ * file-scoped and would otherwise shadow child_process for every other
+ * test in that shared file - the same constraint documented in
+ * grok-capability-discovery-help-fallback.test.ts.
+ *
+ * The detector's own PATH-lookup / --version probe pipeline is stubbed via
+ * a spy on `detector.detect` (the private-field-access pattern already
+ * established in opencode-adapter-wiring.test.ts) rather than also mocking
+ * `which` and exec-version: probeAuth's own `grok models` exec branch is
+ * what is under test here, not detection.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+  exec: vi.fn(),
+}));
+
+vi.mock('node:util', () => ({
+  promisify: (fn: unknown) => fn,
+}));
+
+import { execFile, exec } from 'node:child_process';
+import { GrokAdapter } from '../../src/main/agent/adapters/grok/grok-adapter';
+import type { AgentInfo } from '../../src/main/agent/agent-adapter';
+
+const execMock = exec as unknown as ReturnType<typeof vi.fn>;
+const execFileMock = execFile as unknown as ReturnType<typeof vi.fn>;
+
+/** Bypasses the real which()/--version pipeline; only probeAuth's own exec branch is under test. */
+function stubDetection(adapter: GrokAdapter, info: AgentInfo): void {
+  const detector = (adapter as unknown as { detector: { detect: () => Promise<AgentInfo> } }).detector;
+  vi.spyOn(detector, 'detect').mockResolvedValue(info);
+}
+
+function setModelsOutput(stdout: string): void {
+  const result = Promise.resolve({ stdout, stderr: '' });
+  execMock.mockReturnValue(result);
+  execFileMock.mockReturnValue(result);
+}
+
+beforeEach(() => {
+  execMock.mockReset();
+  execFileMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('GrokAdapter.probeAuth', () => {
+  it('returns null without shelling out to `grok models` when the CLI is not detected', async () => {
+    const adapter = new GrokAdapter();
+    stubDetection(adapter, { found: false, path: null, version: null });
+
+    const result = await adapter.probeAuth();
+
+    expect(result).toBeNull();
+    expect(execMock).not.toHaveBeenCalled();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('returns true when `grok models` succeeds without the "not authenticated" string', async () => {
+    const adapter = new GrokAdapter();
+    stubDetection(adapter, { found: true, path: '/usr/bin/grok', version: '1.0.0' });
+    setModelsOutput('grok-4.6\ngrok-4-fast\n');
+
+    const result = await adapter.probeAuth();
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when `grok models` reports the user is not authenticated', async () => {
+    const adapter = new GrokAdapter();
+    stubDetection(adapter, { found: true, path: '/usr/bin/grok', version: '1.0.0' });
+    setModelsOutput('You are not authenticated. Run `grok login` to continue.\n');
+
+    const result = await adapter.probeAuth();
+
+    expect(result).toBe(false);
+  });
+
+  it('matches the "not authenticated" string case-insensitively', async () => {
+    const adapter = new GrokAdapter();
+    stubDetection(adapter, { found: true, path: '/usr/bin/grok', version: '1.0.0' });
+    setModelsOutput('NOT AUTHENTICATED\n');
+
+    const result = await adapter.probeAuth();
+
+    expect(result).toBe(false);
+  });
+
+  it('returns null when the `grok models` invocation throws (timeout, ENOENT, ...)', async () => {
+    const adapter = new GrokAdapter();
+    stubDetection(adapter, { found: true, path: '/usr/bin/grok', version: '1.0.0' });
+    const reject = (): Promise<{ stdout: string }> => {
+      const promise = Promise.reject(new Error('ETIMEDOUT')) as Promise<{ stdout: string }>;
+      promise.catch(() => {});
+      return promise;
+    };
+    execMock.mockImplementation(reject);
+    execFileMock.mockImplementation(reject);
+
+    const result = await adapter.probeAuth();
+
+    expect(result).toBeNull();
+  });
+});

--- a/tests/unit/task-runtime-override-gating.test.ts
+++ b/tests/unit/task-runtime-override-gating.test.ts
@@ -56,6 +56,11 @@ describe('Adapter getInjectionSequence (drives task:setRuntimeOverride)', () => 
     { name: 'kimi',     importPath: '../../src/main/agent/adapters/kimi/kimi-adapter',         className: 'KimiAdapter' },
     { name: 'opencode', importPath: '../../src/main/agent/adapters/opencode/opencode-adapter', className: 'OpenCodeAdapter' },
     { name: 'droid',    importPath: '../../src/main/agent/adapters/droid/droid-adapter',       className: 'DroidAdapter' },
+    // Grok HAS /model + /effort slash commands, but declares
+    // canVerifySlashSubmission false (slash input runs in the TUI palette and
+    // never becomes a chat_history turn), so an injection could not be
+    // confirmed - the respawn fallback applies overrides deterministically.
+    { name: 'grok',     importPath: '../../src/main/agent/adapters/grok/grok-adapter',         className: 'GrokAdapter' },
   ] as const;
 
   it.each(ADAPTERS_WITHOUT_LIVE_SWITCH)(

--- a/tests/unit/transcript-cleanup.test.ts
+++ b/tests/unit/transcript-cleanup.test.ts
@@ -998,6 +998,39 @@ describe('cleanTranscriptForHandoff', () => {
     });
   });
 
+  describe('Grok Build', () => {
+    // Real structure from a node-pty capture against grok 1.0.0: the
+    // alt-screen TUI leaves a clean conversation dump in the normal buffer
+    // on /quit - user turns prefixed `> `, then the response, then a
+    // "Resume this session with:" trailer. Welcome-banner and status chrome
+    // only leak when the terminal lacks alt-screen support.
+    const GROK_REAL_TRANSCRIPT = [
+      'Grok Build  1.0.0',
+      '[Click here to Upgrade] or use Ctrl+O',
+      'Help improve Grok',
+      'Reply with exactly: PONG',
+      '> Reply with exactly: PONG',
+      '  PONG',
+      'Resume this session with:',
+      '  grok --resume 01a00b66-92e2-7812-a209-b80885090deb',
+    ].join('\n');
+
+    it('routes through the dispatcher and extracts the last turn', () => {
+      const result = cleanTranscriptForHandoff(GROK_REAL_TRANSCRIPT, 'grok');
+      expect(result).not.toBeNull();
+      expect(result).toContain('Reply with exactly: PONG');
+      expect(result).toContain('PONG');
+    });
+
+    it('strips the resume trailer and welcome/upgrade chrome', () => {
+      const result = cleanTranscriptForHandoff(GROK_REAL_TRANSCRIPT, 'grok')!;
+      expect(result).not.toContain('--resume');
+      expect(result).not.toContain('Upgrade');
+      expect(result).not.toContain('Grok Build  1.0.0');
+      expect(result).not.toContain('Help improve Grok');
+    });
+  });
+
   describe('edge cases', () => {
     it('returns null for empty input', () => {
       expect(cleanTranscriptForHandoff('', 'claude')).toBeNull();


### PR DESCRIPTION
## What

Adds Grok Build (xAI's `grok` CLI) as the thirteenth agent adapter, with the full Claude-class harness: hooks-based activity detection, live usage telemetry, Kangentic MCP wiring, folder-trust management, cross-agent handoff, transcript parsing, lifetime usage rollups, headless summarize, an auth probe, project relocation, and a confirm-only command-injection verifier. New adapter folder `src/main/agent/adapters/grok/` (15 files), a committed empirical probe (`scripts/probe-grok.js`), a generic `env:<NAME>` events-path sentinel in `event-bridge.js`, cross-cutting registrations, extended cross-agent guard tests, a new E2E spec with a `mock-grok` fixture, and doc updates across ten files.

## Why

Grok Build is xAI's terminal coding agent, deliberately Claude-compatible in its surface (hook events, `--session-id`/`--resume` semantics, `--permission-mode` vocabulary), which makes a full-parity harness genuinely reachable rather than a thin TUI wrapper. Users can now mix Grok into per-column agent routing, handoffs, and the activity/usage pipelines like any first-class agent.

## How

Every empirical claim was verified against grok 1.0.0 on Windows and is re-checkable via `scripts/probe-grok.js` (headless checks run on grok's free tier; `--skip-pty` skips the interactive leg). Key design points:

- **Sessions**: caller-owned UUIDs (`-s` new / `--resume` existing) with a deterministic store at `~/.grok/sessions/<encodeURIComponent(cwd)>/<id>/`; no capture race, plus a sessions-root scan fallback for encoding mismatches.
- **Hooks**: grok fires the full Claude-compatible event set (headless included). A wholly-Kangentic-owned per-cwd `.grok/hooks/kangentic.json` carries static bridge commands; the per-session events path rides the spawn env through a new generic `env:KANGENTIC_EVENTS_PATH` sentinel in `event-bridge.js`, so concurrent sessions in one cwd route correctly and a user's own manual grok run is a silent no-op. Runtime is `hooksAndPty` because project hooks are trust-gated and fail open.
- **Telemetry**: no statusline exists, so usage tails the native `updates.jsonl` (Codex pattern): running context total from `_meta.totalTokens`, cost at the measured 1e-10 USD tick unit, model/context-window from grok's own `models_cache.json`. The parser deliberately emits no tool events (hooks own those) to avoid double-counting.
- **MCP**: a fully static, sentinel-delimited `[mcp_servers.kangentic]` block in `.grok/config.toml` whose URL and token are both `${VAR}` env references (grok's documented expansion), plus `--allow "MCPTool(kangentic__*)"` so board-driven sessions never stall on the approval prompt (observed live without it).
- **Trust**: grok's folder trust cascades, so only worktrees under an undecided project root get a pre-approval entry, dropped on worktree removal; a project root is never auto-trusted on the user's behalf.
- **Collision guard**: the detector probes only `grok`, never the shared `agent` shim, and its `parseVersion` rejects foreign banners - closing the reverse direction of the known Cursor/Grok PATH collision, pinned in both directions by `cursor-grok-binary-collision.test.ts`.
- **Verifier tier**: `chat_history.jsonl` flushes on submit (measured 313ms/32ms), so a shared-scan verifier is wired but confirm-only: records carry no timestamps to bound the match window and the in-app escalation proof has not been run.

Verified end to end in a live preview: real hook events drove the activity engine (including id-correlated tool pairs for the MCP call), the MCP tool executed against the in-process server through the env-expanded URL and token, suspend and `--resume` round-tripped on the same agent session id, and a genuine free-tier 429 remapped StopFailure to `turn_retrying` exactly as designed.

## Breaking changes

None.

## Tests

- `tests/unit/grok-adapter.test.ts` (identity, builder, hook mapping, file lifecycle, parsers, trust, relocation), `grok-capability-discovery-help-fallback.test.ts`, `grok-probe-auth.test.ts`.
- Extended cross-agent guards: `cursor-grok-binary-collision`, `agent-submission-verifier-shape`, `buildenv-adapter-interface-guard`, `adapter-multiline-prompt`, `agent-summarize-shape`, `agent-login-command`, `transcript-cleanup`, `context-packet`, `task-runtime-override-gating`, `event-bridge` (env: sentinel), plus `tests/integration/agent-cli-validation.test.ts` rows validated against the live CLI.
- New E2E: `tests/e2e/grok-activity-detection.spec.ts` with `tests/fixtures/mock-grok.{js,cmd}` (hook pipeline end to end, and the PTY fallback with hooks gated off).
- CI checks (lint, typecheck, unit, build, UI shards, Linux Electron E2E shards) gate the rest.

Generated with [Claude Code](https://claude.com/claude-code)
