### PR TITLE
fix(sessions): guard resume against Done, archived, and conversations the agent never wrote

### DIFF
--- a/docs/adapter-session-history.md
+++ b/docs/adapter-session-history.md
@@ -335,6 +335,17 @@ Reading the table by class:
 
 ### Why there is no `canResumeSession` transcript-presence guard
 
+> Not to be confused with `isResumeConversationAbsent`
+> (`src/main/transition-engine/resume-conversation-guard.ts`), which DOES downgrade a resume to a
+> fresh spawn, on both chokepoints. It is deliberately narrower than the guard rejected here, and
+> that narrowness is what makes it safe: it never derives a transcript path, requiring the AGENT
+> to have reported one (in its own status file, or in the SessionStart hook payload), and it
+> additionally requires that same report to show the conversation never took a turn. Absence of
+> evidence is never evidence, so a missing report leaves today's behavior untouched, which is
+> exactly what keeps the mocked resumes below passing. See "A resume with no conversation behind
+> it is downgraded to fresh" in session-lifecycle.md. The rejection below still stands for the
+> BLANKET form described in this section.
+
 A natural-looking robustness idea is an optional `canResumeSession(agentSessionId, cwd)` adapter
 method that returns `false` when the resume target is verifiably absent, plus a shared chokepoint
 (`isResumeTranscriptMissing`) in both spawn paths that downgrades a doomed `--resume <id>` to a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,7 +97,7 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 | `task:sessionResync` | on | Event: quiet (toast-free) board re-sync after a column model-change session restart, so the board store's stale `task.session_id` reloads |
 | `task:spawnBlocked` | on | Event: the task was created, promoted, unarchived or MCP-auto-spawned, but its agent could not start because another task holds the same checkout. Those paths deliberately keep the task, so without this the result is indistinguishable from a healthy spawn |
 | `task:autoCommandResult` | on | Event: the outcome of a task's auto_command injection (`AutoCommandResultNotice`: state, command, reason, discardedDraft, interruptedTurn, escalated). Rationed by `shouldNotify` so a routine delivery stays silent and only a failure, an escalation, or a discarded draft reaches the user |
-| `task:spawnProgress` | on | Event: spawn progress phase label during task move |
+| `task:spawnProgress` | on | Event: spawn progress phase label during a task move or a restore from Done |
 | `task:getSpawnProgress` | invoke | Fetch the queryable in-flight spawn-progress map (taskId -> phase label) so `syncSessions` can reconcile after HMR / project switch |
 | `task:setDetailViewState` | invoke | Persist the task-detail dialog's layout blob (debounced from the renderer) so it restores across restarts. Pass null to clear. Does not bump `updated_at`. |
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -647,6 +647,7 @@ Operates on a per-project DB.
 | `reorderWithinSwimlane(swimlaneId, orderedTaskIds)` | Dense rewrite of one swimlane's task order to 0..N-1 in a single transaction. The write behind `kangentic_reorder_tasks` and `kangentic_move_task`'s same-column `position`. Unlike `move()`'s two-shift arithmetic it heals position gaps left by archiving; a stray id from another swimlane is a no-op (`swimlane_id` guard), and re-issuing the same order writes nothing (`position != ?` guard, so `updated_at` moves only on rows that actually shift) |
 | `archive(id)` | Set `archived_at` to now (soft-delete for Done column) |
 | `unarchive(id, targetSwimlaneId, position)` | Clear `archived_at`, move to target swimlane and position |
+| `clearArchived(id)` | Clear `archived_at` WITHOUT moving the task. The exact inverse of `archive(id)`, used by `task-move`s move-out-of-Done path, which has already placed the row and would fight `move()`s sibling reordering if it re-ran the placement |
 | `listArchived()` | All archived tasks ordered by `archived_at` DESC |
 | `listArchivedPreview(limit)` | The newest `limit` archived tasks plus the total archived count; cheap hydration for the Done column (full list loads lazily via `listArchived`) |
 | `delete(id)` | Hard delete with position shift in the owning swimlane |

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -449,7 +449,7 @@ Returns the linked PR (number, url, state) on success, or a message when no PR i
 
 ### kangentic_move_task
 
-Move a task to a different column, optionally placing it at a chosen slot in that column. Triggers the same lifecycle as a UI drag: spawning/suspending agents, creating/cleaning up worktrees, and running configured transition actions. Moving to the Done column auto-archives the task. Moving to To Do kills the session and removes the worktree.
+Move a task to a different column, optionally placing it at a chosen slot in that column. Triggers the same lifecycle as a UI drag: spawning/suspending agents, creating/cleaning up worktrees, and running configured transition actions. Moving to the Done column auto-archives the task, and moving OUT of Done un-archives it again so it returns to the board. Moving to To Do kills the session and removes the worktree.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -216,18 +216,38 @@ a bare shell with the record still reading `running` (the shell PTY outlives the
 
 `isResumeConversationAbsent` (`src/main/transition-engine/resume-conversation-guard.ts`) now
 downgrades that spawn to fresh at both chokepoints (`executeSpawnAgent` and `prepareAgentSpawn`).
-It fires only on positive evidence of an empty conversation, and all of these must hold:
+It fires only on positive evidence of an empty conversation. Two things must hold together:
 
-- the transcript path comes from the AGENT's own status report, never one Kangentic derived;
-- that same report independently shows no turns (no tokens, no cost);
-- the file it names is absent.
+- the transcript path was reported by the AGENT itself, never derived by Kangentic;
+- the same report independently shows the conversation never took a turn;
 
-Anything else - no status file, no status pipeline, malformed JSON, no reported transcript path -
-returns false and resumes exactly as before, so a conversation that had turns is never discarded.
-This is deliberately narrower than the `canResumeSession` transcript-presence guard reverted in
-#255 (see docs/adapter-session-history.md), whose false misses silently lost real conversations.
-The check walks every record sharing the conversation's `agent_session_id`, newest first, because a
-failed resume writes no status file of its own and would otherwise stay broken forever.
+and then the file that report names must be absent.
+
+The evidence comes from either of two agent-written files in Kangentic's own session directory,
+which differ in how each answers the turn question:
+
+| Source | Transcript path | "Never took a turn" means |
+|---|---|---|
+| `status.json` (preferred) | the status line's `transcript_path` | no tokens and no cost |
+| `events.jsonl` (fallback) | `transcript_path` inside the SessionStart hook payload | no event beyond `session_start` / `session_end` |
+
+The fallback exists because the status line only runs once the TUI is up, so a CLI killed in its
+first second leaves none. The SessionStart hook fires far earlier. A missing status file therefore
+does NOT end the check: it falls through to the hook, and only a record that yields neither report
+is skipped.
+
+The guard returns false - resuming exactly as before - when the adapter has no status pipeline,
+when the project path is unknown, or when no record yields a usable report at all. Absence of
+evidence is never evidence, so a conversation that had turns is never discarded. Mocked CLIs land
+on that path structurally, which is what kept the E2E resume specs passing. This is deliberately
+narrower than the `canResumeSession` transcript-presence guard reverted in #255 (see
+docs/adapter-session-history.md), whose false misses silently lost real conversations.
+
+The board chokepoint walks every record sharing the conversation's `agent_session_id`, newest
+first, because a failed resume writes no report of its own and an already-poisoned task would
+otherwise stay broken forever. Startup recovery passes only the record it is recovering: it holds
+no repository handle to walk the lineage, and a record recovered there ran until the crash, so it
+normally has its own status report.
 
 ### A restore reports progress instead of showing a Resume button
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -131,7 +131,7 @@ Session teardown varies by target column:
 
 - **To Do** (role=`todo`), via `TASK_MOVE` - full cleanup via `cleanupTaskResources()`: kills the PTY (via `SessionManager.remove()`), deletes session files from disk, deletes all session DB records for the task, and then removes the worktree and (when `git.autoCleanup` is on) force-deletes the branch. Destructive, which is why the drop is gated behind a pending-changes confirmation. Moving back to an active column spawns a fresh session.
 - **To Do** (role=`todo`), via `TASK_UNARCHIVE` / `TASK_BULK_UNARCHIVE` (restore from Done) - the SESSION-only half, `cleanupTaskSession()`. The worktree and branch are left alone. Without this the task keeps the session Done deliberately suspended, and since `listSessions()` has no status filter the restored card renders "Paused" for the rest of the app session. It is not the full `cleanupTaskResources()` on purpose: `deleteTaskWorktree` nulls `worktree_path` only when the Done-time removal SUCCEEDED, so a task whose worktree was pinned at Done time (routine on Windows) still carries both fields, and the full helper would re-attempt the removal and force-delete the branch holding its committed work with no confirmation on this route.
