### PR TITLE
feat(backlog): bring the edit dialog up to the board's visual treatment

### DIFF
--- a/src/renderer/components/backlog/BacklogDialogs.tsx
+++ b/src/renderer/components/backlog/BacklogDialogs.tsx
@@ -80,6 +80,7 @@ export function BacklogDialogs() {
           onCreate={createItem}
           editTask={editingItem}
           onUpdate={updateItem}
+          onDelete={deleteItem}
         />
       )}
 

--- a/src/renderer/components/backlog/NewBacklogTaskDialog.tsx
+++ b/src/renderer/components/backlog/NewBacklogTaskDialog.tsx
@@ -1,18 +1,23 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { Plus, X } from 'lucide-react';
+import { Plus, Pencil, ExternalLink, Trash2, X } from 'lucide-react';
 import { BaseDialog } from '../dialogs/BaseDialog';
 import { ConfirmDialog } from '../dialogs/ConfirmDialog';
 import { maximizedDialogLayout, MaximizeToggleButton } from '../dialogs/dialog-maximize';
 import { PriorityLabelsRow } from '../dialogs/PriorityLabelsRow';
 import { DialogFooterActions } from '../dialogs/DialogFooterActions';
+import { PriorityBadge } from './PriorityBadge';
+import { GitHubIcon } from '../icons/GitHubIcon';
+import { NameFromPromptButton } from '../NameFromPromptButton';
 import { useProjectStore } from '../../stores/project-store';
 import { useSessionStore } from '../../stores/session-store';
 import { useToastStore } from '../../stores/toast-store';
+import { useConfigStore } from '../../stores/config-store';
 import { useKeybinding } from '../../hooks/useKeybinding';
 import { DescriptionEditor } from '../DescriptionEditor';
 import { AttachmentChipStrip } from '../dialogs/AttachmentChipStrip';
 import { MAX_ATTACHMENT_BYTES, MEDIA_TYPE_EXT, resolveMediaType, isImageMediaType, pastedAttachmentPrefix, reserveNextPastedIndex, openAttachmentWithToast } from '../dialogs/attachment-utils';
 import { compressClipboardImage } from '../dialogs/image-compress';
+import { formatRelativeTime } from '../../lib/datetime';
 import type { BacklogTask, BacklogTaskCreateInput, BacklogTaskUpdateInput } from '../../../shared/types';
 
 interface PendingAttachment {
@@ -43,23 +48,28 @@ interface NewBacklogTaskDialogProps {
   onCreate: (input: BacklogTaskCreateInput) => Promise<unknown>;
   editTask?: BacklogTask;
   onUpdate?: (input: BacklogTaskUpdateInput) => Promise<unknown>;
+  /** Edit mode only. Omit to leave the footer with no Delete affordance. */
+  onDelete?: (id: string) => Promise<void>;
 }
 
 // Non-task sentinel key for the maximize toggle (the backlog dialog has no task
 // row). One key covers both create and edit-backlog modes; it is one surface.
 const NEW_BACKLOG_TASK_ENTITY_ID = 'new-backlog-task-dialog';
 
-export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: NewBacklogTaskDialogProps) {
+export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate, onDelete }: NewBacklogTaskDialogProps) {
   const isEditMode = !!editTask;
   const currentProject = useProjectStore((state) => state.currentProject);
   const isMaximized = useSessionStore((state) => state.maximizedTasks.has(NEW_BACKLOG_TASK_ENTITY_ID));
   const toggleMaximized = useSessionStore((state) => state.toggleMaximized);
   const handleToggleMaximized = useCallback(() => toggleMaximized(NEW_BACKLOG_TASK_ENTITY_ID), [toggleMaximized]);
+  const skipDeleteConfirm = useConfigStore((state) => state.config.skipDeleteConfirm);
+  const updateConfig = useConfigStore((state) => state.updateConfig);
   const [title, setTitle] = useState(editTask?.title ?? '');
   const [description, setDescription] = useState(editTask?.description ?? '');
   const [priority, setPriority] = useState(editTask?.priority ?? 0);
   const [labels, setLabels] = useState<string[]>(editTask?.labels ?? []);
   const [submitting, setSubmitting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [attachments, setAttachments] = useState<DisplayAttachment[]>([]);
   const [previewAttachment, setPreviewAttachment] = useState<DisplayAttachment | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
@@ -72,23 +82,29 @@ export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: 
   const attachmentsRef = useRef<DisplayAttachment[]>([]);
   attachmentsRef.current = attachments;
 
+  // Only PENDING attachments make the form dirty - a freshly loaded saved
+  // attachment is not an edit the user made, so it must not trip the
+  // discard-changes guard on arrival.
+  const hasPendingAttachments = attachments.some((attachment) => !isSavedAttachment(attachment));
+
   const isDirty = isEditMode
     ? title.trim() !== (editTask?.title ?? '') ||
       description.trim() !== (editTask?.description ?? '') ||
       priority !== (editTask?.priority ?? 0) ||
       JSON.stringify(labels) !== JSON.stringify(editTask?.labels ?? []) ||
-      attachments.length > 0
-    : title.trim() !== '' || description.trim() !== '' || labels.length > 0 || priority !== 0 || attachments.length > 0;
+      hasPendingAttachments
+    : title.trim() !== '' || description.trim() !== '' || labels.length > 0 || priority !== 0 || hasPendingAttachments;
 
   // Guard close gestures (X, Escape, backdrop, Ctrl+Shift+W) so unsaved work is
   // not lost: when the form is dirty, ask before discarding. Returns true to let
   // the caller proceed with the close, false when a confirm was shown instead.
   const [confirmDiscard, setConfirmDiscard] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const handleCloseAttempt = useCallback(() => {
-    if (confirmDiscard) return false;
+    if (confirmDiscard || confirmDelete) return false;
     if (isDirty) { setConfirmDiscard(true); return false; }
     return true;
-  }, [confirmDiscard, isDirty]);
+  }, [confirmDiscard, confirmDelete, isDirty]);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -275,6 +291,10 @@ export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: 
 
   const handleSubmit = async (event?: React.FormEvent) => {
     event?.preventDefault();
+    // The delete/discard confirms render as siblings of this <form>, not inside
+    // it, so an Enter keypress while one is open is not consumed by the confirm
+    // and would otherwise reach this handler and save over a pending delete.
+    if (confirmDelete || confirmDiscard) return;
     if (!title.trim() || submitting) return;
     setSubmitting(true);
     try {
@@ -310,8 +330,32 @@ export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: 
     }
   };
 
