### PR TITLE
fix(agents): hide adapter runtime files from git via shared info/exclude seeding

### DIFF
--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -550,7 +550,7 @@ The settings write is gated on hooks **or** MCP, so an MCP-only spawn (no events
 Two things make this work that are easy to miss:
 
 - **Folder trust is load-bearing.** Gemini disables every configured MCP server in an untrusted folder (`gemini mcp list` reports "MCP servers are configured but disabled because this folder is untrusted", and user-level servers are suppressed too), so the entry would be silently inert. `GeminiAdapter.ensureTrust` pre-populates `~/.gemini/trustedFolders.json` via `trust-manager.ts`. Unlike the Qwen equivalent it does **not** gate on `security.folderTrust.enabled`, because Gemini 0.54.4 enforces trust with that flag unset. It never overrides a user's `TRUST_PARENT` or `DO_NOT_TRUST`, at the path itself or on any ancestor, so a `DO_NOT_TRUST` on the repo suppresses approval for every worktree Kangentic creates beneath it (the same deny rule Codex applies to its project root). It also skips the write when an ancestor is already trusted, so a worktree under an already-trusted repo adds no key at all. When no ancestor is trusted, though, it does record one `TRUST_FOLDER` per task worktree, exactly like Codex - which is why `GeminiAdapter.onWorktreeRemoved` drops that entry again when Kangentic deletes the worktree (`removeWorktreeTrust`). Without it the file grows by a dead entry per task forever, the accumulation that reached 473 entries in Codex's `config.toml`. Removal only ever takes an entry Kangentic could have written itself: a `TRUST_PARENT` or `DO_NOT_TRUST` at that path is a user decision and survives, so a later worktree at the same path still honors it. Ancestor matching folds case only on Windows, since POSIX paths are case-sensitive.
-- **The token is plaintext on disk while the session runs.** `.gemini/settings.json` is project-shared and may be intentionally committed, so it cannot be blanket-gitignored like `.kangentic/`. Tokens rotate per app launch and `removeHooks` strips the entry on exit. Do not commit `.gemini/settings.json` while a Kangentic-spawned Gemini session is running. Droid avoids this class of problem entirely because it supports `${NAME}` env expansion inside header values; Gemini does not.
+- **The token is plaintext on disk while the session runs.** `.gemini/settings.json` is project-shared and may be intentionally committed, so it cannot be blanket-gitignored like `.kangentic/`. Tokens rotate per app launch and `removeHooks` strips the entry on exit. For the untracked case this is now self-enforcing: when Kangentic creates the file (it did not exist before the spawn), the builder seeds `.gemini/settings.json` and `.kangentic/` into `.git/info/exclude` via the shared `git-exclude.ts` mechanism (see the Antigravity section), so the file never shows as untracked and cannot ride a `git add -A` into history. A pre-existing file keeps its normal git visibility (the created-by-us carve-out), and ignore rules never affect tracked files - so the rule stands: do not commit `.gemini/settings.json` while a Kangentic-spawned Gemini session is running. Droid avoids this class of problem entirely because it supports `${NAME}` env expansion inside header values; Gemini does not.
 
 ## Qwen Code
 
@@ -596,6 +596,8 @@ The fork swapped Gemini's `auto_edit` (underscore) flag value for `auto-edit` (h
 ### Settings Merge
 
 Qwen Code reads settings from `.qwen/settings.json` in the project directory. Like Gemini it has no `--settings` flag, so Kangentic writes merged settings (with event-bridge hooks) directly to `.qwen/settings.json` in the CWD. Concurrent sessions in the same project are serialized by a per-task reference counter in `QwenAdapter.hookHolders`, identical to the Gemini implementation.
+
+The security trade-off is also identical to Gemini's: the merged file carries the per-launch MCP token in plaintext while the session runs. The same mitigations apply - tokens rotate per app launch, `removeHooks` strips the entry on exit, and when Kangentic creates the file the builder seeds `.qwen/settings.json` and `.kangentic/` into `.git/info/exclude` (created-by-us carve-out: a pre-existing user file keeps its git visibility). Do not commit `.qwen/settings.json` while a Kangentic-spawned Qwen session is running.
 
 ### Session History
 
@@ -653,7 +655,13 @@ The `permissions` list exposes two entries in OpenCode's own vocabulary: `plan` 
 
 ### Settings Merge
 
-None. OpenCode reads MCP and provider configuration from `opencode.json` (project) or `~/.config/opencode/opencode.json` (global). `removeHooks` is a no-op and `clearSettingsCache` has nothing to clear. The Kangentic MCP server IS wired in for a local-mode spawn - `buildOpenCodeEnv` (`command-builder.ts`) emits an inline `mcp.kangentic` entry via the `OPENCODE_CONFIG_CONTENT` env var per PTY spawn, deep-merged over the user's own config so their `mcp.*` entries are preserved (see [MCP Server](mcp-server.md)). It is NOT wired in for a remote-mode spawn (`opencode attach <url>`) - see the Remote Execution subsection below.
+None. OpenCode reads MCP and provider configuration from `opencode.json` (project) or `~/.config/opencode/opencode.json` (global). `clearSettingsCache` has nothing to clear, and `removeHooks` only removes the activity plugin (next subsection). The Kangentic MCP server IS wired in for a local-mode spawn - `buildOpenCodeEnv` (`command-builder.ts`) emits an inline `mcp.kangentic` entry via the `OPENCODE_CONFIG_CONTENT` env var per PTY spawn, deep-merged over the user's own config so their `mcp.*` entries are preserved (see [MCP Server](mcp-server.md)). It is NOT wired in for a remote-mode spawn (`opencode attach <url>`) - see the Remote Execution subsection below.
+
+### Activity Plugin
+
+Local-mode spawns install the Kangentic activity plugin by copying `kangentic-activity.mjs` into `<projectRoot>/.opencode/plugins/`, where OpenCode auto-discovers plugins at TUI startup. The copy is byte-compare idempotent, and removal verifies a sentinel comment on line 1 so a user-authored plugin at the same path is never touched. The plugin runs inline in the OpenCode process and writes activity events straight to the session's `events.jsonl`, reading its output path from the `KANGENTIC_EVENTS_PATH` env var exported by the PTY spawn flow. Note the install lands at the PROJECT ROOT, not the task worktree.
+
+The plugin file is hidden from git via the shared `.git/info/exclude` mechanism (`src/main/agent/shared/git-exclude.ts`, see the Antigravity section), seeded only once the plugin file actually exists at the destination so a failed copy never leaves an entry pointing at a missing file. Earlier releases appended the entry to the project's tracked `.gitignore` instead, which dirtied the user's checkout; a line those releases appended is left in place (harmless - it ignores the same path).
 
 ### Session ID Capture
 
@@ -680,7 +688,7 @@ The adapter tracks which cwd resolved to which remote target in an in-memory `Ma
 ### Limitations
 
 - **Concurrent same-cwd spawns cannot be disambiguated (local mode only):** Two OpenCode tasks spawned within ~30 s against the same `cwd` cannot be reliably distinguished by `captureSessionIdFromFilesystem`. Both rows match the directory + time-window predicate, so the parser returns the most recently created row - which can attribute task A's session ID to task B, or vice versa. Kangentic's per-task worktrees (`git.worktreesEnabled`, default `true`) sidestep this by giving every task its own `cwd`. If you have disabled worktrees and need to run multiple OpenCode tasks against the same project root, either re-enable worktrees in Settings -> Git or stagger the spawns by more than 30 seconds. The Codex CLI parser carries the same caveat. Does not apply to remote-mode sessions (see above).
-- **No status / events telemetry:** OpenCode has no documented hook system, so activity detection is PTY-silence-only (`PTY_SILENCE_THRESHOLD_MS`, same `PtyActivityTracker` shape as Codex) and there is no `status.json` / `events.jsonl` pipeline.
+- **No status.json pipeline:** activity is `hooks_and_pty` - the activity plugin's events are authoritative when they fire, and PTY-silence detection (`PTY_SILENCE_THRESHOLD_MS`, same `PtyActivityTracker` shape as Codex) is the fallback tier for sessions without the plugin (remote mode, failed install). OpenCode has no statusline, so there is no `status.json` pipeline.
 - **No trust dialog:** `ensureTrust` is a no-op. OpenCode does not prompt for directory trust on first run.
 - **Remote mode is single-directory per project:** the server working directory is per-project, not per-task, so concurrent remote tasks in the same project share one directory. Per-task remote worktrees would require remote git operations (OpenCode's `POST /session/:id/shell` is the mechanism, if pursued later).
 
@@ -1016,7 +1024,7 @@ Droid CLI has no per-spawn `--mcp-config` flag, but it does expand `${NAME}` ref
 
 User-defined servers in that file are preserved, and `removeHooks` strips only the `kangentic` entry on session exit (deleting the file when nothing else remains). Verified against droid 0.189.0: `droid mcp list` reports `kangentic  http  connected  [project]`.
 
-Cleanup runs from the PTY exit and suspend paths, so a hard kill (Task Manager, crash, OS reboot) leaves the entry behind pointing at a dead loopback port until the next spawn rewrites it. It holds no secret, but it is a file Kangentic wrote inside the user's tree, so `.factory/` is gitignored alongside `.codex/` and `.gemini/`. A Droid session on a project with worktrees disabled writes it into the project root rather than a worktree, which is what makes that entry matter.
+Cleanup runs from the PTY exit and suspend paths, so a hard kill (Task Manager, crash, OS reboot) leaves the entry behind pointing at a dead loopback port until the next spawn rewrites it. It holds no secret, but it is a file Kangentic wrote inside the user's tree, so when Kangentic creates it the builder seeds `.factory/mcp.json` and `.kangentic/` into `.git/info/exclude` via the shared `git-exclude.ts` mechanism (see the Antigravity section) - the file never shows as untracked and cannot ride a `git add -A`. A pre-existing user `mcp.json` keeps its normal git visibility (the created-by-us carve-out). A Droid session on a project with worktrees disabled writes it into the project root rather than a worktree, which is what makes that entry matter.
 
 ### Limitations
 
@@ -1155,6 +1163,13 @@ approval prompt for Kangentic's own tools - verified live without it,
 `kangentic__kangentic_get_current_task` sat on the approval dialog with nobody there to
 answer. This is Claude's `mcp__kangentic` allow-rule injection, in grok's dialect.
 
+Both runtime files are hidden from git for the untracked case: the builder seeds
+`.grok/hooks/kangentic.json` (unconditionally - the filename is wholly Kangentic-owned),
+`.grok/config.toml` (only when Kangentic creates the file; a pre-existing user config keeps
+its git visibility), and `.kangentic/` into `.git/info/exclude` via the shared
+`git-exclude.ts` mechanism (see the Antigravity section). Neither file carries a secret, so
+this is purely untracked-noise control for the Changes pane and `git add -A`.
+
 **Trust.** Folder trust (`~/.grok/trusted_folders.toml`, entries
 `[folders.'<path>'] / trusted = true / decided_at = <unix>`) gates project hooks and
 project MCP together, and CASCADES to subdirectories - verified live: a Kangentic worktree
@@ -1238,7 +1253,7 @@ Session ids are captured two ways: `fromHook` reads `conversationId` (present in
 
 The Kangentic MCP server is registered as a WORKSPACE PLUGIN at `<cwd>/.agents/plugins/kangentic/` (`plugin.json` marker + `mcp_config.json` with `serverUrl` and a `headers['X-Kangentic-Token']` entry). agy dials `serverUrl` with streamable HTTP (`POST /mcp`) and forwards the headers map, connecting lazily at the first agent turn. A bare workspace `mcp_config.json` (no plugin wrapper) does not load (upstream google-antigravity/antigravity-cli#60). Same plaintext-token trade-off as Gemini: the per-launch token sits on disk during the active session; tokens rotate per app launch and `removeHooks()` deletes the plugin dir on session exit / suspend.
 
-Unlike Gemini, the runtime files are also hidden from git for the session's lifetime: the command builder seeds `.git/info/exclude` (the local, never-committed ignore file, resolved through the worktree's `commondir` so one seeding covers every worktree of the repo) with `.agents/plugins/kangentic/`, `.kangentic/`, and - only when Kangentic created the file itself - `.agents/hooks.json`. Ignore rules affect untracked files only, so a user's own tracked `.agents` customizations keep normal git visibility, while the token-bearing plugin can never ride into a commit on a `git add -A`. The marker comment in the exclude file says the lines are safe to remove.
+The runtime files are also hidden from git for the session's lifetime: the command builder seeds `.git/info/exclude` (the local, never-committed ignore file, resolved through the worktree's `commondir` so one seeding covers every worktree of the repo) with `.agents/plugins/kangentic/`, `.kangentic/`, and - only when Kangentic created the file itself - `.agents/hooks.json`. Ignore rules affect untracked files only, so a user's own tracked `.agents` customizations keep normal git visibility, while the token-bearing plugin can never ride into a commit on a `git add -A`. The marker comment in the exclude file says the lines are safe to remove. This mechanism originated here and now lives in `src/main/agent/shared/git-exclude.ts` (generic `# kangentic:` marker; the legacy antigravity-branded marker is recognized by prefix so already-seeded repos never gain a second marker block), shared by the Gemini, Qwen, Droid, and Grok builders and OpenCode's plugin install - each with its own pattern list and created-by-us carve-outs.
 
 ### Trust
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -66,6 +66,8 @@ Delivery is per-adapter, because no two of these CLIs accept MCP config the same
 | Cursor, Oz CLI | Not wired | n/a |
 | Aider, Ollama | Not possible - neither CLI is an MCP client | n/a |
 
+The project-file rows (Gemini, Qwen, Droid, Grok, Antigravity) are additionally hidden from git while untracked: when Kangentic creates the file, the builder seeds it into the local `.git/info/exclude` so it never shows in `git status` and cannot ride a `git add -A` (shared mechanism in `src/main/agent/shared/git-exclude.ts`; a pre-existing user file keeps its git visibility).
+
 Full per-adapter detail, including the Codex quoting contract and the Gemini folder-trust requirement, lives in [agent-integration.md](agent-integration.md).
 
 #### Claude Code

--- a/src/main/agent/adapters/antigravity/antigravity-adapter.ts
+++ b/src/main/agent/adapters/antigravity/antigravity-adapter.ts
@@ -36,6 +36,17 @@ import { ActivityDetection } from '../../../../shared/types';
 
 const CONVERSATION_UUID = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
 
+// Hoisted: sessionId.fromOutput runs on every raw PTY chunk until capture
+// lands (and for the no-hook fallback spawns, for the session's lifetime),
+// so the patterns compile once here rather than per chunk.
+const SHUTDOWN_CONVERSATION_RE = new RegExp(`agy\\s+--conversation=(${CONVERSATION_UUID})`);
+const PRINT_CONVERSATION_RE = new RegExp(`"conversation_id"\\s*:\\s*"(${CONVERSATION_UUID})"`);
+// Fallback for a truncated hookContext (the bridge caps the serialized
+// payload at 2048 chars, and agy's PreInvocation payload carries the full
+// prompt, so a long task description can push conversationId's JSON past
+// clean parseability even though the field itself made the cut).
+const HOOK_CONVERSATION_RE = new RegExp(`"conversationId"\\s*:\\s*"(${CONVERSATION_UUID})"`);
+
 /**
  * Google Antigravity CLI (`agy`) adapter. Every behavior below was verified
  * against a real agy 1.1.13 install (2026-08-16, the E1/E2/E3 rig runs):
@@ -145,7 +156,15 @@ export class AntigravityAdapter implements AgentAdapter {
    * channel), making this the model pill's ONLY source.
    */
   configuredModelFromCommand(command: string): { id: string; displayName: string } | null {
-    const match = command.match(/--model\s+(?:"([^"]+)"|'([^']+)'|(\S+))/);
+    // Search only the flag region before the prompt. agy has no end-of-options
+    // marker; the builder delivers the prompt exclusively via `-i`/`-p`, and no
+    // flag it emits before that point collides, so the first bare `-i`/`-p`
+    // token bounds the flags. Without this a task text containing a literal
+    // `--model <word>` would seed a bogus model pill that nothing ever
+    // corrects (no live telemetry channel).
+    const promptFlag = command.search(/\s-(?:i|p)\s/);
+    const flagRegion = promptFlag === -1 ? command : command.slice(0, promptFlag);
+    const match = flagRegion.match(/--model\s+(?:"([^"]+)"|'([^']+)'|(\S+))/);
     const id = match?.[1] ?? match?.[2] ?? match?.[3];
     if (!id) return null;
     return { id, displayName: antigravityModelDisplayName(id) };
@@ -333,13 +352,22 @@ export class AntigravityAdapter implements AgentAdapter {
           }
           return null;
         } catch {
+          // The bridge's 2048-char hookContext cap can truncate a large
+          // PreInvocation payload mid-structure. The field itself often
+          // survives inside the truncated prefix, so fall back to a direct
+          // scan before giving up (see HOOK_CONVERSATION_RE).
+          const truncatedMatch = hookContext.match(HOOK_CONVERSATION_RE);
+          if (truncatedMatch) {
+            console.log(`[antigravity] Captured conversation ID from truncated hook payload: ${truncatedMatch[1].slice(0, 16)}...`);
+            return truncatedMatch[1];
+          }
           return null;
         }
       },
       fromOutput(data) {
-        const shutdownMatch = data.match(new RegExp(`agy\\s+--conversation=(${CONVERSATION_UUID})`));
+        const shutdownMatch = data.match(SHUTDOWN_CONVERSATION_RE);
         if (shutdownMatch) return shutdownMatch[1];
-        const printMatch = data.match(new RegExp(`"conversation_id"\\s*:\\s*"(${CONVERSATION_UUID})"`));
+        const printMatch = data.match(PRINT_CONVERSATION_RE);
         return printMatch ? printMatch[1] : null;
       },
     },