-- **Done** (role=`done`) - suspends session (preserves for resume via `SessionManager.suspend()`), archives task, and deletes the worktree to reclaim disk while preserving `branch_name` and the session records. The DB record is marked `suspended` so the session can be resumed if the task is later unarchived into an auto-spawn column.
+- **Done** (role=`done`) - suspends session (preserves for resume via `SessionManager.suspend()`), archives task, and deletes the worktree to reclaim disk while preserving `branch_name` and the session records. The DB record is marked `suspended` so the session can be resumed if the task is later unarchived into an auto-spawn column. That unarchive is the ONLY route back: resuming in place is refused for a Done or archived task (see [Where resume is refused](#where-resume-is-refused)), since it would recreate the worktree this move deleted.
 - **Any column with `auto_spawn=false`** - suspends session (same as Done, but without archiving). A restore into such a column keeps the suspended session and its Resume affordance; only a `role=todo` target resets it.
 
 ### What is preserved on suspend (Done / auto_spawn=false)
@@ -160,6 +160,71 @@ Session teardown varies by target column:
 8. Notify queue (slot freed)
 
 ## Resume
+
+### Where resume is refused
+
+`SESSION_RESUME` (the task detail's Pause/Resume toggle) restarts a suspended session **in
+place**, in the task's current column. It is refused for three states, resolved by one shared
+predicate (`src/shared/session-resume-eligibility.ts`) that both the main-process handler and the
+task detail read, and whose role set startup recovery shares:
+
+| State | Why |
+|---|---|
+| Lane role `todo` | A To Do card has not started; its detail opens straight into the edit form |
+| Lane role `done` | The task is complete. The route back is to move it OUT of Done |
+| `archived_at` set | Same, for a task archived without a live Done-role lane |
+
+Resuming a completed task in place would recreate the worktree the move to Done had just deleted
+and leave the task archived AND running at once, with no board card to show for it. The supported
+route is the recovery move below, which unarchives first and then spawns through the normal
+chokepoint, so the refusal never applies to it. The main-process guard is the contract; the task
+detail hides the control so it is never offered. Pausing a session that is genuinely live is NOT
+refused in any of those states, so a stray agent can still be stopped from the window showing it.
+
+### A resume with no conversation behind it is downgraded to fresh
+
+Kangentic pre-specifies `--session-id` for Claude and persists it on the session record AT SPAWN
+TIME, before the agent has done anything, while the agent CLI writes its transcript on the first
+turn. A session that ends before that turn therefore leaves a resumable-looking record pointing at
+a conversation that does not exist.
+
+That is reachable in seconds of ordinary use: the recovery move out of Done spawns command-free,
+so the agent comes up idle with nothing to do, and moving the task back to Done before typing
+suspends it with its id intact. Every later entry into an auto-spawn column then issued
+`--resume <id>`, the CLI answered "No conversation found with session ID", and the user was left on
+a bare shell with the record still reading `running` (the shell PTY outlives the CLI).
+
+`isResumeConversationAbsent` (`src/main/transition-engine/resume-conversation-guard.ts`) now
+downgrades that spawn to fresh at both chokepoints (`executeSpawnAgent` and `prepareAgentSpawn`).
+It fires only on positive evidence of an empty conversation, and all of these must hold:
+
+- the transcript path comes from the AGENT's own status report, never one Kangentic derived;
+- that same report independently shows no turns (no tokens, no cost);
+- the file it names is absent.
+
+Anything else - no status file, no status pipeline, malformed JSON, no reported transcript path -
+returns false and resumes exactly as before, so a conversation that had turns is never discarded.
+This is deliberately narrower than the `canResumeSession` transcript-presence guard reverted in
+#255 (see docs/adapter-session-history.md), whose false misses silently lost real conversations.
+The check walks every record sharing the conversation's `agent_session_id`, newest first, because a
+failed resume writes no status file of its own and would otherwise stay broken forever.
+
+### A restore reports progress instead of showing a Resume button
+
+Restoring from Done is slow (the worktree is recreated from the preserved branch, then the CLI
+boots) and the task's suspended record survives that whole window, so the UI used to advertise a
+manual "Resume session" button while the engine was already restoring the conversation. Two things
+now prevent that:
+
+- `TASK_UNARCHIVE` / `TASK_BULK_UNARCHIVE` thread `onProgress` into their git helpers exactly as
+  `task-move` does, and emit `resuming` immediately so the card is never silent while the lane is
+  resolved and the git op queues.
+- `getTaskProgress` lets an in-flight spawn label outrank a `suspended` session (only `suspended`;
+  a running or queued session owns its own display). An emitted label means main is spawning right
+  now, which is newer than a record suspended earlier.
+
+The task therefore shows the `preparing` launch overlay from about 100ms after the drop, through
+"Creating worktree..." and "Starting agent...", until the terminal takes over.
 
 When a suspended task moves to an active column:
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -150,14 +150,34 @@ Session teardown varies by target column:
 
 ### SessionManager.suspend() flow
 
-1. Close file watchers
-2. Null out file paths (prevents `onExit` cleanup from deleting files)
-3. Emit synthetic `session_end` event
-4. Clear subagent depth tracking
-5. Mark status as `suspended`
-6. Kill PTY
-7. Emit status change
-8. Notify queue (slot freed)
+1. Remove the adapter's hooks from the project settings file (idempotent with `onExit`)
+2. Close file watchers and detach telemetry readers, preserving the files for resume
+3. Flush the transcript to the DB
+4. Emit a synthetic `session_end` event (the agent's own hook will not fire on a kill)
+5. Clear subagent depth tracking
+6. Mark status as `suspended`
+7. **Emit `session-changed`** - before the shutdown below, not after
+8. Release backpressure so the agent's exit-sequence output is not held back
+9. `gracefulPtyShutdown`: send the exit sequence, wait up to 1500ms for a natural exit, then
+   force-kill and wait up to 1500ms more for kill propagation
+10. Last-resort scrollback scan for an agent session id not yet captured
+11. **Emit `session-changed` again** - now carrying the post-shutdown session
+12. Notify the queue (slot freed)
+
+Steps 7 and 11 are a deliberate DOUBLE emit, and both are load-bearing:
+
+- Step 7 exists because the bottom panel's tab set is `status === 'running'`
+  (`derivePanelSessions`). Emitting only at the end left a tab for a session the user had already
+  watched leave the board, for the whole of step 9. A user-initiated Pause never showed that,
+  because the renderer store writes the suspended status optimistically; a main-driven suspend
+  (move to Done, idle timeout, settings restart) had no such write and wore the full delay.
+- Step 11 carries state that only exists after the shutdown, including an agent session id
+  recovered by step 10.
+
+The gap between them is what sets `FINALIZE_DEBOUNCE_MS` (3500) in
+`src/main/retrieval/retrieval-service.ts`: finalize indexing is debounced per session, and the
+two reports can be up to 3000ms apart on a force-kill, so a shorter window would fail to coalesce
+them on exactly the slow path where the later read matters most.
 
 ## Resume
 

--- a/src/main/db/repositories/task-repository.ts
+++ b/src/main/db/repositories/task-repository.ts
@@ -464,6 +464,20 @@ export class TaskRepository {
   }
 
   /**
+   * Clear the archive flag WITHOUT moving the task, the exact inverse of
+   * `archive()`.
+   *
+   * `unarchive()` below also rewrites swimlane_id and position, which suits the
+   * restore-from-the-Completed-list flow that picks a destination. A task move
+   * has already placed the row by the time it needs this, so re-running the
+   * placement there would fight `move()`'s own sibling reordering.
+   */
+  clearArchived(id: string): void {
+    const now = new Date().toISOString();
+    this.db.prepare('UPDATE tasks SET archived_at = NULL, updated_at = ? WHERE id = ?').run(now, id);
+  }
+
+  /**
    * Record the outcome of this task's most recent auto_command delivery.
    *
    * Deliberately NOT part of `update()`: this is engine telemetry, not a user

--- a/src/main/ipc/handlers/sessions.ts
+++ b/src/main/ipc/handlers/sessions.ts
@@ -159,7 +159,10 @@ export function registerSessionHandlers(context: IpcContext): void {
             return { kind: 'live' as const, session: liveSession };
           }
           const lane = swimlanes.getById(task.swimlane_id);
-          const blocked = resumeBlockReason({ laneRole: lane?.role, isArchived: task.archived_at !== null });
+          // Truthiness, not `!== null`: a Task assembled without the column
+          // (mocks, wire mappers, MCP-constructed rows) carries `undefined`,
+          // which `!== null` reads as ARCHIVED and would refuse every resume.
+          const blocked = resumeBlockReason({ laneRole: lane?.role, isArchived: Boolean(task.archived_at) });
           if (blocked) throw new Error(resumeBlockMessage(blocked));
           return { kind: 'spawn' as const, task };
         });
@@ -209,7 +212,7 @@ export function registerSessionHandlers(context: IpcContext): void {
           // unlocked git I/O above.
           const currentBlocked = resumeBlockReason({
             laneRole: currentLane?.role,
-            isArchived: current.archived_at !== null,
+            isArchived: Boolean(current.archived_at),
           });
           if (currentBlocked) throw new Error(resumeBlockMessage(currentBlocked));
 

--- a/src/main/ipc/handlers/sessions.ts
+++ b/src/main/ipc/handlers/sessions.ts
@@ -22,6 +22,7 @@ import { abortInFlightResume, registerResumeController, releaseResumeController 
 import type { PtyResizeOrigin, Session, TaskResolvePrResult } from '../../../shared/types';
 import type { IpcContext } from '../ipc-context';
 import { isAbortError } from '../../../shared/abort-utils';
+import { resumeBlockMessage, resumeBlockReason } from '../../../shared/session-resume-eligibility';
 import { broadcast } from '../../pop-out/window-broadcast';
 
 // Track session start times for duration calculation on exit
@@ -148,16 +149,18 @@ export function registerSessionHandlers(context: IpcContext): void {
         // surfacing an error the user can't recover from without a restart,
         // we treat resume as idempotent and return the existing handle. The
         // renderer's resumeSession action replaces the stale entry and sets
-        // activeSessionId, restoring the terminal attachment.
+        // activeSessionId, restoring the terminal attachment. That branch stays
+        // AHEAD of the eligibility check below: handing back a PTY that already
+        // exists spawns nothing, and it is the only path that re-attaches a
+        // drifted renderer, including one drifted onto an archived task.
         const phase1Result = await withTaskLock(taskId, async () => {
           const { task, liveSession } = reconcileTaskSessionRef(context, resolvedProjectId, taskId);
           if (liveSession) {
             return { kind: 'live' as const, session: liveSession };
           }
           const lane = swimlanes.getById(task.swimlane_id);
-          if (lane?.role === 'todo') {
-            throw new Error('Cannot resume a session for a task in the To Do column');
-          }
+          const blocked = resumeBlockReason({ laneRole: lane?.role, isArchived: task.archived_at !== null });
+          if (blocked) throw new Error(resumeBlockMessage(blocked));
           return { kind: 'spawn' as const, task };
         });
 
@@ -201,9 +204,14 @@ export function registerSessionHandlers(context: IpcContext): void {
             swimlanes.getById(current.swimlane_id),
             loadTaskProfile(context, current, resolvedProjectPath),
           );
-          if (currentLane?.role === 'todo') {
-            throw new Error('Cannot resume a session for a task in the To Do column');
-          }
+          // Re-read, not the Phase 1 snapshot: the task could have been moved or
+          // archived (a move to Done archives in the same tick) during the
+          // unlocked git I/O above.
+          const currentBlocked = resumeBlockReason({
+            laneRole: currentLane?.role,
+            isArchived: current.archived_at !== null,
+          });
+          if (currentBlocked) throw new Error(resumeBlockMessage(currentBlocked));
 
           const db = getProjectDb(resolvedProjectId);
           const sessionRepo = new SessionRepository(db);

--- a/src/main/ipc/handlers/task-archive.ts
+++ b/src/main/ipc/handlers/task-archive.ts
@@ -15,6 +15,7 @@ import { resolveProjectContext } from '../helpers/project-repos';
 import { applyProfileToLane } from '../../transition-engine/column-strategy';
 import { loadTaskProfile } from '../helpers/task-profile';
 import { withTaskLock } from '../task-lifecycle-lock';
+import { createProgressCallback, clearSpawnProgress } from '../../transition-engine/spawn-progress';
 import type { TaskRepository } from '../../db/repositories/task-repository';
 import type { SwimlaneRole, Task } from '../../../shared/types';
 import type { IpcContext } from '../ipc-context';
@@ -114,20 +115,35 @@ export function registerTaskArchiveHandlers(context: IpcContext): void {
         return tasks.getById(input.id);
       }
 
+      // Report progress exactly as task-move does. Restoring from Done deletes
+      // no time: the worktree has to be recreated from the preserved branch and
+      // the CLI booted, and the task's suspended record survives that whole
+      // window. Without a label the card sits on "Paused" behind a manual
+      // "Resume session" button while the engine is already restoring the
+      // conversation; with one, getTaskProgress reports 'preparing' and the
+      // restore reads as continuous.
+      const onProgress = createProgressCallback(context.mainWindow, task.id);
+      // Emitted immediately, before any git work: the several seconds spent
+      // resolving the lane and queueing the worktree op are exactly when the
+      // card would otherwise still read "Paused".
+      onProgress('resuming');
+
       // Create worktree if needed (any non-backlog column gets an agent)
       try {
-        await ensureTaskWorktree(context, task, tasks, resolvedProjectPath);
+        await ensureTaskWorktree(context, task, tasks, resolvedProjectPath, { onProgress });
       } catch (worktreeError) {
         console.error('[TASK_UNARCHIVE] Worktree creation failed:', worktreeError);
+        clearSpawnProgress(context.mainWindow, task.id);
         return tasks.getById(input.id);
       }
 
       // Checkout the task's branch in the main repo (non-worktree tasks only).
       // If checkout fails, the task is still unarchived but no agent is spawned.
       try {
-        await ensureTaskBranchCheckout(context, task, resolvedProjectPath);
+        await ensureTaskBranchCheckout(context, task, resolvedProjectPath, { onProgress });
       } catch (checkoutError) {
         console.error('[TASK_UNARCHIVE] Branch checkout failed:', checkoutError);
+        clearSpawnProgress(context.mainWindow, task.id);
         notifyBranchCheckoutBlocked(context, task, checkoutError, resolvedProjectId);
         return tasks.getById(input.id);
       }
@@ -160,8 +176,17 @@ export function registerTaskArchiveHandlers(context: IpcContext): void {
             });
           } catch (err) {
             console.error('[TASK_UNARCHIVE] Failed to start session:', err);
+          } finally {
+            // Mirrors task-move's Phase 3: the label must go once the spawn has
+            // resolved either way, so a task that never reaches a live session
+            // does not sit on "preparing" until the 120s TTL sweeps it.
+            clearSpawnProgress(context.mainWindow, task.id);
           }
+        } else {
+          clearSpawnProgress(context.mainWindow, task.id);
         }
+      } else {
+        clearSpawnProgress(context.mainWindow, task.id);
       }
 
       return tasks.getById(input.id);
@@ -195,19 +220,27 @@ export function registerTaskArchiveHandlers(context: IpcContext): void {
           return;
         }
 
+        // Per task, same as the single-unarchive handler above: a restore is
+        // slow enough (worktree recreate + CLI boot) that the card must show
+        // it is working rather than a stale "Paused".
+        const onProgress = createProgressCallback(context.mainWindow, task.id);
+        onProgress('resuming');
+
         try {
-          await ensureTaskWorktree(context, task, tasks, resolvedProjectPath);
+          await ensureTaskWorktree(context, task, tasks, resolvedProjectPath, { onProgress });
         } catch (worktreeError) {
           console.error(`[TASK_BULK_UNARCHIVE] Worktree creation failed for task ${id.slice(0, 8)}:`, worktreeError);
+          clearSpawnProgress(context.mainWindow, task.id);
           return;
         }
 
         // Checkout the task's branch in the main repo (non-worktree tasks only).
         // Catch per-task so one failure doesn't block the entire batch.
         try {
-          await ensureTaskBranchCheckout(context, task, resolvedProjectPath);
+          await ensureTaskBranchCheckout(context, task, resolvedProjectPath, { onProgress });
         } catch (checkoutError) {
           console.error(`[TASK_BULK_UNARCHIVE] Branch checkout failed for task ${id.slice(0, 8)}:`, checkoutError);
+          clearSpawnProgress(context.mainWindow, task.id);
           notifyBranchCheckoutBlocked(context, task, checkoutError, resolvedProjectId);
           return;
         }
@@ -237,8 +270,14 @@ export function registerTaskArchiveHandlers(context: IpcContext): void {
               });
             } catch (error) {
               console.error('[TASK_BULK_UNARCHIVE] Failed to start session:', error);
+            } finally {
+              clearSpawnProgress(context.mainWindow, task.id);
             }
+          } else {
+            clearSpawnProgress(context.mainWindow, task.id);
           }
+        } else {
+          clearSpawnProgress(context.mainWindow, task.id);
         }
       });
     }

--- a/src/main/ipc/handlers/task-archive.ts
+++ b/src/main/ipc/handlers/task-archive.ts
@@ -128,68 +128,71 @@ export function registerTaskArchiveHandlers(context: IpcContext): void {
       // card would otherwise still read "Paused".
       onProgress('resuming');
 
-      // Create worktree if needed (any non-backlog column gets an agent)
+      // ONE `finally` for the whole labelled region, rather than a clear in each
+      // exit branch. Every branch below retires the label unconditionally, so
+      // per-branch calls were pure duplication - and they covered only the
+      // branches someone remembered: the engine construction below (getProjectDb
+      // / new SessionRepository / createTransitionEngine) sat outside every
+      // `try`, so a throw there (a project DB closed by a concurrent switch)
+      // stranded the card on "Resuming session..." until the 120s TTL swept it.
       try {
-        await ensureTaskWorktree(context, task, tasks, resolvedProjectPath, { onProgress });
-      } catch (worktreeError) {
-        console.error('[TASK_UNARCHIVE] Worktree creation failed:', worktreeError);
-        clearSpawnProgress(context.mainWindow, task.id);
-        return tasks.getById(input.id);
-      }
-
-      // Checkout the task's branch in the main repo (non-worktree tasks only).
-      // If checkout fails, the task is still unarchived but no agent is spawned.
-      try {
-        await ensureTaskBranchCheckout(context, task, resolvedProjectPath, { onProgress });
-      } catch (checkoutError) {
-        console.error('[TASK_UNARCHIVE] Branch checkout failed:', checkoutError);
-        clearSpawnProgress(context.mainWindow, task.id);
-        notifyBranchCheckoutBlocked(context, task, checkoutError, resolvedProjectId);
-        return tasks.getById(input.id);
-      }
-
-      // Execute transition actions (from Done -> target) for ALL non-kill columns,
-      // via the shared spawn chokepoint (spawn preamble, transition actions,
-      // fallback spawn). Recovery move: unarchive is always the FIRST move out
-      // of Done, so suppressAutoCommand keeps the destination column's
-      // auto_command out of the resumed session - it comes up idle, ready for
-      // the user to inspect, matching startup recovery (resume-suspended.ts).
-      // The next normal move injects per column config. skipPromptTemplate for
-      // the same reason: an unarchived task is never a fresh "do this task" run.
-      if (resolvedProjectPath) {
-        const doneLane = swimlanes.list().find((l) => l.role === 'done');
-        if (doneLane) {
-          const db = getProjectDb(resolvedProjectId);
-          const sessionRepo = new SessionRepository(db);
-          const engine = createTransitionEngine(context, actions, tasks, sessionRepo, attachmentRepo, resolvedProjectId, resolvedProjectPath);
-
-          try {
-            await spawnAgent({
-              context, engine, tasks, sessionRepo, task,
-              fromSwimlaneId: doneLane.id,
-              toLane,
-              skipPromptTemplate: true,
-              suppressAutoCommand: true,
-              projectId: resolvedProjectId,
-              projectPath: resolvedProjectPath,
-              attachments: attachmentRepo,
-            });
-          } catch (err) {
-            console.error('[TASK_UNARCHIVE] Failed to start session:', err);
-          } finally {
-            // Mirrors task-move's Phase 3: the label must go once the spawn has
-            // resolved either way, so a task that never reaches a live session
-            // does not sit on "preparing" until the 120s TTL sweeps it.
-            clearSpawnProgress(context.mainWindow, task.id);
-          }
-        } else {
-          clearSpawnProgress(context.mainWindow, task.id);
+        // Create worktree if needed (any non-backlog column gets an agent)
+        try {
+          await ensureTaskWorktree(context, task, tasks, resolvedProjectPath, { onProgress });
+        } catch (worktreeError) {
+          console.error('[TASK_UNARCHIVE] Worktree creation failed:', worktreeError);
+          return tasks.getById(input.id);
         }
-      } else {
+
+        // Checkout the task's branch in the main repo (non-worktree tasks only).
+        // If checkout fails, the task is still unarchived but no agent is spawned.
+        try {
+          await ensureTaskBranchCheckout(context, task, resolvedProjectPath, { onProgress });
+        } catch (checkoutError) {
+          console.error('[TASK_UNARCHIVE] Branch checkout failed:', checkoutError);
+          notifyBranchCheckoutBlocked(context, task, checkoutError, resolvedProjectId);
+          return tasks.getById(input.id);
+        }
+
+        // Execute transition actions (from Done -> target) for ALL non-kill columns,
+        // via the shared spawn chokepoint (spawn preamble, transition actions,
+        // fallback spawn). Recovery move: unarchive is always the FIRST move out
+        // of Done, so suppressAutoCommand keeps the destination column's
+        // auto_command out of the resumed session - it comes up idle, ready for
+        // the user to inspect, matching startup recovery (resume-suspended.ts).
+        // The next normal move injects per column config. skipPromptTemplate for
+        // the same reason: an unarchived task is never a fresh "do this task" run.
+        if (resolvedProjectPath) {
+          const doneLane = swimlanes.list().find((l) => l.role === 'done');
+          if (doneLane) {
+            const db = getProjectDb(resolvedProjectId);
+            const sessionRepo = new SessionRepository(db);
+            const engine = createTransitionEngine(context, actions, tasks, sessionRepo, attachmentRepo, resolvedProjectId, resolvedProjectPath);
+
+            try {
+              await spawnAgent({
+                context, engine, tasks, sessionRepo, task,
+                fromSwimlaneId: doneLane.id,
+                toLane,
+                skipPromptTemplate: true,
+                suppressAutoCommand: true,
+                projectId: resolvedProjectId,
+                projectPath: resolvedProjectPath,
+                attachments: attachmentRepo,
+              });
+            } catch (err) {
+              console.error('[TASK_UNARCHIVE] Failed to start session:', err);
+            }
+          }
+        }
+
+        return tasks.getById(input.id);
+      } finally {
+        // Mirrors task-move's Phase 3: the label goes once the restore has
+        // resolved, whichever way, so a task that never reaches a live session
+        // does not sit on "preparing" until the 120s TTL sweeps it.
         clearSpawnProgress(context.mainWindow, task.id);
       }
-
-      return tasks.getById(input.id);
     });
   });
 
@@ -226,57 +229,57 @@ export function registerTaskArchiveHandlers(context: IpcContext): void {
         const onProgress = createProgressCallback(context.mainWindow, task.id);
         onProgress('resuming');
 
+        // One `finally` for the whole labelled region, as in the single-unarchive
+        // handler above. `task.id` here comes from this iteration's own
+        // `tasks.unarchive(...)` inside the per-task `withTaskLock`, so the clear
+        // can only ever retire this task's label, never a sibling's.
         try {
-          await ensureTaskWorktree(context, task, tasks, resolvedProjectPath, { onProgress });
-        } catch (worktreeError) {
-          console.error(`[TASK_BULK_UNARCHIVE] Worktree creation failed for task ${id.slice(0, 8)}:`, worktreeError);
-          clearSpawnProgress(context.mainWindow, task.id);
-          return;
-        }
-
-        // Checkout the task's branch in the main repo (non-worktree tasks only).
-        // Catch per-task so one failure doesn't block the entire batch.
-        try {
-          await ensureTaskBranchCheckout(context, task, resolvedProjectPath, { onProgress });
-        } catch (checkoutError) {
-          console.error(`[TASK_BULK_UNARCHIVE] Branch checkout failed for task ${id.slice(0, 8)}:`, checkoutError);
-          clearSpawnProgress(context.mainWindow, task.id);
-          notifyBranchCheckoutBlocked(context, task, checkoutError, resolvedProjectId);
-          return;
-        }
-
-        if (resolvedProjectPath) {
-          const doneLane = swimlanes.list().find((lane) => lane.role === 'done');
-          if (doneLane) {
-            const db = getProjectDb(resolvedProjectId);
-            const sessionRepo = new SessionRepository(db);
-            const engine = createTransitionEngine(context, actions, tasks, sessionRepo, attachmentRepo, resolvedProjectId, resolvedProjectPath);
-
-            // Same shared-chokepoint recovery-move contract as the single
-            // TASK_UNARCHIVE handler above: suppressAutoCommand +
-            // skipPromptTemplate, session resumes idle.
-            try {
-              await spawnAgent({
-                context, engine, tasks, sessionRepo, task,
-                fromSwimlaneId: doneLane.id,
-                // The per-task folded lane, so a bulk unarchive spawns each task
-                // on its own profile's rung rather than the column's base.
-                toLane: taskLane,
-                skipPromptTemplate: true,
-                suppressAutoCommand: true,
-                projectId: resolvedProjectId,
-                projectPath: resolvedProjectPath,
-                attachments: attachmentRepo,
-              });
-            } catch (error) {
-              console.error('[TASK_BULK_UNARCHIVE] Failed to start session:', error);
-            } finally {
-              clearSpawnProgress(context.mainWindow, task.id);
-            }
-          } else {
-            clearSpawnProgress(context.mainWindow, task.id);
+          try {
+            await ensureTaskWorktree(context, task, tasks, resolvedProjectPath, { onProgress });
+          } catch (worktreeError) {
+            console.error(`[TASK_BULK_UNARCHIVE] Worktree creation failed for task ${id.slice(0, 8)}:`, worktreeError);
+            return;
           }
-        } else {
+
+          // Checkout the task's branch in the main repo (non-worktree tasks only).
+          // Catch per-task so one failure doesn't block the entire batch.
+          try {
+            await ensureTaskBranchCheckout(context, task, resolvedProjectPath, { onProgress });
+          } catch (checkoutError) {
+            console.error(`[TASK_BULK_UNARCHIVE] Branch checkout failed for task ${id.slice(0, 8)}:`, checkoutError);
+            notifyBranchCheckoutBlocked(context, task, checkoutError, resolvedProjectId);
+            return;
+          }
+
+          if (resolvedProjectPath) {
+            const doneLane = swimlanes.list().find((lane) => lane.role === 'done');
+            if (doneLane) {
+              const db = getProjectDb(resolvedProjectId);
+              const sessionRepo = new SessionRepository(db);
+              const engine = createTransitionEngine(context, actions, tasks, sessionRepo, attachmentRepo, resolvedProjectId, resolvedProjectPath);
+
+              // Same shared-chokepoint recovery-move contract as the single
+              // TASK_UNARCHIVE handler above: suppressAutoCommand +
+              // skipPromptTemplate, session resumes idle.
+              try {
+                await spawnAgent({
+                  context, engine, tasks, sessionRepo, task,
+                  fromSwimlaneId: doneLane.id,
+                  // The per-task folded lane, so a bulk unarchive spawns each task
+                  // on its own profile's rung rather than the column's base.
+                  toLane: taskLane,
+                  skipPromptTemplate: true,
+                  suppressAutoCommand: true,
+                  projectId: resolvedProjectId,
+                  projectPath: resolvedProjectPath,
+                  attachments: attachmentRepo,
+                });
+              } catch (error) {
+                console.error('[TASK_BULK_UNARCHIVE] Failed to start session:', error);
+              }
+            }
+          }
+        } finally {
           clearSpawnProgress(context.mainWindow, task.id);
         }
       });

--- a/src/main/ipc/handlers/task-move.ts
+++ b/src/main/ipc/handlers/task-move.ts
@@ -255,7 +255,9 @@ export async function handleTaskMove(
       // Keyed on the task's own flag rather than the source lane's role, so a
       // legacy archived row parked outside Done is repaired too. Moving WITHIN
       // Done keeps its archive (toLane is still the done role).
-      if (task.archived_at !== null && toLane?.role !== 'done') {
+      // Truthiness, not `!== null`: a Task assembled without the column carries
+      // `undefined`, and `!== null` would try to unarchive every ordinary move.
+      if (Boolean(task.archived_at) && toLane?.role !== 'done') {
         tasks.clearArchived(input.taskId);
         console.log(`[TASK_MOVE] Unarchived task ${input.taskId.slice(0, 8)} (moved out of Done)`);
       }

--- a/src/main/ipc/handlers/task-move.ts
+++ b/src/main/ipc/handlers/task-move.ts
@@ -240,6 +240,26 @@ export async function handleTaskMove(
         console.log(`[TASK_MOVE] Auto-archived task ${input.taskId.slice(0, 8)} (moved to Done)`);
       }
 
+      // The inverse, in the same tick and for the same reason. A move OUT of
+      // Done must clear the flag this handler set on the way in, or the task
+      // lands in a live column while still archived: absent from the board
+      // (every list query filters `archived_at IS NULL`) yet holding a worktree
+      // and, in an auto-spawn column, a running agent. That is the same
+      // "live agent with no card" state the Done/archived resume guard exists
+      // to prevent, reached through a different door.
+      //
+      // The UI never takes this path - dragging or restoring an archived card
+      // routes to TASK_UNARCHIVE - so this is reached by MCP `move_task` and
+      // any other main-process caller of handleTaskMove.
+      //
+      // Keyed on the task's own flag rather than the source lane's role, so a
+      // legacy archived row parked outside Done is repaired too. Moving WITHIN
+      // Done keeps its archive (toLane is still the done role).
+      if (task.archived_at !== null && toLane?.role !== 'done') {
+        tasks.clearArchived(input.taskId);
+        console.log(`[TASK_MOVE] Unarchived task ${input.taskId.slice(0, 8)} (moved out of Done)`);
+      }
+
       // Within-column reorder: no side effects needed
       if (fromSwimlaneId === input.targetSwimlaneId) return null;
 

--- a/src/main/pty/session-manager.ts
+++ b/src/main/pty/session-manager.ts
@@ -1364,6 +1364,20 @@ export class SessionManager extends EventEmitter {
     // Mark suspended BEFORE killing so the async onExit handler preserves it
     session.status = 'suspended';
 
+    // ...and TELL the renderer now, not after the shutdown below. That await is
+    // up to 1500ms for a natural exit plus another 1500ms for kill propagation,
+    // and the bottom panel's tab set is `status === 'running'`
+    // (derivePanelSessions), so emitting only at the end left a tab for a
+    // session the user had already watched leave the board - the card gone, the
+    // agent gone, a dead terminal still tabbed for seconds. A user-initiated
+    // Pause never showed it because the store writes that status optimistically;
+    // a main-driven suspend (move to Done, idle timeout, settings restart) had
+    // no such write and wore the full delay.
+    //
+    // The trailing emit stays: it carries the post-shutdown session, including
+    // an agent session id recovered from the final scrollback scan below.
+    this.emit('session-changed', sessionId, toSession(session));
+
     // Resume a backpressure-paused PTY so the agent's exit-sequence output is
     // not held back during the graceful shutdown window.
     this.backpressure.release(sessionId);

--- a/src/main/retrieval/retrieval-service.ts
+++ b/src/main/retrieval/retrieval-service.ts
@@ -39,8 +39,17 @@ import type { Embedder } from './types';
 import type { MemoryStatus, MemorySemanticState, MemoryModelState, Project, ActivityState } from '../../shared/types';
 
 /** Grace period after a finalize event before indexing, so the agent CLI has
- *  flushed its native history file. */
-const FINALIZE_DEBOUNCE_MS = 2000;
+ *  flushed its native history file.
+ *
+ *  Must also OUTLAST one suspend's two reports, or the per-session debounce
+ *  below cannot coalesce them. `SessionManager.suspend` emits `session-changed`
+ *  immediately and again after `gracefulPtyShutdown`, which is up to
+ *  `gracePeriodMs` (1500) + `killPropagationMs` (1500) = 3000ms later when the
+ *  agent needs a force-kill. At 2000ms the first timer fired and cleared itself
+ *  before the trailing report arrived, so the slow path - the one that most
+ *  needs the later, fuller read of the transcript - was the one that still
+ *  indexed twice. Kept above that worst case with a margin. */
+const FINALIZE_DEBOUNCE_MS = 3500;
 /** Grace period after a turn completes (session goes idle / awaits permission)
  *  before a live re-index, so a burst of activity transitions within a turn
  *  coalesces into one index and the CLI has flushed the new turn to disk. */

--- a/src/main/retrieval/retrieval-service.ts
+++ b/src/main/retrieval/retrieval-service.ts
@@ -57,6 +57,8 @@ let jobChain: Promise<void> = Promise.resolve();
 const pendingTimers = new Set<NodeJS.Timeout>();
 /** Per-session trailing-debounce timers for live (turn-boundary) re-indexing. */
 const liveIndexTimers = new Map<string, NodeJS.Timeout>();
+/** Per-session trailing-debounce timers for finalize (suspend / exit) indexing. */
+const finalizeIndexTimers = new Map<string, NodeJS.Timeout>();
 
 // Model-file download state (downloading the local embedding model to disk).
 // The embed WORKER and its warm-hold / crash / device state live in
@@ -134,8 +136,21 @@ function chain(job: () => Promise<unknown>): void {
 
 function scheduleFinalizeIndex(context: IpcContext, sessionId: string): void {
   if (disposed || !isIndexingEnabled(context)) return;
+  // Per-session TRAILING debounce, like scheduleLiveIndex below. One suspend
+  // now reports twice - once when the status is marked, once after the graceful
+  // PTY shutdown, so the UI does not wait seconds to drop the session - and a
+  // suspend followed by an exit already reported twice before that. Without a
+  // per-session timer each report booked its own indexing pass over the same
+  // transcript. Keeping only the LAST one is also the more correct read: the
+  // later a finalize runs, the more of the agent's final flush it sees.
+  const existing = finalizeIndexTimers.get(sessionId);
+  if (existing) {
+    clearTimeout(existing);
+    pendingTimers.delete(existing);
+  }
   const timer = setTimeout(() => {
     pendingTimers.delete(timer);
+    finalizeIndexTimers.delete(sessionId);
     if (disposed || !isIndexingEnabled(context)) return;
     // Transient (command-terminal) sessions have no DB row; skip them.
     if (context.sessionManager.getSession(sessionId)?.transient) return;
@@ -151,6 +166,7 @@ function scheduleFinalizeIndex(context: IpcContext, sessionId: string): void {
   }, FINALIZE_DEBOUNCE_MS);
   timer.unref();
   pendingTimers.add(timer);
+  finalizeIndexTimers.set(sessionId, timer);
 }
 
 /**
@@ -405,6 +421,8 @@ export const retrievalService = {
     pendingTimers.clear();
     for (const timer of liveIndexTimers.values()) clearTimeout(timer);
     liveIndexTimers.clear();
+    for (const timer of finalizeIndexTimers.values()) clearTimeout(timer);
+    finalizeIndexTimers.clear();
     embedEngine.dispose();
   },
 };

--- a/src/main/transition-engine/resume-conversation-guard.ts
+++ b/src/main/transition-engine/resume-conversation-guard.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { AgentAdapter } from '../agent/agent-adapter';
+import type { SessionUsage } from '../../shared/types';
 import { sessionOutputPaths } from './session-paths';
 
 /**
@@ -118,7 +119,10 @@ interface ConversationEvidence {
 /** The status line's report. Null when absent, malformed, or pathless. */
 function readStatusEvidence(
   sessionDir: string,
-  parseStatus: (raw: string) => { transcriptPath?: string; contextWindow: { usedTokens: number; totalInputTokens: number; totalOutputTokens: number }; cost: { totalCostUsd: number } } | null,
+  // The adapter's own signature, not a re-declared subset: a local structural
+  // copy typechecks against today's SessionUsage and then silently stops
+  // tracking it.
+  parseStatus: (raw: string) => SessionUsage | null,
 ): ConversationEvidence | null {
   const { statusOutputPath } = sessionOutputPaths(sessionDir);
   let raw: string;

--- a/src/main/transition-engine/resume-conversation-guard.ts
+++ b/src/main/transition-engine/resume-conversation-guard.ts
@@ -1,0 +1,200 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { AgentAdapter } from '../agent/agent-adapter';
+import { sessionOutputPaths } from './session-paths';
+
+/**
+ * Detect a `--resume` that would target a conversation the agent never
+ * persisted, so the spawn can be downgraded to fresh instead.
+ *
+ * Kangentic pre-specifies `--session-id` for Claude and persists that id on the
+ * session record AT SPAWN TIME, before the agent has done anything. A session
+ * that ends before its first turn therefore leaves a resumable-looking record
+ * pointing at a conversation that does not exist: the agent CLI writes its
+ * transcript on the first turn, not at boot.
+ *
+ * That is reachable in a few seconds of ordinary board use. Drag a task out of
+ * Done and the recovery move spawns it command-free (`skipPromptTemplate`), so
+ * the agent comes up idle with nothing to do; drag it back before typing and
+ * the record is suspended with its id intact. Every later entry into an
+ * auto-spawn column then resolves to `--resume <id>`, the CLI answers "No
+ * conversation found with session ID", and the user lands on a bare shell with
+ * the agent gone - while the session record still reads `running`, because the
+ * shell PTY outlived the CLI.
+ *
+ * ## Why this is not the guard that was reverted in #255
+ *
+ * The `canResumeSession` transcript-presence guard (see
+ * docs/adapter-session-history.md) gated EVERY resume on `fs.accessSync` of a
+ * path Kangentic COMPUTED by slugifying the cwd. Its failure mode is fatal and
+ * silent: a false miss (a mocked CLI, or one of the more fragile per-agent
+ * locators) discards a real conversation. This is a different predicate on
+ * three counts, and all three have to hold before anything is downgraded:
+ *
+ *  1. The path is the one the AGENT reported in its own status file
+ *     (`transcript_path`), never one we derived. No locator heuristics.
+ *  2. The same status report must independently say the conversation never
+ *     started (no tokens, no cost). Downgrading a zero-turn conversation cannot
+ *     lose anything, because there is nothing in it. A session that had turns is
+ *     never downgraded, even if its transcript has moved.
+ *  3. Absence of evidence is never evidence: a missing session dir, missing or
+ *     malformed status file, an adapter with no status pipeline, or a status
+ *     report carrying no transcript path all return false and leave today's
+ *     behavior exactly as it was. Mocked E2E resumes hit that path structurally
+ *     (mock-claude writes no status.json), which is what broke the ten
+ *     session-resume specs the first time around.
+ *
+ * Both the read and the decision stay inside Kangentic's own session directory
+ * plus one existence check of a path the agent handed us.
+ */
+export async function isResumeConversationAbsent(params: {
+  adapter: AgentAdapter;
+  /**
+   * Every record that has run this conversation, NEWEST FIRST (each id is its
+   * `.kangentic/sessions/` dir name). The first one carrying a usable status
+   * report decides.
+   *
+   * A list rather than just the retiring record, because a failed resume is
+   * self-perpetuating otherwise: the CLI dies before its status line runs, so
+   * that record has no status file, and the next spawn retires IT and finds no
+   * evidence either. The proof of emptiness stays on the first record of the
+   * lineage, so an already-poisoned task heals on its next spawn instead of
+   * being stuck forever.
+   */
+  recordIds: ReadonlyArray<string | null | undefined>;
+  projectPath: string | null | undefined;
+}): Promise<boolean> {
+  const { adapter, recordIds, projectPath } = params;
+  if (!projectPath) return false;
+
+  // Adapters with no status-file pipeline never report a transcript path, so
+  // there is nothing to check: structural no-op, same as the resume-time id
+  // reconcile. Optional-chained because a partially-shaped adapter stub may
+  // lack `runtime` entirely.
+  const statusFileHook = adapter.runtime?.statusFile;
+  if (!statusFileHook) return false;
+
+  for (const recordId of recordIds) {
+    if (!recordId) continue;
+    try {
+      const sessionDir = path.join(projectPath, '.kangentic', 'sessions', recordId);
+      // Two independent reports, both agent-written and both Kangentic-owned.
+      // The status line is preferred (richest usage), but it only runs once the
+      // TUI is up: a CLI killed in its first second leaves none, which used to
+      // blind the whole lineage. The SessionStart hook fires far earlier and
+      // carries the same `transcript_path`, so it covers that window.
+      const evidence = readStatusEvidence(sessionDir, statusFileHook.parseStatus)
+        ?? readSessionStartEvidence(sessionDir);
+      // Nothing usable here (mocked CLI, pruned dir, or the agent died before
+      // writing anything at all). Try an older record of the same conversation.
+      if (!evidence) continue;
+
+      // Signal 2: the agent's own report says nothing ever happened. A
+      // conversation that had turns keeps today's behavior no matter what the
+      // file check below would say.
+      if (evidence.hadTurns) return false;
+
+      // Signal 1: the transcript the agent named is not on disk. Checked last so
+      // a conversation with turns never pays for the stat.
+      return !fs.existsSync(evidence.transcriptPath);
+    } catch (error) {
+      console.warn(`[SESSION_LIFECYCLE] Resume conversation probe failed for record ${recordId.slice(0, 8)}:`, error);
+      return false;
+    }
+  }
+
+  // No record produced a usable report: unknown, so resume exactly as before.
+  return false;
+}
+
+/** What one record's on-disk reports say about its conversation. */
+interface ConversationEvidence {
+  /** The transcript path the AGENT reported, never one Kangentic derived. */
+  transcriptPath: string;
+  /** Whether anything beyond starting and stopping ever happened. */
+  hadTurns: boolean;
+}
+
+/** The status line's report. Null when absent, malformed, or pathless. */
+function readStatusEvidence(
+  sessionDir: string,
+  parseStatus: (raw: string) => { transcriptPath?: string; contextWindow: { usedTokens: number; totalInputTokens: number; totalOutputTokens: number }; cost: { totalCostUsd: number } } | null,
+): ConversationEvidence | null {
+  const { statusOutputPath } = sessionOutputPaths(sessionDir);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(statusOutputPath, 'utf8');
+  } catch {
+    return null;
+  }
+  const usage = parseStatus(raw);
+  const transcriptPath = usage?.transcriptPath;
+  if (!usage || typeof transcriptPath !== 'string' || transcriptPath.length === 0) return null;
+  return {
+    transcriptPath,
+    hadTurns: usage.contextWindow.usedTokens > 0
+      || usage.contextWindow.totalInputTokens > 0
+      || usage.contextWindow.totalOutputTokens > 0
+      || usage.cost.totalCostUsd > 0,
+  };
+}
+
+/**
+ * The SessionStart hook's report, from Kangentic's own events file.
+ *
+ * The hook payload is stored as a JSON STRING under `hookContext`, and carries
+ * the same `transcript_path` the status line would have. Turn detection is by
+ * elimination: a conversation that ran has prompt / tool / idle events, so
+ * anything beyond the two lifecycle markers counts as a turn. Erring that way
+ * is the safe direction, since "had turns" always means "resume as before".
+ *
+ * Mocked CLIs stay structurally clear of this: `mock-claude` writes an events
+ * file only under an opt-in env flag, and even then writes activity events with
+ * no `session_start` hook payload, so this returns null for them exactly as the
+ * status-file reader does.
+ */
+function readSessionStartEvidence(sessionDir: string): ConversationEvidence | null {
+  const { eventsOutputPath } = sessionOutputPaths(sessionDir);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(eventsOutputPath, 'utf8');
+  } catch {
+    return null;
+  }
+
+  const LIFECYCLE_ONLY = new Set(['session_start', 'session_end']);
+  let transcriptPath: string | null = null;
+  let hadTurns = false;
+
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let event: { type?: unknown; hookContext?: unknown };
+    try {
+      event = JSON.parse(trimmed) as { type?: unknown; hookContext?: unknown };
+    } catch {
+      // A torn final line is normal for an append-only file being written.
+      continue;
+    }
+    const type = typeof event.type === 'string' ? event.type : '';
+    if (!LIFECYCLE_ONLY.has(type)) {
+      hadTurns = true;
+      // A turn is decisive on its own; the path is only needed when there is none.
+      break;
+    }
+    if (type === 'session_start' && typeof event.hookContext === 'string' && !transcriptPath) {
+      try {
+        const context = JSON.parse(event.hookContext) as { transcript_path?: unknown };
+        if (typeof context.transcript_path === 'string' && context.transcript_path.length > 0) {
+          transcriptPath = context.transcript_path;
+        }
+      } catch {
+        // Not the payload shape we know: no evidence, not a turn.
+      }
+    }
+  }
+
+  if (hadTurns) return { transcriptPath: transcriptPath ?? '', hadTurns: true };
+  if (!transcriptPath) return null;
+  return { transcriptPath, hadTurns: false };
+}

--- a/src/main/transition-engine/session-startup/prepare-spawn.ts
+++ b/src/main/transition-engine/session-startup/prepare-spawn.ts
@@ -11,6 +11,7 @@ import { runSpawnPreamble, resolveEffectivePermissionMode, projectModelDefaultsA
 import { applyProfileToLane, findTaskProfile } from '../column-strategy';
 import { sessionOutputPaths } from '../session-paths';
 import { reconcileResumeAgentSessionId } from '../resume-id-reconcile';
+import { isResumeConversationAbsent } from '../resume-conversation-guard';
 import type { SessionRepository } from '../../db/repositories/session-repository';
 import { resolveExecutionTarget } from '../../agent/shared/execution-target';
 import { resolveLaunchOptions } from '../../agent/shared/launch-options';
@@ -166,7 +167,26 @@ export async function prepareAgentSpawn(input: {
   );
 
   let agentSessionId: string | null;
-  const canResume = input.resume !== null;
+  // Same downgrade the board spawn path applies: a record whose conversation
+  // the agent never persisted (session ended before its first turn) must not be
+  // recovered with `--resume`, or startup hands the user a dead CLI. Returns
+  // false on every uncertainty, so a real conversation is never discarded.
+  let canResume = input.resume !== null;
+  if (canResume && await isResumeConversationAbsent({
+    adapter,
+    // Startup recovery holds only the record it is recovering; unlike the board
+    // path it has no repository handle to walk the conversation's lineage. A
+    // record recovered here ran until the crash, so it normally has its own
+    // status report.
+    recordIds: [input.resume!.recordId ?? null],
+    projectPath,
+  })) {
+    console.log(
+      `[SESSION_RECOVERY] Resume downgraded to fresh for task ${task.id.slice(0, 8)}:`
+      + ` agent session ${input.resume!.agentSessionId.slice(0, 8)} never wrote a conversation`,
+    );
+    canResume = false;
+  }
   if (canResume) {
     // Reconcile the resumed id against the retiring record's own status.json:
     // a mid-session fork (Claude /clear) in the final seconds before suspend

--- a/src/main/transition-engine/session-startup/resume-suspended.ts
+++ b/src/main/transition-engine/session-startup/resume-suspended.ts
@@ -5,7 +5,8 @@ import { TaskRepository } from '../../db/repositories/task-repository';
 import { SwimlaneRepository } from '../../db/repositories/swimlane-repository';
 import { SessionManager } from '../../pty/session-manager';
 import { ConfigManager } from '../../config/config-manager';
-import type { BoardProfile, SessionRecord, SwimlaneRole, Task } from '../../../shared/types';
+import type { BoardProfile, SessionRecord, Task } from '../../../shared/types';
+import { RESUME_HIDDEN_ROLES } from '../../../shared/session-resume-eligibility';
 import { isResumeEligible } from '../spawn-intent';
 import { applyProfileToLane, findTaskProfile } from '../column-strategy';
 import { resolveIsolatedSwimlaneId } from '../session-isolation';
@@ -13,21 +14,6 @@ import { retireRecord, markRecordSuspended } from '../session-lifecycle';
 import { isShuttingDown } from '../../shutdown-state';
 import { prepareAgentSpawn, type PreparedSpawn } from './prepare-spawn';
 import { startStartupTimer } from './timing';
-
-/**
- * Columns that deliberately offer no Resume, so a suspended record in one gets
- * no placeholder registered.
- *
- * `SwimlaneRole` is exactly 'todo' | 'done'; a custom column has `role: null`.
- * There is no live 'backlog' role - it was migrated to 'todo', and the Backlog
- * is a separate table rather than a swimlane. Typed as the union rather than
- * `string` so a typo in either literal is a compile error, not a silent miss
- * that would register a placeholder on a To Do card.
- *
- * The gate is the ROLE, not `auto_spawn`: To Do and Done both default to
- * `auto_spawn = 0`, so keying off the flag would sweep them in.
- */
-const RESUME_HIDDEN_ROLES: ReadonlySet<SwimlaneRole> = new Set<SwimlaneRole>(['todo', 'done']);
 
 /**
  * Recover suspended and orphaned agent sessions on project open.
@@ -234,8 +220,9 @@ export async function resumeSuspendedSessions(
       // branch below can run. Without a placeholder the renderer has NO session
       // for the task at all, so the card opens the edit form and offers no
       // Resume - the task is stranded, since `SESSION_RESUME` itself is happy to
-      // resume here (it rejects only role 'todo'). Register one so Resume stays
-      // reachable whatever the column's auto_spawn setting is.
+      // resume here (it refuses only the roles in RESUME_HIDDEN_ROLES, plus
+      // archived tasks). Register one so Resume stays reachable whatever the
+      // column's auto_spawn setting is.
       //
       // CUSTOM columns only. To Do and Done are `auto_spawn = 0` by default, and
       // both deliberately hide Resume: a To Do card also relies on having no

--- a/src/main/transition-engine/spawn-progress.ts
+++ b/src/main/transition-engine/spawn-progress.ts
@@ -104,6 +104,7 @@ export function __resetSpawnProgressForTest(): void {
 
 /** Valid spawn progress phases. */
 export type SpawnPhase =
+  | 'resuming'
   | 'fetching'
   | 'creating-worktree'
   | 'init-script'
@@ -114,6 +115,12 @@ export type SpawnPhase =
 
 /** Phase → user-facing label (single source of truth for display text). */
 const PHASE_LABELS: Record<SpawnPhase, string> = {
+  // Emitted the instant a restore begins, before any git work. Unlike
+  // 'fetching' (deliberately not emitted eagerly, because a queue wait would
+  // masquerade as an active fetch), this one is always true when sent: the
+  // restore IS starting. Without it the card holds its stale "Paused" for the
+  // several seconds before the worktree helper produces its first phase.
+  'resuming': 'Resuming session...',
   'fetching': 'Fetching latest...',
   'creating-worktree': 'Creating worktree...',
   'init-script': 'Running setup script...',

--- a/src/main/transition-engine/spawn-progress.ts
+++ b/src/main/transition-engine/spawn-progress.ts
@@ -14,6 +14,11 @@ import { IPC } from '../../shared/ipc-channels';
 //   Base branch task:   starting-agent
 //   Has worktree:       starting-agent
 //   Cross-agent:        packaging-handoff → detecting-agent → starting-agent
+//   Restore from Done:  resuming → (whichever of the above the task needs)
+//
+// 'resuming' is emitted by TASK_UNARCHIVE / TASK_BULK_UNARCHIVE before any git
+// work, so the card is never silent while the lane resolves and the git op
+// queues. Every other phase is emitted by the git helpers themselves.
 //
 // QUERYABLE STATE (not just fire-once IPC): the latest in-flight label per
 // task is also retained in a module-level map so the renderer can re-derive

--- a/src/main/transition-engine/transition-engine.ts
+++ b/src/main/transition-engine/transition-engine.ts
@@ -209,7 +209,7 @@ export class TransitionEngine {
     // so cross-agent and main-vs-isolated resume mismatches are structurally
     // impossible (no guard needed). Resume is only attempted when agent_session_id
     // is non-null (real CLI session ID has been captured or pre-specified).
-    const intent = resolveSpawnIntent({
+    const spawnIntentOptions = {
       taskId: task.id,
       sessionType: adapter.sessionType,
       isolatedSwimlaneId,
@@ -218,7 +218,8 @@ export class TransitionEngine {
       templateVars: vars,
       resumePrompt,
       forceFresh: spawnOverrides?.forceFresh,
-    });
+    };
+    let intent = resolveSpawnIntent(spawnIntentOptions);
 
     // A resume whose conversation the agent never persisted (a session that
     // ended before its first turn - see resume-conversation-guard.ts) would
@@ -226,30 +227,41 @@ export class TransitionEngine {
     // a bare shell. Downgrade it to a fresh spawn instead. The probe only fires
     // on positive evidence of an empty conversation and returns false on every
     // uncertainty, so a real conversation is never discarded.
-    let canResume = intent.mode === 'resume';
-    // Every record that ran this conversation, newest first: a record whose CLI
-    // died on a failed resume wrote no status file, so the proof of emptiness
-    // can only be on an older one (see the guard's `recordIds` doc).
-    const conversationRecordIds = canResume
-      ? [
-          intent.retireRecordId,
-          ...(this.sessionRepo?.listForTaskNewestFirst(task.id) ?? [])
-            .filter((record) => record.agent_session_id === intent.agentSessionId)
-            .map((record) => record.id),
-        ]
-      : [];
-    if (canResume && await isResumeConversationAbsent({
-      adapter,
-      recordIds: conversationRecordIds,
-      projectPath: appConfig.projectPath || cwd,
-    })) {
-      console.log(
-        `[spawnAgent] Resume downgraded to fresh for task ${task.id.slice(0, 8)}:`
-        + ` agent session ${intent.agentSessionId?.slice(0, 8)} never wrote a conversation`
-        + ` (session ended before its first turn)`,
-      );
-      canResume = false;
+    if (intent.mode === 'resume') {
+      // Every record that ran this conversation, newest first: a record whose CLI
+      // died on a failed resume wrote no status file, so the proof of emptiness
+      // can only be on an older one (see the guard's `recordIds` doc). Built
+      // BEFORE the re-resolve below, which clears both fields it reads.
+      const conversationRecordIds = [
+        intent.retireRecordId,
+        ...(this.sessionRepo?.listForTaskNewestFirst(task.id) ?? [])
+          .filter((record) => record.agent_session_id === intent.agentSessionId)
+          .map((record) => record.id),
+      ];
+      if (await isResumeConversationAbsent({
+        adapter,
+        recordIds: conversationRecordIds,
+        projectPath: appConfig.projectPath || cwd,
+      })) {
+        console.log(
+          `[spawnAgent] Resume downgraded to fresh for task ${task.id.slice(0, 8)}:`
+          + ` agent session ${intent.agentSessionId?.slice(0, 8)} never wrote a conversation`
+          + ` (session ended before its first turn)`,
+        );
+        // Re-RESOLVE, rather than just clearing a boolean. The two branches of
+        // resolveSpawnIntent do not carry the same prompt: resume takes
+        // `resumePrompt` (undefined for an ordinary task spawn) while fresh
+        // interpolates `promptTemplate`. Flipping a flag would therefore boot a
+        // brand-new `--session-id` with NO task prompt - and a promptless
+        // session suspended before the user types is precisely the zero-turn
+        // conversation this guard detects, so the downgrade would seed its own
+        // next false positive. `forceFresh` takes the fresh branch whole: the
+        // interpolated prompt, a null agentSessionId, and the same poisoned
+        // record still retired.
+        intent = resolveSpawnIntent({ ...spawnIntentOptions, forceFresh: true });
+      }
     }
+    const canResume = intent.mode === 'resume';
 
     // agent_session_id: the agent CLI's real session ID for --resume/--session-id.
     // - Resume: use the captured/specified ID from the DB record, reconciled

--- a/src/main/transition-engine/transition-engine.ts
+++ b/src/main/transition-engine/transition-engine.ts
@@ -17,6 +17,7 @@ import { resolveEffectivePermissionMode } from './spawn-preamble';
 import { resolveSpawnIntent } from './spawn-intent';
 import { migrateResumeCwdIfRenamed } from './resume-cwd-migration';
 import { reconcileResumeAgentSessionId } from './resume-id-reconcile';
+import { isResumeConversationAbsent } from './resume-conversation-guard';
 import { sessionOutputPaths } from './session-paths';
 import type { ActionRepository } from '../db/repositories/action-repository';
 import type { TaskRepository } from '../db/repositories/task-repository';
@@ -219,7 +220,36 @@ export class TransitionEngine {
       forceFresh: spawnOverrides?.forceFresh,
     });
 
-    const canResume = intent.mode === 'resume';
+    // A resume whose conversation the agent never persisted (a session that
+    // ended before its first turn - see resume-conversation-guard.ts) would
+    // spawn `--resume <id>`, get "No conversation found", and leave the user on
+    // a bare shell. Downgrade it to a fresh spawn instead. The probe only fires
+    // on positive evidence of an empty conversation and returns false on every
+    // uncertainty, so a real conversation is never discarded.
+    let canResume = intent.mode === 'resume';
+    // Every record that ran this conversation, newest first: a record whose CLI
+    // died on a failed resume wrote no status file, so the proof of emptiness
+    // can only be on an older one (see the guard's `recordIds` doc).
+    const conversationRecordIds = canResume
+      ? [
+          intent.retireRecordId,
+          ...(this.sessionRepo?.listForTaskNewestFirst(task.id) ?? [])
+            .filter((record) => record.agent_session_id === intent.agentSessionId)
+            .map((record) => record.id),
+        ]
+      : [];
+    if (canResume && await isResumeConversationAbsent({
+      adapter,
+      recordIds: conversationRecordIds,
+      projectPath: appConfig.projectPath || cwd,
+    })) {
+      console.log(
+        `[spawnAgent] Resume downgraded to fresh for task ${task.id.slice(0, 8)}:`
+        + ` agent session ${intent.agentSessionId?.slice(0, 8)} never wrote a conversation`
+        + ` (session ended before its first turn)`,
+      );
+      canResume = false;
+    }
 
     // agent_session_id: the agent CLI's real session ID for --resume/--session-id.
     // - Resume: use the captured/specified ID from the DB record, reconciled
@@ -247,7 +277,9 @@ export class TransitionEngine {
     const ptySessionId = randomUUID();
 
     console.log(
-      `[spawnAgent] task=${task.id.slice(0, 8)} intent=${intent.mode} session=${isolatedSwimlaneId ?? 'main'}`
+      // Reports the mode actually spawned, not the resolver's proposal: a
+      // never-persisted conversation is downgraded to fresh above.
+      `[spawnAgent] task=${task.id.slice(0, 8)} intent=${canResume ? 'resume' : 'fresh'} session=${isolatedSwimlaneId ?? 'main'}`
       + ` agent=${agentName} ptySessionId=${ptySessionId.slice(0, 8)}`
       + (agentSessionId ? ` agentSessionId=${agentSessionId.slice(0, 8)}` : '')
       + (intent.retireRecordId ? ` retiring=${intent.retireRecordId.slice(0, 8)}` : ''),

--- a/src/renderer/components/dialogs/task-detail/TaskDetailBody.tsx
+++ b/src/renderer/components/dialogs/task-detail/TaskDetailBody.tsx
@@ -9,6 +9,7 @@ import { BrowserPane } from '../../browser/BrowserPane';
 import { PriorityBadge } from '../../backlog/PriorityBadge';
 import { LabelPills } from '../../Pill';
 import { useTaskDetailHost } from './task-detail-host';
+import { taskDetailSurfaceFor } from '../../../utils/task-progress';
 import { QueuedPlaceholder } from './QueuedPlaceholder';
 import { taskHasDescriptionContent } from './description-content';
 import { AttachmentChipStrip } from '../AttachmentChipStrip';
@@ -66,6 +67,7 @@ interface TaskDetailBodyProps {
   isFocused: boolean;
   isArchived: boolean;
   isInTodo: boolean;
+  isInDone: boolean;
   hasSessionContext: boolean;
   sessionId: string | null;
   displayKind: SessionDisplayState['kind'];
@@ -99,6 +101,7 @@ export function TaskDetailBody({
   isFocused,
   isArchived,
   isInTodo,
+  isInDone,
   hasSessionContext,
   sessionId,
   displayKind,
@@ -304,8 +307,14 @@ export function TaskDetailBody({
   // <webview> (Browser pane) and the xterm canvas.
   const resizeCaptureOverlay = isSplitResizing && <div className="fixed inset-0 z-50 cursor-col-resize" />;
 
-  // Active terminal session
-  if (sessionId && displayKind !== 'queued' && displayKind !== 'suspended') {
+  // Active terminal session.
+  //
+  // Gated on the classifier rather than a chain of `kind !== ...` exclusions: a
+  // denylist adopts every kind added later, which is how a restore came to paint
+  // the outgoing session's dead terminal once 'preparing' started winning. The
+  // table in task-progress.ts is compile-enforced, so a new kind cannot land
+  // here by default.
+  if (sessionId && taskDetailSurfaceFor(displayKind) === 'terminal') {
     // Browser, Changes, and the Description peek are mutually exclusive; when one
     // shares the row with the terminal, a draggable divider sets the per-task split.
     const showDivider = rightPanelPresent && !changesExpanded;
@@ -374,7 +383,7 @@ export function TaskDetailBody({
   }
 
   // Queued
-  if (displayKind === 'queued') {
+  if (taskDetailSurfaceFor(displayKind) === 'queued-placeholder') {
     return <QueuedPlaceholder sessionId={sessionId} />;
   }
 
@@ -382,7 +391,7 @@ export function TaskDetailBody({
   // exists. The terminal area is otherwise blank here, so mirror the board
   // card's launch treatment - a centered muted spinner + the spawn status
   // label - and keep PreSpawnContextBar pinned at the bottom.
-  if (displayKind === 'preparing') {
+  if (taskDetailSurfaceFor(displayKind) === 'launch-overlay') {
     // No session/PTY yet, so the only right panel that applies is the Description
     // peek (Browser needs a live session; Changes is not offered here). It rides
     // the same split so it survives the transition into the running terminal.
@@ -408,8 +417,12 @@ export function TaskDetailBody({
     );
   }
 
-  // Suspended or toggling
-  if ((isSuspended || toggling) && !isArchived && !isInTodo) {
+  // Suspended or toggling. The big centered Play button is a resume surface, so
+  // it follows the same eligibility as the header toggle: main refuses an
+  // in-place resume for To Do, Done, and archived tasks. Done is checked
+  // alongside isArchived rather than folded into it, because a task placed
+  // directly in a Done-role column was never archived.
+  if ((isSuspended || toggling) && !isArchived && !isInTodo && !isInDone) {
     if (pendingCommandLabel) {
       return (
         <>

--- a/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
+++ b/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
@@ -280,6 +280,7 @@ export function TaskDetailHeader({
         <button
           onClick={onToggle}
           disabled={toggling}
+          data-testid="header-toggle-session-btn"
           className={`inline-flex items-center justify-center p-1 rounded-full transition-colors flex-shrink-0 disabled:cursor-not-allowed ${
             toggling
               ? 'text-fg-muted'

--- a/src/renderer/components/dialogs/task-detail/useTaskActions.ts
+++ b/src/renderer/components/dialogs/task-detail/useTaskActions.ts
@@ -6,6 +6,7 @@ import { useToastStore } from '../../../stores/toast-store';
 import { useTaskDetailHost } from './task-detail-host';
 import type { Task, Session, AgentCommand, Swimlane, PermissionMode, TaskRunMode } from '../../../../shared/types';
 import type { useBranchConfig } from './useBranchConfig';
+import { hasSessionLifecycle } from '../../../utils/task-progress';
 import type { useTaskProgress } from '../../../utils/task-progress';
 
 /**
@@ -173,8 +174,12 @@ export function useTaskActions(input: {
   // Includes a 5s safety timeout in case the transition never arrives.
   useEffect(() => {
     if (!pendingAction) return;
+    // "No session lifecycle left" is the ended bucket of SESSION_LIFECYCLE_PHASE
+    // ('none' / 'exited'), read through the compile-enforced table rather than
+    // re-listed here, so a kind added later cannot leave a pause hanging on the
+    // 5s timeout below.
     const reached = pendingAction === 'pausing'
-      ? (input.isSuspended || input.displayState.kind === 'none' || input.displayState.kind === 'exited')
+      ? (input.isSuspended || !hasSessionLifecycle(input.displayState.kind))
       : input.isSessionActive;
     if (reached) {
       setPendingAction(null);

--- a/src/renderer/components/dialogs/task-detail/useTaskSessionState.ts
+++ b/src/renderer/components/dialogs/task-detail/useTaskSessionState.ts
@@ -1,7 +1,8 @@
 import { useEffect, useLayoutEffect, useRef } from 'react';
 import { useSessionStore } from '../../../stores/session-store';
-import { useTaskProgress } from '../../../utils/task-progress';
+import { useTaskProgress, isActiveKind, hasSessionLifecycle } from '../../../utils/task-progress';
 import { isActive, requiresUserInteraction } from '../../../../shared/activity-state';
+import { resumeBlockReason } from '../../../../shared/session-resume-eligibility';
 import type { Task, Session } from '../../../../shared/types';
 
 interface TaskSessionState {
@@ -56,17 +57,30 @@ export function useTaskSessionState(input: {
 
   const displayState = useTaskProgress(input.task.id, session?.id);
 
-  const canToggle = !input.isInTodo && (
-    displayState.kind === 'running'
-    || displayState.kind === 'queued'
-    || displayState.kind === 'initializing'
-    || displayState.kind === 'suspended'
-    || displayState.kind === 'preparing'
-  );
-  const isSessionActive = displayState.kind === 'running'
-    || displayState.kind === 'queued'
-    || displayState.kind === 'initializing'
-    || displayState.kind === 'preparing';
+  // Main refuses an in-place resume for To Do, Done, and archived tasks, so the
+  // control must not be offered for them (a completed task in Done otherwise
+  // offers a Play button that recreates the worktree Done deleted and spawns a
+  // live agent on a card the board no longer shows).
+  //
+  // Pausing is deliberately NOT blocked: this one flag gates both directions,
+  // and this button is the only in-window stop for a session that is genuinely
+  // live. A view that drifted to 'suspended' while main holds a live PTY
+  // self-heals through the reconcile probe below, which flips isSessionActive
+  // back to true and restores Pause. To Do stays a separate factor because it
+  // hides both directions (its cards open straight into the edit form).
+  const resumeBlocked = resumeBlockReason({
+    laneRole: input.currentSwimlaneRole,
+    isArchived: input.isArchived,
+  }) !== null;
+
+  // Classified through the compile-enforced tables in task-progress.ts rather
+  // than literal chains, so a new display kind cannot silently inherit either
+  // answer (see the note above TASK_DETAIL_SURFACE).
+  const isSessionActive = isActiveKind(displayState.kind);
+
+  const canToggle = !input.isInTodo
+    && (isSessionActive || !resumeBlocked)
+    && hasSessionLifecycle(displayState.kind);
   const isQueued = displayState.kind === 'queued';
   const isSuspended = displayState.kind === 'suspended';
   // Activity-while-running, classified the same way the board card does
@@ -79,8 +93,7 @@ export function useTaskSessionState(input: {
   // Base session-context flag - excludes the "during-toggle transition"
   // compensation, which callers add in to keep the dialog large while
   // pendingAction is non-null.
-  const hasSessionContext = !input.isArchived
-    && (displayState.kind !== 'none' && displayState.kind !== 'exited');
+  const hasSessionContext = !input.isArchived && hasSessionLifecycle(displayState.kind);
 
   // Show Changes button when the task isn't in a terminal column.
   // Works with or without a branch/worktree - tasks on main show uncommitted working tree changes.

--- a/src/renderer/utils/task-progress.ts
+++ b/src/renderer/utils/task-progress.ts
@@ -52,6 +52,90 @@ function deriveOverlayLabel(
  *   2. Session-based display state (queued, initializing, running, etc.)
  *   3. None (no session, no progress)
  */
+// ---------------------------------------------------------------------------
+// Display-kind classification (compile-enforced)
+//
+// Consumers used to ask "which kind is this?" with chains of string-literal
+// comparisons, e.g. the task-detail body's terminal gate:
+//
+//   sessionId && kind !== 'queued' && kind !== 'suspended'
+//
+// A denylist like that silently ADOPTS every kind added later, which is exactly
+// how a restore came to paint the outgoing session's dead terminal: the moment
+// an in-flight spawn label started resolving to 'preparing', a gate that had
+// never heard of it matched. The failure is invisible - no type error, no test,
+// just the wrong face.
+//
+// Both tables below are `satisfies Record<SessionDisplayState['kind'], ...>`, so
+// adding a kind to the union fails `npm run typecheck` until every consumer has
+// been told what to do with it. Same mechanism as ACTIVITY_DISPOSITION in
+// shared/activity-state.ts (see .claude/rules/activity-state-classification.md).
+// ---------------------------------------------------------------------------
+
+/** Which face the task-detail body paints. */
+export type TaskDetailSurface =
+  /** The live xterm for the task's session. */
+  | 'terminal'
+  /** Spinner + spawn phase label: work is happening, no session to show yet. */
+  | 'launch-overlay'
+  /** Waiting for a concurrency slot. */
+  | 'queued-placeholder'
+  /** Offer to restart a session that is genuinely parked. */
+  | 'resume-prompt'
+  /** Nothing session-shaped to show; the body falls through to its other faces. */
+  | 'inert';
+
+const TASK_DETAIL_SURFACE = {
+  // A session exists and is producing output (its boot noise included).
+  running: 'terminal',
+  initializing: 'terminal',
+  // Pre-session work. NOTE: during a restore the outgoing session's id is still
+  // on the row, so this must not fall through to 'terminal' or the user watches
+  // a dead shell while the agent is being restored.
+  preparing: 'launch-overlay',
+  queued: 'queued-placeholder',
+  suspended: 'resume-prompt',
+  exited: 'inert',
+  none: 'inert',
+} satisfies Record<SessionDisplayState['kind'], TaskDetailSurface>;
+
+/** The task-detail face for a display kind. Total by construction. */
+export function taskDetailSurfaceFor(kind: SessionDisplayState['kind']): TaskDetailSurface {
+  return TASK_DETAIL_SURFACE[kind];
+}
+
+/** Where a display kind sits in the session lifecycle. */
+export type SessionLifecyclePhase =
+  /** The agent is working or on its way to working. */
+  | 'active'
+  /** Parked, but resumable - it still has a session behind it. */
+  | 'paused'
+  /** No session lifecycle at all (never started, or finished). */
+  | 'ended';
+
+const SESSION_LIFECYCLE_PHASE = {
+  running: 'active',
+  queued: 'active',
+  initializing: 'active',
+  preparing: 'active',
+  suspended: 'paused',
+  exited: 'ended',
+  none: 'ended',
+} satisfies Record<SessionDisplayState['kind'], SessionLifecyclePhase>;
+
+/** True while the agent is working or starting: the Pause direction of a toggle. */
+export function isActiveKind(kind: SessionDisplayState['kind']): boolean {
+  return SESSION_LIFECYCLE_PHASE[kind] === 'active';
+}
+
+/**
+ * True when the task has a session lifecycle to talk about (active or paused).
+ * The complement of "never started / already finished".
+ */
+export function hasSessionLifecycle(kind: SessionDisplayState['kind']): boolean {
+  return SESSION_LIFECYCLE_PHASE[kind] !== 'ended';
+}
+
 export function getTaskProgress(inputs: {
   session?: Session;
   usage?: SessionUsage;
@@ -60,8 +144,21 @@ export function getTaskProgress(inputs: {
 }): SessionDisplayState {
   const { session, usage, activity, spawnProgressLabel } = inputs;
 
-  // Pre-session: spawn progress from main process (worktree creation, etc.)
-  if (spawnProgressLabel && !session) {
+  // Pre-session: spawn progress from main process (worktree creation, etc.).
+  //
+  // A SUSPENDED session does not suppress this. Main only emits a spawn label
+  // while it is actively spawning or resuming right now, which is strictly
+  // newer information than a record that was suspended earlier. Restoring a
+  // task from Done is the case that made this obvious: the suspended record is
+  // deliberately preserved for the resume, so the old `!session` test discarded
+  // the label for the entire worktree-recreate and CLI-boot window and left the
+  // card reading "Paused" with a manual "Resume session" button, while the
+  // engine was already restoring the conversation behind it. The same stale
+  // window hit any suspended task moved into an auto-spawn column.
+  //
+  // Only 'suspended' is overridden. A running/queued session owns its own
+  // display, and a stale label must never mask a live agent.
+  if (spawnProgressLabel && (!session || session.status === 'suspended')) {
     return { kind: 'preparing', label: spawnProgressLabel };
   }
 

--- a/src/renderer/utils/task-progress.ts
+++ b/src/renderer/utils/task-progress.ts
@@ -74,7 +74,7 @@ function deriveOverlayLabel(
 
 /** Which face the task-detail body paints. */
 export type TaskDetailSurface =
-  /** The live xterm for the task's session. */
+  /** The xterm for the task's session, live or finished (its scrollback). */
   | 'terminal'
   /** Spinner + spawn phase label: work is happening, no session to show yet. */
   | 'launch-overlay'
@@ -89,13 +89,18 @@ const TASK_DETAIL_SURFACE = {
   // A session exists and is producing output (its boot noise included).
   running: 'terminal',
   initializing: 'terminal',
+  // An agent that has finished keeps its terminal. The scrollback is the only
+  // record of WHY it exited, and this window is the only surface that shows it:
+  // the bottom panel's tab set is `status === 'running'` (panel-sessions.ts), so
+  // an exited session has no tab either. 'inert' here sends the user to "No
+  // active session" with the output still on disk but nowhere to read it.
+  exited: 'terminal',
   // Pre-session work. NOTE: during a restore the outgoing session's id is still
   // on the row, so this must not fall through to 'terminal' or the user watches
   // a dead shell while the agent is being restored.
   preparing: 'launch-overlay',
   queued: 'queued-placeholder',
   suspended: 'resume-prompt',
-  exited: 'inert',
   none: 'inert',
 } satisfies Record<SessionDisplayState['kind'], TaskDetailSurface>;
 

--- a/src/renderer/window-manager/components/TaskDetailWindow.tsx
+++ b/src/renderer/window-manager/components/TaskDetailWindow.tsx
@@ -181,8 +181,8 @@ export function TaskDetailWindow({
   //
   // `displayKind` is the field that actually does the work here, not the two
   // flags the Resume prompt reads. TaskDetailBody picks its branch in order, and
-  // the active-terminal branch is gated FIRST, on `sessionId && displayKind !==
-  // 'queued' && displayKind !== 'suspended' && displayKind !== 'preparing'`.
+  // the active-terminal branch is gated FIRST, on
+  // `sessionId && taskDetailSurfaceFor(displayKind) === 'terminal'`.
   // `displayKind` is derived from `session.status` (task-progress.ts, which also
   // lets an in-flight spawn label outrank a suspended session), so the
   // optimistic write flips it
@@ -314,11 +314,13 @@ export function TaskDetailWindow({
   // Unlike canShowBrowser we do NOT require a live session?.id, because the
   // pre-session 'preparing' branch renders the peek too (the description is
   // meaningful before the PTY exists), and preparing has no session yet.
+  // The two surfaces that actually render the peek are the terminal branch and
+  // the launch overlay, so ask the classifier for those rather than re-listing
+  // the kinds that are not them.
+  const descriptionSurface = taskDetailSurfaceFor(sessionState.displayState.kind);
   const canShowDescription = !isArchived
     && hasDescriptionContent
-    && sessionState.displayState.kind !== 'none'
-    && sessionState.displayState.kind !== 'queued'
-    && sessionState.displayState.kind !== 'suspended';
+    && (descriptionSurface === 'terminal' || descriptionSurface === 'launch-overlay');
 
   // Unsaved-changes detection for edit mode: any editable field differing from
   // the persisted task counts as dirty (mirrors handleCancel's reverts).
@@ -433,14 +435,16 @@ export function TaskDetailWindow({
   // The Browser pane binds to a session id, so it must not be offered while one
   // is being REPLACED: during a restore the outgoing session's id is still on
   // the row (that is why the id check below passes), and opening a pane against
-  // it would re-register the guest the moment the new session lands. Excluded
-  // through the surface classifier rather than another `!== 'preparing'`, so a
-  // future pre-session kind is covered by mapping it in one table.
+  // it would re-register the guest the moment the new session lands.
+  //
+  // Gated on the SAME classifier answer as the body's terminal branch, which is
+  // the only place BrowserPane actually mounts. A mixed predicate here (one
+  // classifier check AND a leftover `!== 'queued' && !== 'suspended'` chain) let
+  // the two disagree: the toggle offered a pane the body would never render.
+  // One table, one answer, so a future kind cannot split them again.
   const canShowBrowser = browserEnabled
     && !!sessionState.session?.id
-    && taskDetailSurfaceFor(sessionState.displayState.kind) !== 'launch-overlay'
-    && sessionState.displayState.kind !== 'queued'
-    && sessionState.displayState.kind !== 'suspended';
+    && taskDetailSurfaceFor(sessionState.displayState.kind) === 'terminal';
   const { copied: displayIdCopied, copy: copyDisplayId } = useCopyDisplayId(task.display_id);
 
   const moveTargets = useMemo(() =>

--- a/src/renderer/window-manager/components/TaskDetailWindow.tsx
+++ b/src/renderer/window-manager/components/TaskDetailWindow.tsx
@@ -43,6 +43,7 @@ import {
   useTaskDetailHost,
 } from '../../components/dialogs/task-detail';
 import { useLayerStore } from '../context';
+import { taskDetailSurfaceFor } from '../../utils/task-progress';
 import { registerWindowCloser, unregisterWindowCloser } from '../store/window-close-registry';
 import { classifySnapZone, nextSnap } from '../dnd/snap-zones';
 import type { SnapDirection } from '../dnd/snap-zones';
@@ -181,8 +182,10 @@ export function TaskDetailWindow({
   // `displayKind` is the field that actually does the work here, not the two
   // flags the Resume prompt reads. TaskDetailBody picks its branch in order, and
   // the active-terminal branch is gated FIRST, on `sessionId && displayKind !==
-  // 'queued' && displayKind !== 'suspended'`. `displayKind` is derived straight
-  // from `session.status` (task-progress.ts), so the optimistic write flips it
+  // 'queued' && displayKind !== 'suspended' && displayKind !== 'preparing'`.
+  // `displayKind` is derived from `session.status` (task-progress.ts, which also
+  // lets an in-flight spawn label outrank a suspended session), so the
+  // optimistic write flips it
   // to 'suspended' on the same render that starts the fade. Freezing only
   // `isSuspended` / `toggling` therefore fails BOTH gates at once - the terminal
   // branch because displayKind is live-suspended, the resume branch because the
@@ -427,8 +430,15 @@ export function TaskDetailWindow({
     toggleChangesOpen(task.id);
   }, [browserOpen, changesOpen, descriptionPeekOpen, toggleBrowserOpen, toggleChangesOpen, task.id]);
 
+  // The Browser pane binds to a session id, so it must not be offered while one
+  // is being REPLACED: during a restore the outgoing session's id is still on
+  // the row (that is why the id check below passes), and opening a pane against
+  // it would re-register the guest the moment the new session lands. Excluded
+  // through the surface classifier rather than another `!== 'preparing'`, so a
+  // future pre-session kind is covered by mapping it in one table.
   const canShowBrowser = browserEnabled
     && !!sessionState.session?.id
+    && taskDetailSurfaceFor(sessionState.displayState.kind) !== 'launch-overlay'
     && sessionState.displayState.kind !== 'queued'
     && sessionState.displayState.kind !== 'suspended';
   const { copied: displayIdCopied, copy: copyDisplayId } = useCopyDisplayId(task.display_id);
@@ -740,6 +750,7 @@ export function TaskDetailWindow({
               isFocused={isFocused}
               isArchived={isArchived}
               isInTodo={isInTodo}
+              isInDone={sessionState.isInDone}
               hasSessionContext={hasSessionContext}
               sessionId={bodySessionView.sessionId}
               displayKind={bodySessionView.displayKind}

--- a/src/shared/session-resume-eligibility.ts
+++ b/src/shared/session-resume-eligibility.ts
@@ -1,0 +1,64 @@
+import type { SwimlaneRole } from './types';
+
+/**
+ * Columns that deliberately offer no Resume.
+ *
+ * `SwimlaneRole` is exactly 'todo' | 'done'; a custom column has `role: null`.
+ * There is no live 'backlog' role - it was migrated to 'todo', and the Backlog
+ * is a separate table rather than a swimlane. Typed as the union rather than
+ * `string` so a typo in either literal is a compile error, not a silent miss.
+ *
+ * The gate is the ROLE, not `auto_spawn`: To Do and Done both default to
+ * `auto_spawn = 0`, so keying off the flag would sweep in every custom column
+ * a user has turned auto-spawn off for.
+ */
+export const RESUME_HIDDEN_ROLES: ReadonlySet<SwimlaneRole> = new Set<SwimlaneRole>(['todo', 'done']);
+
+/** Why a task refuses an in-place resume. */
+export type ResumeBlockReason = 'todo' | 'done' | 'archived';
+
+/**
+ * Whether an in-place resume (`SESSION_RESUME`) is refused for a task, and why.
+ * Returns null when resume is allowed.
+ *
+ * A completed task lives in Done with `archived_at` set, its worktree deleted
+ * and its session suspended. Resuming it in place recreates that worktree and
+ * spawns a live agent on a task with no board card - real quota burn with no
+ * affordance to notice it, and a task that is archived AND running at once. The
+ * designed route back is to move the task OUT of Done (the recovery move in
+ * `task-move.ts` / `TASK_UNARCHIVE`), which unarchives first and then spawns
+ * through the normal chokepoint, so this predicate never sees it.
+ *
+ * `laneRole` is typed loosely so the renderer can pass a swimlane's `role`
+ * straight through; the lookup narrows against the typed set above.
+ */
+export function resumeBlockReason(input: {
+  laneRole: string | null | undefined;
+  isArchived: boolean;
+}): ResumeBlockReason | null {
+  const laneRole = input.laneRole;
+  if (laneRole && (RESUME_HIDDEN_ROLES as ReadonlySet<string>).has(laneRole)) {
+    return laneRole as ResumeBlockReason;
+  }
+  // Checked after the role so a task in Done reports the Done message, which
+  // names the move that restores it. An archived task in any other column
+  // (legacy rows) still falls through to here.
+  if (input.isArchived) return 'archived';
+  return null;
+}
+
+/**
+ * User-facing copy for a refusal. The main-process handler throws this string
+ * and the task detail surfaces it verbatim in a toast, so it reads as guidance,
+ * not as an internal error.
+ */
+export function resumeBlockMessage(reason: ResumeBlockReason): string {
+  switch (reason) {
+    case 'todo':
+      return 'Cannot resume a session for a task in the To Do column';
+    case 'done':
+      return 'This task is complete. Move it out of Done to continue working on it.';
+    case 'archived':
+      return 'This task is archived. Restore it to the board to continue working on it.';
+  }
+}

--- a/tests/ui/restore-from-done-shows-progress.spec.ts
+++ b/tests/ui/restore-from-done-shows-progress.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * Restoring a task from Done shows the restore in progress, on BOTH surfaces.
+ *
+ * The restore keeps the outgoing session's suspended record and its id while
+ * main recreates the worktree and boots the CLI, which is several seconds. Two
+ * separate defects lived in that window, and fixing the first exposed the
+ * second:
+ *
+ *   1. `getTaskProgress` discarded the spawn label whenever a session existed,
+ *      so the card read "Paused" and the detail offered a manual "Resume
+ *      session" button while the engine was already restoring.
+ *   2. Once the label won, `displayKind` became 'preparing' - but the detail's
+ *      active-terminal branch only excluded 'queued' and 'suspended', so it
+ *      matched on the STALE session id and painted the dead session's terminal
+ *      (the echoed `--resume` command over a bare shell prompt). Visually that
+ *      reads as a broken agent, which is worse than the button it replaced.
+ *
+ * Both surfaces are asserted together because they are driven by one predicate
+ * and disagreeing about it is the whole bug class.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-restore-progress';
+const TASK_ID = 'task-restore-progress';
+const TASK_TITLE = 'Restore Progress Probe';
+const SESSION_ID = 'session-restore-progress';
+const SPAWN_LABEL = 'Creating worktree...';
+
+interface StoreWindow {
+  __zustandStores: {
+    session: {
+      getState: () => {
+        setDetailTaskId: (id: string) => void;
+        spawnProgress: Record<string, string>;
+      };
+      setState: (partial: { spawnProgress: Record<string, string> }) => void;
+    };
+    window: { getState: () => { windows: Record<string, { id: string; anchor: string }> } };
+  };
+}
+
+async function launch(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+  const page = await context.newPage();
+
+  const preConfigScript = `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+      state.projects.push({
+        id: '${PROJECT_ID}',
+        name: 'Restore Progress Test',
+        path: '/mock/restore-progress-test',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        state.swimlanes.push(Object.assign({}, s, {
+          id: 'lane-' + s.name.toLowerCase().replace(/\\s+/g, '-'),
+          position: i,
+          created_at: ts,
+        }));
+      });
+      // Mid-restore: already unarchived into an auto-spawn column, but the
+      // outgoing session record and its id are still on the row because the new
+      // one has not spawned yet.
+      state.tasks.push({
+        id: '${TASK_ID}',
+        title: '${TASK_TITLE}',
+        description: 'Restored from Done, worktree being recreated.',
+        swimlane_id: 'lane-executing',
+        position: 0,
+        agent: 'claude',
+        session_id: '${SESSION_ID}',
+        worktree_path: null,
+        branch_name: 'feature/restore-progress',
+        pr_number: null,
+        pr_url: null,
+        base_branch: 'main',
+        use_worktree: 1,
+        labels: [],
+        priority: 0,
+        attachment_count: 0,
+        archived_at: null,
+        created_at: ts,
+        updated_at: ts,
+      });
+      state.sessions.push({
+        id: '${SESSION_ID}',
+        taskId: '${TASK_ID}',
+        projectId: '${PROJECT_ID}',
+        pid: 4242,
+        status: 'suspended',
+        shell: 'pwsh',
+        cwd: '/mock/restore-progress-test',
+        startedAt: ts,
+        exitCode: null,
+        resuming: false,
+        agentSessionId: 'agent-restore-progress',
+      });
+      return { currentProjectId: '${PROJECT_ID}' };
+    });
+  `;
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(preConfigScript);
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  await page.locator('[data-swimlane-name="Executing"]').waitFor({ state: 'visible', timeout: 15000 });
+  return { browser, page };
+}
+
+/** The push main sends while it recreates the worktree. */
+async function emitSpawnProgress(page: Page): Promise<void> {
+  await page.evaluate(({ taskId, label }) => {
+    const store = (window as unknown as StoreWindow).__zustandStores.session;
+    store.setState({ spawnProgress: { ...store.getState().spawnProgress, [taskId]: label } });
+  }, { taskId: TASK_ID, label: SPAWN_LABEL });
+}
+
+test.describe('Restore from Done reports progress on both surfaces', () => {
+  test('the card shows the spawn label instead of Paused', async () => {
+    const { browser, page } = await launch();
+    try {
+      const card = page.locator(`[data-task-id="${TASK_ID}"]`);
+      await expect(card).toBeVisible({ timeout: 10000 });
+
+      // Precondition: with no label in flight, the suspended record reads Paused.
+      await expect(card).toContainText('Paused');
+
+      await emitSpawnProgress(page);
+
+      await expect(card).toContainText(SPAWN_LABEL, { timeout: 5000 });
+      await expect(card).not.toContainText('Paused');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('the detail shows the launch overlay, not the dead terminal and not a Resume button', async () => {
+    const { browser, page } = await launch();
+    try {
+      await page.evaluate((taskId) => {
+        (window as unknown as StoreWindow).__zustandStores.session.getState().setDetailTaskId(taskId);
+      }, TASK_ID);
+
+      let windowId: string | null = null;
+      await expect.poll(async () => {
+        windowId = await page.evaluate((anchorId) => {
+          const windows = (window as unknown as StoreWindow).__zustandStores.window.getState().windows;
+          return Object.values(windows).find((candidate) => candidate.anchor === anchorId)?.id ?? null;
+        }, TASK_ID);
+        return windowId;
+      }, { timeout: 5000 }).not.toBeNull();
+
+      const frame = page.locator(`[data-testid="window-frame-${windowId}"]`);
+      await frame.locator('[data-testid="task-detail-dialog"]').waitFor({ state: 'visible', timeout: 5000 });
+
+      // Before the label: the suspended record earns the Resume prompt.
+      await expect(frame.locator('button:has-text("Resume session")')).toBeVisible();
+
+      await emitSpawnProgress(page);
+
+      // The restore is now advertised as in flight...
+      await expect(frame).toContainText(SPAWN_LABEL, { timeout: 5000 });
+      // ...with no manual button competing with it...
+      await expect(frame.locator('button:has-text("Resume session")')).toHaveCount(0);
+      // ...and crucially NOT the outgoing session's terminal, which is what the
+      // branch-order regression painted once 'preparing' started winning.
+      await expect(frame.locator('.xterm')).toHaveCount(0);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/ui/task-detail-archived-no-resume.spec.ts
+++ b/tests/ui/task-detail-archived-no-resume.spec.ts
@@ -1,0 +1,225 @@
+/**
+ * A completed task in Done offers no Resume control.
+ *
+ * Moving a task to Done archives it, suspends its session, and deletes its
+ * worktree. The task detail nevertheless kept offering Resume, and clicking it
+ * recreated that worktree and spawned a live `--resume` agent on a task with no
+ * board card: real quota burn with nothing on the board to notice it. Main now
+ * refuses the resume outright (see tests/unit/session-resume-guard.test.ts), so
+ * the three renderer surfaces must stop offering a control that throws:
+ *
+ *   1. the header Play button (TaskDetailHeader),
+ *   2. the "Resume session" kebab item (TaskDetailKebabItems),
+ *   3. the big centered Play button (TaskDetailBody).
+ *
+ * A suspended task in an ordinary column is checked in the same run as the
+ * control group, so a green result cannot come from a fixture that never
+ * rendered a toggle anywhere.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady, collectPageErrors } from './helpers';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-archived-no-resume';
+
+const ARCHIVED_TASK_ID = 'task-archived-no-resume';
+const ARCHIVED_TASK_TITLE = 'Completed Release Probe';
+const ARCHIVED_SESSION_ID = 'session-archived-no-resume';
+
+const LIVE_TASK_ID = 'task-suspended-control';
+const LIVE_TASK_TITLE = 'Suspended Control Probe';
+const LIVE_SESSION_ID = 'session-suspended-control';
+
+interface StoreWindow {
+  __zustandStores: {
+    session: {
+      getState: () => {
+        setDetailTaskId: (id: string) => void;
+        sessions: Array<{ id: string; taskId: string; status: string }>;
+      };
+    };
+    window: { getState: () => { windows: Record<string, { id: string; anchor: string }> } };
+  };
+}
+
+async function launch(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+  const page = await context.newPage();
+
+  const preConfigScript = `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+      state.projects.push({
+        id: '${PROJECT_ID}',
+        name: 'Archived No Resume Test',
+        path: '/mock/archived-no-resume-test',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        state.swimlanes.push(Object.assign({}, s, {
+          id: 'lane-' + s.name.toLowerCase().replace(/\\s+/g, '-'),
+          position: i,
+          created_at: ts,
+        }));
+      });
+      function makeTask(overrides) {
+        return Object.assign({
+          description: 'Fixture task',
+          position: 0,
+          agent: 'claude',
+          session_id: null,
+          worktree_path: null,
+          branch_name: 'feature/archived-no-resume',
+          pr_number: null,
+          pr_url: null,
+          base_branch: 'main',
+          use_worktree: 1,
+          labels: [],
+          priority: 0,
+          attachment_count: 0,
+          archived_at: null,
+          created_at: ts,
+          updated_at: ts,
+        }, overrides);
+      }
+      function makeSession(overrides) {
+        return Object.assign({
+          projectId: '${PROJECT_ID}',
+          pid: 4242,
+          status: 'suspended',
+          shell: 'bash',
+          cwd: '/mock/archived-no-resume-test',
+          startedAt: ts,
+          exitCode: null,
+          resuming: false,
+        }, overrides);
+      }
+      // Exactly how a completed task looks after the move to Done: archived,
+      // worktree deleted, session_id nulled, but the session record preserved
+      // as 'suspended' so an unarchive into an auto-spawn column can resume it.
+      state.archivedTasks.push(makeTask({
+        id: '${ARCHIVED_TASK_ID}',
+        title: '${ARCHIVED_TASK_TITLE}',
+        swimlane_id: 'lane-done',
+        archived_at: ts,
+      }));
+      state.sessions.push(makeSession({
+        id: '${ARCHIVED_SESSION_ID}',
+        taskId: '${ARCHIVED_TASK_ID}',
+        agentSessionId: 'agent-session-archived',
+      }));
+      // Control group: same suspended session shape, ordinary column, not
+      // archived. This one MUST still offer Resume.
+      state.tasks.push(makeTask({
+        id: '${LIVE_TASK_ID}',
+        title: '${LIVE_TASK_TITLE}',
+        swimlane_id: 'lane-executing',
+        worktree_path: '/mock/archived-no-resume-test/.kangentic/worktrees/control',
+      }));
+      state.sessions.push(makeSession({
+        id: '${LIVE_SESSION_ID}',
+        taskId: '${LIVE_TASK_ID}',
+        agentSessionId: 'agent-session-control',
+      }));
+      return { currentProjectId: '${PROJECT_ID}' };
+    });
+  `;
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(preConfigScript);
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  await page.locator('[data-swimlane-name="Done"]').waitFor({ state: 'visible', timeout: 15000 });
+  return { browser, page };
+}
+
+/** Open a task-detail window the way CompletedTasksDialog's "View Details" row
+ *  action does. An archived task has no board card to click. */
+async function openDetailWindow(page: Page, taskId: string): Promise<string> {
+  await page.evaluate((detailTaskId) => {
+    (window as unknown as StoreWindow).__zustandStores.session.getState().setDetailTaskId(detailTaskId);
+  }, taskId);
+
+  let resolvedWindowId: string | null = null;
+  await expect.poll(async () => {
+    resolvedWindowId = await page.evaluate((anchorId) => {
+      const windows = (window as unknown as StoreWindow).__zustandStores.window.getState().windows;
+      return Object.values(windows).find((candidate) => candidate.anchor === anchorId)?.id ?? null;
+    }, taskId);
+    return resolvedWindowId;
+  }, { timeout: 5000 }).not.toBeNull();
+  return resolvedWindowId as string;
+}
+
+/** The kebab popover is portaled to document.body, so its items are located on
+ *  the page, not inside the window frame. */
+async function openKebab(page: Page, windowId: string): Promise<void> {
+  await page.locator(`[data-testid="window-frame-${windowId}"] button[title="Actions"]`).click();
+  // The menu really opened: an item that is rendered unconditionally, so an
+  // absent toggle below cannot just be a menu that never appeared.
+  await expect(page.locator('[data-testid="view-conversation-btn"]')).toBeVisible({ timeout: 5000 });
+}
+
+/** Close via the trigger, not Escape or an outside click: KebabMenu dismisses on
+ *  outside mousedown only, and an outside click would also light-dismiss the
+ *  window. Leaving a menu open would put two portaled copies on the page. */
+async function closeKebab(page: Page, windowId: string): Promise<void> {
+  await page.locator(`[data-testid="window-frame-${windowId}"] button[title="Actions"]`).click();
+  await expect(page.locator('[data-testid="view-conversation-btn"]')).toHaveCount(0);
+}
+
+test.describe('Task detail for an archived Done task', () => {
+  test('offers no pause/resume toggle, while a suspended task in an ordinary column still does', async () => {
+    const { browser, page } = await launch();
+    const getPageErrors = collectPageErrors(page);
+
+    try {
+      // Precondition: both suspended sessions really are in the renderer store,
+      // so an absent toggle cannot be an unwired fixture.
+      await expect.poll(async () => page.evaluate(() => {
+        const sessions = (window as unknown as StoreWindow).__zustandStores.session.getState().sessions;
+        return sessions.filter((session) => session.status === 'suspended').length;
+      }), { timeout: 5000 }).toBe(2);
+
+      // --- The archived task in Done: no resume surface anywhere ---
+      const archivedWindowId = await openDetailWindow(page, ARCHIVED_TASK_ID);
+      const archivedFrame = page.locator(`[data-testid="window-frame-${archivedWindowId}"]`);
+      await archivedFrame.locator('[data-testid="task-detail-dialog"]').waitFor({ state: 'visible', timeout: 5000 });
+      await expect(archivedFrame.locator('[data-testid="task-title-text"]')).toHaveText(ARCHIVED_TASK_TITLE);
+
+      await expect(archivedFrame.locator('[data-testid="header-toggle-session-btn"]')).toHaveCount(0);
+      await expect(archivedFrame.locator('button:has-text("Resume session")')).toHaveCount(0);
+
+      await openKebab(page, archivedWindowId);
+      await expect(page.locator('[data-testid="toggle-session-btn"]')).toHaveCount(0);
+      await closeKebab(page, archivedWindowId);
+
+      // --- Control: a suspended task in an ordinary column keeps its toggle ---
+      const liveWindowId = await openDetailWindow(page, LIVE_TASK_ID);
+      const liveFrame = page.locator(`[data-testid="window-frame-${liveWindowId}"]`);
+      await liveFrame.locator('[data-testid="task-detail-dialog"]').waitFor({ state: 'visible', timeout: 5000 });
+      await expect(liveFrame.locator('[data-testid="task-title-text"]')).toHaveText(LIVE_TASK_TITLE);
+
+      await expect(liveFrame.locator('[data-testid="header-toggle-session-btn"]')).toBeVisible();
+      await expect(liveFrame.locator('button:has-text("Resume session")')).toBeVisible();
+
+      await openKebab(page, liveWindowId);
+      await expect(page.locator('[data-testid="toggle-session-btn"]')).toHaveCount(1);
+      await closeKebab(page, liveWindowId);
+
+      expect(getPageErrors()).toHaveLength(0);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/unit/done-move-bookkeeping.test.ts
+++ b/tests/unit/done-move-bookkeeping.test.ts
@@ -41,7 +41,13 @@ describe('a move out of Done clears the archive flag it set on the way in', () =
   it('keys the unarchive on the task flag, not the source lane', () => {
     // A legacy archived row parked outside Done must be repaired too, and the
     // guard has to exclude a move WITHIN Done (which keeps its archive).
-    expect(source).toMatch(/task\.archived_at !== null && toLane\?\.role !== 'done'/);
+    //
+    // Truthiness, never `!== null`: a Task assembled without the column carries
+    // `undefined`, which `!== null` reads as archived. That exact slip made the
+    // handler try to unarchive on ordinary moves and shipped as a unit-tier
+    // failure across split-lock-cas.
+    expect(source).toMatch(/Boolean\(task\.archived_at\) && toLane\?\.role !== 'done'/);
+    expect(source).not.toMatch(/task\.archived_at !== null/);
   });
 
   it('uses the placement-free repository method', () => {

--- a/tests/unit/done-move-bookkeeping.test.ts
+++ b/tests/unit/done-move-bookkeeping.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Two symmetry bugs around the Done column, both found while verifying the
+ * Done/archived resume guard. Neither is reachable through the UI, which is why
+ * both survived: the board routes archived cards to TASK_UNARCHIVE and writes
+ * suspend status optimistically, so only main-driven callers saw them.
+ *
+ * 1. `handleTaskMove` archived on the way INTO Done and never unarchived on the
+ *    way out. MCP `move_task` therefore left the task archived in a live column:
+ *    absent from every board query (`archived_at IS NULL`) while holding a
+ *    worktree and, in an auto-spawn column, a running agent. That is the same
+ *    "live agent with no card" state the resume guard exists to prevent.
+ *
+ * 2. `SessionManager.suspend` marked the session suspended, then awaited a
+ *    graceful PTY shutdown (up to 1500ms for a natural exit plus 1500ms for kill
+ *    propagation) BEFORE telling the renderer. The bottom panel's tab set is
+ *    `status === 'running'`, so a task dragged to Done kept a dead terminal
+ *    tabbed for seconds after its card was gone.
+ *
+ * Both are static checks: the first is an absent statement and the second an
+ * ordering, neither of which any type or existing test could catch.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+function readSource(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8');
+}
+
+describe('a move out of Done clears the archive flag it set on the way in', () => {
+  const source = readSource('src/main/ipc/handlers/task-move.ts');
+
+  it('archives into Done and unarchives out of it, in the same handler', () => {
+    expect(source).toContain('tasks.archive(');
+    expect(source).toContain('tasks.clearArchived(');
+  });
+
+  it('keys the unarchive on the task flag, not the source lane', () => {
+    // A legacy archived row parked outside Done must be repaired too, and the
+    // guard has to exclude a move WITHIN Done (which keeps its archive).
+    expect(source).toMatch(/task\.archived_at !== null && toLane\?\.role !== 'done'/);
+  });
+
+  it('uses the placement-free repository method', () => {
+    // `unarchive()` also rewrites swimlane_id and position, which would fight
+    // `move()`'s own sibling reordering earlier in the same tick.
+    const repository = readSource('src/main/db/repositories/task-repository.ts');
+    expect(repository).toMatch(/clearArchived\(id: string\): void/);
+    expect(repository).toMatch(/UPDATE tasks SET archived_at = NULL, updated_at = \? WHERE id = \?/);
+  });
+});
+
+describe('suspend announces before it waits, not after', () => {
+  const source = readSource('src/main/pty/session-manager.ts');
+  const suspendBody = source.slice(source.indexOf('async suspend(sessionId: string)'));
+
+  it('emits session-changed between marking suspended and the graceful shutdown', () => {
+    const marked = suspendBody.indexOf("session.status = 'suspended'");
+    const firstEmit = suspendBody.indexOf("this.emit('session-changed'", marked);
+    const shutdown = suspendBody.indexOf('await gracefulPtyShutdown(');
+
+    expect(marked).toBeGreaterThan(-1);
+    expect(shutdown).toBeGreaterThan(-1);
+    expect(firstEmit).toBeGreaterThan(marked);
+    // The whole point: the renderer hears about it BEFORE the up-to-3s wait.
+    expect(firstEmit).toBeLessThan(shutdown);
+  });
+
+  it('still emits after the shutdown, so the recovered session id is published', () => {
+    const shutdown = suspendBody.indexOf('await gracefulPtyShutdown(');
+    const trailingEmit = suspendBody.indexOf("this.emit('session-changed'", shutdown);
+    expect(trailingEmit).toBeGreaterThan(shutdown);
+  });
+});
+
+describe('the panel tab set is what makes the emit ordering matter', () => {
+  it('still keys visible tabs on running status', () => {
+    // If this ever stops being the predicate, the ordering guarantee above is
+    // guarding the wrong thing and this file should be revisited.
+    const source = readSource('src/renderer/utils/panel-sessions.ts');
+    expect(source).toMatch(/session\.status === 'running'/);
+  });
+});

--- a/tests/unit/prepare-spawn-resume-conversation-guard.test.ts
+++ b/tests/unit/prepare-spawn-resume-conversation-guard.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for the resume-conversation-absent downgrade WIRING inside
+ * prepareAgentSpawn (src/main/transition-engine/session-startup/prepare-spawn.ts),
+ * the STARTUP spawn chokepoint (crash recovery / auto-spawn reconcile).
+ *
+ * isResumeConversationAbsent itself is fully unit-tested in
+ * tests/unit/resume-conversation-guard.test.ts. The board-move chokepoint's own
+ * wiring (executeSpawnAgent in transition-engine.ts) is covered by the
+ * "resume downgraded to fresh..." describe block added to
+ * transition-engine.test.ts in the same change. But transition-engine.ts and
+ * prepare-spawn.ts are two INDEPENDENT implementations of the same guard - the
+ * board path re-resolves via resolveSpawnIntent (a different prompt on the
+ * fresh branch), while the startup path (this file) has no spawn-intent
+ * resolver at all and just flips a local `canResume` boolean, since a startup
+ * recovery spawn carries no prompt to begin with (skipPromptTemplate is
+ * implicit: `commandOptions.prompt` is always `undefined` here). Per
+ * .claude/rules/spawn-entry-point-parity.md, both chokepoints have to apply the
+ * same guard - and before this file, only ONE of the two had any test
+ * exercising the downgrade actually firing (verified by grep: no
+ * resume-suspended / session-auto-resume test configures
+ * `adapter.runtime.statusFile`, so the block was structurally unreachable in
+ * every existing test for this chokepoint).
+ *
+ * Deliberately does NOT test the conversation-lineage walk (multiple
+ * recordIds): prepare-spawn.ts's own comment says startup recovery holds only
+ * the record it is recovering and has no repository handle to walk the
+ * lineage, so it always passes a single-element `recordIds` array. Asserting a
+ * lineage walk here would be pinning a contract this call site does not
+ * implement.
+ *
+ * Uses a REAL mkdtemp projectPath (matches prepare-spawn-resume-reconcile.test.ts)
+ * because isResumeConversationAbsent reads a real status.json from disk.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AppConfig, Swimlane, Task } from '../../src/shared/types';
+import { ClaudeStatusParser } from '../../src/main/agent/adapters/claude/status-parser';
+
+const buildCommandMock = vi.fn((options: { sessionId?: string; resume?: boolean }) =>
+  `claude ${options.resume ? `--resume ${options.sessionId ?? ''}` : `--session-id ${options.sessionId ?? ''}`}`);
+const locateSessionHistoryFileMock = vi.fn(async (_agentSessionId: string, _cwd: string): Promise<string | null> => null);
+
+const adapter = {
+  name: 'claude',
+  displayName: 'Claude',
+  sessionType: 'claude_agent',
+  supportsCallerSessionId: true,
+  detect: vi.fn(async () => ({ found: true, path: '/mock/bin/claude', version: '1.0.0' })),
+  ensureTrust: vi.fn(async () => {}),
+  buildCommand: buildCommandMock,
+  locateSessionHistoryFile: locateSessionHistoryFileMock,
+  // The REAL Claude status parser, not a stub - isResumeConversationAbsent's
+  // decision depends on the actual hadTurns / transcriptPath derivation
+  // (contextWindow + cost fields), which a `{ sessionId }`-only stub (as used
+  // in prepare-spawn-resume-reconcile.test.ts, which never exercises this
+  // guard) cannot produce.
+  runtime: { statusFile: { parseStatus: ClaudeStatusParser.parseStatus } },
+};
+
+vi.mock('../../src/main/agent/agent-registry', () => ({
+  agentRegistry: {
+    get: vi.fn((agentName: string) => (agentName === 'claude' ? adapterRef : undefined)),
+  },
+}));
+
+// Referenced from the vi.mock factory above (hoisted), so declared via
+// module scope after the mock declaration runs.
+const adapterRef = adapter;
+
+import { prepareAgentSpawn } from '../../src/main/transition-engine/session-startup/prepare-spawn';
+
+const TASK_ID = 'task-startup-downgrade-001';
+const LANE_ID = 'lane-main';
+const RECORD_ID = 'startup-poisoned-record-1';
+const STORED_ID = 'stored-agent-session-id-startup';
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  const merged = {
+    id: TASK_ID,
+    display_id: 1,
+    title: 'Startup recovery task',
+    description: 'Recover me',
+    swimlane_id: LANE_ID,
+    position: 0,
+    // Non-null task.agent + run_mode 'column_settings': not a first-ever
+    // spawn, so lockAdvancedOverridesOnFirstSpawn is a no-op and this file's
+    // assertions stay focused on the downgrade wiring.
+    agent: 'claude',
+    agent_override: null,
+    model_override: null,
+    effort_override: null,
+    permission_mode: null,
+    run_mode: 'column_settings',
+    session_id: null,
+    worktree_path: null,
+    branch_name: null,
+    pr_number: null,
+    pr_url: null,
+    base_branch: null,
+    use_worktree: null,
+    labels: [],
+    priority: 0,
+    attachment_count: 0,
+    archived_at: null,
+    created_at: '2025-01-01T00:00:00.000Z',
+    updated_at: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+  return merged as Task;
+}
+
+function makeSwimlane(overrides: Partial<Swimlane> = {}): Swimlane {
+  return {
+    id: LANE_ID,
+    name: 'Main',
+    role: null,
+    position: 0,
+    color: '#888',
+    icon: null,
+    is_archived: false,
+    is_ghost: false,
+    permission_mode: null,
+    auto_spawn: true,
+    auto_command: null,
+    plan_exit_target_id: null,
+    agent_override: null,
+    model_override: null,
+    effort_override: null,
+    handoff_context: false,
+    session_target: 'main',
+    session_spawn_strategy: 'create_or_resume',
+    created_at: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  } as Swimlane;
+}
+
+function makeEffectiveConfig(): AppConfig {
+  return {
+    agent: {
+      permissionMode: 'acceptEdits',
+      cliPaths: {},
+    },
+    mcpServer: { enabled: false },
+  } as unknown as AppConfig;
+}
+
+describe('prepareAgentSpawn downgrades a resume to fresh when the conversation was never persisted (startup chokepoint)', () => {
+  let projectPath: string;
+
+  /** The exact reported state a session that ended before its first turn
+   * leaves behind: a named transcript_path that was never written, and zero
+   * cost/token usage. Mirrors resume-conversation-guard.test.ts's and
+   * transition-engine.test.ts's identical fixture, which pins that this shape
+   * makes isResumeConversationAbsent resolve true. */
+  function writeEmptyStatusFile(recordId: string): void {
+    const sessionDir = path.join(projectPath, '.kangentic', 'sessions', recordId);
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionDir, 'status.json'), JSON.stringify({
+      session_id: STORED_ID,
+      transcript_path: path.join(projectPath, 'history', `${STORED_ID}.jsonl`),
+      model: { id: 'claude-haiku-4-5-20251001', display_name: 'Haiku 4.5' },
+      cost: { total_cost_usd: 0, total_duration_ms: 1200, total_api_duration_ms: 0 },
+      context_window: {
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        context_window_size: 200000,
+        current_usage: null,
+        used_percentage: null,
+      },
+    }));
+  }
+
+  /** The report a conversation that actually had a turn leaves behind: nonzero
+   * cost, and (for this test) a transcript that really exists on disk. Used to
+   * prove the guard is not just always-downgrading. */
+  function writeRealConversationStatusFile(recordId: string): string {
+    const sessionDir = path.join(projectPath, '.kangentic', 'sessions', recordId);
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const transcriptPath = path.join(projectPath, 'history', `${STORED_ID}.jsonl`);
+    fs.mkdirSync(path.dirname(transcriptPath), { recursive: true });
+    fs.writeFileSync(transcriptPath, '{"type":"user","message":"hi"}\n');
+    fs.writeFileSync(path.join(sessionDir, 'status.json'), JSON.stringify({
+      session_id: STORED_ID,
+      transcript_path: transcriptPath,
+      model: { id: 'claude-haiku-4-5-20251001', display_name: 'Haiku 4.5' },
+      cost: { total_cost_usd: 0.02, total_duration_ms: 4000, total_api_duration_ms: 1200 },
+      context_window: {
+        total_input_tokens: 400,
+        total_output_tokens: 120,
+        context_window_size: 200000,
+        current_usage: null,
+        used_percentage: null,
+      },
+    }));
+    return transcriptPath;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    buildCommandMock.mockImplementation((options: { sessionId?: string; resume?: boolean }) =>
+      `claude ${options.resume ? `--resume ${options.sessionId ?? ''}` : `--session-id ${options.sessionId ?? ''}`}`);
+    locateSessionHistoryFileMock.mockResolvedValue(null);
+    projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'kangentic-prepare-spawn-downgrade-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  async function runPrepare() {
+    const sessionRepo = { updateAgentSessionId: vi.fn() };
+    const tasksUpdate = vi.fn();
+    const result = await prepareAgentSpawn({
+      task: makeTask(),
+      swimlane: makeSwimlane(),
+      cwd: projectPath,
+      projectId: 'proj-123',
+      projectPath,
+      effectiveConfig: makeEffectiveConfig(),
+      projectDefaultAgent: 'claude',
+      projectDefaultModel: null,
+      projectDefaultEffort: null,
+      resolvedShell: 'bash',
+      mcpServerHandle: null,
+      resume: { agentSessionId: STORED_ID, recordId: RECORD_ID },
+      sessionRepo,
+      hasSessionRecord: true,
+      tasks: { update: tasksUpdate },
+    });
+    return { result, sessionRepo };
+  }
+
+  it('downgrades to fresh: a new agent session id, resume=false on the built command, and no id-reconcile attempt', async () => {
+    writeEmptyStatusFile(RECORD_ID);
+
+    const { result, sessionRepo } = await runPrepare();
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // Red: reverting the downgrade block (or inverting its condition) leaves
+    // canResume=true, so this stays STORED_ID instead of a freshly generated one.
+    expect(result.data.agentSessionId).not.toBe(STORED_ID);
+    // Claude accepts caller-specified ids, so the fresh branch still generates
+    // a real one rather than leaving it null.
+    expect(result.data.agentSessionId).toMatch(/^[0-9a-f-]{36}$/);
+
+    expect(buildCommandMock).toHaveBeenCalledTimes(1);
+    const commandOptions = buildCommandMock.mock.calls[0][0] as { resume?: boolean; sessionId?: string };
+    expect(commandOptions.resume).toBe(false);
+    expect(commandOptions.sessionId).not.toBe(STORED_ID);
+
+    // The reconcile branch (reconcileResumeAgentSessionId) is only reached
+    // when canResume stays true - the downgrade must skip it entirely, not
+    // just discard its result.
+    expect(locateSessionHistoryFileMock).not.toHaveBeenCalled();
+    expect(sessionRepo.updateAgentSessionId).not.toHaveBeenCalled();
+  });
+
+  it('does NOT downgrade a resume whose conversation actually has turns, even though the same record id is probed', async () => {
+    const transcriptPath = writeRealConversationStatusFile(RECORD_ID);
+    expect(fs.existsSync(transcriptPath)).toBe(true);
+
+    const { result, sessionRepo } = await runPrepare();
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // The stored id survives (reconciled, since locateSessionHistoryFileMock
+    // resolves null by default in beforeEach - keeping the stored id unchanged
+    // is reconcileResumeAgentSessionId's own "not found" contract, not this
+    // guard's concern).
+    expect(result.data.agentSessionId).toBe(STORED_ID);
+
+    const commandOptions = buildCommandMock.mock.calls[0][0] as { resume?: boolean; sessionId?: string };
+    expect(commandOptions.resume).toBe(true);
+    expect(commandOptions.sessionId).toBe(STORED_ID);
+    expect(sessionRepo.updateAgentSessionId).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/resume-conversation-guard.test.ts
+++ b/tests/unit/resume-conversation-guard.test.ts
@@ -315,8 +315,33 @@ describe('both spawn chokepoints apply the downgrade', () => {
   ])('%s calls isResumeConversationAbsent', (relativePath) => {
     const source = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
     expect(source).toContain('isResumeConversationAbsent(');
-    // The downgrade has to be able to flip the decision, so the flag cannot be
-    // a `const` initialized from the resolver alone.
-    expect(source).toMatch(/let canResume/);
+  });
+
+  it('the board path re-resolves the intent instead of clearing a flag', () => {
+    // A `let canResume` that the guard flips to false is NOT enough, and asserting
+    // only that the `let` exists cannot tell the difference: the declaration alone
+    // satisfies it, so deleting the downgrade passed. Worse, flipping the flag
+    // leaves `intent.prompt` on the RESUME branch's value (`resumePrompt`,
+    // undefined for an ordinary task spawn), so the fresh spawn it produces comes
+    // up with no task prompt - itself a zero-turn conversation, which is exactly
+    // what this guard downgrades. Only re-running the resolver forceFresh takes
+    // the fresh branch's interpolated promptTemplate with it.
+    const source = fs.readFileSync(
+      path.join(repoRoot, 'src/main/transition-engine/transition-engine.ts'), 'utf8',
+    );
+    expect(source).toMatch(/resolveSpawnIntent\(\{ \.\.\.spawnIntentOptions, forceFresh: true \}\)/);
+    // And the decision is then READ from the re-resolved intent, not a stale flag.
+    expect(source).toMatch(/const canResume = intent\.mode === 'resume'/);
+  });
+
+  it('startup recovery is structurally promptless, so it only needs the flag', () => {
+    // prepare-spawn.ts passes `prompt: undefined` unconditionally - a recovered
+    // session never carries one - so there is no fresh-branch prompt for a
+    // downgrade to lose there. If that ever changes, this file's board-path
+    // re-resolve has to be mirrored into it.
+    const source = fs.readFileSync(
+      path.join(repoRoot, 'src/main/transition-engine/session-startup/prepare-spawn.ts'), 'utf8',
+    );
+    expect(source).toMatch(/prompt: undefined/);
   });
 });

--- a/tests/unit/resume-conversation-guard.test.ts
+++ b/tests/unit/resume-conversation-guard.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Guard against resuming a conversation the agent never persisted.
+ *
+ * Reproduced on a real board in seconds: drag a task out of Done (the recovery
+ * move spawns command-free, so the agent boots idle with nothing to do), drag it
+ * back before typing, then drag it out again. Kangentic pre-specifies
+ * `--session-id` and persists it AT SPAWN TIME, so the never-used id looks
+ * resumable forever. Every later entry into an auto-spawn column issued
+ * `--resume <id>`, the CLI answered "No conversation found with session ID", and
+ * the user landed on a bare shell with the record still reading `running`.
+ *
+ * The status fixtures below are trimmed from the real captured file of that
+ * session (Claude Code 2.1.233): `current_usage: null`, zero totals, and a
+ * `transcript_path` naming a file the CLI never wrote.
+ *
+ * The predicate has to stay narrower than the `canResumeSession` guard that was
+ * built and deliberately reverted in #255, whose false misses silently
+ * destroyed real conversations. These tests pin the three properties that keep
+ * it narrow: the path comes from the agent's own report, a conversation with
+ * turns is NEVER downgraded, and absence of evidence always degrades to today's
+ * resume behavior.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { isResumeConversationAbsent } from '../../src/main/transition-engine/resume-conversation-guard';
+import { ClaudeStatusParser } from '../../src/main/agent/adapters/claude/status-parser';
+import type { AgentAdapter } from '../../src/main/agent/agent-adapter';
+
+const RECORD_ID = '6fc5d715-77ca-47d6-9c50-8f27ad05e4a7';
+const AGENT_SESSION_ID = '935a5611-0f79-4f34-a5ea-62f2a4bd7894';
+
+let projectPath: string;
+let transcriptPath: string;
+
+beforeEach(() => {
+  projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'kng-resume-guard-'));
+  transcriptPath = path.join(projectPath, 'history', `${AGENT_SESSION_ID}.jsonl`);
+});
+
+afterEach(() => {
+  fs.rmSync(projectPath, { recursive: true, force: true });
+});
+
+/** An adapter shaped like Claude's: a status pipeline that parses real status JSON. */
+function adapterWithStatusPipeline(): AgentAdapter {
+  return {
+    runtime: { statusFile: { parseStatus: ClaudeStatusParser.parseStatus } },
+  } as unknown as AgentAdapter;
+}
+
+/** Codex, Aider, and friends: no status file, so nothing to probe. */
+function adapterWithoutStatusPipeline(): AgentAdapter {
+  return { runtime: {} } as unknown as AgentAdapter;
+}
+
+function writeStatusFile(options: {
+  includeTranscriptPath?: boolean;
+  usedPercentage?: number | null;
+  currentUsage?: Record<string, number> | null;
+  totalCostUsd?: number;
+  raw?: string;
+}): void {
+  const sessionDir = path.join(projectPath, '.kangentic', 'sessions', RECORD_ID);
+  fs.mkdirSync(sessionDir, { recursive: true });
+  const contents = options.raw ?? JSON.stringify({
+    session_id: AGENT_SESSION_ID,
+    ...(options.includeTranscriptPath === false ? {} : { transcript_path: transcriptPath }),
+    model: { id: 'claude-haiku-4-5-20251001', display_name: 'Haiku 4.5' },
+    cost: { total_cost_usd: options.totalCostUsd ?? 0, total_duration_ms: 1388, total_api_duration_ms: 0 },
+    context_window: {
+      total_input_tokens: options.currentUsage ? 4200 : 0,
+      total_output_tokens: 0,
+      context_window_size: 200000,
+      current_usage: options.currentUsage ?? null,
+      used_percentage: options.usedPercentage ?? null,
+    },
+  });
+  fs.writeFileSync(path.join(sessionDir, 'status.json'), contents, 'utf8');
+}
+
+describe('isResumeConversationAbsent - downgrades only a provably empty conversation', () => {
+  it('reports absent when the agent recorded no turns and never wrote the transcript it named', async () => {
+    // The exact reported state: booted, zero turns, transcript path named but no file.
+    writeStatusFile({});
+    expect(fs.existsSync(transcriptPath)).toBe(false);
+
+    await expect(isResumeConversationAbsent({
+      adapter: adapterWithStatusPipeline(),
+      recordIds: [RECORD_ID],
+      projectPath,
+    })).resolves.toBe(true);
+  });
+
+  it('resumes when the named transcript exists, even with no turns recorded yet', async () => {
+    writeStatusFile({});
+    fs.mkdirSync(path.dirname(transcriptPath), { recursive: true });
+    fs.writeFileSync(transcriptPath, '{"type":"user"}\n', 'utf8');
+
+    await expect(isResumeConversationAbsent({
+      adapter: adapterWithStatusPipeline(),
+      recordIds: [RECORD_ID],
+      projectPath,
+    })).resolves.toBe(false);
+  });
+});
+
+describe('isResumeConversationAbsent - falls back to the SessionStart hook', () => {
+  // The status line only runs once the TUI is up, so a CLI killed in its first
+  // second leaves none and used to blind the whole lineage. The SessionStart
+  // hook fires far earlier and carries the same `transcript_path`. Lines below
+  // are the real captured shape: the payload is a JSON STRING under hookContext.
+  function writeEventsFile(lines: string[]): void {
+    const sessionDir = path.join(projectPath, '.kangentic', 'sessions', RECORD_ID);
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionDir, 'events.jsonl'), lines.join('\n') + '\n', 'utf8');
+  }
+
+  const sessionStartLine = () => JSON.stringify({
+    ts: 1786997736868,
+    type: 'session_start',
+    hookContext: JSON.stringify({
+      session_id: AGENT_SESSION_ID,
+      transcript_path: transcriptPath,
+      hook_event_name: 'SessionStart',
+      source: 'startup',
+    }),
+  });
+
+  it('reports absent from a start/end-only events file with no transcript on disk', () => {
+    writeEventsFile([sessionStartLine(), JSON.stringify({ ts: 1786997738763, type: 'session_end' })]);
+
+    return expect(isResumeConversationAbsent({
+      adapter: adapterWithStatusPipeline(),
+      recordIds: [RECORD_ID],
+      projectPath,
+    })).resolves.toBe(true);
+  });
+
+  it('resumes when the events file shows any real turn', async () => {
+    // Anything beyond the two lifecycle markers counts as a turn, so a prompt,
+    // a tool call, or an idle all keep today's behavior.
+    for (const turnEvent of ['user_prompt', 'tool_start', 'idle']) {
+      writeEventsFile([sessionStartLine(), JSON.stringify({ ts: 1786997737000, type: turnEvent })]);
+      await expect(isResumeConversationAbsent({
+        adapter: adapterWithStatusPipeline(),
+        recordIds: [RECORD_ID],
+        projectPath,
+      })).resolves.toBe(false);
+    }
+  });
+
+  it('resumes when the events file carries no SessionStart payload (the mocked-CLI shape)', async () => {
+    // mock-claude writes activity events with no session_start hook payload.
+    writeEventsFile([JSON.stringify({ ts: 1786997737000, type: 'session_start' })]);
+    await expect(isResumeConversationAbsent({
+      adapter: adapterWithStatusPipeline(),
+      recordIds: [RECORD_ID],
+      projectPath,
+    })).resolves.toBe(false);
+  });
+
+  it('prefers the status line when both reports exist', async () => {
+    // Status says the conversation had turns; the events file alone would have
+    // said otherwise. The richer report wins and the conversation is kept.
+    writeEventsFile([sessionStartLine(), JSON.stringify({ ts: 1786997738763, type: 'session_end' })]);
+    writeStatusFile({ currentUsage: { input_tokens: 4200, output_tokens: 130, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 } });
+
+    await expect(isResumeConversationAbsent({
+      adapter: adapterWithStatusPipeline(),
+      recordIds: [RECORD_ID],
+      projectPath,
+    })).resolves.toBe(false);
+  });
+
+  it('tolerates a torn final line', async () => {
+    writeEventsFile([sessionStartLine(), '{"ts":1786997738763,"type":"sess']);
+    await expect(isResumeConversationAbsent({
+      adapter: adapterWithStatusPipeline(),
+      recordIds: [RECORD_ID],
+      projectPath,
+    })).resolves.toBe(true);
+  });
+});
+
+describe('isResumeConversationAbsent - heals an already-poisoned lineage', () => {
+  // A failed resume is self-perpetuating: the CLI dies before its status line
+  // runs, so THAT record has no status file, and the next spawn retires it and
+  // finds no evidence either. The observed board had three records sharing one
+  // agent_session_id, and only the first (the original empty session) carried a
+  // status report. Probing the retiring record alone leaves such a task stuck
+  // forever, which is why the guard walks the whole conversation.
+  const DEAD_RESUME_RECORD_ID = '2fec0dab-99d2-407a-8782-2a748dfc935e';
+
+  it('finds the proof on an older record when the retiring one wrote no status file', async () => {
+    writeStatusFile({});
+    // The newest record's session dir exists but holds no status.json, exactly
+    // as the failed resumes left it.
+    fs.mkdirSync(path.join(projectPath, '.kangentic', 'sessions', DEAD_RESUME_RECORD_ID), { recursive: true });
+
+    await expect(isResumeConversationAbsent({
+      adapter: adapterWithStatusPipeline(),
+      recordIds: [DEAD_RESUME_RECORD_ID, RECORD_ID],
+      projectPath,
+    })).resolves.toBe(true);
+  });
+
+  it('still resumes when no record in the lineage has a status file', async () => {
+    await expect(isResumeConversationAbsent({
+      adapter: adapterWithStatusPipeline(),
+      recordIds: [DEAD_RESUME_RECORD_ID, RECORD_ID],
+      projectPath,
+    })).resolves.toBe(false);
+  });
+});
+
+describe('isResumeConversationAbsent - never discards a conversation that had turns', () => {
+  // This is the #255 failure mode. A session with turns keeps today's resume
+  // behavior no matter what the file check would say, because its transcript
+  // may simply have moved (a worktree rename migrates the per-cwd history, so
+  // an older status report can name a stale path).
+  it('resumes when token usage was recorded, even though the named transcript is missing', async () => {
+    writeStatusFile({ currentUsage: { input_tokens: 4200, output_tokens: 130, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 } });
+    expect(fs.existsSync(transcriptPath)).toBe(false);
+
+    await expect(isResumeConversationAbsent({
+      adapter: adapterWithStatusPipeline(),
+      recordIds: [RECORD_ID],
+      projectPath,
+    })).resolves.toBe(false);
+  });
+
+  it('resumes when cost was recorded but current_usage has already been cleared', async () => {
+    writeStatusFile({ totalCostUsd: 0.42 });
+
+    await expect(isResumeConversationAbsent({
+      adapter: adapterWithStatusPipeline(),
+      recordIds: [RECORD_ID],
+      projectPath,
+    })).resolves.toBe(false);
+  });
+
+  it('resumes when only used_percentage survives (no current_usage block)', async () => {
+    // parseStatus estimates usedTokens from used_percentage when current_usage
+    // is absent, which is the shape of a very early status update mid-turn.
+    writeStatusFile({ usedPercentage: 12 });
+
+    await expect(isResumeConversationAbsent({
+      adapter: adapterWithStatusPipeline(),
+      recordIds: [RECORD_ID],
+      projectPath,
+    })).resolves.toBe(false);
+  });
+});
+
+describe('isResumeConversationAbsent - absence of evidence is never evidence', () => {
+  it('resumes when no status file was ever written (the mocked-CLI path)', async () => {
+    // mock-claude writes no status.json. This is exactly the case that broke
+    // ten session-resume E2E specs when #255 gated on a computed path instead.
+    await expect(isResumeConversationAbsent({
+      adapter: adapterWithStatusPipeline(),
+      recordIds: [RECORD_ID],
+      projectPath,
+    })).resolves.toBe(false);
+  });
+
+  it('resumes when the adapter has no status pipeline at all', async () => {
+    writeStatusFile({});
+
+    await expect(isResumeConversationAbsent({
+      adapter: adapterWithoutStatusPipeline(),
+      recordIds: [RECORD_ID],
+      projectPath,
+    })).resolves.toBe(false);
+  });
+
+  it('resumes when the status file is malformed', async () => {
+    writeStatusFile({ raw: 'not json {' });
+
+    await expect(isResumeConversationAbsent({
+      adapter: adapterWithStatusPipeline(),
+      recordIds: [RECORD_ID],
+      projectPath,
+    })).resolves.toBe(false);
+  });
+
+  it('resumes when the status report carries no transcript path', async () => {
+    writeStatusFile({ includeTranscriptPath: false });
+
+    await expect(isResumeConversationAbsent({
+      adapter: adapterWithStatusPipeline(),
+      recordIds: [RECORD_ID],
+      projectPath,
+    })).resolves.toBe(false);
+  });
+
+  it('resumes when the record id or project path is unknown', async () => {
+    const adapter = adapterWithStatusPipeline();
+    await expect(isResumeConversationAbsent({ adapter, recordIds: [null], projectPath })).resolves.toBe(false);
+    await expect(isResumeConversationAbsent({ adapter, recordIds: [RECORD_ID], projectPath: null })).resolves.toBe(false);
+  });
+});
+
+describe('both spawn chokepoints apply the downgrade', () => {
+  // The board path (transition-engine) is where the reported bug fired; startup
+  // recovery reaches the same dead --resume after a crash. A guard on only one
+  // of them is the drift this check exists to stop.
+  const repoRoot = path.resolve(__dirname, '../..');
+
+  it.each([
+    ['src/main/transition-engine/transition-engine.ts'],
+    ['src/main/transition-engine/session-startup/prepare-spawn.ts'],
+  ])('%s calls isResumeConversationAbsent', (relativePath) => {
+    const source = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+    expect(source).toContain('isResumeConversationAbsent(');
+    // The downgrade has to be able to flip the decision, so the flag cannot be
+    // a `const` initialized from the resolver alone.
+    expect(source).toMatch(/let canResume/);
+  });
+});

--- a/tests/unit/retrieval-service-finalize-debounce.test.ts
+++ b/tests/unit/retrieval-service-finalize-debounce.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for retrievalService's per-session finalize (suspend / exit)
+ * debounce.
+ *
+ * `SessionManager.suspend` emits `session-changed` TWICE for one suspend: once
+ * immediately when the status is marked, and again after `gracefulPtyShutdown`
+ * - up to `gracePeriodMs` (1500) + `killPropagationMs` (1500) = 3000ms later
+ * when the agent needs a force-kill. Without a per-session trailing debounce,
+ * each report booked its own `ConversationIndexer.indexSession` pass over the
+ * same transcript. `scheduleFinalizeIndex` (module-private in
+ * retrieval-service.ts) fixes this with a per-session timer keyed in the
+ * `finalizeIndexTimers` map, keeping only the LAST report - which is also the
+ * more correct read, since the later a finalize runs, the more of the agent's
+ * final flush it sees.
+ *
+ * These tests drive the real `retrievalService.attach(context)` seam (a fake
+ * EventEmitter-backed sessionManager firing 'exit' / 'session-changed', under
+ * `vi.useFakeTimers()`) rather than reimplementing the debounce, so they pin
+ * the shipped wiring, not a parallel model of it.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { IpcContext } from '../../src/main/ipc/ipc-context';
+
+// retrieval-service.ts's other direct imports that would otherwise drag in
+// electron (vec-extension.ts) or a native module built for Electron's Node
+// ABI (better-sqlite3, via db/database.ts) - neither is exercised by the
+// finalize-debounce path, so both are stubbed rather than pulled in for real.
+vi.mock('../../src/main/db/database', () => ({ getProjectDb: vi.fn(() => ({})) }));
+vi.mock('../../src/main/retrieval/vec-extension', () => ({
+  lastVecLoadError: vi.fn(() => null),
+  loadVecExtension: vi.fn(() => false),
+}));
+
+const conversationIndexerMock = vi.hoisted(() => ({
+  indexSession: vi.fn(async () => ({})),
+}));
+vi.mock('../../src/main/retrieval/conversation/conversation-indexer', () => ({
+  ConversationIndexer: class {
+    indexSession = conversationIndexerMock.indexSession;
+  },
+}));
+
+const embedEngineMock = vi.hoisted(() => ({
+  attach: vi.fn(),
+  markDirty: vi.fn(),
+  dispose: vi.fn(),
+  getEmbedder: vi.fn(() => null),
+  reconcile: vi.fn(),
+  activeDevice: null as string | null,
+  workerCrashed: false,
+}));
+vi.mock('../../src/main/retrieval/embedder/embed-engine', () => ({
+  embedEngine: embedEngineMock,
+}));
+
+/** Minimal fake of the SessionManager surface scheduleFinalizeIndex reads:
+ *  a real EventEmitter (so `.on('exit'|'session-changed', ...)` wiring in
+ *  `attach()` is exercised as written) plus the two lookups the debounced
+ *  timer body performs before indexing. */
+class FakeSessionManager extends EventEmitter {
+  private readonly projectIdBySession = new Map<string, string>();
+
+  registerSession(sessionId: string, projectId: string): void {
+    this.projectIdBySession.set(sessionId, projectId);
+  }
+
+  getSession(_sessionId: string): { transient: boolean } {
+    return { transient: false };
+  }
+
+  getSessionProjectId(sessionId: string): string | undefined {
+    return this.projectIdBySession.get(sessionId);
+  }
+}
+
+function makeContext(sessionManager: FakeSessionManager): IpcContext {
+  return {
+    sessionManager,
+    configManager: { load: () => ({ memory: { indexingEnabled: true } }) },
+    currentProjectId: null,
+  } as unknown as IpcContext;
+}
+
+describe('retrievalService - per-session finalize debounce', () => {
+  let retrievalService: typeof import('../../src/main/retrieval/retrieval-service')['retrievalService'];
+  let sessionManager: FakeSessionManager;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    // The module holds `attached` / `disposed` / `finalizeIndexTimers` as
+    // singleton state with no reset hook, so each test gets a fresh module
+    // instance via resetModules + a fresh dynamic import, rather than relying
+    // on cross-test ordering around dispose().
+    vi.resetModules();
+    ({ retrievalService } = await import('../../src/main/retrieval/retrieval-service'));
+    sessionManager = new FakeSessionManager();
+  });
+
+  afterEach(() => {
+    retrievalService.dispose();
+    vi.useRealTimers();
+  });
+
+  it('coalesces two finalize reports for the SAME session (one suspend, reported twice) into exactly one indexSession call', async () => {
+    const context = makeContext(sessionManager);
+    retrievalService.attach(context);
+    sessionManager.registerSession('sess-1', 'proj-1');
+
+    // First report: SessionManager.suspend's immediate `session-changed`.
+    sessionManager.emit('session-changed', 'sess-1', { status: 'suspended' });
+
+    // The worst-case gap documented on FINALIZE_DEBOUNCE_MS: gracePeriodMs
+    // (1500) + killPropagationMs (1500) = up to 3000ms before the trailing
+    // report arrives. Advancing to just under that proves the debounce
+    // window survives it - a regression back to the old 2000ms would already
+    // have fired the first timer (and called indexSession) by this point.
+    await vi.advanceTimersByTimeAsync(2900);
+    expect(conversationIndexerMock.indexSession).not.toHaveBeenCalled();
+
+    // Second report: the trailing `session-changed` after gracefulPtyShutdown.
+    sessionManager.emit('session-changed', 'sess-1', { status: 'suspended' });
+
+    // Comfortably longer than the debounce window from this reset point.
+    await vi.advanceTimersByTimeAsync(4000);
+
+    expect(conversationIndexerMock.indexSession).toHaveBeenCalledTimes(1);
+    expect(conversationIndexerMock.indexSession).toHaveBeenCalledWith('proj-1', 'sess-1');
+    expect(embedEngineMock.markDirty).toHaveBeenCalledTimes(1);
+    expect(embedEngineMock.markDirty).toHaveBeenCalledWith('proj-1');
+  });
+
+  it('debounces per session, not globally: two DIFFERENT sessions each get their own indexSession call', async () => {
+    const context = makeContext(sessionManager);
+    retrievalService.attach(context);
+    sessionManager.registerSession('sess-a', 'proj-a');
+    sessionManager.registerSession('sess-b', 'proj-b');
+
+    // Exercises both finalize hooks attach() wires: a suspend (session-changed)
+    // for one session and a clean exit for the other.
+    sessionManager.emit('session-changed', 'sess-a', { status: 'suspended' });
+    sessionManager.emit('exit', 'sess-b');
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(conversationIndexerMock.indexSession).toHaveBeenCalledTimes(2);
+    expect(conversationIndexerMock.indexSession).toHaveBeenCalledWith('proj-a', 'sess-a');
+    expect(conversationIndexerMock.indexSession).toHaveBeenCalledWith('proj-b', 'sess-b');
+  });
+
+  it('dispose() clears pending finalize timers so no indexing pass fires afterward', async () => {
+    const context = makeContext(sessionManager);
+    retrievalService.attach(context);
+    sessionManager.registerSession('sess-1', 'proj-1');
+
+    sessionManager.emit('session-changed', 'sess-1', { status: 'suspended' });
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    retrievalService.dispose();
+
+    // The distinguishing assertion: the pending finalize timer must actually be
+    // CLEARED (clearTimeout), not merely left to fire and no-op against the
+    // `disposed` flag its own callback checks - that flag guard would mask a
+    // regression that dropped dispose()'s `finalizeIndexTimers` cleanup, since
+    // indexSession would still never be called either way.
+    expect(vi.getTimerCount()).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(conversationIndexerMock.indexSession).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/session-display-state.test.ts
+++ b/tests/unit/session-display-state.test.ts
@@ -188,8 +188,17 @@ describe('display-kind classifiers are total', () => {
     expect(taskDetailSurfaceFor('preparing')).toBe('launch-overlay');
     expect(taskDetailSurfaceFor('queued')).toBe('queued-placeholder');
     expect(taskDetailSurfaceFor('suspended')).toBe('resume-prompt');
-    expect(taskDetailSurfaceFor('exited')).toBe('inert');
     expect(taskDetailSurfaceFor('none')).toBe('inert');
+  });
+
+  it('keeps a finished agent on the terminal, so its scrollback stays readable', () => {
+    // Converting the old denylist (`kind !== 'queued' && kind !== 'suspended'`)
+    // to this table must not narrow it beyond the one intended exclusion above.
+    // 'exited' passed that gate, and the task detail is the ONLY surface that
+    // shows it: the bottom panel tabs `status === 'running'` only
+    // (panel-sessions.ts). Mapping it to 'inert' drops the user on "No active
+    // session" and takes the record of why the agent stopped with it.
+    expect(taskDetailSurfaceFor('exited')).toBe('terminal');
   });
 
   it('classifies the lifecycle phases the toggle reads', () => {

--- a/tests/unit/session-display-state.test.ts
+++ b/tests/unit/session-display-state.test.ts
@@ -4,8 +4,15 @@
  * activity, and spawn progress data. Covers all state kinds plus edge cases.
  */
 import { describe, it, expect } from 'vitest';
-import { getTaskProgress } from '../../src/renderer/utils/task-progress';
-import type { Session, SessionUsage, ActivityState } from '../../src/shared/types';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  getTaskProgress,
+  taskDetailSurfaceFor,
+  isActiveKind,
+  hasSessionLifecycle,
+} from '../../src/renderer/utils/task-progress';
+import type { Session, SessionUsage, ActivityState, SessionDisplayState } from '../../src/shared/types';
 
 /** Minimal session factory - only fields that matter for the function. */
 function makeSession(overrides: Partial<Session> = {}): Session {
@@ -52,10 +59,41 @@ describe('getTaskProgress', () => {
       .toEqual({ kind: 'preparing', label: 'Creating worktree...' });
   });
 
-  it('ignores spawn progress once session exists', () => {
+  it('ignores spawn progress once a LIVE session exists', () => {
+    // A running session owns its own display; a stale label must never mask a
+    // live agent.
     const session = makeSession({ status: 'running' });
     const result = getTaskProgress({ session, spawnProgressLabel: 'Fetching latest...' });
     expect(result.kind).toBe('running');
+  });
+
+  it('ignores spawn progress for a queued session', () => {
+    const session = makeSession({ status: 'queued' });
+    expect(getTaskProgress({ session, spawnProgressLabel: 'Creating worktree...' }).kind).toBe('queued');
+  });
+
+  // Restoring a task from Done deliberately preserves its suspended record for
+  // the resume, so the old `!session` test threw the label away and the card sat
+  // on "Paused" behind a manual "Resume session" button for the whole
+  // worktree-recreate and CLI-boot window, while the engine was already
+  // restoring the conversation. An in-flight spawn label is strictly newer
+  // information than a record suspended earlier.
+  it('prefers spawn progress over a SUSPENDED session (restore-from-Done is not "Paused")', () => {
+    const session = makeSession({ status: 'suspended' });
+    expect(getTaskProgress({ session, spawnProgressLabel: 'Creating worktree...' }))
+      .toEqual({ kind: 'preparing', label: 'Creating worktree...' });
+  });
+
+  it('still reports suspended when no spawn is in flight', () => {
+    const session = makeSession({ status: 'suspended' });
+    expect(getTaskProgress({ session }).kind).toBe('suspended');
+    expect(getTaskProgress({ session, spawnProgressLabel: null }).kind).toBe('suspended');
+  });
+
+  it('ignores spawn progress for an exited session', () => {
+    // An exited session is terminal, not a restore in flight.
+    const session = makeSession({ status: 'exited', exitCode: 0 });
+    expect(getTaskProgress({ session, spawnProgressLabel: 'Creating worktree...' }).kind).toBe('exited');
   });
 
   it('returns { kind: "exited" } with explicit exitCode', () => {
@@ -123,5 +161,70 @@ describe('getTaskProgress', () => {
     const session = makeSession({ status: 'running' });
     const result = getTaskProgress({ session, usage: MOCK_USAGE, activity: 'idle' as ActivityState });
     expect(result).toEqual({ kind: 'running', activity: 'idle', usage: MOCK_USAGE });
+  });
+});
+
+describe('display-kind classifiers are total', () => {
+  // The tables are `satisfies Record<SessionDisplayState['kind'], ...>`, so a new
+  // kind fails `npm run typecheck` before it can reach here (verified by adding
+  // a probe kind to the union: both tables error with the missing key named).
+  // These cases pin the ANSWERS, which the compiler cannot check.
+  const ALL_KINDS: SessionDisplayState['kind'][] = [
+    'none', 'preparing', 'initializing', 'queued', 'running', 'suspended', 'exited',
+  ];
+
+  it('assigns every kind a task-detail surface', () => {
+    for (const kind of ALL_KINDS) {
+      expect(taskDetailSurfaceFor(kind)).toBeTruthy();
+    }
+  });
+
+  it('routes only real terminal states to the terminal', () => {
+    // 'preparing' is the load-bearing exclusion: during a restore the outgoing
+    // session's id is still on the row, so a 'terminal' answer here paints a
+    // dead shell over an agent that is being restored.
+    expect(taskDetailSurfaceFor('running')).toBe('terminal');
+    expect(taskDetailSurfaceFor('initializing')).toBe('terminal');
+    expect(taskDetailSurfaceFor('preparing')).toBe('launch-overlay');
+    expect(taskDetailSurfaceFor('queued')).toBe('queued-placeholder');
+    expect(taskDetailSurfaceFor('suspended')).toBe('resume-prompt');
+    expect(taskDetailSurfaceFor('exited')).toBe('inert');
+    expect(taskDetailSurfaceFor('none')).toBe('inert');
+  });
+
+  it('classifies the lifecycle phases the toggle reads', () => {
+    expect(ALL_KINDS.filter(isActiveKind))
+      .toEqual(['preparing', 'initializing', 'queued', 'running']);
+    // Everything except the two terminal states has a session to talk about.
+    expect(ALL_KINDS.filter(hasSessionLifecycle))
+      .toEqual(['preparing', 'initializing', 'queued', 'running', 'suspended']);
+  });
+});
+
+describe('every slow restore path reports spawn progress', () => {
+  // The predicate above can only show "Resuming" if main actually sends a
+  // label. Restoring from Done shipped without one: task-move.ts threaded
+  // `onProgress` into its git helpers while task-archive.ts called the same
+  // helpers with no options at all, so a restore was silent for its whole
+  // worktree-recreate window and the card stayed on "Paused". Nothing but this
+  // check couples the two halves, since the omission is an absent argument.
+  const repoRoot = path.resolve(__dirname, '../..');
+  const SLOW_GIT_HELPERS = ['ensureTaskWorktree', 'ensureTaskBranchCheckout'];
+
+  it.each([
+    ['src/main/ipc/handlers/task-archive.ts'],
+    ['src/main/ipc/handlers/task-move.ts'],
+  ])('%s passes onProgress to every slow git helper it awaits', (relativePath) => {
+    const source = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+    for (const helper of SLOW_GIT_HELPERS) {
+      const calls = source.match(new RegExp(`await ${helper}\\([^;]*?\\);`, 'gs')) ?? [];
+      expect(calls.length).toBeGreaterThan(0);
+      for (const call of calls) {
+        expect(call).toContain('onProgress');
+      }
+    }
+    // And the label is always retired, or a task that never reaches a live
+    // session sits on "preparing" until the 120s TTL sweeps it.
+    expect(source).toContain('clearSpawnProgress(');
   });
 });

--- a/tests/unit/session-resume-guard.test.ts
+++ b/tests/unit/session-resume-guard.test.ts
@@ -1,0 +1,129 @@
+/**
+ * SESSION_RESUME eligibility guard.
+ *
+ * A task moved to Done is archived, its session suspended and its worktree
+ * deleted. Resume used to reject only `role === 'todo'` and never read
+ * `archived_at`, so clicking Resume on a completed task in Done recreated the
+ * worktree Done had just deleted and spawned a live `--resume` agent on a task
+ * with no board card: archived AND running at the same time, a state no other
+ * code path produces, burning quota with nothing on the board to notice it.
+ *
+ * Two halves, deliberately:
+ *
+ *   (a) the CONTRACT - the pure predicate every consumer reads;
+ *   (b) the STRUCTURAL parity check - that `handlers/sessions.ts` actually
+ *       calls it at both lane checks. (a) alone is green the moment it is
+ *       written and says nothing about the handler where the bug lived, so
+ *       (b) is the regression guard.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  RESUME_HIDDEN_ROLES,
+  resumeBlockMessage,
+  resumeBlockReason,
+} from '../../src/shared/session-resume-eligibility';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const SESSIONS_HANDLER = 'src/main/ipc/handlers/sessions.ts';
+const RESUME_SUSPENDED = 'src/main/transition-engine/session-startup/resume-suspended.ts';
+
+function readSource(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8');
+}
+
+describe('resumeBlockReason', () => {
+  it('blocks a task in the To Do column', () => {
+    expect(resumeBlockReason({ laneRole: 'todo', isArchived: false })).toBe('todo');
+  });
+
+  it('blocks a task in the Done column', () => {
+    // The reported bug: Done was absent from the guard entirely.
+    expect(resumeBlockReason({ laneRole: 'done', isArchived: false })).toBe('done');
+  });
+
+  it('blocks an archived task, reporting Done when it sits in Done', () => {
+    // The real shape of a completed task: both flags set. The Done message is
+    // the actionable one (it names the move that restores the task).
+    expect(resumeBlockReason({ laneRole: 'done', isArchived: true })).toBe('done');
+  });
+
+  it('blocks an archived task in any other column', () => {
+    // Legacy rows: archived without a Done-role lane, or the lane was deleted.
+    expect(resumeBlockReason({ laneRole: null, isArchived: true })).toBe('archived');
+    expect(resumeBlockReason({ laneRole: undefined, isArchived: true })).toBe('archived');
+    expect(resumeBlockReason({ laneRole: 'In Progress', isArchived: true })).toBe('archived');
+  });
+
+  it('allows a live task in a custom column', () => {
+    expect(resumeBlockReason({ laneRole: null, isArchived: false })).toBeNull();
+    expect(resumeBlockReason({ laneRole: undefined, isArchived: false })).toBeNull();
+  });
+
+  it('exposes exactly the two roles that hide Resume', () => {
+    expect([...RESUME_HIDDEN_ROLES].sort()).toEqual(['done', 'todo']);
+  });
+
+  it('phrases every refusal as user-facing guidance', () => {
+    // These strings reach the user verbatim through the task detail's
+    // "Failed to resume session: <reason>" toast.
+    for (const reason of ['todo', 'done', 'archived'] as const) {
+      const message = resumeBlockMessage(reason);
+      expect(message.length).toBeGreaterThan(0);
+      // Built from its code point so this assertion is not itself an authored
+      // long dash (see .claude/rules/text-formatting.md).
+      expect(message).not.toContain(String.fromCharCode(0x2014));
+      expect(message).not.toContain('--');
+    }
+  });
+});
+
+describe('SESSION_RESUME routes both lane checks through the shared predicate', () => {
+  const source = readSource(SESSIONS_HANDLER);
+
+  it('imports the shared eligibility predicate', () => {
+    expect(source).toMatch(/from '\.\.\/\.\.\/\.\.\/shared\/session-resume-eligibility'/);
+  });
+
+  it('has no hand-rolled lane rejection left', () => {
+    // The exact shape of the bug: a bare role comparison that knows about To Do
+    // and nothing else. Any new terminal state has to be taught to the shared
+    // predicate, where all three consumers see it.
+    const bareRoleCheck = /role\s*===\s*'(todo|done)'/g;
+    expect(source.match(bareRoleCheck) ?? []).toEqual([]);
+  });
+
+  it('checks eligibility at BOTH the Phase 1 and Phase 3 lane checks', () => {
+    // Phase 2 (worktree git I/O) runs unlocked, so Phase 3 must re-check against
+    // the re-read row: a concurrent move to Done archives the task in that gap.
+    const callSites = source.match(/resumeBlockReason\(/g) ?? [];
+    expect(callSites).toHaveLength(2);
+  });
+
+  it('reads archived_at at both call sites, not just the lane role', () => {
+    const archivedReads = source.match(/archived_at !== null/g) ?? [];
+    expect(archivedReads).toHaveLength(2);
+  });
+
+  it('keeps the self-heal early return ahead of the eligibility check', () => {
+    // Handing back a PTY that already exists spawns nothing, and it is the only
+    // path that re-attaches a renderer whose view drifted to 'suspended'.
+    // Ordering it after the check would strand that renderer on an archived task.
+    const selfHealIndex = source.indexOf("return { kind: 'live' as const, session: liveSession }");
+    const firstGuardIndex = source.indexOf('resumeBlockReason(');
+    expect(selfHealIndex).toBeGreaterThan(-1);
+    expect(firstGuardIndex).toBeGreaterThan(selfHealIndex);
+  });
+});
+
+describe('RESUME_HIDDEN_ROLES has a single definition', () => {
+  it('is not redeclared in startup recovery', () => {
+    // Startup recovery and the IPC guard disagreeing about which columns hide
+    // Resume is exactly how Done ended up guarded in one place and not the other.
+    const source = readSource(RESUME_SUSPENDED);
+    expect(source).not.toMatch(/const RESUME_HIDDEN_ROLES/);
+    expect(source).toMatch(/import \{ RESUME_HIDDEN_ROLES \} from '.*session-resume-eligibility'/);
+  });
+});

--- a/tests/unit/session-resume-guard.test.ts
+++ b/tests/unit/session-resume-guard.test.ts
@@ -103,8 +103,11 @@ describe('SESSION_RESUME routes both lane checks through the shared predicate', 
   });
 
   it('reads archived_at at both call sites, not just the lane role', () => {
-    const archivedReads = source.match(/archived_at !== null/g) ?? [];
+    // Truthiness, never `!== null`: a Task assembled without the column carries
+    // `undefined`, and `!== null` reads that as ARCHIVED, refusing every resume.
+    const archivedReads = source.match(/isArchived: Boolean\((task|current)\.archived_at\)/g) ?? [];
     expect(archivedReads).toHaveLength(2);
+    expect(source).not.toMatch(/archived_at !== null/);
   });
 
   it('keeps the self-heal early return ahead of the eligibility check', () => {

--- a/tests/unit/spawn-intent.test.ts
+++ b/tests/unit/spawn-intent.test.ts
@@ -344,4 +344,38 @@ describe('resolveSpawnIntent', () => {
     expect(intent.mode).toBe('fresh');
     expect(intent.resumeFromCwd).toBeNull();
   });
+
+  it('re-resolving forceFresh after a resume match takes the fresh branch whole, not a partial flip of the resume intent', () => {
+    // Mirrors the downgrade wiring in transition-engine.ts's executeSpawnAgent:
+    // on a resumable match whose conversation was never persisted
+    // (isResumeConversationAbsent), the engine RE-RESOLVES the same options with
+    // forceFresh: true rather than flipping a `canResume` boolean on the
+    // already-resolved (resume-mode) intent. This pins the two branches'
+    // incompatible `prompt` fields: a boolean flip would leave `prompt` on the
+    // resume branch's value (resumePrompt), never falling through to the fresh
+    // branch's interpolated promptTemplate - so a downgraded spawn would boot
+    // with no task prompt at all.
+    const record = mockSessionRecord({ status: 'suspended' });
+    const options = {
+      ...baseOptions,
+      sessionRepo: mockSessionRepo(record),
+      resumePrompt: '/review',
+    };
+
+    const resumeIntent = resolveSpawnIntent(options);
+    expect(resumeIntent.mode).toBe('resume');
+    expect(resumeIntent.prompt).toBe('/review');
+
+    const downgradedIntent = resolveSpawnIntent({ ...options, forceFresh: true });
+
+    expect(downgradedIntent.mode).toBe('fresh');
+    expect(downgradedIntent.agentSessionId).toBeNull();
+    expect(downgradedIntent.resumeFromCwd).toBeNull();
+    // Retires the SAME record the resume branch would have kept alive.
+    expect(downgradedIntent.retireRecordId).toBe(resumeIntent.retireRecordId);
+    // The whole point: the fresh branch's interpolated prompt, never the
+    // resume branch's resumePrompt ('/review').
+    expect(downgradedIntent.prompt).toBe('Fix bug: login broken');
+    expect(downgradedIntent.prompt).not.toBe(resumeIntent.prompt);
+  });
 });

--- a/tests/unit/task-move-clear-archived.test.ts
+++ b/tests/unit/task-move-clear-archived.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Unit tests for the `tasks.clearArchived(...)` branch in handleTaskMove
+ * (src/main/ipc/handlers/task-move.ts), the inverse of the auto-archive-into-Done
+ * bookkeeping.
+ *
+ * tests/unit/done-move-bookkeeping.test.ts already pins this wiring with a
+ * STATIC source-text scan (the call site exists, the conditional expression's
+ * literal text is `Boolean(task.archived_at) && toLane?.role !== 'done'`, and
+ * the repository's SQL string is correct). That is airtight for "the call site
+ * exists with this exact text" but cannot catch an INTEGRATION bug: the
+ * conditional reachable but never actually invoked (an earlier return sits
+ * above it), `toLane` resolved from the wrong swimlane, or the condition
+ * silently inverted while still matching some other regex. This file drives
+ * the REAL handler (mirrors task-move-complete-analytics.test.ts's harness)
+ * with a mocked TaskRepository exposing `clearArchived: vi.fn()`, so it
+ * observes what the handler actually DOES, not what its source text says.
+ *
+ * Every scenario targets a lane with `auto_spawn: false` (Priority 2.5 in
+ * task-move.ts) or a same-lane reorder, both of which return early with no
+ * worktree/spawnAgent work - the clearArchived branch runs unconditionally
+ * before any of those branches, so this keeps the harness to the same minimal
+ * mock surface task-move-complete-analytics.test.ts uses.
+ *
+ * Covers the four branches of `Boolean(task.archived_at) && toLane?.role !== 'done'`:
+ *   1. archived task, Done -> non-Done lane: clearArchived called
+ *   2. archived task, reorder WITHIN Done (toLane.role stays 'done'): not called
+ *   3. non-archived task, Done -> non-Done lane: not called (nothing to clear)
+ *   4. archived task OUTSIDE Done moved to another non-Done lane (legacy row):
+ *      still called - keyed on the task's own flag, not the source lane
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Task, Swimlane } from '../../src/shared/types';
+
+vi.mock('electron', () => ({ ipcMain: { handle: vi.fn() } }));
+
+vi.mock('simple-git', () => ({
+  simpleGit: vi.fn(() => ({
+    diffSummary: vi.fn(async () => ({ insertions: 0, deletions: 0, changed: 0 })),
+  })),
+  default: vi.fn(() => ({})),
+}));
+
+vi.mock('../../src/main/db/database', () => ({ getProjectDb: vi.fn(() => ({})) }));
+vi.mock('../../src/main/db/repositories/task-repository', () => ({ TaskRepository: class {} }));
+vi.mock('../../src/main/db/repositories/session-repository', () => ({
+  SessionRepository: class {
+    getLatestForTask = vi.fn(() => null);
+    getSummaryForTask = vi.fn(() => null);
+    updateGitStats = vi.fn();
+    updateAppliedSettings = vi.fn();
+  },
+}));
+vi.mock('../../src/main/db/repositories/swimlane-repository', () => ({ SwimlaneRepository: class {} }));
+vi.mock('../../src/main/db/repositories/action-repository', () => ({ ActionRepository: class {} }));
+vi.mock('../../src/main/db/repositories/attachment-repository', () => ({ AttachmentRepository: class {} }));
+
+vi.mock('../../src/main/git/worktree-manager', () => ({
+  WorktreeManager: class {
+    static scheduleBackgroundPrune = vi.fn();
+  },
+}));
+
+vi.mock('../../src/main/analytics/analytics', () => ({ trackEvent: vi.fn() }));
+
+vi.mock('../../src/main/transition-engine/session-lifecycle', () => ({
+  markRecordExited: vi.fn(),
+  markRecordSuspended: vi.fn(),
+}));
+
+vi.mock('../../src/main/transition-engine/spawn-progress', () => ({
+  emitSpawnProgress: vi.fn(),
+  emitSpawnWaiting: vi.fn(),
+  clearSpawnProgress: vi.fn(),
+  createProgressCallback: vi.fn(() => vi.fn()),
+  getInFlightSpawnProgress: vi.fn(() => ({})),
+}));
+
+vi.mock('../../src/main/transition-engine/agent-resolver', () => ({
+  resolveTargetAgent: vi.fn(() => ({ agent: 'claude', isHandoff: false })),
+}));
+
+vi.mock('../../src/main/transition-engine/injection-plan', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/main/transition-engine/injection-plan')>()),
+  prepareInjectionPlan: vi.fn(() => null),
+}));
+
+vi.mock('../../src/main/agent/agent-registry', () => ({
+  agentRegistry: { get: vi.fn(() => undefined) },
+}));
+
+vi.mock('../../src/main/ipc/handlers/backlog', () => ({ abortBacklogPromotion: vi.fn() }));
+vi.mock('../../src/main/ipc/handlers/session-metrics', () => ({ captureSessionMetrics: vi.fn(), refineTranscriptTokens: vi.fn(), refineTranscriptToolCounts: vi.fn() }));
+
+vi.mock('../../src/main/agent/shared', () => ({
+  interpolateTemplate: vi.fn((template: string) => template),
+  resolveBridgeScript: vi.fn(() => '/mock/bridge.js'),
+  execVersion: vi.fn(async () => '1.0.0'),
+}));
+
+const mockGetProjectRepos = vi.fn();
+const mockEnsureTaskWorktree = vi.fn(async () => null);
+const mockEnsureTaskBranchCheckout = vi.fn(async () => {});
+const mockSpawnAgent = vi.fn(async () => {});
+const mockCreateTransitionEngine = vi.fn(() => ({}));
+
+vi.mock('../../src/main/ipc/helpers/index', () => ({
+  getProjectRepos: (...args: unknown[]) => mockGetProjectRepos(...args),
+  ensureTaskWorktree: (...args: unknown[]) => mockEnsureTaskWorktree(...args),
+  ensureTaskBranchCheckout: (...args: unknown[]) => mockEnsureTaskBranchCheckout(...args),
+  spawnAgent: (...args: unknown[]) => mockSpawnAgent(...args),
+  createTransitionEngine: (...args: unknown[]) => mockCreateTransitionEngine(...args),
+  cleanupTaskResources: vi.fn(async () => {}),
+  deleteTaskWorktree: vi.fn(async () => true),
+  autoSpawnForTask: vi.fn(async () => {}),
+}));
+vi.mock('../../src/main/pr/pr-linking', () => ({
+  autoLinkPRForTask: vi.fn(),
+}));
+
+import { handleTaskMove } from '../../src/main/ipc/handlers/task-move';
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-clear-archived-001',
+    display_id: 1,
+    title: 'My Task',
+    description: '',
+    swimlane_id: 'lane-done',
+    position: 0,
+    agent: 'claude',
+    session_id: null,
+    worktree_path: null,
+    branch_name: 'my-task',
+    pr_number: null,
+    pr_url: null,
+    base_branch: null,
+    use_worktree: null,
+    labels: [],
+    priority: 0,
+    attachment_count: 0,
+    archived_at: null,
+    created_at: '2025-01-01T00:00:00.000Z',
+    updated_at: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeSwimlane(id: string, overrides: Partial<Swimlane> = {}): Swimlane {
+  return {
+    id,
+    name: `Lane ${id}`,
+    role: null,
+    position: 0,
+    color: '#888',
+    icon: null,
+    is_archived: false,
+    is_ghost: false,
+    permission_mode: null,
+    auto_spawn: true,
+    auto_command: null,
+    plan_exit_target_id: null,
+    agent_override: null,
+    model_override: null,
+    effort_override: null,
+    handoff_context: false,
+    session_target: 'main',
+    session_spawn_strategy: 'create_or_resume',
+    created_at: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeTaskRepo(task: Task) {
+  return {
+    getById: vi.fn(() => ({ ...task })),
+    move: vi.fn(),
+    update: vi.fn(),
+    list: vi.fn(() => [{ ...task }]),
+    archive: vi.fn(),
+    clearArchived: vi.fn(),
+  };
+}
+
+function makeSwimlaneRepo(lanes: Swimlane[]) {
+  const laneMap = new Map(lanes.map((lane) => [lane.id, lane]));
+  return {
+    getById: vi.fn((id: string) => laneMap.get(id) ?? null),
+    list: vi.fn(() => Array.from(laneMap.values())),
+  };
+}
+
+function makeContext(taskRepo: unknown, swimlaneRepo: unknown) {
+  const sessionManager = {
+    removeByTaskId: vi.fn(),
+    killByTaskId: vi.fn(),
+    listSessions: vi.fn(() => []),
+    suspend: vi.fn(async () => {}),
+  };
+  const context = {
+    currentProjectId: 'proj-test',
+    currentProjectPath: '/mock/project',
+    mainWindow: { isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } },
+    sessionManager,
+    configManager: { getEffectiveConfig: vi.fn(() => ({ git: { defaultBaseBranch: 'main' } })) },
+    boardConfigManager: { getDefaultBaseBranch: vi.fn(() => null) },
+    terminalSubmitScheduler: { cancel: vi.fn(), scheduleKeystrokes: vi.fn() },
+    projectRepo: { getById: vi.fn(() => ({ id: 'proj-test', default_agent: 'claude' })) },
+  };
+  mockGetProjectRepos.mockReturnValue({
+    tasks: taskRepo,
+    swimlanes: swimlaneRepo,
+    actions: { getTransitionsFor: vi.fn(() => []) },
+    attachments: { deleteByTaskId: vi.fn() },
+  });
+  return context;
+}
+
+const DONE_LANE_ID = 'lane-done';
+const AUTO_SPAWN_OFF_LANE_ID = 'lane-no-spawn';
+const CUSTOM_LANE_ID = 'lane-custom';
+
+async function move(task: Task, targetSwimlaneId: string, lanes: Swimlane[]) {
+  const swimlaneRepo = makeSwimlaneRepo(lanes);
+  const taskRepo = makeTaskRepo(task);
+  const context = makeContext(taskRepo, swimlaneRepo);
+
+  await handleTaskMove(context as never, {
+    taskId: task.id,
+    targetSwimlaneId,
+    targetPosition: 0,
+  });
+
+  return { taskRepo };
+}
+
+describe('handleTaskMove clears archived_at on a move out of Done', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('clears archived_at when an archived task moves from Done to a non-Done lane', async () => {
+    const doneLane = makeSwimlane(DONE_LANE_ID, { role: 'done' });
+    const noSpawnLane = makeSwimlane(AUTO_SPAWN_OFF_LANE_ID, { role: null, auto_spawn: false });
+    const task = makeTask({ swimlane_id: DONE_LANE_ID, archived_at: '2025-06-01T00:00:00.000Z' });
+
+    const { taskRepo } = await move(task, AUTO_SPAWN_OFF_LANE_ID, [doneLane, noSpawnLane]);
+
+    expect(taskRepo.clearArchived).toHaveBeenCalledTimes(1);
+    expect(taskRepo.clearArchived).toHaveBeenCalledWith(task.id);
+  });
+
+  it('does NOT clear archived_at when the move is a reorder WITHIN Done', async () => {
+    // Red: inverting the handler's `!== 'done'` to `=== 'done'` makes this
+    // assertion fail (clearArchived would be called once).
+    const doneLane = makeSwimlane(DONE_LANE_ID, { role: 'done' });
+    const task = makeTask({ swimlane_id: DONE_LANE_ID, archived_at: '2025-06-01T00:00:00.000Z' });
+
+    const { taskRepo } = await move(task, DONE_LANE_ID, [doneLane]);
+
+    expect(taskRepo.clearArchived).not.toHaveBeenCalled();
+  });
+
+  it('does NOT clear anything for a non-archived task moving out of Done', async () => {
+    const doneLane = makeSwimlane(DONE_LANE_ID, { role: 'done' });
+    const noSpawnLane = makeSwimlane(AUTO_SPAWN_OFF_LANE_ID, { role: null, auto_spawn: false });
+    const task = makeTask({ swimlane_id: DONE_LANE_ID, archived_at: null });
+
+    const { taskRepo } = await move(task, AUTO_SPAWN_OFF_LANE_ID, [doneLane, noSpawnLane]);
+
+    expect(taskRepo.clearArchived).not.toHaveBeenCalled();
+  });
+
+  it('still clears a legacy archived task parked OUTSIDE Done (keyed on the flag, not the source lane)', async () => {
+    const customLane = makeSwimlane(CUSTOM_LANE_ID, { role: null, auto_spawn: false });
+    const otherLane = makeSwimlane(AUTO_SPAWN_OFF_LANE_ID, { role: null, auto_spawn: false });
+    // A legacy row: archived_at set but sitting in a non-Done lane (e.g. its
+    // Done-role lane was deleted, or an older code path archived it there).
+    const task = makeTask({ swimlane_id: CUSTOM_LANE_ID, archived_at: '2025-06-01T00:00:00.000Z' });
+
+    const { taskRepo } = await move(task, AUTO_SPAWN_OFF_LANE_ID, [customLane, otherLane]);
+
+    expect(taskRepo.clearArchived).toHaveBeenCalledTimes(1);
+    expect(taskRepo.clearArchived).toHaveBeenCalledWith(task.id);
+  });
+});

--- a/tests/unit/task-repository.test.ts
+++ b/tests/unit/task-repository.test.ts
@@ -274,6 +274,24 @@ describe('TaskRepository SQL contracts', () => {
     });
   });
 
+  // done-move-bookkeeping.test.ts pins clearArchived's SQL TEXT via a source
+  // regex; that cannot catch a `.run(id, now)` argument-order swap (the SQL
+  // string is unchanged, but archived_at would bind to the task id and the
+  // WHERE clause would bind to the timestamp). This calls the real method
+  // through the tracker to pin the actual bound argument order.
+  it('clearArchived binds the timestamp then the id, matching the SQL positional order', () => {
+    const before = new Date().toISOString();
+    repo.clearArchived('task-to-restore');
+    const after = new Date().toISOString();
+
+    const statement = tracker.statements.find((s) => s.sql.includes('archived_at = NULL'));
+    expect(statement).toBeDefined();
+    const [updatedAtArg, idArg] = statement!.args;
+    expect(idArg).toBe('task-to-restore');
+    expect(updatedAtArg as string >= before).toBe(true);
+    expect(updatedAtArg as string <= after).toBe(true);
+  });
+
   describe('create - createdAt handling', () => {
     // Added for kangentic_move_task_to_project: create() gained an optional
     // `createdAt` on TaskCreateInput so a relocated task can preserve its

--- a/tests/unit/transition-engine.test.ts
+++ b/tests/unit/transition-engine.test.ts
@@ -79,6 +79,11 @@ function makeSessionRepo() {
     // below). Every other test's mockAdapter has no runtime, so the reconcile
     // returns before ever calling this.
     updateAgentSessionId: vi.fn(),
+    // The conversation lineage isResumeConversationAbsent walks on a resume:
+    // every record sharing the resumed agent_session_id, newest first. Empty
+    // here, so the guard falls back to the retiring record alone and finds no
+    // report, which is its "unknown, resume as before" path.
+    listForTaskNewestFirst: vi.fn(() => []),
     insertedRecords,
   };
 }

--- a/tests/unit/transition-engine.test.ts
+++ b/tests/unit/transition-engine.test.ts
@@ -28,6 +28,7 @@ import { TransitionEngine } from '../../src/main/transition-engine/transition-en
 import { buildTaskXml } from '../../src/main/agent/shared/prompt-xml';
 import { sanitizeForPty } from '../../src/shared/paths';
 import { migrateResumeCwdIfRenamed } from '../../src/main/transition-engine/resume-cwd-migration';
+import { ClaudeStatusParser } from '../../src/main/agent/adapters/claude/status-parser';
 import { OpenCodeCommandBuilder, type OpenCodeCommandOptions } from '../../src/main/agent/adapters/opencode';
 import { CodexCommandBuilder, type CodexCommandOptions } from '../../src/main/agent/adapters/codex';
 import type { AgentExecutionServer, AgentProjectExecution, AgentLaunchOptionInfo, SessionUsage } from '../../src/shared/types';
@@ -1149,5 +1150,173 @@ describe('TransitionEngine - MCP caller-session URL stamping (executeSpawnAgent 
     await engine.executeTransition(task as Parameters<typeof engine.executeTransition>[0], 'todo', 'doing');
 
     expect(capturedOptions?.mcpServerUrl).toBeUndefined();
+  });
+});
+
+describe('TransitionEngine - resume downgraded to fresh when the conversation was never persisted (executeSpawnAgent chokepoint)', () => {
+  // Coverage hole (review): executeSpawnAgent's downgrade path RE-RESOLVES the
+  // spawn intent (`resolveSpawnIntent({ ...spawnIntentOptions, forceFresh: true })`)
+  // when isResumeConversationAbsent proves a resumable match never persisted a
+  // conversation, rather than flipping a `canResume` boolean on the
+  // already-resolved resume intent. resolveSpawnIntent's own forceFresh
+  // contract is unit-pinned in spawn-intent.test.ts; what is untested here is
+  // the WIRING - that a real resumable record whose status.json proves a
+  // zero-turn conversation actually produces a built command carrying the
+  // interpolated promptTemplate, not the resume branch's resumePrompt
+  // (undefined for an ordinary task spawn). A boolean-flip regression leaves
+  // `intent` unchanged (still resume-mode, prompt = resumePrompt = undefined),
+  // so the downgraded spawn would boot with no task prompt at all - exactly
+  // the zero-turn conversation the guard exists to prevent.
+  //
+  // Uses a REAL mkdtemp projectPath (like the reconcile-wiring describe above)
+  // because isResumeConversationAbsent reads a real status.json from disk; this
+  // file's node:fs mock stubs mkdirSync only, so fs.promises.mkdir +
+  // fs.writeFileSync below reach the real filesystem.
+  const RECORD_ID = 'poisoned-record-1';
+  const AGENT_SESSION_ID = 'agent-uuid-poisoned';
+
+  let projectPath: string;
+
+  /** The exact reported state a session that ended before its first turn
+   * leaves behind: a named transcript_path that was never written, and zero
+   * cost/token usage. Mirrors resume-conversation-guard.test.ts's identical
+   * fixture, which pins that this shape makes isResumeConversationAbsent
+   * resolve true. Takes the record id so the lineage-walk test below can
+   * write it under an OLDER record than the one being retired. */
+  async function writeEmptyStatusFile(recordId: string): Promise<void> {
+    const sessionDir = path.join(projectPath, '.kangentic', 'sessions', recordId);
+    await fs.promises.mkdir(sessionDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionDir, 'status.json'), JSON.stringify({
+      session_id: AGENT_SESSION_ID,
+      transcript_path: path.join(projectPath, 'history', `${AGENT_SESSION_ID}.jsonl`),
+      model: { id: 'claude-haiku-4-5-20251001', display_name: 'Haiku 4.5' },
+      cost: { total_cost_usd: 0, total_duration_ms: 1388, total_api_duration_ms: 0 },
+      context_window: {
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        context_window_size: 200000,
+        current_usage: null,
+        used_percentage: null,
+      },
+    }));
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAdapter.buildCommand.mockImplementation((options: { prompt?: string }) => {
+      return `claude ${options.prompt ?? ''}`;
+    });
+    projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'kangentic-te-downgrade-'));
+    mockAdapter.runtime = { statusFile: { parseStatus: ClaudeStatusParser.parseStatus } };
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectPath, { recursive: true, force: true });
+    mockAdapter.runtime = undefined;
+  });
+
+  it('spawns fresh with the interpolated prompt, not resumePrompt, when the resumable record never persisted a conversation', async () => {
+    await writeEmptyStatusFile(RECORD_ID);
+
+    const sessionRepo = makeSessionRepo();
+    sessionRepo.getLatestForTaskByTypeAndIsolation.mockReturnValue({
+      id: RECORD_ID,
+      agent_session_id: AGENT_SESSION_ID,
+      session_type: 'claude_agent',
+      status: 'suspended',
+      cwd: projectPath,
+    });
+
+    let capturedOptions: { resume?: boolean; sessionId?: string; prompt?: string } | undefined;
+    mockAdapter.buildCommand.mockImplementation((options: { resume?: boolean; sessionId?: string; prompt?: string }) => {
+      capturedOptions = options;
+      return `claude ${options.prompt ?? ''}`;
+    });
+
+    // worktree_path: null so `cwd` (task.worktree_path || appConfig.projectPath
+    // || process.cwd()) resolves to the same mkdtemp root writeEmptyStatusFile
+    // wrote under, matching makeTask's own default.
+    const task = makeTask({ worktree_path: null });
+    const sessionManager = makeSessionManager();
+    const { engine } = makeEngine({ sessionManager, sessionRepo, projectPath });
+
+    await engine.executeTransition(task as Parameters<typeof engine.executeTransition>[0], 'todo', 'doing');
+
+    // Red: reverting executeSpawnAgent's
+    // `intent = resolveSpawnIntent({ ...spawnIntentOptions, forceFresh: true })`
+    // to a `canResume = false` boolean flip on the STALE resume intent (intent
+    // left unchanged) makes this undefined (intent.prompt = resumePrompt,
+    // never passed to this spawn) instead of the interpolated task_xml prompt.
+    expect(capturedOptions?.resume).toBe(false);
+    expect(capturedOptions?.prompt).toContain('Fix login flow');
+
+    expect(sessionManager.spawnedSessions).toHaveLength(1);
+
+    // The poisoned record is still retired even though the spawn goes fresh
+    // (forceFresh's retireRecordId carries the same match.id forward).
+    expect(sessionRepo.compareAndUpdateStatus).toHaveBeenCalledWith(
+      RECORD_ID,
+      ['suspended', 'orphaned', 'exited'],
+      'exited',
+      expect.objectContaining({ exited_at: expect.any(String) }),
+    );
+
+    expect(sessionRepo.insertedRecords).toHaveLength(1);
+    const inserted = sessionRepo.insertedRecords[0] as { agent_session_id?: string | null; prompt?: string | null };
+    // Fresh spawns generate their own PTY session id (Claude
+    // supportsCallerSessionId), never the stale DB-stored AGENT_SESSION_ID.
+    expect(inserted.agent_session_id).not.toBe(AGENT_SESSION_ID);
+    expect(inserted.prompt).toContain('Fix login flow');
+  });
+
+  it('walks the conversation lineage: finds the downgrade proof on an OLDER record when the retiring record wrote no status file', async () => {
+    // A failed resume is self-perpetuating (see resume-conversation-guard.ts's
+    // "heals an already-poisoned lineage" case): the CLI dies before its
+    // status line runs, so the RETIRING record has no status.json, and the
+    // proof of emptiness can only be found on an older record of the same
+    // conversation. `conversationRecordIds` in executeSpawnAgent spreads
+    // `listForTaskNewestFirst(...)` (filtered to the resumed agent_session_id)
+    // onto `intent.retireRecordId` for exactly this reason.
+    const OLDER_RECORD_ID = 'poisoned-record-older';
+    await writeEmptyStatusFile(OLDER_RECORD_ID);
+    // The retiring (latest) record's session dir exists but holds no
+    // status.json - exactly what a failed resume leaves behind.
+    await fs.promises.mkdir(path.join(projectPath, '.kangentic', 'sessions', RECORD_ID), { recursive: true });
+
+    const sessionRepo = makeSessionRepo();
+    sessionRepo.getLatestForTaskByTypeAndIsolation.mockReturnValue({
+      id: RECORD_ID,
+      agent_session_id: AGENT_SESSION_ID,
+      session_type: 'claude_agent',
+      status: 'suspended',
+      cwd: projectPath,
+    });
+    // Newest first, including a record from an UNRELATED conversation (a
+    // different agent_session_id) that must be filtered out, not walked.
+    sessionRepo.listForTaskNewestFirst.mockReturnValue([
+      { id: RECORD_ID, agent_session_id: AGENT_SESSION_ID },
+      { id: OLDER_RECORD_ID, agent_session_id: AGENT_SESSION_ID },
+      { id: 'unrelated-record', agent_session_id: 'a-different-conversation-id' },
+    ]);
+
+    let capturedOptions: { resume?: boolean; prompt?: string } | undefined;
+    mockAdapter.buildCommand.mockImplementation((options: { resume?: boolean; prompt?: string }) => {
+      capturedOptions = options;
+      return `claude ${options.prompt ?? ''}`;
+    });
+
+    const task = makeTask({ worktree_path: null });
+    const { engine } = makeEngine({ sessionRepo, projectPath });
+
+    await engine.executeTransition(task as Parameters<typeof engine.executeTransition>[0], 'todo', 'doing');
+
+    // Red: dropping the `...listForTaskNewestFirst(...).filter(...).map(...)`
+    // spread (passing only `[intent.retireRecordId]`) leaves RECORD_ID as the
+    // only candidate. It has no status.json, so the guard finds no evidence
+    // and returns false (unknown -> resume as before), making this true
+    // instead - the task would stay stuck resuming a dead conversation
+    // forever.
+    expect(capturedOptions?.resume).toBe(false);
+    expect(capturedOptions?.prompt).toContain('Fix login flow');
   });
 });


### PR DESCRIPTION
## What

Closes the Done/archived hole in `SESSION_RESUME`, plus the cluster of related defects that fell out of investigating it.

- **`SESSION_RESUME` refuses Done and archived tasks.** Both lane checks route through a new shared predicate, `src/shared/session-resume-eligibility.ts`, which also owns `RESUME_HIDDEN_ROLES` (hoisted out of startup recovery, which already honored Done).
- **A resume with no conversation behind it is downgraded to a fresh spawn.** `isResumeConversationAbsent` (`src/main/transition-engine/resume-conversation-guard.ts`), applied at both spawn chokepoints.
- **Restoring from Done reads as in progress**, not as "Paused" behind a manual Resume button. `TASK_UNARCHIVE` now emits spawn progress (new `resuming` phase) and `getTaskProgress` lets an in-flight label outrank a suspended session.
- **Session display kinds are classified by compile-enforced tables** instead of chains of `kind !== '...'` exclusions.
- **A move out of Done un-archives** (new `TaskRepository.clearArchived`), mirroring archive-on-move-in.
- **`suspend()` announces immediately** instead of after the graceful PTY shutdown, so the bottom panel drops its tab with the card.
- Finalize indexing is debounced per session.

## Why

A completed task auto-archived into Done still offered Resume. Clicking it recreated the worktree Done had just deleted and spawned a live `--resume` agent on a task with **no board card**: archived AND running at once, burning quota with nothing on the board to notice it. Observed on the kangentic.com board (task 66, "Release 0.35.0").

This is not a recent regression. The ingredients date to the Done redesign in **v0.16.0** (2026-04-19), and it became trivially reachable in **v0.23.0** (2026-06-16) when the first move out of Done became command-free, so the agent never takes a turn on its own. It is present in every release through v0.35.0.

Investigating it surfaced the rest: a `--resume` against a conversation the agent never wrote (the CLI answers "No conversation found with session ID" and drops the user on a bare shell), a restore that advertised a manual button while the engine was already restoring, and two Done-column asymmetries reachable only by main-process callers.

## How

The resume-conversation guard is the piece that needs a reviewer's attention, because a guard that downgrades a resume can **discard conversation continuity** if it misfires. That exact shape was built and deliberately reverted in #255. This one is narrower on three counts, and all must hold before anything is downgraded:

1. The transcript path comes from the **agent's own report** (its status file, or the SessionStart hook payload), never one Kangentic derived.
2. That same report must independently show the conversation never took a turn.
3. The file it names must be absent.

Absence of evidence is never evidence: a missing report, no status pipeline, malformed JSON, or no reported path all return false and resume exactly as before. Mocked CLIs hit that path structurally, which is what broke ten E2E specs the first time around. The check walks every record sharing the conversation's `agent_session_id`, because a failed resume writes no report of its own and an already-poisoned task would otherwise stay broken forever.

Trade-off accepted: a session killed so fast that neither its status line nor its SessionStart hook ever ran leaves no evidence anywhere, so the guard cannot fire. That degrades to today's behavior rather than to data loss.

`docs/adapter-session-history.md` now carries a backlink explaining why this guard is not the reverted one.

## Breaking changes

None. Every change either refuses an action that previously produced a broken state, or degrades to existing behavior when evidence is missing.

## Tests

CI runs lint, typecheck, unit, build, the UI shards, and the Linux Electron E2E shards.

Locally, before this PR: the full gate green at 11383 unit, 1315 UI, 98 E2E. That gate caught a real defect the scoped runs missed - `task.archived_at !== null` reads an absent column as archived, so any partially-constructed `Task` was refused resume and mis-unarchived.

Added on this branch:
- `tests/unit/session-resume-guard.test.ts`, `tests/ui/task-detail-archived-no-resume.spec.ts` - the refusal and all three renderer surfaces, with a control group against an ordinary column.
- `tests/unit/resume-conversation-guard.test.ts` - the three-signal predicate, both evidence sources, the lineage walk, and every degrade-to-resume path.
- `tests/ui/restore-from-done-shows-progress.spec.ts` - the restore shows progress and never the dead terminal.
- `tests/unit/done-move-bookkeeping.test.ts`, `tests/unit/task-move-clear-archived.test.ts`, `tests/unit/prepare-spawn-resume-conversation-guard.test.ts` - the Done asymmetries and the startup chokepoint's own downgrade, which had no coverage at all.

Two review passes ran on the branch. A `/code-review` pass caught two behavior regressions (a silently narrowed `exited` display kind, and a downgrade that flipped a boolean instead of re-resolving the spawn intent, which would have booted a promptless session and seeded its own next false positive). A coverage pass replaced two static source-text scans with behavioral tests, including one pinning a SQL bound-argument order whose swap would have been silent data corruption.

Generated with [Claude Code](https://claude.com/claude-code)
