### PR TITLE
fix(announcements): floor the history panel, and stop /preview relighting the badge

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -677,11 +677,13 @@ active **for that client**, most recently seen first, capped at 50 entries with 
 on write. Ordering is by when this client first saw an entry, not by the announcement's own
 `publishedAt`, so a high-priority older announcement that arrives on a later poll sorts above
 entries published after it.
-It is written from the same filtered list the banner uses, so targeting is inherited for free (an
-announcement that never matched this client never enters its history), and it is what makes the
+The poll writes it from the same filtered list the banner uses, so targeting is inherited for free
+(an announcement that never matched this client never enters its history), and it is what makes the
 megaphone useful in the three cases the live feed cannot cover: the ~10 seconds before the first
 poll, an offline launch, and an entry deleted upstream. An entry's stored copy is refreshed when
-the feed edits it in place, but its `firstSeenAt` and read-state are not.
+the feed edits it in place, but its `firstSeenAt` and read-state are not. The poll is the only
+writer that filters; the ephemeral preview seeds this file directly and does not, so that targeting
+guarantee holds everywhere except a preview (see the end of this section).
 
 **Dismissed and read are different states, stored apart:**
 
@@ -706,6 +708,21 @@ message wants more, it should be a link to a page, not a longer announcement.
 
 Dismissals persist per-announcement-id in `dismissedAnnouncementIds` (see the
 [Top-Level reference](#top-level)). Read-state does not: it lives on the archive entry.
+
+**The ephemeral preview seeds both states.** A `/preview` boot wipes its data directory, which
+takes the archive with it, so the first poll used to re-append every announcement as unread and
+relight the badge on every launch. Before Electron starts, `scripts/dev.js` now writes the archive
+with every entry's `readAt` stamped AND lists those same ids in `dismissedAnnouncementIds`. Both,
+because they are the separate states above: the first darkens the badge, the second keeps the
+banner down. `--fresh` skips the seed, so the first-launch experience still shows announcements
+unread. A regular `npm start` is unaffected: it uses the real data directory and its real
+read-state.
+
+Two limits are deliberate. The seed reads the repo's committed `announcements.json`, so an
+announcement published to `main` after this worktree branched is absent from it and still arrives
+unread on the next poll; that self-corrects on a rebase. And the seed applies no targeting, so a
+preview's history can list an entry that `minVersion` or `platforms` would have filtered for this
+client.
 
 ## Environment Variables
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -171,9 +171,9 @@ Three parallel processes:
 Native modules (`better-sqlite3`, `node-pty`, `sherpa-onnx-node`, `font-list`, `simple-git`) are marked external in esbuild -- loaded at runtime from `node_modules`.
 
 Flags:
-- `--port=<n>` -- override Vite port
-- `--ephemeral` -- isolated data directory, auto-cleaned on exit (used for worktree previews). The data directory is wiped on every boot, so a previous (possibly crashed) preview's clones never persist.
-- `--fresh` -- ephemeral preview with NO project pre-cloned or auto-opened, so the app starts on the Welcome Screen. Use it to exercise the first-launch experience (pick a folder, land on the board, onboarding checklist). Implies the same wipe as `--ephemeral`; without it, two projects are pre-cloned from the worktree and Project 1 is opened.
+- `--port=<n>` - override Vite port
+- `--ephemeral` - isolated data directory, auto-cleaned on exit (used for worktree previews). The data directory is wiped on every boot, so a previous (possibly crashed) preview's clones never persist. Because the wipe also takes the markers that say what the user has already seen, the boot seeds them back: `hasCompletedFirstRun`, `lastWhatsNewShownVersion`, and every announcement in the committed `announcements.json` stamped read and dismissed. Without that last one the megaphone badge and the announcement banner returned on every preview launch.
+- `--fresh` - ephemeral preview with NO project pre-cloned or auto-opened, so the app starts on the Welcome Screen. Use it to exercise the first-launch experience (pick a folder, land on the board, onboarding checklist). Implies the same wipe as `--ephemeral`, but deliberately gets NONE of the seeded markers above, so onboarding, What's New, and unread announcements all present as they would to a real first-time user.
 
 ### Production (`npm run build` / `scripts/build.js`)
 

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -121,7 +121,38 @@ async function start() {
     // --fresh deliberately gets neither seed: that mode exists to test the real
     // first-launch experience, where the app's own seed does run.
     const previewAppVersion = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), 'utf-8')).version;