--- a/src/main/agent/adapters/antigravity/command-builder.ts
+++ b/src/main/agent/adapters/antigravity/command-builder.ts
@@ -9,7 +9,7 @@ import {
   spaceFreeAgentsToken,
   type AntigravityHooksFile,
 } from './hook-manager';
-import { ensureLocalGitExcludes } from './git-exclude';
+import { ensureLocalGitExcludes } from '../../shared/git-exclude';
 import type { PermissionMode } from '../../../../shared/types';
 
 /**

--- a/src/main/agent/adapters/antigravity/hook-manager.ts
+++ b/src/main/agent/adapters/antigravity/hook-manager.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { EventType } from '../../../../shared/types';
 import { toForwardSlash } from '../../../../shared/paths';
-import { filterKangenticHooks, safelyUpdateSettingsFile } from '../../shared/hook-utils';
+import { isKangenticHookCommand, safelyUpdateSettingsFile } from '../../shared/hook-utils';
 import { resolveBridgeScript } from '../../shared/bridge-utils';
 import {
   captureHookContext,
@@ -97,34 +97,69 @@ export function deployWorkspaceBridgeCopy(cwd: string): string | null {
   }
 }
 
-/** Collect every command string reachable from one named hook, for filtering. */
-function collectCommands(entry: AntigravityNamedHook): string[] {
-  const commands: string[] = [];
-  for (const group of [...(entry.PreToolUse ?? []), ...(entry.PostToolUse ?? [])]) {
-    for (const handler of group.hooks ?? []) commands.push(handler.command);
-  }
-  for (const handler of [
-    ...(entry.PreInvocation ?? []),
-    ...(entry.PostInvocation ?? []),
-    ...(entry.Stop ?? []),
-  ]) {
-    commands.push(handler.command);
-  }
-  return commands;
+/**
+ * Drop the individual handlers whose command carries the Kangentic
+ * fingerprint, preserving the entry's other handlers. PER-HANDLER
+ * granularity is load-bearing: a user's named hook that happens to mix
+ * their own handler with a stale/renamed Kangentic command (e.g. a copied
+ * bridge invocation) must lose only the Kangentic handler, never the whole
+ * entry - entry-level filtering silently destroyed the user's own handlers
+ * alongside it. Returns null when nothing user-owned survives (the entry
+ * was 100% ours, however it was named).
+ */
+function stripKangenticHandlers(entry: AntigravityNamedHook): AntigravityNamedHook | null {
+  const keepHandler = (handler: AntigravityHookHandler): boolean =>
+    !isKangenticHookCommand(handler.command);
+  const filterGroups = (groups: AntigravityHookGroup[] | undefined): AntigravityHookGroup[] | undefined => {
+    if (!groups) return undefined;
+    return groups
+      .map((group) => ({ ...group, hooks: (group.hooks ?? []).filter(keepHandler) }))
+      .filter((group) => group.hooks.length > 0);
+  };
+  const filterHandlers = (handlers: AntigravityHookHandler[] | undefined): AntigravityHookHandler[] | undefined =>
+    handlers ? handlers.filter(keepHandler) : undefined;
+
+  const survivor: AntigravityNamedHook = {
+    ...entry,
+    PreToolUse: filterGroups(entry.PreToolUse),
+    PostToolUse: filterGroups(entry.PostToolUse),
+    PreInvocation: filterHandlers(entry.PreInvocation),
+    PostInvocation: filterHandlers(entry.PostInvocation),
+    Stop: filterHandlers(entry.Stop),
+  };
+
+  const survivingHandlerCount =
+    (survivor.PreToolUse ?? []).reduce((count, group) => count + group.hooks.length, 0)
+    + (survivor.PostToolUse ?? []).reduce((count, group) => count + group.hooks.length, 0)
+    + (survivor.PreInvocation ?? []).length
+    + (survivor.PostInvocation ?? []).length
+    + (survivor.Stop ?? []).length;
+  const originalHandlerCount =
+    (entry.PreToolUse ?? []).reduce((count, group) => count + (group.hooks ?? []).length, 0)
+    + (entry.PostToolUse ?? []).reduce((count, group) => count + (group.hooks ?? []).length, 0)
+    + (entry.PreInvocation ?? []).length
+    + (entry.PostInvocation ?? []).length
+    + (entry.Stop ?? []).length;
+
+  // A handler-less entry (nothing to fingerprint) is the user's to keep,
+  // untouched; an entry whose every handler was ours is dropped whole.
+  if (originalHandlerCount === 0) return entry;
+  return survivingHandlerCount > 0 ? survivor : null;
 }
 
 /**
- * Drop Kangentic-owned named hooks, keeping user-defined ones. Matches on the
- * reserved name prefix AND on the shared command fingerprint
- * (`isKangenticHookCommand` via filterKangenticHooks), so both a normally
- * named stale entry and a renamed-but-ours command are swept.
+ * Drop Kangentic-owned hooks, keeping user-defined ones. An entry named with
+ * the reserved `kangentic-` prefix is dropped whole; everywhere else the
+ * shared command fingerprint (`isKangenticHookCommand`) sweeps
+ * renamed-but-ours handlers PER HANDLER, so a mixed user entry keeps its own
+ * handlers (see stripKangenticHandlers).
  */
 export function filterOurHooks(root: AntigravityHooksFile): AntigravityHooksFile {
   const kept: AntigravityHooksFile = {};
   for (const [name, entry] of Object.entries(root)) {
     if (name.startsWith('kangentic-')) continue;
-    const survivors = filterKangenticHooks([entry], collectCommands);
-    if (survivors.length > 0) kept[name] = entry;
+    const survivor = stripKangenticHandlers(entry);
+    if (survivor) kept[name] = survivor;
   }
   return kept;
 }

--- a/src/main/agent/adapters/antigravity/print-runner.ts
+++ b/src/main/agent/adapters/antigravity/print-runner.ts
@@ -20,6 +20,11 @@ import type * as pty from 'node-pty';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+// The control-code core only (steps 1-5), DELIBERATELY without
+// stripAnsiEscapes' newline normalization and trailing-whitespace trim
+// (steps 6-8): those rewrite bytes that may sit inside the JSON payload
+// extracted below.
+import { stripAnsiControlCodes } from '../../../../shared/ansi-strip';
 import { ensureWorkspaceTrust } from './trust-manager';
 
 const PRINT_TIMEOUT_MS = 25_000;
@@ -30,25 +35,13 @@ function scratchDirectory(): string {
   return path.join(os.tmpdir(), 'kangentic-antigravity-print');
 }
 
-// Steps 1-5 of `stripAnsiEscapes` (src/shared/ansi-strip.ts), DELIBERATELY
-// without its newline normalization and trailing-whitespace trim (steps 6-8):
-// those rewrite bytes that may sit inside the JSON payload extracted below.
-function stripAnsi(text: string): string {
-  return text
-    .replace(/(?:\x1b[P\]X^_]|\x90|\x9d|\x9e|\x9f|\x98)[\s\S]*?(?:\x1b\\|\x07|\x9c)/g, '')
-    .replace(/(?:\x1b\[|\x9b)[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g, '')
-    .replace(/\x1b[\x20-\x7e]/g, '')
-    .replace(/[\x80-\x9f]/g, '')
-    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
-}
-
 /**
  * Pull the print-mode result object out of captured PTY output: the LAST
  * `{...}` JSON blob carrying a `response` field (PTY chrome like the clear
  * sequence and the shell's OSC title precede/follow it).
  */
 export function extractPrintResponse(rawOutput: string): string | null {
-  const cleaned = stripAnsi(rawOutput);
+  const cleaned = stripAnsiControlCodes(rawOutput);
   const candidates: string[] = [...(cleaned.match(/\{[\s\S]*?\}(?=\s*$|\s*\{)/g) ?? [])];
   // Also try a greedy whole-object match: the result JSON can contain nested
   // braces (usage object), which the lazy candidate split above would cut.
@@ -119,7 +112,11 @@ export async function runAntigravityPrint(cliPath: string, prompt: string): Prom
     const timer = setTimeout(() => finish(new Error('antigravity print run timed out')), PRINT_TIMEOUT_MS);
 
     printProcess.onData((data) => {
-      if (output.length < OUTPUT_CAP_BYTES) output += data;
+      // Retain the TAIL under the cap, not the head: extractPrintResponse
+      // reads the result JSON from the END of the captured stream, so a
+      // drop-forward guard would discard exactly the closing chunk that
+      // carries it once a chatty run crosses the cap.
+      output = (output + data).slice(-OUTPUT_CAP_BYTES);
     });
     printProcess.onExit(() => {
       // Give the final chunk a tick to land before parsing.

--- a/src/main/agent/adapters/droid/command-builder.ts
+++ b/src/main/agent/adapters/droid/command-builder.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { toForwardSlash, quoteArg, isUnixLikeShell } from '../../../../shared/paths';
 import { interpolateTemplate } from '../../shared/template-utils';
+import { ensureLocalGitExcludes } from '../../shared/git-exclude';
 import type { PermissionMode } from '../../../../shared/types';
 
 /**
@@ -93,6 +94,11 @@ export class DroidCommandBuilder {
     const { shell } = options;
     const parts: string[] = [quoteArg(options.droidPath, shell)];
 
+    // Seed .git/info/exclude BEFORE the write so the mcp.json pre-existence
+    // check reflects the user's file, not ours: the config otherwise sits
+    // untracked in the worktree for the whole session, polluting git status
+    // and riding along with any `git add -A` an agent runs.
+    this.seedGitExcludes(options);
     this.writeMcpConfig(options);
 
     parts.push('--cwd', quoteArg(toForwardSlash(options.cwd), shell));
@@ -114,6 +120,23 @@ export class DroidCommandBuilder {
     }
 
     return parts.join(' ');
+  }
+
+  /**
+   * Hide the Kangentic-written runtime files from git for the untracked
+   * case. `<cwd>/.factory/mcp.json` gets the created-by-us carve-out: a
+   * file already present may be the user's own project MCP config, possibly
+   * destined for a commit. The file holds no secret (the token is a
+   * `${KANGENTIC_MCP_TOKEN}` env reference), so this is purely about
+   * untracked-file noise in the task worktree.
+   */
+  private seedGitExcludes(options: DroidCommandOptions): void {
+    if (!droidMcpWiringEnabled(options)) return;
+    const patterns = ['.kangentic/'];
+    if (!fs.existsSync(path.join(options.cwd, '.factory', 'mcp.json'))) {
+      patterns.push('.factory/mcp.json');
+    }
+    ensureLocalGitExcludes(options.cwd, patterns);
   }
 
   /**

--- a/src/main/agent/adapters/gemini/command-builder.ts
+++ b/src/main/agent/adapters/gemini/command-builder.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { toForwardSlash, quoteArg, isUnixLikeShell } from '../../../../shared/paths';
 import { interpolateTemplate } from '../../shared/template-utils';
 import { resolveBridgeScript } from '../../shared/bridge-utils';
+import { ensureLocalGitExcludes } from '../../shared/git-exclude';
 import { buildHooks } from './hook-manager';
 import type { GeminiHookEntry } from './hook-manager';
 import type { PermissionMode } from '../../../../shared/types';
@@ -67,7 +68,12 @@ export class GeminiCommandBuilder {
     const parts = [quoteArg(options.geminiPath, shell)];
 
     // Write merged settings with event-bridge hooks and / or the Kangentic
-    // MCP server entry.
+    // MCP server entry. Seed .git/info/exclude BEFORE the write so the
+    // settings.json pre-existence check reflects the user's file, not ours:
+    // the merged file otherwise sits untracked in the worktree for the whole
+    // session, polluting git status and riding along with any `git add -A`
+    // an agent runs - which would commit the per-launch plaintext token.
+    this.seedGitExcludes(options);
     if (this.shouldWriteMergedSettings(options)) {
       this.createMergedSettings(options);
     }
@@ -144,6 +150,23 @@ export class GeminiCommandBuilder {
 
   private shouldWriteMergedSettings(options: GeminiCommandOptions): boolean {
     return Boolean(options.eventsOutputPath) || geminiMcpWiringEnabled(options);
+  }
+
+  /**
+   * Hide the Kangentic-written runtime files from git for the untracked
+   * case. `.gemini/settings.json` gets the created-by-us carve-out: a file
+   * already present in the cwd may be the user's own, possibly destined for
+   * a commit, so only a file Kangentic is about to create is excluded.
+   * Ignore rules never affect tracked files, so a committed settings.json
+   * keeps its normal git visibility either way.
+   */
+  private seedGitExcludes(options: GeminiCommandOptions): void {
+    if (!this.shouldWriteMergedSettings(options)) return;
+    const patterns = ['.kangentic/'];
+    if (!fs.existsSync(path.join(options.cwd, '.gemini', 'settings.json'))) {
+      patterns.push('.gemini/settings.json');
+    }
+    ensureLocalGitExcludes(options.cwd, patterns);
   }
 
   /**

--- a/src/main/agent/adapters/grok/command-builder.ts
+++ b/src/main/agent/adapters/grok/command-builder.ts
@@ -1,7 +1,9 @@
+import fs from 'node:fs';
 import { quoteArg, isUnixLikeShell } from '../../../../shared/paths';
 import { interpolateTemplate } from '../../shared/template-utils';
+import { ensureLocalGitExcludes } from '../../shared/git-exclude';
 import { writeHooksFile, KANGENTIC_EVENTS_PATH_ENV } from './hook-manager';
-import { writeMcpConfig, KANGENTIC_MCP_URL_ENV, KANGENTIC_MCP_TOKEN_ENV } from './mcp-config';
+import { writeMcpConfig, configTomlPath, KANGENTIC_MCP_URL_ENV, KANGENTIC_MCP_TOKEN_ENV } from './mcp-config';
 import type { PermissionMode } from '../../../../shared/types';
 
 /**
@@ -94,7 +96,12 @@ export class GrokCommandBuilder {
 
     // Wire the per-cwd hook file (static, env-routed) whenever this spawn
     // participates in the events pipeline, and the MCP config block
-    // whenever the server is attached. Both are idempotent rewrites.
+    // whenever the server is attached. Both are idempotent rewrites. Seed
+    // .git/info/exclude BEFORE the writes so the config.toml pre-existence
+    // check reflects the user's file, not ours: the runtime files otherwise
+    // sit untracked in the worktree for the whole session, polluting git
+    // status and riding along with any `git add -A` an agent runs.
+    this.seedGitExcludes(options);
     if (options.eventsOutputPath) {
       writeHooksFile(options.cwd);
     }
@@ -148,6 +155,33 @@ export class GrokCommandBuilder {
     }
 
     return parts.join(' ');
+  }
+
+  /**
+   * Hide the Kangentic-written runtime files from git for the untracked
+   * case. `.grok/hooks/kangentic.json` is a wholly Kangentic-owned filename
+   * (a pre-existing copy is ours from a prior or crashed session), so it is
+   * excluded unconditionally. `.grok/config.toml` is a user-owned file that
+   * gets the created-by-us carve-out: only a file Kangentic is about to
+   * create is excluded, and the exclude line persists once seeded, so a
+   * crash-leftover copy stays covered on respawn. Neither file carries a
+   * secret (URL and token are env references), so this is purely
+   * untracked-file noise control.
+   */
+  private seedGitExcludes(options: GrokCommandOptions): void {
+    const patterns: string[] = [];
+    if (options.eventsOutputPath || grokMcpWiringEnabled(options)) {
+      patterns.push('.kangentic/');
+    }
+    if (options.eventsOutputPath) {
+      patterns.push('.grok/hooks/kangentic.json');
+    }
+    if (grokMcpWiringEnabled(options) && !fs.existsSync(configTomlPath(options.cwd))) {
+      patterns.push('.grok/config.toml');
+    }
+    if (patterns.length > 0) {
+      ensureLocalGitExcludes(options.cwd, patterns);
+    }
   }
 
   /**

--- a/src/main/agent/adapters/grok/grok-adapter.ts
+++ b/src/main/agent/adapters/grok/grok-adapter.ts
@@ -294,9 +294,17 @@ export class GrokAdapter implements AgentAdapter {
   }
 
   configuredModelFromCommand(command: string): { id: string; displayName: string } | null {
-    const match = command.match(/--model\s+"?([^\s"]+)"?/);
-    if (!match) return null;
-    const id = match[1];
+    // Search only the flag region before the end-of-options `--` marker the
+    // builder emits ahead of the prompt, so a task text containing a literal
+    // `--model <word>` is never misread as a real flag (the
+    // parseModelFromClaudeCommand precedent). The alternation accepts the
+    // single quotes quoteArg emits on unix-like shells as well as double
+    // quotes and bare tokens.
+    const endOfOptions = command.search(/\s--\s/);
+    const flagRegion = endOfOptions === -1 ? command : command.slice(0, endOfOptions);
+    const match = flagRegion.match(/--model\s+(?:"([^"]+)"|'([^']+)'|(\S+))/);
+    const id = (match?.[1] ?? match?.[2] ?? match?.[3] ?? '').trim();
+    if (!id) return null;
     return { id, displayName: grokModelDisplayName(id) };
   }
 

--- a/src/main/agent/adapters/grok/mcp-config.ts
+++ b/src/main/agent/adapters/grok/mcp-config.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { atomicWriteFileWithBackup } from '../../shared/relocation-utils';
 
 /**
  * Kangentic MCP server wiring for Grok Build.
@@ -48,7 +49,8 @@ const MANAGED_BLOCK = [
   '',
 ].join('\n');
 
-function configTomlPath(directory: string): string {
+/** Exported for the command builder's git-exclude created-by-us check. */
+export function configTomlPath(directory: string): string {
   return path.join(directory, '.grok', 'config.toml');
 }
 
@@ -87,7 +89,16 @@ export function writeMcpConfig(directory: string): void {
     const base = stripManagedBlock(existing);
     const separator = base.length === 0 || base.endsWith('\n') ? '' : '\n';
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(filePath, `${base}${separator}${MANAGED_BLOCK}`);
+    // Atomic (write-temp + rename): config.toml is the USER'S file, and this
+    // full rewrite runs on every spawn, so a crash mid-write must never leave
+    // it truncated (the trust-manager rewrite discipline). `backup: false`
+    // because rename-replace already preserves the original on any failure
+    // before the rename, and a per-spawn backup file would litter the
+    // user's `.grok/` dir.
+    atomicWriteFileWithBackup(filePath, `${base}${separator}${MANAGED_BLOCK}`, {
+      backup: false,
+      logTag: '[grok]',
+    });
   } catch (error) {
     console.error(`[grok] Failed to write MCP config: ${filePath}`, error);
   }
@@ -115,7 +126,9 @@ export function removeMcpConfig(directory: string): void {
       fs.rmSync(filePath, { force: true });
       try { fs.rmdirSync(path.dirname(filePath)); } catch { /* not empty or already gone */ }
     } else {
-      fs.writeFileSync(filePath, remaining);
+      // Atomic for the same reason as writeMcpConfig: `remaining` is purely
+      // the user's own content, so a crash mid-write must never truncate it.
+      atomicWriteFileWithBackup(filePath, remaining, { backup: false, logTag: '[grok]' });
     }
   } catch (error) {
     console.error(`[grok] Failed to clean up MCP config: ${filePath}`, error);

--- a/src/main/agent/adapters/grok/project-relocation.ts
+++ b/src/main/agent/adapters/grok/project-relocation.ts
@@ -30,19 +30,51 @@ export async function migrateGrokProjectData(oldProjectPath: string, newProjectP
   for (const pair of pairs) {
     try {
       renameOrMergeDirectory(
-        path.join(sessionsRoot, cwdToSessionsDirName(pair.oldAbsolute)),
+        findSessionsDirForCwd(sessionsRoot, pair.oldAbsolute),
         path.join(sessionsRoot, cwdToSessionsDirName(pair.newAbsolute)),
       );
-    } catch (err) {
-      console.warn(`[GROK_RELOCATE] Failed to migrate sessions for ${pair.oldAbsolute}:`, err);
+    } catch (error) {
+      console.warn(`[GROK_RELOCATE] Failed to migrate sessions for ${pair.oldAbsolute}:`, error);
     }
   }
 
   try {
     rewriteTrustedFolderPaths(pairs);
-  } catch (err) {
-    console.warn('[GROK_RELOCATE] Failed to rewrite trusted_folders.toml:', err);
+  } catch (error) {
+    console.warn('[GROK_RELOCATE] Failed to rewrite trusted_folders.toml:', error);
   }
+}
+
+/**
+ * Resolve the on-disk sessions directory for a cwd, tolerating an encoding
+ * mismatch between the key we compute and the key grok actually wrote (e.g.
+ * a drive-letter casing difference on Windows) - the same hazard
+ * session-paths.ts's `findSessionDirAcrossCwds` defends the attach path
+ * against. The exact-encoded path wins when present; otherwise a one-level
+ * scan of the sessions root looks for a key that DECODES to the same path
+ * under `normalizeForCompare`. Falls back to the exact-encoded path (a
+ * no-op rename source) when nothing matches.
+ */
+function findSessionsDirForCwd(sessionsRoot: string, cwd: string): string {
+  const exact = path.join(sessionsRoot, cwdToSessionsDirName(cwd));
+  if (fs.existsSync(exact)) return exact;
+
+  let cwdKeys: string[];
+  try {
+    cwdKeys = fs.readdirSync(sessionsRoot);
+  } catch {
+    return exact;
+  }
+  for (const cwdKey of cwdKeys) {
+    try {
+      if (pathsEqual(decodeURIComponent(cwdKey), cwd)) {
+        return path.join(sessionsRoot, cwdKey);
+      }
+    } catch {
+      // Malformed percent-encoding in a foreign directory name - skip.
+    }
+  }
+  return exact;
 }
 
 function rewriteTrustedFolderPaths(

--- a/src/main/agent/adapters/grok/session-history-parser.ts
+++ b/src/main/agent/adapters/grok/session-history-parser.ts
@@ -80,17 +80,18 @@ export class GrokSessionHistoryParser {
       if (!isRecord(entry)) continue;
       const params = entry.params;
       if (!isRecord(params)) continue;
-      const update = params.update;
-      if (!isRecord(update)) continue;
-
       // Running context total: present in `params._meta.totalTokens` on
-      // streaming and tool updates. Harvested BEFORE the dispatch-type
-      // guard so lines of an unknown sessionUpdate type (hook_execution,
-      // task_backgrounded) still contribute - see GROK_DISPATCH_TYPES.
+      // streaming and tool updates. Harvested BEFORE the dispatch-type guard
+      // (it is a sibling of `update`, not type-specific), so an unknown
+      // update type like hook_execution still contributes its total instead
+      // of leaving the ContextBar stale at the last dispatch-type line.
       const paramsMeta = params._meta;
       if (isRecord(paramsMeta) && typeof paramsMeta.totalTokens === 'number') {
         contextTotalTokens = paramsMeta.totalTokens;
       }
+
+      const update = params.update;
+      if (!isRecord(update)) continue;
 
       const rawType = update.sessionUpdate;
       if (!isGrokDispatchType(rawType)) continue;

--- a/src/main/agent/adapters/opencode/hook-manager.ts
+++ b/src/main/agent/adapters/opencode/hook-manager.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { EventType } from '../../../../shared/types';
 import { resolvePluginScript } from '../../shared/bridge-utils';
-import { isGitRepo } from '../../../git/git-checks';
+import { ensureLocalGitExcludes } from '../../shared/git-exclude';
 
 /**
  * OpenCode plugin events mapped to event-bridge event types. Documented
@@ -34,7 +34,7 @@ export const OPENCODE_HOOK_EVENTS: Array<{
 
 const PLUGIN_FILENAME = 'kangentic-activity.mjs';
 const PLUGIN_SENTINEL = '// kangentic-activity';
-const PLUGIN_GITIGNORE_ENTRY = '.opencode/plugins/kangentic-activity.mjs';
+const PLUGIN_EXCLUDE_PATTERN = '.opencode/plugins/kangentic-activity.mjs';
 
 /** Directory under a project root where OpenCode auto-loads plugins. */
 function pluginsDir(projectRoot: string): string {
@@ -43,37 +43,6 @@ function pluginsDir(projectRoot: string): string {
 
 function pluginPath(projectRoot: string): string {
   return path.join(pluginsDir(projectRoot), PLUGIN_FILENAME);
-}
-
-/**
- * Add `.opencode/plugins/kangentic-activity.mjs` to the project's
- * `.gitignore` so the auto-installed plugin file is not committed by
- * mistake. Only runs when the project is a git repo - in non-git
- * directories there is nothing to ignore. Idempotent: skips the write
- * if the entry is already present. Wrapped in try/catch so a read-only
- * directory cannot break the spawn path.
- */
-function ensurePluginGitignored(projectRoot: string): void {
-  if (!isGitRepo(projectRoot)) return;
-  try {
-    const gitignorePath = path.join(projectRoot, '.gitignore');
-    let content = '';
-    try {
-      content = fs.readFileSync(gitignorePath, 'utf-8');
-    } catch {
-      // No .gitignore yet - we'll create one.
-    }
-
-    const alreadyIgnored = content
-      .split('\n')
-      .some((line) => line.trim() === PLUGIN_GITIGNORE_ENTRY);
-    if (alreadyIgnored) return;
-
-    const separator = content.length > 0 && !content.endsWith('\n') ? '\n' : '';
-    fs.writeFileSync(gitignorePath, content + separator + PLUGIN_GITIGNORE_ENTRY + '\n');
-  } catch (error) {
-    console.warn(`[opencode-hooks] Could not update .gitignore at ${projectRoot}:`, error);
-  }
 }
 
 /**
@@ -126,12 +95,15 @@ export function buildHooks(projectRoot: string): void {
     }
   }
 
-  // Only ignore the plugin file once it actually exists at the destination.
-  // This covers both "we just copied it" and "it was already there from a
-  // previous spawn", and skips cleanly when the copy/mkdir failed - so the
-  // gitignore entry is never written ahead of the file it ignores.
+  // Only hide the plugin file from git once it actually exists at the
+  // destination. This covers both "we just copied it" and "it was already
+  // there from a previous spawn", and skips cleanly when the copy/mkdir
+  // failed - so the exclude entry is never written ahead of the file it
+  // hides. `.git/info/exclude` is local and never committed, unlike the
+  // tracked `.gitignore` this used to append to (which dirtied the user's
+  // checkout); a non-git directory is a silent no-op inside the helper.
   if (fs.existsSync(destinationFile)) {
-    ensurePluginGitignored(projectRoot);
+    ensureLocalGitExcludes(projectRoot, [PLUGIN_EXCLUDE_PATTERN]);
   }
 }
 

--- a/src/main/agent/adapters/qwen-code/command-builder.ts
+++ b/src/main/agent/adapters/qwen-code/command-builder.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { toForwardSlash, quoteArg, isUnixLikeShell } from '../../../../shared/paths';
 import { interpolateTemplate } from '../../shared/template-utils';
 import { resolveBridgeScript } from '../../shared/bridge-utils';
+import { ensureLocalGitExcludes } from '../../shared/git-exclude';
 import { buildHooks } from './hook-manager';
 import type { QwenHookEntry } from './hook-manager';
 import type { PermissionMode } from '../../../../shared/types';
@@ -58,7 +59,12 @@ export class QwenCommandBuilder {
     // Write merged settings whenever event-bridge hooks OR the kangentic
     // MCP server entry need to land in `.qwen/settings.json`. Either alone
     // is sufficient - hooks need eventsOutputPath, MCP needs the URL+token
-    // pair.
+    // pair. Seed .git/info/exclude BEFORE the write so the settings.json
+    // pre-existence check reflects the user's file, not ours: the merged
+    // file otherwise sits untracked in the worktree for the whole session,
+    // polluting git status and riding along with any `git add -A` an agent
+    // runs - which would commit the per-launch plaintext token.
+    this.seedGitExcludes(options);
     if (this.shouldWriteMergedSettings(options)) {
       this.createMergedSettings(options);
     }
@@ -145,6 +151,23 @@ export class QwenCommandBuilder {
       Boolean(options.mcpServerUrl) &&
       Boolean(options.mcpServerToken)
     );
+  }
+
+  /**
+   * Hide the Kangentic-written runtime files from git for the untracked
+   * case. `.qwen/settings.json` gets the created-by-us carve-out: a file
+   * already present in the cwd may be the user's own, possibly destined for
+   * a commit, so only a file Kangentic is about to create is excluded.
+   * Ignore rules never affect tracked files, so a committed settings.json
+   * keeps its normal git visibility either way.
+   */
+  private seedGitExcludes(options: QwenCommandOptions): void {
+    if (!this.shouldWriteMergedSettings(options)) return;
+    const patterns = ['.kangentic/'];
+    if (!fs.existsSync(path.join(options.cwd, '.qwen', 'settings.json'))) {
+      patterns.push('.qwen/settings.json');
+    }
+    ensureLocalGitExcludes(options.cwd, patterns);
   }
 
   /**

--- a/src/main/agent/event-bridge.js
+++ b/src/main/agent/event-bridge.js
@@ -156,7 +156,11 @@ process.stdin.on('end', () => {
 
     switch (kind) {
       case 'extractTool': {
-        if (ctx && payload.field && ctx[payload.field] != null) event.tool = ctx[payload.field];
+        // Stringify + cap like firstNonNull: a non-primitive landing on the
+        // field must never embed an unbounded nested object into the JSONL.
+        if (ctx && payload.field && ctx[payload.field] != null) {
+          event.tool = String(ctx[payload.field]).slice(0, 200);
+        }
         break;
       }
       case 'extractToolPath': {
@@ -167,7 +171,8 @@ process.stdin.on('end', () => {
         for (const segment of payload.path) {
           value = value && typeof value === 'object' ? value[segment] : undefined;
         }
-        if (value != null) event.tool = value;
+        // Same stringify + cap contract as extractTool above.
+        if (value != null) event.tool = String(value).slice(0, 200);
         break;
       }
       case 'extractToolId': {

--- a/src/main/agent/shared/git-exclude.ts
+++ b/src/main/agent/shared/git-exclude.ts
@@ -2,24 +2,33 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 /**
- * Hide Antigravity's Kangentic-written runtime files from git.
+ * Hide Kangentic-written agent runtime files from git.
  *
- * The agy CLI has no per-spawn settings flag, so the event hooks and the MCP
- * plugin (which carries the per-launch `X-Kangentic-Token`) must live in the
- * WORKSPACE at `.agents/`. During a live session they therefore show up as
- * untracked files in `git status` - polluting the Changes pane and, far
- * worse, riding along with any `git add -A` an agent runs, which would land
- * the token in git history.
+ * Several agent CLIs have no per-spawn settings flag, so their event hooks
+ * and MCP wiring (sometimes carrying the per-launch `X-Kangentic-Token`)
+ * must live in the WORKSPACE (`.agents/`, `.gemini/`, `.qwen/`, `.factory/`,
+ * `.grok/`, ...). During a live session those files show up as untracked in
+ * `git status` - polluting the Changes pane and, far worse, riding along
+ * with any `git add -A` an agent runs, which would land the token in git
+ * history.
  *
  * `.git/info/exclude` is the local, never-committed ignore file, and for a
  * worktree it resolves to the repository's COMMON git dir, so one seeding
  * covers every worktree of the repo. Ignore rules only affect UNTRACKED
  * files, which gives exactly the wanted semantics: files Kangentic created
- * vanish from status and `add -A`, while a user's own TRACKED `.agents`
- * customizations keep their normal git visibility.
+ * vanish from status and `add -A`, while a user's own TRACKED files keep
+ * their normal git visibility. The created-by-us carve-out for shared-name
+ * files (a settings file the user may own and commit) is caller-side
+ * policy: an adapter excludes such a file only when Kangentic is about to
+ * create it, checked with `fs.existsSync` BEFORE its write.
  */
 
-const EXCLUDE_MARKER = '# kangentic: antigravity adapter runtime files (local ignore, safe to remove)';
+const EXCLUDE_MARKER = '# kangentic: agent runtime files (local ignore, safe to remove)';
+
+// Any prior Kangentic marker line (including the legacy adapter-branded
+// "# kangentic: antigravity adapter runtime files ..." one) counts as
+// "marker already present", so re-seeding never stacks a second marker.
+const EXCLUDE_MARKER_PREFIX = '# kangentic:';
 
 /**
  * Resolve the directory whose `info/exclude` this checkout reads, following
@@ -79,13 +88,14 @@ export function ensureLocalGitExcludes(directory: string, patterns: string[]): v
     const missing = patterns.filter((pattern) => !existingLines.has(pattern));
     if (missing.length === 0) return;
 
+    const hasMarker = [...existingLines].some((line) => line.startsWith(EXCLUDE_MARKER_PREFIX));
     fs.mkdirSync(path.dirname(excludePath), { recursive: true });
     const needsNewline = existing.length > 0 && !existing.endsWith('\n');
-    const block = (existingLines.has(EXCLUDE_MARKER) ? [] : [EXCLUDE_MARKER])
+    const block = (hasMarker ? [] : [EXCLUDE_MARKER])
       .concat(missing)
       .join('\n');
     fs.appendFileSync(excludePath, `${needsNewline ? '\n' : ''}${block}\n`);
   } catch (error) {
-    console.error('[antigravity] Failed to seed .git/info/exclude', error);
+    console.error('[git-exclude] Failed to seed .git/info/exclude', error);
   }
 }

--- a/src/main/ipc/helpers/project-setup.ts
+++ b/src/main/ipc/helpers/project-setup.ts
@@ -60,9 +60,10 @@ export async function ensureGitignore(projectPath: string): Promise<void> {
     }
 
     // Note: the OpenCode activity plugin (`.opencode/plugins/kangentic-activity.mjs`)
-    // is NOT ignored here. That entry is added lazily by the OpenCode adapter's
-    // buildHooks() at spawn time, so projects that never use OpenCode never get
-    // a stray ignore line.
+    // is NOT ignored here. The OpenCode adapter's buildHooks() seeds it into the
+    // local `.git/info/exclude` at spawn time (shared/git-exclude.ts), so projects
+    // that never use OpenCode never get a stray entry and the tracked .gitignore
+    // is never dirtied.
   } catch (err) {
     // Non-fatal: log and continue. Project may be read-only or on a network drive.
     console.warn(`[PROJECT_OPEN] Could not update .gitignore at ${projectPath}:`, err);

--- a/src/main/pty/buffer/pty-buffer-manager.ts
+++ b/src/main/pty/buffer/pty-buffer-manager.ts
@@ -801,7 +801,15 @@ export class PtyBufferManager {
 
   /** Report bytes a replay sample drained out of the pending buffer (see
    *  PtyBufferManagerCallbacks.onDrain). One chokepoint for every drain site
-   *  so the non-empty guard, the trace, and the throw guard cannot diverge. */
+   *  so the non-empty guard, the trace, and the throw guard cannot diverge.
+   *
+   *  ORDERING RULE for every call site: clear `state.buffer` BEFORE calling
+   *  this. The emptied buffer plus the non-empty guard below is what makes a
+   *  re-entrant listener (one that synchronously calls getScrollback /
+   *  getReplaySnapshot back into this manager) a harmless no-op instead of
+   *  unbounded recursion with duplicate tap delivery - and at the serialize
+   *  site it is also the counter's exception-safety. Report-before-clear
+   *  breaks both silently. */
   private reportDrain(sessionId: string, drained: string): void {
     if (!drained) return;
     traceTerminal(sessionId, 'replay-drain', { bytes: drained.length });
@@ -1001,9 +1009,13 @@ export class PtyBufferManager {
       } finally {
         if (deadlineTimer) clearTimeout(deadlineTimer);
       }
-      if (!this.buffers.get(sessionId)) {
+      if (this.buffers.get(sessionId) !== state) {
         // Torn down mid-sample (removeSession disposed the parser): nothing to
         // replay; the renderer's empty-scrollback path flushes its held bytes.
+        // IDENTITY comparison, not presence: if the id were ever re-initialized
+        // while this sample was in flight, a presence check would pass on the
+        // NEW state while the tail fold below read - and reported to data-tap -
+        // the dead generation's buffer under a live session id.
         traceTerminal(sessionId, 'scrollback-sample', { source: 'parsed-grid-torn-down', bytes: 0 });
         return '';
       }

--- a/src/main/transition-engine/turn-completion.ts
+++ b/src/main/transition-engine/turn-completion.ts
@@ -121,8 +121,16 @@ export function waitForTurnCompletion(
 
     const onOutput = (evtSessionId: string): void => {
       if (evtSessionId !== sessionId) return;
-      lastOutputAt = Date.now();
-      evaluate();
+      try {
+        lastOutputAt = Date.now();
+        evaluate();
+      } catch (caughtError) {
+        // Same contract as onActivity above - and 'data-tap' can now fire
+        // SYNCHRONOUSLY inside a replay's IPC stack (the buffer manager's
+        // replay-drain report), so a throw here would fail an unrelated
+        // getScrollback reply, not just a flush timer.
+        console.error(`[turn-completion] output handler failed for ${sessionId.slice(0, 8)}:`, caughtError);
+      }
     };
 
     const onExit = (evtSessionId: string): void => {

--- a/src/shared/ansi-strip.ts
+++ b/src/shared/ansi-strip.ts
@@ -29,7 +29,15 @@
  *
  * The result is readable plain text. Not pretty, but complete.
  */
-export function stripAnsiEscapes(text: string): string {
+
+/**
+ * The control-code core of `stripAnsiEscapes` (steps 1-5): removes escape
+ * sequences and control bytes WITHOUT the whitespace normalization of steps
+ * 6-8, so callers that must preserve exact payload bytes (e.g. a JSON blob
+ * embedded in PTY output - see antigravity's print-runner) can share the
+ * hardened patterns instead of carrying a copy that silently drifts.
+ */
+export function stripAnsiControlCodes(text: string): string {
   // 1. String-type sequences terminated by ST (ESC \) or BEL:
   //    OSC (ESC ]), DCS (ESC P), APC (ESC _), PM (ESC ^), SOS (ESC X)
   //    Also handles 8-bit C1 initiators (\x9d for OSC, \x90 for DCS, etc.)
@@ -64,7 +72,10 @@ export function stripAnsiEscapes(text: string): string {
   // 5. C0 control characters except \t (0x09), \n (0x0a), \r (0x0d).
   //    Strips NUL, BEL, BS, VT, FF, SO, SI, DLE, DC1-DC4, NAK, SYN,
   //    ETB, CAN, EM, SUB, ESC (orphaned), FS, GS, RS, US, DEL.
-  result = result.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
+  return result.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
+}
+export function stripAnsiEscapes(text: string): string {
+  let result = stripAnsiControlCodes(text);
 
   // 6. Normalize line endings: \r\n -> \n, standalone \r -> \n
   result = result.replace(/\r\n/g, '\n');

--- a/tests/integration/agent-cli-validation.test.ts
+++ b/tests/integration/agent-cli-validation.test.ts
@@ -40,6 +40,7 @@ import { QwenAdapter } from '../../src/main/agent/adapters/qwen-code/qwen-adapte
 import { KimiAdapter } from '../../src/main/agent/adapters/kimi/kimi-adapter';
 import { DroidAdapter } from '../../src/main/agent/adapters/droid/droid-adapter';
 import { GrokAdapter } from '../../src/main/agent/adapters/grok/grok-adapter';
+import { AntigravityAdapter } from '../../src/main/agent/adapters/antigravity/antigravity-adapter';
 import type { AgentAdapter, SpawnCommandOptions } from '../../src/main/agent/agent-adapter';
 import type { PermissionMode } from '../../src/shared/types';
 
@@ -184,6 +185,7 @@ const ADAPTERS: ProbeAdapter[] = [
   { name: 'kimi', adapter: new KimiAdapter() },
   { name: 'droid', adapter: new DroidAdapter() },
   { name: 'grok', adapter: new GrokAdapter() },
+  { name: 'antigravity', adapter: new AntigravityAdapter() },
 ];
 
 /**
@@ -240,6 +242,21 @@ const SESSIONS_ROOTS: Record<string, SessionRootSpec | undefined> = {
   // same source its /model picker uses), which the CLI writes on first use -
   // so an install with sessions on disk reliably has a populated cache.
   grok: { root: path.join(os.homedir(), '.grok', 'sessions'), expectModels: true },
+  // Antigravity's conversation transcripts live under
+  // `~/.gemini/antigravity-cli/brain/<uuid>/.system_generated/logs/
+  // transcript.jsonl` (data-paths.ts's antigravityDataRoot), so `brain/` -
+  // not the data root itself, which also holds settings.json even for a user
+  // who has only completed the trust dance and never actually run a
+  // conversation - is the closest on-disk proxy for "has run agy before".
+  // Unlike Grok's persisted models_cache.json, `discoverAntigravityCapabilities`
+  // has no local model cache: `agy models` is a live NETWORK fetch on every
+  // call (capability-discovery.ts), so a populated transcript directory does
+  // not reliably predict a populated model list at test-run time (offline,
+  // or an auth hiccup, degrades to no models by design - "best-effort and
+  // never throws"). expectModels: false keeps the directory-scan path
+  // exercised without asserting something the adapter's own source does not
+  // guarantee.
+  antigravity: { root: path.join(os.homedir(), '.gemini', 'antigravity-cli', 'brain'), expectModels: false },
 };
 
 /**

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -2294,6 +2294,18 @@
             supportsSummarize: true,
           },
           {
+            name: 'qwen', displayName: 'Qwen Code', found: false, path: null, version: null,
+            // KEEP IN SYNC with QwenAdapter.permissions in src/main/agent/adapters/qwen-code/qwen-adapter.ts
+            permissions: [
+              { mode: 'plan', label: 'Plan (Read-Only Research)' },
+              { mode: 'default', label: 'Default (Confirm Actions)' },
+              { mode: 'acceptEdits', label: 'Auto Edit (Auto-Approve Edits)' },
+              { mode: 'bypassPermissions', label: 'YOLO (Auto-Approve All)' },
+            ],
+            defaultPermission: 'acceptEdits',
+            supportsSummarize: true,
+          },
+          {
             name: 'aider', displayName: 'Aider', found: false, path: null, version: null,
             permissions: [
               { mode: 'default', label: 'Interactive (Confirm)' },

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -2345,18 +2345,6 @@
             supportsSummarize: true,
           },
           {
-            name: 'qwen', displayName: 'Qwen Code', found: false, path: null, version: null,
-            // KEEP IN SYNC with QwenAdapter.permissions in src/main/agent/adapters/qwen-code/qwen-adapter.ts
-            permissions: [
-              { mode: 'plan', label: 'Plan (Read-Only Research)' },
-              { mode: 'default', label: 'Default (Confirm Actions)' },
-              { mode: 'acceptEdits', label: 'Auto Edit (Auto-Approve Edits)' },
-              { mode: 'bypassPermissions', label: 'YOLO (Auto-Approve All)' },
-            ],
-            defaultPermission: 'acceptEdits',
-            supportsSummarize: true,
-          },
-          {
             name: 'kimi', displayName: 'Kimi Code', found: false, path: null, version: null,
             // KEEP IN SYNC with KimiAdapter.permissions in src/main/agent/adapters/kimi/kimi-adapter.ts
             permissions: [

--- a/tests/unit/ansi-strip.test.ts
+++ b/tests/unit/ansi-strip.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Unit tests for `src/shared/ansi-strip.ts`, focused on the contract this
+ * branch introduced: `stripAnsiControlCodes` is the control-code-only core
+ * (steps 1-5) that `stripAnsiEscapes` now delegates to, and it is used
+ * standalone by antigravity's print-runner to clean PTY chrome around a
+ * captured JSON blob WITHOUT rewriting bytes that may sit inside that JSON
+ * (`stripAnsiEscapes`'s line-ending normalization and trailing-whitespace
+ * trim - steps 6-8 - would corrupt a `\r\n` or trailing space embedded in a
+ * JSON string value). That divergence between the two functions is the
+ * whole reason `stripAnsiControlCodes` exists as its own export, and had no
+ * direct test before this file.
+ */
+import { describe, it, expect } from 'vitest';
+import { stripAnsiControlCodes, stripAnsiEscapes } from '../../src/shared/ansi-strip';
+
+describe('stripAnsiControlCodes', () => {
+  it('strips CSI (color) sequences and orphaned control bytes', () => {
+    const input = '\x1b[31mred text\x1b[0m plain\x07';
+    expect(stripAnsiControlCodes(input)).toBe('red text plain');
+  });
+
+  it('preserves \\r\\n line endings and trailing whitespace, unlike stripAnsiEscapes', () => {
+    // Same input to both functions: only the control-code stripping (steps
+    // 1-5) is shared. stripAnsiControlCodes must stop there; stripAnsiEscapes
+    // additionally normalizes line endings (steps 6) and trims trailing
+    // whitespace per line (step 8).
+    const input = 'line one   \r\nline two\x1b[31m colored\x1b[0m   \r\n';
+
+    expect(stripAnsiControlCodes(input)).toBe('line one   \r\nline two colored   \r\n');
+    expect(stripAnsiEscapes(input)).toBe('line one\nline two colored\n');
+  });
+});

--- a/tests/unit/antigravity-adapter.test.ts
+++ b/tests/unit/antigravity-adapter.test.ts
@@ -142,6 +142,35 @@ describe('AntigravityAdapter identity', () => {
   });
 });
 
+// ── liveTelemetryUnsupported capability ─────────────────────────────────────
+//
+// Antigravity has no per-session telemetry channel Kangentic can subscribe
+// to (verified 1.1.13: neither the interactive transcript nor the hook
+// payloads carry usage). The adapter declares a static
+// `liveTelemetryUnsupported` affordance so ContextBar can render a static
+// pill instead of an indefinite spinner. Same droid-adapter.test.ts
+// precedent: (a) the field is defined, (b) the label is a non-empty string,
+// (c) the tooltip title contains the "Antigravity" product-name marker so an
+// accidental field-clear is caught.
+
+describe('AntigravityAdapter.liveTelemetryUnsupported', () => {
+  it('is defined on the adapter instance', () => {
+    expect(adapter.liveTelemetryUnsupported).toBeDefined();
+  });
+
+  it('unavailableLabel is a non-empty string', () => {
+    const label = adapter.liveTelemetryUnsupported?.unavailableLabel;
+    expect(typeof label).toBe('string');
+    expect(label!.length).toBeGreaterThan(0);
+  });
+
+  it('unavailableTitle contains "Antigravity" so an empty-field refactor is caught', () => {
+    const title = adapter.liveTelemetryUnsupported?.unavailableTitle;
+    expect(typeof title).toBe('string');
+    expect(title).toContain('Antigravity');
+  });
+});
+
 // ---------------------------------------------------------------------------
 // AntigravityDetector: binary probing and the platform-conditional
 // fallback-path list. Uses the private-config-access pattern already
@@ -292,6 +321,27 @@ describe('AntigravityAdapter session-id capture', () => {
     expect(adapter.runtime.sessionId?.fromHook?.('{}')).toBeNull();
     expect(adapter.runtime.sessionId?.fromHook?.('not json')).toBeNull();
   });
+
+  it('fromHook falls back to a direct scan on a valid-prefix-but-truncated payload (the bridge caps hookContext at 2048 chars)', () => {
+    const conversationId = '08939dbf-7975-4a3e-988e-54962828b379';
+    const fullPayload = JSON.stringify({
+      conversationId,
+      modelName: 'gemini-3.7-flash-high',
+      // Pads the serialized payload well past 2048 chars so the slice below
+      // lands mid-string, mirroring a real long task prompt in agy's
+      // PreInvocation payload.
+      prompt: 'x'.repeat(4000),
+    });
+    const truncated = fullPayload.slice(0, 2048);
+    expect(() => JSON.parse(truncated)).toThrow(); // sanity: this is genuinely invalid JSON
+    expect(adapter.runtime.sessionId?.fromHook?.(truncated)).toBe(conversationId);
+  });
+
+  it('fromHook returns null for truncated garbage whose surviving prefix has no conversationId', () => {
+    const truncated = JSON.stringify({ modelName: 'gemini-3.7-flash-high', prompt: 'y'.repeat(4000) }).slice(0, 2048);
+    expect(() => JSON.parse(truncated)).toThrow();
+    expect(adapter.runtime.sessionId?.fromHook?.(truncated)).toBeNull();
+  });
 });
 
 describe('AntigravityAdapter activity detection', () => {
@@ -333,6 +383,22 @@ describe('configuredModelFromCommand and model display names', () => {
 
   it('returns null when the command has no model override', () => {
     expect(adapter.configuredModelFromCommand('"/usr/local/bin/agy"')).toBeNull();
+  });
+
+  it('ignores a literal "--model" string that only appears inside the -i prompt text (no real flag present)', () => {
+    // The flag-region guard truncates the search at the first bare -i/-p
+    // token, so a task prompt containing "--model bug" must never seed a
+    // bogus model pill.
+    const command = "/usr/local/bin/agy -i '--model bug'";
+    expect(adapter.configuredModelFromCommand(command)).toBeNull();
+  });
+
+  it('still parses a real --model flag positioned before -i, even when the prompt text also contains "--model"', () => {
+    const command = "/usr/local/bin/agy --model 'gemini-3.1-pro-high' -i '--model bug'";
+    expect(adapter.configuredModelFromCommand(command)).toEqual({
+      id: 'gemini-3.1-pro-high',
+      displayName: 'Gemini 3.1 Pro (High)',
+    });
   });
 
   it('extracts a double-quoted --model value with a friendly display name', () => {
@@ -390,6 +456,12 @@ describe('print-runner response extraction', () => {
 
   it('returns null when no result object is present', () => {
     expect(extractPrintResponse('spinner noise only')).toBeNull();
+  });
+
+  it('resolves the response from the LATER of two JSON-shaped candidates when only it carries a response field (last-blob policy)', () => {
+    const raw = '{"conversation_id":"a1-progress-blob","status":"partial","usage":{}}\n'
+      + '{"conversation_id":"a2-result-blob","status":"done","response":"final title","usage":{}}';
+    expect(extractPrintResponse(raw)).toBe('final title');
   });
 });
 
@@ -803,6 +875,61 @@ describe('AntigravityAdapter.locateSessionHistoryFile', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AntigravityAdapter.locateSessionHistoryFile: the brain-dir transcript can
+// appear a beat after conversation-id capture, so the adapter polls briefly.
+// vi.useFakeTimers() drives the 500ms poll interval virtually.
+// ---------------------------------------------------------------------------
+
+describe('AntigravityAdapter.locateSessionHistoryFile', () => {
+  let sandboxHome: string;
+
+  beforeEach(() => {
+    sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agy-locate-'));
+    homeOverride = sandboxHome;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    homeOverride = null;
+    fs.rmSync(sandboxHome, { recursive: true, force: true });
+  });
+
+  function transcriptPathFor(conversationId: string): string {
+    return path.join(
+      sandboxHome, '.gemini', 'antigravity-cli', 'brain', conversationId,
+      '.system_generated', 'logs', 'transcript.jsonl',
+    );
+  }
+
+  it('finds a transcript that appears mid-poll, after a few virtual 500ms ticks', async () => {
+    const conversationId = '08939dbf-7975-4a3e-988e-54962828b379';
+    const resultPromise = adapter.locateSessionHistoryFile(conversationId, '/project');
+
+    // The first couple of polling attempts see nothing yet.
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(500);
+
+    // The transcript lands mid-poll.
+    const expectedPath = transcriptPathFor(conversationId);
+    fs.mkdirSync(path.dirname(expectedPath), { recursive: true });
+    fs.writeFileSync(expectedPath, '');
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(resultPromise).resolves.toBe(expectedPath);
+  });
+
+  it('returns null after 10 polling attempts when the transcript never appears', async () => {
+    const resultPromise = adapter.locateSessionHistoryFile('never-appears-uuid', '/project');
+
+    await vi.advanceTimersByTimeAsync(500 * 10);
+
+    await expect(resultPromise).resolves.toBeNull();
   });
 });
 

--- a/tests/unit/antigravity-hooks-and-trust.test.ts
+++ b/tests/unit/antigravity-hooks-and-trust.test.ts
@@ -45,10 +45,6 @@ import {
   type AntigravityHooksFile,
 } from '../../src/main/agent/adapters/antigravity/hook-manager';
 import { migrateAntigravityProjectData } from '../../src/main/agent/adapters/antigravity/project-relocation';
-import {
-  ensureLocalGitExcludes,
-  resolveGitCommonDir,
-} from '../../src/main/agent/adapters/antigravity/git-exclude';
 import { normalizeForCompare } from '../../src/main/agent/adapters/antigravity/trust-manager';
 
 let tmpRoot: string;
@@ -144,26 +140,40 @@ describe('buildHooks', () => {
     expect(merged[KANGENTIC_HOOK_NAME].Stop![0].command).toContain('../.kangentic/events.jsonl');
   });
 
-  it('PostToolUse directives carry the exact extractToolPath/extractDetailPath payload shape', () => {
-    // The command only carries opaque base64 directive tokens (see
-    // directive-builders.ts); decode them out of the built command string
-    // rather than substring-matching the directive KIND, so a change to the
-    // segment/field arrays themselves is caught.
+  // Decodes the ACTUAL base64 directive payloads the production call in
+  // hook-manager.ts writes (extractToolPath/extractDetailPath on PostToolUse,
+  // captureHookContext on PreInvocation), rather than substring-matching the
+  // opaque wire tokens like the tests above. A typo'd path segment or a
+  // dropped field in that call is invisible to `.toContain('extractToolPath:')`
+  // but must fail this decode.
+  it('decodes the production extractToolPath / extractDetailPath / captureHookContext payloads written to hooks.json', () => {
     const merged = buildHooks('../.kangentic/agy-event-bridge.cjs', '../.kangentic/sessions/s1/events.jsonl', {});
-    const command = merged[KANGENTIC_HOOK_NAME].PostToolUse![0].hooks[0].command;
+    const entry = merged[KANGENTIC_HOOK_NAME];
 
-    function decodeDirective(kind: string): unknown {
-      const token = command.split(' ').find((candidate) => candidate.startsWith(`${kind}:`));
-      if (!token) throw new Error(`no ${kind} directive found in: ${command}`);
-      const base64Payload = token.slice(kind.length + 1);
-      return JSON.parse(Buffer.from(base64Payload, 'base64').toString('utf8'));
+    function decodeDirective(token: string): { kind: string; payload: unknown } {
+      const separatorIndex = token.indexOf(':');
+      const kind = token.slice(0, separatorIndex);
+      const base64Payload = token.slice(separatorIndex + 1);
+      const payload: unknown = JSON.parse(Buffer.from(base64Payload, 'base64').toString('utf8'));
+      return { kind, payload };
     }
 
-    expect(decodeDirective('extractToolPath')).toEqual({ path: ['toolCall', 'name'] });
-    expect(decodeDirective('extractDetailPath')).toEqual({
+    const postToolUseTokens = entry.PostToolUse![0].hooks[0].command.split(' ');
+    const decodedToolPath = decodeDirective(postToolUseTokens[4]);
+    expect(decodedToolPath.kind).toBe('extractToolPath');
+    expect(decodedToolPath.payload).toEqual({ path: ['toolCall', 'name'] });
+
+    const decodedDetailPath = decodeDirective(postToolUseTokens[5]);
+    expect(decodedDetailPath.kind).toBe('extractDetailPath');
+    expect(decodedDetailPath.payload).toEqual({
       parents: ['toolCall', 'args'],
       fields: ['TargetFile', 'CommandLine', 'DirectoryPath', 'AbsolutePath', 'Query'],
     });
+
+    const preInvocationTokens = entry.PreInvocation![0].command.split(' ');
+    const decodedCapture = decodeDirective(preInvocationTokens[4]);
+    expect(decodedCapture.kind).toBe('captureHookContext');
+    expect(decodedCapture.payload).toEqual({});
   });
 });
 
@@ -176,6 +186,42 @@ describe('filterOurHooks', () => {
     };
     const kept = filterOurHooks(root);
     expect(Object.keys(kept)).toEqual(['mine']);
+  });
+
+  // Per-handler (not entry-level) filtering: a user-named entry mixing their
+  // own handler with a stale/renamed Kangentic command must lose only the
+  // Kangentic handler, never the user's own handler alongside it. Red against
+  // the old wholesale-drop code, which dropped the whole entry as soon as ANY
+  // handler fingerprinted as ours.
+  it('keeps the user handler and drops only the Kangentic-fingerprinted handler within the same named entry', () => {
+    const root: AntigravityHooksFile = {
+      mixed: {
+        PreInvocation: [
+          { type: 'command', command: './my-notify.sh' },
+          { type: 'command', command: 'node event-bridge.cjs ../.kangentic/e.jsonl prompt' },
+        ],
+      },
+    };
+    const kept = filterOurHooks(root);
+    expect(Object.keys(kept)).toEqual(['mixed']);
+    expect(kept.mixed.PreInvocation).toEqual([{ type: 'command', command: './my-notify.sh' }]);
+  });
+
+  it('drops a named entry whole when every one of its handlers is Kangentic-fingerprinted', () => {
+    const root: AntigravityHooksFile = {
+      allOurs: {
+        PreInvocation: [{ type: 'command', command: 'node event-bridge.cjs ../.kangentic/e.jsonl prompt' }],
+        Stop: [{ type: 'command', command: 'node event-bridge.cjs ../.kangentic/e.jsonl idle' }],
+      },
+    };
+    expect(filterOurHooks(root)).toEqual({});
+  });
+
+  it('leaves a handler-less user entry untouched (nothing to fingerprint)', () => {
+    const root: AntigravityHooksFile = {
+      disabledPlaceholder: { enabled: false },
+    };
+    expect(filterOurHooks(root)).toEqual({ disabledPlaceholder: { enabled: false } });
   });
 });
 
@@ -560,57 +606,14 @@ describe('removeAntigravityWorkspaceTrust', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Local git excludes for the runtime files
+// Local git excludes for the runtime files (seeding POLICY only; the shared
+// mechanism itself is covered in tests/unit/git-exclude.test.ts)
 // ---------------------------------------------------------------------------
 
 describe('git-exclude seeding', () => {
   function excludePath(): string {
     return path.join(workspace, '.git', 'info', 'exclude');
   }
-
-  it('resolves a plain .git directory and a worktree .git file with commondir', () => {
-    fs.mkdirSync(path.join(workspace, '.git'), { recursive: true });
-    expect(resolveGitCommonDir(workspace)).toBe(path.join(workspace, '.git'));
-
-    // Worktree layout: <repo>/.git/worktrees/<name> gitdir, commondir -> ../..
-    const repo = path.join(tmpRoot, 'repo');
-    const worktreeGitDir = path.join(repo, '.git', 'worktrees', 'task-1');
-    const worktreeCheckout = path.join(tmpRoot, 'checkout');
-    fs.mkdirSync(worktreeGitDir, { recursive: true });
-    fs.mkdirSync(worktreeCheckout, { recursive: true });
-    fs.writeFileSync(path.join(worktreeCheckout, '.git'), `gitdir: ${worktreeGitDir}\n`);
-    fs.writeFileSync(path.join(worktreeGitDir, 'commondir'), '../..\n');
-    expect(resolveGitCommonDir(worktreeCheckout)).toBe(path.join(repo, '.git'));
-  });
-
-  it('returns null for a .git FILE whose content does not match the gitdir pointer format', () => {
-    fs.writeFileSync(path.join(workspace, '.git'), 'not a gitdir pointer\n');
-    expect(resolveGitCommonDir(workspace)).toBeNull();
-  });
-
-  it('returns null outside a git checkout (seeding is a silent no-op)', () => {
-    expect(resolveGitCommonDir(workspace)).toBeNull();
-    ensureLocalGitExcludes(workspace, ['.agents/plugins/kangentic/']);
-    expect(fs.existsSync(excludePath())).toBe(false);
-  });
-
-  it('appends missing patterns under the marker, idempotently', () => {
-    fs.mkdirSync(path.join(workspace, '.git'), { recursive: true });
-    ensureLocalGitExcludes(workspace, ['.agents/plugins/kangentic/', '.kangentic/']);
-    ensureLocalGitExcludes(workspace, ['.agents/plugins/kangentic/', '.kangentic/']);
-    const content = fs.readFileSync(excludePath(), 'utf-8');
-    expect(content.split('\n').filter((line) => line === '.kangentic/')).toHaveLength(1);
-    expect(content).toContain('# kangentic:');
-  });
-
-  it('preserves an existing exclude file and appends with a separating newline', () => {
-    fs.mkdirSync(path.join(workspace, '.git', 'info'), { recursive: true });
-    fs.writeFileSync(excludePath(), '*.log'); // no trailing newline
-    ensureLocalGitExcludes(workspace, ['.agents/plugins/kangentic/']);
-    const lines = fs.readFileSync(excludePath(), 'utf-8').split('\n');
-    expect(lines[0]).toBe('*.log');
-    expect(lines).toContain('.agents/plugins/kangentic/');
-  });
 
   it('builder seeds excludes: hooks.json only when Kangentic creates it', () => {
     fs.mkdirSync(path.join(workspace, '.git'), { recursive: true });
@@ -653,6 +656,27 @@ describe('git-exclude seeding', () => {
     const content = fs.readFileSync(excludePath(), 'utf-8');
     expect(content).not.toContain('.agents/hooks.json');
     expect(content).toContain('.kangentic/');
+  });
+
+  it('seeds excludes for an MCP-only spawn (no eventsOutputPath) - the OR-gate\'s MCP disjunct', () => {
+    // Every other seeding test wires events AND MCP together; isolate the
+    // second half of the OR so an accidental AND-gating regression (seeding
+    // only when BOTH wirings are present) is caught.
+    fs.mkdirSync(path.join(workspace, '.git'), { recursive: true });
+    new AntigravityCommandBuilder().buildAntigravityCommand({
+      agyPath: '/usr/bin/agy',
+      taskId: 't1',
+      cwd: workspace,
+      permissionMode: 'default',
+      shell: 'bash',
+      mcpServerUrl: 'http://127.0.0.1:4123/mcp',
+      mcpServerToken: 'token-abc',
+    });
+
+    const content = fs.readFileSync(excludePath(), 'utf-8');
+    expect(content).toContain('.agents/plugins/kangentic/');
+    expect(content).not.toContain('.kangentic/');
+    expect(content).not.toContain('.agents/hooks.json');
   });
 });
 
@@ -735,6 +759,14 @@ describe('migrateAntigravityProjectData', () => {
     writeSettings({ trustedWorkspaces: ['/old/repo', '/new/repo'] });
     await migrateAntigravityProjectData('/old/repo', '/new/repo');
     expect(readSettings().trustedWorkspaces).toEqual(['/new/repo']);
+  });
+
+  it('collapses a duplicate: when newPath is already a trusted entry, migration leaves exactly one entry for it', async () => {
+    writeSettings({ trustedWorkspaces: ['/old/repo', '/new/repo', '/other'] });
+    await migrateAntigravityProjectData('/old/repo', '/new/repo');
+    const trustedWorkspaces = readSettings().trustedWorkspaces as string[];
+    expect(trustedWorkspaces.filter((entry) => entry === '/new/repo')).toHaveLength(1);
+    expect(trustedWorkspaces).toEqual(['/other', '/new/repo']);
   });
 
   it('logs and never throws when both settings.json and last_conversations.json are corrupt', async () => {

--- a/tests/unit/antigravity-print-runner.test.ts
+++ b/tests/unit/antigravity-print-runner.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the real `runAntigravityPrint` (print-runner.ts).
+ *
+ * `tests/unit/antigravity-adapter.test.ts` globally mocks this module out
+ * (its summarize()-wiring tests only need to assert the WRAPPING, not the
+ * PTY-driving internals), so the onData capping behavior added in this
+ * branch has no other coverage. This file does NOT mock print-runner
+ * itself: node-pty is mocked so the PTY output stream is fully
+ * controllable with no native binding involved, and trust-manager's
+ * `ensureWorkspaceTrust` is mocked to a no-op so nothing here touches a
+ * real home directory (`scratchDirectory()` uses the real `os.tmpdir()`,
+ * which is the sandboxed-write rule's own carve-out).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock('../../src/main/agent/adapters/antigravity/trust-manager', () => ({
+  ensureWorkspaceTrust: vi.fn(async () => undefined),
+}));
+
+import * as pty from 'node-pty';
+import { runAntigravityPrint } from '../../src/main/agent/adapters/antigravity/print-runner';
+
+const spawnMock = pty.spawn as unknown as ReturnType<typeof vi.fn>;
+
+interface FakePtyProcess {
+  emitData: (data: string) => void;
+  emitExit: () => void;
+  killMock: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Install a scripted fake PTY, following the claude-model-picker-probe.test.ts
+ * precedent: `onSpawn` fires from a `queueMicrotask` scheduled at the moment
+ * `spawn()` is called, so it always runs AFTER the synchronous `onData`/
+ * `onExit` registration inside print-runner's `new Promise(executor)` -
+ * causally ordered, no fixed-delay guess needed.
+ */
+function installFakePty(onSpawn: (fake: FakePtyProcess) => void): void {
+  let dataCallback: ((data: string) => void) | null = null;
+  let exitCallback: (() => void) | null = null;
+  const fake: FakePtyProcess = {
+    emitData: (data: string) => {
+      if (!dataCallback) throw new Error('test setup: onData handler not registered yet');
+      dataCallback(data);
+    },
+    emitExit: () => {
+      if (!exitCallback) throw new Error('test setup: onExit handler not registered yet');
+      exitCallback();
+    },
+    killMock: vi.fn(),
+  };
+  spawnMock.mockImplementation(() => {
+    queueMicrotask(() => onSpawn(fake));
+    return {
+      onData: (callback: (data: string) => void) => {
+        dataCallback = callback;
+      },
+      onExit: (callback: () => void) => {
+        exitCallback = callback;
+      },
+      kill: fake.killMock,
+    };
+  });
+}
+
+beforeEach(() => {
+  spawnMock.mockReset();
+});
+
+describe('runAntigravityPrint output capping', () => {
+  it('retains the TAIL of PTY output under the 64KB cap so a closing result JSON survives a chatty run', async () => {
+    // Before this branch, the cap guard was drop-forward
+    // (`if (output.length < OUTPUT_CAP_BYTES) output += data`): once 64KB of
+    // output had accumulated, every subsequent chunk - including the closing
+    // result JSON extractPrintResponse reads from the END of the stream -
+    // was silently discarded. The fix retains the tail instead
+    // (`output = (output + data).slice(-OUTPUT_CAP_BYTES)`), so a run that
+    // is chatty BEFORE printing its result must still resolve correctly.
+    const resultJson = JSON.stringify({
+      conversation_id: 'a1b2c3',
+      status: 'done',
+      response: 'Fix the login timeout bug',
+      usage: {},
+    });
+
+    const resultPromise = runAntigravityPrint('/usr/bin/agy', 'summarize this task');
+
+    installFakePty((fake) => {
+      // 80KB of noise BEFORE the result JSON: on its own this already
+      // exceeds the 64KB cap, so a drop-forward guard would have frozen
+      // `output` at this noise's head and never seen the JSON chunk below.
+      // Kept free of `{`/`}` and control bytes so it cannot itself parse as
+      // (or corrupt) a JSON candidate.
+      fake.emitData('n'.repeat(80 * 1024));
+      fake.emitData(resultJson);
+      fake.emitExit();
+    });
+
+    await expect(resultPromise).resolves.toBe('Fix the login timeout bug');
+  });
+});

--- a/tests/unit/directive-builders.test.ts
+++ b/tests/unit/directive-builders.test.ts
@@ -13,7 +13,10 @@ import { EventType } from '../../src/shared/types';
 import {
   extractTool,
   extractToolId,
+  extractToolPath,
   extractDetail,
+  extractDetailPath,
+  captureHookContext,
   setDetail,
   setTypeWhen,
   setTypeWhenDetailContains,
@@ -55,6 +58,17 @@ describe('directive builders - wire format contract', () => {
     ['setTypeWhenDetailMatches', setTypeWhenDetailMatches('^[\\w-]{1,64}$', EventType.BackgroundShellStart), 'setTypeWhenDetailMatches', { pattern: '^[\\w-]{1,64}$', to: 'background_shell_start' }],
     ['extractDetailPattern', extractDetailPattern('prompt', '<task-id>([\\w-]+)</task-id>'), 'extractDetailPattern', { field: 'prompt', pattern: '<task-id>([\\w-]+)</task-id>' }],
     ['emitOnlyWhenDetailMatches', emitOnlyWhenDetailMatches('^[\\w-]{1,64}$'), 'emitOnlyWhenDetailMatches', { pattern: '^[\\w-]{1,64}$' }],
+    // Nested-payload siblings (Antigravity's `ctx.toolCall.name` /
+    // `ctx.toolCall.args.TargetFile` shape) and the no-once-per-session
+    // hookContext opt-in. Each is its OWN wire kind for the fail-closed
+    // reason documented on the builders (a stale bridge copy rejects an
+    // unknown kind via `default` instead of misreading the payload) - a
+    // lockstep rename of the kind string here goes red the moment it drifts
+    // from event-bridge.js's `case` labels, since that would silently no-op
+    // on any deployed bridge copy still running the old kind name.
+    ['extractToolPath', extractToolPath(['toolCall', 'name']), 'extractToolPath', { path: ['toolCall', 'name'] }],
+    ['extractDetailPath', extractDetailPath(['toolCall', 'args'], ['TargetFile', 'CommandLine']), 'extractDetailPath', { parents: ['toolCall', 'args'], fields: ['TargetFile', 'CommandLine'] }],
+    ['captureHookContext', captureHookContext(), 'captureHookContext', {}],
   ];
 
   it.each(cases)('%s encodes to <kind>:<base64> and round-trips', (_label, directive, expectedKind, expectedPayload) => {
@@ -83,6 +97,12 @@ describe('directive builders - wire format contract', () => {
   it('throws on an empty field list (authoring mistake caught at build time)', () => {
     expect(() => extractDetail([])).toThrow();
     expect(() => extractToolId([])).toThrow();
+  });
+
+  it('extractToolPath and extractDetailPath throw on an empty segment list (authoring mistake caught at build time)', () => {
+    expect(() => extractToolPath([])).toThrow();
+    expect(() => extractDetailPath([], ['field'])).toThrow();
+    expect(() => extractDetailPath(['parent'], [])).toThrow();
   });
 
   it('setTypeWhen throws when both nested and field are provided (mutually exclusive)', () => {

--- a/tests/unit/droid-adapter.test.ts
+++ b/tests/unit/droid-adapter.test.ts
@@ -335,6 +335,50 @@ describe('Droid Adapter', () => {
     });
   });
 
+  describe('git-exclude seeding', () => {
+    const excludePath = () => path.join(tempDir, '.git', 'info', 'exclude');
+
+    const build = (overrides: Partial<SpawnCommandOptions> = {}) =>
+      adapter.buildCommand(makeOptions({
+        cwd: tempDir,
+        mcpServerEnabled: true,
+        mcpServerUrl: 'http://127.0.0.1:5555/mcp/project-123/sess-xyz',
+        mcpServerToken: 'secret-token',
+        ...overrides,
+      }));
+
+    beforeEach(() => {
+      fs.mkdirSync(path.join(tempDir, '.git'), { recursive: true });
+    });
+
+    it('seeds .factory/mcp.json and .kangentic/ when Kangentic creates the file', () => {
+      build();
+      const content = fs.readFileSync(excludePath(), 'utf-8');
+      expect(content).toContain('.factory/mcp.json');
+      expect(content).toContain('.kangentic/');
+    });
+
+    it('never excludes a pre-existing user mcp.json (created-by-us carve-out)', () => {
+      // Also pins the seed-BEFORE-write ordering: after the build the merged
+      // file always exists, so a post-write existence check could never
+      // distinguish the user's file from ours.
+      fs.mkdirSync(path.join(tempDir, '.factory'), { recursive: true });
+      fs.writeFileSync(
+        path.join(tempDir, '.factory', 'mcp.json'),
+        JSON.stringify({ mcpServers: { linear: { type: 'http', url: 'http://example.test/mcp' } } }),
+      );
+      build();
+      const content = fs.readFileSync(excludePath(), 'utf-8');
+      expect(content).not.toContain('.factory/mcp.json');
+      expect(content).toContain('.kangentic/');
+    });
+
+    it('seeds nothing when MCP wiring is disabled', () => {
+      build({ mcpServerEnabled: false });
+      expect(fs.existsSync(excludePath())).toBe(false);
+    });
+  });
+
   describe('interpolateTemplate', () => {
     it('replaces {{key}} placeholders', () => {
       const result = adapter.interpolateTemplate(

--- a/tests/unit/event-bridge.test.ts
+++ b/tests/unit/event-bridge.test.ts
@@ -453,6 +453,41 @@ describe('event-bridge', () => {
     expect(readEvent().detail).toBeUndefined();
   });
 
+  // --- extractToolPath / extractTool: a non-primitive leaf must be bounded,
+  // never embedded raw ---
+  //
+  // Both arms now match firstNonNull's own contract: `String(value).slice(0,
+  // 200)`. Before that, `event.tool` was assigned the raw walked/looked-up
+  // value with no stringify/cap - so a leaf that resolves to a nested OBJECT
+  // (e.g. a future agy payload shape whose `toolCall.name` is itself a
+  // structured value, or any adapter whose top-level field is an object)
+  // would embed that object directly into `event`, and JSON.stringify(event)
+  // would serialize it as an unbounded nested JSON blob inside the JSONL line
+  // instead of a bounded string. Pinned here as the '[object Object]' string
+  // coercion, exactly what `String({...})` produces.
+
+  it('extractToolPath with a non-primitive leaf stringifies and bounds it, never embedding a raw object', () => {
+    const stdin = JSON.stringify({ toolCall: { name: { nested: 'object' } } });
+    runBridge(stdin, [outputFile, 'tool_end', extractToolPath(['toolCall', 'name'])]);
+    const line = readEvent();
+    expect(line.tool).toBe('[object Object]');
+    expect(typeof line.tool).toBe('string');
+  });
+
+  it('extractTool with a top-level non-primitive field stringifies and bounds it the same way', () => {
+    const stdin = JSON.stringify({ tool_name: { nested: 'object' } });
+    runBridge(stdin, [outputFile, 'tool_start', extractTool('tool_name')]);
+    const line = readEvent();
+    expect(line.tool).toBe('[object Object]');
+    expect(typeof line.tool).toBe('string');
+  });
+
+  it('extractToolPath with a normal string leaf is unchanged', () => {
+    const stdin = JSON.stringify({ toolCall: { name: 'write_to_file' } });
+    runBridge(stdin, [outputFile, 'tool_end', extractToolPath(['toolCall', 'name'])]);
+    expect(readEvent().tool).toBe('write_to_file');
+  });
+
   // --- No directives (events that need no extraction) ---
 
   it('event with no directives writes type only', () => {

--- a/tests/unit/gemini-command-builder.test.ts
+++ b/tests/unit/gemini-command-builder.test.ts
@@ -144,6 +144,72 @@ describe('GeminiCommandBuilder', () => {
     });
   });
 
+  describe('git-exclude seeding', () => {
+    let tmpDir: string;
+
+    const excludePath = () => path.join(tmpDir, '.git', 'info', 'exclude');
+
+    const build = (overrides: Partial<GeminiCommandOptions> = {}) =>
+      new GeminiCommandBuilder().buildGeminiCommand(baseOptions({
+        cwd: tmpDir,
+        mcpServerEnabled: true,
+        mcpServerUrl: 'http://127.0.0.1:5555/mcp/project-123/sess-xyz',
+        mcpServerToken: 'secret-token',
+        ...overrides,
+      }));
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kng-gemini-exclude-'));
+      fs.mkdirSync(path.join(tmpDir, '.git'), { recursive: true });
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('seeds .gemini/settings.json and .kangentic/ when Kangentic creates the file', () => {
+      build();
+      const content = fs.readFileSync(excludePath(), 'utf-8');
+      expect(content).toContain('.gemini/settings.json');
+      expect(content).toContain('.kangentic/');
+    });
+
+    it('never excludes a pre-existing user settings.json (created-by-us carve-out)', () => {
+      // Also pins the seed-BEFORE-write ordering: after the build the merged
+      // file always exists, so a post-write existence check could never
+      // distinguish the user's file from ours.
+      fs.mkdirSync(path.join(tmpDir, '.gemini'), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, '.gemini', 'settings.json'),
+        JSON.stringify({ mcpServers: { context7: { httpUrl: 'http://example.test/mcp' } } }),
+      );
+      build({ projectRoot: tmpDir });
+      const content = fs.readFileSync(excludePath(), 'utf-8');
+      expect(content).not.toContain('.gemini/settings.json');
+      expect(content).toContain('.kangentic/');
+    });
+
+    it('seeds nothing when no settings write happens', () => {
+      build({ mcpServerEnabled: false });
+      expect(fs.existsSync(excludePath())).toBe(false);
+    });
+
+    it('an events-only spawn (no MCP) still seeds .gemini/settings.json and .kangentic/', () => {
+      // shouldWriteMergedSettings / seedGitExcludes are OR-gated on
+      // eventsOutputPath OR mcp wiring - either alone must trigger seeding.
+      // Regression guard against the two conditions drifting apart.
+      build({
+        mcpServerEnabled: false,
+        mcpServerUrl: undefined,
+        mcpServerToken: undefined,
+        eventsOutputPath: path.join(tmpDir, '.kangentic', 'sessions', 's1', 'events.jsonl'),
+      });
+      const content = fs.readFileSync(excludePath(), 'utf-8');
+      expect(content).toContain('.gemini/settings.json');
+      expect(content).toContain('.kangentic/');
+    });
+  });
+
   describe('permission modes', () => {
     it('default mode produces no flags', () => {
       const command = buildCommand({ permissionMode: 'default' });

--- a/tests/unit/git-exclude.test.ts
+++ b/tests/unit/git-exclude.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the shared `.git/info/exclude` seeding mechanism
+ * (`src/main/agent/shared/git-exclude.ts`): worktree commondir resolution,
+ * idempotent marker-block appends, and legacy-marker compatibility. The
+ * per-adapter seeding POLICIES (which patterns, carve-outs, gating) are
+ * pinned in each adapter's own test file. All filesystem writes are
+ * sandboxed under os.tmpdir().
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  ensureLocalGitExcludes,
+  resolveGitCommonDir,
+} from '../../src/main/agent/shared/git-exclude';
+
+let tmpRoot: string;
+let workspace: string;
+
+function excludePath(): string {
+  return path.join(workspace, '.git', 'info', 'exclude');
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'git-exclude-'));
+  workspace = path.join(tmpRoot, 'ws');
+  fs.mkdirSync(workspace, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('resolveGitCommonDir', () => {
+  it('resolves a plain .git directory and a worktree .git file with commondir', () => {
+    fs.mkdirSync(path.join(workspace, '.git'), { recursive: true });
+    expect(resolveGitCommonDir(workspace)).toBe(path.join(workspace, '.git'));
+
+    // Worktree layout: <repo>/.git/worktrees/<name> gitdir, commondir -> ../..
+    const repo = path.join(tmpRoot, 'repo');
+    const worktreeGitDir = path.join(repo, '.git', 'worktrees', 'task-1');
+    const worktreeCheckout = path.join(tmpRoot, 'checkout');
+    fs.mkdirSync(worktreeGitDir, { recursive: true });
+    fs.mkdirSync(worktreeCheckout, { recursive: true });
+    fs.writeFileSync(path.join(worktreeCheckout, '.git'), `gitdir: ${worktreeGitDir}\n`);
+    fs.writeFileSync(path.join(worktreeGitDir, 'commondir'), '../..\n');
+    expect(resolveGitCommonDir(worktreeCheckout)).toBe(path.join(repo, '.git'));
+  });
+
+  it('returns null for a .git FILE whose content does not match the gitdir pointer format', () => {
+    fs.writeFileSync(path.join(workspace, '.git'), 'not a gitdir pointer\n');
+    expect(resolveGitCommonDir(workspace)).toBeNull();
+  });
+
+  it('returns null outside a git checkout (seeding is a silent no-op)', () => {
+    expect(resolveGitCommonDir(workspace)).toBeNull();
+    ensureLocalGitExcludes(workspace, ['.agents/plugins/kangentic/']);
+    expect(fs.existsSync(excludePath())).toBe(false);
+  });
+});
+
+describe('ensureLocalGitExcludes', () => {
+  it('appends missing patterns under the marker, idempotently', () => {
+    fs.mkdirSync(path.join(workspace, '.git'), { recursive: true });
+    ensureLocalGitExcludes(workspace, ['.agents/plugins/kangentic/', '.kangentic/']);
+    ensureLocalGitExcludes(workspace, ['.agents/plugins/kangentic/', '.kangentic/']);
+    const content = fs.readFileSync(excludePath(), 'utf-8');
+    expect(content.split('\n').filter((line) => line === '.kangentic/')).toHaveLength(1);
+    expect(content).toContain('# kangentic:');
+  });
+
+  it('preserves an existing exclude file and appends with a separating newline', () => {
+    fs.mkdirSync(path.join(workspace, '.git', 'info'), { recursive: true });
+    fs.writeFileSync(excludePath(), '*.log'); // no trailing newline
+    ensureLocalGitExcludes(workspace, ['.agents/plugins/kangentic/']);
+    const lines = fs.readFileSync(excludePath(), 'utf-8').split('\n');
+    expect(lines[0]).toBe('*.log');
+    expect(lines).toContain('.agents/plugins/kangentic/');
+  });
+
+  it('seeds the generic marker on a fresh exclude file', () => {
+    fs.mkdirSync(path.join(workspace, '.git'), { recursive: true });
+    ensureLocalGitExcludes(workspace, ['.kangentic/']);
+    const content = fs.readFileSync(excludePath(), 'utf-8');
+    expect(content).toContain('# kangentic: agent runtime files (local ignore, safe to remove)');
+  });
+
+  it('dedupes when the pattern is already the last line, with no trailing newline', () => {
+    // Regression coverage carried over from the pre-move opencode-specific
+    // suite: a file whose final byte IS the pattern (no trailing \n) must
+    // still be recognized as "already present" so re-seeding never appends
+    // a duplicate occurrence.
+    fs.mkdirSync(path.join(workspace, '.git', 'info'), { recursive: true });
+    fs.writeFileSync(
+      excludePath(),
+      '# kangentic: agent runtime files (local ignore, safe to remove)\n.kangentic/',
+    );
+    ensureLocalGitExcludes(workspace, ['.kangentic/']);
+    const lines = fs.readFileSync(excludePath(), 'utf-8').split('\n');
+    expect(lines.filter((line) => line === '.kangentic/')).toHaveLength(1);
+  });
+
+  it('never stacks a second marker over the legacy antigravity marker', () => {
+    // Repos seeded before the module moved to shared/ carry the
+    // adapter-branded marker; re-seeding with a NEW pattern must append the
+    // pattern under that existing marker, not add a second marker block.
+    fs.mkdirSync(path.join(workspace, '.git', 'info'), { recursive: true });
+    fs.writeFileSync(
+      excludePath(),
+      '# kangentic: antigravity adapter runtime files (local ignore, safe to remove)\n.agents/plugins/kangentic/\n',
+    );
+    ensureLocalGitExcludes(workspace, ['.gemini/settings.json']);
+    const lines = fs.readFileSync(excludePath(), 'utf-8').split('\n');
+    expect(lines.filter((line) => line.startsWith('# kangentic:'))).toHaveLength(1);
+    expect(lines).toContain('.gemini/settings.json');
+    expect(lines).toContain('.agents/plugins/kangentic/');
+  });
+});

--- a/tests/unit/grok-adapter.test.ts
+++ b/tests/unit/grok-adapter.test.ts
@@ -1622,6 +1622,44 @@ describe('migrateGrokProjectData', () => {
     expect(fs.existsSync(mismatchedSessionDir)).toBe(false);
   });
 
+  it('skips a sessions-root sibling whose name is malformed percent-encoding, without logging a rename failure', async () => {
+    // findSessionsDirForCwd's scan-and-decode fallback calls
+    // decodeURIComponent(cwdKey) on every sibling in the sessions root; a
+    // THIRD-PARTY (grok-written) directory name that is not valid
+    // percent-encoding (e.g. a lone "%" not followed by two hex digits) must
+    // be skipped, not propagate an uncaught URIError out of the scan.
+    //
+    // Deliberately no decodable match exists in this sessions root (only the
+    // malformed sibling), so this assertion cannot pass by accident of
+    // readdirSync ordering: on correct behavior the scan exhausts safely,
+    // falls back to the (non-existent) exact-encoded path, and
+    // renameOrMergeDirectory silently no-ops (relocation-utils.ts returns
+    // early when the source does not exist) - no warning is logged. On
+    // broken behavior (the guarding try/catch removed) decodeURIComponent
+    // throws INSIDE the scan; that throw propagates, uncaught, out of
+    // findSessionsDirForCwd and into migrateGrokProjectData's per-pair
+    // try/catch, which DOES log "[GROK_RELOCATE] Failed to migrate
+    // sessions" - so the assertion below is genuinely red against the
+    // unguarded scan, not vacuously true.
+    const home = useTempGrokHome();
+    const oldProject = path.join(home, 'old-project');
+    const newProject = path.join(home, 'new-project');
+    const sessionsRoot = path.join(home, 'sessions');
+
+    fs.mkdirSync(path.join(sessionsRoot, '%zz-not-percent-encoded'), { recursive: true });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(migrateGrokProjectData(oldProject, newProject)).resolves.toBeUndefined();
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('[GROK_RELOCATE] Failed to migrate sessions'),
+      expect.anything(),
+    );
+
+    warnSpy.mockRestore();
+  });
+
   it('rewrites a double-quoted trust header for the old path, leaving an unrelated header untouched', async () => {
     // grok itself always writes single-quoted literals, but a double-quoted
     // key is legal TOML and must not be silently left pointing at the old

--- a/tests/unit/grok-adapter.test.ts
+++ b/tests/unit/grok-adapter.test.ts
@@ -12,6 +12,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { GrokAdapter } from '../../src/main/agent/adapters/grok/grok-adapter';
 import { GrokCommandBuilder, grokMcpWiringEnabled } from '../../src/main/agent/adapters/grok/command-builder';
+import type { GrokCommandOptions } from '../../src/main/agent/adapters/grok/command-builder';
 import { parseGrokVersion, GrokDetector } from '../../src/main/agent/adapters/grok/detector';
 import { buildGrokHooks, writeHooksFile, removeHooksFile } from '../../src/main/agent/adapters/grok/hook-manager';
 import { writeMcpConfig, removeMcpConfig } from '../../src/main/agent/adapters/grok/mcp-config';
@@ -150,6 +151,18 @@ describe('GrokAdapter identity', () => {
       .toEqual({ id: 'grok-4.6', displayName: 'Grok 4.6' });
     expect(adapter.configuredModelFromCommand('grok -s x --model grok-unlisted -- "hi"'))
       .toEqual({ id: 'grok-unlisted', displayName: 'grok-unlisted' });
+  });
+
+  it('only reads --model from the flag region before the end-of-options marker', () => {
+    // A prompt that happens to contain the literal text "--model usage" must
+    // never be misread as a real flag: only text BEFORE the ` -- ` marker
+    // the builder emits ahead of the prompt is a candidate flag region
+    // (the parseModelFromClaudeCommand precedent).
+    expect(adapter.configuredModelFromCommand("grok -s x -- 'run --model usage now'")).toBeNull();
+  });
+
+  it('parses a single-quoted --model value (the unix quoteArg form)', () => {
+    expect(adapter.configuredModelFromCommand("grok -s x --model 'my-model' -- 'hi'")?.id).toBe('my-model');
   });
 });
 
@@ -413,8 +426,15 @@ describe('buildGrokHooks', () => {
     const directives = tokens.slice(4).map(decodeDirective);
     expect(directives[0]).toEqual({ kind: 'extractTool', payload: { field: 'toolName' } });
     expect(directives[1]).toEqual({ kind: 'extractToolId', payload: { fields: ['toolUseId'] } });
-    expect(directives[2].kind).toBe('extractDetail');
-    expect(directives[2].payload).toMatchObject({ nested: 'toolInput' });
+    // Pinned exactly (not toMatchObject) so a field silently dropped from or
+    // added to buildGrokHooks's PreToolUse detail list is caught here.
+    expect(directives[2]).toEqual({
+      kind: 'extractDetail',
+      payload: {
+        fields: ['command', 'target_file', 'file_path', 'path', 'query', 'pattern', 'url', 'description'],
+        nested: 'toolInput',
+      },
+    });
   });
 
   it('maps PostToolUse to tool_end with tool-name/tool-id extraction and NO error-detail directive', () => {
@@ -480,6 +500,87 @@ describe('buildGrokHooks', () => {
     const preCompactTokens = hooks.PreCompact[0].hooks[0].command.split(' ');
     expect(preCompactTokens[3]).toBe('compact');
     expect(preCompactTokens).toHaveLength(4);
+  });
+});
+
+describe('git-exclude seeding', () => {
+  const builder = new GrokCommandBuilder();
+  let tempCwd: string;
+
+  const excludePath = () => path.join(tempCwd, '.git', 'info', 'exclude');
+
+  const build = (overrides: Partial<GrokCommandOptions> = {}) =>
+    builder.buildGrokCommand({
+      grokPath: '/usr/bin/grok',
+      taskId: 'task-1',
+      cwd: tempCwd,
+      permissionMode: 'acceptEdits' as PermissionMode,
+      shell: 'bash',
+      ...overrides,
+    });
+
+  beforeEach(() => {
+    tempCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-exclude-'));
+    fs.mkdirSync(path.join(tempCwd, '.git'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempCwd, { recursive: true, force: true });
+  });
+
+  it('full spawn seeds the hook file, config.toml, and .kangentic/', () => {
+    build({
+      eventsOutputPath: path.join(tempCwd, '.kangentic', 'sessions', 's1', 'events.jsonl'),
+      mcpServerUrl: 'http://127.0.0.1:4100/mcp/p1/s1',
+      mcpServerToken: 'secret-token',
+    });
+    const content = fs.readFileSync(excludePath(), 'utf-8');
+    expect(content).toContain('.grok/hooks/kangentic.json');
+    expect(content).toContain('.grok/config.toml');
+    expect(content).toContain('.kangentic/');
+  });
+
+  it('never excludes a pre-existing user config.toml, but still excludes the hook file', () => {
+    // Also pins the seed-BEFORE-write ordering: after the build the managed
+    // block has been appended, so a post-write existence check could never
+    // distinguish the user's config.toml from a Kangentic-created one.
+    fs.mkdirSync(path.join(tempCwd, '.grok'), { recursive: true });
+    fs.writeFileSync(path.join(tempCwd, '.grok', 'config.toml'), '[settings]\ntheme = "dark"\n');
+    build({
+      eventsOutputPath: path.join(tempCwd, '.kangentic', 'sessions', 's1', 'events.jsonl'),
+      mcpServerUrl: 'http://127.0.0.1:4100/mcp/p1/s1',
+      mcpServerToken: 'secret-token',
+    });
+    const content = fs.readFileSync(excludePath(), 'utf-8');
+    expect(content).not.toContain('.grok/config.toml');
+    expect(content).toContain('.grok/hooks/kangentic.json');
+  });
+
+  it('events-only spawn seeds the hook file and .kangentic/ but not config.toml', () => {
+    build({
+      eventsOutputPath: path.join(tempCwd, '.kangentic', 'sessions', 's1', 'events.jsonl'),
+      mcpServerEnabled: false,
+    });
+    const content = fs.readFileSync(excludePath(), 'utf-8');
+    expect(content).toContain('.grok/hooks/kangentic.json');
+    expect(content).toContain('.kangentic/');
+    expect(content).not.toContain('.grok/config.toml');
+  });
+
+  it('MCP-only spawn (no eventsOutputPath) seeds config.toml and .kangentic/ but not the hook file', () => {
+    build({
+      mcpServerUrl: 'http://127.0.0.1:4100/mcp/p1/s1',
+      mcpServerToken: 'secret-token',
+    });
+    const content = fs.readFileSync(excludePath(), 'utf-8');
+    expect(content).toContain('.grok/config.toml');
+    expect(content).toContain('.kangentic/');
+    expect(content).not.toContain('.grok/hooks/kangentic.json');
+  });
+
+  it('seeds nothing when neither events nor MCP are wired', () => {
+    build({ mcpServerEnabled: false });
+    expect(fs.existsSync(excludePath())).toBe(false);
   });
 });
 
@@ -616,6 +717,27 @@ describe('hooks file + MCP config lifecycle', () => {
 
     adapter.removeHooks(projectDir, 'task-b');
     expect(fs.existsSync(configPath)).toBe(false);
+  });
+
+  it('leaves no .kangentic-tmp or .kangentic-backup file behind after write and remove', () => {
+    // writeMcpConfig / removeMcpConfig now go through the atomic
+    // write-temp + rename helper with `backup: false` (config.toml is the
+    // user's own file, and rename-replace already preserves the original on
+    // any failure before the rename - a per-spawn backup file would litter
+    // .grok/). Both the temp file and any backup file must be gone once the
+    // write settles.
+    const configPath = path.join(projectDir, '.grok', 'config.toml');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, '[settings]\ntheme = "dark"\n');
+
+    writeMcpConfig(projectDir);
+    expect(fs.existsSync(`${configPath}.kangentic-tmp`)).toBe(false);
+    expect(fs.existsSync(`${configPath}.kangentic-backup`)).toBe(false);
+
+    removeMcpConfig(projectDir);
+    expect(fs.existsSync(`${configPath}.kangentic-tmp`)).toBe(false);
+    expect(fs.existsSync(`${configPath}.kangentic-backup`)).toBe(false);
+    expect(fs.readFileSync(configPath, 'utf-8')).toContain('[settings]');
   });
 
   it('recovers from a truncated managed block (BEGIN present, END missing) by dropping to EOF', () => {
@@ -777,6 +899,20 @@ describe('GrokSessionHistoryParser', () => {
     const result = GrokSessionHistoryParser.parse(content, 'append');
     expect(result.activity).toBeNull();
     expect(result.events).toEqual([]);
+  });
+
+  it('harvests params._meta.totalTokens on an unknown dispatch type (hook_execution)', () => {
+    // The totalTokens harvest runs BEFORE the dispatch-type guard (it is a
+    // sibling of `update`, not type-specific), so an update type the parser
+    // does not otherwise dispatch on still contributes its context total
+    // instead of leaving the ContextBar stale at the last dispatch-type line.
+    const content = updateLine(
+      { sessionUpdate: 'hook_execution' },
+      { totalTokens: 70000 },
+    );
+    const result = GrokSessionHistoryParser.parse(content, 'append');
+    expect(result.usage?.contextWindow.usedTokens).toBe(70000);
+    expect(result.usage?.contextWindow.totalInputTokens).toBe(70000);
   });
 
   it('falls back to the LAST modelUsage key for the model id when no user_message_chunk carried one', () => {
@@ -1256,6 +1392,41 @@ describe('discoverGrokCapabilities', () => {
     expect(capabilities.modelDisplayNames).toEqual({ 'grok-4.6': 'Grok 4.6' });
     expect(capabilities.effortLevels).toEqual(['low', 'medium', 'high', 'xhigh']);
   });
+
+  it('memoizes the result: a second call does not re-read models_cache.json', async () => {
+    const home = useTempGrokHome();
+    fs.writeFileSync(path.join(home, 'models_cache.json'), JSON.stringify({
+      models: { 'grok-4.6': { info: { id: 'grok-4.6', name: 'Grok 4.6', context_window: 500000 } } },
+    }));
+
+    const first = await discoverGrokCapabilities('/usr/bin/grok');
+    expect(first.models).toEqual(['grok-4.6']);
+
+    // Change the on-disk cache after the memoized call. If the memo were not
+    // honored, the second call would pick this up and report grok-5 instead.
+    fs.writeFileSync(path.join(home, 'models_cache.json'), JSON.stringify({
+      models: { 'grok-5': { info: { id: 'grok-5', name: 'Grok 5', context_window: 1000000 } } },
+    }));
+
+    const second = await discoverGrokCapabilities('/usr/bin/grok');
+    expect(second.models).toEqual(['grok-4.6']);
+  });
+
+  it('forceRefresh bypasses the memo and re-reads the current models_cache.json', async () => {
+    const home = useTempGrokHome();
+    fs.writeFileSync(path.join(home, 'models_cache.json'), JSON.stringify({
+      models: { 'grok-4.6': { info: { id: 'grok-4.6', name: 'Grok 4.6', context_window: 500000 } } },
+    }));
+
+    await discoverGrokCapabilities('/usr/bin/grok');
+
+    fs.writeFileSync(path.join(home, 'models_cache.json'), JSON.stringify({
+      models: { 'grok-5': { info: { id: 'grok-5', name: 'Grok 5', context_window: 1000000 } } },
+    }));
+
+    const refreshed = await discoverGrokCapabilities('/usr/bin/grok', true);
+    expect(refreshed.models).toEqual(['grok-5']);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1277,6 +1448,19 @@ describe('trust manager', () => {
     expect(store).toContain(`[folders.'${path.resolve(worktree)}']`);
     expect(store).toContain('trusted = true');
     expect(store).toMatch(/decided_at = \d+/);
+  });
+
+  it('is idempotent: calling it twice for the same worktree appends exactly one table', async () => {
+    const home = useTempGrokHome();
+    const projectRoot = path.join(home, 'fake-project');
+    const worktree = worktreePathUnder(projectRoot);
+
+    await ensureWorktreeTrust(worktree);
+    await ensureWorktreeTrust(worktree);
+
+    const store = fs.readFileSync(path.join(home, 'trusted_folders.toml'), 'utf-8');
+    const occurrences = store.split(`[folders.'${path.resolve(worktree)}']`).length - 1;
+    expect(occurrences).toBe(1);
   });
 
   it('does nothing when a trusted ancestor already cascades over the worktree', async () => {
@@ -1408,6 +1592,34 @@ describe('migrateGrokProjectData', () => {
     const store = fs.readFileSync(path.join(home, 'trusted_folders.toml'), 'utf-8');
     expect(store).toContain(`[folders.'${path.resolve(newProject)}']`);
     expect(store).not.toContain(`[folders.'${path.resolve(oldProject)}']`);
+  });
+
+  it('falls back to a scan-and-decode match when the on-disk key carries a stray trailing separator', async () => {
+    // cwdToSessionsDirName is bare encodeURIComponent (no normalization), but
+    // normalizeForCompare resolves and strips a trailing separator. A key
+    // encoded with a trailing separator is therefore a genuine STRING
+    // mismatch against the exact-encoded key (unlike a same-machine drive-
+    // letter casing difference, which Windows' case-insensitive filesystem
+    // already tolerates at the exact-match existsSync check, making that
+    // scenario unable to exercise this fallback at all) - real fs calls only,
+    // no mocking needed, and platform-neutral since normalizeForCompare's
+    // trailing-separator strip is not win32-gated.
+    const home = useTempGrokHome();
+    const oldProject = path.join(home, 'old-project');
+    const newProject = path.join(home, 'new-project');
+    const sessionsRoot = path.join(home, 'sessions');
+
+    const resolvedOld = path.resolve(oldProject);
+    const keyWithTrailingSep = resolvedOld + path.sep;
+    const mismatchedSessionDir = path.join(sessionsRoot, cwdToSessionsDirName(keyWithTrailingSep), SESSION_ID);
+    fs.mkdirSync(mismatchedSessionDir, { recursive: true });
+    fs.writeFileSync(path.join(mismatchedSessionDir, 'updates.jsonl'), '');
+
+    await migrateGrokProjectData(oldProject, newProject);
+
+    const newSessionDir = path.join(sessionsRoot, cwdToSessionsDirName(path.resolve(newProject)), SESSION_ID);
+    expect(fs.existsSync(newSessionDir)).toBe(true);
+    expect(fs.existsSync(mismatchedSessionDir)).toBe(false);
   });
 
   it('rewrites a double-quoted trust header for the old path, leaving an unrelated header untouched', async () => {

--- a/tests/unit/mock-agent-list-parity.test.ts
+++ b/tests/unit/mock-agent-list-parity.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Self-maintaining guard for a gap that let 'qwen' silently go missing from
+ * the UI mock's `agents.list()` fixture: `agent-registry.ts` registers an
+ * adapter, but `tests/ui/mock-electron-api.js` (the headless mock every UI
+ * spec runs against - `docs/developer-guide.md`'s UI tier) is a hand-authored
+ * fixture with no mechanical tie to the registry, so a new adapter can ship
+ * with zero UI-tier coverage and nothing fails until a real launch surfaces
+ * the missing agent in the dropdown.
+ *
+ * A static text scan (not a `require`/`import` of the mock file, which
+ * attaches itself to `window` and is meant to run inside a Playwright page,
+ * not a Node/vitest process) - deterministic and dependency-free, per the
+ * "Keep it a static text-scan if importing is heavy" guidance.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { agentRegistry } from '../../src/main/agent/agent-registry';
+
+const MOCK_ELECTRON_API_PATH = path.resolve(__dirname, '../ui/mock-electron-api.js');
+
+/**
+ * Extract the agent `name` literals from the `agents.list()` default fixture
+ * in mock-electron-api.js.
+ *
+ * Bounded between the two markers below so the scan cannot accidentally pick
+ * up the SINGULAR `agent.listCommands` fixture (a different mock namespace,
+ * `agent:` not `agents:`) or any other unrelated `name:` field elsewhere in
+ * the file. `displayName: '...'` never matches the `name: '` pattern (capital
+ * `N`, no literal lowercase `name: ` substring), so it does not need its own
+ * exclusion.
+ */
+function readMockAgentListNames(): string[] {
+  const source = fs.readFileSync(MOCK_ELECTRON_API_PATH, 'utf-8');
+  const startMarker = 'list: async function (_forceRefresh) {';
+  const endMarker = 'return defaults.map(function (agent) {';
+  const startIndex = source.indexOf(startMarker);
+  const endIndex = startIndex === -1 ? -1 : source.indexOf(endMarker, startIndex);
+  if (startIndex === -1 || endIndex === -1) {
+    throw new Error(
+      'mock-agent-list-parity: could not locate the agents.list() defaults array in '
+      + 'tests/ui/mock-electron-api.js - the extraction markers moved; update '
+      + 'readMockAgentListNames() in tests/unit/mock-agent-list-parity.test.ts.',
+    );
+  }
+  const block = source.slice(startIndex, endIndex);
+  const names: string[] = [];
+  for (const match of block.matchAll(/\bname: '([a-zA-Z0-9_-]+)'/g)) {
+    names.push(match[1]);
+  }
+  return names;
+}
+
+describe('mock-electron-api agents.list() fixture stays in sync with the agent registry', () => {
+  it('every registered adapter has a matching entry in the mock agents.list() fixture', () => {
+    const registeredAgentNames = agentRegistry.list();
+    const mockAgentNames = readMockAgentListNames();
+
+    const missingFromMock = registeredAgentNames.filter((name) => !mockAgentNames.includes(name));
+
+    expect(
+      missingFromMock,
+      `Adapter(s) ${JSON.stringify(missingFromMock)} are registered in `
+      + 'src/main/agent/agent-registry.ts but have no entry in the agents.list() defaults array '
+      + "in tests/ui/mock-electron-api.js. This is the gap that let 'qwen' silently disappear "
+      + 'from every UI-tier test. Add a `{ name: \'<id>\', displayName: ... }` entry to the '
+      + 'defaults array (see the KEEP IN SYNC comments alongside the existing entries) so the '
+      + 'mock fixture stays a complete mirror of the registry.',
+    ).toEqual([]);
+  });
+
+  it('sanity: the extraction itself finds a plausible number of mock agent entries', () => {
+    // Guards the marker-bounded extraction against silent drift (e.g. the
+    // fixture is refactored and the regex starts matching zero names), which
+    // would make the subset assertion above vacuously pass no matter how far
+    // the fixture drifts from the registry.
+    const mockAgentNames = readMockAgentListNames();
+    expect(mockAgentNames.length).toBeGreaterThanOrEqual(agentRegistry.list().length);
+    expect(new Set(mockAgentNames).size).toBe(mockAgentNames.length);
+  });
+});

--- a/tests/unit/opencode-hook-manager.test.ts
+++ b/tests/unit/opencode-hook-manager.test.ts
@@ -132,15 +132,17 @@ describe('opencode-hook-manager', () => {
     });
   });
 
-  describe('buildHooks gitignore behavior', () => {
-    const PLUGIN_GITIGNORE_ENTRY = '.opencode/plugins/kangentic-activity.mjs';
+  describe('buildHooks git-exclude behavior', () => {
+    const PLUGIN_EXCLUDE_PATTERN = '.opencode/plugins/kangentic-activity.mjs';
 
-    function gitignorePath(): string {
-      return path.join(projectDir, '.gitignore');
+    function excludePath(): string {
+      return path.join(projectDir, '.git', 'info', 'exclude');
     }
 
-    function readGitignore(): string {
-      return fs.readFileSync(gitignorePath(), 'utf-8');
+    function readExclude(): string {
+      // `git init` may or may not seed a template info/exclude, so a missing
+      // file reads as empty rather than failing the assertion.
+      return fs.existsSync(excludePath()) ? fs.readFileSync(excludePath(), 'utf-8') : '';
     }
 
     function initGitRepo(): void {
@@ -156,12 +158,21 @@ describe('opencode-hook-manager', () => {
       });
     }
 
-    it('adds the plugin entry to .gitignore after a successful install', () => {
+    it('adds the plugin entry to .git/info/exclude after a successful install', () => {
       initGitRepo();
       buildHooks(projectDir);
 
-      expect(fs.existsSync(gitignorePath())).toBe(true);
-      expect(readGitignore()).toContain(PLUGIN_GITIGNORE_ENTRY);
+      expect(readExclude()).toContain(PLUGIN_EXCLUDE_PATTERN);
+    });
+
+    it('never touches the tracked .gitignore', () => {
+      // The pre-exclude implementation appended to the project's .gitignore,
+      // dirtying a TRACKED file in the user's checkout. The exclude file is
+      // local to .git/ and never committed.
+      initGitRepo();
+      buildHooks(projectDir);
+
+      expect(fs.existsSync(path.join(projectDir, '.gitignore'))).toBe(false);
     });
 
     it('is idempotent on repeated calls (no duplicate entry)', () => {
@@ -170,55 +181,41 @@ describe('opencode-hook-manager', () => {
       buildHooks(projectDir);
       buildHooks(projectDir);
 
-      const occurrences = readGitignore()
+      const occurrences = readExclude()
         .split('\n')
-        .filter((line) => line.trim() === PLUGIN_GITIGNORE_ENTRY);
+        .filter((line) => line.trim() === PLUGIN_EXCLUDE_PATTERN);
       expect(occurrences).toHaveLength(1);
     });
 
-    it('does not touch .gitignore when the directory is not a git repo', () => {
+    it('writes no exclude when the directory is not a git repo', () => {
       // projectDir has no .git directory.
       buildHooks(projectDir);
 
       // The plugin must still install...
       expect(fs.existsSync(path.join(projectDir, '.opencode', 'plugins', 'kangentic-activity.mjs'))).toBe(true);
-      // ...but no .gitignore must be created.
-      expect(fs.existsSync(gitignorePath())).toBe(false);
+      // ...but no exclude file must be created.
+      expect(fs.existsSync(excludePath())).toBe(false);
     });
 
-    it('preserves pre-existing user content in .gitignore', () => {
+    it('preserves pre-existing content in the exclude file', () => {
       initGitRepo();
-      const userContent = 'node_modules/\ndist/\n*.log\n';
-      fs.writeFileSync(gitignorePath(), userContent);
+      fs.mkdirSync(path.dirname(excludePath()), { recursive: true });
+      fs.writeFileSync(excludePath(), 'node_modules/\n*.log\n');
 
       buildHooks(projectDir);
 
-      const content = readGitignore();
+      const content = readExclude();
       expect(content).toContain('node_modules/');
-      expect(content).toContain('dist/');
       expect(content).toContain('*.log');
-      expect(content).toContain(PLUGIN_GITIGNORE_ENTRY);
+      expect(content).toContain(PLUGIN_EXCLUDE_PATTERN);
     });
 
-    it('does not duplicate the entry if it is already present without a trailing newline', () => {
-      initGitRepo();
-      // No trailing newline - the helper must still detect the existing line.
-      fs.writeFileSync(gitignorePath(), `node_modules/\n${PLUGIN_GITIGNORE_ENTRY}`);
-
-      buildHooks(projectDir);
-
-      const occurrences = readGitignore()
-        .split('\n')
-        .filter((line) => line.trim() === PLUGIN_GITIGNORE_ENTRY);
-      expect(occurrences).toHaveLength(1);
-    });
-
-    it('does not write a .gitignore entry when copyFileSync fails', () => {
+    it('does not write an exclude entry when copyFileSync fails', () => {
       // This test protects the ordering invariant that is the heart of the
-      // "stop appending opencode" fix: ensurePluginGitignored is only called
-      // when fs.existsSync(destinationFile) is true AFTER the copy attempt.
-      // If the copy fails the file does not exist, existsSync returns false,
-      // and the gitignore entry must never be written - otherwise we would
+      // "stop appending opencode" fix: the exclude is only seeded when
+      // fs.existsSync(destinationFile) is true AFTER the copy attempt. If
+      // the copy fails the file does not exist, existsSync returns false,
+      // and the exclude entry must never be written - otherwise we would
       // add an entry pointing to a non-existent file.
       initGitRepo();
 
@@ -232,8 +229,8 @@ describe('opencode-hook-manager', () => {
       // Assert before restoring spies: mockRestore() resets call history.
       // The plugin file must not exist because the copy threw.
       expect(fs.existsSync(pluginPath())).toBe(false);
-      // The gitignore entry must not have been written.
-      expect(fs.existsSync(gitignorePath())).toBe(false);
+      // The exclude entry must not have been written.
+      expect(readExclude()).not.toContain(PLUGIN_EXCLUDE_PATTERN);
       // The copy failure must have been logged via console.error.
       expect(errorSpy).toHaveBeenCalledOnce();
 

--- a/tests/unit/pty-buffer-manager.test.ts
+++ b/tests/unit/pty-buffer-manager.test.ts
@@ -1579,6 +1579,62 @@ describe('PtyBufferManager', () => {
       expect(snapshot).toBe('');
     });
 
+    it('a stale-generation identity guard: removeSession + initSession under the SAME id mid-await never resolves the old sample to a live-looking snapshot, and never touches the new generation\'s pending bytes', async () => {
+      const onFlush = vi.fn();
+      const onDrain = vi.fn();
+      const manager = new PtyBufferManager({ onFlush, onDrain });
+      manager.initSession(SESSION, '', 80, 24);
+      const ALT_BYTES = '\x1b[?1049h\x1b[2J\x1b[1;1Halt frame';
+      manager.onData(SESSION, ALT_BYTES);
+
+      // Make the OLD generation's serialize a controllable deferred promise
+      // (rather than the permanently-wedged pattern used above) so the test
+      // can resolve it deterministically AFTER swapping in a new generation,
+      // instead of racing REPLAY_SERIALIZE_MAX_WAIT_MS.
+      interface ManagerInternals {
+        buffers: Map<string, { headless: { serialize: () => Promise<string> } }>;
+      }
+      const oldBufferState = (manager as unknown as ManagerInternals).buffers.get(SESSION);
+      if (!oldBufferState) throw new Error('test setup: session buffer state missing');
+      let resolveSerialize: ((value: string) => void) | undefined;
+      const deferredSerialize = new Promise<string>((resolve) => { resolveSerialize = resolve; });
+      oldBufferState.headless.serialize = () => deferredSerialize;
+
+      const pendingSnapshot = manager.getReplaySnapshot(SESSION); // do not await yet
+      // The pre-serialize drain reports the OLD generation's pending bytes
+      // synchronously, before the await.
+      expect(onDrain.mock.calls).toEqual([[SESSION, ALT_BYTES]]);
+
+      // Same session id, a NEW generation, while the old sample is still
+      // in flight (`state` inside the pending call still points at the OLD
+      // BufferState object).
+      manager.removeSession(SESSION);
+      manager.initSession(SESSION, '', 80, 24);
+      manager.onData(SESSION, 'NEW_GENERATION_BYTES');
+
+      // Let the old sample's serialize resolve now that a new generation
+      // exists under the same id.
+      if (!resolveSerialize) throw new Error('test setup: resolveSerialize not captured');
+      resolveSerialize('stale frame from the disposed generation');
+      const snapshot = await pendingSnapshot;
+
+      // The mid-await identity check (`this.buffers.get(sessionId) !== state`)
+      // must reject the stale sample rather than resolve the OLD generation's
+      // frame under the now-live session id.
+      expect(snapshot).toBe('');
+
+      // The old sample's teardown must never drain or tap-report the NEW
+      // generation's pending buffer: onDrain has still seen only the OLD
+      // generation's pre-serialize drain, never NEW_GENERATION_BYTES.
+      expect(onDrain.mock.calls).toEqual([[SESSION, ALT_BYTES]]);
+
+      // And the new generation's bytes are still there, untouched, for its
+      // own sample to find.
+      expect(manager.getScrollback(SESSION)).toContain('NEW_GENERATION_BYTES');
+
+      manager.removeSession(SESSION);
+    });
+
     it('resumes normal flush delivery once a sample completes (replaySamplesInFlight must not stick)', async () => {
       const onFlush = vi.fn();
       const manager = new PtyBufferManager({ onFlush, onDrain: vi.fn() });
@@ -1831,6 +1887,34 @@ describe('PtyBufferManager', () => {
       expect(onFlush).toHaveBeenCalledWith(SESSION, 'new data after the failed drain');
 
       manager.removeSession(SESSION);
+    });
+
+    it('a re-entrant onDrain that synchronously calls getScrollback for the same session sees exactly one drain report (no recursion, no duplicate delivery)', () => {
+      vi.useFakeTimers();
+      const onFlush = vi.fn();
+      // Closes over `manager`, assigned on the next line - safe because this
+      // callback only ever RUNS once manager.getScrollback(SESSION) is called
+      // below, by which point the const is initialized.
+      const onDrain = vi.fn((sessionId: string) => {
+        // Synchronously call back into the manager for the SAME session, from
+        // inside the drain report itself. reportDrain's ORDERING RULE
+        // (state.buffer cleared BEFORE onDrain fires, see the comment on
+        // PtyBufferManager.reportDrain) is what makes this re-entrant call
+        // find an already-empty buffer and become a harmless no-op instead of
+        // unbounded recursion with duplicate tap delivery.
+        manager.getScrollback(sessionId);
+      });
+      const manager = new PtyBufferManager({ onFlush, onDrain });
+      manager.initSession(SESSION, '', 80);
+      manager.onResize(SESSION, 80);
+
+      manager.onData(SESSION, 'hello world');
+      manager.getScrollback(SESSION);
+
+      expect(onDrain).toHaveBeenCalledTimes(1);
+      expect(onDrain).toHaveBeenCalledWith(SESSION, 'hello world');
+
+      vi.useRealTimers();
     });
   });
 

--- a/tests/unit/qwen-command-builder.test.ts
+++ b/tests/unit/qwen-command-builder.test.ts
@@ -198,6 +198,73 @@ describe('QwenCommandBuilder', () => {
     });
   });
 
+  describe('git-exclude seeding', () => {
+    let tmpDir: string;
+
+    const excludePath = () => path.join(tmpDir, '.git', 'info', 'exclude');
+
+    const build = (overrides: Partial<QwenCommandOptions> = {}) =>
+      new QwenCommandBuilder().buildQwenCommand(baseOptions({
+        cwd: tmpDir,
+        projectRoot: tmpDir,
+        mcpServerEnabled: true,
+        mcpServerUrl: 'http://127.0.0.1:51234/mcp/proj-1',
+        mcpServerToken: 'test-token-abc',
+        ...overrides,
+      }));
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-cmd-exclude-'));
+      fs.mkdirSync(path.join(tmpDir, '.git'), { recursive: true });
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('seeds .qwen/settings.json and .kangentic/ when Kangentic creates the file', () => {
+      build();
+      const content = fs.readFileSync(excludePath(), 'utf-8');
+      expect(content).toContain('.qwen/settings.json');
+      expect(content).toContain('.kangentic/');
+    });
+
+    it('never excludes a pre-existing user settings.json (created-by-us carve-out)', () => {
+      // Also pins the seed-BEFORE-write ordering: after the build the merged
+      // file always exists, so a post-write existence check could never
+      // distinguish the user's file from ours.
+      fs.mkdirSync(path.join(tmpDir, '.qwen'), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, '.qwen', 'settings.json'),
+        JSON.stringify({ mcpServers: { 'user-server': { httpUrl: 'http://example.com/mcp' } } }),
+      );
+      build();
+      const content = fs.readFileSync(excludePath(), 'utf-8');
+      expect(content).not.toContain('.qwen/settings.json');
+      expect(content).toContain('.kangentic/');
+    });
+
+    it('seeds nothing when no settings write happens', () => {
+      build({ mcpServerEnabled: false });
+      expect(fs.existsSync(excludePath())).toBe(false);
+    });
+
+    it('an events-only spawn (no MCP) still seeds .qwen/settings.json and .kangentic/', () => {
+      // shouldWriteMergedSettings / seedGitExcludes are OR-gated on
+      // eventsOutputPath OR mcp wiring - either alone must trigger seeding.
+      // Regression guard against the two conditions drifting apart.
+      build({
+        mcpServerEnabled: false,
+        mcpServerUrl: undefined,
+        mcpServerToken: undefined,
+        eventsOutputPath: path.join(tmpDir, '.kangentic', 'sessions', 's1', 'events.jsonl'),
+      });
+      const content = fs.readFileSync(excludePath(), 'utf-8');
+      expect(content).toContain('.qwen/settings.json');
+      expect(content).toContain('.kangentic/');
+    });
+  });
+
   /**
    * MCP server config tests touch the filesystem (`createMergedSettings`
    * writes `.qwen/settings.json` into options.cwd), so each test gets a


### PR DESCRIPTION
## What

Promotes the Antigravity adapter's `.git/info/exclude` seeding to a shared module (`src/main/agent/shared/git-exclude.ts`) and applies it to every adapter that writes runtime files into the spawn cwd:

- **Gemini / Qwen**: seed `.kangentic/` plus `.gemini/settings.json` / `.qwen/settings.json`, the settings file only when Kangentic creates it (created-by-us carve-out).
- **Droid**: seed `.kangentic/` plus `.factory/mcp.json` with the same carve-out.
- **Grok**: seed `.kangentic/`, `.grok/hooks/kangentic.json` (wholly Kangentic-owned filename, unconditional), and `.grok/config.toml` with the carve-out. Also hardens `writeMcpConfig` / `removeMcpConfig` to atomic write-temp + rename so a crash mid-write can never truncate the user's `config.toml`.
- **OpenCode**: the activity-plugin install now seeds the project root's `.git/info/exclude` instead of appending to the tracked `.gitignore`, so Kangentic stops dirtying a tracked file.
- **Antigravity**: pure refactor onto the shared module. The exclude marker is now generic (`# kangentic: agent runtime files ...`); the legacy antigravity-branded marker is recognized by prefix so already-seeded repos never gain a second marker block.

Claude, Codex, Aider, Kimi, Copilot, Cursor, Ollama, and Warp were audited and write nothing into the spawn cwd (Claude delivers via `--settings` / `--mcp-config` from the gitignored session dir).

The branch also carries the Code Review column's hardening pass for the grok/antigravity adapters, the pty drain seam, and the event bridge (`fix(review)` commit), which was authored in this worktree upstream of the PR.

## Why

Adapter runtime files sat untracked in every task worktree for the whole session: noise in the Changes pane, and a real hazard for Gemini/Qwen, whose merged settings file carries the per-launch MCP token in plaintext. A `git add -A` by the agent, or the review pass's set-math commit, could sweep that token into git history. Both `git add -A` and the review pass's `git ls-files --others --exclude-standard` honor `.git/info/exclude`, so seeding it makes the protection self-enforcing for the untracked case. Ignore rules never affect tracked files, so a user's own committed config keeps normal git visibility.

## How

`ensureLocalGitExcludes` resolves the checkout's common git dir through the worktree `commondir` indirection (one seeding covers every worktree of the repo), dedupes patterns line-exactly, appends under a single `# kangentic:` marker, and never throws. Each command builder keeps its own pattern list in a private `seedGitExcludes`, called BEFORE its runtime-file write so the `fs.existsSync` carve-out check reflects the user's file, never ours.

Verified end-to-end in a live preview build with mock CLIs: ten real spawns across Gemini, Qwen, Droid, Grok, Antigravity, OpenCode, and Claude, in both task-worktree and project-root modes, confirming clean `git status`, empty `git add -A` dry-runs, correct carve-outs against committed user files, and a single marker block across sequential seedings by different adapters.

## Breaking changes

None. The exclude entries are local to `.git/`, never committed, and marked safe to remove. Lines earlier OpenCode releases appended to a project's `.gitignore` are left in place (harmless).

## Tests

- New `tests/unit/git-exclude.test.ts` covers the shared mechanism (worktree commondir resolution, malformed gitdir pointer, idempotence, legacy-marker prefix compatibility, newline handling).
- Per-adapter seeding-policy describes in the gemini/qwen/droid/grok/antigravity/opencode unit suites (patterns, carve-outs, gating, seed-before-write ordering, tracked-`.gitignore` untouched).
- Coverage-audit additions: `tests/unit/antigravity-print-runner.test.ts` (tail-retention output cap against the real implementation), `tests/unit/ansi-strip.test.ts` (`stripAnsiControlCodes` semantics), and a grok project-relocation malformed-percent-encoding case. All red-green verified.
- CI runs the full unit, UI, and E2E tiers as PR checks.

Generated with [Claude Code](https://claude.com/claude-code)
