### PR TITLE
feat(mobile-bridge): announce revocation and act on the phone's unpair Final

### DIFF
--- a/docs/mobile-bridge.md
+++ b/docs/mobile-bridge.md
@@ -120,6 +120,8 @@ The paired-devices list identifies each device by a **key fingerprint** (`packag
 
 Revoking a device (`revokeDevice()`) removes its entry from the roster **and** is intended to rotate the desktop's own static identity key. Dropping the roster entry alone is not sufficient: Noise KK's mutual authentication only proves possession of a static keypair, so a revoked device that already completed a handshake could still authenticate against a future session as long as the desktop's static key is unchanged. Phases 1 and 2 ship the roster-side "drop" half (`roster-store.ts`'s `revokeDevice`) plus live `BridgeSession`/subscription teardown for that device (`MobileBridgeService.disposeSession`); a full key-rotation-and-re-provisioning flow for any *other* still-paired devices is Phase 3 scope, since a small paired-device count is the common case in practice.
 
+Revocation is also **announced**: before the drop, `revokeDevice()` sends a `FrameTag.Final` goodbye over the established session (`BridgeSession.sendGoodbye`, a no-op when the session is not established or its transport is down), so a connected phone clears its own pairing - trust anchor, push key, cached desktop content - immediately instead of showing "Connecting" forever against a slot the desktop will never dial again. The same signal works in reverse: when the phone's own unpair Final arrives, the desktop drops the device outright (roster, push registration, session) rather than merely marking it offline, with no goodbye echoed back. A Final is only ever sent on deliberate unpair - never on quit, disable, shutdown, backgrounding, or reconnect - which is exactly what lets both sides act on it as revocation.
+
 ## Capability Verbs
 
 `packages/protocol/src/capabilities/verbs.ts` defines the complete allowlist a paired device can be granted:
@@ -238,7 +240,10 @@ Two guards keep the value honest without making it twitchy:
 - **A probe budget before `offline`.** Every handshake initiation doubles as a presence probe.
   Silence for `PEER_PRESENCE_TIMEOUT_MS` (5s) spends one unit; only `PEER_PRESENCE_FAILURES_BEFORE_ABSENT`
   (2) consecutive failures conclude the peer is absent, so one slow round trip never flashes
-  "Offline" on a live phone. An explicit goodbye (a `FrameTag.Final` frame) skips the budget. Once
+  "Offline" on a live phone. An explicit goodbye (a `FrameTag.Final` frame) skips the budget -
+  and, because a Final is only ever a deliberate unpair (neither side sends it on quit, sleep,
+  backgrounding, or reconnect), the service now goes further and drops the device from the
+  roster entirely (see [Revocation](#revocation-is-drop-plus-rekey)). Once
   absent, `PEER_PROBE_INTERVAL_MS` (15s) keeps probing so a returning phone is picked up in ~20s
   rather than on the next rekey tick. The probe window is anchored to the start of an
   unestablished episode and is **never restarted** by a later initiation: `HANDSHAKE_RETRY_MS`

--- a/src/main/mobile-bridge/mobile-bridge-service.ts
+++ b/src/main/mobile-bridge/mobile-bridge-service.ts
@@ -452,13 +452,21 @@ export class MobileBridgeService extends EventEmitter {
       });
     });
     session.on('remoteClosed', () => {
-      // Stop pushing events into a dead channel. The BridgeSession/transport
-      // stay alive so the relay's reconnect + next re-handshake re-establish
-      // the connection; the phone re-arms live subscriptions with fresh
-      // read-* requests once reconnected, rather than this side guessing
-      // what to re-push.
+      // Synchronous half: stop pushing events into a dead channel now.
       this.subscriptionsByDevice.get(deviceId)?.dispose();
       this.subscriptionsByDevice.delete(deviceId);
+      // A Final is only ever the phone's deliberate unpair (its Unpair
+      // button; never backgrounding, reconnect, or an app kill - those stay
+      // silent), so the device is dropped outright: roster, push
+      // registration, session. Deferred a microtask because this listener
+      // fires from inside the session's own frame handling and the drop
+      // disposes that very session; the sessions-map guard makes a second
+      // Final, or a drop that already happened, a no-op. Deliberately no
+      // goodbye echo at a peer that already left.
+      queueMicrotask(() => {
+        if (this.sessions.get(deviceId) !== session) return;
+        this.dropDevice(deviceId);
+      });
     });
     session.on('peerAbsent', () => {
       // The SILENT departure (backgrounding, lost network, OS kill) sends no
@@ -635,6 +643,21 @@ export class MobileBridgeService extends EventEmitter {
   }
 
   revokeDevice(deviceId: string): void {
+    // The goodbye goes FIRST: dropDevice() disposes the session and closes
+    // its transport, after which no frame can leave. sendGoodbye() guards
+    // establishment and transport state itself and never throws, so an
+    // unreachable phone simply gets no goodbye and discovers the revocation
+    // through its own sustained-silence heuristic instead.
+    this.sessions.get(deviceId)?.sendGoodbye();
+    this.dropDevice(deviceId);
+  }
+
+  /**
+   * The teardown half of revocation, shared by the user's own revoke (which
+   * says goodbye first) and the phone's inbound unpair Final (which must NOT
+   * echo a goodbye back at a peer that just left).
+   */
+  private dropDevice(deviceId: string): void {
     // A revoked device must stop receiving pushes too, unconditionally -
     // before the identity guard, so a registration can never outlive its
     // device under any teardown ordering.

--- a/src/main/mobile-bridge/session/bridge-session.ts
+++ b/src/main/mobile-bridge/session/bridge-session.ts
@@ -465,7 +465,10 @@ export class BridgeSession extends EventEmitter {
       // An explicit goodbye is unambiguous, so it skips the probe budget the
       // silent case has to spend. `streams` is deliberately left intact: this
       // side's send stream is independent, and clearing it would change push
-      // presence suppression and the send path (see the class doc).
+      // presence suppression and the send path (see the class doc). The
+      // service escalates 'remoteClosed' to a full device drop - a Final is
+      // only ever a deliberate unpair - but that is its decision; the
+      // session-level contract here stays presence-only.
       this.markPeerAbsent();
       this.emit('remoteClosed');
       return;
@@ -487,6 +490,31 @@ export class BridgeSession extends EventEmitter {
     if (!this.streams) throw new Error('BridgeSession is not established yet');
     const frame = this.streams.send.seal(encodeMessage(message));
     this.transport.send(wrapSessionFrame(SessionFrameKind.Application, frame));
+  }
+
+  /**
+   * Seals an empty FrameTag.Final frame - the revoke goodbye, the mirror of
+   * the phone's own unpair Final. Not a sendMessage() tag parameter on
+   * purpose: it is the only frame with no BridgeMessage inside, and callers
+   * should not be able to tag an ordinary message Final by accident.
+   * Sealing burns a send-counter slot, so it only seals when the frame can
+   * actually leave: a frame sealed and then dropped by a disconnected
+   * transport would desync the phone's receive counter and poison every
+   * later frame on this stream. Never throws - it runs first in the revoke
+   * chain, and a failed goodbye must not stop the revoke. A Final is only
+   * ever sent on deliberate unpair; dispose() (quit, disable, shutdown)
+   * stays silent by contract.
+   */
+  sendGoodbye(): void {
+    if (this.disposed || !this.streams) return;
+    if (this.transport.state !== 'connected') return;
+    try {
+      const frame = this.streams.send.seal(new Uint8Array(0), FrameTag.Final);
+      this.transport.send(wrapSessionFrame(SessionFrameKind.Application, frame));
+    } catch {
+      // The socket dropped between the check and the send; the phone's own
+      // disconnect handling covers this case.
+    }
   }
 
   dispose(): void {

--- a/tests/unit/mobile-bridge/bridge-session.test.ts
+++ b/tests/unit/mobile-bridge/bridge-session.test.ts
@@ -78,6 +78,7 @@ class SimulatedDeviceResponder {
   private handshake: HandshakeState;
   streams: SecretstreamDirectionPair | null = null;
   readonly receivedMessages: BridgeMessage[] = [];
+  receivedGoodbyes = 0;
 
   constructor(
     private readonly deviceStatic: ReturnType<typeof generateX25519KeyPair>,
@@ -102,8 +103,14 @@ class SimulatedDeviceResponder {
       }
     } else {
       if (!this.streams) throw new Error('Received an application frame before the handshake completed');
-      const { plaintext } = this.streams.receive.open(payload);
-      this.receivedMessages.push(decodeMessage(plaintext));
+      const opened = this.streams.receive.open(payload);
+      // A goodbye's plaintext is empty and decodeMessage throws on empty
+      // bytes - branch on the tag first, the way the phone's receiver does.
+      if (opened.tag === FrameTag.Final) {
+        this.receivedGoodbyes += 1;
+        return;
+      }
+      this.receivedMessages.push(decodeMessage(opened.plaintext));
     }
   }
 
@@ -988,5 +995,98 @@ describe('BridgeSession.connectionState', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+/**
+ * The revoke goodbye. A FrameTag.Final is only ever sent on deliberate
+ * unpair - revokeDevice() says it, dispose() (quit, disable, shutdown)
+ * never does - and it must only be sealed when the frame can actually
+ * leave, because a sealed-but-dropped frame desyncs the phone's receive
+ * counter and poisons every later frame on the stream.
+ */
+describe('BridgeSession.sendGoodbye', () => {
+  function establishSession(transport: Transport, desktopIdentity: BridgeIdentity, devicePublicKey: Uint8Array): BridgeSession {
+    const session = new BridgeSession({
+      identity: desktopIdentity,
+      deviceId: 'device-1',
+      remoteStaticPublicKey: devicePublicKey,
+      capabilities: new Set(['read-board']) as CapabilitySet,
+      transport,
+    });
+    session.start();
+    return session;
+  }
+
+  it('seals exactly one Final the phone opens as a goodbye, leaving later sends intact', () => {
+    const desktopIdentity = testIdentity();
+    const deviceStatic = generateX25519KeyPair();
+    const [desktopTransport, deviceTransport] = createLoopbackTransportPair();
+    const responder = new SimulatedDeviceResponder(deviceStatic, desktopIdentity.staticKeyPair.publicKey, deviceTransport);
+    const session = establishSession(desktopTransport, desktopIdentity, deviceStatic.publicKey);
+    expect(session.isEstablished).toBe(true);
+
+    session.sendGoodbye();
+
+    expect(responder.receivedGoodbyes).toBe(1);
+    expect(responder.receivedMessages).toEqual([]);
+    // The goodbye spent one counter slot legitimately: a later frame on the
+    // same stream still opens, so the counters stayed aligned.
+    session.sendMessage({ type: 'heartbeat' });
+    expect(responder.receivedMessages).toEqual([{ type: 'heartbeat' }]);
+
+    session.dispose();
+  });
+
+  it('sends nothing before the session is established', () => {
+    const desktopIdentity = testIdentity();
+    const deviceStatic = generateX25519KeyPair();
+    // No responder is attached, so the initiation goes unanswered.
+    const { desktop } = createReconnectableLoopback();
+    const session = establishSession(desktop, desktopIdentity, deviceStatic.publicKey);
+    expect(session.isEstablished).toBe(false);
+
+    const sendSpy = vi.spyOn(desktop, 'send');
+    expect(() => session.sendGoodbye()).not.toThrow();
+
+    const applicationFrames = sendSpy.mock.calls.filter(([frame]) => unwrapSessionFrame(frame).kind === SessionFrameKind.Application);
+    expect(applicationFrames).toEqual([]);
+
+    session.dispose();
+  });
+
+  it('sends nothing and does not throw while the transport is disconnected', () => {
+    const desktopIdentity = testIdentity();
+    const deviceStatic = generateX25519KeyPair();
+    const { desktop, device, setDesktopState } = createReconnectableLoopback();
+    new SimulatedDeviceResponder(deviceStatic, desktopIdentity.staticKeyPair.publicKey, device);
+    const session = establishSession(desktop, desktopIdentity, deviceStatic.publicKey);
+    expect(session.isEstablished).toBe(true);
+
+    // A blip, not a teardown: the session still holds streams, but the
+    // socket cannot carry a frame. The transport-state guard is the only
+    // thing standing between this call and a burned counter slot.
+    setDesktopState('reconnecting');
+    const sendSpy = vi.spyOn(desktop, 'send');
+    expect(() => session.sendGoodbye()).not.toThrow();
+    expect(sendSpy).not.toHaveBeenCalled();
+
+    session.dispose();
+  });
+
+  it('dispose() never sends a goodbye - Final means unpair, never shutdown', () => {
+    const desktopIdentity = testIdentity();
+    const deviceStatic = generateX25519KeyPair();
+    const [desktopTransport, deviceTransport] = createLoopbackTransportPair();
+    const responder = new SimulatedDeviceResponder(deviceStatic, desktopIdentity.staticKeyPair.publicKey, deviceTransport);
+    const session = establishSession(desktopTransport, desktopIdentity, deviceStatic.publicKey);
+    expect(session.isEstablished).toBe(true);
+
+    const sendSpy = vi.spyOn(desktopTransport, 'send');
+    session.dispose();
+
+    const applicationFrames = sendSpy.mock.calls.filter(([frame]) => unwrapSessionFrame(frame).kind === SessionFrameKind.Application);
+    expect(applicationFrames).toEqual([]);
+    expect(responder.receivedGoodbyes).toBe(0);
   });
 });

--- a/tests/unit/mobile-bridge/mobile-bridge-relay-state.test.ts
+++ b/tests/unit/mobile-bridge/mobile-bridge-relay-state.test.ts
@@ -106,6 +106,7 @@ class FakeBridgeSession extends EventEmitter {
   start = vi.fn();
   dispose = vi.fn();
   sendMessage = vi.fn();
+  sendGoodbye = vi.fn();
   constructor(options: { deviceId: string }) {
     super();
     this.deviceId = options.deviceId;

--- a/tests/unit/mobile-bridge/mobile-bridge-session-lifecycle.test.ts
+++ b/tests/unit/mobile-bridge/mobile-bridge-session-lifecycle.test.ts
@@ -17,12 +17,13 @@
  *    resulting session, and never revokes or disables afterward.
  *
  * This file closes that gap: message routing through capabilityRouter back
- * out via sendMessage(), remoteClosed's subscriptions-only teardown (session
- * stays alive for the relay's reconnect), revokeDevice()/reconcile(disable)
- * actually disposing a LIVE session (not just the "no identity yet" no-op
- * already covered), and the roster-diff eviction path that disposes a
- * session whose device fell out of the roster without going through
- * revokeDevice() at all.
+ * out via sendMessage(), remoteClosed's full device drop (a Final is only
+ * ever the phone's deliberate unpair, so roster + push registration +
+ * session all go, with no goodbye echo), revokeDevice()'s goodbye-then-drop
+ * ordering, reconcile(disable) actually disposing a LIVE session (not just
+ * the "no identity yet" no-op already covered), and the roster-diff
+ * eviction path that disposes a session whose device fell out of the
+ * roster without going through revokeDevice() at all.
  *
  * Mocking mirrors mobile-bridge-sync-race.test.ts's pattern (mock
  * electron/analytics/paths/identity/roster-store/bridge-session/transport),
@@ -95,6 +96,7 @@ class FakeBridgeSession extends EventEmitter {
   start = vi.fn();
   dispose = vi.fn();
   sendMessage = vi.fn();
+  sendGoodbye = vi.fn();
   constructor(options: { deviceId: string; capabilities: Set<string> }) {
     super();
     this.deviceId = options.deviceId;
@@ -191,9 +193,16 @@ describe('MobileBridgeService session-lifecycle wiring', () => {
     service.dispose();
   });
 
-  it('remoteClosed tears down the device live subscriptions but leaves the session itself alive for the relay reconnect', async () => {
+  it('an inbound Final drops the device outright - roster, session, subscriptions - with no goodbye echo', async () => {
     const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
     const session = await openSession(service);
+    // The mocked roster reads from rosterDevices, so the mocked revoke has
+    // to mutate it for pairedDeviceCount to reflect the drop.
+    revokeDeviceSpy.mockImplementation(() => {
+      rosterDevices = [];
+    });
+    const stateChanged = vi.fn();
+    service.on('stateChanged', stateChanged);
 
     // Register a live subscription the same way a real handler would (via
     // the getSubscriptions closure attachContext() wires into the router),
@@ -205,12 +214,62 @@ describe('MobileBridgeService session-lifecycle wiring', () => {
       .set('board:proj-1', subscriptionTeardown);
 
     session.emit('remoteClosed');
+    await flushMicrotasks();
 
+    // A Final is only ever the phone's deliberate unpair, so the device is
+    // gone entirely, not merely quiet until the next reconnect.
     expect(subscriptionTeardown).toHaveBeenCalledTimes(1);
-    expect(session.dispose).not.toHaveBeenCalled();
-    // Session-count bookkeeping is untouched by a remote close (unlike an
-    // actual revoke/eviction) - the device is still "paired".
-    expect(service.getStatus().pairedDeviceCount).toBe(1);
+    expect(revokeDeviceSpy).toHaveBeenCalledWith(fakeIdentity, session.deviceId);
+    expect(session.dispose).toHaveBeenCalledTimes(1);
+    expect(service.getStatus().pairedDeviceCount).toBe(0);
+    expect(stateChanged).toHaveBeenCalled();
+    // No goodbye echo at a peer that already left.
+    expect(session.sendGoodbye).not.toHaveBeenCalled();
+
+    service.dispose();
+  });
+
+  it('a second remoteClosed for the same device is a no-op', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const session = await openSession(service);
+
+    session.emit('remoteClosed');
+    session.emit('remoteClosed');
+    await flushMicrotasks();
+
+    expect(revokeDeviceSpy).toHaveBeenCalledTimes(1);
+    expect(session.dispose).toHaveBeenCalledTimes(1);
+
+    service.dispose();
+  });
+
+  it('a stale remoteClosed from a replaced session does not drop the new session', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const firstSession = await openSession(service);
+
+    // A relay URL change replaces the device's session with a fresh one.
+    service.reconcile({ enabled: true, relayUrl: 'wss://relay2.example.com' });
+    await flushMicrotasks();
+    const secondSession = createdSessions.at(-1);
+    if (!secondSession || secondSession === firstSession) throw new Error('expected a replacement session');
+
+    // The sessions-map guard is what stops a Final from the superseded
+    // session tearing down the freshly opened one.
+    firstSession.emit('remoteClosed');
+    await flushMicrotasks();
+
+    expect(revokeDeviceSpy).not.toHaveBeenCalled();
+    expect(secondSession.dispose).not.toHaveBeenCalled();
+
+    service.dispose();
+  });
+
+  it('revokeDevice() on an offline (session-less) device drops it without throwing', () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+
+    expect(() => service.revokeDevice('device-A')).not.toThrow();
+
+    expect(revokeDeviceSpy).toHaveBeenCalledWith(fakeIdentity, 'device-A');
 
     service.dispose();
   });
@@ -242,16 +301,33 @@ describe('MobileBridgeService session-lifecycle wiring', () => {
     service.dispose();
   });
 
-  it('revokeDevice() disposes a LIVE session, not just the no-identity no-op', async () => {
+  it('revokeDevice() says the goodbye exactly once, BEFORE disposing the live session', async () => {
     const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
     const session = await openSession(service);
 
     service.revokeDevice(session.deviceId);
 
-    expect(revokeDeviceSpy).toHaveBeenCalledWith(fakeIdentity, session.deviceId);
+    // Ordering is the feature: dispose() closes the transport, after which
+    // no frame can leave, so the goodbye must have gone out first.
+    expect(session.sendGoodbye).toHaveBeenCalledTimes(1);
     expect(session.dispose).toHaveBeenCalledTimes(1);
+    expect(session.sendGoodbye.mock.invocationCallOrder[0]).toBeLessThan(session.dispose.mock.invocationCallOrder[0]);
+    expect(revokeDeviceSpy).toHaveBeenCalledWith(fakeIdentity, session.deviceId);
 
     service.dispose();
+  });
+
+  it('service dispose() (the quit path) never sends a goodbye', async () => {
+    const service = new MobileBridgeService({ enabled: true, relayUrl: 'wss://relay.example.com' });
+    const session = await openSession(service);
+
+    service.dispose();
+
+    expect(session.dispose).toHaveBeenCalledTimes(1);
+    // Quit, disable, and shutdown all stay silent by contract: a Final only
+    // ever means deliberate unpair, so an ordinary desktop quit must never
+    // read as one on the phone.
+    expect(session.sendGoodbye).not.toHaveBeenCalled();
   });
 
   it('reconcile() disabling the bridge disposes a LIVE session, not just an in-progress pairing', async () => {

--- a/tests/unit/mobile-bridge/relay-client.test.ts
+++ b/tests/unit/mobile-bridge/relay-client.test.ts
@@ -126,6 +126,33 @@ describe('RelayClient', () => {
     expect(new TextDecoder().decode(received)).toBe('still alive');
   }, 15_000);
 
+  /**
+   * The guarantee revokeDevice()'s goodbye rides on: sendGoodbye() is
+   * immediately followed by dispose(), which calls transport.close(). Per
+   * the WHATWG close algorithm the closing handshake starts AFTER queued
+   * messages, so the frame must reach the server anyway - this pins that
+   * for the global (undici) WebSocket this client actually uses, the way
+   * the mobile repo's relayTransport.test.ts pins it for `ws`.
+   */
+  it('flushes a frame written immediately before close()', async () => {
+    const { url, wss } = await startEchoServer();
+    activeServers.push(wss);
+    const serverReceived = new Promise<Uint8Array>((resolve) => {
+      wss.on('connection', (socket) => {
+        socket.on('message', (data) => resolve(new Uint8Array(data as Buffer)));
+      });
+    });
+    const client = new RelayClient({ relayUrl: url, slotId: 'test-slot' });
+    activeClients.push(client);
+    await client.connect();
+
+    client.send(new TextEncoder().encode('goodbye'));
+    client.close();
+
+    const received = await serverReceived;
+    expect(new TextDecoder().decode(received)).toBe('goodbye');
+  });
+
   it('does not reconnect after an explicit close()', async () => {
     const { url, wss } = await startEchoServer();
     activeServers.push(wss);


### PR DESCRIPTION
## What

Makes unpair a two-way, acted-on signal in the mobile bridge.

- `src/main/mobile-bridge/session/bridge-session.ts` - new `sendGoodbye()`, which seals an
  empty `FrameTag.Final`.
- `src/main/mobile-bridge/mobile-bridge-service.ts` - `revokeDevice()` announces before
  tearing down; the new shared `dropDevice()` is the teardown half; the `remoteClosed`
  handler escalates to a full device drop.
- `docs/mobile-bridge.md` - Revocation section and the peer-presence probe-budget note.

## Why

Unpair was silent in both directions.

Revoking a device from the desktop dropped the roster entry and tore down the session but
told the phone nothing, so a connected phone sat on "Connecting" forever against a slot the
desktop will never dial again. In reverse, the phone's own unpair Final only marked the peer
absent, leaving the device on the roster with a live push registration.

A `FrameTag.Final` is only ever a **deliberate** unpair. Neither side sends one on quit,
disable, shutdown, backgrounding, or reconnect, and those silent departures keep going
through the existing probe-budget path. That distinction is what makes it safe to treat a
Final as revocation rather than as a presence blip.

## How

Three details are load-bearing and worth a reviewer's attention:

**Ordering in `revokeDevice()`.** The goodbye goes first, because `dropDevice()` closes the
transport and no frame can leave after that. `sendGoodbye()` guards establishment and
transport state itself and never throws, so an unreachable phone simply gets no goodbye and
falls back to discovering the revocation through its own sustained-silence heuristic. A
failed goodbye must never block a revoke.

**Why `sendGoodbye()` is its own method rather than a `sendMessage()` tag parameter.** It is
the only frame that carries no `BridgeMessage`, and a tag parameter would let a caller mark
an ordinary message Final by accident.

**Why it seals only when the frame can actually leave.** Sealing burns a send-counter slot.
A frame sealed and then dropped by a disconnected transport would desync the phone's receive
counter and poison every later frame on that stream, so the transport-state check has to
precede the seal, not follow it.

**Re-entrancy on the inbound path.** The `remoteClosed` listener fires from inside the
session's own frame handling, and the drop disposes that very session. The escalation is
therefore deferred a microtask, with a sessions-map identity guard making a second Final, or
an already-completed drop, a no-op. No goodbye is echoed back at a peer that already left.

The session-level contract is deliberately unchanged and stays presence-only: escalating a
`remoteClosed` to revocation is the service's decision, not the session's.

## Breaking changes

None for existing pairings. No protocol version change, no schema change, and no wire format
addition: `FrameTag.Final` already existed and was already sent by the phone on unpair. This
changes what each side *does* on receiving one. A phone on an older build that never sends a
Final keeps working exactly as before, via the unchanged silent-departure probe budget.

## Tests

Unit tier, across four existing mobile-bridge suites: `bridge-session.test.ts`,
`mobile-bridge-session-lifecycle.test.ts`, `mobile-bridge-relay-state.test.ts`, and
`relay-client.test.ts`.

Locally: `npm run typecheck`, `npm run lint`, and `npx vitest run tests/unit/mobile-bridge`
(41 files, 394 tests) all green. Full unit / UI / Electron E2E tiers run as the PR checks
here.

Generated with [Claude Code](https://claude.com/claude-code)