-    fs.writeFileSync(path.join(ephemeralDataDir, 'config.json'), JSON.stringify({ hasCompletedFirstRun: true, lastWhatsNewShownVersion: previewAppVersion }, null, 2));
+    // Announcements need the same treatment for the same reason. Read-state lives in
+    // an archive sidecar inside this wiped data dir, so every boot started empty, the
+    // first poll appended each active announcement as unread, and the megaphone badge
+    // and banner came back. Seeded from the COMMITTED feed, which is the document the
+    // poll fetches (ANNOUNCEMENTS_URL is this file on main); appendToArchive keeps the
+    // readAt of an id it has already archived, so the 10s poll cannot relight it.
+    //
+    // Two deliberate gaps. This script is plain CJS and cannot import
+    // selectActiveAnnouncements, so every entry is stamped regardless of minVersion /
+    // platforms and a preview may list one real targeting would have filtered. And an
+    // announcement added to main after this worktree branched is absent here, so it
+    // arrives unread; that self-corrects on a rebase.
+    const previewAnnouncementsArchiveFile = path.join(ephemeralDataDir, 'announcements-archive.json');
+    let previewDismissedAnnouncementIds = [];
+    try {
+      const feed = JSON.parse(fs.readFileSync(path.join(projectDir, 'announcements.json'), 'utf-8'));
+      const seenAt = new Date().toISOString();
+      const archive = (Array.isArray(feed.announcements) ? feed.announcements : [])
+        .map((announcement) => ({ announcement, firstSeenAt: seenAt, readAt: seenAt }));
+      previewDismissedAnnouncementIds = archive.map((entry) => entry.announcement.id);
+      // A bare array, which is the on-disk shape readArchive expects; an object
+      // wrapper parses as empty and would silently undo the whole seed.
+      fs.writeFileSync(previewAnnouncementsArchiveFile, JSON.stringify(archive, null, 2));
+    } catch (announcementsSeedError) {
+      // Best-effort, exactly like the pre-clone below: a missing or malformed feed
+      // costs a relit badge, never a preview boot.
+      console.warn('[dev] could not seed the preview announcements archive:', announcementsSeedError);
+    }
+    // dismissedAnnouncementIds too, or the banner reappears even with the badge dark:
+    // dismissed and read are separate states (see the note above
+    // computeDismissedIdsAfterDismiss in src/shared/announcements.ts).
+    fs.writeFileSync(path.join(ephemeralDataDir, 'config.json'), JSON.stringify({ hasCompletedFirstRun: true, lastWhatsNewShownVersion: previewAppVersion, dismissedAnnouncementIds: previewDismissedAnnouncementIds }, null, 2));
     const preClone = (cloneDir) => new Promise((resolve) => {
       const cloneProc = spawn('git', ['clone', '--no-checkout', '--local', resolvedTarget, cloneDir], { stdio: 'inherit', windowsHide: true });
       cloneProc.on('close', () => resolve());

--- a/src/renderer/components/announcements/AnnouncementHistoryDialog.tsx
+++ b/src/renderer/components/announcements/AnnouncementHistoryDialog.tsx
@@ -1,4 +1,4 @@
-import { Megaphone } from 'lucide-react';
+import { ChevronRight, Megaphone } from 'lucide-react';
 import { BaseDialog } from '../dialogs/BaseDialog';
 import { useAnnouncementsStore } from '../../stores/announcements-store';
 import { formatRelativeTime } from '../../lib/datetime';
@@ -15,7 +15,10 @@ function AnnouncementHistoryRow({ entry }: { entry: AnnouncementArchiveEntry }) 
       data-announcement-id={entry.announcement.id}
       data-unread={unread ? 'true' : 'false'}
       onClick={() => openDialog(entry.announcement, 'history')}
-      className="w-full flex items-center gap-2.5 px-4 py-2.5 text-left border-b border-edge/50 hover:bg-surface-hover transition-colors cursor-pointer"
+      // last:border-b-0 so a one-entry archive does not draw a full-width rule
+      // under its only row: against the floor's empty space below, that read as a
+      // section header over a blank panel rather than as a list item.
+      className="group w-full flex items-center gap-2.5 px-4 py-2.5 text-left border-b border-edge/50 last:border-b-0 hover:bg-surface-hover transition-colors cursor-pointer"
     >
       {/* Always drawn, never hover-only (ui-conventions.md): the unread state
           is the reason the megaphone badge is lit, so it has to be readable
@@ -37,9 +40,28 @@ function AnnouncementHistoryRow({ entry }: { entry: AnnouncementArchiveEntry }) 
       <span className="flex-shrink-0 text-[11px] text-fg-faint tabular-nums">
         {formatRelativeTime(entry.announcement.publishedAt ?? entry.firstSeenAt)}
       </span>
+      {/* The row opens the announcement, and nothing else in it said so: at rest
+          it read as a static line of text, since the only affordance was the
+          hover fill. This is the same disclosure chevron BoardManagerDialog and
+          ShortcutsTab use for a row that opens something, and it is drawn at all
+          times rather than on hover (ui-conventions.md). */}
+      <ChevronRight size={14} className="text-fg-faint group-hover:text-fg-muted flex-shrink-0" />
     </button>
   );
 }
