### PR TITLE
fix(release): publish one release per tag, and locate renderer errors

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -198,8 +198,16 @@ Summarize the release:
 - Commits included: N
 - Changelog entry: show the generated entry
 - **Release notes:** Read `RELEASE_NOTES.md` and display the contents. Tell the user: "These release notes will be applied to the draft GitHub Release automatically by CI."
-- GitHub Actions: link to `https://github.com/Kangentic/kangentic/actions` -- the tag push triggers the Release workflow which builds platform artifacts and creates a draft GitHub Release.
-- **Open the releases page** in the user's browser: run `start https://github.com/Kangentic/kangentic/releases` so the user can review and publish the draft once the workflow completes.
+- GitHub Actions: link to `https://github.com/Kangentic/kangentic/actions`. The tag push triggers the Release workflow, which creates ONE draft Release, builds all three platforms into it, verifies the asset manifest, and then publishes it automatically.
+- **Open the releases page** in the user's browser: run `start https://github.com/Kangentic/kangentic/releases` so the user can confirm the release went live.
+
+**Never publish the draft by hand.** Publishing is automatic once
+`scripts/verify-release-assets.js` confirms the tag resolves to exactly one release carrying all
+11 expected assets. So a release still sitting as a draft after the workflow finishes means that
+gate FAILED, and the draft is presumed incomplete. Clicking Publish in the GitHub UI bypasses the
+only check that stands between a partial release and every user's auto-updater, which is exactly
+how v0.35.0 shipped macOS-less. Read the `publish-release` job log, fix the cause, and re-run the
+workflow instead.
 
 ## Allowed Tools
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,79 @@ jobs:
           git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}"
           git push origin "v${{ inputs.version }}"
 
-  release:
+  # Create THE single draft release, before any platform build starts.
+  #
+  # electron-builder's GitHub publisher does a check-then-create with no locking:
+  # getOrCreateRelease() lists releases, scans for a matching tag_name, and creates
+  # a draft if it finds none (electron-publish/out/gitHubPublisher.js:55, verified
+  # against electron-builder 26.8.1 - a caret range, so re-check the line numbers
+  # after a bump). The three matrix legs each run `npm run publish` in parallel, so
+  # on v0.35.0 all three listed before any had created, all three saw nothing, and
+  # all three created a draft. GitHub permits duplicate drafts for one tag (a draft
+  # binds no git ref), so all three succeeded and the release split three ways.
+  #
+  # Pre-creating the draft closes that: `needs:` is a hard barrier, so the draft
+  # provably exists before any leg lists releases, and every leg then takes the
+  # `if (release.draft) return release` branch at gitHubPublisher.js:66 and reuses
+  # it. The legs upload disjoint filenames and never read-modify-write the release
+  # object, so nothing else races.
+  #
+  # Deliberately carries no `environment:`: the matrix legs gate on the
+  # release-<platform> environments, and a required reviewer or wait timer here
+  # would stall draft creation for all three.
+  create-draft-release:
     needs: [create-tag]
     if: always() && (needs.create-tag.result == 'success' || needs.create-tag.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref }}
+
+      - name: Determine version tag
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=v${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Idempotent, so a re-run reuses whatever already exists. Titled without the
+      # leading "v" to match what electron-builder's own createRelease() produces.
+      #
+      # Page 1 only, unlike scripts/verify-release-assets.js, which pages to 20.
+      # The tag being created is by definition among the newest releases, so it
+      # cannot have fallen off page 1 here. The deeper paging matters only in the
+      # verify gate, which must also SEE a duplicate to fail on it. If this check
+      # ever did miss an existing release, the result is a second draft, and that
+      # gate then fails the release rather than publishing a partial one.
+      - name: Create the draft release if absent
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ steps.version.outputs.tag }}"
+          existing=$(gh api "repos/${{ github.repository }}/releases?per_page=100" \
+            --jq "[.[] | select(.tag_name == \"$tag\")] | length")
+          if [ "$existing" -gt 0 ]; then
+            echo "A release already exists for $tag; reusing it."
+            exit 0
+          fi
+          gh release create "$tag" \
+            --draft \
+            --title "${tag#v}" \
+            --notes-file RELEASE_NOTES.md \
+            --repo "${{ github.repository }}"
+
+  release:
+    needs: [create-tag, create-draft-release]
+    # The create-draft-release clause is load-bearing. always() is present to
+    # tolerate the conditional create-tag, which means adding a job to needs:
+    # without also naming it here would let the matrix run when draft creation
+    # FAILED, straight back to the three-way split this job exists to prevent.
+    if: always() && (needs.create-tag.result == 'success' || needs.create-tag.result == 'skipped') && needs.create-draft-release.result == 'success'
     environment: release-${{ matrix.platform }}
     strategy:
       fail-fast: false
@@ -206,9 +276,15 @@ jobs:
           docker run --rm -v "$PWD/out:/out:ro" ubuntu:24.04 sh -c \
             "apt-get update -qq && apt-get install -y \"/out/$(basename "$deb_file")\""
 
-  # Only publish the draft release when ALL platform builds succeed.
-  # This prevents partial releases (e.g. missing macOS artifacts) from
-  # reaching users. If any platform fails, the release stays as a draft.
+  # Publish the draft release, but only after verifying what is actually attached
+  # to it.
+  #
+  # The needs.release.result == 'success' gate is necessary and not sufficient. On
+  # v0.35.0 every platform job DID succeed and the release still shipped Windows-
+  # only, because the artifacts landed on three separate release objects and this
+  # job published one of them. Build success says nothing about what is attached to
+  # the release being published, so the asset-manifest check below is the gate that
+  # actually prevents a partial release. A failure here leaves the release a draft.
   #
   # Publishing (--draft=false) and setting the notes body happen in the SAME
   # `gh release edit` call so the release is never live with an empty body:
@@ -234,6 +310,13 @@ jobs:
           else
             echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi
+
+      # Must run BEFORE --draft=false: a failure here has to leave the release
+      # unpublished rather than roll one back.
+      - name: Verify the release carries every expected asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/verify-release-assets.js "${{ steps.version.outputs.tag }}" --repo ${{ github.repository }}
 
       - name: Publish release with notes (remove draft status)
         env:

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -11,7 +11,7 @@ Nine event types are tracked, all on critical-path actions only:
 | `app_launch` | App starts (when analytics is enabled) | platform, arch, clientId |
 | `app_heartbeat` | Every 30 minutes while at least one agent session is active; skipped when idle. Also fires once right before system sleep if a session is active | activeSessions, suspendedSessions, queuedSessions, totalSessions |
 | `app_close` | Graceful quit, Ctrl+C, SIGTERM, or OS shutdown/reboot/log-off | durationSeconds |
-| `app_error` | Uncaught exception, unhandled rejection, renderer crash, or React ErrorBoundary | source, message (sanitized), reason (renderer crashes), exitCode (renderer crashes) |
+| `app_error` | Uncaught exception, unhandled rejection, renderer crash, or React ErrorBoundary | source, message (sanitized), reason (renderer crashes), exitCode (renderer crashes), boundary / panel / components (renderer errors) |
 | `project_create` | User creates a project | (none) |
 | `task_complete` | Task moves to Done | agent, model, durationSeconds, costUsd, inputTokens, outputTokens, toolCalls |
 | `session_spawn` | Agent session reaches running state (board or transient) | agent, isTransient |