+  // --- Delete (edit mode only) ---
+
+  const performDelete = useCallback(async (dontAskAgain: boolean) => {
+    if (!editTask || !onDelete || deleting) return;
+    setDeleting(true);
+    try {
+      await onDelete(editTask.id);
+      // Persist "don't ask again" only after the delete actually lands. The
+      // catch below keeps the confirm open so the user can retry, and arming
+      // the global bypass on a FAILED delete would make that retry - and every
+      // later delete - skip the confirmation the user was still looking at.
+      if (dontAskAgain) updateConfig({ skipDeleteConfirm: true });
+      setConfirmDelete(false);
+      onClose();
+    } catch (error) {
+      console.error('[NewBacklogTaskDialog] Failed to delete backlog task:', error);
+      useToastStore.getState().addToast({
+        message: 'Failed to delete backlog task',
+        variant: 'error',
+      });
+      setDeleting(false);
+    }
+  }, [editTask, onDelete, deleting, updateConfig, onClose]);
+
   const { dialogClassName, backdropPositionClass, backdropClassName, contentRadiusClass } =
-    maximizedDialogLayout(isMaximized, 'w-[840px] max-w-[90vw]');
+    maximizedDialogLayout(isMaximized, 'w-[840px] max-w-[90vw] h-[80vh]');
 
   return (
     <>
@@ -320,8 +364,28 @@ export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: 
           onClose={onClose}
           onHeaderDoubleClick={handleToggleMaximized}
           onCloseRequest={handleCloseAttempt}
-          title={isEditMode ? 'Edit Backlog Task' : 'New Backlog Task'}
-          icon={<Plus size={14} className="text-fg-muted" />}
+          title={
+            <span className="flex items-center gap-2 min-w-0">
+              <span className="flex-shrink-0">{isEditMode ? 'Edit Backlog Task' : 'New Backlog Task'}</span>
+              {editTask?.external_source && editTask.external_url && (
+                <button
+                  type="button"
+                  onClick={() => window.electronAPI.shell.openExternal(editTask.external_url!)}
+                  className="flex-shrink-0 text-fg-faint hover:text-fg-secondary transition-colors"
+                  title={`Open in ${editTask.external_source.startsWith('github') ? 'GitHub' : editTask.external_source}`}
+                  data-testid="backlog-task-external-link"
+                >
+                  {editTask.external_source.startsWith('github')
+                    ? <GitHubIcon size={13} />
+                    : <ExternalLink size={13} />}
+                </button>
+              )}
+              <PriorityBadge priority={priority} />
+            </span>
+          }
+          icon={isEditMode
+            ? <Pencil size={14} className="text-fg-muted" />
+            : <Plus size={14} className="text-fg-muted" />}
           headerRight={
             <MaximizeToggleButton isMaximized={isMaximized} onToggle={handleToggleMaximized} />
           }
@@ -329,7 +393,7 @@ export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: 
           backdropPositionClass={backdropPositionClass}
           backdropClassName={backdropClassName}
           contentRadiusClass={contentRadiusClass}
-          bodyClassName="flex-1 flex flex-col"
+          bodyClassName="flex-1 min-h-0 flex flex-col overflow-y-auto"
           closeHotkeyActionId="panel.close"
           testId="new-backlog-task-dialog"
           footer={
@@ -340,6 +404,17 @@ export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: 
               busy={submitting}
               disabled={!title.trim()}
               submitTestId="create-backlog-task-btn"
+              leading={isEditMode && onDelete ? (
+                <button
+                  type="button"
+                  data-testid="delete-backlog-task-btn"
+                  onClick={() => skipDeleteConfirm ? void performDelete(false) : setConfirmDelete(true)}
+                  className="flex items-center gap-1.5 rounded px-3 py-1.5 text-xs text-fg-faint transition-colors hover:bg-danger/10 hover:text-danger"
+                >
+                  <Trash2 size={14} />
+                  Delete
+                </button>
+              ) : undefined}
             />
           }
         >
@@ -349,15 +424,18 @@ export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: 
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
           >
-            <input
-              ref={inputRef}
-              type="text"
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
-              placeholder="Task title"
-              className="w-full bg-surface-control border border-edge-input rounded px-3 py-2 text-sm text-fg placeholder-fg-faint focus:outline-none focus:border-accent"
-              data-testid="backlog-task-title"
-            />
+            <div className="flex items-center gap-2">
+              <input
+                ref={inputRef}
+                type="text"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="Task title"
+                className="flex-1 min-w-0 bg-surface-control border border-edge-input rounded px-3 py-2 text-sm text-fg placeholder-fg-faint focus:outline-none focus:border-accent"
+                data-testid="backlog-task-title"
+              />
+              <NameFromPromptButton description={description} onTitle={setTitle} />
+            </div>
 
             <DescriptionEditor
               value={description}
@@ -382,6 +460,25 @@ export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: 
               testIdPrefix="backlog-task-"
             />
 
+            {isEditMode && editTask && (
+              <div
+                className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-fg-faint"
+                data-testid="backlog-task-meta"
+              >
+                {/* One flowing sentence, not two adjacent label:value spans -
+                    two capitalized chunks ("Created X" next to "Updated Y")
+                    read as a stutter, especially right after creating an item
+                    when the two times are seconds apart. Lowercasing "updated"
+                    into a clause continuation reads as one fact with two parts
+                    instead of two competing labels. */}
+                <span>
+                  Created {formatRelativeTime(editTask.created_at)}, updated{' '}
+                  {formatRelativeTime(editTask.updated_at)}
+                </span>
+                {editTask.assignee && <span>@{editTask.assignee}</span>}
+              </div>
+            )}
+
             {/* Drag overlay */}
             {isDragOver && (
               <div className="absolute inset-0 bg-accent/10 border-2 border-dashed border-accent rounded-lg flex items-center justify-center z-10 pointer-events-none">
@@ -404,6 +501,22 @@ export function NewBacklogTaskDialog({ onClose, onCreate, editTask, onUpdate }: 
             : 'Closing now will discard this new backlog task and its unsaved changes.'}
           onConfirm={() => { setConfirmDiscard(false); onClose(); }}
           onCancel={() => setConfirmDiscard(false)}
+        />
+      )}
+
+      {/* Delete confirmation */}
+      {confirmDelete && (
+        <ConfirmDialog
+          title="Delete backlog task"
+          message={<>
+            <p>This will permanently delete the backlog task.</p>
+            <p className="text-red-400 font-medium">This action cannot be undone.</p>
+          </>}
+          confirmLabel="Delete"
+          variant="danger"
+          showDontAskAgain
+          onConfirm={(dontAskAgain) => { void performDelete(dontAskAgain); }}
+          onCancel={() => setConfirmDelete(false)}
         />
       )}
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -88,8 +88,19 @@ const TEMPLATE_DIR = path.join(TEMPLATE_PARENT, `worker-${process.pid}`);
 const TMP_PROJECT_ROOT = path.join(__dirname, '..', '.tmp', `worker-${process.pid}`);
 let templateInitialized = false;
 
+// Structural completeness check for the git template: a bare `existsSync(TEMPLATE_DIR)`
+// is true as soon as `mkdirSync` runs, before `git init` / `git commit` have written
+// anything into `.git/objects`. That let a fast-path caller (or a caller racing an
+// in-progress first init) trust a half-built template and hand a broken `.git` dir to
+// `fs.cpSync`, producing an ENOENT on `.git/objects` inside the copy destination. Checking
+// for `.git/objects` specifically (created by `git init`, populated by the first commit)
+// is a cheap proxy for "git init + commit actually finished".
+function isGitTemplateComplete(dir: string): boolean {
+  return fs.existsSync(path.join(dir, '.git', 'objects'));
+}
+
 function ensureGitTemplate(): string {
-  if (templateInitialized && fs.existsSync(TEMPLATE_DIR)) return TEMPLATE_DIR;
+  if (templateInitialized && isGitTemplateComplete(TEMPLATE_DIR)) return TEMPLATE_DIR;
   // Only remove OUR own PID-specific subdirectory. Do NOT rmSync the entire
   // TEMPLATE_PARENT: with workers=4 on CI, multiple worker processes call
   // ensureGitTemplate concurrently and each owns a unique pid-keyed dir under
@@ -125,8 +136,32 @@ export function createTempProject(testName: string): string {
   try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
   // Copy from the cached git template instead of running git init + commit
   // every call. fs.cpSync recursively copies including the .git directory.
-  const template = ensureGitTemplate();
-  fs.cpSync(template, tmpDir, { recursive: true });
+  //
+  // fs.cpSync's recursive walk can transiently ENOENT on a directory it just
+  // created on the destination side (its mkdir/readdir report whichever path
+  // they were acting on, so the error can name a destination path even though
+  // the underlying cause is elsewhere) under heavy parallel I/O on a loaded CI
+  // filesystem. cpSync is synchronous and this template is tiny (~400KB, a
+  // single empty commit), so a tight retry is cheap; three attempts absorbs a
+  // transient hiccup without masking a real, persistent failure (which will
+  // still throw after the retries are exhausted). ensureGitTemplate() is
+  // called INSIDE the loop (not once above it) so that if the template itself
+  // is ever found incomplete on a retry, isGitTemplateComplete() rebuilds it
+  // instead of the retry reusing a possibly-stale template reference.
+  const MAX_COPY_ATTEMPTS = 3;
+  for (let attempt = 1; attempt <= MAX_COPY_ATTEMPTS; attempt++) {
+    try {
+      const template = ensureGitTemplate();
+      fs.cpSync(template, tmpDir, { recursive: true });
+      break;
+    } catch (error) {
+      const isEnoent = error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT';
+      if (!isEnoent || attempt === MAX_COPY_ATTEMPTS) throw error;
+      // Clear any partial copy before retrying so we don't leave a half-copied
+      // tree if the retry also fails, and so the next cpSync starts clean.
+      try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  }
   return tmpDir;
 }
 

--- a/tests/ui/attachment-open-failure.spec.ts
+++ b/tests/ui/attachment-open-failure.spec.ts
@@ -173,10 +173,11 @@ async function openBacklogEditDialog(taskTitle: string): Promise<void> {
 /**
  * Close NewBacklogTaskDialog by driving the backlog store's editingItem
  * slot directly (the same function BaseDialog's own X button calls), rather
- * than clicking a close gesture. A saved attachment makes the edit form
- * report dirty (NewBacklogTaskDialog.tsx's isDirty includes
- * `attachments.length > 0` in edit mode), which would otherwise route any
- * close gesture through the discard-changes ConfirmDialog.
+ * than clicking a close gesture. NewBacklogTaskDialog.tsx's isDirty counts
+ * only PENDING attachments, so a saved one no longer reports the edit form
+ * dirty and a real close gesture would work here too; driving the store
+ * directly is kept for symmetry with openBacklogEditDialog below, which also
+ * bypasses the UI to seed state no create/edit flow can currently write.
  *
  * Also switches back to the board view, so a later test in this shared-page
  * file (e.g. the task-detail describe above, which needs the "To Do" swimlane

--- a/tests/ui/backlog-dialog-ux.spec.ts
+++ b/tests/ui/backlog-dialog-ux.spec.ts
@@ -2,6 +2,9 @@
  * UI tests for the New Backlog Task dialog UX:
  *   - Escape/discard-confirm guard in create mode and edit mode
  *   - Maximize toggle button and Ctrl+Shift+M hotkey
+ *   - Header (Pencil/Plus icon, source link, priority badge), the read-only
+ *     meta row, and the footer Delete affordance added to bring this dialog
+ *     up to the board task-detail's visual treatment
  *
  * Coverage gaps addressed (#2 from the branch audit):
  *   NewBacklogTaskDialog has the same dirty-changes guard as NewTaskDialog
@@ -198,9 +201,13 @@ test.describe('New Backlog Task Dialog - Maximize Toggle', () => {
 
     await expect(maximizeButton).toBeVisible();
 
-    // Windowed state: action is "Maximize", dialog has windowed class.
+    // Windowed state: action is "Maximize", dialog has windowed class. The
+    // windowed class now carries a definite height (h-[80vh]) so the
+    // description editor's flex-1 chain has something to fill against
+    // instead of being inert - see NewBacklogTaskDialog.tsx's maximizedDialogLayout call.
     await expect(maximizeButton).toHaveAttribute('aria-label', 'Maximize dialog');
     await expect(dialog).toHaveClass(/w-\[840px\]/);
+    await expect(dialog).toHaveClass(/h-\[80vh\]/);
     await expect(dialog).toHaveClass(/rounded-lg/);
 
     // Click maximize - content fills the area between title bar and status bar.
@@ -246,6 +253,467 @@ test.describe('New Backlog Task Dialog - Maximize Toggle', () => {
     await expect(dialog).not.toHaveClass(/w-full/);
 
     await page.keyboard.press('Escape');
+    await expect(dialog).not.toBeVisible();
+  });
+});
+
+// Seed the edit dialog directly through the backlog store, mirroring
+// attachment-open-failure.spec.ts's openBacklogEditDialog helper. Bypasses the
+// row-click UI so fields no create/edit flow can currently write (assignee,
+// external_source/url) can still be exercised.
+async function seedBacklogEditItem(
+  page: Page,
+  title: string,
+  overrides: Record<string, unknown> = {},
+): Promise<void> {
+  await page.locator('[data-testid="view-toggle-backlog"]').click();
+  await expect(page.locator('[data-testid="backlog-view"]')).toBeVisible();
+
+  await page.evaluate(({ taskTitle, taskOverrides }) => {
+    const stores = (window as unknown as {
+      __zustandStores?: { backlog?: { getState: () => { setEditingItem: (task: unknown) => void } } };
+    }).__zustandStores;
+    if (!stores?.backlog) throw new Error('backlog store not exposed on __zustandStores');
+    const now = new Date().toISOString();
+    stores.backlog.getState().setEditingItem(Object.assign({
+      id: `backlog-header-test-${Date.now()}`,
+      title: taskTitle,
+      description: '',
+      priority: 0,
+      labels: [],
+      position: 0,
+      assignee: null,
+      due_date: null,
+      item_type: null,
+      external_id: null,
+      external_source: null,
+      external_url: null,
+      sync_status: null,
+      external_metadata: null,
+      attachment_count: 0,
+      created_at: now,
+      updated_at: now,
+    }, taskOverrides));
+  }, { taskTitle: title, taskOverrides: overrides });
+
+  await expect(page.locator('[data-testid="new-backlog-task-dialog"]')).toBeVisible();
+}
+
+test.describe('New Backlog Task Dialog - Header, Delete, Meta', () => {
+  let browser: Browser;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    const result = await launchPage();
+    browser = result.browser;
+    page = result.page;
+    await createProject(page, `backlog-header-delete-${Date.now()}`);
+  });
+
+  test.afterAll(async () => {
+    await browser?.close();
+  });
+
+  test('header shows the Plus icon in create mode and the Pencil icon in edit mode', async () => {
+    await openBacklogView(page);
+    await openNewBacklogDialog(page);
+    const createDialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    await expect(createDialog.locator('svg.lucide-plus')).toBeVisible();
+    await expect(createDialog.locator('svg.lucide-pencil')).toHaveCount(0);
+    await page.keyboard.press('Escape');
+    await expect(createDialog).not.toBeVisible();
+
+    await seedBacklogEditItem(page, 'Icon check item');
+    const editDialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    await expect(editDialog.locator('svg.lucide-pencil')).toBeVisible();
+    await expect(editDialog.locator('svg.lucide-plus')).toHaveCount(0);
+    await page.keyboard.press('Escape');
+    await expect(editDialog).not.toBeVisible();
+  });
+
+  test('header priority badge tracks the live Priority select and hides at None', async () => {
+    await openBacklogView(page);
+    await openNewBacklogDialog(page);
+    const dialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    const headerTitle = dialog.locator('h3');
+
+    // No priority selected yet - the badge self-hides (PriorityBadge returns
+    // null at priority 0 with no showLabel), so the header carries only the
+    // dialog title.
+    await expect(headerTitle).toHaveText('New Backlog Task');
+
+    await dialog.locator('[data-testid="backlog-task-priority"]').selectOption({ label: 'Medium' });
+    await expect(headerTitle).toContainText('Medium');
+
+    await dialog.locator('[data-testid="backlog-task-priority"]').selectOption({ label: 'None' });
+    await expect(headerTitle).toHaveText('New Backlog Task');
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).not.toBeVisible();
+  });
+
+  test('header shows a source link only when external_source and external_url are set, and opens it', async () => {
+    await seedBacklogEditItem(page, 'No source item');
+    const plainDialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    await expect(plainDialog.locator('[data-testid="backlog-task-external-link"]')).toHaveCount(0);
+    await page.keyboard.press('Escape');
+    await expect(plainDialog).not.toBeVisible();
+
+    await seedBacklogEditItem(page, 'Imported item', {
+      external_source: 'github_issues',
+      external_url: 'https://github.com/kangentic/kangentic/issues/42',
+    });
+    const importedDialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    const link = importedDialog.locator('[data-testid="backlog-task-external-link"]');
+    await expect(link).toBeVisible();
+    await link.click();
+    const openedUrls = await page.evaluate(() => (window as unknown as { __openedExternalUrls?: string[] }).__openedExternalUrls ?? []);
+    expect(openedUrls).toContain('https://github.com/kangentic/kangentic/issues/42');
+
+    await page.keyboard.press('Escape');
+    await expect(importedDialog).not.toBeVisible();
+  });
+
+  test('meta row is edit-mode only, always shows Created and updated as one sentence, and the assignee chip only when set', async () => {
+    await openBacklogView(page);
+    await openNewBacklogDialog(page);
+    const createDialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    await expect(createDialog.locator('[data-testid="backlog-task-meta"]')).toHaveCount(0);
+    await page.keyboard.press('Escape');
+    await expect(createDialog).not.toBeVisible();
+
+    // Both times always show, joined as one sentence ("Created X, updated Y")
+    // rather than two adjacent capitalized spans - the latter read as a
+    // stutter, especially right after creating an item when both times are
+    // seconds apart.
+    await seedBacklogEditItem(page, 'Edited item', {
+      created_at: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+      updated_at: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+    });
+    const editedDialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    const editedMeta = editedDialog.locator('[data-testid="backlog-task-meta"]');
+    await expect(editedMeta).toBeVisible();
+    await expect(editedMeta).toContainText('Created');
+    await expect(editedMeta).toContainText('updated');
+    await expect(editedMeta).not.toContainText('@');
+    await page.keyboard.press('Escape');
+    await expect(editedDialog).not.toBeVisible();
+
+    await seedBacklogEditItem(page, 'Assigned item', { assignee: 'octocat' });
+    const assignedDialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    const assignedMeta = assignedDialog.locator('[data-testid="backlog-task-meta"]');
+    await expect(assignedMeta).toContainText('@octocat');
+    await page.keyboard.press('Escape');
+    await expect(assignedDialog).not.toBeVisible();
+  });
+
+  test('Delete is absent in create mode and present in edit mode; confirming deletes the item and closes', async () => {
+    await openBacklogView(page);
+    await openNewBacklogDialog(page);
+    const createDialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    await expect(createDialog.locator('[data-testid="delete-backlog-task-btn"]')).toHaveCount(0);
+    await page.keyboard.press('Escape');
+    await expect(createDialog).not.toBeVisible();
+
+    await createBacklogItem(page, 'Delete me from the dialog');
+    await expect(page.locator('text=Delete me from the dialog')).toBeVisible();
+    await page.locator('[data-testid="edit-item-btn"]').click();
+    const editDialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    await expect(editDialog).toBeVisible();
+
+    const deleteButton = editDialog.locator('[data-testid="delete-backlog-task-btn"]');
+    await expect(deleteButton).toBeVisible();
+    await deleteButton.click();
+
+    const confirmHeading = page.locator('h3:has-text("Delete backlog task")');
+    await expect(confirmHeading).toBeVisible();
+    await page.locator('button:has-text("Delete")').last().click();
+
+    await expect(editDialog).not.toBeVisible();
+    await expect(page.locator('text=Delete me from the dialog')).not.toBeVisible();
+  });
+
+  test('Delete with skipDeleteConfirm set deletes immediately with no confirm dialog', async () => {
+    await openBacklogView(page);
+    await createBacklogItem(page, 'Delete me without asking');
+    await expect(page.locator('text=Delete me without asking')).toBeVisible();
+
+    await page.evaluate(() => {
+      const stores = (window as unknown as {
+        __zustandStores?: { config?: { getState: () => { updateConfig: (partial: Record<string, unknown>) => Promise<void> } } };
+      }).__zustandStores;
+      void stores?.config?.getState().updateConfig({ skipDeleteConfirm: true });
+    });
+
+    await page.locator('[data-testid="edit-item-btn"]').click();
+    const editDialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    await expect(editDialog).toBeVisible();
+
+    await editDialog.locator('[data-testid="delete-backlog-task-btn"]').click();
+    await expect(editDialog).not.toBeVisible({ timeout: 3000 });
+    await expect(page.locator('text=Delete me without asking')).not.toBeVisible();
+
+    // Restore the shared page's config for any later test in this describe.
+    await page.evaluate(() => {
+      const stores = (window as unknown as {
+        __zustandStores?: { config?: { getState: () => { updateConfig: (partial: Record<string, unknown>) => Promise<void> } } };
+      }).__zustandStores;
+      void stores?.config?.getState().updateConfig({ skipDeleteConfirm: false });
+    });
+  });
+
+  // Red-green for the isDirty defect: edit-mode isDirty used to end with
+  // `attachments.length > 0`, but the load effect pushes SAVED attachments
+  // into that same array - so opening an item that already has an attachment
+  // reported dirty on arrival and Escape popped the discard confirm with zero
+  // user edits. Fails before the `hasPendingAttachments` fix.
+  test('opening an edit item with a saved attachment and Escape closes immediately, no false discard confirm', async () => {
+    await page.evaluate(() => {
+      window.electronAPI.backlogAttachments.list = async () => [{
+        id: 'ba-dirty-regression',
+        backlog_task_id: 'unused',
+        filename: 'spec.pdf',
+        file_path: '/mock/spec.pdf',
+        media_type: 'application/pdf',
+        size_bytes: 10,
+        created_at: new Date().toISOString(),
+      }];
+    });
+
+    await seedBacklogEditItem(page, 'Has a saved attachment');
+    const dialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    await expect(dialog.locator('[data-testid="attachment-chip"]')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).not.toBeVisible();
+    await expect(page.locator('h3:has-text("Discard unsaved changes?")')).not.toBeVisible();
+
+    // Restore the default (empty) mock for any later test in this describe.
+    await page.evaluate(() => {
+      window.electronAPI.backlogAttachments.list = async () => [];
+    });
+  });
+
+  // Red-green for the delete-failure ordering fix: performDelete used to
+  // persist "don't ask again" BEFORE calling onDelete, so a delete that
+  // failed still armed the global skip-confirm bypass while the user was
+  // staring straight at the error. It now persists only after onDelete
+  // resolves; on rejection the catch path toasts an error, leaves both the
+  // confirm and the edit dialog open, and does not touch skipDeleteConfirm.
+  test('a rejected delete keeps the dialog open, toasts an error, and does not persist "don\'t ask again"', async () => {
+    await openBacklogView(page);
+    await createBacklogItem(page, 'Delete failure item');
+    await expect(page.locator('text=Delete failure item')).toBeVisible();
+
+    await page.evaluate(() => {
+      const api = window as unknown as { __originalBacklogDelete?: typeof window.electronAPI.backlog.delete };
+      api.__originalBacklogDelete = window.electronAPI.backlog.delete;
+      window.electronAPI.backlog.delete = async () => {
+        throw new Error('mock delete failure');
+      };
+    });
+
+    await page.locator('[data-testid="edit-item-btn"]').click();
+    const editDialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    await expect(editDialog).toBeVisible();
+
+    await editDialog.locator('[data-testid="delete-backlog-task-btn"]').click();
+    const confirmHeading = page.locator('h3:has-text("Delete backlog task")');
+    await expect(confirmHeading).toBeVisible();
+
+    const dontAskAgainCheckbox = page.locator('label', { hasText: "Don't ask again" }).locator('input[type="checkbox"]');
+    await dontAskAgainCheckbox.check();
+    await page.locator('button:has-text("Delete")').last().click();
+
+    // The delete failed: an error toast appears, and both the confirm and the
+    // edit dialog stay open - performDelete's catch never calls
+    // setConfirmDelete(false) or onClose().
+    await expect(page.locator('[data-testid="toast"]')).toContainText('Failed to delete backlog task');
+    await expect(confirmHeading).toBeVisible();
+    await expect(editDialog).toBeVisible();
+
+    // The global bypass must not have been persisted on a failed delete.
+    const skipDeleteConfirm = await page.evaluate(() => {
+      const stores = (window as unknown as {
+        __zustandStores?: { config?: { getState: () => { config: { skipDeleteConfirm: boolean } } } };
+      }).__zustandStores;
+      return stores?.config?.getState().config.skipDeleteConfirm ?? null;
+    });
+    expect(skipDeleteConfirm).toBe(false);
+
+    // The item was never removed.
+    await expect(page.locator('text=Delete failure item')).toBeVisible();
+
+    // Clean up: dismiss the confirm, close the (still clean) edit dialog,
+    // restore the real backlog.delete mock, then remove the item through the
+    // store so the describe's single-row invariant holds for later tests.
+    // .last() picks the confirm's own Cancel button - the edit dialog's
+    // footer Cancel button is still in the DOM underneath (same ambiguity as
+    // the existing "Delete" button locator further down in this file).
+    await page.locator('button:has-text("Cancel")').last().click();
+    await expect(confirmHeading).not.toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(editDialog).not.toBeVisible();
+
+    await page.evaluate(async () => {
+      const api = window as unknown as { __originalBacklogDelete?: typeof window.electronAPI.backlog.delete };
+      if (api.__originalBacklogDelete) window.electronAPI.backlog.delete = api.__originalBacklogDelete;
+      const stores = (window as unknown as {
+        __zustandStores?: {
+          backlog?: {
+            getState: () => {
+              items: { id: string; title: string }[];
+              deleteItem: (id: string) => Promise<void>;
+            };
+          };
+        };
+      }).__zustandStores;
+      const target = stores?.backlog?.getState().items.find((item) => item.title === 'Delete failure item');
+      if (target) await stores?.backlog?.getState().deleteItem(target.id);
+    });
+    await expect(page.locator('text=Delete failure item')).not.toBeVisible();
+  });
+
+  // "Don't ask again" on a SUCCESSFUL delete persists skipDeleteConfirm - the
+  // failure test above only proves it stays false on rejection.
+  test('checking "don\'t ask again" on a successful delete persists skipDeleteConfirm', async () => {
+    await openBacklogView(page);
+    await createBacklogItem(page, 'Delete with dont ask again');
+    await expect(page.locator('text=Delete with dont ask again')).toBeVisible();
+
+    await page.locator('[data-testid="edit-item-btn"]').click();
+    const editDialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    await expect(editDialog).toBeVisible();
+
+    await editDialog.locator('[data-testid="delete-backlog-task-btn"]').click();
+    const confirmHeading = page.locator('h3:has-text("Delete backlog task")');
+    await expect(confirmHeading).toBeVisible();
+
+    const dontAskAgainCheckbox = page.locator('label', { hasText: "Don't ask again" }).locator('input[type="checkbox"]');
+    await dontAskAgainCheckbox.check();
+    await page.locator('button:has-text("Delete")').last().click();
+
+    await expect(editDialog).not.toBeVisible();
+    await expect(page.locator('text=Delete with dont ask again')).not.toBeVisible();
+
+    const skipDeleteConfirm = await page.evaluate(() => {
+      const stores = (window as unknown as {
+        __zustandStores?: { config?: { getState: () => { config: { skipDeleteConfirm: boolean } } } };
+      }).__zustandStores;
+      return stores?.config?.getState().config.skipDeleteConfirm ?? null;
+    });
+    expect(skipDeleteConfirm).toBe(true);
+
+    // Restore for any later test in this describe.
+    await page.evaluate(() => {
+      const stores = (window as unknown as {
+        __zustandStores?: { config?: { getState: () => { updateConfig: (partial: Record<string, unknown>) => Promise<void> } } };
+      }).__zustandStores;
+      void stores?.config?.getState().updateConfig({ skipDeleteConfirm: false });
+    });
+  });
+
+  // Coverage gap: NameFromPromptButton sits beside the title input but only
+  // renders once `description` is non-empty, and no existing test in this
+  // file ever fills the description - so the whole wiring was unverified.
+  test('Name from prompt button appears once the description is filled and updates the title', async () => {
+    await openBacklogView(page);
+    await openNewBacklogDialog(page);
+    const dialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+
+    await expect(dialog.locator('[data-testid="name-from-prompt-button"]')).toHaveCount(0);
+
+    await dialog.locator('[data-testid="backlog-task-description"]').fill('rename a backlog item whose title is fix bug');
+    const nameFromPromptButton = dialog.locator('[data-testid="name-from-prompt-button"]');
+    await expect(nameFromPromptButton).toBeVisible();
+
+    await page.evaluate(() => {
+      (window as unknown as { __mockAgentSummarize: (input: { prompt: string }) => unknown }).__mockAgentSummarize =
+        (input) => ({ ok: true, title: `Suggested: ${(input as { prompt: string }).prompt.slice(0, 20)}` });
+    });
+
+    await nameFromPromptButton.click();
+    await expect(dialog.locator('[data-testid="backlog-task-title"]')).toHaveValue(/^Suggested:/);
+
+    // Restore the default summarize mock and discard the now-dirty form.
+    await page.evaluate(() => {
+      delete (window as unknown as { __mockAgentSummarize?: unknown }).__mockAgentSummarize;
+    });
+    await page.keyboard.press('Escape');
+    await expect(page.locator('h3:has-text("Discard unsaved changes?")')).toBeVisible();
+    await page.locator('button:has-text("Discard")').click();
+    await expect(dialog).not.toBeVisible();
+  });
+
+  test('header uses a plain external-link icon and "Open in <source>" title for a non-GitHub source', async () => {
+    await seedBacklogEditItem(page, 'Jira item', {
+      external_source: 'jira',
+      external_url: 'https://example.atlassian.net/browse/ISSUE-1',
+    });
+    const dialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    const link = dialog.locator('[data-testid="backlog-task-external-link"]');
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('title', 'Open in jira');
+    await page.keyboard.press('Escape');
+    await expect(dialog).not.toBeVisible();
+
+    // The GitHub case, for contrast - the title differs.
+    await seedBacklogEditItem(page, 'GitHub title check item', {
+      external_source: 'github_issues',
+      external_url: 'https://github.com/kangentic/kangentic/issues/7',
+    });
+    const githubDialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    const githubLink = githubDialog.locator('[data-testid="backlog-task-external-link"]');
+    await expect(githubLink).toHaveAttribute('title', 'Open in GitHub');
+    await page.keyboard.press('Escape');
+    await expect(githubDialog).not.toBeVisible();
+  });
+
+  // The header link guards on `external_source && external_url`. Only
+  // both-null and both-set were covered, so a regression from `&&` to `||`
+  // would still pass every existing test.
+  test('header hides the source link when external_source is set but external_url is null', async () => {
+    await seedBacklogEditItem(page, 'Source with no url item', {
+      external_source: 'jira',
+      external_url: null,
+    });
+    const dialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    await expect(dialog.locator('[data-testid="backlog-task-external-link"]')).toHaveCount(0);
+    await page.keyboard.press('Escape');
+    await expect(dialog).not.toBeVisible();
+  });
+
+  // Positive direction of the isDirty fix above: a PENDING attachment (one
+  // the user just added, not loaded from disk) must still make the edit form
+  // dirty, so Escape shows the discard confirm.
+  test('adding a pending attachment in edit mode makes the form dirty and Escape shows the discard confirm', async () => {
+    await seedBacklogEditItem(page, 'Has a pending attachment');
+    const dialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+
+    // Simulate pasting an image into the description textarea - mirrors the
+    // paste simulation in task-attachments.spec.ts.
+    await page.evaluate(() => {
+      const textarea = document.querySelector('[data-testid="backlog-task-description"]');
+      if (!textarea) return;
+      const base64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+      const binary = atob(base64);
+      const bytes = new Uint8Array(binary.length);
+      for (let index = 0; index < binary.length; index++) bytes[index] = binary.charCodeAt(index);
+      const blob = new Blob([bytes], { type: 'image/png' });
+      const file = new File([blob], 'pending.png', { type: 'image/png' });
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      const pasteEvent = new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: dataTransfer });
+      textarea.dispatchEvent(pasteEvent);
+    });
+
+    await expect(dialog.locator('[data-testid="attachment-chip"]')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    const confirmHeading = page.locator('h3:has-text("Discard unsaved changes?")');
+    await expect(confirmHeading).toBeVisible();
+
+    await page.locator('button:has-text("Discard")').click();
     await expect(dialog).not.toBeVisible();
   });
 });

--- a/tests/ui/backlog-dialog-ux.spec.ts
+++ b/tests/ui/backlog-dialog-ux.spec.ts
@@ -716,4 +716,53 @@ test.describe('New Backlog Task Dialog - Header, Delete, Meta', () => {
     await page.locator('button:has-text("Discard")').click();
     await expect(dialog).not.toBeVisible();
   });
+
+  // Red-green for the confirmDelete/confirmDiscard early-return in
+  // handleSubmit: the delete confirm uses variant="danger", which disables
+  // ConfirmDialog's own Enter-to-confirm handler (see ConfirmDialog.tsx), so
+  // nothing upstream prevents a stray Enter keypress from reaching the
+  // form's native submit while the confirm sits on top. Without the guard,
+  // a title input that still (or again) has focus would submit the edited
+  // title over the pending delete and silently close everything out from
+  // under the confirmation the user is looking at.
+  test('Enter while the delete confirm is open does not submit the edit form over it', async () => {
+    await openBacklogView(page);
+    await createBacklogItem(page, 'Enter guard item');
+    await expect(page.locator('text=Enter guard item')).toBeVisible();
+
+    await page.locator('[data-testid="edit-item-btn"]').click();
+    const editDialog = page.locator('[data-testid="new-backlog-task-dialog"]');
+    await expect(editDialog).toBeVisible();
+
+    const titleInput = editDialog.locator('[data-testid="backlog-task-title"]');
+    await titleInput.fill('Enter guard item CHANGED');
+
+    await editDialog.locator('[data-testid="delete-backlog-task-btn"]').click();
+    const confirmHeading = page.locator('h3:has-text("Delete backlog task")');
+    await expect(confirmHeading).toBeVisible();
+
+    // Re-focus the title input (trapFocus only intercepts Tab, not an
+    // explicit .focus() call) to reproduce the exact scenario the guard
+    // defends against, then press Enter.
+    await titleInput.focus();
+    await titleInput.press('Enter');
+
+    // Nothing must have happened: a submit would call onUpdate, which
+    // resolves and closes the whole dialog tree (including this confirm,
+    // since it is a sibling unmounted along with the rest on onClose). Both
+    // stay open and the title is untouched.
+    await expect(confirmHeading).toBeVisible();
+    await expect(editDialog).toBeVisible();
+    await expect(titleInput).toHaveValue('Enter guard item CHANGED');
+
+    // Clean up: cancel the confirm, then discard the still-dirty edit.
+    await page.locator('button:has-text("Cancel")').last().click();
+    await expect(confirmHeading).not.toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.locator('h3:has-text("Discard unsaved changes?")')).toBeVisible();
+    await page.locator('button:has-text("Discard")').click();
+    await expect(editDialog).not.toBeVisible();
+    await expect(page.locator('text=Enter guard item CHANGED')).not.toBeVisible();
+    await expect(page.locator('text=Enter guard item')).toBeVisible();
+  });
 });


### PR DESCRIPTION
## What

Restyles the backlog task edit/create modal (`NewBacklogTaskDialog.tsx`, rendered twice by
`BacklogDialogs.tsx`) to match the board's `Edit Task` window treatment. It stays a modal - no
change to the window-manager layer.

- **Header:** `Pencil` icon in edit mode (`Plus` in create), a live `PriorityBadge` that tracks
  the Priority select as you change it, and a `GitHub`/generic external-link button when the item
  carries `external_source` + `external_url` (imported items only).
- **Title row:** `NameFromPromptButton` added next to the title input in both modes.
- **Meta row (edit mode only):** `Created X ago, updated Y ago` as one sentence, plus an
  `@assignee` chip when set. Went through a couple of rounds of feedback on this exact wording -
  see the commit history and the final shape below.
- **Delete:** wired into the footer's `leading` slot, mirroring the board exactly - `ConfirmDialog`
  + `skipDeleteConfirm` fast path, wrapped in `try`/`catch` with an error toast on failure (the
  store's `deleteItem` had none).
- **Height fix:** `maximizedDialogLayout`'s windowed size supplied width only, so the description
  editor's `flex-1` chain was inert until maximized - that's the actual cause of the thin
  description block, not a pixel-target problem. Now carries a definite height (`h-[80vh]`) plus a
  scrolling body, applied to both create and edit.
- **Bug fix:** `isDirty` in edit mode ended with `attachments.length > 0`, but the load effect
  pushes *saved* attachments into that same array - so opening an item that already had an
  attachment reported dirty on arrival and Escape popped a spurious "Discard unsaved changes?"
  confirm. Fixed to only count pending attachments.
- **Guard:** `handleSubmit` now bails if `confirmDelete || confirmDiscard` is set, so a stray Enter
  behind the delete confirm (which disables its own Enter-to-confirm for `variant="danger"`) can't
  reach the form's native submit and save over a pending delete.

Explicitly out of scope (per the task): no ticket number/`display_id` (doesn't exist on
`BacklogTask`), no branch row / Column Settings / Agent Override / PR URL / worktree controls (a
backlog item has none of those), no backlog list redesign.

## Why

Task #540: opening a task from the Backlog gave a noticeably thinner surface than opening the same
kind of task on the board, even though the two dialogs already share most of their leaf primitives
(`DescriptionEditor`, `PriorityLabelsRow`, `AttachmentChipStrip`, `DialogFooterActions`,
`PriorityBadge`). This was a treatment gap, not a rebuild.

## How

Create and edit modes stay one component - every difference above is a per-mode prop, never a
fork. Reused existing shared primitives everywhere possible rather than hand-rolling new UI;
the only genuinely new pieces are the header's source-link button (ported from
`backlog/view/useBacklogColumns.tsx`) and the meta row.

Which optional `BacklogTask` fields to surface was decided from the live data, not the type:
`assignee` / `external_source` / `external_url` are written by the GitHub Issues, GitHub Projects,
Azure DevOps, and Asana import adapters, so they're real; `due_date` / `item_type` are dead
columns the repository accepts but nothing anywhere writes, so they're dropped rather than shipped
as permanently-blank UI. `attachment_count` was already covered - the dialog already renders real
attachments via `AttachmentChipStrip`.

## Breaking changes

None.

## Tests

`tests/ui/backlog-dialog-ux.spec.ts` - extended from 7 to 21 tests, covering: header icon per
mode, the live priority badge (including hide-at-None), the external-source link (GitHub vs
generic, and the `&&` guard when only one of `external_source`/`external_url` is set), the meta
row's content and edit-mode-only gating, `NameFromPromptButton` availability, Delete
absent-in-create/present-in-edit plus the full confirm-and-delete flow, `skipDeleteConfirm`
persisting on "don't ask again", a rejected delete keeping the dialog open with an error toast and
not persisting the config, the `isDirty` saved-vs-pending-attachment fix (red-green verified: the
new test fails without the fix, passes with it), and Enter behind the delete confirm not reaching
the form's submit (red-green verified the same way). The existing maximize-toggle test was
extended to assert the new `h-[80vh]` windowed class.

Also manually verified in a live preview: the height fix, header treatment, meta row, delete flow,
and the Enter-behind-confirm guard.

Generated with [Claude Code](https://claude.com/claude-code)