+
+/**
+ * The floor beneath the content-sized body, ~4 rows tall (a row is py-2.5 plus
+ * one text line plus its border). Without it a one-entry archive rendered a
+ * 520x95 box that read as a toast rather than a panel.
+ *
+ * On the list this REPLACES min-h-0 rather than joining it. min-h-0 was there
+ * only to override the flex default `min-height: auto`, so the list can shrink
+ * to the 60vh cap and scroll instead of growing the dialog; an explicit floor
+ * overrides `auto` just as well. Two min-h utilities on one element would be
+ * competing declarations resolved by Tailwind's emit order.
+ */
+const HISTORY_BODY_MIN_HEIGHT = 'min-h-[150px]';
 
 /**
  * The megaphone's history list: every announcement this client has ever had
@@ -83,13 +105,19 @@ export function AnnouncementHistoryDialog() {
     >
       {history.length === 0 ? (
         <div
-          className="flex-1 flex items-center justify-center px-6 py-10 text-center text-sm text-fg-muted"
+          // py-10 is kept below the floor, not replaced by it: the padding is
+          // symmetric so items-center still centers the copy, and it is what
+          // keeps the text off the edges if it ever wraps past the floor.
+          className={`flex-1 ${HISTORY_BODY_MIN_HEIGHT} flex items-center justify-center px-6 py-10 text-center text-sm text-fg-muted`}
           data-testid="announcement-history-empty"
         >
           No announcements yet. Product news shows up here as it is published.
         </div>
       ) : (
-        <div className="flex-1 min-h-0 overflow-y-auto" data-testid="announcement-history-list">
+        <div
+          className={`flex-1 ${HISTORY_BODY_MIN_HEIGHT} overflow-y-auto`}
+          data-testid="announcement-history-list"
+        >
           {history.map((entry) => (
             <AnnouncementHistoryRow key={entry.announcement.id} entry={entry} />
           ))}

--- a/tests/ui/announcements.spec.ts
+++ b/tests/ui/announcements.spec.ts
@@ -327,6 +327,21 @@ test.describe('Announcements megaphone and history', () => {
     await megaphone().click();
     await expect(historyRows()).toHaveCount(1);
     await expect(historyRows().first()).toContainText('Retired announcement');
+    // The row opens the announcement, so it carries a disclosure chevron, and it
+    // is drawn WITHOUT hovering (ui-conventions.md bans hover-only affordances).
+    // Asserted with no preceding hover, which is the whole point of the check.
+    await expect(historyRows().first().locator('svg')).toBeVisible();
+    // toBeVisible() reads box size and visibility/display, NOT computed
+    // opacity, so it would still pass against the `opacity-0
+    // group-hover:opacity-100` reveal ui-conventions.md actually bans. Read the
+    // opacity back explicitly, still with no hover, or the ban is unpinned.
+    await expect
+      .poll(() => historyRows().first().locator('svg')
+        .evaluate((element) => Number(getComputedStyle(element).opacity)))
+      .toBeGreaterThan(0);
+    // last:border-b-0: the sole row draws no trailing rule, so a one-entry
+    // archive does not read as a section header over a blank panel.
+    await expect(historyRows().first()).toHaveCSS('border-bottom-width', '0px');
 
     await historyDialog().locator('[aria-label="Close dialog"]').click();
     await fireAnnouncements([]);
@@ -488,6 +503,16 @@ test.describe('Announcements megaphone and history', () => {
 
     const shortHeight = await dialogHeight();
     expect(shortHeight).toBeLessThan(viewportHeight * 0.3);
+    // ...but not so small it reads as a toast. Asserted on the LIST, which is the
+    // element carrying the floor, so this still fails if the min-h is dropped after
+    // a header redesign changes the dialog root's height. clientHeight, not
+    // boundingBox: the dialog's entrance animation scales the content box from
+    // 0.96, and a bounding rect is the TRANSFORMED one, so a mid-flight read is
+    // 150 * 0.96 = 144 and the assertion would flake on animation timing.
+    await expect
+      .poll(() => page.locator('[data-testid="announcement-history-list"]')
+        .evaluate((element) => element.clientHeight))
+      .toBeGreaterThanOrEqual(150);
     // Nothing to scroll at one entry.
     await expect
       .poll(() => page.locator('[data-testid="announcement-history-list"]')
@@ -498,6 +523,12 @@ test.describe('Announcements megaphone and history', () => {
     await fireAnnouncements([], Array.from({ length: 50 }, (_unused, index) =>
       makeHistoryEntry(makeAnnouncement({ id: `scroll-many-${stamp}-${index}` }))));
     await expect(historyRows()).toHaveCount(50);
+    // The trailing rule is dropped on the LAST row ONLY. Asserted against a
+    // populated list because the one-entry case alone cannot tell
+    // `last:border-b-0` apart from having dropped `border-b` outright, which
+    // would un-separate all 50.
+    await expect(historyRows().first()).toHaveCSS('border-bottom-width', '1px');
+    await expect(historyRows().nth(49)).toHaveCSS('border-bottom-width', '0px');
 
     const tallHeight = await dialogHeight();
     expect(tallHeight).toBeGreaterThan(shortHeight);
@@ -618,9 +649,17 @@ test.describe('Announcements megaphone and history', () => {
     await fireAnnouncements([], []);
 
     await megaphone().click();
-    await expect(page.locator('[data-testid="announcement-history-empty"]')).toBeVisible();
+    const empty = page.locator('[data-testid="announcement-history-empty"]');
+    await expect(empty).toBeVisible();
     await expect(historyRows()).toHaveCount(0);
     await expect(badge()).toHaveCount(0);
+    // The empty state carries the same floor as the list, so the panel does not
+    // shrink below panel size on the one state that has no content at all.
+    // clientHeight for the same reason as the sizing test above: the entrance
+    // animation scales the box, so a bounding rect reads short mid-flight.
+    await expect
+      .poll(() => empty.evaluate((element) => element.clientHeight))
+      .toBeGreaterThanOrEqual(150);
 
     await historyDialog().locator('[aria-label="Close dialog"]').click();
     await expect(historyDialog()).toHaveCount(0);

--- a/tests/unit/announcements-archive.test.ts
+++ b/tests/unit/announcements-archive.test.ts
@@ -299,3 +299,183 @@ describe('archive file store', () => {
     expect(fs.readdirSync(tempDir)).toEqual(['announcements-archive.json']);
   });
 });
+
+describe('ephemeral preview seed', () => {
+  // scripts/dev.js wipes <worktree>/.kangentic/data on every /preview boot and
+  // exports it as KANGENTIC_DATA_DIR, so the archive that carries read-state is
+  // recreated empty each launch and the first poll relit the megaphone badge.
+  // The seed writes a pre-read archive there from the committed feed. These
+  // tests own the contract that seed depends on; dev.js is plain CJS and cannot
+  // import any of this, so nothing else would catch a break.
+  const REPO_ROOT = path.join(__dirname, '..', '..');
+  const FEED_PATH = path.join(REPO_ROOT, 'announcements.json');
+  const DEV_SCRIPT_PATH = path.join(REPO_ROOT, 'scripts', 'dev.js');
+
+  function readFeedAnnouncements(): unknown[] {
+    const feed: unknown = JSON.parse(fs.readFileSync(FEED_PATH, 'utf-8'));
+    const announcements = (feed as { announcements?: unknown[] }).announcements;
+    return Array.isArray(announcements) ? announcements : [];
+  }
+
+  /**
+   * One announcement in the RAW shape announcements.json commits them: nested
+   * `sections` carrying their own links, `publishedAt` / `expiresAt` /
+   * `priority`, and no top-level `links`. Deliberately a literal rather than
+   * makeAnnouncement's output, which is already the PARSED shape and so could
+   * never catch parseAnnouncement rejecting a field only the raw feed carries.
+   *
+   * The contract tests below run off this rather than off the committed feed:
+   * the feed is live content whose entries are DELETED upstream once they
+   * expire, so asserting the real file is non-empty would turn the unit tier
+   * red on a pure JSON edit. The real feed is still exercised, separately and
+   * guarded, by 'accepts the committed feed as it stands today' below.
+   */
+  const RAW_FEED_ANNOUNCEMENT = {
+    id: 'raw-feed-shape',
+    title: 'Raw feed shape',
+    body: 'Body copied verbatim out of the feed.',
+    sections: [
+      {
+        heading: 'A section',
+        body: 'Sections carry their own links.',
+        links: [{ label: 'Docs', url: 'https://kangentic.com/', qr: true }],
+      },
+    ],
+    publishedAt: '2026-08-05T00:00:00Z',
+    expiresAt: '2026-09-30T00:00:00Z',
+    priority: 0,
+  };
+
+  /** The exact entry shape dev.js writes, built from RAW feed objects. */
+  function buildSeedFrom(rawAnnouncements: unknown[], seenAt: string): unknown[] {
+    return rawAnnouncements.map((announcement) => ({
+      announcement,
+      firstSeenAt: seenAt,
+      readAt: seenAt,
+    }));
+  }
+
+  let tempDir: string;
+  let archivePath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'announcements-seed-test-'));
+    archivePath = path.join(tempDir, 'announcements-archive.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('survives the archive reader with raw feed objects, unparsed', () => {
+    // The load-bearing one. dev.js copies feed announcements VERBATIM rather
+    // than running them through parseAnnouncement (it cannot import it), so if
+    // parseEntry ever required a field the feed omits, the seed would be
+    // silently discarded on read and the whole fix would no-op with no error.
+    const seed = buildSeedFrom([RAW_FEED_ANNOUNCEMENT], NOW.toISOString());
+
+    fs.writeFileSync(archivePath, JSON.stringify(seed, null, 2));
+
+    expect(readArchive(archivePath)).toHaveLength(1);
+  });
+
+  it('accepts the committed feed as it stands today', () => {
+    // Belt and braces on the fixture above: if announcements.json ever grows a
+    // field the fixture does not carry, this still catches parseEntry rejecting
+    // it. Returns early rather than failing on an empty feed, which is a
+    // sanctioned content-only edit - entries are deleted upstream once they
+    // expire, and that must never redden the unit tier.
+    const feedAnnouncements = readFeedAnnouncements();
+    if (feedAnnouncements.length === 0) return;
+
+    fs.writeFileSync(
+      archivePath,
+      JSON.stringify(buildSeedFrom(feedAnnouncements, NOW.toISOString()), null, 2),
+    );
+
+    expect(readArchive(archivePath)).toHaveLength(feedAnnouncements.length);
+  });
+
+  it('leaves nothing unread once the first poll folds the live feed in', () => {
+    // The invariant the preview fix rests on: appendToArchive keeps the readAt
+    // of an id it has already archived, so the 10s poll refreshes the payload
+    // without relighting the badge.
+    fs.writeFileSync(
+      archivePath,
+      JSON.stringify(buildSeedFrom([RAW_FEED_ANNOUNCEMENT], NOW.toISOString()), null, 2),
+    );
+    const seeded = readArchive(archivePath);
+    expect(seeded).toHaveLength(1);
+    const active = seeded.map((entry) => entry.announcement);
+
+    const folded = appendToArchive(seeded, active, LATER);
+
+    expect(folded).toHaveLength(seeded.length);
+    expect(countUnreadAnnouncements(folded)).toBe(0);
+  });
+
+  it('still counts an announcement the seed could not have known about', () => {
+    // The seed reads THIS worktree's copy of the feed, so an announcement added
+    // to main after the branch point is absent and legitimately arrives unread.
+    // Pins that the fix suppresses stale ids only, never the mechanism.
+    fs.writeFileSync(
+      archivePath,
+      JSON.stringify(buildSeedFrom([RAW_FEED_ANNOUNCEMENT], NOW.toISOString()), null, 2),
+    );
+    const seeded = readArchive(archivePath);
+    expect(seeded).toHaveLength(1);
+
+    const folded = appendToArchive(
+      seeded,
+      [...seeded.map((entry) => entry.announcement), makeAnnouncement({ id: 'published-after-branch' })],
+      LATER,
+    );
+
+    expect(countUnreadAnnouncements(folded)).toBe(1);
+  });
+
+  it('is still wired into the ephemeral branch of scripts/dev.js', () => {
+    // A source scan, in the shape external-scripts-parity.test.ts uses for the
+    // same script: nothing else can observe dev.js, so without this the seed
+    // could be dropped in a refactor and only a human running /preview would
+    // notice. Anchored on the named path const, not the bare filename.
+    //
+    // Scoped to the GUARDED BLOCK rather than the whole file, which is what
+    // makes the nesting load-bearing. Three bare whole-file toContain checks
+    // all still pass with the seed hoisted OUT of the !fresh guard, and that
+    // is precisely the regression worth catching: it would leave a genuine
+    // first-launch preview opening with its announcements already read.
+    const devScript = fs.readFileSync(DEV_SCRIPT_PATH, 'utf-8');
+    const guardCondition = 'if (ephemeral && !fresh && ephemeralDataDir)';
+    const guardIndex = devScript.indexOf(guardCondition);
+    expect(guardIndex).toBeGreaterThan(-1);
+    // Unique, so the slice below is unambiguous.
+    expect(devScript.indexOf(guardCondition, guardIndex + 1)).toBe(-1);
+
+    // Brace matching over source text. Every brace in this block is a balanced
+    // code brace today (no braces inside its string literals or comments); a
+    // future one would break the match and fail LOUDLY here, which is the
+    // right direction for a tripwire.
+    const openIndex = devScript.indexOf('{', guardIndex);
+    let depth = 0;
+    let closeIndex = -1;
+    for (let index = openIndex; index < devScript.length; index++) {
+      if (devScript[index] === '{') depth++;
+      else if (devScript[index] === '}') {
+        depth--;
+        if (depth === 0) { closeIndex = index; break; }
+      }
+    }
+    expect(closeIndex).toBeGreaterThan(openIndex);
+    const guardedBlock = devScript.slice(openIndex, closeIndex + 1);
+
+    expect(guardedBlock).toContain('previewAnnouncementsArchiveFile');
+    expect(guardedBlock).toContain('dismissedAnnouncementIds');
+    // Proves the slice is genuinely BOUNDED rather than silently spanning the
+    // rest of the file: this marker lives well past the guard's closing brace,
+    // so a runaway match would sweep it in and the two checks above would be
+    // whole-file checks again, which is the weakness this test was rewritten
+    // to remove.
+    expect(guardedBlock).not.toContain('KANGENTIC_DATA_DIR');
+  });
+});