@@ -27,6 +27,28 @@ For Claude sessions, `model` is normalized to its base id via `parseModelId` (`s
 `costUsd`, `inputTokens`, `outputTokens`, and `toolCalls` are cumulative session metrics, omitted when not yet available (e.g. a session that exited before any usage was recorded). `session_exit` carries `costUsd`/`toolCalls` only, since its token counts would otherwise be a point-in-time context-window snapshot rather than a cumulative total; `task_complete` is the source for cumulative token counts.
 
 The `app_launch` event also carries `clientId`, an anonymous id Kangentic generates and attaches (see "Unique Installs" below). It is attached only to `app_launch` (the one authoritative per-launch install signal), not to every event, to avoid inflating high-cardinality string-prop volume on events like `app_heartbeat` where it adds no install-counting value.
+
+Renderer errors (`source: error_boundary`) carry three extra properties that say *where* the error
+happened, since a message alone is rarely enough to locate one. `boundary` is `root`, `panel`, or
+`unhandled_rejection` and identifies which of the three reporters caught it; `panel` is the
+failing panel's static label; `components` is a trail of React component names, innermost first.
+The raw component stack is never sent: a production stack frame embeds a `file://` URL containing
+the user's home directory, so main reduces it to component names, which cannot contain a path.
+
+`boundary` and `panel` read directly. `components` does not: React takes frame names from
+`fn.name` and the packaged renderer bundle is minified, so the trail arrives mangled. It still
+distinguishes one code path from another, and a matching build's sourcemap resolves it, but it is
+not readable on its own. `boundary` is the field to reach for first.
+
+Aptabase truncates any string property at 180 characters server-side, so `panel` and `components`
+are capped at that length rather than sending text that would be silently cut. `message` is the
+exception: `sanitizeErrorMessage` caps it at 200, so a message longer than 180 is still cut
+server-side.
+
+`boundary` classifies only `source: error_boundary` events. The other `app_error` sources
+(`uncaughtException`, `unhandledRejection`, `render-process-gone`, all raised in the main process)
+never carry it, and they are separate from the local crash-log system under
+`.kangentic/logs/crashes/`, which records its own JSON files and never reaches Aptabase.
 
 The analytics SDK automatically detects: OS name, OS version, locale, app version, anonymous session ID, and country (derived from IP, then discarded).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -389,7 +389,7 @@ Detach a registered UI surface (usage stats, git changes, the task Browser pane,
 ### Analytics (1 channel)
 | Channel | Pattern | Purpose |
 |---------|---------|---------|
-| `analytics:trackRendererError` | invoke | Report renderer-side errors to main process |
+| `analytics:trackRendererError` | send | Report a renderer-side error to main, with a `RendererErrorContext` (`boundary`, `panel?`, `componentStack?`) saying where it came from. See [Analytics](analytics.md). |
 
 ### App (1 channel)
 | Channel | Pattern | Purpose |

--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -70,13 +70,17 @@ The PowerShell case fixes a Windows PowerShell 5.1 quirk: it treats `[` / `]` in
 | node-pty | Prebuilt NAPI binaries, no rebuild needed | Included via `files`, prebuilds unpacked from asar via `asarUnpack` |
 | sherpa-onnx-node | Prebuilt platform-specific binaries (no rebuild needed) | Included via `files` (`sherpa-onnx-node/**` plus the `sherpa-onnx-*/**` platform packages), unpacked from asar via `asarUnpack: node_modules/sherpa-onnx-*/**` (voice dictation engine) |
 | font-list | Shells out to `fc-list` (Linux) / a PowerShell script (Windows) / a bundled binary (macOS); no rebuild needed | Included via `files` (`font-list/**`), unpacked from asar via `asarUnpack` since the macOS binary is spawned via `child_process` (Terminal Font Family picker) |
+| sqlite-vec | Loadable SQLite extension shipped as per-platform binary packages; no rebuild needed | Included via `files` (`sqlite-vec/**` plus the `sqlite-vec-*/**` platform packages), unpacked via `asarUnpack` because SQLite's dlopen cannot read a loadable extension inside an asar archive (conversation-memory retrieval) |
+| @huggingface/transformers | Pure JavaScript (transformers.js); no rebuild needed | Included via `files`, unpacked via `asarUnpack` so the embed worker resolves it from the unpacked tree by plain node_modules resolution |
+| onnxruntime-node | Prebuilt native binaries (`onnxruntime_binding.node`, plus `onnxruntime.dll` and `DirectML.dll` on Windows) | Included via `files`, unpacked via `asarUnpack` because a native `.node` addon cannot be dlopen'd from inside asar (the embed worker's execution provider) |
+| onnxruntime-web | Pure JavaScript; retained only as transformers' optional peer, its wasm path currently unused | Included via `files` and unpacked alongside the others |
 | simple-git | Pure JavaScript, bundled by esbuild | Not in node_modules (bundled into main process) |
 
-The `files` array in `electron-builder.yml` explicitly whitelists `.vite/build/**`, `better-sqlite3`, `node-pty`, `sherpa-onnx-node`, the `sherpa-onnx-*` platform packages, `font-list`, `bindings`, and `file-uri-to-path`. Everything else is excluded from the packaged app.
+The `files` array in `electron-builder.yml` explicitly whitelists `.vite/build/**`, `package.json`, `better-sqlite3`, `node-pty`, `sherpa-onnx-node`, the `sherpa-onnx-*` platform packages, `font-list`, `bindings`, `file-uri-to-path`, `sqlite-vec`, the `sqlite-vec-*` platform packages, `@huggingface/transformers`, `onnxruntime-node`, and `onnxruntime-web`. Everything else is excluded from the packaged app.
 
 ### Bridge Script Unpacking
 
-Bridge scripts (`event-bridge.js`, `status-bridge.js`) are executed by Claude Code hooks in a separate `node` process outside Electron. Plain Node.js cannot read files inside asar archives, so `asar.unpackDir` extracts `.vite/build/` to `app.asar.unpacked/`. The `resolveBridgeScript()` function in `src/main/agent/shared/bridge-utils.ts` rewrites `app.asar` to `app.asar.unpacked` in resolved paths when running in a packaged build.
+Bridge scripts (`event-bridge.js`, `status-bridge.js`) are executed by Claude Code hooks in a separate `node` process outside Electron. Plain Node.js cannot read files inside asar archives, so `asarUnpack` names them individually, alongside `embed-worker.js`, `line-count-worker.js`, and `plugins/**` (unpacked for the retrieval and embedding subsystem rather than for the hook bridges). Only those five entries under `.vite/build/` are extracted to `app.asar.unpacked/`; the rest of the directory stays inside the archive. The `resolveBridgeScript()` function in `src/main/agent/shared/bridge-utils.ts` rewrites `app.asar` to `app.asar.unpacked` in resolved paths when running in a packaged build.
 
 ## Config Directory Locations
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -96,24 +96,45 @@ Electron's `autoUpdater` on macOS only works with signed apps (Electron docs: "m
 
 ### Draft Releases Are Invisible to Auto-Updater
 
-`electron-updater` only sees **published** releases. Draft releases are invisible to the auto-updater and to `npx kangentic`. The manual publish step is the review gate -- always verify artifacts before publishing.
+`electron-updater` only sees **published** releases. Draft releases are invisible to the auto-updater and to `npx kangentic`.
+
+That invisibility is what made the v0.35.0 failure user-facing: the three platform jobs each raced
+to create their own draft for the same tag, the publish step resolved the tag to the Windows one,
+and the macOS and Linux artifacts stayed on drafts nobody could download. Two things now prevent a
+repeat. `create-draft-release` creates the single draft before any build starts, so every platform
+job attaches to the same release. Then `scripts/verify-release-assets.js` runs before
+`--draft=false` and fails the release unless the tag resolves to exactly one release object
+carrying all 11 expected assets, all fully uploaded. A build that succeeds on every platform is
+not evidence that the release is complete; only the asset check is.
 
 ### GitHub Actions Workflows
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | `ci.yml` | Push to main, PRs | Typecheck, unit tests, UI tests |
-| `release.yml` | Tag push (`v*`) or `workflow_dispatch` | Build + sign + draft GitHub Release, then publish with notes (one atomic `gh release edit`) + publish launcher to npm (via OIDC trusted publishing) |
+| `release.yml` | Tag push (`v*`) or `workflow_dispatch` | Create one draft Release, build + sign on all 3 platforms into it, verify the asset manifest, then publish with notes (one atomic `gh release edit`) + publish launcher to npm (via OIDC trusted publishing) |
 
 ### CI Build Matrix
 
-The release workflow produces 3 builds:
+The release workflow produces 3 builds, contributing 11 assets in total to one release. The full
+expected filename set is `scripts/release-assets.js`, which the publish gate checks against and
+`tests/unit/release-asset-manifest.test.ts` keeps in sync with `electron-builder.yml` and the
+launcher.
 
 | Runner | Platform | Artifacts |
 |--------|----------|-----------|
-| `ubuntu-latest` | linux-x64 | `.deb`, `.rpm` |
-| `windows-latest` | windows-x64 | `Setup.exe`, `.nupkg` |
-| `macos-latest` | macos-arm64 | `.dmg`, `.zip` |
+| `ubuntu-latest` | linux-x64 | `.deb`, `.rpm`, `latest-linux.yml` |
+| `windows-latest` | windows-x64 | `Setup.exe`, `.exe.blockmap`, `latest.yml` |
+| `macos-latest` | macos-arm64 | `.dmg`, `.zip`, a `.blockmap` for each, `latest-mac.yml` |
+
+The three `latest*.yml` files are the update manifests `electron-updater` fetches, so a release
+missing one is broken for that platform even when its installer uploaded fine.
+
+Every artifact filename is pinned via `artifactName` in `electron-builder.yml` rather than
+inherited from electron-builder's defaults. Three of the five templates (the macOS zip, the dmg,
+and the deb) were inherited until v0.35.0; only `nsis` and `rpm` were already pinned. The launcher
+hardcodes the names it downloads, so a default change would have silently 404'd `npx kangentic` on
+that platform.
 
 Linux arm64 and macOS x64 are not built in v1. Documented in the [Installation Guide](installation.md).
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -361,10 +361,13 @@ electron-builder handles platform-specific packaging via `electron-builder.yml`:
 | Linux | Package | deb, rpm |
 
 Native modules:
