### PR TITLE
fix(transcript): make every adapter's entry uuid absolute and session-scoped

### DIFF
--- a/src/main/agent/adapters/antigravity/transcript-parser.ts
+++ b/src/main/agent/adapters/antigravity/transcript-parser.ts
@@ -133,11 +133,21 @@ export async function parseAntigravityTranscript(
 ): Promise<ParsedTranscript> {
   const sourcePath = locateAntigravityTranscriptFile(agentSessionId);
   if (!sourcePath) return { entries: [], sourcePath: null };
-  return parseAntigravityTranscriptFile(sourcePath);
+  return parseAntigravityTranscriptFile(sourcePath, agentSessionId);
 }
 
-/** Parse a known transcript file path (the `transcriptPath`-driven callers). */
-export async function parseAntigravityTranscriptFile(sourcePath: string): Promise<ParsedTranscript> {
+/**
+ * Parse a known transcript file path (the `transcriptPath`-driven callers).
+ *
+ * `agentSessionId` namespaces the entry uuids. It is optional because the
+ * tool-count reader can be handed a bare `transcriptPath` with no session id,
+ * and that caller only counts tool calls - it never persists a uuid. Every
+ * caller whose entries reach the viewer or the retrieval index passes one.
+ */
+export async function parseAntigravityTranscriptFile(
+  sourcePath: string,
+  agentSessionId?: string,
+): Promise<ParsedTranscript> {
   const entries: TranscriptEntry[] = [];
   // The id of the most recent tool_use block, so a following ERROR_MESSAGE
   // step (agy records tool failures as their own step) can be attached as
@@ -146,7 +156,12 @@ export async function parseAntigravityTranscriptFile(sourcePath: string): Promis
 
   const { steps, omittedBytes, totalBytes } = await readSteps(sourcePath);
   for (const step of steps) {
-    const uuid = `step-${step.step_index}`;
+    // `step_index` is already absolute (readSteps dedups and sorts by it), so
+    // only the session namespace was missing: `resolveTaskTranscript` stitches
+    // every session a task has had and dedups by uuid keeping the first, so two
+    // agy sessions on one task both minting `step-0..N` made the second
+    // session's steps vanish from the Conversation tab.
+    const uuid = agentSessionId ? `${agentSessionId}:step-${step.step_index}` : `step-${step.step_index}`;
     const ts = stepTimestamp(step);
 
     switch (step.type) {

--- a/src/main/agent/adapters/claude/transcript-parser.ts
+++ b/src/main/agent/adapters/claude/transcript-parser.ts
@@ -75,6 +75,20 @@ function parseTranscriptLine(
   }
   if (!isRecord(raw)) return;
 
+  // KNOWN GAP, id-less records only. `''` is not an absent uuid but a SHARED
+  // one, and `resolveTaskTranscript` dedups by uuid keeping the first, so a
+  // second id-less entry would vanish from the stitched Conversation tab.
+  //
+  // Every other adapter falls back to a session-scoped absolute line index.
+  // Claude cannot, for a structural reason rather than a cost one: none of its
+  // three read paths can supply a physical line index. This function is shared
+  // by all three with deliberately identical per-line semantics (see the note
+  // above it); the incremental path parses out of a carry buffer that has no
+  // line notion at all; and `parseClaudeTranscriptWindow` is called once per
+  // window by the indexer, so counting the omitted head per window would make
+  // a whole-file walk quadratic. Closing this means giving the shared line
+  // parser a line-numbering contract across all three, which is its own change
+  // - hence a follow-up rather than a bend through the hot incremental path.
   const uuid = typeof raw.uuid === 'string' ? raw.uuid : '';
   const ts = parseTimestamp(raw.timestamp);
   const type = raw.type;

--- a/src/main/agent/adapters/codex/codex-adapter.ts
+++ b/src/main/agent/adapters/codex/codex-adapter.ts
@@ -271,7 +271,7 @@ export class CodexAdapter implements AgentAdapter {
   async parseTranscript(agentSessionId: string, _cwd: string): Promise<ParsedTranscript> {
     const filePath = locateCodexTranscriptFile(agentSessionId);
     if (!filePath) return { entries: [], sourcePath: null };
-    const entries = await parseCodexTranscript(filePath);
+    const entries = await parseCodexTranscript(agentSessionId, filePath);
     return { entries, sourcePath: filePath };
   }
 

--- a/src/main/agent/adapters/codex/transcript-parser.ts
+++ b/src/main/agent/adapters/codex/transcript-parser.ts
@@ -33,18 +33,29 @@ import { parseWindowBytes, prependTruncationMarker } from '../../shared/transcri
  *
  * Defensive parsing throughout: a malformed line is skipped, never thrown.
  */
-export async function parseCodexTranscript(filePath: string): Promise<TranscriptEntry[]> {
+export async function parseCodexTranscript(
+  agentSessionId: string,
+  filePath: string,
+): Promise<TranscriptEntry[]> {
   // Bounded tail read rather than a whole-file one: a transcript has no size
   // ceiling, and reading one whole is what OOM'd the main process.
-  const window = await readJsonlWindow(filePath, { maxBytes: parseWindowBytes() });
+  // `countOmittedLines` because the uuids below embed the ABSOLUTE physical
+  // line index (see there). A rollout is append-only, so that index is stable.
+  const window = await readJsonlWindow(filePath, {
+    maxBytes: parseWindowBytes(),
+    countOmittedLines: true,
+  });
   if (window.totalBytes === 0) return [];
 
   const entries: TranscriptEntry[] = [];
   const lines = window.text.split(/\r?\n/);
   let currentModel: string | undefined;
-  let entryIndex = 0;
+  // Line indices must stay absolute within the FILE, not relative to the
+  // window (the Grok precedent).
+  const lineIndexBase = window.omittedLineCount;
 
-  for (const line of lines) {
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex];
     if (line.length === 0) continue;
     let raw: unknown;
     try {
@@ -64,17 +75,19 @@ export async function parseCodexTranscript(filePath: string): Promise<Transcript
 
     if (raw.type !== 'response_item' || !isRecord(raw.payload)) continue;
     const payload = raw.payload;
-    // KNOWN LIMITATION, above MAX_PARSE_SOURCE_BYTES only: this counter is
-    // WINDOW-relative, so once a transcript outgrows the read cap the same turn
-    // gets a different uuid as the tail window slides. Grok avoids this by
-    // deriving its uuid from an absolute physical line index (`countOmittedLines`),
-    // but an ENTRY index cannot be recovered from a line count - entries are
-    // emitted conditionally. The blast radius is citation anchors
-    // (`aroundUuid`, retrieval chunk `turnUuidStart`) drifting for a >16MB
-    // Codex transcript, which degrades to the full transcript rather than
-    // failing. A real fix means minting the uuid from something intrinsic to
-    // the record; out of scope for the OOM fix.
-    const uuid = `codex-${entryIndex++}`;
+    // Session-scoped and ABSOLUTE. Both halves are load-bearing, and a rollout
+    // carries no per-record id to derive either from (only `function_call` /
+    // `function_call_output` have a `call_id`, and they share it as a pair).
+    //   - absolute, because these uuids are the persisted citation anchors
+    //     `sliceTranscriptAroundUuid` resolves against. The window-relative
+    //     counter this replaced renumbered every turn once a transcript grew
+    //     past the read cap and the tail window started sliding.
+    //   - session-scoped, because `resolveTaskTranscript` stitches every
+    //     session a task has had and dedups by uuid keeping the first. Two
+    //     Codex sessions on one task both minted `codex-0..N`, so the second
+    //     session's turns collided with the first's and vanished from the
+    //     Conversation tab. That bug did not need a large transcript.
+    const uuid = `${agentSessionId}:${lineIndexBase + lineIndex}`;
 
     if (payload.type === 'message') {
       const role = payload.role;

--- a/src/main/agent/adapters/droid/droid-adapter.ts
+++ b/src/main/agent/adapters/droid/droid-adapter.ts
@@ -207,7 +207,7 @@ export class DroidAdapter implements AgentAdapter {
 
   async parseTranscript(agentSessionId: string, cwd: string): Promise<ParsedTranscript> {
     const filePath = droidTranscriptFilePath(agentSessionId, cwd);
-    const entries = await parseDroidTranscript(filePath);
+    const entries = await parseDroidTranscript(agentSessionId, filePath);
     return { entries, sourcePath: filePath };
   }
 

--- a/src/main/agent/adapters/droid/transcript-parser.ts
+++ b/src/main/agent/adapters/droid/transcript-parser.ts
@@ -38,17 +38,27 @@ import { cwdToSessionSlug } from './session-id-capture';
  * too fragile to scrape. Assistant entries therefore carry no `model` field;
  * the markdown formatter falls back to a plain `## Assistant` header.
  */
-export async function parseDroidTranscript(filePath: string): Promise<TranscriptEntry[]> {
+export async function parseDroidTranscript(
+  agentSessionId: string,
+  filePath: string,
+): Promise<TranscriptEntry[]> {
   // Bounded tail read rather than a whole-file one: a transcript has no size
   // ceiling (it grows for as long as the user keeps working), and reading one
   // whole is what OOM'd the main process.
-  const window = await readJsonlWindow(filePath, { maxBytes: parseWindowBytes() });
+  const window = await readJsonlWindow(filePath, {
+    maxBytes: parseWindowBytes(),
+    countOmittedLines: true,
+  });
   if (window.totalBytes === 0) return [];
 
   const entries: TranscriptEntry[] = [];
   const lines = window.text.split(/\r?\n/);
+  // Only used when a record turns out to lack its own `id`. See the Qwen
+  // parser for why this is resolved up front rather than lazily.
+  const lineIndexBase = window.omittedLineCount;
 
-  for (const line of lines) {
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex];
     if (line.length === 0) continue;
     let raw: unknown;
     try {
@@ -60,7 +70,14 @@ export async function parseDroidTranscript(filePath: string): Promise<Transcript
 
     if (raw.type !== 'message') continue;
 
-    const uuid = typeof raw.id === 'string' ? raw.id : '';
+    // An id-less record used to fall back to `''`, which is not an absent uuid
+    // but a SHARED one: `resolveTaskTranscript` dedups by uuid keeping the
+    // first, so every such entry after the first vanished from the stitched
+    // Conversation tab. Fall back to the session-scoped absolute line index
+    // instead (the Codex/Kimi shape) so the entry keeps a real identity.
+    const uuid = typeof raw.id === 'string' && raw.id.length > 0
+      ? raw.id
+      : `${agentSessionId}:${lineIndexBase + lineIndex}`;
     const ts = parseTimestamp(raw.timestamp);
     const message = raw.message;
     if (!isRecord(message)) continue;

--- a/src/main/agent/adapters/gemini/gemini-adapter.ts
+++ b/src/main/agent/adapters/gemini/gemini-adapter.ts
@@ -218,7 +218,7 @@ export class GeminiAdapter implements AgentAdapter {
   async parseTranscript(agentSessionId: string, cwd: string): Promise<ParsedTranscript> {
     const filePath = locateGeminiTranscriptFile(agentSessionId, cwd);
     if (!filePath) return { entries: [], sourcePath: null };
-    const entries = await parseGeminiTranscript(filePath);
+    const entries = await parseGeminiTranscript(agentSessionId, filePath);
     return { entries, sourcePath: filePath };
   }
 

--- a/src/main/agent/adapters/gemini/transcript-parser.ts
+++ b/src/main/agent/adapters/gemini/transcript-parser.ts
@@ -35,20 +35,45 @@ import { computeGeminiProjectDirName } from './session-history-parser';
  * Also tolerates the legacy single-JSON-object form (`{ messages: [...] }`) so
  * older sessions still parse. Defensive throughout: malformed lines skipped.
  */
-export async function parseGeminiTranscript(filePath: string): Promise<TranscriptEntry[]> {
+export async function parseGeminiTranscript(
+  agentSessionId: string,
+  filePath: string,
+): Promise<TranscriptEntry[]> {
   // Bounded tail read rather than a whole-file one: a transcript has no size
   // ceiling, and reading one whole is what OOM'd the main process.
-  const window = await readJsonlWindow(filePath, { maxBytes: parseWindowBytes() });
+  const window = await readJsonlWindow(filePath, {
+    maxBytes: parseWindowBytes(),
+    countOmittedLines: true,
+  });
   if (window.totalBytes === 0) return [];
   const content = window.text;
 
+  // Only used when a message lacks its own `id`. See the Qwen parser for why
+  // this is resolved up front rather than lazily.
+  const lineIndexBase = window.omittedLineCount;
+
   // Dedupe by message id, last-wins, first-seen order preserved.
+  //
+  // The map KEY is the entry uuid. Deriving both from one value is the point:
+  // the key used to fall back to `gemini-${messagesById.size}` while the uuid
+  // fell back to `''`, so an id-less message was keyed distinctly but then
+  // emitted with a uuid shared by every other id-less message - and
+  // `resolveTaskTranscript` dedups by uuid keeping the first, so all but one
+  // vanished from the stitched Conversation tab. The fallback is now the
+  // session-scoped absolute line index used by the Codex and Kimi parsers.
   const messagesById = new Map<string, Record<string, unknown>>();
-  const addMessage = (message: unknown): void => {
+  const addMessage = (message: unknown, lineIndex: number, indexWithinLine: number | null): void => {
     if (!isRecord(message)) return;
     const type = message.type;
     if (type !== 'user' && type !== 'gemini') return;
-    const messageId = typeof message.id === 'string' ? message.id : `gemini-${messagesById.size}`;
+    let messageId = typeof message.id === 'string' && message.id.length > 0 ? message.id : null;
+    if (messageId === null) {
+      const absoluteLine = lineIndexBase + lineIndex;
+      // A `$set` line seeds SEVERAL messages, so the line alone is not unique.
+      messageId = indexWithinLine === null
+        ? `${agentSessionId}:${absoluteLine}`
+        : `${agentSessionId}:${absoluteLine}.${indexWithinLine}`;
+    }
     messagesById.set(messageId, message);
   };
 
@@ -67,27 +92,33 @@ export async function parseGeminiTranscript(filePath: string): Promise<Transcrip
     // Legacy single-object form: one JSON object with a messages[] array.
     const parsed = tryParseJson(trimmed);
     if (isRecord(parsed) && Array.isArray(parsed.messages)) {
-      for (const message of parsed.messages) addMessage(message);
+      // The legacy form is one object on one line, so every message shares
+      // line 0 and is distinguished by its index within the array.
+      for (const [index, message] of parsed.messages.entries()) addMessage(message, 0, index);
     }
   } else {
-    for (const line of content.split(/\r?\n/)) {
+    const lines = content.split(/\r?\n/);
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+      const line = lines[lineIndex];
       if (line.length === 0) continue;
       const parsed = tryParseJson(line);
       if (!isRecord(parsed)) continue;
       // `$set` patch line: fold in any seeded messages, ignore other keys.
       if (isRecord(parsed.$set)) {
         if (Array.isArray(parsed.$set.messages)) {
-          for (const message of parsed.$set.messages) addMessage(message);
+          for (const [index, message] of parsed.$set.messages.entries()) {
+            addMessage(message, lineIndex, index);
+          }
         }
         continue;
       }
-      addMessage(parsed);
+      addMessage(parsed, lineIndex, null);
     }
   }
 
   const entries: TranscriptEntry[] = [];
-  for (const message of messagesById.values()) {
-    const uuid = typeof message.id === 'string' ? message.id : '';
+  // The key IS the uuid (see `addMessage`).
+  for (const [uuid, message] of messagesById) {
     const ts = parseTimestamp(message.timestamp);
 
     if (message.type === 'user') {

--- a/src/main/agent/adapters/kimi/kimi-adapter.ts
+++ b/src/main/agent/adapters/kimi/kimi-adapter.ts
@@ -233,7 +233,7 @@ export class KimiAdapter implements AgentAdapter {
   async parseTranscript(agentSessionId: string, _cwd: string): Promise<ParsedTranscript> {
     const filePath = locateKimiTranscriptFile(agentSessionId);
     if (!filePath) return { entries: [], sourcePath: null };
-    const entries = await parseKimiTranscript(filePath);
+    const entries = await parseKimiTranscript(agentSessionId, filePath);
     return { entries, sourcePath: filePath };
   }
 

--- a/src/main/agent/adapters/kimi/transcript-parser.ts
+++ b/src/main/agent/adapters/kimi/transcript-parser.ts
@@ -30,26 +30,55 @@ import { findSessionWireFile } from './session-history-parser';
  * defensively. Tool calls/results and user prompts ARE pinned to the verified
  * on-disk shapes.
  */
-export async function parseKimiTranscript(filePath: string): Promise<TranscriptEntry[]> {
+export async function parseKimiTranscript(
+  agentSessionId: string,
+  filePath: string,
+): Promise<TranscriptEntry[]> {
   // Bounded tail read rather than a whole-file one: a transcript has no size
   // ceiling, and reading one whole is what OOM'd the main process.
-  const window = await readJsonlWindow(filePath, { maxBytes: parseWindowBytes() });
+  // `countOmittedLines` because the uuids below embed the ABSOLUTE physical
+  // line index. `wire.jsonl` is an append-only event stream, so it is stable.
+  const window = await readJsonlWindow(filePath, {
+    maxBytes: parseWindowBytes(),
+    countOmittedLines: true,
+  });
   if (window.totalBytes === 0) return [];
 
   const entries: TranscriptEntry[] = [];
+  const lines = window.text.split(/\r?\n/);
   let pendingAssistantText = '';
   let pendingTs = 0;
-  // WINDOW-relative counter: above MAX_PARSE_SOURCE_BYTES the same turn gets a
-  // different uuid as the tail window slides. See the fuller note in the Codex
-  // parser; same limitation, same graceful degradation for citation anchors.
-  let entryIndex = 0;
+  // The line the CURRENT pending run of ContentPart fragments started on,
+  // captured alongside `pendingTs` for the same reason: the flushed entry
+  // belongs to where its text began, not to the boundary record that happened
+  // to trigger the flush. It is also what keeps the uuid unique - a boundary
+  // line emits at most its own entry plus this flush, and the two therefore
+  // never claim the same line.
+  //
+  // KNOWN RESIDUAL, over-cap transcripts only. This is the line the run starts
+  // on IN THIS WINDOW, which is its true start only while the whole run is
+  // visible. Once the tail window slides into the middle of a run, the flush
+  // anchors to the first fragment still visible instead. Usually harmless: the
+  // dropped fragment also changes the flushed text, so the chunk diverges and
+  // is re-inserted with the new anchor rather than keeping a stale one. It goes
+  // stale only when the dropped leading fragment contributes nothing after
+  // `.trim()` (a whitespace-only fragment), leaving byte-identical text under a
+  // shifted uuid. Resolving it means carrying the run's start across parses,
+  // which this deliberately stateless parser has no place to keep.
+  let pendingLineIndex = 0;
+  // Session-scoped and ABSOLUTE; see the fuller note in the Codex parser, which
+  // has the identical shape and the identical two bugs behind it. Kimi's wire
+  // records carry no per-record id either (only ToolCall/ToolResult do, as a
+  // shared pair).
+  const lineIndexBase = window.omittedLineCount;
+  const uuidForLine = (lineIndex: number): string => `${agentSessionId}:${lineIndexBase + lineIndex}`;
 
   const flushAssistantText = (): void => {
     const text = pendingAssistantText.trim();
     if (text.length > 0) {
       entries.push({
         kind: 'assistant',
-        uuid: `kimi-${entryIndex++}`,
+        uuid: uuidForLine(pendingLineIndex),
         ts: pendingTs,
         blocks: [{ type: 'text', text }],
       });
@@ -57,7 +86,8 @@ export async function parseKimiTranscript(filePath: string): Promise<TranscriptE
     pendingAssistantText = '';
   };
 
-  for (const line of window.text.split(/\r?\n/)) {
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex];
     if (line.length === 0) continue;
     let raw: unknown;
     try {
@@ -77,14 +107,17 @@ export async function parseKimiTranscript(filePath: string): Promise<TranscriptE
     if (type === 'TurnBegin' || type === 'SteerInput') {
       flushAssistantText();
       const text = extractUserInputText(payload.user_input);
-      if (text) entries.push({ kind: 'user', uuid: `kimi-${entryIndex++}`, ts, text });
+      if (text) entries.push({ kind: 'user', uuid: uuidForLine(lineIndex), ts, text });
       continue;
     }
 
     if (type === 'ContentPart') {
       const fragment = extractContentPartText(payload);
       if (fragment) {
-        if (pendingAssistantText.length === 0) pendingTs = ts;
+        if (pendingAssistantText.length === 0) {
+          pendingTs = ts;
+          pendingLineIndex = lineIndex;
+        }
         pendingAssistantText += fragment;
       }
       continue;
@@ -99,7 +132,7 @@ export async function parseKimiTranscript(filePath: string): Promise<TranscriptE
         ? (tryParseJson(callFunction.arguments) ?? callFunction.arguments)
         : callFunction.arguments;
       const blocks: TranscriptBlock[] = [{ type: 'tool_use', id, name, input }];
-      entries.push({ kind: 'assistant', uuid: `kimi-${entryIndex++}`, ts, blocks });
+      entries.push({ kind: 'assistant', uuid: uuidForLine(lineIndex), ts, blocks });
       continue;
     }
 
@@ -108,7 +141,7 @@ export async function parseKimiTranscript(filePath: string): Promise<TranscriptE
       const returnValue = isRecord(payload.return_value) ? payload.return_value : {};
       entries.push({
         kind: 'tool_result',
-        uuid: `kimi-${entryIndex++}`,
+        uuid: uuidForLine(lineIndex),
         ts,
         toolUseId,
         content: extractToolResultContent(returnValue),

--- a/src/main/agent/adapters/qwen-code/qwen-adapter.ts
+++ b/src/main/agent/adapters/qwen-code/qwen-adapter.ts
@@ -243,7 +243,7 @@ export class QwenAdapter implements AgentAdapter {
 
   async parseTranscript(agentSessionId: string, cwd: string): Promise<ParsedTranscript> {
     const filePath = locateQwenTranscriptFile(agentSessionId, cwd);
-    const entries = await parseQwenTranscript(filePath);
+    const entries = await parseQwenTranscript(agentSessionId, filePath);
     return { entries, sourcePath: filePath };
   }
 

--- a/src/main/agent/adapters/qwen-code/transcript-parser.ts
+++ b/src/main/agent/adapters/qwen-code/transcript-parser.ts
@@ -25,16 +25,27 @@ import { qwenChatsDir } from './session-history-parser';
  * GenAI part schema (no real tool-call sessions were available locally to
  * pin them); they are handled defensively and degrade to text if absent.
  */
-export async function parseQwenTranscript(filePath: string): Promise<TranscriptEntry[]> {
+export async function parseQwenTranscript(
+  agentSessionId: string,
+  filePath: string,
+): Promise<TranscriptEntry[]> {
   // Bounded tail read rather than a whole-file one: a transcript has no size
   // ceiling, and reading one whole is what OOM'd the main process.
-  const window = await readJsonlWindow(filePath, { maxBytes: parseWindowBytes() });
+  const window = await readJsonlWindow(filePath, {
+    maxBytes: parseWindowBytes(),
+    countOmittedLines: true,
+  });
   if (window.totalBytes === 0) return [];
 
   const entries: TranscriptEntry[] = [];
-  let entryIndex = 0;
+  const lines = window.text.split(/\r?\n/);
+  // Only used when a record turns out to lack its own `uuid`. Resolved up
+  // front rather than lazily: the scan is free below the cap and ~27ms on the
+  // largest transcript measured, which is not worth a second code shape.
+  const lineIndexBase = window.omittedLineCount;
 
-  for (const line of window.text.split(/\r?\n/)) {
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex];
     if (line.length === 0) continue;
     let raw: unknown;
     try {
@@ -51,10 +62,16 @@ export async function parseQwenTranscript(filePath: string): Promise<TranscriptE
     const parts = message.parts;
     if (!Array.isArray(parts)) continue;
 
-    // WINDOW-relative counter: above MAX_PARSE_SOURCE_BYTES the same turn gets a
-    // different uuid as the tail window slides. See the fuller note in the Codex
-    // parser; same limitation, same graceful degradation for citation anchors.
-    const uuid = `qwen-${entryIndex++}`;
+    // The record's own `uuid` is the best anchor available: intrinsic, stable
+    // across re-parses, and already unique per session (real sessions carry
+    // `uuid` / `parentUuid` / `sessionId` per line). Older or partial writers
+    // may omit it, so fall back to the session-scoped absolute line index the
+    // Codex and Kimi parsers use - see the fuller note there for why both
+    // halves matter. Sharing one uuid across the several entries a single
+    // record can emit is deliberate and pre-existing (Droid does the same).
+    const uuid = typeof raw.uuid === 'string' && raw.uuid.length > 0
+      ? raw.uuid
+      : `${agentSessionId}:${lineIndexBase + lineIndex}`;
     const ts = parseTimestamp(raw.timestamp);
 
     if (type === 'user') {

--- a/src/main/agent/shared/history-scan.ts
+++ b/src/main/agent/shared/history-scan.ts
@@ -185,11 +185,19 @@ export interface JsonlWindowOptions {
   maxBytes: number;
   /**
    * Count physical lines before the window by streaming `[0, startByte)` and
-   * counting newline bytes (O(1) memory, no JSON.parse). Off by default because
-   * it costs a full scan of the omitted head. Exists solely for Grok, whose
-   * transcript entry uuids are `<sessionId>:<physicalLineIndex>` and are the
-   * persisted anchors citations resolve against - it is the one parser that
-   * cannot renumber lines when its read stops covering the whole file.
+   * counting newline bytes (O(1) memory, no JSON.parse). Off by default, and
+   * on for every parser whose transcript entry uuids embed
+   * `<sessionId>:<physicalLineIndex>` - those uuids are the persisted anchors
+   * citations resolve against, so a parser that renumbers lines when its read
+   * stops covering the whole file silently breaks every stored citation.
+   *
+   * The scan is free below the parse cap (`endByte <= 0` returns immediately)
+   * and cheap above it: measured against the real transcripts on a dev machine,
+   * the worst case was 27ms to scan the 121.9MB omitted head of a 137.9MB
+   * transcript, and it only reruns when the file has actually changed (the
+   * transcript cache is stat-validated). That is why parsers which need the
+   * count only as a FALLBACK still just set this flag rather than resolving it
+   * lazily - the laziness measured as noise and cost a second code shape.
    */
   countOmittedLines?: boolean;
 }
@@ -259,7 +267,19 @@ export async function readJsonlWindow(
     // No explicit start means a tail window: the most recent `maxBytes`.
     const requestedStart = options.startByte ?? Math.max(0, size - maxBytes);
     if (requestedStart >= size) {
-      return { ...empty, startByte: size, nextByteOffset: size, omittedBytes: size, totalBytes: size };
+      // `omittedLineCount` has to be computed here too, not left at the spread
+      // `empty`'s 0. This branch reports the WHOLE file as omitted, so a caller
+      // deriving absolute line indices from it would restart at 0 and mint
+      // uuids colliding with the file's real first lines. Unreachable on the
+      // tail path (`requestedStart` is `size - maxBytes`, and `size <= 0` has
+      // already returned), but reachable the moment a windowed walk asks for an
+      // offset at or past EOF.
+      const omittedLineCount = options.countOmittedLines
+        ? await countNewlinesBefore(filePath, size)
+        : 0;
+      return {
+        ...empty, startByte: size, nextByteOffset: size, omittedBytes: size, omittedLineCount, totalBytes: size,
+      };
     }
 
     const readLength = Math.min(maxBytes, size - requestedStart);

--- a/src/main/retrieval/retrieval-store.ts
+++ b/src/main/retrieval/retrieval-store.ts
@@ -13,6 +13,8 @@ interface ExistingChunkRow {
   id: number;
   seq: number;
   content_hash: string;
+  turn_uuid_start: string | null;
+  turn_uuid_end: string | null;
 }
 
 interface StoredChunkRow {
@@ -99,7 +101,7 @@ export class RetrievalStore {
     const run = this.db.transaction(() => {
       const existing = this.db
         .prepare(
-          'SELECT id, seq, content_hash FROM memory_chunks WHERE corpus = ? AND doc_id = ? ORDER BY seq ASC',
+          'SELECT id, seq, content_hash, turn_uuid_start, turn_uuid_end FROM memory_chunks WHERE corpus = ? AND doc_id = ? ORDER BY seq ASC',
         )
         .all(ref.corpus, ref.docId) as ExistingChunkRow[];
       const existingBySeq = new Map<number, ExistingChunkRow>();
@@ -137,6 +139,37 @@ export class RetrievalStore {
            embedded_model, meta_json, created_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)`,
       );
+      // Re-anchor the identical leading prefix. Those rows are left in place to
+      // preserve their embeddings, but `content_hash` is `sha1(text)` only, so a
+      // chunk whose TEXT is unchanged while its turn uuids changed looks
+      // identical to the diff above and would keep its old anchors forever. That
+      // is not hypothetical: it is what a uuid-scheme change produces, and it is
+      // why "Rebuild index" (`resetIndexState`) could not repair one. Updating
+      // these two columns fires no FTS trigger (that one is `AFTER UPDATE OF
+      // text`) and leaves `content_hash` alone, so nothing is re-embedded.
+      //
+      // Reach, precisely: this repairs a document only on a pass that actually
+      // re-parses it. A sweep SKIPS a session whose source signature is
+      // unchanged (`needsIndex`), so a finished session is repaired only once
+      // "Rebuild index" clears the state rows and forces the re-parse. A
+      // session whose transcript is GONE is never repaired at all: it returns
+      // `missing-source` before reaching here and keeps its chunks, and
+      // `entriesFromIndex` is exactly what serves those stale anchors to the
+      // viewer. Both populations degrade gracefully (an unresolvable anchor
+      // opens the full transcript), but neither self-heals.
+      const reanchor = this.db.prepare(
+        'UPDATE memory_chunks SET turn_uuid_start = ?, turn_uuid_end = ? WHERE id = ?',
+      );
+      for (const chunk of chunks) {
+        if (chunk.seq >= divergence) continue;
+        const stored = existingBySeq.get(chunk.seq);
+        if (!stored) continue;
+        if (stored.turn_uuid_start === chunk.turnUuidStart && stored.turn_uuid_end === chunk.turnUuidEnd) {
+          continue;
+        }
+        reanchor.run(chunk.turnUuidStart, chunk.turnUuidEnd, stored.id);
+      }
+
       for (const chunk of chunks) {
         if (chunk.seq < divergence) continue;
         const result = insert.run(

--- a/tests/unit/antigravity-adapter.test.ts
+++ b/tests/unit/antigravity-adapter.test.ts
@@ -627,18 +627,51 @@ describe('parseAntigravityTranscriptFile', () => {
       fs.writeFileSync(filePath, steps.join('\n') + '\n');
       expect(fs.statSync(filePath).size).toBeGreaterThan(cap);
 
-      const parsed = await parseAntigravityTranscriptFile(filePath);
+      const parsed = await parseAntigravityTranscriptFile(filePath, 'agy-session-1');
 
       // The oldest step is gone, the newest is present: a TAIL window.
       expect(parsed.entries.length).toBeLessThan(steps.length);
-      expect(parsed.entries.some((entry) => entry.uuid === 'step-0')).toBe(false);
-      expect(parsed.entries.some((entry) => entry.uuid === `step-${lastStepIndex}`)).toBe(true);
+      expect(parsed.entries.some((entry) => entry.uuid === 'agy-session-1:step-0')).toBe(false);
+      expect(parsed.entries.some((entry) => entry.uuid === `agy-session-1:step-${lastStepIndex}`)).toBe(true);
 
       // The omission is reported in-band as the first entry.
       expect(parsed.entries[0]).toMatchObject({ kind: 'system', subtype: 'truncated' });
     } finally {
       setParseWindowBytesForTests();
       fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('namespaces step uuids by session so two sessions on one task cannot collide', async () => {
+    // `step_index` restarts at 0 per session, so the unscoped `step-N` made
+    // the second session's steps collide with the first's in the task stitch,
+    // which dedups by uuid keeping the first.
+    const filePath = writeTranscriptFixture();
+    try {
+      const one = await parseAntigravityTranscriptFile(filePath, 'agy-session-1');
+      const two = await parseAntigravityTranscriptFile(filePath, 'agy-session-2');
+
+      expect(one.entries[0].uuid).toBe('agy-session-1:step-0');
+      expect(two.entries[0].uuid).toBe('agy-session-2:step-0');
+      const overlap = one.entries
+        .map((entry) => entry.uuid)
+        .filter((uuid) => two.entries.some((entry) => entry.uuid === uuid));
+      expect(overlap).toEqual([]);
+    } finally {
+      fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the unscoped step id when no session id is supplied', async () => {
+    // The tool-count reader can be handed a bare transcriptPath. It only
+    // counts tool calls and never persists a uuid, so an unscoped id is fine
+    // there - but it must still parse rather than mint `undefined:step-0`.
+    const filePath = writeTranscriptFixture();
+    try {
+      const parsed = await parseAntigravityTranscriptFile(filePath);
+      expect(parsed.entries[0].uuid).toBe('step-0');
+    } finally {
+      fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
     }
   });
 });
@@ -828,6 +861,11 @@ describe('parseAntigravityTranscript (async entry point)', () => {
     expect(parsed.sourcePath).toBe(expectedPath);
     expect(parsed.entries).toHaveLength(1);
     expect(parsed.entries[0].kind).toBe('user');
+    // Every existing namespacing test calls parseAntigravityTranscriptFile
+    // directly with a hand-picked session id. `agentSessionId` is OPTIONAL on
+    // that function, so nothing else forces this real call chain (the one the
+    // viewer and the retrieval index actually use) to keep forwarding it.
+    expect(parsed.entries[0].uuid).toBe(`${conversationId}:step-0`);
   });
 
   it('resolves to empty entries and a null sourcePath without throwing when no transcript exists', async () => {

--- a/tests/unit/codex-transcript-parser.test.ts
+++ b/tests/unit/codex-transcript-parser.test.ts
@@ -5,6 +5,28 @@ import path from 'node:path';
 import { parseCodexTranscript, locateCodexTranscriptFile } from '../../src/main/agent/adapters/codex/transcript-parser';
 import { setParseWindowBytesForTests } from '../../src/main/agent/shared/transcript-truncation';
 
+const SESSION_ID = '019df02a-e744-7de2-8f30-63d9ae3ab36a';
+
+/** Enough `response_item` user turns to overflow `cap` several times over,
+ *  each one identifiable by the index embedded in its text. `startIndex` lets
+ *  a caller append a second, distinct batch to simulate the file growing. */
+function buildOverCapLines(cap: number, startIndex = 0): { lines: object[]; lastLineIndex: number } {
+  const lines: object[] = [];
+  let written = 0;
+  let lineIndex = startIndex;
+  while (written <= cap * 3) {
+    const fixtureLine = {
+      type: 'response_item',
+      timestamp: '2026-06-12T10:00:00Z',
+      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: `turn ${lineIndex} ${'q'.repeat(200)}` }] },
+    };
+    lines.push(fixtureLine);
+    written += Buffer.byteLength(JSON.stringify(fixtureLine), 'utf-8') + 1;
+    lineIndex += 1;
+  }
+  return { lines, lastLineIndex: lineIndex - 1 };
+}
+
 function writeFixture(lines: object[]): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-transcript-'));
   const file = path.join(dir, 'rollout.jsonl');
@@ -22,7 +44,7 @@ describe('parseCodexTranscript', () => {
   });
 
   it('returns [] for a missing file', async () => {
-    const entries = await parseCodexTranscript(path.join(os.tmpdir(), 'codex-missing.jsonl'));
+    const entries = await parseCodexTranscript(SESSION_ID, path.join(os.tmpdir(), 'codex-missing.jsonl'));
     expect(entries).toEqual([]);
   });
 
@@ -32,7 +54,7 @@ describe('parseCodexTranscript', () => {
       { type: 'response_item', timestamp: '2026-06-12T10:00:01Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: '<environment_context>\n<cwd>C:/Users/dev/p</cwd>\n</environment_context>' }] } },
       { type: 'response_item', timestamp: '2026-06-12T10:00:02Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'real prompt' }] } },
     ]);
-    const entries = await parseCodexTranscript(tmpFile);
+    const entries = await parseCodexTranscript(SESSION_ID, tmpFile);
     expect(entries).toEqual([
       { kind: 'user', uuid: expect.any(String), ts: expect.any(Number), text: 'real prompt' },
     ]);
@@ -43,7 +65,7 @@ describe('parseCodexTranscript', () => {
       { type: 'response_item', timestamp: '2026-06-12T10:00:00Z', payload: { type: 'reasoning', summary: [], encrypted_content: 'gAAA' } },
       { type: 'response_item', timestamp: '2026-06-12T10:00:01Z', payload: { type: 'reasoning', summary: [{ type: 'summary_text', text: 'plan the work' }] } },
     ]);
-    const entries = await parseCodexTranscript(tmpFile);
+    const entries = await parseCodexTranscript(SESSION_ID, tmpFile);
     expect(entries).toEqual([
       { kind: 'assistant', uuid: expect.any(String), ts: expect.any(Number), model: undefined, blocks: [{ type: 'thinking', text: 'plan the work' }] },
     ]);
@@ -55,50 +77,107 @@ describe('parseCodexTranscript', () => {
       { type: 'response_item', timestamp: '2026-06-12T10:00:01Z', payload: { type: 'function_call', name: 'shell', arguments: '{"command":["ls"]}', call_id: 'call_1' } },
       { type: 'response_item', timestamp: '2026-06-12T10:00:02Z', payload: { type: 'function_call_output', call_id: 'call_1', output: 'a.txt' } },
     ]);
-    const entries = await parseCodexTranscript(tmpFile);
+    const entries = await parseCodexTranscript(SESSION_ID, tmpFile);
     expect(entries[0]).toMatchObject({ kind: 'assistant', model: 'gpt-5-codex', blocks: [{ type: 'tool_use', id: 'call_1', name: 'shell', input: { command: ['ls'] } }] });
     expect(entries[1]).toMatchObject({ kind: 'tool_result', toolUseId: 'call_1', content: 'a.txt' });
   });
 
   it('parses only the tail of a transcript larger than the parse cap, marking the omission', async () => {
-    // codex mints uuids window-relative (`codex-${entryIndex++}`, starting at
-    // 0 within whatever window was actually read), so `codex-0` is present
-    // regardless of truncation - assert on the per-turn TEXT instead.
     const cap = 2 * 1024;
     setParseWindowBytesForTests(cap);
     try {
-      const lines: object[] = [];
-      let written = 0;
-      let lineIndex = 0;
-      while (written <= cap * 3) {
-        const fixtureLine = {
-          type: 'response_item',
-          timestamp: '2026-06-12T10:00:00Z',
-          payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: `turn ${lineIndex} ${'q'.repeat(200)}` }] },
-        };
-        lines.push(fixtureLine);
-        written += Buffer.byteLength(JSON.stringify(fixtureLine), 'utf-8') + 1;
-        lineIndex += 1;
-      }
-      const lastLineIndex = lineIndex - 1;
+      const { lines, lastLineIndex } = buildOverCapLines(cap);
       tmpFile = writeFixture(lines);
       expect(fs.statSync(tmpFile).size).toBeGreaterThan(cap);
 
-      const entries = await parseCodexTranscript(tmpFile);
+      const entries = await parseCodexTranscript(SESSION_ID, tmpFile);
 
       expect(entries.length).toBeLessThan(lines.length);
       expect(entries.some((entry) => entry.kind === 'user' && entry.text.startsWith('turn 0 '))).toBe(false);
       expect(entries.some((entry) => entry.kind === 'user' && entry.text.startsWith(`turn ${lastLineIndex} `))).toBe(true);
 
       expect(entries[0]).toMatchObject({ kind: 'system', subtype: 'truncated' });
+      // Absolute, so the surviving tail is numbered by its position in the
+      // FILE, not renumbered from 0 within the window that was read.
+      expect(entries[1].uuid).toBe(`${SESSION_ID}:${lines.length - entries.length + 1}`);
     } finally {
       setParseWindowBytesForTests();
     }
   });
 
+  it('keeps a turnuuid stable when the transcript grows past the cap and the window slides', async () => {
+    // The regression this guards: a window-relative counter reassigned a
+    // different uuid to the same logical turn on every re-parse of a growing
+    // over-cap transcript. Those uuids are the persisted citation anchors
+    // (`memory_chunks.turn_uuid_start`), so they must survive the slide.
+    const cap = 2 * 1024;
+    setParseWindowBytesForTests(cap);
+    try {
+      const { lines } = buildOverCapLines(cap);
+      tmpFile = writeFixture(lines);
+      const before = await parseCodexTranscript(SESSION_ID, tmpFile);
+
+      // Append only a couple of turns, so the window slides far enough to drop
+      // the oldest but still overlaps the previous one. Appending a whole
+      // window's worth would leave nothing in common and prove nothing.
+      const appended = [0, 1].map((offset) => ({
+        type: 'response_item',
+        timestamp: '2026-06-12T10:00:00Z',
+        payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: `turn ${lines.length + offset} ${'q'.repeat(200)}` }] },
+      }));
+      fs.writeFileSync(tmpFile, [...lines, ...appended].map((line) => JSON.stringify(line)).join('\n'));
+      const after = await parseCodexTranscript(SESSION_ID, tmpFile);
+
+      // The window slid: the oldest turn of the first parse is gone from the
+      // second, which is what makes this a real test of the sliding case.
+      const firstTurn = before.find((entry) => entry.kind === 'user');
+      const lastTurnBefore = before[before.length - 1];
+      expect(after.some((entry) => entry.uuid === firstTurn!.uuid)).toBe(false);
+
+      // ...but a turn present in BOTH windows keeps the SAME uuid.
+      const sameTurnAfter = after.find(
+        (entry) => entry.kind === 'user' && lastTurnBefore.kind === 'user' && entry.text === lastTurnBefore.text,
+      );
+      expect(sameTurnAfter).toBeDefined();
+      expect(sameTurnAfter!.uuid).toBe(lastTurnBefore.uuid);
+    } finally {
+      setParseWindowBytesForTests();
+    }
+  });
+
+  it('namespaces uuids by session so two sessions on one task cannot collide', async () => {
+    // `resolveTaskTranscript` stitches a task's sessions and dedups by uuid
+    // keeping the first, so an unscoped `codex-0..N` made the second session's
+    // turns disappear from the Conversation tab.
+    tmpFile = writeFixture([
+      { type: 'response_item', timestamp: '2026-06-12T10:00:00Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'first' }] } },
+    ]);
+    const one = await parseCodexTranscript('session-one', tmpFile);
+    const two = await parseCodexTranscript('session-two', tmpFile);
+
+    expect(one[0].uuid).toBe('session-one:0');
+    expect(two[0].uuid).toBe('session-two:0');
+    const overlap = one.map((entry) => entry.uuid).filter((uuid) => two.some((entry) => entry.uuid === uuid));
+    expect(overlap).toEqual([]);
+  });
+
+  it('derives the uuid from the PHYSICAL line, counting lines it emits no entry for', async () => {
+    // The exact string is the contract, not merely uniqueness or ordering:
+    // these are persisted anchors, so a renumbering is a silent break. The
+    // skipped `turn_context` and developer lines must still consume an index.
+    tmpFile = writeFixture([
+      { type: 'session_meta', timestamp: '2026-06-12T10:00:00Z', payload: { id: SESSION_ID } },
+      { type: 'turn_context', timestamp: '2026-06-12T10:00:01Z', payload: { model: 'gpt-5-codex' } },
+      { type: 'response_item', timestamp: '2026-06-12T10:00:02Z', payload: { type: 'message', role: 'developer', content: [{ type: 'input_text', text: 'skipped' }] } },
+      { type: 'response_item', timestamp: '2026-06-12T10:00:03Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'real prompt' }] } },
+    ]);
+    const entries = await parseCodexTranscript(SESSION_ID, tmpFile);
+    expect(entries.map((entry) => entry.uuid)).toEqual([`${SESSION_ID}:3`]);
+  });
+
   it('parses the pinned rollout fixture, ignoring duplicate event_msg entries', async () => {
     const fixturePath = path.join(__dirname, '..', 'fixtures', 'codex-real-rollout.jsonl');
-    const entries = await parseCodexTranscript(fixturePath);
+    const entries = await parseCodexTranscript(SESSION_ID, fixturePath);
     expect(entries.map((entry) => entry.kind)).toEqual([
       'user', 'assistant', 'assistant', 'assistant', 'tool_result', 'assistant',
     ]);
@@ -106,6 +185,20 @@ describe('parseCodexTranscript', () => {
     expect(entries[1]).toMatchObject({ blocks: [{ type: 'thinking', text: 'I should run a directory listing.' }] });
     expect(entries[3]).toMatchObject({ blocks: [{ type: 'tool_use', id: 'call_abc123', name: 'shell' }] });
     expect(entries[4]).toMatchObject({ kind: 'tool_result', toolUseId: 'call_abc123', content: 'file1.txt\nfile2.txt' });
+
+    // The uuid is the absolute PHYSICAL line, 0-indexed against the fixture
+    // file. The lines with no corresponding entry above are still counted:
+    // 0 session_meta, 1 turn_context, 2 the developer message, 3 the injected
+    // environment_context wrapper, 5 the duplicate event_msg, 6 the empty
+    // (encrypted-only) reasoning, and 11 the second duplicate event_msg.
+    expect(entries.map((entry) => entry.uuid)).toEqual([
+      `${SESSION_ID}:4`,
+      `${SESSION_ID}:7`,
+      `${SESSION_ID}:8`,
+      `${SESSION_ID}:9`,
+      `${SESSION_ID}:10`,
+      `${SESSION_ID}:12`,
+    ]);
   });
 });
 

--- a/tests/unit/conversation-indexer-decisions.test.ts
+++ b/tests/unit/conversation-indexer-decisions.test.ts
@@ -535,6 +535,8 @@ interface SharedFakeChunkRow {
   sessionId: string | null;
   taskId: string | null;
   contentHash: string;
+  turnUuidStart: string | null;
+  turnUuidEnd: string | null;
 }
 
 interface SharedFakeDbState {
@@ -572,12 +574,18 @@ function makeSharedFakeDb(state: SharedFakeDbState): Database.Database {
           throw new Error(`unexpected get SQL: ${sql}`);
         },
         all: (...args: unknown[]) => {
-          if (sql.includes('SELECT id, seq, content_hash FROM memory_chunks')) {
+          if (sql.includes('SELECT id, seq, content_hash') && sql.includes('FROM memory_chunks')) {
             const [corpus, docId] = args as [string, string];
             return state.chunks
               .filter((chunk) => chunk.corpus === corpus && chunk.docId === docId)
               .sort((first, second) => first.seq - second.seq)
-              .map((chunk) => ({ id: chunk.id, seq: chunk.seq, content_hash: chunk.contentHash }));
+              .map((chunk) => ({
+                id: chunk.id,
+                seq: chunk.seq,
+                content_hash: chunk.contentHash,
+                turn_uuid_start: chunk.turnUuidStart ?? null,
+                turn_uuid_end: chunk.turnUuidEnd ?? null,
+              }));
           }
           throw new Error(`unexpected all SQL: ${sql}`);
         },
@@ -608,8 +616,12 @@ function makeSharedFakeDb(state: SharedFakeDbState): Database.Database {
             const sessionId = (args[3] as string | null) ?? null;
             const taskId = (args[4] as string | null) ?? null;
             const contentHash = String(args[8]);
+            const turnUuidStart = (args[12] as string | null) ?? null;
+            const turnUuidEnd = (args[13] as string | null) ?? null;
             const id = state.nextChunkId++;
-            state.chunks.push({ id, corpus, docId, seq, sessionId, taskId, contentHash });
+            state.chunks.push({
+              id, corpus, docId, seq, sessionId, taskId, contentHash, turnUuidStart, turnUuidEnd,
+            });
             return { changes: 1, lastInsertRowid: id };
           }
           if (sql.includes('DELETE FROM memory_chunks WHERE id IN')) {
@@ -618,6 +630,17 @@ function makeSharedFakeDb(state: SharedFakeDbState): Database.Database {
             const removedCount = state.chunks.length - remaining.length;
             state.chunks = remaining;
             return { changes: removedCount };
+          }
+          if (sql.includes('UPDATE memory_chunks SET turn_uuid_start')) {
+            // The diff-upsert's re-anchor of the untouched leading prefix,
+            // keyed by row id: WHERE id = ?.
+            const [turnUuidStart, turnUuidEnd, id] = args as [string | null, string | null, number];
+            const target = state.chunks.find((chunk) => chunk.id === id);
+            if (target) {
+              target.turnUuidStart = turnUuidStart;
+              target.turnUuidEnd = turnUuidEnd;
+            }
+            return { changes: target ? 1 : 0 };
           }
           if (sql.includes('UPDATE memory_chunks SET session_id')) {
             // The diff-upsert's ownership re-point over the untouched leading

--- a/tests/unit/droid-transcript-parser.test.ts
+++ b/tests/unit/droid-transcript-parser.test.ts
@@ -61,6 +61,22 @@ describe('parseDroidTranscript', () => {
     expect(entries.every((entry) => entry.uuid.length > 0)).toBe(true);
   });
 
+  it('treats an explicit empty-string id the same as a missing one', async () => {
+    // `raw.id` present but `''` is a distinct on-disk shape from the field
+    // being absent, and the guard is `typeof raw.id === 'string' && raw.id.length > 0`
+    // - dropping the length check would let `''` through as a "real" id,
+    // recreating the exact shared-uuid collision this parser exists to fix.
+    tmpFile = writeFixture([
+      { type: 'message', id: '', timestamp: '2026-06-12T10:00:00Z', message: { role: 'user', content: [{ type: 'text', text: 'first' }] } },
+      { type: 'message', id: '', timestamp: '2026-06-12T10:00:01Z', message: { role: 'user', content: [{ type: 'text', text: 'second' }] } },
+    ]);
+    const entries = await parseDroidTranscript(SESSION_ID, tmpFile);
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => entry.uuid)).toEqual([`${SESSION_ID}:0`, `${SESSION_ID}:1`]);
+    expect(entries.every((entry) => entry.uuid.length > 0)).toBe(true);
+  });
+
   it('parses user, assistant, and tool_result entries from the message envelope', async () => {
     tmpFile = writeFixture([
       { type: 'session_start', id: 's1', title: 't', owner: 'dev', version: 2, cwd: 'C:\\Users\\dev\\project' },

--- a/tests/unit/droid-transcript-parser.test.ts
+++ b/tests/unit/droid-transcript-parser.test.ts
@@ -22,6 +22,8 @@ describe('droidTranscriptFilePath', () => {
   });
 });
 
+const SESSION_ID = 'aaaa-bbbb-cccc-dddd';
+
 function writeFixture(lines: object[]): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'droid-transcript-test-'));
   const file = path.join(dir, 'session.jsonl');
@@ -40,8 +42,23 @@ describe('parseDroidTranscript', () => {
   });
 
   it('returns [] for missing files', async () => {
-    const entries = await parseDroidTranscript(path.join(os.tmpdir(), 'does-not-exist.jsonl'));
+    const entries = await parseDroidTranscript(SESSION_ID, path.join(os.tmpdir(), 'does-not-exist.jsonl'));
     expect(entries).toEqual([]);
+  });
+
+  it('gives id-less records distinct session-scoped uuids rather than a shared empty one', async () => {
+    // `''` is not an absent uuid but a SHARED one, and `resolveTaskTranscript`
+    // dedups by uuid keeping the first - so every id-less entry after the
+    // first used to vanish from the stitched Conversation tab.
+    tmpFile = writeFixture([
+      { type: 'message', timestamp: '2026-06-12T10:00:00Z', message: { role: 'user', content: [{ type: 'text', text: 'first' }] } },
+      { type: 'message', timestamp: '2026-06-12T10:00:01Z', message: { role: 'user', content: [{ type: 'text', text: 'second' }] } },
+    ]);
+    const entries = await parseDroidTranscript(SESSION_ID, tmpFile);
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => entry.uuid)).toEqual([`${SESSION_ID}:0`, `${SESSION_ID}:1`]);
+    expect(entries.every((entry) => entry.uuid.length > 0)).toBe(true);
   });
 
   it('parses user, assistant, and tool_result entries from the message envelope', async () => {
@@ -85,7 +102,7 @@ describe('parseDroidTranscript', () => {
       },
     ]);
 
-    const entries = await parseDroidTranscript(tmpFile);
+    const entries = await parseDroidTranscript(SESSION_ID, tmpFile);
     expect(entries).toHaveLength(4);
     expect(entries[0]).toMatchObject({ kind: 'user', uuid: 'u1', text: 'list files' });
     expect(entries[1]).toMatchObject({
@@ -126,7 +143,7 @@ describe('parseDroidTranscript', () => {
       },
     ]);
 
-    const entries = await parseDroidTranscript(tmpFile);
+    const entries = await parseDroidTranscript(SESSION_ID, tmpFile);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
       kind: 'user',
@@ -157,7 +174,7 @@ describe('parseDroidTranscript', () => {
       },
     ]);
 
-    const entries = await parseDroidTranscript(tmpFile);
+    const entries = await parseDroidTranscript(SESSION_ID, tmpFile);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
       kind: 'tool_result',
@@ -194,7 +211,7 @@ describe('parseDroidTranscript', () => {
       },
     ]);
 
-    const entries = await parseDroidTranscript(tmpFile);
+    const entries = await parseDroidTranscript(SESSION_ID, tmpFile);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
       kind: 'assistant',
@@ -227,7 +244,7 @@ describe('parseDroidTranscript', () => {
       },
     ]);
 
-    const entries = await parseDroidTranscript(tmpFile);
+    const entries = await parseDroidTranscript(SESSION_ID, tmpFile);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({ kind: 'user', text: 'hello' });
   });
@@ -240,7 +257,7 @@ describe('parseDroidTranscript', () => {
       { type: 'message', id: 'd', timestamp: '2026-04-09T00:00:03Z', message: { role: 'user', content: [{ type: 'text', text: 'real' }] } },
     ]);
 
-    const entries = await parseDroidTranscript(tmpFile);
+    const entries = await parseDroidTranscript(SESSION_ID, tmpFile);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({ kind: 'user', text: 'real' });
   });
@@ -261,7 +278,7 @@ describe('parseDroidTranscript', () => {
       },
     ]);
 
-    const entries = await parseDroidTranscript(tmpFile);
+    const entries = await parseDroidTranscript(SESSION_ID, tmpFile);
     expect(entries).toEqual([]);
   });
 
@@ -272,7 +289,7 @@ describe('parseDroidTranscript', () => {
     fs.appendFileSync(tmpFile, '\n{not valid json\n');
     fs.appendFileSync(tmpFile, JSON.stringify({ type: 'message', id: 'u2', timestamp: '2026-04-09T00:00:01Z', message: { role: 'user', content: [{ type: 'text', text: 'two' }] } }) + '\n');
 
-    const entries = await parseDroidTranscript(tmpFile);
+    const entries = await parseDroidTranscript(SESSION_ID, tmpFile);
     expect(entries).toHaveLength(2);
     expect(entries[0]).toMatchObject({ text: 'one' });
     expect(entries[1]).toMatchObject({ text: 'two' });
@@ -301,7 +318,7 @@ describe('parseDroidTranscript', () => {
       },
     ]);
 
-    const entries = await parseDroidTranscript(tmpFile);
+    const entries = await parseDroidTranscript(SESSION_ID, tmpFile);
     // tool_result is emitted first, then the user text entry follows.
     expect(entries).toHaveLength(2);
     expect(entries[0]).toMatchObject({
@@ -335,7 +352,7 @@ describe('parseDroidTranscript', () => {
       },
     ]);
 
-    const entries = await parseDroidTranscript(tmpFile);
+    const entries = await parseDroidTranscript(SESSION_ID, tmpFile);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
       kind: 'tool_result',
@@ -361,7 +378,7 @@ describe('parseDroidTranscript', () => {
       },
     ]);
 
-    const entries = await parseDroidTranscript(tmpFile);
+    const entries = await parseDroidTranscript(SESSION_ID, tmpFile);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
       kind: 'tool_result',
@@ -388,7 +405,7 @@ describe('parseDroidTranscript', () => {
     ]);
     const afterMs = Date.now();
 
-    const entries = await parseDroidTranscript(tmpFile);
+    const entries = await parseDroidTranscript(SESSION_ID, tmpFile);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({ kind: 'user', text: 'numeric timestamp' });
     // `ts` should be a Date.now() fallback within the test window.
@@ -419,7 +436,7 @@ describe('parseDroidTranscript', () => {
       tmpFile = writeFixture(lines);
       expect(fs.statSync(tmpFile).size).toBeGreaterThan(cap);
 
-      const entries = await parseDroidTranscript(tmpFile);
+      const entries = await parseDroidTranscript(SESSION_ID, tmpFile);
 
       // The oldest turn is gone, the newest is present: a TAIL window.
       expect(entries.length).toBeLessThan(lines.length);
@@ -433,12 +450,65 @@ describe('parseDroidTranscript', () => {
     }
   });
 
+  it('keeps a fallback uuid stable when id-less records grow past the cap and the window slides', async () => {
+    // `countOmittedLines: true` is functionally dead unless a test combines
+    // BOTH an id-less record (the only path that reads `lineIndexBase`) and a
+    // transcript that outgrows the parse cap. The over-cap test above gives
+    // every record a real `id` (`u${lineIndex}`) and so never exercises this
+    // path at all - deleting `countOmittedLines: true` from the parser makes
+    // zero tests in this file fail.
+    const cap = 2 * 1024;
+    setParseWindowBytesForTests(cap);
+    try {
+      const lines: object[] = [];
+      let written = 0;
+      let lineIndex = 0;
+      while (written <= cap * 3) {
+        const fixtureLine = {
+          type: 'message',
+          timestamp: '2026-04-09T00:00:00Z',
+          message: { role: 'user', content: [{ type: 'text', text: `turn ${lineIndex} ${'q'.repeat(200)}` }] },
+        };
+        lines.push(fixtureLine);
+        written += Buffer.byteLength(JSON.stringify(fixtureLine), 'utf-8') + 1;
+        lineIndex += 1;
+      }
+      tmpFile = writeFixture(lines);
+      const before = await parseDroidTranscript(SESSION_ID, tmpFile);
+
+      // Append only a couple of turns, so the window slides far enough to
+      // drop the oldest but still overlaps the previous one.
+      const appended = [0, 1].map((offset) => ({
+        type: 'message',
+        timestamp: '2026-04-09T00:00:00Z',
+        message: { role: 'user', content: [{ type: 'text', text: `turn ${lines.length + offset} ${'q'.repeat(200)}` }] },
+      }));
+      fs.writeFileSync(tmpFile, [...lines, ...appended].map((line) => JSON.stringify(line)).join('\n'));
+      const after = await parseDroidTranscript(SESSION_ID, tmpFile);
+
+      // The window slid: the oldest turn of the first parse is gone from the
+      // second, which is what makes this a real test of the sliding case.
+      const firstTurn = before.find((entry) => entry.kind === 'user');
+      const lastTurnBefore = before[before.length - 1];
+      expect(after.some((entry) => entry.uuid === firstTurn!.uuid)).toBe(false);
+
+      // ...but a turn present in BOTH windows keeps the SAME uuid.
+      const sameTurnAfter = after.find(
+        (entry) => entry.kind === 'user' && lastTurnBefore.kind === 'user' && entry.text === lastTurnBefore.text,
+      );
+      expect(sameTurnAfter).toBeDefined();
+      expect(sameTurnAfter!.uuid).toBe(lastTurnBefore.uuid);
+    } finally {
+      setParseWindowBytesForTests();
+    }
+  });
+
   it('parses the real-shape fixture end-to-end', async () => {
     // Sanitized capture from a real Droid 0.109.1 session (read tool over
     // a sample.txt). Locks the parser against the actual on-disk schema:
     // any field-name drift in a future Droid version will fail this test.
     const fixturePath = path.join(__dirname, '..', 'fixtures', 'droid-real-session.jsonl');
-    const entries = await parseDroidTranscript(fixturePath);
+    const entries = await parseDroidTranscript(SESSION_ID, fixturePath);
 
     // Expected: user prompt -> assistant tool_use -> tool_result -> assistant final text
     // The session_start line is not surfaced as a transcript entry.

--- a/tests/unit/gemini-transcript-parser.test.ts
+++ b/tests/unit/gemini-transcript-parser.test.ts
@@ -59,6 +59,22 @@ describe('parseGeminiTranscript', () => {
     expect(entries.map((entry) => entry.uuid)).toEqual([`${SESSION_ID}:0`, `${SESSION_ID}:1`]);
   });
 
+  it('treats an explicit empty-string id the same as a missing one', async () => {
+    // The map KEY is the uuid, so this is the sharpest case: an unguarded `''`
+    // id would make both messages collide on the SAME map key and the second
+    // would silently overwrite the first (last-wins), not just share a uuid -
+    // one message would vanish from the parse entirely, before the task stitch
+    // ever runs.
+    tmpFile = writeFixture([
+      JSON.stringify({ type: 'user', id: '', content: [{ text: 'first' }] }),
+      JSON.stringify({ type: 'user', id: '', content: [{ text: 'second' }] }),
+    ]);
+    const entries = await parseGeminiTranscript(SESSION_ID, tmpFile);
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => entry.uuid)).toEqual([`${SESSION_ID}:0`, `${SESSION_ID}:1`]);
+  });
+
   it('distinguishes id-less messages seeded from the same $set line', async () => {
     // One `$set` line seeds several messages, so the line alone is not unique.
     // A second line is needed for this to stay JSONL - a lone `{...}` with no

--- a/tests/unit/gemini-transcript-parser.test.ts
+++ b/tests/unit/gemini-transcript-parser.test.ts
@@ -5,11 +5,30 @@ import path from 'node:path';
 import { parseGeminiTranscript } from '../../src/main/agent/adapters/gemini/transcript-parser';
 import { setParseWindowBytesForTests } from '../../src/main/agent/shared/transcript-truncation';
 
+const SESSION_ID = '7d21b8e4-5a63-4f0c-b19d-3e8a2c6f4b70';
+
 function writeFixture(lines: string[]): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-transcript-'));
   const file = path.join(dir, 'session.jsonl');
   fs.writeFileSync(file, lines.join('\n'));
   return file;
+}
+
+/** Enough id-less standalone `user` message lines to overflow `cap` several
+ *  times over, each one identifiable by the index embedded in its text.
+ *  `startIndex` lets a caller append a second, distinct batch to simulate
+ *  the file growing. */
+function buildOverCapIdLessLines(cap: number, startIndex = 0): { lines: string[]; lastLineIndex: number } {
+  const lines: string[] = [];
+  let written = 0;
+  let lineIndex = startIndex;
+  while (written <= cap * 3) {
+    const fixtureLine = JSON.stringify({ type: 'user', content: [{ text: `turn ${lineIndex} ${'q'.repeat(200)}` }] });
+    lines.push(fixtureLine);
+    written += Buffer.byteLength(fixtureLine, 'utf-8') + 1;
+    lineIndex += 1;
+  }
+  return { lines, lastLineIndex: lineIndex - 1 };
 }
 
 describe('parseGeminiTranscript', () => {
@@ -22,8 +41,43 @@ describe('parseGeminiTranscript', () => {
   });
 
   it('returns [] for a missing file', async () => {
-    const entries = await parseGeminiTranscript(path.join(os.tmpdir(), 'gemini-missing.jsonl'));
+    const entries = await parseGeminiTranscript(SESSION_ID, path.join(os.tmpdir(), 'gemini-missing.jsonl'));
     expect(entries).toEqual([]);
+  });
+
+  it('gives id-less messages distinct session-scoped uuids rather than a shared empty one', async () => {
+    // The map key used to fall back to `gemini-${size}` while the emitted uuid
+    // fell back to `''`, so id-less messages were keyed apart but then all
+    // shared one uuid - and the task stitch dedups by uuid, keeping the first.
+    tmpFile = writeFixture([
+      JSON.stringify({ type: 'user', content: [{ text: 'first' }] }),
+      JSON.stringify({ type: 'user', content: [{ text: 'second' }] }),
+    ]);
+    const entries = await parseGeminiTranscript(SESSION_ID, tmpFile);
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => entry.uuid)).toEqual([`${SESSION_ID}:0`, `${SESSION_ID}:1`]);
+  });
+
+  it('distinguishes id-less messages seeded from the same $set line', async () => {
+    // One `$set` line seeds several messages, so the line alone is not unique.
+    // A second line is needed for this to stay JSONL - a lone `{...}` with no
+    // newline is the LEGACY single-object form and takes a different branch.
+    tmpFile = writeFixture([
+      JSON.stringify({ $set: { messages: [
+        { type: 'user', content: [{ text: 'first' }] },
+        { type: 'user', content: [{ text: 'second' }] },
+      ] } }),
+      JSON.stringify({ type: 'user', id: 'm-3', content: [{ text: 'third' }] }),
+    ]);
+    const entries = await parseGeminiTranscript(SESSION_ID, tmpFile);
+
+    expect(entries).toHaveLength(3);
+    expect(entries.map((entry) => entry.uuid)).toEqual([
+      `${SESSION_ID}:0.0`,
+      `${SESSION_ID}:0.1`,
+      'm-3',
+    ]);
   });
 
   it('dedupes a re-emitted message by id, last emission wins', async () => {
@@ -32,7 +86,7 @@ describe('parseGeminiTranscript', () => {
       JSON.stringify({ id: 'g1', type: 'gemini', content: '', model: 'gemini-3-pro', thoughts: [] }),
       JSON.stringify({ id: 'g1', type: 'gemini', content: 'final text', model: 'gemini-3-pro', thoughts: [] }),
     ]);
-    const entries = await parseGeminiTranscript(tmpFile);
+    const entries = await parseGeminiTranscript(SESSION_ID, tmpFile);
     // Exactly one assistant entry, carrying the LAST emission's content.
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({ kind: 'assistant', blocks: [{ type: 'text', text: 'final text' }] });
@@ -44,10 +98,34 @@ describe('parseGeminiTranscript', () => {
       JSON.stringify({ $set: { messages: [{ id: 'seed', type: 'user', content: [{ text: '<session_context>\nintro\n</session_context>' }] }] } }),
       JSON.stringify({ id: 'u1', type: 'user', content: [{ text: 'real prompt' }] }),
     ]);
-    const entries = await parseGeminiTranscript(tmpFile);
+    const entries = await parseGeminiTranscript(SESSION_ID, tmpFile);
     expect(entries).toEqual([
       { kind: 'user', uuid: 'u1', ts: expect.any(Number), text: 'real prompt' },
     ]);
+  });
+
+  it('gives an id-less message in the legacy single-document form a session-scoped uuid', async () => {
+    // The legacy branch calls `addMessage(message, 0, index)`, so an id-less
+    // message there should fall back to `${agentSessionId}:0.<index>` - but
+    // the only test that reaches this branch (below) gives every message an
+    // `id`, so the literal `0` line-index argument is never asserted.
+    tmpFile = writeFixture([
+      JSON.stringify({
+        messages: [
+          { id: 'u1', type: 'user', content: [{ text: 'first' }] },
+          { type: 'gemini', content: 'unlabeled reply', model: 'gemini-3-pro', thoughts: [] },
+        ],
+      }),
+    ]);
+
+    const entries = await parseGeminiTranscript(SESSION_ID, tmpFile);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ kind: 'user', uuid: 'u1', text: 'first' });
+    expect(entries[1]).toMatchObject({
+      kind: 'assistant',
+      uuid: `${SESSION_ID}:0.1`,
+      blocks: [{ type: 'text', text: 'unlabeled reply' }],
+    });
   });
 
   it('parses the legacy single-JSON-document form (one line, no newlines)', async () => {
@@ -67,7 +145,7 @@ describe('parseGeminiTranscript', () => {
       }),
     ]);
 
-    const entries = await parseGeminiTranscript(tmpFile);
+    const entries = await parseGeminiTranscript(SESSION_ID, tmpFile);
     expect(entries).toHaveLength(2);
     expect(entries[0]).toMatchObject({ kind: 'user', uuid: 'u1', text: 'legacy prompt' });
     expect(entries[1]).toMatchObject({
@@ -94,7 +172,7 @@ describe('parseGeminiTranscript', () => {
       tmpFile = writeFixture([JSON.stringify({ messages })]);
       expect(fs.statSync(tmpFile).size).toBeGreaterThan(512);
 
-      const entries = await parseGeminiTranscript(tmpFile);
+      const entries = await parseGeminiTranscript(SESSION_ID, tmpFile);
 
       // Whatever else happens, the user is TOLD the transcript was cut rather
       // than being shown a silently empty conversation.
@@ -104,9 +182,49 @@ describe('parseGeminiTranscript', () => {
     }
   });
 
+  it('keeps a fallback uuid stable when id-less messages grow past the cap and the window slides', async () => {
+    // `countOmittedLines: true` is functionally dead unless a test combines
+    // BOTH an id-less message (the only path that reads `lineIndexBase`) and
+    // a transcript that outgrows the parse cap. The only other over-cap test
+    // in this suite goes through the LEGACY single-document branch, a
+    // different code path entirely - deleting `countOmittedLines: true` here
+    // makes zero tests in this file fail.
+    const cap = 2 * 1024;
+    setParseWindowBytesForTests(cap);
+    try {
+      const { lines } = buildOverCapIdLessLines(cap);
+      tmpFile = writeFixture(lines);
+      const before = await parseGeminiTranscript(SESSION_ID, tmpFile);
+
+      // Append only a couple of turns, so the window slides far enough to
+      // drop the oldest but still overlaps the previous one.
+      const appended = [0, 1].map((offset) => JSON.stringify({
+        type: 'user',
+        content: [{ text: `turn ${lines.length + offset} ${'q'.repeat(200)}` }],
+      }));
+      fs.writeFileSync(tmpFile, [...lines, ...appended].join('\n'));
+      const after = await parseGeminiTranscript(SESSION_ID, tmpFile);
+
+      // The window slid: the oldest turn of the first parse is gone from the
+      // second, which is what makes this a real test of the sliding case.
+      const firstTurn = before.find((entry) => entry.kind === 'user');
+      const lastTurnBefore = before[before.length - 1];
+      expect(after.some((entry) => entry.uuid === firstTurn!.uuid)).toBe(false);
+
+      // ...but a turn present in BOTH windows keeps the SAME uuid.
+      const sameTurnAfter = after.find(
+        (entry) => entry.kind === 'user' && lastTurnBefore.kind === 'user' && entry.text === lastTurnBefore.text,
+      );
+      expect(sameTurnAfter).toBeDefined();
+      expect(sameTurnAfter!.uuid).toBe(lastTurnBefore.uuid);
+    } finally {
+      setParseWindowBytesForTests();
+    }
+  });
+
   it('parses the pinned fixture: thoughts -> thinking, toolCalls -> tool_use + tool_result', async () => {
     const fixturePath = path.join(__dirname, '..', 'fixtures', 'gemini-real-session.jsonl');
-    const entries = await parseGeminiTranscript(fixturePath);
+    const entries = await parseGeminiTranscript(SESSION_ID, fixturePath);
     expect(entries.map((entry) => entry.kind)).toEqual(['user', 'assistant', 'tool_result']);
     expect(entries[0]).toMatchObject({ kind: 'user', text: 'List the files in this directory.' });
     expect(entries[1]).toMatchObject({

--- a/tests/unit/jsonl-window-stream.test.ts
+++ b/tests/unit/jsonl-window-stream.test.ts
@@ -16,8 +16,15 @@ import {
  * The invariants that matter are the ones a caller silently depends on: a
  * window must never hand back a partial line, consecutive windows must tile the
  * file exactly once with no gap and no overlap, and the stream's physical line
- * index must match `content.split(/\r?\n/)` indexing including blank lines
- * (Grok's citation-anchor uuids are built from it).
+ * index must match `content.split(/\r?\n/)` indexing including blank lines.
+ *
+ * On that last one, mind WHICH mechanism backs the persisted citation anchors.
+ * The session-scoped `<sessionId>:<lineIndex>` uuids come from
+ * `readJsonlWindow`'s `omittedLineCount`, which counts `0x0A` BYTES; they are
+ * not built from `streamJsonlRecords`, whose line index every current caller
+ * discards. The two are not interchangeable: readline also breaks on a bare
+ * `\r`, which `/\r?\n/` does not, so an anchor derived from the stream index
+ * could drift where the byte count would not.
  */
 
 function record(index: number, payload = 'x'): string {
@@ -116,6 +123,27 @@ describe('readJsonlWindow', () => {
     // Five physical lines precede the window (2 records, 2 blanks, 1 record).
     expect(window.omittedLineCount).toBe(5);
     expect(window.text.trim()).toBe(record(3));
+  });
+
+  it('still counts omitted lines when the requested start is at or past EOF', async () => {
+    // That branch reports the WHOLE file as omitted but used to return
+    // `omittedLineCount: 0` from a spread of the empty window. A caller
+    // deriving absolute line indices from it would restart numbering at 0 and
+    // mint uuids colliding with the file's real first lines. Unreachable on
+    // the tail path, reachable the moment a windowed walk asks for EOF.
+    const lines = [record(0), record(1), record(2)];
+    fs.writeFileSync(file, `${lines.join('\n')}\n`);
+    const totalBytes = fs.statSync(file).size;
+
+    const window = await readJsonlWindow(file, {
+      startByte: totalBytes,
+      maxBytes: 1024,
+      countOmittedLines: true,
+    });
+
+    expect(window.text).toBe('');
+    expect(window.omittedBytes).toBe(totalBytes);
+    expect(window.omittedLineCount).toBe(lines.length);
   });
 
   it('keeps a final record that has no trailing newline', async () => {
@@ -294,7 +322,10 @@ describe('streamJsonlRecords', () => {
   it('advances the physical line index across blank and unparseable lines', async () => {
     // Must match `content.split(/\r?\n/)` indexing exactly: index 0 is the
     // first record, index 1 the blank, index 2 the malformed line, index 3 the
-    // second record. Anything that renumbers here breaks Grok's uuids.
+    // second record. No persisted uuid is derived from THIS index (the citation
+    // anchors come from `readJsonlWindow`'s `omittedLineCount`), but the
+    // contract is what lets an aggregate reader line a record up with the
+    // physical line a windowed reader would give it.
     const raw = [record(0), '', '{not json', record(1)].join('\n');
     fs.writeFileSync(file, `${raw}\n`);
 

--- a/tests/unit/kimi-transcript-parser.test.ts
+++ b/tests/unit/kimi-transcript-parser.test.ts
@@ -157,6 +157,22 @@ describe('parseKimiTranscript', () => {
     expect(new Set(entries.map((entry) => entry.uuid)).size).toBe(entries.length);
   });
 
+  it('flushes a trailing assistant fragment left pending at end of transcript', async () => {
+    // Every other flush in this file is triggered by a boundary record
+    // (ToolCall/TurnEnd/TurnBegin) mid-loop. A transcript that ends mid-stream
+    // with no closing boundary relies on the unconditional `flushAssistantText()`
+    // call AFTER the loop - deleting that line would silently drop this entry
+    // rather than throw, since nothing else calls flush for it.
+    tmpFile = writeFixture([
+      { type: 'metadata', protocol_version: '1.9' },
+      { timestamp: 1780430656.9, message: { type: 'ContentPart', payload: { text: 'trailing thought' } } },
+    ]);
+    const entries = await parseKimiTranscript(SESSION_ID, tmpFile);
+    expect(entries).toEqual([
+      { kind: 'assistant', uuid: `${SESSION_ID}:1`, ts: expect.any(Number), blocks: [{ type: 'text', text: 'trailing thought' }] },
+    ]);
+  });
+
   it('flags an error tool result via return_value.is_error', async () => {
     tmpFile = writeFixture([
       { type: 'metadata', protocol_version: '1.9' },

--- a/tests/unit/kimi-transcript-parser.test.ts
+++ b/tests/unit/kimi-transcript-parser.test.ts
@@ -10,6 +10,8 @@ import { setParseWindowBytesForTests } from '../../src/main/agent/shared/transcr
 // fixture mirrors the verified envelope shape; tool calls/results and prompts
 // are pinned to the on-disk shapes from the mock CLI.
 
+const SESSION_ID = '4f1c0b2a-8d3e-4a91-9c77-2b5e6f0a1d34';
+
 function writeFixture(lines: object[]): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-transcript-'));
   const file = path.join(dir, 'wire.jsonl');
@@ -27,25 +29,34 @@ describe('parseKimiTranscript', () => {
   });
 
   it('returns [] for a missing file', async () => {
-    const entries = await parseKimiTranscript(path.join(os.tmpdir(), 'kimi-missing.jsonl'));
+    const entries = await parseKimiTranscript(SESSION_ID, path.join(os.tmpdir(), 'kimi-missing.jsonl'));
     expect(entries).toEqual([]);
   });
 
   it('accumulates ContentPart fragments and pairs ToolCall/ToolResult by id', async () => {
     const fixturePath = path.join(__dirname, '..', 'fixtures', 'kimi-wire-session.jsonl');
-    const entries = await parseKimiTranscript(fixturePath);
+    const entries = await parseKimiTranscript(SESSION_ID, fixturePath);
     expect(entries.map((entry) => entry.kind)).toEqual(['user', 'assistant', 'assistant', 'tool_result']);
     expect(entries[0]).toMatchObject({ kind: 'user', text: 'List the files in this directory.' });
     // ContentPart fragments "Here are " + "the files." flushed at the ToolCall.
     expect(entries[1]).toMatchObject({ kind: 'assistant', blocks: [{ type: 'text', text: 'Here are the files.' }] });
     expect(entries[2]).toMatchObject({ kind: 'assistant', blocks: [{ type: 'tool_use', id: 'tc-1', name: 'Shell', input: { command: 'ls' } }] });
     expect(entries[3]).toMatchObject({ kind: 'tool_result', toolUseId: 'tc-1', content: 'file1.txt\nfile2.txt\n', isError: false });
+
+    // The exact strings are the contract (persisted citation anchors), and
+    // they show the two rules that make them unique: every uuid is the
+    // PHYSICAL line (line 0 is the metadata envelope, so the first turn is 1),
+    // and the flushed assistant text is attributed to the line its FIRST
+    // ContentPart arrived on (2), not to the ToolCall line that flushed it (4).
+    expect(entries.map((entry) => entry.uuid)).toEqual([
+      `${SESSION_ID}:1`,
+      `${SESSION_ID}:2`,
+      `${SESSION_ID}:4`,
+      `${SESSION_ID}:5`,
+    ]);
   });
 
   it('parses only the tail of a transcript larger than the parse cap, marking the omission', async () => {
-    // kimi mints uuids window-relative (`kimi-${entryIndex++}`, starting at 0
-    // within whatever window was actually read), so `kimi-0` is present
-    // regardless of truncation - assert on the per-turn TEXT instead.
     const cap = 2 * 1024;
     setParseWindowBytesForTests(cap);
     try {
@@ -65,7 +76,7 @@ describe('parseKimiTranscript', () => {
       tmpFile = writeFixture(lines);
       expect(fs.statSync(tmpFile).size).toBeGreaterThan(cap);
 
-      const entries = await parseKimiTranscript(tmpFile);
+      const entries = await parseKimiTranscript(SESSION_ID, tmpFile);
 
       expect(entries.length).toBeLessThan(lines.length);
       expect(entries.some((entry) => entry.kind === 'user' && entry.text.startsWith('turn 0 '))).toBe(false);
@@ -77,12 +88,81 @@ describe('parseKimiTranscript', () => {
     }
   });
 
+  it('keeps a turn uuid stable when the transcript grows past the cap and the window slides', async () => {
+    // Guards the same regression as the Codex parser: a window-relative
+    // counter reassigned a different uuid to the same logical turn on every
+    // re-parse, silently breaking the persisted citation anchors.
+    const cap = 2 * 1024;
+    setParseWindowBytesForTests(cap);
+    try {
+      const lines: object[] = [{ type: 'metadata', protocol_version: '1.9' }];
+      let written = Buffer.byteLength(JSON.stringify(lines[0]), 'utf-8') + 1;
+      let lineIndex = 0;
+      while (written <= cap * 3) {
+        const fixtureLine = {
+          timestamp: 1780430656.8 + lineIndex,
+          message: { type: 'TurnBegin', payload: { user_input: `turn ${lineIndex} ${'q'.repeat(200)}` } },
+        };
+        lines.push(fixtureLine);
+        written += Buffer.byteLength(JSON.stringify(fixtureLine), 'utf-8') + 1;
+        lineIndex += 1;
+      }
+      tmpFile = writeFixture(lines);
+      const before = await parseKimiTranscript(SESSION_ID, tmpFile);
+
+      // Append just enough to slide the window without clearing it entirely.
+      const appended = [0, 1].map((offset) => ({
+        timestamp: 1780430656.8 + lineIndex + offset,
+        message: { type: 'TurnBegin', payload: { user_input: `turn ${lineIndex + offset} ${'q'.repeat(200)}` } },
+      }));
+      fs.writeFileSync(tmpFile, [...lines, ...appended].map((line) => JSON.stringify(line)).join('\n'));
+      const after = await parseKimiTranscript(SESSION_ID, tmpFile);
+
+      const oldestBefore = before.find((entry) => entry.kind === 'user');
+      expect(after.some((entry) => entry.uuid === oldestBefore!.uuid)).toBe(false);
+
+      const lastBefore = before[before.length - 1];
+      const sameTurnAfter = after.find(
+        (entry) => entry.kind === 'user' && lastBefore.kind === 'user' && entry.text === lastBefore.text,
+      );
+      expect(sameTurnAfter).toBeDefined();
+      expect(sameTurnAfter!.uuid).toBe(lastBefore.uuid);
+    } finally {
+      setParseWindowBytesForTests();
+    }
+  });
+
+  it('namespaces uuids by session so two sessions on one task cannot collide', async () => {
+    tmpFile = writeFixture([
+      { type: 'metadata', protocol_version: '1.9' },
+      { timestamp: 1780430656.8, message: { type: 'TurnBegin', payload: { user_input: 'hello' } } },
+    ]);
+    const one = await parseKimiTranscript('session-one', tmpFile);
+    const two = await parseKimiTranscript('session-two', tmpFile);
+
+    expect(one[0].uuid).toBe('session-one:1');
+    expect(two[0].uuid).toBe('session-two:1');
+  });
+
+  it('gives the flushed assistant text and the record that flushed it distinct uuids', async () => {
+    // One line can trigger a flush AND emit its own entry. They must not
+    // collide: the stitch dedups by uuid and would drop the second.
+    tmpFile = writeFixture([
+      { type: 'metadata', protocol_version: '1.9' },
+      { timestamp: 1780430656.9, message: { type: 'ContentPart', payload: { text: 'thinking out loud' } } },
+      { timestamp: 1780430656.97, message: { type: 'ToolCall', payload: { type: 'function', id: 'tc-9', function: { name: 'Shell', arguments: '{}' } } } },
+    ]);
+    const entries = await parseKimiTranscript(SESSION_ID, tmpFile);
+    expect(entries.map((entry) => entry.uuid)).toEqual([`${SESSION_ID}:1`, `${SESSION_ID}:2`]);
+    expect(new Set(entries.map((entry) => entry.uuid)).size).toBe(entries.length);
+  });
+
   it('flags an error tool result via return_value.is_error', async () => {
     tmpFile = writeFixture([
       { type: 'metadata', protocol_version: '1.9' },
       { timestamp: 1780430657.02, message: { type: 'ToolResult', payload: { tool_call_id: 'tc-2', return_value: { is_error: true, message: 'boom' } } } },
     ]);
-    const entries = await parseKimiTranscript(tmpFile);
+    const entries = await parseKimiTranscript(SESSION_ID, tmpFile);
     expect(entries).toEqual([
       { kind: 'tool_result', uuid: expect.any(String), ts: expect.any(Number), toolUseId: 'tc-2', content: 'boom', isError: true },
     ]);
@@ -93,7 +173,7 @@ describe('parseKimiTranscript', () => {
       { type: 'metadata', protocol_version: '1.9' },
       { timestamp: 1780430656.8, message: { type: 'TurnBegin', payload: { user_input: [{ type: 'text', text: 'hello' }, { type: 'image' }] } } },
     ]);
-    const entries = await parseKimiTranscript(tmpFile);
+    const entries = await parseKimiTranscript(SESSION_ID, tmpFile);
     expect(entries).toEqual([
       { kind: 'user', uuid: expect.any(String), ts: expect.any(Number), text: 'hello' },
     ]);

--- a/tests/unit/qwen-transcript-parser.test.ts
+++ b/tests/unit/qwen-transcript-parser.test.ts
@@ -6,6 +6,8 @@ import { parseQwenTranscript, locateQwenTranscriptFile } from '../../src/main/ag
 import { qwenChatsDir } from '../../src/main/agent/adapters/qwen-code/session-history-parser';
 import { setParseWindowBytesForTests } from '../../src/main/agent/shared/transcript-truncation';
 
+const SESSION_ID = '1ac39801-6b52-4a0e-9d18-7c3f2ea4b510';
+
 describe('parseQwenTranscript', () => {
   let tmpFile: string | null = null;
   afterEach(() => {
@@ -16,13 +18,13 @@ describe('parseQwenTranscript', () => {
   });
 
   it('returns [] for a missing file', async () => {
-    const entries = await parseQwenTranscript(path.join(os.tmpdir(), 'qwen-missing.jsonl'));
+    const entries = await parseQwenTranscript(SESSION_ID, path.join(os.tmpdir(), 'qwen-missing.jsonl'));
     expect(entries).toEqual([]);
   });
 
   it('parses the pinned fixture: thought + text + functionCall, with a paired functionResponse', async () => {
     const fixturePath = path.join(__dirname, '..', 'fixtures', 'qwen-real-session-tools.jsonl');
-    const entries = await parseQwenTranscript(fixturePath);
+    const entries = await parseQwenTranscript(SESSION_ID, fixturePath);
     expect(entries.map((entry) => entry.kind)).toEqual(['user', 'assistant', 'tool_result']);
     expect(entries[0]).toMatchObject({ kind: 'user', text: 'List the files in this directory.' });
     expect(entries[1]).toMatchObject({
@@ -35,12 +37,40 @@ describe('parseQwenTranscript', () => {
       ],
     });
     expect(entries[2]).toMatchObject({ kind: 'tool_result', toolUseId: 'fc-1', content: 'file1.txt\nfile2.txt' });
+    // This fixture is synthetic and carries no per-record `uuid`, so it
+    // exercises the session-scoped physical-line fallback. Line 1 is the
+    // skipped `ui_telemetry` system record, so the assistant is line 2.
+    expect(entries.map((entry) => entry.uuid)).toEqual([
+      `${SESSION_ID}:0`,
+      `${SESSION_ID}:2`,
+      `${SESSION_ID}:3`,
+    ]);
+  });
+
+  it('prefers the record own uuid when the on-disk format carries one', async () => {
+    // Real Qwen sessions write `uuid` / `parentUuid` / `sessionId` per record.
+    // An intrinsic id needs no positional anchor at all, so this path never
+    // pays the omitted-line scan.
+    const fixturePath = path.join(__dirname, '..', 'fixtures', 'qwen-real-session.jsonl');
+    const entries = await parseQwenTranscript(SESSION_ID, fixturePath);
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries[0].uuid).toBe('ff2655c3-c716-4f70-b580-fc81d895aa6d');
+    for (const entry of entries) {
+      expect(entry.uuid).not.toContain(`${SESSION_ID}:`);
+    }
+  });
+
+  it('namespaces the fallback uuid by session so two sessions cannot collide', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-transcript-'));
+    tmpFile = path.join(dir, 'session.jsonl');
+    fs.writeFileSync(tmpFile, JSON.stringify({ type: 'user', message: { role: 'user', parts: [{ text: 'hi' }] } }));
+    const one = await parseQwenTranscript('session-one', tmpFile);
+    const two = await parseQwenTranscript('session-two', tmpFile);
+    expect(one[0].uuid).toBe('session-one:0');
+    expect(two[0].uuid).toBe('session-two:0');
   });
 
   it('parses only the tail of a transcript larger than the parse cap, marking the omission', async () => {
-    // qwen mints uuids window-relative (`qwen-${entryIndex++}`, starting at 0
-    // within whatever window was actually read), so `qwen-0` is present
-    // regardless of truncation - assert on the per-turn TEXT instead.
     const cap = 2 * 1024;
     setParseWindowBytesForTests(cap);
     try {
@@ -62,13 +92,57 @@ describe('parseQwenTranscript', () => {
       fs.writeFileSync(tmpFile, lines.join('\n'));
       expect(fs.statSync(tmpFile).size).toBeGreaterThan(cap);
 
-      const entries = await parseQwenTranscript(tmpFile);
+      const entries = await parseQwenTranscript(SESSION_ID, tmpFile);
 
       expect(entries.length).toBeLessThan(lines.length);
       expect(entries.some((entry) => entry.kind === 'user' && entry.text.startsWith('turn 0 '))).toBe(false);
       expect(entries.some((entry) => entry.kind === 'user' && entry.text.startsWith(`turn ${lastLineIndex} `))).toBe(true);
 
       expect(entries[0]).toMatchObject({ kind: 'system', subtype: 'truncated' });
+    } finally {
+      setParseWindowBytesForTests();
+    }
+  });
+
+  it('keeps a turn uuid stable when the transcript grows past the cap and the window slides', async () => {
+    // The fallback path is the one that could drift, so it is the one pinned:
+    // these records carry no `uuid`, so the uuid is the absolute physical line.
+    const cap = 2 * 1024;
+    setParseWindowBytesForTests(cap);
+    try {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-transcript-'));
+      tmpFile = path.join(dir, 'session.jsonl');
+      const lines: string[] = [];
+      let written = 0;
+      let lineIndex = 0;
+      while (written <= cap * 3) {
+        const fixtureLine = JSON.stringify({
+          type: 'user',
+          message: { role: 'user', parts: [{ text: `turn ${lineIndex} ${'q'.repeat(200)}` }] },
+        });
+        lines.push(fixtureLine);
+        written += Buffer.byteLength(fixtureLine, 'utf-8') + 1;
+        lineIndex += 1;
+      }
+      fs.writeFileSync(tmpFile, lines.join('\n'));
+      const before = await parseQwenTranscript(SESSION_ID, tmpFile);
+
+      const appended = [0, 1].map((offset) => JSON.stringify({
+        type: 'user',
+        message: { role: 'user', parts: [{ text: `turn ${lineIndex + offset} ${'q'.repeat(200)}` }] },
+      }));
+      fs.writeFileSync(tmpFile, [...lines, ...appended].join('\n'));
+      const after = await parseQwenTranscript(SESSION_ID, tmpFile);
+
+      const oldestBefore = before.find((entry) => entry.kind === 'user');
+      expect(after.some((entry) => entry.uuid === oldestBefore!.uuid)).toBe(false);
+
+      const lastBefore = before[before.length - 1];
+      const sameTurnAfter = after.find(
+        (entry) => entry.kind === 'user' && lastBefore.kind === 'user' && entry.text === lastBefore.text,
+      );
+      expect(sameTurnAfter).toBeDefined();
+      expect(sameTurnAfter!.uuid).toBe(lastBefore.uuid);
     } finally {
       setParseWindowBytesForTests();
     }
@@ -81,7 +155,7 @@ describe('parseQwenTranscript', () => {
       JSON.stringify({ type: 'system', subtype: 'ui_telemetry' }),
       JSON.stringify({ type: 'user', message: { role: 'user', parts: [{ text: 'hi' }] } }),
     ].join('\n'));
-    const entries = await parseQwenTranscript(tmpFile);
+    const entries = await parseQwenTranscript(SESSION_ID, tmpFile);
     expect(entries).toEqual([{ kind: 'user', uuid: expect.any(String), ts: expect.any(Number), text: 'hi' }]);
   });
 });

--- a/tests/unit/qwen-transcript-parser.test.ts
+++ b/tests/unit/qwen-transcript-parser.test.ts
@@ -70,6 +70,25 @@ describe('parseQwenTranscript', () => {
     expect(two[0].uuid).toBe('session-two:0');
   });
 
+  it('treats an explicit empty-string uuid the same as a missing one', async () => {
+    // `raw.uuid` present but `''` is a distinct on-disk shape from the field
+    // being absent, and the guard is
+    // `typeof raw.uuid === 'string' && raw.uuid.length > 0` - dropping the
+    // length check would let `''` through as a "real" uuid, recreating the
+    // shared-uuid collision the fallback exists to fix.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-transcript-'));
+    tmpFile = path.join(dir, 'session.jsonl');
+    const lines = [
+      JSON.stringify({ type: 'user', uuid: '', message: { role: 'user', parts: [{ text: 'first' }] } }),
+      JSON.stringify({ type: 'user', uuid: '', message: { role: 'user', parts: [{ text: 'second' }] } }),
+    ];
+    fs.writeFileSync(tmpFile, lines.join('\n'));
+    const entries = await parseQwenTranscript(SESSION_ID, tmpFile);
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => entry.uuid)).toEqual([`${SESSION_ID}:0`, `${SESSION_ID}:1`]);
+  });
+
   it('parses only the tail of a transcript larger than the parse cap, marking the omission', async () => {
     const cap = 2 * 1024;
     setParseWindowBytesForTests(cap);

--- a/tests/unit/retrieval-store-sql.test.ts
+++ b/tests/unit/retrieval-store-sql.test.ts
@@ -80,8 +80,8 @@ function findRun(calls: RecordedCall[], needle: string): RecordedCall | undefine
 describe('RetrievalStore.upsertDocument diff', () => {
   it('deletes from the first divergent seq and inserts only the new chunk, leaving the identical prefix', () => {
     const existing = [
-      { id: 10, seq: 0, content_hash: 'hashA' },
-      { id: 11, seq: 1, content_hash: 'hashB' },
+      { id: 10, seq: 0, content_hash: 'hashA', turn_uuid_start: 'u0', turn_uuid_end: 'u0' },
+      { id: 11, seq: 1, content_hash: 'hashB', turn_uuid_start: 'u1', turn_uuid_end: 'u1' },
     ];
     const { db, calls } = makeRecordingDb({
       all: (sql) => (sql.includes('content_hash') ? existing : []),
@@ -107,8 +107,8 @@ describe('RetrievalStore.upsertDocument diff', () => {
 
   it('preserves an identical document (no delete/insert) but re-points its ownership at the current session', () => {
     const existing = [
-      { id: 10, seq: 0, content_hash: 'hashA' },
-      { id: 11, seq: 1, content_hash: 'hashB' },
+      { id: 10, seq: 0, content_hash: 'hashA', turn_uuid_start: 'u0', turn_uuid_end: 'u0' },
+      { id: 11, seq: 1, content_hash: 'hashB', turn_uuid_start: 'u1', turn_uuid_end: 'u1' },
     ];
     const { db, calls } = makeRecordingDb({
       all: (sql) => (sql.includes('content_hash') ? existing : []),
@@ -128,10 +128,49 @@ describe('RetrievalStore.upsertDocument diff', () => {
     // session-delete trigger (which keys on session_id) track the live session.
     const ownershipUpdate = findRun(calls, 'UPDATE memory_chunks SET session_id');
     expect(ownershipUpdate?.args).toEqual(['session-1', 'task-1', 'conversation', 'doc-1', 2]);
+
+    // The anchors already match, so nothing is re-anchored.
+    expect(findRun(calls, 'UPDATE memory_chunks SET turn_uuid_start')).toBeUndefined();
+  });
+
+  it('re-anchors an identical prefix whose turn uuids changed, without touching its embeddings', () => {
+    // `content_hash` is sha1(TEXT) only, so a chunk whose text is unchanged
+    // while its turn uuids changed is invisible to the divergence walk and
+    // used to keep its stale anchors forever - which is exactly what a
+    // uuid-scheme change produces, and why "Rebuild index" could not fix one.
+    const existing = [
+      { id: 10, seq: 0, content_hash: 'hashA', turn_uuid_start: 'codex-0', turn_uuid_end: 'codex-0' },
+      { id: 11, seq: 1, content_hash: 'hashB', turn_uuid_start: 'codex-1', turn_uuid_end: 'codex-1' },
+    ];
+    const { db, calls } = makeRecordingDb({
+      all: (sql) => (sql.includes('content_hash') ? existing : []),
+    });
+
+    const result = new RetrievalStore(db).upsertDocument(ref, [chunk(0, 'hashA'), chunk(1, 'hashB')]);
+
+    // Still no churn: the rows (and their embeddings) stay put.
+    expect(result.deletedIds).toEqual([]);
+    expect(result.insertedIds).toEqual([]);
+    expect(findRun(calls, 'DELETE FROM memory_chunks')).toBeUndefined();
+    expect(calls.some((call) => call.sql.includes('INSERT INTO memory_chunks'))).toBe(false);
+
+    // ...but both rows are re-anchored in place, keyed by row id.
+    const reanchorCalls = calls.filter(
+      (call) => call.method === 'run' && call.sql.includes('UPDATE memory_chunks SET turn_uuid_start'),
+    );
+    expect(reanchorCalls.map((call) => call.args)).toEqual([
+      ['u0', 'u0', 10],
+      ['u1', 'u1', 11],
+    ]);
+    // `content_hash` is never rewritten, so no chunk is re-embedded. Asserted
+    // over EVERY statement the pass issued, not just the re-anchor ones: the
+    // re-anchor sql is a fixed literal that structurally cannot mention
+    // `content_hash`, so scoping this to those calls could never fail.
+    expect(calls.some((call) => call.sql.includes('SET content_hash'))).toBe(false);
   });
 
   it('appends a new trailing chunk without deleting the identical prefix', () => {
-    const existing = [{ id: 10, seq: 0, content_hash: 'hashA' }];
+    const existing = [{ id: 10, seq: 0, content_hash: 'hashA', turn_uuid_start: 'u0', turn_uuid_end: 'u0' }];
     const { db, calls } = makeRecordingDb({
       all: (sql) => (sql.includes('content_hash') ? existing : []),
       run: (sql) => (sql.includes('INSERT INTO memory_chunks') ? { lastInsertRowid: 300, changes: 1 } : { changes: 1 }),

--- a/tests/unit/transcript-service-task.test.ts
+++ b/tests/unit/transcript-service-task.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import type Database from 'better-sqlite3';
 import type { SessionRecord } from '../../src/shared/types';
 
@@ -20,6 +23,7 @@ vi.mock('../../src/main/agent/agent-registry', () => ({
 
 import { resolveTaskTranscript } from '../../src/main/agent/transcript-service';
 import { agentRegistry } from '../../src/main/agent/agent-registry';
+import { parseCodexTranscript } from '../../src/main/agent/adapters/codex/transcript-parser';
 
 function makeRecord(overrides: Partial<SessionRecord> = {}): SessionRecord {
   return {
@@ -106,6 +110,61 @@ function makeFakeDb(options: FakeDbOptions): Database.Database {
 const getBySessionType = vi.mocked(agentRegistry.getBySessionType);
 
 describe('resolveTaskTranscript', () => {
+  let tmpDir: string | null = null;
+  afterEach(() => {
+    if (tmpDir) {
+      try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+      tmpDir = null;
+    }
+  });
+
+  it('keeps both sessions\' turns when a task has two sessions of the same agent', async () => {
+    // The uuid dedupe below (`a resume replays parent turns verbatim`) keeps
+    // the FIRST entry for a uuid. Codex/Kimi/Qwen/Antigravity used to mint
+    // parse-relative uuids restarting at 0 per session, so a task's SECOND
+    // session collided with the first entry-for-entry and vanished from the
+    // Conversation tab entirely. Driven through the REAL Codex parser, since
+    // the fix is that the parser namespaces its uuids by session.
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stitch-two-sessions-'));
+    const writeRollout = (name: string, text: string): string => {
+      const filePath = path.join(tmpDir!, name);
+      fs.writeFileSync(filePath, JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-06-01T10:00:00Z',
+        payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text }] },
+      }));
+      return filePath;
+    };
+    const rolloutBySession: Record<string, string> = {
+      'agent-old': writeRollout('old.jsonl', 'from the old session'),
+      'agent-new': writeRollout('new.jsonl', 'from the new session'),
+    };
+
+    const older = makeRecord({ id: 'session-old', started_at: '2026-06-01T10:00:00Z', session_type: 'codex_agent', agent_session_id: 'agent-old' });
+    const newer = makeRecord({ id: 'session-new', started_at: '2026-06-01T12:00:00Z', session_type: 'codex_agent', agent_session_id: 'agent-new' });
+    const db = makeFakeDb({
+      sessionsById: { 'session-old': older, 'session-new': newer },
+      sessionsByTask: { 'task-1': [newer, older] },
+      taskTitle: 'Wire the auth flow',
+    });
+    getBySessionType.mockReturnValue({
+      displayName: 'Codex',
+      parseTranscript: async (agentSessionId: string) => ({
+        entries: await parseCodexTranscript(agentSessionId, rolloutBySession[agentSessionId]),
+        sourcePath: rolloutBySession[agentSessionId],
+      }),
+    } as unknown as ReturnType<typeof agentRegistry.getBySessionType>);
+
+    const result = await resolveTaskTranscript(db, 'session-new');
+
+    const userTexts = result!.entries.filter((entry) => entry.kind === 'user').map((entry) => entry.text);
+    expect(userTexts).toEqual(['from the old session', 'from the new session']);
+
+    // Nothing was deduped away, which means no uuid was shared across sessions.
+    const uuids = result!.entries.map((entry) => entry.uuid);
+    expect(new Set(uuids).size).toBe(uuids.length);
+  });
+
   it('returns null when the anchor session id resolves to no record at all', async () => {
     const db = makeFakeDb({ sessionsById: {}, sessionsByTask: {} });
     getBySessionType.mockReturnValue(undefined);


### PR DESCRIPTION
## What

Makes every agent transcript parser's entry `uuid` absolute and session-scoped, under one rule:

> An entry uuid is either an id intrinsic to the record, or `<agentSessionId>:<absoluteLineIndex>`. Never a parse-relative counter, never empty.

Affects `codex`, `kimi`, `qwen-code`, `antigravity`, `droid`, and `gemini` transcript parsers, plus `retrieval-store.ts` and `history-scan.ts`. Grok already satisfied the rule and is unchanged. Claude and OpenCode use native GUIDs.

## Why

These uuids are persisted citation anchors (`memory_chunks.turn_uuid_start` / `turn_uuid_end`), resolved by `sliceTranscriptAroundUuid`. Two separate defects were minting them badly.

**The reported one.** `codex`, `kimi`, and `qwen-code` derived a uuid from a counter that restarted at 0 on every parse. Before the bounded-read change each parser always read from byte 0, so the counter was stable. Now an over-cap transcript is read as a sliding tail window, so every re-parse of a still-growing large session reassigned different uuids to the same logical turns.

**The worse one, found while reviewing the other adapters, and live at ANY transcript size.** Those uuids were not session-scoped either. `resolveTaskTranscript` stitches every session a task has ever had and dedups by uuid keeping the first:

```ts
if (seenUuids.has(entry.uuid)) continue; // a resume replays parent turns verbatim
```

Two Codex sessions on one task both minted `codex-0..N`, so the second session's turns collided with the first's and **silently vanished from the Conversation tab**. Antigravity's `step-${step_index}` had the same flaw. The `''` fallback in `claude` / `droid` / `gemini` is the same bug in another form: an empty uuid is not absent, it is SHARED.

## How

Both defects have one root cause, so all of it moves to the single rule above.

- **codex, kimi** - absolute line indices via `readJsonlWindow`'s existing `countOmittedLines` option. Neither format carries a per-record id (only tool calls do, as a shared pair), and Codex timestamps collide at millisecond precision, so a positional anchor is the only option.
- **qwen-code** - prefers the record's own native `uuid`, which real sessions carry and the parser was ignoring, falling back to the line index.
- **antigravity** - session-scopes the already-absolute step index.
- **droid, gemini** - happy path untouched, so no existing anchor for them changes; only the `''` fallback moves.
- **claude** - deliberately NOT changed. All three of its read paths share one `parseTranscriptLine` with intentionally identical per-line semantics, its incremental path parses out of a carry buffer with no line notion, and `parseClaudeTranscriptWindow` is called once per window by the indexer, so counting the omitted head per window would make a whole-file walk quadratic. The gap is documented at the fallback and left for a follow-up.

**Also stops the retrieval store freezing anchors it already holds.** `upsertDocument` leaves the identical leading chunk prefix in place to preserve its embeddings, but `content_hash` is `sha1(text)` only, so a chunk whose text is unchanged while its turn uuids changed was invisible to the diff and kept stale anchors forever. That is exactly what a uuid-scheme change produces, and it is why "Rebuild index" could not repair one. The prefix is now re-anchored in place, alongside the existing `session_id` / `task_id` re-point. Updating those two columns fires no FTS trigger (that one is `AFTER UPDATE OF text`) and leaves `content_hash` alone, so **nothing is re-embedded**.

### Trade-offs worth a reviewer's attention

**Existing anchors.** The uuid format changes for the four affected adapters, so anchors already in `memory_chunks` go stale once. They degrade safely rather than mis-resolving: `sliceTranscriptAroundUuid` returns the full transcript on a miss, and the session-id prefix guarantees an old `codex-7` can never alias onto the new namespace. `CHUNKER_VERSION` was deliberately NOT bumped - that calls `purgeAll()`, dropping all corpora in every project and forcing a full background re-embed for every user, which is a large cost for a rare case.

**Performance.** `countOmittedLines` streams the omitted head counting newline bytes. Measured against the real transcripts on a dev machine, worst case was **27ms to scan the 121.9MB omitted head of a 137.9MB transcript**, it is free below the 16MB cap, and it only reruns when the file has actually changed (the transcript cache is stat-validated). That measurement is why all six positional parsers just set the flag rather than resolving the count lazily - an earlier draft did resolve it lazily, and the laziness measured as noise while costing a second code shape.

**`turn_usage` is unaffected.** Its `ON CONFLICT(turn_uuid)` cross-session dedup (`docs/database.md`) only ever sees entries carrying `usage`, and only the Claude parser populates that - whose uuids did not change. Confirmed independently by the doc audit.

## Breaking changes

None. The public `AgentAdapter.parseTranscript(agentSessionId, cwd)` interface is unchanged; only internal parser function signatures gained a leading `agentSessionId`. No schema change, no migration, no IPC change. Doc anchors audited clean (2 anchors, 0 gaps, 0 prose drift).

## Tests

CI runs lint, typecheck, unit, build, the UI shards, and the Linux Electron E2E shards.

Added here, all red-green verified:

- **Cross-session stitch** (`transcript-service-task.test.ts`) - two Codex sessions on one task, driven through the real parser. Confirmed red against the old scheme: it returned only `["from the old session"]`, reproducing the vanishing-turns bug exactly.
- **Window-slide stability** - parse, append, re-parse; a turn present in both windows keeps the same uuid (codex, kimi, qwen, droid, gemini).
- **Exact-string physical-line contracts**, including against the pinned real Codex rollout fixture with a line-by-line accounting of the lines that emit no entry.
- **Cross-session disjointness** (codex, kimi, qwen, antigravity), and antigravity's real `parseAntigravityTranscript` entry point forwarding the session id - which nothing otherwise forced, since the parameter is optional on the file-path variant.
- **Id-less and empty-id fallbacks** (droid, gemini, qwen), covering both a missing field and a present-but-empty one. The `.length > 0` sub-clause was mutation-dead until the empty-string case was added. Gemini's is the sharpest: its id doubles as the map key, so an unguarded `''` makes the second message overwrite the first and disappear during the parse.
- **Anchor refresh** (`retrieval-store-sql.test.ts`) - anchors updated on the identical prefix while row ids, `content_hash`, and `embedded_model` stay unchanged.
- **`omittedLineCount` at or past EOF** (`jsonl-window-stream.test.ts`), a latent branch that reported the whole file omitted but zero lines.

Also verified against the **real Codex rollouts on a dev machine** (read-only, no agent spawned): every uuid non-empty, session-prefixed, unique, and stable across re-parses.

### Known follow-ups (not in scope here)

- Claude's `''` fallback, for the structural reasons above.
- `buildTruncationMarker` mints `kangentic-truncated:${omittedBytes}`, which is not session-scoped either. Two truncated sessions on one task with byte-identical `omittedBytes` would collide at the same dedup. Rare, and it costs a notice line rather than conversation turns.

Generated with [Claude Code](https://claude.com/claude-code)