### PR DESCRIPTION
## What

Two follow-ups on the announcements surface.

**The history panel opened as a toast.** `AnnouncementHistoryDialog` had a `max-h-[60vh]` cap and no floor, so it was purely content-sized: a one-entry archive rendered a 520x95 box. It now carries a 150px floor (~4 rows at the measured 38px row height) on the body.

**The rows did not look clickable.** Their only signal that they open an announcement was the hover fill, which `ui-conventions.md` calls out as the wrong pattern. They gain the same always-drawn disclosure chevron `BoardManagerDialog` and `ShortcutsTab` already use, plus `last:border-b-0`.

**Every `/preview` boot relit the megaphone badge** with the full unread count, and brought the banner back with it. `scripts/dev.js` now seeds announcement read-state into the ephemeral data directory.

Changed: `src/renderer/components/announcements/AnnouncementHistoryDialog.tsx`, `scripts/dev.js`, plus `docs/configuration.md` and `docs/developer-guide.md`.

## Why

The panel reading as a toast was reported with a screenshot. The preview badge is the more interesting one, and the cause chain is worth stating: `worktree-preview.js` always passes `--ephemeral`; `dev.js` wipes and recreates the data directory on every boot and exports it as `KANGENTIC_DATA_DIR`; `PATHS.announcementsArchiveFile` resolves inside it. So the archive that carries read-state was always missing, the first poll appended every active announcement with `readAt: null`, and because dismissed and read are separate states, the slim banner returned too.