-- `better-sqlite3` -- rebuilt against Electron headers via `scripts/rebuild-native.js`
-- `node-pty` -- uses prebuilt NAPI binaries, no rebuild needed
-- `sherpa-onnx-node` -- prebuilt platform-specific binaries, no rebuild needed (voice dictation; unpacked from asar via the `sherpa-onnx-*` glob in `asarUnpack`)
-- `font-list` -- shells out to `fc-list` / a PowerShell script / a bundled macOS binary, no rebuild needed (Terminal Font Family picker; unpacked from asar via `asarUnpack` since the macOS binary is spawned via `child_process`)
+- `better-sqlite3` - rebuilt against Electron headers via `scripts/rebuild-native.js`
+- `node-pty` - uses prebuilt NAPI binaries, no rebuild needed
+- `sherpa-onnx-node` - prebuilt platform-specific binaries, no rebuild needed (voice dictation; unpacked from asar via the `sherpa-onnx-*` glob in `asarUnpack`)
+- `font-list` - shells out to `fc-list` / a PowerShell script / a bundled macOS binary, no rebuild needed (Terminal Font Family picker; unpacked from asar via `asarUnpack` since the macOS binary is spawned via `child_process`)
+- `sqlite-vec` - a loadable SQLite extension shipped as per-platform binary packages, no rebuild needed (conversation-memory retrieval; unpacked via the `sqlite-vec-*` glob in `asarUnpack`, since dlopen cannot read an extension inside asar)
+- `onnxruntime-node` - prebuilt native binaries (`onnxruntime_binding.node`, plus `onnxruntime.dll` and `DirectML.dll` on Windows), no rebuild needed (the embed worker's execution provider; unpacked via `asarUnpack`)
+- `@huggingface/transformers` and `onnxruntime-web` - pure JavaScript, but both shipped and unpacked so the embed worker resolves them from the unpacked tree
 
 Security fuses enabled: no RunAsNode, no NodeOptions, no inspection, cookie encryption, ASAR integrity validation.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,8 +31,8 @@ Download the latest release for your platform from [GitHub Releases](https://git
 
 | Platform | File | Notes |
 |----------|------|-------|
-| Windows | `Kangentic Setup X.Y.Z.exe` | NSIS installer. Auto-updates. |
-| macOS | `Kangentic-X.Y.Z.dmg` | Drag to Applications. See [Gatekeeper note](#macos-gatekeeper). |
+| Windows | `Kangentic-Setup-X.Y.Z.exe` | NSIS installer. Auto-updates. |
+| macOS (Apple Silicon) | `Kangentic-X.Y.Z-arm64.dmg` | Drag to Applications. See [Gatekeeper note](#macos-gatekeeper). |
 | Linux (Debian/Ubuntu) | `kangentic_X.Y.Z_amd64.deb` | `sudo apt install ./kangentic_*.deb` |
 | Linux (Fedora/RHEL/openSUSE) | `kangentic-X.Y.Z-1.x86_64.rpm` | `sudo dnf install kangentic-*.rpm` |
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -90,6 +90,21 @@ mac:
   target:
     - dmg
     - zip
+  # Pin filenames to match what the launcher (packages/launcher/bin/kangentic.js)
+  # and scripts/release-assets.js expect. These were previously electron-builder
+  # defaults, which only carry the "-arm64" infix because the default arch is x64
+  # and the default templates omit ${arch} when it matches: adding mac.defaultArch,
+  # or an upstream change to that comparison, would silently rename both assets and
+  # 404 every `npx kangentic` on macOS. Any user-set pattern flips isUserForced
+  # (platformPackager.js:551, verified against electron-builder 26.8.1; it is a
+  # caret range, so re-check that line number after a bump), so ${arch} then
+  # always expands.
+  #
+  # This one is the ZIP pattern, not a shared one. Resolution order is
+  # target options -> mac.artifactName -> config.artifactName, and only dmg has a
+  # target-options section, so the zip lands here while dmg.artifactName below
+  # overrides for the dmg. The ${os} macro expands to "mac".
+  artifactName: "${productName}-${version}-${arch}-${os}.${ext}"
   icon: node_modules/@kangentic/branding/resources/desktop/icon.icns
   category: public.app-category.developer-tools
   hardenedRuntime: true
@@ -102,6 +117,11 @@ mac:
     # Shown in the macOS microphone-permission prompt for voice dictation.
     NSMicrophoneUsageDescription: "Kangentic uses your microphone for voice-to-text dictation into terminals. Audio is transcribed locally and never leaves your machine unless you configure a remote backend."
 
+dmg:
+  # Overrides mac.artifactName for the dmg only: the dmg carries no "-mac" infix.
+  # Without this the dmg would inherit the zip pattern above and be renamed.
+  artifactName: "${productName}-${version}-${arch}.${ext}"
+
 linux:
   target:
     - deb
@@ -110,6 +130,9 @@ linux:
   category: Development
 
 deb:
+  # Pin filename to match the launcher and scripts/release-assets.js. Same reason
+  # as mac.artifactName above: this was an inherited electron-builder default.
+  artifactName: "${name}_${version}_${arch}.${ext}"
   depends:
     - libnss3
     - libatk-bridge2.0-0

--- a/scripts/release-assets.js
+++ b/scripts/release-assets.js
@@ -1,0 +1,61 @@
+/**
+ * The complete set of assets a release must carry, for one version.
+ *
+ * The release gate (scripts/verify-release-assets.js) reads this file directly.
+ * The launcher does NOT: packages/launcher/bin/kangentic.js is deliberately
+ * zero-dependency and hardcodes its own copies of these filenames. So the two are
+ * cross-CHECKED, not shared, and changing a name here does not update the
+ * launcher. tests/unit/release-asset-manifest.test.ts is what pins them together,
+ * along with electron-builder.yml's artifactName templates.
+ *
+ * It is a plain explicit list rather than something derived from
+ * electron-builder.yml at runtime: the gate runs at the moment of publishing,
+ * where a YAML-parsing bug would be expensive and hard to diagnose. Drift is
+ * caught in CI instead.
+ *
+ * The three channel files are what electron-updater actually fetches, so a
+ * release missing one of them is broken for that platform even though every
+ * platform build succeeded. That is exactly how v0.35.0 shipped Windows-only.
+ */
+
+/**
+ * The macOS arch built today. Intel macs and linux arm64 have no artifacts.
+ *
+ * Adding a second macOS arch is NOT a matter of reassigning this constant: that
+ * would rename the existing four mac entries and silently drop arm64 coverage.
+ * Duplicate the four mac lines below for the new arch instead, and bump the asset
+ * count the test and the docs hardcode (tests/unit/release-asset-manifest.test.ts,
+ * docs/deployment.md, .claude/skills/release/SKILL.md all say 11).
+ */
+const MAC_ARCH = 'arm64';
+
+/**
+ * @param {string} version Version without a leading "v" (e.g. "0.35.0").
+ * @returns {string[]} Every filename the release must carry.
+ */
+function expectedReleaseAssets(version) {
+  return [
+    // Windows (nsis)
+    `Kangentic-Setup-${version}.exe`,
+    `Kangentic-Setup-${version}.exe.blockmap`,
+    'latest.yml',
+
+    // macOS (dmg + zip)
+    `Kangentic-${version}-${MAC_ARCH}.dmg`,
+    `Kangentic-${version}-${MAC_ARCH}.dmg.blockmap`,
+    `Kangentic-${version}-${MAC_ARCH}-mac.zip`,
+    `Kangentic-${version}-${MAC_ARCH}-mac.zip.blockmap`,
+    'latest-mac.yml',
+
+    // Linux (deb + rpm)
+    `kangentic_${version}_amd64.deb`,
+    `kangentic-${version}-1.x86_64.rpm`,
+    'latest-linux.yml',
+  ];
+}
+
+/** The updater manifests, called out separately because a release missing one is
+ *  broken for that platform even when every binary is present. */
+const CHANNEL_FILES = ['latest.yml', 'latest-mac.yml', 'latest-linux.yml'];
+
+module.exports = { expectedReleaseAssets, CHANNEL_FILES, MAC_ARCH };

--- a/scripts/verify-release-assets.js
+++ b/scripts/verify-release-assets.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Release gate: prove a tag resolves to exactly ONE release carrying every
+ * expected asset, before that release is published.
+ *
+ * v0.35.0 shipped Windows-only while every platform job reported success. The
+ * artifacts had landed on three separate release objects for one tag, and the
+ * publish step resolved the tag to one of them. Build success says nothing about
+ * what is attached to the release being published, so this is the check that
+ * actually prevents a partial release. A failure here leaves the release a draft.
+ *
+ * Usage: node scripts/verify-release-assets.js <tag> [--repo owner/name]
+ */
+
+const { execFileSync } = require('node:child_process');
+const { expectedReleaseAssets, CHANNEL_FILES } = require('./release-assets');
+
+function parseArgs(argv) {
+  const positional = [];
+  let repo = process.env.GITHUB_REPOSITORY || 'Kangentic/kangentic';
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === '--repo') {
+      repo = argv[index + 1];
+      index += 1;
+    } else {
+      positional.push(argv[index]);
+    }
+  }
+  return { tag: positional[0], repo };
+}
+
+/**
+ * Every release object carrying this tag.
+ *
+ * Deliberately lists /releases and filters, rather than calling
+ * /releases/tags/<tag>: that endpoint resolves only PUBLISHED releases, and this
+ * gate runs while the release is still a draft. It is also the only way to see a
+ * duplicate draft, which is the failure this exists to catch.
+ *
+ * Pages explicitly rather than using `gh api --paginate`, which concatenates raw
+ * JSON arrays: stitching those back together means splicing on `][`, and release
+ * bodies contain markdown reference links that produce exactly that sequence.
+ */
+function releasesForTag(repo, tag) {
+  const matching = [];
+  for (let page = 1; page <= 20; page += 1) {
+    const raw = execFileSync(
+      'gh',
+      ['api', `repos/${repo}/releases?per_page=100&page=${page}`],
+      { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 }
+    );
+    const releases = JSON.parse(raw);
+    if (releases.length === 0) break;
+    matching.push(...releases.filter((release) => release.tag_name === tag));
+    if (releases.length < 100) break;
+  }
+  return matching;
+}
+
+/**
+ * The pure decision. Split out from the I/O above so every failure branch is
+ * unit-testable without a network round trip.
+ *
+ * @param {Array} releases Release objects already filtered to one tag.
+ * @param {string} tag
+ * @returns {{ ok: boolean, problems: string[], release: object | null }}
+ */
+function verifyReleaseAssets(releases, tag) {
+  const version = tag.replace(/^v/, '');
+  const expected = expectedReleaseAssets(version);
+  const problems = [];
+
+  if (releases.length === 0) {
+    return { ok: false, problems: [`No release found for tag ${tag}.`], release: null };
+  }
+
+  // The split itself. Naming the ids matters: drafts are invisible to
+  // `gh release view <tag>`, so without them the extras are hard to even find.
+  if (releases.length > 1) {
+    const described = releases
+      .map((release) => `      id=${release.id} draft=${release.draft} assets=${release.assets.length}`)
+      .join('\n');
+    problems.push(
+      `Tag ${tag} resolves to ${releases.length} release objects; expected exactly 1.\n${described}\n` +
+        '      Consolidate the assets onto one release and delete the extras before publishing.'
+    );
+  }
+
+  const release = releases.find((candidate) => candidate.draft) || releases[0];
+  const assetsByName = new Map(release.assets.map((asset) => [asset.name, asset]));
+
+  const missing = expected.filter((name) => !assetsByName.has(name));
+  if (missing.length > 0) {
+    const missingChannels = missing.filter((name) => CHANNEL_FILES.includes(name));
+    problems.push(
+      `Release id=${release.id} is missing ${missing.length} of ${expected.length} expected assets:\n` +
+        missing.map((name) => `      ${name}`).join('\n') +
+        (missingChannels.length > 0
+          ? `\n      ${missingChannels.length} of these are updater channel files, so auto-update ` +
+            'would be broken for those platforms.'
+          : '')
+    );
+  }
+
+  // An asset still uploading is listed but not yet fetchable.
+  const incomplete = expected
+    .map((name) => assetsByName.get(name))
+    .filter((asset) => asset && asset.state !== 'uploaded');
+  if (incomplete.length > 0) {
+    problems.push(
+      'Some assets are not in the "uploaded" state:\n' +
+        incomplete.map((asset) => `      ${asset.name} (state=${asset.state})`).join('\n')
+    );
+  }
+
+  return { ok: problems.length === 0, problems, release };
+}
+
+function main() {
+  const { tag, repo } = parseArgs(process.argv.slice(2));
+  if (!tag) {
+    console.error('Usage: node scripts/verify-release-assets.js <tag> [--repo owner/name]');
+    process.exit(1);
+  }
+
+  const { ok, problems, release } = verifyReleaseAssets(releasesForTag(repo, tag), tag);
+
+  if (!ok) {
+    console.error(`\nRelease verification FAILED for ${tag}.\n`);
+    for (const problem of problems) console.error(`  - ${problem}\n`);
+    console.error('Refusing to publish. The release stays a draft.');
+    console.error(
+      'If this is an intentional rename, a new platform, or a dropped one, update the expected\n' +
+        'list in scripts/release-assets.js (and tests/unit/release-asset-manifest.test.ts) first.'
+    );
+    process.exit(1);
+  }
+
+  const expectedCount = expectedReleaseAssets(tag.replace(/^v/, '')).length;
+  console.log(
+    `Release verification passed for ${tag}: release id=${release.id} carries all ${expectedCount} expected assets.`
+  );
+}
+
+if (require.main === module) {
+  main();
+}
+
+// parseArgs and main are exported for tests: main is what turns an `ok: false`
+// decision into the nonzero exit that actually blocks the publish step, so it is
+// load-bearing rather than glue.
+module.exports = { verifyReleaseAssets, releasesForTag, parseArgs, main };

--- a/src/main/analytics/analytics.ts
+++ b/src/main/analytics/analytics.ts
@@ -92,6 +92,49 @@ export function sanitizeErrorMessage(message: string): string {
 }
 
 /**
+ * Aptabase truncates a string property at 180 characters server-side (appending
+ * "..."), so anything longer is silently lost. Cap locally at the same length so
+ * what we send is what lands.
+ */
+export const MAX_ANALYTICS_STRING_LENGTH = 180;
+
+/**
+ * Reduce a React componentStack to a PII-free trail of component names,
+ * innermost first (e.g. "BrowserPane < WindowContent < App").
+ *
+ * The raw stack is NOT sent. A production frame reads
+ * `at BrowserPane (file:///C:/Users/dev/.../index-abc.js:1:2)`, so it carries the
+ * user's home directory in a URL form that sanitizeErrorMessage only partly
+ * catches. Keeping just the identifier after `at` / `in` is PII-free by
+ * construction rather than by pattern-matching.
+ *
+ * KNOW THIS BEFORE RELYING ON THE OUTPUT: React derives frame names from
+ * `fn.name`, and the production renderer bundle is minified with name mangling,
+ * so a packaged build yields mangled names ("t < Yn < Ao") rather than readable
+ * ones. Since telemetry is gated on `app.isPackaged`, that is the ONLY build this
+ * ever runs in. The value is still real (mangled names are stable within a build,
+ * so distinct trails mean distinct code paths, and a matching build's sourcemap
+ * resolves them) but it is not human-readable on arrival. `boundary` and `panel`
+ * are the fields that read directly, because a string literal and a prop both
+ * survive minification. Making this readable would need name preservation turned
+ * on for the renderer build, which is a bundle-size tradeoff, not a free switch.
+ */
+export function summarizeComponentStack(
+  stack: string | null | undefined,
+  maxFrames = 6
+): string {
+  if (!stack) return '';
+  const names: string[] = [];
+  for (const line of stack.split('\n')) {
+    const match = /^\s*(?:at|in)\s+([A-Za-z0-9_$.]+)/.exec(line);
+    if (!match) continue;
+    names.push(match[1]);
+    if (names.length >= maxFrames) break;
+  }
+  return names.join(' < ').slice(0, MAX_ANALYTICS_STRING_LENGTH);
+}
+
+/**
  * Track an event and return its delivery promise. Use this when the caller
  * needs to await delivery (e.g. during shutdown) rather than fire-and-forget.
  */

--- a/src/main/ipc/register-all.ts
+++ b/src/main/ipc/register-all.ts
@@ -1,7 +1,12 @@
 import { type BrowserWindow, ipcMain } from 'electron';
 import { IPC } from '../../shared/ipc-channels';
-import type { ProjectOpenByPathOverrides } from '../../shared/types';
-import { trackEvent, sanitizeErrorMessage } from '../analytics/analytics';
+import type { ProjectOpenByPathOverrides, RendererErrorContext } from '../../shared/types';
+import {
+  trackEvent,
+  sanitizeErrorMessage,
+  summarizeComponentStack,
+  MAX_ANALYTICS_STRING_LENGTH,
+} from '../analytics/analytics';
 import { ProjectRepository } from '../db/repositories/project-repository';
 import { ProjectGroupRepository } from '../db/repositories/project-group-repository';
 import { SessionManager } from '../pty/session-manager';
@@ -243,12 +248,38 @@ export function registerAllIpc(mainWindow: BrowserWindow, mcpServerHandle: McpHt
   startMetricsSnapshotTimer(sessionManager);
 
   // Analytics: renderer error tracking (fire-and-forget from renderer)
-  ipcMain.on(IPC.TRACK_RENDERER_ERROR, (_event, message: string) => {
-    trackEvent('app_error', {
-      source: 'error_boundary',
-      message: sanitizeErrorMessage(message),
-    });
-  });
+  //
+  // `source` stays 'error_boundary' for every reporter so the existing telemetry
+  // grouping is continuous. The origin is carried by `boundary` instead, which is
+  // what makes a message like "Cannot read properties of undefined (reading
+  // 'split')" locatable: it says whether a component stack exists at all.
+  //
+  // Every field is re-checked at RUNTIME because `RendererErrorContext` is erased
+  // at the IPC boundary, and `error.message` is already `undefined` whenever a
+  // component throws a non-Error value (`throw 'boom'`). A throw in here would not
+  // crash (the global `uncaughtException` handler swallows it) - it would silently
+  // drop the very error report this handler exists to send.
+  ipcMain.on(
+    IPC.TRACK_RENDERER_ERROR,
+    (_event, message: string, errorContext?: RendererErrorContext) => {
+      const props: Record<string, string> = {
+        source: 'error_boundary',
+        message: sanitizeErrorMessage(
+          typeof message === 'string' ? message : String(message ?? 'Unknown error')
+        ),
+      };
+      const boundary = errorContext?.boundary;
+      if (typeof boundary === 'string') props.boundary = boundary;
+      const panel = errorContext?.panel;
+      if (typeof panel === 'string') props.panel = panel.slice(0, MAX_ANALYTICS_STRING_LENGTH);
+      const componentStack = errorContext?.componentStack;
+      const components = summarizeComponentStack(
+        typeof componentStack === 'string' ? componentStack : undefined
+      );
+      if (components) props.components = components;
+      trackEvent('app_error', props);
+    }
+  );
 }
 
 // Thin wrappers -- same signatures as before, zero changes in index.ts

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import { IPC } from '../shared/ipc-channels';
-import type { ElectronAPI, NotificationInput, Project, PtyResizeOrigin, Session, SessionUsage, ActivityState, ActivityReason, SessionEvent, UpdateDownloadedInfo, UsageTimePeriod, UsageStatsScope, UsageDayDrill, UsageCustomWindow, TaskBulkDeleteProgress, ProjectMoveProgress, DictationModelProgress, MobilePairingSasPayload, MobilePairingConfirmedPayload, MobilePairingEndedPayload, MonitorSnapshot, TaskDetailHost, TaskDetailRemoteOwner, AutoCommandResultNotice, BrowserDownloadDone, GuestMouseButtonEvent } from '../shared/types';
+import type { ElectronAPI, NotificationInput, Project, PtyResizeOrigin, Session, SessionUsage, ActivityState, ActivityReason, SessionEvent, UpdateDownloadedInfo, UsageTimePeriod, UsageStatsScope, UsageDayDrill, UsageCustomWindow, TaskBulkDeleteProgress, ProjectMoveProgress, DictationModelProgress, MobilePairingSasPayload, MobilePairingConfirmedPayload, MobilePairingEndedPayload, MonitorSnapshot, TaskDetailHost, TaskDetailRemoteOwner, AutoCommandResultNotice, BrowserDownloadDone, GuestMouseButtonEvent, RendererErrorContext } from '../shared/types';
 import type { AnnouncementsChangedPayload } from '../shared/announcements';
 import { POPOUT_ARG_PREFIX } from '../shared/pop-out';
 import type { PopOutDescriptor, PopOutKind, PopOutParamsByKind } from '../shared/pop-out';
@@ -465,7 +465,8 @@ const api: ElectronAPI = {
   },
 
   analytics: {
-    trackRendererError: (message: string) => ipcRenderer.send(IPC.TRACK_RENDERER_ERROR, message),
+    trackRendererError: (message: string, context?: RendererErrorContext) =>
+      ipcRenderer.send(IPC.TRACK_RENDERER_ERROR, message, context),
   },
 
   app: {

--- a/src/renderer/components/ErrorBoundary.tsx
+++ b/src/renderer/components/ErrorBoundary.tsx
@@ -22,7 +22,10 @@ export class ErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, info: React.ErrorInfo): void {
     console.error('ErrorBoundary caught:', error, info.componentStack);
-    window.electronAPI?.analytics?.trackRendererError(error.message);
+    window.electronAPI?.analytics?.trackRendererError(error.message, {
+      boundary: 'root',
+      componentStack: info.componentStack ?? undefined,
+    });
   }
 
   handleRetry = () => {

--- a/src/renderer/components/PanelErrorBoundary.tsx
+++ b/src/renderer/components/PanelErrorBoundary.tsx
@@ -48,7 +48,11 @@ export class PanelErrorBoundary extends React.Component<
 
   componentDidCatch(error: Error, info: React.ErrorInfo): void {
     console.error('PanelErrorBoundary caught:', error, info.componentStack);
-    window.electronAPI?.analytics?.trackRendererError(error.message);
+    window.electronAPI?.analytics?.trackRendererError(error.message, {
+      boundary: 'panel',
+      panel: this.props.label,
+      componentStack: info.componentStack ?? undefined,
+    });
   }
 
   handleRetry = () => {

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -9,7 +9,12 @@ import './index.css';
 
 window.addEventListener('unhandledrejection', (event) => {
   const message = event.reason instanceof Error ? event.reason.message : String(event.reason);
-  window.electronAPI?.analytics?.trackRendererError(message);
+  // No component stack exists here: a rejected promise is not a render error.
+  // Reporting the boundary anyway is the point - it distinguishes this path from
+  // the two error boundaries, which previously all reported identically.
+  window.electronAPI?.analytics?.trackRendererError(message, {
+    boundary: 'unhandled_rejection',
+  });
 });
 
 // Dev-server tab / devtools favicon (the packaged app icon is the native BrowserWindow icon,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4354,6 +4354,26 @@ export interface GuestMouseButtonEvent {
   at: number;
 }
 
+/**
+ * Where a renderer error came from, sent alongside the message on
+ * `ElectronAPI['analytics']['trackRendererError']`.
+ *
+ * The message alone is not locatable: `Cannot read properties of undefined
+ * (reading 'split')` told us nothing about which surface threw it, because all
+ * three reporters (both error boundaries and the bare unhandled-rejection
+ * listener) sent a message and nothing else.
+ */
+export interface RendererErrorContext {
+  /** Which reporter caught it. The most useful field by far: it says whether a
+   *  component stack exists at all, since only the boundaries have one. */
+  boundary: 'root' | 'panel' | 'unhandled_rejection';
+  /** `PanelErrorBoundary`'s static `label` prop ("Changes", "Monitor"). */
+  panel?: string;
+  /** React's `info.componentStack`. Main reduces it to component names before
+   *  sending; the raw value never leaves the process. */
+  componentStack?: string;
+}
+
 export interface ElectronAPI {
   // Dev-only (preview): present only when __KANGENTIC_DEV__ (build-excluded in prod).
   dev?: {
@@ -4839,7 +4859,7 @@ export interface ElectronAPI {
 
   // Analytics
   analytics: {
-    trackRendererError: (message: string) => void;
+    trackRendererError: (message: string, context?: RendererErrorContext) => void;
   };
 
   // App

--- a/tests/ui/changes-panel-lazy-retry.spec.ts
+++ b/tests/ui/changes-panel-lazy-retry.spec.ts
@@ -24,6 +24,7 @@ import { test, expect } from '@playwright/test';
 import { chromium, type Browser, type Page } from '@playwright/test';
 import path from 'node:path';
 import { waitForViteReady } from './helpers';
+import type { RendererErrorContext } from '../../src/shared/types';
 
 const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
 const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
@@ -170,6 +171,31 @@ test.describe('Changes panel: lazy-import failure is scoped and recoverable', ()
     // "Something went wrong" page, and the dialog is still open.
     await expect(page.locator('text=Something went wrong')).not.toBeVisible();
     await expect(page.locator('[data-testid="task-detail-dialog"]')).toBeVisible();
+
+    // The catch above ran through a MOUNTED PanelErrorBoundary under a live React
+    // reconciler and the real UI-tier mock (tests/ui/mock-electron-api.js), unlike
+    // tests/unit/panel-error-boundary.test.ts, which hand-instantiates the class and
+    // stubs window.electronAPI.analytics.trackRendererError with a bare vi.fn(). This
+    // is the only place that proves the two-argument (message, context) call actually
+    // round-trips end to end and that the mock records both rather than dropping the
+    // second one.
+    //
+    // A failed dynamic import also fires `window`'s unhandledrejection listener
+    // (index.tsx's separate reporter, boundary: 'unhandled_rejection') independently
+    // of React's own catch, so this filters to the panel-boundary report rather than
+    // asserting a total call count.
+    const trackedErrors = await page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __mockTrackRendererErrorCalls?: Array<{ message: string; context?: RendererErrorContext }>;
+          }
+        ).__mockTrackRendererErrorCalls ?? [],
+    );
+    const panelReports = trackedErrors.filter((entry) => entry.context?.boundary === 'panel');
+    expect(panelReports).toHaveLength(1);
+    expect(typeof panelReports[0].message).toBe('string');
+    expect(panelReports[0].context).toMatchObject({ boundary: 'panel', panel: 'Changes panel' });
 
     // A chunk-load failure cannot be healed by a remount (the module URL is
     // poisoned in the module map), so the boundary offers Reload, not Retry.

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -2583,7 +2583,13 @@
     },
 
     analytics: {
-      trackRendererError: function () {},
+      // Records rather than discarding, like the other fire-and-forget mocks, so a
+      // UI test can assert what a boundary actually reported.
+      // context carries { boundary, panel?, componentStack? }.
+      trackRendererError: function (message, context) {
+        window.__mockTrackRendererErrorCalls = window.__mockTrackRendererErrorCalls || [];
+        window.__mockTrackRendererErrorCalls.push({ message: message, context: context });
+      },
     },
 
     app: {

--- a/tests/unit/panel-error-boundary.test.ts
+++ b/tests/unit/panel-error-boundary.test.ts
@@ -22,10 +22,19 @@
  * perform the same shallow merge a real reconciler would, so `handleRetry`'s
  * real body runs untouched and its effect on `instance.state` is directly
  * observable.
+ *
+ * This file also covers `componentDidCatch`'s analytics wiring for BOTH
+ * `PanelErrorBoundary` and the root `ErrorBoundary`. `componentDidCatch` is a
+ * plain instance method (no reconciler needed to call it), and
+ * `window.electronAPI` is stubbed with `vi.stubGlobal` the same way
+ * `dictation-sink.test.ts` stubs `window` for a DOM-less unit test. Coverage
+ * hole this closes: if either boundary's second `trackRendererError`
+ * argument were ever dropped, no existing test would fail.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import React from 'react';
 import { PanelErrorBoundary } from '../../src/renderer/components/PanelErrorBoundary';
+import { ErrorBoundary } from '../../src/renderer/components/ErrorBoundary';
 
 interface BoundaryState {
   hasError: boolean;
@@ -163,5 +172,88 @@ describe('PanelErrorBoundary', () => {
     // Do NOT invoke the click handler: jsdom is not available here, and
     // handleReload calls the real window.location.reload(), which is
     // neither implemented nor safe to trigger in a unit test process.
+  });
+});
+
+describe('componentDidCatch analytics wiring', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubTrackRendererError(): ReturnType<typeof vi.fn> {
+    const trackRendererError = vi.fn();
+    vi.stubGlobal('window', { electronAPI: { analytics: { trackRendererError } } });
+    return trackRendererError;
+  }
+
+  it('PanelErrorBoundary forwards boundary "panel", the label prop as panel, and the component stack', () => {
+    const trackRendererError = stubTrackRendererError();
+    // componentDidCatch also calls console.error; silence it so the test's
+    // own output stays clean, as instructed by the established pattern.
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const children = React.createElement('span', null, 'child content');
+    const instance = new PanelErrorBoundary({ children, label: 'Changes panel' });
+
+    instance.componentDidCatch(new Error('Cannot read properties of undefined (reading map)'), {
+      componentStack: '\n    at Foo (x)\n    at Bar (y)',
+    });
+
+    // The real production label ('Changes panel') must land in `panel`, not
+    // just any string - this is the specific regression Hole 2 calls out:
+    // PanelErrorBoundary forwarding its OWN `label` prop, not a hardcoded one.
+    expect(trackRendererError).toHaveBeenCalledTimes(1);
+    expect(trackRendererError).toHaveBeenCalledWith(
+      'Cannot read properties of undefined (reading map)',
+      {
+        boundary: 'panel',
+        panel: 'Changes panel',
+        componentStack: '\n    at Foo (x)\n    at Bar (y)',
+      },
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('PanelErrorBoundary forwards panel: undefined when no label prop is given', () => {
+    const trackRendererError = stubTrackRendererError();
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const children = React.createElement('span', null, 'child content');
+    const instance = new PanelErrorBoundary({ children });
+
+    instance.componentDidCatch(new Error('boom'), { componentStack: '\n    at Foo (x)' });
+
+    expect(trackRendererError).toHaveBeenCalledWith('boom', {
+      boundary: 'panel',
+      panel: undefined,
+      componentStack: '\n    at Foo (x)',
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('ErrorBoundary sends boundary "root" with the component stack, and no panel field', () => {
+    const trackRendererError = stubTrackRendererError();
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const children = React.createElement('span', null, 'child content');
+    const instance = new ErrorBoundary({ children });
+
+    instance.componentDidCatch(new Error('Something went wrong'), {
+      componentStack: '\n    at App (x)',
+    });
+
+    expect(trackRendererError).toHaveBeenCalledTimes(1);
+    expect(trackRendererError).toHaveBeenCalledWith('Something went wrong', {
+      boundary: 'root',
+      componentStack: '\n    at App (x)',
+    });
+    // ErrorBoundary's context never carries a `panel` key at all - unlike
+    // PanelErrorBoundary, which always sets it (to undefined without a label).
+    const [, context] = trackRendererError.mock.calls[0];
+    expect(context).not.toHaveProperty('panel');
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/tests/unit/preload-track-renderer-error-context.test.ts
+++ b/tests/unit/preload-track-renderer-error-context.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Guards the literal preload glue that forwards a renderer error's context
+ * from `window.electronAPI.analytics.trackRendererError(message, context)`
+ * through to `ipcRenderer.send`.
+ *
+ * Why this needs its own test: TypeScript's structural typing allows a
+ * function with FEWER parameters to satisfy an interface that declares an
+ * optional trailing parameter - `(message: string) => void` is assignable
+ * to `ElectronAPI['analytics']['trackRendererError']`
+ * (`(message: string, context?: RendererErrorContext) => void`). So `tsc`
+ * would not catch a regression where preload silently stopped forwarding
+ * `context`, and neither would the two existing tests that touch this data
+ * flow: `tests/unit/panel-error-boundary.test.ts` stubs
+ * `window.electronAPI.analytics.trackRendererError` directly (never runs
+ * preload.ts), and `tests/unit/register-all-idempotency.test.ts` invokes the
+ * registered `ipcMain.on` callback directly (never runs `ipcRenderer.send`).
+ * The one line in `src/preload/preload.ts` that actually threads `context`
+ * across the process boundary is otherwise exercised nowhere.
+ *
+ * preload.ts cannot be safely dynamic-imported in vitest: it calls
+ * `installConsoleCapture()` at module scope, which patches `window.console.*`
+ * and registers `window` listeners unconditionally, so importing it needs a
+ * full `window`/`electron` shim just to load. `tests/unit/project-scoped-ipc.test.ts`
+ * hits the same constraint and parses the source as text instead - this test
+ * follows that established pattern.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const PRELOAD_SOURCE = fs.readFileSync(path.join(REPO_ROOT, 'src/preload/preload.ts'), 'utf-8');
+
+describe('preload analytics.trackRendererError forwards its context argument', () => {
+  it('passes both parameters through to ipcRenderer.send, in declaration order', () => {
+    const match = PRELOAD_SOURCE.match(
+      /trackRendererError:\s*\(([^)]*)\)\s*=>\s*ipcRenderer\.send\(([^)]*)\)/,
+    );
+    expect(
+      match,
+      'trackRendererError implementation not found in preload.ts in the expected arrow-function shape',
+    ).not.toBeNull();
+
+    const [, paramList, callArgs] = match as RegExpMatchArray;
+    const paramNames = paramList
+      .split(',')
+      .map((parameter) => parameter.trim().split(':')[0].replace('?', '').trim())
+      .filter(Boolean);
+    expect(
+      paramNames.length,
+      'trackRendererError must declare exactly (message, context)',
+    ).toBe(2);
+    const [messageParam, contextParam] = paramNames;
+
+    const callArgList = callArgs.split(',').map((argument) => argument.trim());
+    // First argument is always the channel constant.
+    expect(callArgList[0]).toBe('IPC.TRACK_RENDERER_ERROR');
+    // The remaining two must be the declared params, forwarded IN ORDER - this
+    // is exactly the shape a "just forward message and drop context" revert
+    // would break, and it would break silently (see file header).
+    expect(callArgList[1]).toBe(messageParam);
+    expect(callArgList[2]).toBe(contextParam);
+  });
+});

--- a/tests/unit/register-all-idempotency.test.ts
+++ b/tests/unit/register-all-idempotency.test.ts
@@ -8,6 +8,8 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { KANGENTIC_HOSTED_RELAY_URL } from '../../src/shared/relay';
+import { IPC } from '../../src/shared/ipc-channels';
+import type { RendererErrorContext } from '../../src/shared/types';
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────
 
@@ -109,9 +111,29 @@ vi.mock('../../src/main/agent/adapters/claude/hook-manager', () => ({
   buildHooks: vi.fn(),
   removeHooks: vi.fn(),
 }));
+// Must mirror every export register-all.ts imports from this module. A missing one
+// is invisible here (this suite only counts registrations, it never invokes a
+// handler) but throws "is not a function" the moment a test calls one.
+//
+// `summarizeComponentStack` is deliberately NOT importOriginal'd here: the real
+// analytics.ts module-level-imports `@aptabase/electron/main`, a real node_modules
+// package whose own internal `from 'electron'` import is externalized by vitest
+// (bypasses the `vi.mock('electron', ...)` above entirely) and resolves to the
+// real 'electron' npm shim, which has no named exports outside a real Electron
+// process - importOriginal here throws "Named export 'ipcMain' not found" for
+// EVERY test in this file, not just the new ones. So it stays a stub, but a
+// deliberately non-constant one: it returns a fixed non-empty trail only when
+// handed a non-empty string, so the TRACK_RENDERER_ERROR handler's
+// `if (components) props.components = ...` conditional is exercised truthfully
+// in both directions without duplicating the real regex coverage already
+// pinned in tests/unit/summarize-component-stack.test.ts.
 vi.mock('../../src/main/analytics/analytics', () => ({
   trackEvent: vi.fn(),
-  sanitizeErrorMessage: vi.fn((msg: string) => msg),
+  sanitizeErrorMessage: vi.fn((message: string) => message),
+  summarizeComponentStack: vi.fn((stack: string | undefined) =>
+    typeof stack === 'string' && stack.length > 0 ? 'Foo < Bar' : ''
+  ),
+  MAX_ANALYTICS_STRING_LENGTH: 180,
 }));
 vi.mock('node-pty', () => ({ spawn: vi.fn() }));
 vi.mock('better-sqlite3', () => ({ default: vi.fn() }));
@@ -431,4 +453,121 @@ describe('registerAllIpc idempotency', () => {
       relayUrl: new URL('wss://relay.example.com').href,
     });
   }, 30000);
+
+  describe('TRACK_RENDERER_ERROR analytics handler', () => {
+    // register-all.ts wires exactly one direct `ipcMain.on(...)` call (the
+    // rest of the suite only exercises `registerXxxHandlers`, which are
+    // themselves mocked out and never touch the real ipcMain.on). Coverage
+    // hole this closes: nothing else in the repo ever invokes this callback,
+    // so reverting its second parameter to the old one-arg form, or removing
+    // a runtime guard, would fail nothing without these tests.
+    type TrackRendererErrorCallback = (
+      event: unknown,
+      message: string,
+      context?: RendererErrorContext,
+    ) => void;
+
+    function getTrackRendererErrorCallback(): TrackRendererErrorCallback {
+      const entry = mockOn.mock.calls.find((call) => call[0] === IPC.TRACK_RENDERER_ERROR);
+      if (!entry) {
+        throw new Error('ipcMain.on was never called with IPC.TRACK_RENDERER_ERROR');
+      }
+      return entry[1] as TrackRendererErrorCallback;
+    }
+
+    it('sends boundary, panel, and a real component trail when full context is provided', async () => {
+      const { registerAllIpc } = await import('../../src/main/ipc/register-all');
+      const { trackEvent } = await import('../../src/main/analytics/analytics');
+      registerAllIpc(makeMockWindow(1));
+
+      const callback = getTrackRendererErrorCallback();
+      callback({}, 'Cannot read properties of undefined (reading split)', {
+        boundary: 'panel',
+        panel: 'Changes panel',
+        componentStack: '    at Foo (x)\n    at Bar (y)',
+      });
+
+      // `components` is produced by the REAL summarizeComponentStack (see the
+      // importOriginal mock above), not a stub - this would go red if the
+      // trail-building logic broke, not just if the call were dropped.
+      expect(vi.mocked(trackEvent)).toHaveBeenCalledWith('app_error', {
+        source: 'error_boundary',
+        message: 'Cannot read properties of undefined (reading split)',
+        boundary: 'panel',
+        panel: 'Changes panel',
+        components: 'Foo < Bar',
+      });
+    }, 30000);
+
+    it('omits boundary, panel, and components when no context argument is given', async () => {
+      const { registerAllIpc } = await import('../../src/main/ipc/register-all');
+      const { trackEvent } = await import('../../src/main/analytics/analytics');
+      registerAllIpc(makeMockWindow(1));
+
+      const callback = getTrackRendererErrorCallback();
+      callback({}, 'boom');
+
+      const trackEventMock = vi.mocked(trackEvent);
+      expect(trackEventMock).toHaveBeenCalledTimes(1);
+      const [, props] = trackEventMock.mock.calls[0];
+      // An explicit key-presence check, not toEqual/toHaveBeenCalledWith:
+      // Jest/vitest's default object equality treats a key present with an
+      // `undefined` value the same as a key that is genuinely absent, so
+      // toEqual({ source, message }) would pass even if the handler
+      // regressed to unconditionally writing `props.boundary = undefined`.
+      // The keys must be ABSENT, which only Object.keys can prove.
+      expect(Object.keys(props ?? {}).sort()).toEqual(['message', 'source']);
+      expect(props).toMatchObject({ source: 'error_boundary', message: 'boom' });
+    }, 30000);
+
+    it('does not throw on a malformed payload and omits only the malformed fields', async () => {
+      const { registerAllIpc } = await import('../../src/main/ipc/register-all');
+      const { trackEvent } = await import('../../src/main/analytics/analytics');
+      registerAllIpc(makeMockWindow(1));
+
+      const callback = getTrackRendererErrorCallback();
+      // RendererErrorContext is erased at the IPC boundary: a renderer could
+      // send a payload that violates the compile-time type at runtime.
+      // `panel` as a number and `componentStack` as an object are exactly the
+      // shapes that would throw inside `.slice()` / `.split()` without the
+      // per-field typeof guards - a throw here silently drops the error
+      // report (the global uncaughtException handler swallows it).
+      const malformedContext = {
+        boundary: 'panel',
+        panel: 42,
+        componentStack: { not: 'a string' },
+      } as unknown as RendererErrorContext;
+
+      expect(() => {
+        callback({}, undefined as unknown as string, malformedContext);
+      }).not.toThrow();
+
+      const trackEventMock = vi.mocked(trackEvent);
+      expect(trackEventMock).toHaveBeenCalledTimes(1);
+      const [, props] = trackEventMock.mock.calls[0];
+      expect(Object.keys(props ?? {}).sort()).toEqual(['boundary', 'message', 'source']);
+      expect(props).toMatchObject({
+        source: 'error_boundary',
+        message: 'Unknown error',
+        boundary: 'panel',
+      });
+    }, 30000);
+
+    it('truncates panel to MAX_ANALYTICS_STRING_LENGTH characters', async () => {
+      const { registerAllIpc } = await import('../../src/main/ipc/register-all');
+      const { trackEvent, MAX_ANALYTICS_STRING_LENGTH } = await import(
+        '../../src/main/analytics/analytics'
+      );
+      registerAllIpc(makeMockWindow(1));
+
+      const callback = getTrackRendererErrorCallback();
+      const longPanel = 'p'.repeat(MAX_ANALYTICS_STRING_LENGTH + 20);
+      callback({}, 'boom', { boundary: 'panel', panel: longPanel });
+
+      const trackEventMock = vi.mocked(trackEvent);
+      const [, props] = trackEventMock.mock.calls[0];
+      expect(props?.panel).toBe(longPanel.slice(0, MAX_ANALYTICS_STRING_LENGTH));
+      expect(props?.panel).toHaveLength(MAX_ANALYTICS_STRING_LENGTH);
+    }, 30000);
+  });
 });

--- a/tests/unit/release-asset-manifest.test.ts
+++ b/tests/unit/release-asset-manifest.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+// v0.35.0 shipped Windows-only: three matrix legs each created their own draft release for one
+// tag, and the publish step resolved the tag to one of them. scripts/verify-release-assets.js is
+// the gate that now blocks that, and scripts/release-assets.js is the manifest it checks against.
+//
+// A manifest is only as good as its agreement with what actually gets built and downloaded, and
+// there are two independent ways for it to drift:
+//
+//   1. electron-builder.yml renames an artifact  -> the gate fails the release (loud, recoverable)
+//   2. the launcher expects a different name     -> `npx kangentic` 404s (silent, user-facing)
+//
+// Nothing cross-checked those before. This test pins all three to each other, so a rename in any
+// one of them fails CI instead of a release. Two of the four platform filenames were inherited
+// electron-builder defaults until this task pinned them; see the comments in electron-builder.yml.
+//
+// Follows linux-package-deps.test.ts in regex-extracting YAML rather than adding a parser
+// (js-yaml is only transitively present, not a declared dependency).
+//
+// What this does NOT catch: the arch NAMES. Both the manifest and the expectations below
+// hardcode the same values ("amd64" for deb, "x86_64" for rpm, MAC_ARCH for the mac pair), so if
+// electron-builder's getArtifactArchName ever mapped x64 to a different string for one of these
+// targets, both sides would move together and this stayed green while the real filename changed.
+// It is a cross-reference check between three files, not a check against electron-builder's
+// actual output. The release gate catching a missing asset is the backstop for that class.
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const requireFromRepo = createRequire(path.join(REPO_ROOT, 'package.json'));
+
+const { expectedReleaseAssets, CHANNEL_FILES, MAC_ARCH } = requireFromRepo(
+  './scripts/release-assets.js'
+) as {
+  expectedReleaseAssets: (version: string) => string[];
+  CHANNEL_FILES: string[];
+  MAC_ARCH: string;
+};
+
+const { verifyReleaseAssets } = requireFromRepo('./scripts/verify-release-assets.js') as {
+  verifyReleaseAssets: (
+    releases: ReleaseFixture[],
+    tag: string
+  ) => { ok: boolean; problems: string[]; release: ReleaseFixture | null };
+};
+
+interface ReleaseFixture {
+  id: number;
+  draft: boolean;
+  assets: { name: string; state: string }[];
+}
+
+const VERSION = '9.9.9';
+const PRODUCT_NAME = 'Kangentic';
+const PACKAGE_NAME = 'kangentic';
+
+/** Extract the full indented body of a top-level YAML key. Mirrors linux-package-deps.test.ts. */
+function extractTopLevelBlock(yamlSource: string, topLevelKey: string): string {
+  const match = yamlSource.match(new RegExp(`\\n${topLevelKey}:\\n((?:[ \\t].*\\n?)*)`));
+  if (!match) {
+    throw new Error(`electron-builder.yml: could not find top-level key "${topLevelKey}:"`);
+  }
+  return match[1];
+}
+
+/** Read `artifactName: "<template>"` out of an already-extracted block. */
+function extractArtifactName(block: string, blockName: string): string {
+  const match = block.match(/^\s*artifactName:\s*"([^"]+)"/m);
+  if (!match) {
+    throw new Error(
+      `electron-builder.yml: "${blockName}" has no artifactName. All four platform artifact ` +
+        'names must stay pinned, or the release manifest is guessing at electron-builder defaults.'
+    );
+  }
+  return match[1];
+}
+
+/**
+ * Expand an electron-builder artifactName template. Only the macros the four pinned templates
+ * actually use are supported: an unknown macro throws rather than silently expanding to "".
+ */
+function expandTemplate(
+  template: string,
+  values: { version: string; arch: string; ext: string; os: string }
+): string {
+  return template.replace(/\$\{(\w+)\}/g, (_match, macro: string) => {
+    switch (macro) {
+      case 'productName':
+        return PRODUCT_NAME;
+      case 'name':
+        return PACKAGE_NAME;
+      case 'version':
+        return values.version;
+      case 'arch':
+        return values.arch;
+      case 'ext':
+        return values.ext;
+      case 'os':
+        return values.os;
+      default:
+        throw new Error(`Unsupported macro \${${macro}} in artifactName template "${template}"`);
+    }
+  });
+}
+
+const electronBuilderYaml = fs.readFileSync(path.join(REPO_ROOT, 'electron-builder.yml'), 'utf8');
+const launcherSource = fs.readFileSync(
+  path.join(REPO_ROOT, 'packages/launcher/bin/kangentic.js'),
+  'utf8'
+);
+
+describe('release asset manifest', () => {
+  it('lists exactly 11 assets, including all three updater channel files', () => {
+    const assets = expectedReleaseAssets(VERSION);
+    expect(assets).toHaveLength(11);
+    expect(new Set(assets).size).toBe(11);
+    for (const channelFile of CHANNEL_FILES) {
+      expect(assets).toContain(channelFile);
+    }
+  });
+
+  it('matches the artifactName pinned in electron-builder.yml for every platform', () => {
+    const assets = expectedReleaseAssets(VERSION);
+
+    // Windows: nsis.artifactName
+    const nsisTemplate = extractArtifactName(extractTopLevelBlock(electronBuilderYaml, 'nsis'), 'nsis');
+    const exeName = expandTemplate(nsisTemplate, {
+      version: VERSION,
+      arch: 'x64',
+      ext: 'exe',
+      os: 'win',
+    });
+    expect(assets).toContain(exeName);
+    expect(assets).toContain(`${exeName}.blockmap`);
+
+    // macOS zip: mac.artifactName (the dmg overrides it below)
+    const macTemplate = extractArtifactName(extractTopLevelBlock(electronBuilderYaml, 'mac'), 'mac');
+    const zipName = expandTemplate(macTemplate, {
+      version: VERSION,
+      arch: MAC_ARCH,
+      ext: 'zip',
+      os: 'mac',
+    });
+    expect(assets).toContain(zipName);
+    expect(assets).toContain(`${zipName}.blockmap`);
+
+    // macOS dmg: dmg.artifactName
+    const dmgTemplate = extractArtifactName(extractTopLevelBlock(electronBuilderYaml, 'dmg'), 'dmg');
+    const dmgName = expandTemplate(dmgTemplate, {
+      version: VERSION,
+      arch: MAC_ARCH,
+      ext: 'dmg',
+      os: 'mac',
+    });
+    expect(assets).toContain(dmgName);
+    expect(assets).toContain(`${dmgName}.blockmap`);
+
+    // Linux deb + rpm
+    const debTemplate = extractArtifactName(extractTopLevelBlock(electronBuilderYaml, 'deb'), 'deb');
+    expect(assets).toContain(
+      expandTemplate(debTemplate, { version: VERSION, arch: 'amd64', ext: 'deb', os: 'linux' })
+    );
+
+    const rpmTemplate = extractArtifactName(extractTopLevelBlock(electronBuilderYaml, 'rpm'), 'rpm');
+    expect(assets).toContain(
+      expandTemplate(rpmTemplate, { version: VERSION, arch: 'x86_64', ext: 'rpm', os: 'linux' })
+    );
+  });
+
+  // The silent half of the drift: a renamed asset makes the gate fail loudly, but a launcher that
+  // expects the old name just 404s for every new user on that platform.
+  it('matches the filenames the launcher builds its download URLs from', () => {
+    const assets = expectedReleaseAssets(VERSION);
+
+    // win32: `Kangentic-Setup-${version}.exe`
+    expect(launcherSource).toContain(`${PRODUCT_NAME}-Setup-\${version}.exe`);
+    expect(assets).toContain(`${PRODUCT_NAME}-Setup-${VERSION}.exe`);
+
+    // darwin: `Kangentic-${version}-${platformInfo.arch}-mac.zip`
+    expect(launcherSource).toMatch(
+      /`Kangentic-\$\{version\}-\$\{[\w.]*arch\}-mac\.zip`/
+    );
+    expect(assets).toContain(`${PRODUCT_NAME}-${VERSION}-${MAC_ARCH}-mac.zip`);
+
+    // linux: rpm when rpm exists and apt does not, else deb
+    expect(launcherSource).toMatch(/`kangentic-\$\{version\}-1\.x86_64\.rpm`/);
+    expect(launcherSource).toMatch(/`kangentic_\$\{version\}_amd64\.deb`/);
+    expect(assets).toContain(`${PACKAGE_NAME}-${VERSION}-1.x86_64.rpm`);
+    expect(assets).toContain(`${PACKAGE_NAME}_${VERSION}_amd64.deb`);
+  });
+});
+
+function releaseWithAllAssets(id: number, draft: boolean): ReleaseFixture {
+  return {
+    id,
+    draft,
+    assets: expectedReleaseAssets(VERSION).map((name) => ({ name, state: 'uploaded' })),
+  };
+}
+
+describe('verifyReleaseAssets', () => {
+  it('passes for a single release carrying every expected asset', () => {
+    const result = verifyReleaseAssets([releaseWithAllAssets(1, true)], `v${VERSION}`);
+    expect(result.ok).toBe(true);
+    expect(result.problems).toEqual([]);
+  });
+
+  it('fails when the tag has no release at all', () => {
+    const result = verifyReleaseAssets([], `v${VERSION}`);
+    expect(result.ok).toBe(false);
+    expect(result.problems[0]).toContain('No release found');
+  });
+
+  // The exact v0.35.0 shape: one published Windows release plus two orphaned drafts.
+  it('fails when a tag resolves to more than one release object', () => {
+    const windowsOnly: ReleaseFixture = {
+      id: 371785632,
+      draft: false,
+      assets: [
+        { name: `Kangentic-Setup-${VERSION}.exe`, state: 'uploaded' },
+        { name: `Kangentic-Setup-${VERSION}.exe.blockmap`, state: 'uploaded' },
+        { name: 'latest.yml', state: 'uploaded' },
+      ],
+    };
+    const macDraft: ReleaseFixture = {
+      id: 371785746,
+      draft: true,
+      assets: [{ name: 'latest-mac.yml', state: 'uploaded' }],
+    };
+    const linuxDraft: ReleaseFixture = {
+      id: 371785726,
+      draft: true,
+      assets: [{ name: 'latest-linux.yml', state: 'uploaded' }],
+    };
+
+    const result = verifyReleaseAssets([windowsOnly, macDraft, linuxDraft], `v${VERSION}`);
+    expect(result.ok).toBe(false);
+    const joined = result.problems.join('\n');
+    expect(joined).toContain('resolves to 3 release objects');
+    expect(joined).toContain('371785746');
+    expect(joined).toContain('371785726');
+  });
+
+  it('fails, and says so, when an updater channel file is missing', () => {
+    const release = releaseWithAllAssets(1, true);
+    release.assets = release.assets.filter((asset) => asset.name !== 'latest-mac.yml');
+
+    const result = verifyReleaseAssets([release], `v${VERSION}`);
+    expect(result.ok).toBe(false);
+    const joined = result.problems.join('\n');
+    expect(joined).toContain('latest-mac.yml');
+    expect(joined).toContain('updater channel files');
+  });
+
+  it('fails when an expected asset is listed but still uploading', () => {
+    const release = releaseWithAllAssets(1, true);
+    const zip = release.assets.find((asset) => asset.name.endsWith('-mac.zip'));
+    if (!zip) throw new Error('fixture is missing the mac zip');
+    zip.state = 'starting';
+
+    const result = verifyReleaseAssets([release], `v${VERSION}`);
+    expect(result.ok).toBe(false);
+    expect(result.problems.join('\n')).toContain('state=starting');
+  });
+
+  it('accepts a tag with or without the leading v', () => {
+    expect(verifyReleaseAssets([releaseWithAllAssets(1, true)], VERSION).ok).toBe(true);
+  });
+});

--- a/tests/unit/summarize-component-stack.test.ts
+++ b/tests/unit/summarize-component-stack.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// analytics.ts imports electron and the Aptabase SDK at module scope; mock both
+// so this stays a pure unit test. Mirrors sanitize-error-message.test.ts.
+vi.mock('electron', () => ({ app: { isPackaged: false } }));
+vi.mock('@aptabase/electron/main', () => ({
+  initialize: vi.fn().mockResolvedValue(undefined),
+  trackEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  summarizeComponentStack,
+  MAX_ANALYTICS_STRING_LENGTH,
+} from '../../src/main/analytics/analytics';
+
+// Renderer error telemetry used to send only `error.message`, which made
+// "Cannot read properties of undefined (reading 'split')" unlocatable: all three
+// reporters looked identical in the data. The component stack is the missing
+// signal, but the RAW stack cannot be sent - a production frame embeds a file://
+// URL containing the user's home directory. This reduces it to component names,
+// which are PII-free by construction rather than by pattern-matching.
+
+describe('summarizeComponentStack', () => {
+  it('returns an empty string for nothing to summarize', () => {
+    expect(summarizeComponentStack(undefined)).toBe('');
+    expect(summarizeComponentStack(null)).toBe('');
+    expect(summarizeComponentStack('')).toBe('');
+  });
+
+  it('extracts component names from a production stack without leaking the path', () => {
+    const stack = [
+      '',
+      '    at BrowserPane (file:///C:/Users/dev/AppData/Local/Kangentic/app/assets/index-a1b2c3.js:12:345)',
+      '    at WindowContent (file:///C:/Users/dev/AppData/Local/Kangentic/app/assets/index-a1b2c3.js:44:9)',
+      '    at App (file:///C:/Users/dev/AppData/Local/Kangentic/app/assets/index-a1b2c3.js:88:1)',
+    ].join('\n');
+
+    const summary = summarizeComponentStack(stack);
+
+    expect(summary).toBe('BrowserPane < WindowContent < App');
+    expect(summary).not.toContain('file://');
+    expect(summary).not.toContain('Users');
+    expect(summary).not.toContain('.js');
+  });
+
+  it('handles a Unix production path the same way', () => {
+    const stack =
+      '\n    at MonitorPage (file:///Users/dev/Applications/Kangentic.app/Contents/assets/index.js:1:2)';
+    const summary = summarizeComponentStack(stack);
+    expect(summary).toBe('MonitorPage');
+    expect(summary).not.toContain('/Users/');
+  });
+
+  it('reads a dev-server stack, including the "in" frame form', () => {
+    const stack = [
+      '    in ChangesPanel (at TaskDetailBody.tsx:257)',
+      '    in PanelErrorBoundary (at TaskDetailBody.tsx:255)',
+    ].join('\n');
+
+    expect(summarizeComponentStack(stack)).toBe('ChangesPanel < PanelErrorBoundary');
+  });
+
+  it('keeps dotted and $-bearing component names intact', () => {
+    const stack = '    at Foo.Bar (x)\n    at _Baz$ (y)';
+    expect(summarizeComponentStack(stack)).toBe('Foo.Bar < _Baz$');
+  });
+
+  it('caps the number of frames, innermost first', () => {
+    const stack = Array.from({ length: 20 }, (_unused, index) => `    at Component${index} (x)`).join(
+      '\n'
+    );
+
+    const summary = summarizeComponentStack(stack, 3);
+
+    expect(summary).toBe('Component0 < Component1 < Component2');
+  });
+
+  it('never exceeds the length Aptabase preserves', () => {
+    // Aptabase truncates a string property at 180 chars server-side, so anything
+    // longer is silently lost rather than delivered.
+    const stack = Array.from(
+      { length: 30 },
+      (_unused, index) => `    at AVeryLongComponentNameIndeed${index} (x)`
+    ).join('\n');
+
+    const summary = summarizeComponentStack(stack, 30);
+
+    expect(summary.length).toBeLessThanOrEqual(MAX_ANALYTICS_STRING_LENGTH);
+    expect(MAX_ANALYTICS_STRING_LENGTH).toBe(180);
+  });
+
+  it('ignores lines that are not frames', () => {
+    const stack = 'Some preamble\n\n    at RealComponent (x)\ntrailing noise';
+    expect(summarizeComponentStack(stack)).toBe('RealComponent');
+  });
+});

--- a/tests/unit/verify-release-assets-main.test.ts
+++ b/tests/unit/verify-release-assets-main.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+// scripts/verify-release-assets.js is the CI gate that blocks `gh release edit --draft=false`
+// unless a tag resolves to exactly one release carrying all 11 expected assets. This file covers
+// the two things tests/unit/release-asset-manifest.test.ts does NOT: main() (the wrapper that
+// turns an `ok: false` decision into the nonzero exit that actually blocks publishing) and
+// releasesForTag's pagination loop. The pure decision function verifyReleaseAssets is fully
+// covered there and is exercised here only incidentally, through main().
+//
+// main() and releasesForTag() are not currently mockable through vi.mock: verify-release-assets.js
+// is a plain CommonJS script loaded via createRequire, which goes through Node's native module
+// loader rather than vitest's module graph. Two approaches were tried and empirically rejected
+// before landing on the one below:
+//   1. `vi.spyOn(childProcessNamespace, 'execFileSync')` on an ESM `import * as childProcess from
+//      'node:child_process'` throws: "Module namespace is not configurable in ESM".
+//   2. `vi.mock('node:child_process', ...)` silently does nothing for this require path: a script
+//      loaded via createRequire still resolved the REAL execFileSync and threw ENOENT for a
+//      nonexistent binary in a throwaway probe.
+// What does work: node:child_process's CJS module.exports object is an ordinary mutable object
+// (unlike the frozen ESM namespace), and it is a process-wide singleton regardless of which
+// `require`/createRequire call touches it. So we obtain it via CJS require, overwrite its
+// `execFileSync` property with a vi.fn(), then evict verify-release-assets.js from the require
+// cache and re-require it: its top-level `const { execFileSync } = require('node:child_process')`
+// destructures a reference at require time, so the mocked function must already be in place
+// BEFORE that fresh require runs. Restoring the builtin afterwards is unconditional (top-level
+// afterEach, not vi.restoreAllMocks, which does not undo a plain property assignment) because a
+// leaked mock here would silently poison any other test in the same worker that shells out.
+//
+// vi.restoreAllMocks() is also unconditional here: process.exit/console.error/console.log are
+// re-spied per test via vi.spyOn, and vi.spyOn on an already-spied property reuses the existing
+// spy rather than replacing it. Without restoring between tests, an earlier test's recorded
+// calls leak into a later test's assertions on the "same" spy - which is exactly the false
+// failure this file hit while under development (a later test's `.not.toHaveBeenCalled()` was
+// tripped by an earlier test's real, expected call that nobody ever cleared).
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const requireFromRepo = createRequire(path.join(REPO_ROOT, 'package.json'));
+const scriptPath = path.join(REPO_ROOT, 'scripts/verify-release-assets.js');
+
+interface RawRelease {
+  id: number;
+  draft: boolean;
+  tag_name: string;
+  assets: { name: string; state: string }[];
+}
+
+interface VerifyReleaseAssetsExports {
+  verifyReleaseAssets: (
+    releases: RawRelease[],
+    tag: string
+  ) => { ok: boolean; problems: string[]; release: RawRelease | null };
+  releasesForTag: (repo: string, tag: string) => RawRelease[];
+  parseArgs: (argv: string[]) => { tag: string | undefined; repo: string };
+  main: () => void;
+}
+
+const childProcessModule = requireFromRepo('node:child_process') as {
+  execFileSync: (...args: unknown[]) => string;
+};
+const realExecFileSync = childProcessModule.execFileSync;
+const originalArgv = process.argv;
+const originalGithubRepository = process.env.GITHUB_REPOSITORY;
+
+afterEach(() => {
+  childProcessModule.execFileSync = realExecFileSync;
+  process.argv = originalArgv;
+  if (originalGithubRepository === undefined) {
+    delete process.env.GITHUB_REPOSITORY;
+  } else {
+    process.env.GITHUB_REPOSITORY = originalGithubRepository;
+  }
+  vi.restoreAllMocks();
+});
+
+/** Load a fresh copy of the script with execFileSync already patched at require time. */
+function loadScriptWithMockedExecFileSync(
+  execFileSyncImplementation: (file: string, args: readonly string[]) => string
+): VerifyReleaseAssetsExports {
+  childProcessModule.execFileSync = vi.fn(execFileSyncImplementation);
+  delete requireFromRepo.cache[requireFromRepo.resolve(scriptPath)];
+  return requireFromRepo(scriptPath) as VerifyReleaseAssetsExports;
+}
+
+/** The real error the mocked process.exit throws, so control flow stops exactly like the real one. */
+class ProcessExitSentinel extends Error {
+  constructor(public readonly code: number | string | null | undefined) {
+    super(`process.exit(${String(code)})`);
+  }
+}
+
+function spyOnProcessExit() {
+  return vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new ProcessExitSentinel(code);
+  }) as never);
+}
+
+describe('parseArgs', () => {
+  // parseArgs never touches execFileSync, so a plain unmocked require is safe here.
+  const { parseArgs } = requireFromRepo(scriptPath) as VerifyReleaseAssetsExports;
+
+  it('parses a tag and an explicit --repo', () => {
+    expect(parseArgs(['v1.2.3', '--repo', 'owner/name'])).toEqual({
+      tag: 'v1.2.3',
+      repo: 'owner/name',
+    });
+  });
+
+  it('returns an undefined tag when given no arguments, so main() hits the usage branch', () => {
+    expect(parseArgs([]).tag).toBeUndefined();
+  });
+
+  it('defaults repo from GITHUB_REPOSITORY when set', () => {
+    process.env.GITHUB_REPOSITORY = 'someOrg/someRepo';
+    expect(parseArgs(['v1.2.3'])).toEqual({ tag: 'v1.2.3', repo: 'someOrg/someRepo' });
+  });
+
+  it('falls back to Kangentic/kangentic when GITHUB_REPOSITORY is unset', () => {
+    delete process.env.GITHUB_REPOSITORY;
+    expect(parseArgs(['v1.2.3'])).toEqual({ tag: 'v1.2.3', repo: 'Kangentic/kangentic' });
+  });
+});
+
+describe('main', () => {
+  const VERSION = '9.9.9';
+  const TAG = `v${VERSION}`;
+
+  it('exits nonzero on the verification-failure branch, not just the usage branch', () => {
+    // No release at all for the tag -> verifyReleaseAssets returns ok:false.
+    const { main } = loadScriptWithMockedExecFileSync(() => JSON.stringify([]));
+    const exitSpy = spyOnProcessExit();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    process.argv = [...originalArgv.slice(0, 2), TAG, '--repo', 'Kangentic/kangentic'];
+
+    expect(() => main()).toThrow(ProcessExitSentinel);
+    expect(exitSpy).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    // Pin the branch: this must be the verification-failure message, not the `!tag` usage
+    // message, or a future test typo (e.g. an empty argv) would report the same exit code
+    // for the wrong reason and this test would stay green even if the verification-failure
+    // branch's process.exit(1) were deleted.
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Release verification FAILED'));
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Usage:'));
+  });
+
+  it('does not exit nonzero when verification passes', () => {
+    const { expectedReleaseAssets } = requireFromRepo('./scripts/release-assets.js') as {
+      expectedReleaseAssets: (version: string) => string[];
+    };
+    const release: RawRelease = {
+      id: 1,
+      draft: true,
+      tag_name: TAG,
+      assets: expectedReleaseAssets(VERSION).map((name) => ({ name, state: 'uploaded' })),
+    };
+    // A single release satisfies the whole expected set, so page 1 (length 1, under 100) is the
+    // only page requested; the loop breaks there regardless of what a page 2 would contain.
+    const { main } = loadScriptWithMockedExecFileSync(() => JSON.stringify([release]));
+    const exitSpy = spyOnProcessExit();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    process.argv = [...originalArgv.slice(0, 2), TAG, '--repo', 'Kangentic/kangentic'];
+
+    expect(() => main()).not.toThrow();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Release verification passed'));
+  });
+});
+
+describe('releasesForTag pagination', () => {
+  it('walks past two full 100-item pages to a short page and collects matches from all three', () => {
+    const tag = 'v9.9.9';
+    const otherTag = 'v0.0.0';
+    const makeRelease = (id: number, tagName: string): RawRelease => ({
+      id,
+      draft: true,
+      tag_name: tagName,
+      assets: [],
+    });
+
+    // One match seeded on each page proves the loop both walks past the two full pages
+    // (rather than stopping at page 1) and keeps accumulating (rather than returning only
+    // the last page's matches).
+    const page1 = Array.from({ length: 100 }, (_unused, index) =>
+      makeRelease(index + 1, index + 1 === 50 ? tag : otherTag)
+    );
+    const page2 = Array.from({ length: 100 }, (_unused, index) =>
+      makeRelease(index + 101, index + 101 === 150 ? tag : otherTag)
+    );
+    const page3 = [makeRelease(201, tag)]; // length 1, under 100 -> loop stops here
+
+    let callCount = 0;
+    const { releasesForTag } = loadScriptWithMockedExecFileSync(() => {
+      callCount += 1;
+      if (callCount === 1) return JSON.stringify(page1);
+      if (callCount === 2) return JSON.stringify(page2);
+      return JSON.stringify(page3);
+    });
+
+    const matches = releasesForTag('Kangentic/kangentic', tag);
+
+    expect(callCount).toBe(3);
+    expect(matches.map((release) => release.id)).toEqual([50, 150, 201]);
+  });
+});


### PR DESCRIPTION
## What

- **`.github/workflows/release.yml`** - a new `create-draft-release` job that the build matrix
  depends on, and an asset-verification gate in `publish-release` that runs before
  `--draft=false`. The comment claiming the old gate prevented partial releases is corrected.
- **`scripts/release-assets.js`, `scripts/verify-release-assets.js`** - the expected 11-asset
  manifest, and the gate that enforces it.
- **`electron-builder.yml`** - pins `mac.artifactName` (the zip), a new `dmg.artifactName`, and
  `deb.artifactName`.
- **Renderer error telemetry** - a `RendererErrorContext` threaded through `src/shared/types.ts`,
  the preload bridge, the handler in `src/main/ipc/register-all.ts`, and all three reporters, plus
  `summarizeComponentStack()` in `src/main/analytics/analytics.ts`.
- **Docs** - `analytics.md`, `deployment.md`, `installation.md`, `architecture.md`, and the
  `/release` skill.

## Why

v0.35.0 shipped Windows-only. electron-builder's GitHub publisher does a check-then-create with no
locking (`electron-publish/out/gitHubPublisher.js:55`), so the three platform matrix legs each
listed the releases before any had created a draft, all three saw nothing for the tag, and all
three created their own. GitHub permits duplicate drafts for one tag, so all three succeeded. The
publish step then resolved the tag to one of them and published it, stranding the macOS and Linux
artifacts on two orphaned drafts.

Every platform job reported success throughout. The result was 35 `app_error` updater events, and
`npx kangentic` 404ing for every new macOS and Linux user.

The live v0.35.0 release has already been repaired by hand (assets consolidated onto the published
release, verified by sha512 before upload, orphan drafts deleted). This PR is about preventing a
recurrence.

## How

**Removing the race, not narrowing it.** `create-draft-release` creates the single draft before any
build starts. `gitHubPublisher.js:66` returns an existing draft as-is, and `needs:` is a hard
barrier, so every leg provably converges on one release. The legs upload disjoint filenames and
never read-modify-write the release object.

One subtlety worth a reviewer's eye: the matrix `if:` already carried `always()` to tolerate the
conditional `create-tag`, so adding the new job to `needs:` **without** also naming it in the `if:`
would let the matrix run when draft creation failed, straight back to the split. The added
`&& needs.create-draft-release.result == 'success'` clause is load-bearing.

**The gate.** It lists `/repos/:owner/:repo/releases` and filters by tag rather than calling
`/releases/tags/<tag>`, because that endpoint resolves only published releases and this runs while
the release is still a draft. It fails unless the tag resolves to exactly one release carrying all
11 expected assets, all in `uploaded` state. It has no third-party imports, since the
`publish-release` job has no `npm ci` step.

**Artifact names.** Two of the four platform filenames were inherited electron-builder defaults.
The mac pair carries its `-arm64` infix only because the default arch is x64 and the default
templates omit `${arch}` when it matches, so adding `mac.defaultArch` would silently rename both and
404 every `npx kangentic` on macOS. Note that `mac.artifactName` falls through to *both* mac
targets, so the dmg needs its own override or it loses the `-mac` infix distinction.

**Telemetry.** `boundary` is the field that carries the diagnostic weight: it says whether an error
came from a render (component stack available) or the bare `unhandledrejection` listener (none).
`source` deliberately stays `error_boundary` so existing dashboard grouping is continuous. The raw
component stack is never sent, since a production frame embeds a `file://` URL holding the user's
home directory; main reduces it to component names, which cannot contain a path.

**Known limitation, documented in code and docs:** `components` arrives minified in packaged
builds, which is the only build where telemetry runs. It still distinguishes code paths and
resolves against a matching build's sourcemap, but it is not readable on its own. `boundary` and
`panel` are unaffected, since a string literal and a prop both survive minification.

## Breaking changes

None. Artifact filenames are unchanged, since the pins encode exactly what electron-builder already
produced. The `trackRendererError` context argument is optional.

## Tests

New unit tests: `release-asset-manifest` (the manifest cross-checked against every `artifactName` in
`electron-builder.yml` AND against the launcher's download filenames, plus every
`verifyReleaseAssets` branch including the exact three-release v0.35.0 shape),
`summarize-component-stack`, and `verify-release-assets-main` (`parseArgs`, `main()`'s nonzero exit,
and `releasesForTag` pagination).

Extended: `panel-error-boundary` (all three reporters forwarding context) and
`register-all-idempotency` (the handler with full, absent, and malformed context).

The gate was also validated against real GitHub data: it passes on v0.34.0 and the repaired
v0.35.0, and exits nonzero on a missing tag. The manifest guard was red-greened by renaming an
asset.

Generated with [Claude Code](https://claude.com/claude-code)