## How

**The floor REPLACES the list's `min-h-0` rather than joining it.** Both exist to override the flex default `min-height: auto` so the list can still shrink to the 60vh cap and scroll; an explicit floor does that job too. Two `min-h` utilities on one element would instead be competing declarations resolved by Tailwind's emit order. It goes on the body, not the dialog root, so the empty state is not double-padded.

**The per-announcement dialog was checked for the same collapse and deliberately left alone.** Its chrome alone is ~140px, so the shortest possible announcement lands near 180px at 640px wide. It is also a content dialog: the comment at its content div states its height is content-fit by contract, which a floor would contradict, and both siblings in that family (`WhatsNewDialog`, `ReleaseNotesDialog`) carry no floor either.

**The preview fix is a seed, not a path change.** Resolving the archive off `getPlatformConfigDir()` the way `modelCacheDir` does would leak real read-state into previews and silently change `--data-dir` behavior for everyone. Instead the seed sits inside the existing `ephemeral && !fresh` block that already writes `hasCompletedFirstRun` and `lastWhatsNewShownVersion` for exactly this reason. Two consequences fall out for free: `--fresh` keeps showing a genuine first-launch experience, and nothing gates on dev mode, so `npm start` dogfooding still exercises the live announcements surface.

Two limits are deliberate, commented at the write site, and documented:

- `dev.js` is plain CJS and cannot import `selectActiveAnnouncements`, so the seed applies no targeting. A preview's history can list an entry `minVersion` or `platforms` would have filtered.
- An announcement published to `main` after this worktree branched is absent from the committed feed the seed reads, so it still arrives unread. That self-corrects on a rebase.

The docs change is not just additive: `configuration.md` stated, unscoped, that the archive is "written from the same filtered list the banner uses, so targeting is inherited for free". This adds a second writer that does not filter, so that invariant is now scoped to the poll.

## Breaking changes

None. No new config keys, IPC channels, or types. The seed only affects the ephemeral `/preview` data directory; a real install and a regular `npm start` are untouched.

## Tests

CI runs lint, typecheck, unit, build, the UI shards, and the Linux Electron E2E shards.

Added in this change:

- **UI, red-green proven.** The two floor assertions were confirmed red by stashing the component: the list measured 38px and the empty state 100px against the 150px floor. They assert `clientHeight`, not `boundingBox()`, because the dialog's entrance animation scales the content box from 0.96, so a bounding rect read mid-flight is exactly 144 and would flake on animation timing. A third assertion pins the chevron visible with **no preceding hover**, so a future `opacity-0 group-hover:opacity-100` refactor cannot silently reintroduce the hover-only affordance.
- **Unit, `describe('ephemeral preview seed')`.** The load-bearing one is that raw feed objects survive `readArchive` unparsed: `dev.js` copies them verbatim because it cannot import `parseAnnouncement`, so if `parseEntry` ever required a field the feed omits, the seed would be silently discarded on read and the whole fix would no-op with no error anywhere. It runs off a raw-shape fixture rather than the live feed, so a content-only edit that empties `announcements.json` cannot redden the unit tier; the real feed is exercised separately behind an empty-feed guard.
- **A source scan pinning the seed into `dev.js`**, since nothing else can observe that file. It is brace-matched to the `!fresh` guard block rather than a whole-file `toContain`: three bare checks all still pass with the seed hoisted OUT of the guard, which is precisely the regression worth catching, because it would leave a genuine first-launch preview opening with its announcements already read.

Also verified locally: the seed block was executed verbatim out of `dev.js` against a temp directory rather than re-typed, confirming it produces the `AnnouncementArchiveEntry` shape with `readAt` stamped and the id in `dismissedAnnouncementIds`.

Generated with [Claude Code](https://claude.com/claude-code)
