### PR TITLE
fix(terminal): pace mouse reports as individual PTY writes; keeplist scroll-speed env

### DIFF
--- a/docs/adapter-session-history.md
+++ b/docs/adapter-session-history.md
@@ -371,11 +371,11 @@ The actual root cause of the #255 bug was unrelated to a missing transcript: whe
 launched from inside a Claude Code session it leaked `CLAUDE_CODE_*` markers into spawned agents,
 so a Claude spawned with `--session-id <id>` never persisted a transcript under that id and the
 later `--resume` found nothing. The cure was `buildSpawnEnv` stripping `CLAUDECODE` plus every
-`CLAUDE_CODE_*` identity marker (`src/main/pty/spawn/pty-spawn.ts`, commit `4b236593`; the sole
-exception is the keeplisted `CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT` renderer flag, which carries no
-session identity), which makes every spawned Claude a clean top-level session that persists its
-own resumable transcript. With that in
-place the resume target reliably exists, so the presence guard earns nothing and was dropped.
+`CLAUDE_CODE_*` identity marker (`src/main/pty/spawn/pty-spawn.ts`, commit `4b236593`; the
+exceptions are the keeplisted `CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT` and `CLAUDE_CODE_SCROLL_SPEED`
+renderer tuning flags, which carry no session identity), which makes every spawned Claude a clean
+top-level session that persists its own resumable transcript. With that in place the resume
+target reliably exists, so the presence guard earns nothing and was dropped.
 
 The non-Claude agents never exhibited an analogous missing-resume-target failure: each captures
 or owns its session id against a store the CLI itself writes, and none inherits the Claude env

--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -273,12 +273,19 @@ from inside a Claude Code session, and those markers would otherwise re-parent t
 the launching session, so a later `--resume` finds nothing. A Kangentic-spawned agent must always be
 a clean top-level session. `ANTHROPIC_*` keys (BYOK / API auth) are deliberately left untouched.
 
-One key is keeplisted: `CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT`. It is a renderer tuning flag, not an
-identity marker, so it cannot re-parent a session. Kangentic defaults it to `1` on **win32 only**,
-matching what Claude Code's own agent views do on Windows, because the fullscreen TUI otherwise
-intermittently drops history entries from its incremental scrolled-view updates. An explicit value
-already present in the environment always wins, including a user's opt-out. Non-Claude agents ignore
-the variable.
+Two keys are keeplisted, both renderer tuning flags rather than identity markers, so neither can
+re-parent a session. An explicit value already present in the environment always wins for both,
+including a user's opt-out, and non-Claude agents ignore them.
+
+- `CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT`: defaulted to `1` on **win32 only**, matching what Claude
+  Code's own agent views do on Windows, because the fullscreen TUI otherwise intermittently drops
+  history entries from its incremental scrolled-view updates.
+- `CLAUDE_CODE_SCROLL_SPEED`: keeplisted only, **no default**. A default of `3` was shipped and
+  reverted the same day: the fullscreen TUI's differential renderer intermittently mis-assembles
+  frames on large scrolled jumps, pipe reads coalesce rapid wheel reports into one jump, and the
+  3x multiplier tripled every such jump past that corruption threshold. The CLI default of `1`
+  matches the native terminals verified clean; the keeplist exists so a user's exported tuning
+  still survives the identity-marker strip.
 
 `NO_COLOR` is stripped too, but only when the merged environment also carries `CLAUDECODE`. Claude
 Code exports `NO_COLOR=1` into its tool shells alongside `CLAUDECODE`, so a dev/preview Kangentic

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -847,6 +847,26 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   path uses, skipping when a replay is already in flight so a mount-time replay is never aborted
   and re-issued for the same frame. Both registries are kept: only parking additionally makes the
   incoming queue ack-and-discard, so neither subsumes the other.
+- **Mouse reports are paced, never batched.** Outgoing terminal input rides a microtask write
+  batcher (`src/renderer/utils/write-batcher.ts`) that coalesces synchronous onData bursts into
+  one IPC write - byte-safe, but not semantics-safe for a fullscreen TUI, which treats a chunk
+  as one input batch: a run of wheel reports delivered together becomes one multi-line jump, and
+  the TUI's differential frame for a multi-line jump intermittently mis-assembles (the
+  missing-entries family below). Verified by controlled injection (2026-08-23): ten spaced
+  reports produced ten clean frames and ~29KB of output; the same ten in one chunk produced one
+  ~2KB spliced frame. Unbatching alone is NOT enough - a pipe preserves no message boundaries,
+  so reports written back-to-back still land in one read while the TUI renders the previous
+  frame. So `useTerminal` routes every mouse report (`isMouseReport`) through `writePaced`: an
+  ordered queue that writes each report as its own payload at a 16ms-per-report floor, restoring
+  the physical-wheel cadence a native terminal delivers; typed bytes keep arrival order across
+  the two paths, and teardown drops pending reports rather than writing them joined.
+  (Ack-clocking each report to the TUI's answer was tried and reverted: the TUI coalesces
+  repaints onto its own frame clock, so input-clocking capped scrolling at ~10Hz.) The jump a
+  coalesced read still produces is bounded by keeping `CLAUDE_CODE_SCROLL_SPEED` at the CLI
+  default of 1 - see [docs/cross-platform.md](cross-platform.md) for why Kangentic no longer
+  raises it. This targets the wheel-scroll flavor at the source; single-report multi-line jumps
+  the CLI performs internally (Ctrl+End, PageUp/Down) remain exposed and are what the repaint
+  nudge below repairs.
 - **Post-interaction repaint nudge.** A fullscreen TUI intermittently emits a frame that erases
   the grid and then redraws only some of it, leaving either the whole transcript blank or a
   contiguous band of rows missing mid-frame. Its renderer is differential, so it never revisits
@@ -860,7 +880,14 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   not-parked plus no-replay-pending, floored at one per 750ms per session. `isUserInputData`
   filters out xterm's OWN focus and motion reports, which arrive through the same `onData` channel
   and would otherwise self-arm a nudge on every mount replay. The before/after grid comparison is
-  reporting only and never gates the nudge. Upstream: anthropics/claude-code#83714.
+  reporting only and never gates the nudge. A richer repair layer (resize and replay arming
+  channels, a spaced focus pair, mid-burst fires, floor deferral, a persisted verdict log) was
+  built, dogfooded, and removed the same day: against a producer-side defect it bought visible
+  repair flicker, not correctness. Upstream: anthropics/claude-code#83714 - reproduced NATIVELY
+  (PowerShell, wheel-scrolling deep into a large resumed session), so this whole family is the
+  CLI renderer's, not the host's. Every host-side workaround site carries an
+  `UNWIND(claude-code#83714)` marker; grep for it and sweep them out when upstream fixes the
+  renderer.
 - **Trace vocabulary for the two mechanisms above.** `focus-union-gained` / `focus-union-lost`
   (main, `recomputeFocusedUnion`), `terminal-unfocus` / `terminal-refocus` (renderer,
   `focused-terminals.ts`), and `repaint-repaired` / `repaint-verified` (renderer,

--- a/src/main/pty/spawn/pty-spawn.ts
+++ b/src/main/pty/spawn/pty-spawn.ts
@@ -96,8 +96,9 @@ export function resolveShellArgs(shell: string): ShellInvocation {
  */
 
 /**
- * The one `CLAUDE_CODE_*` key that survives the strip, and its Windows
- * default. Unlike the identity markers above, this is a renderer tuning flag:
+ * The first of the two `CLAUDE_CODE_*` keys that survive the strip (the
+ * keeplist is KEEPLISTED_CLAUDE_CODE_KEYS below), and its Windows default.
+ * Unlike the identity markers above, this is a renderer tuning flag:
  * it cannot re-parent a child session. Claude Code's fullscreen TUI
  * intermittently omits history entries from its incremental scrolled-view
  * updates (deep scroll up, ride back down: entries vanish with the layout
@@ -109,10 +110,30 @@ export function resolveShellArgs(shell: string): ShellInvocation {
  * user's opt-out) always wins, and non-Claude agents ignore the var, the
  * same argument the strip itself relies on. PARTIAL mitigation: it removes
  * the dominant closed-up flavor, while the rarer blank-band flavor (a
- * window-assembly defect upstream) persists. Unwind this default once the
- * upstream issue is fixed.
+ * window-assembly defect upstream) persists.
+ * UNWIND(claude-code#83714): drop this default once the upstream issue is
+ * fixed.
  */
 export const FULL_REPAINT_ENV_KEY = 'CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT';
+
+/**
+ * The second keeplisted renderer tuning flag - keeplisted so a user's
+ * exported value survives the strip, but deliberately NOT defaulted. A
+ * default of 3 (vim's, per the fullscreen docs) was shipped and reverted the
+ * same day: the fullscreen TUI's differential renderer intermittently
+ * mis-assembles frames on large scrolled jumps, pipe reads coalesce rapid
+ * wheel reports into one jump, and a 3x multiplier tripled every such jump
+ * past the corruption threshold (dogfooded; single 3-line jumps rendered
+ * clean under controlled injection, coalesced multiples spliced rows). The
+ * CLI default of 1 matches the native terminals verified clean. Non-Claude
+ * agents ignore the var, the same argument the strip itself relies on.
+ */
+export const SCROLL_SPEED_ENV_KEY = 'CLAUDE_CODE_SCROLL_SPEED';
+
+const KEEPLISTED_CLAUDE_CODE_KEYS: ReadonlySet<string> = new Set([
+  FULL_REPAINT_ENV_KEY,
+  SCROLL_SPEED_ENV_KEY,
+]);
 
 export function buildSpawnEnv(
   inputEnv: Record<string, string> | undefined,
@@ -126,7 +147,7 @@ export function buildSpawnEnv(
   const result: Record<string, string> = {};
   for (const [key, value] of Object.entries(merged)) {
     if (value === undefined) continue;
-    if (key === 'CLAUDECODE' || (key.startsWith('CLAUDE_CODE_') && key !== FULL_REPAINT_ENV_KEY)) continue;
+    if (key === 'CLAUDECODE' || (key.startsWith('CLAUDE_CODE_') && !KEEPLISTED_CLAUDE_CODE_KEYS.has(key))) continue;
     if (key === 'NO_COLOR' && stripNoColor) continue;
     result[key] = value;
   }

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -17,7 +17,7 @@ import {
   registerDevtoolsTerminal,
   traceTerminalRenderer,
 } from '../utils/terminal-grid-registry';
-import { createRepaintNudge, isUserInputData, type RepaintNudgeController } from '../utils/repaint-nudge';
+import { createRepaintNudge, isUserInputData, isMouseReport, type RepaintNudgeController } from '../utils/repaint-nudge';
 import { registerMountedTerminal } from '../utils/terminal-mount-registry';
 import { registerTerminalAnchor } from '../utils/terminal-anchor-registry';
 import type { PtyResizeOrigin, TerminalColorOverrides } from '../../shared/types';
@@ -920,14 +920,28 @@ export function useTerminal(options: UseTerminalOptions) {
     // Send user input to PTY (via the microtask-batched queue above).
     if (options.sessionId) {
       terminal.onData((data) => {
-        // Arms the post-interaction repaint nudge. Any REAL input counts, not
-        // just a wheel event: the confirmed repro of the missing-rows family is
-        // a KEYBOARD jump (Ctrl+End / Ctrl+Home), so a wheel-only trigger would
-        // miss it entirely. But `onData` also carries xterm's own focus and
+        // Arms the repaint nudge. Any REAL input counts:
+        // wheel-scroll-then-stop is the primary real-world repro of the
+        // missing-rows family, and the keyboard jump (Ctrl+End / Ctrl+Home) is
+        // the secondary one, so neither a wheel-only nor a keys-only trigger
+        // would cover it. But `onData` also carries xterm's own focus and
         // mouse-motion reports, which are not input at all and would otherwise
         // self-arm the nudge on every replay - see isUserInputData.
         if (isUserInputData(data)) repaintNudgeRef.current?.noteInput();
-        batcher.schedule(data);
+        // UNWIND(claude-code#83714): revert to plain batcher.schedule(data)
+        // for all input when upstream fixes the fullscreen renderer.
+        // A mouse report must reach the TUI as its OWN small jump. Joined
+        // into one chunk (or read-coalesced from a fast burst - a pipe keeps
+        // no message boundaries), a run of reports becomes one multi-line
+        // jump whose differential frame intermittently splices stale rows
+        // (the missing-entries family). So reports are PACED, not just
+        // unbatched: one write per MOUSE_REPORT_PACE_MS restores the
+        // physical-wheel cadence a native terminal delivers. The jump each
+        // single report produces is CLAUDE_CODE_SCROLL_SPEED's territory, not
+        // this path's - see write-batcher.ts for the schemes tried and
+        // rejected. Ordering against typed bytes holds.
+        if (isMouseReport(data)) batcher.writePaced(data);
+        else batcher.schedule(data);
       });
 
       // Debounced PTY resize -- coalesces rapid dimension changes so the
@@ -1153,6 +1167,8 @@ export function useTerminal(options: UseTerminalOptions) {
     // Post-interaction repaint nudge (see repaint-nudge.ts). Created alongside
     // the queue so it shares the session's lifetime, and reached from the input
     // side through a ref because that hook lives in initTerminal.
+    // UNWIND(claude-code#83714): delete this block and the onData noteInput
+    // arm when upstream fixes the fullscreen renderer.
     const repaintNudge = createRepaintNudge({
       readGate: () => {
         const terminal = xtermRef.current;

--- a/src/renderer/utils/repaint-nudge.ts
+++ b/src/renderer/utils/repaint-nudge.ts
@@ -33,6 +33,10 @@
  * The before/after grid comparison is REPORTING ONLY. It never gates the nudge.
  * That is what keeps this threshold-free while still producing a real-world
  * defect rate, which is the evidence an upstream report needs.
+ *
+ * UNWIND(claude-code#83714): this entire module is a workaround for that
+ * upstream renderer defect. When upstream fixes it, delete the module along
+ * with its useTerminal wiring and tests.
  */
 
 /** FocusOut then FocusIn. Costs the TUI one render and moves no cursor. */
@@ -65,7 +69,11 @@ export const REPAINT_NUDGE_BYTES = '\x1b[O\x1b[I';
  */
 const FOCUS_REPORT_PATTERN = /^\x1b\[[IO]$/;
 const SGR_MOUSE_REPORT_PATTERN = /^\x1b\[<(\d+);\d+;\d+[Mm]$/;
-const X10_MOUSE_REPORT_PATTERN = /^\x1b\[M([\s\S])/;
+/** A complete X10 report is CSI M plus exactly three bytes (button, x, y).
+ *  Anchored at both ends like the SGR pattern above: a payload that only
+ *  STARTS with a report (trailing bytes, two reports joined) must not
+ *  classify as one. */
+const X10_MOUSE_REPORT_PATTERN = /^\x1b\[M([\s\S])[\s\S]{2}$/;
 /** Bit 5 of a mouse report's button byte marks motion (drift or drag). */
 const MOUSE_MOTION_BIT = 32;
 
@@ -84,6 +92,21 @@ export function isUserInputData(data: string): boolean {
   if (x10Report) return ((x10Report[1].charCodeAt(0) - 32) & MOUSE_MOTION_BIT) === 0;
 
   return true;
+}
+
+/**
+ * True when `data` is a single mouse report (SGR or X10), motion and wheel
+ * included. Used by the input path to give each report its OWN paced PTY
+ * write (write-batcher.ts): a fullscreen TUI processes a chunk as one input
+ * batch, so a burst of wheel reports coalesced into one write becomes one
+ * multi-line jump, and the TUI's differential frame for that jump
+ * intermittently mis-assembles (verified by controlled injection: spaced
+ * reports render clean, the same reports in one chunk splice stale rows).
+ * Unlike isUserInputData above - an arming policy about intent - this is
+ * about encoding, so motion counts too.
+ */
+export function isMouseReport(data: string): boolean {
+  return SGR_MOUSE_REPORT_PATTERN.test(data) || X10_MOUSE_REPORT_PATTERN.test(data);
 }
 
 /**

--- a/src/renderer/utils/write-batcher.ts
+++ b/src/renderer/utils/write-batcher.ts
@@ -4,34 +4,134 @@
  *  onData calls (e.g. from programmatic terminal.paste(), key-repeat,
  *  or the clipboard callback) into one IPC write. PTY byte order is
  *  preserved across sequential pty.write calls, so concatenating the
- *  burst into a single payload is safe.
+ *  burst into a single payload is BYTE-safe - but not always
+ *  SEMANTICS-safe: some consumers treat chunk boundaries as event
+ *  boundaries. Claude Code's fullscreen TUI processes a chunk as one
+ *  input batch, so N coalesced wheel reports become one N-line jump,
+ *  whose differential frame intermittently mis-assembles (verified by
+ *  controlled injection, 2026-08-23: ten spaced reports produced ten
+ *  clean frames; the same ten in one chunk produced a spliced frame).
+ *  Hence `writePaced`: mouse reports drain from the ordered queue at
+ *  a per-report floor (MOUSE_REPORT_PACE_MS), restoring the
+ *  physical-wheel cadence a native terminal delivers.
+ *
+ *  Two stronger schemes were tried and rejected on dogfooding
+ *  evidence, in this order - do not resurrect them without new data:
+ *  ack-clocking each report to the TUI's answer caps scrolling at the
+ *  TUI's OWN frame clock (~10Hz when idle - felt like 10fps), and no
+ *  input-side scheme can shrink the jump a single report produces;
+ *  that is CLAUDE_CODE_SCROLL_SPEED's job (the CLI default of 1
+ *  matches the native terminals verified clean).
+ *
+ *  UNWIND(claude-code#83714): writePaced and the isMouseReport routing
+ *  exist because the fullscreen renderer mis-assembles multi-line-jump
+ *  frames. When upstream fixes that, revert mouse reports to plain
+ *  schedule() and delete writePaced.
  */
 export interface WriteBatcher {
   /** Push data into the queue and schedule a microtask flush if not already scheduled. */
   schedule: (data: string) => void;
-  /** Flush any pending data synchronously. Safe to call when queue is empty. */
+  /** Drain synchronously: batched items are written (joined), pending PACED
+   *  items are DROPPED - they are scroll intents for a view being torn down,
+   *  and writing them joined would recreate the exact coalesced chunk the
+   *  paced path exists to prevent. Safe to call when the queue is empty. */
   flush: () => void;
+  /** Queue `data` to be written as its OWN payload, at most one paced write
+   *  per paceMs. Ordering against `schedule` data always holds: items drain
+   *  strictly in arrival order, whichever path they came in through. A call
+   *  drains synchronously, so batched bytes already queued flush immediately
+   *  rather than waiting for their microtask. */
+  writePaced: (data: string) => void;
 }
 
-export function createWriteBatcher(write: (payload: string) => void): WriteBatcher {
-  const queue: string[] = [];
-  let scheduled = false;
+/** One frame at 60Hz: long enough that the TUI's read loop usually catches
+ *  each report individually, short enough that a flick's worth of reports
+ *  still lands within a couple hundred milliseconds. */
+const MOUSE_REPORT_PACE_MS = 16;
 
-  const flush = () => {
-    scheduled = false;
-    if (queue.length === 0) return;
-    const payload = queue.length === 1 ? queue[0] : queue.join('');
-    queue.length = 0;
-    write(payload);
-  };
+interface QueueItem {
+  data: string;
+  paced: boolean;
+}
 
-  const schedule = (data: string) => {
-    queue.push(data);
-    if (!scheduled) {
-      scheduled = true;
-      queueMicrotask(flush);
+export function createWriteBatcher(
+  write: (payload: string) => void,
+  paceMs: number = MOUSE_REPORT_PACE_MS,
+): WriteBatcher {
+  const queue: QueueItem[] = [];
+  let microtaskScheduled = false;
+  let paceTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastPacedWriteAt = Number.NEGATIVE_INFINITY;
+
+  const drain = (): void => {
+    while (queue.length > 0) {
+      const head = queue[0];
+      if (!head.paced) {
+        // A contiguous run of batchable items keeps the original
+        // one-write-per-burst behavior. Removed with one splice: a per-item
+        // shift() would reindex the whole remainder once per item.
+        let runLength = 0;
+        while (runLength < queue.length && !queue[runLength].paced) runLength += 1;
+        const run = queue.splice(0, runLength);
+        write(run.length === 1 ? run[0].data : run.map((item) => item.data).join(''));
+        continue;
+      }
+      // Clamped so a backward wall-clock jump (NTP, sleep/resume skew) can
+      // never inflate the wait past one pace interval and stall the queue.
+      const wait = Math.min(lastPacedWriteAt + paceMs - Date.now(), paceMs);
+      if (wait > 0) {
+        if (paceTimer === null) {
+          paceTimer = setTimeout(() => {
+            paceTimer = null;
+            drain();
+          }, wait);
+        }
+        return;
+      }
+      if (paceTimer !== null) {
+        // A writePaced call can reach here before a due timer's callback has
+        // run and consume the very head that timer was scheduled for; clear
+        // it so timer bookkeeping stays symmetric with consumption.
+        clearTimeout(paceTimer);
+        paceTimer = null;
+      }
+      lastPacedWriteAt = Date.now();
+      queue.shift();
+      write(head.data);
     }
   };
 
-  return { schedule, flush };
+  const schedule = (data: string): void => {
+    queue.push({ data, paced: false });
+    if (!microtaskScheduled) {
+      microtaskScheduled = true;
+      queueMicrotask(() => {
+        microtaskScheduled = false;
+        drain();
+      });
+    }
+  };
+
+  const writePaced = (data: string): void => {
+    queue.push({ data, paced: true });
+    drain();
+  };
+
+  const flush = (): void => {
+    // microtaskScheduled is deliberately left set: the still-pending
+    // microtask resets it itself and then drains an already-empty queue,
+    // so clearing it here would be redundant, not a leak fix.
+    if (paceTimer !== null) {
+      clearTimeout(paceTimer);
+      paceTimer = null;
+    }
+    const kept: string[] = [];
+    for (const item of queue) {
+      if (!item.paced) kept.push(item.data);
+    }
+    queue.length = 0;
+    if (kept.length > 0) write(kept.length === 1 ? kept[0] : kept.join(''));
+  };
+
+  return { schedule, flush, writePaced };
 }

--- a/tests/unit/pty-spawn.test.ts
+++ b/tests/unit/pty-spawn.test.ts
@@ -13,6 +13,7 @@ import {
   resolveSpawnCwd,
   diagnoseSpawnFailure,
   FULL_REPAINT_ENV_KEY,
+  SCROLL_SPEED_ENV_KEY,
 } from '../../src/main/pty/spawn/pty-spawn';
 
 describe('resolveShellArgs', () => {
@@ -152,6 +153,50 @@ describe('buildSpawnEnv full-repaint keeplist', () => {
       'linux',
     );
     expect(env[FULL_REPAINT_ENV_KEY]).toBe('1');
+    expect(env.CLAUDECODE).toBeUndefined();
+    expect(env.CLAUDE_CODE_SESSION_ID).toBeUndefined();
+  });
+});
+
+// CLAUDE_CODE_SCROLL_SPEED is keeplisted (a user's exported tuning survives
+// the identity-marker strip) but deliberately NOT defaulted: a default of 3
+// was shipped and reverted the same day, because the fullscreen TUI's
+// differential renderer mis-assembles frames on large scrolled jumps and the
+// 3x multiplier tripled every coalesced-read jump past that threshold. The
+// CLI default of 1 matches the native terminals verified clean. These pin the
+// no-default decision and the keeplist survival.
+describe('buildSpawnEnv scroll-speed keeplist', () => {
+  let savedHostValue: string | undefined;
+
+  beforeEach(() => {
+    // Hermetic: a dogfooding machine may legitimately export the key globally.
+    savedHostValue = process.env[SCROLL_SPEED_ENV_KEY];
+    delete process.env[SCROLL_SPEED_ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (savedHostValue === undefined) delete process.env[SCROLL_SPEED_ENV_KEY];
+    else process.env[SCROLL_SPEED_ENV_KEY] = savedHostValue;
+  });
+
+  it.each(['win32', 'linux', 'darwin'] as const)(
+    'applies NO default on %s - the CLI default of 1 is the clean-scroll regime',
+    (platform) => {
+      const env = buildSpawnEnv({}, platform);
+      expect(env[SCROLL_SPEED_ENV_KEY]).toBeUndefined();
+    },
+  );
+
+  it('keeplists an explicit user value through the strip while identity markers still drop', () => {
+    const env = buildSpawnEnv(
+      {
+        [SCROLL_SPEED_ENV_KEY]: '5',
+        CLAUDECODE: '1',
+        CLAUDE_CODE_SESSION_ID: 'parent-session-uuid',
+      },
+      'linux',
+    );
+    expect(env[SCROLL_SPEED_ENV_KEY]).toBe('5');
     expect(env.CLAUDECODE).toBeUndefined();
     expect(env.CLAUDE_CODE_SESSION_ID).toBeUndefined();
   });

--- a/tests/unit/repaint-nudge.test.ts
+++ b/tests/unit/repaint-nudge.test.ts
@@ -17,6 +17,7 @@ import {
   shouldSendRepaintNudge,
   diffViewportRows,
   isUserInputData,
+  isMouseReport,
   REPAINT_NUDGE_BYTES,
   type RepaintNudgeGate,
 } from '../../src/renderer/utils/repaint-nudge';
@@ -140,6 +141,45 @@ describe('isUserInputData', () => {
     ['Page Up', '\x1b[5~', true],
   ])('%s', (_label, data, expected) => {
     expect(isUserInputData(data as string)).toBe(expected as boolean);
+  });
+});
+
+describe('isMouseReport', () => {
+  // The input path routes every mouse report through the write batcher's paced
+  // path so each one reaches the PTY as its own chunk - coalesced reports
+  // become one multi-line jump whose differential frame intermittently
+  // mis-assembles upstream. Motion and wheel are deliberately INCLUDED here
+  // (unlike isUserInputData, which is an arming policy): chunk isolation is
+  // about encoding, not intent. And ONLY a single complete report classifies:
+  // a payload that merely starts with one (trailing bytes, two reports
+  // joined) would ride the paced path as one unsplit chunk, recreating the
+  // exact coalesced jump writePaced exists to prevent.
+  const x10MotionReportBytes = String.fromCharCode(32 + 35, 40, 40);
+  const x10ClickReportBytes = String.fromCharCode(32 + 0, 40, 40);
+
+  it.each([
+    ['SGR wheel up', '\x1b[<64;10;5M', true],
+    ['SGR wheel down', '\x1b[<65;10;5M', true],
+    ['SGR click press', '\x1b[<0;10;5M', true],
+    ['SGR click release (lowercase m)', '\x1b[<0;10;5m', true],
+    ['SGR motion', '\x1b[<35;10;5M', true],
+    ['X10 mouse motion', '\x1b[M' + x10MotionReportBytes, true],
+    ['X10 mouse click', '\x1b[M' + x10ClickReportBytes, true],
+    ['an SGR report with trailing bytes', '\x1b[<64;10;5Mhello', false],
+    ['an X10 report with trailing bytes', '\x1b[M' + x10MotionReportBytes + 'hello', false],
+    ['two SGR reports joined into one chunk', '\x1b[<64;10;5M\x1b[<65;10;5M', false],
+    [
+      'two X10 reports joined into one chunk',
+      '\x1b[M' + x10MotionReportBytes + '\x1b[M' + x10MotionReportBytes,
+      false,
+    ],
+    ['a FocusIn report (not a mouse report)', '\x1b[I', false],
+    ['an ordinary typed character', 'a', false],
+    ['a carriage return', '\r', false],
+    ['an arrow-key sequence', '\x1b[A', false],
+    ['a multi-character paste', 'hello world', false],
+  ])('%s', (_label, data, expected) => {
+    expect(isMouseReport(data as string)).toBe(expected as boolean);
   });
 });
 

--- a/tests/unit/repaint-nudge.test.ts
+++ b/tests/unit/repaint-nudge.test.ts
@@ -119,6 +119,18 @@ describe('isUserInputData', () => {
     ['SGR wheel down, buttonByte=65 (no motion bit)', '\x1b[<65;10;5M', true],
     ['X10 mouse motion', '\x1b[M' + x10MotionByte, false],
     ['X10 mouse click', '\x1b[M' + x10ClickByte, true],
+    // X10_MOUSE_REPORT_PATTERN is anchored at both ends (this diff), matching
+    // SGR_MOUSE_REPORT_PATTERN's pre-existing anchoring. A payload this
+    // predicate cannot resolve to one clean report - trailing bytes, or two
+    // reports joined by a coalesced onData burst - falls through to `true`
+    // the same way an unparseable SGR payload already does: conservatively
+    // treat it as real input rather than risk silently swallowing a genuine
+    // keystroke riding alongside the reports. Pinned here so a future change
+    // to the shared pattern cannot silently flip this fallback without a
+    // failing test - `isMouseReport`'s own tests only prove these payloads
+    // are NOT a single clean report, not what isUserInputData does with them.
+    ['an X10 report with trailing bytes - falls through to true (unparseable as one report)', '\x1b[M' + x10MotionByte + 'hello', true],
+    ['two X10 reports joined into one chunk - same fallback as above', '\x1b[M' + x10MotionByte + '\x1b[M' + x10MotionByte, true],
     ['an ordinary typed character', 'a', true],
     ['a carriage return (Enter)', '\r', true],
     ['Ctrl+C', '\x03', true],

--- a/tests/unit/write-batcher.test.ts
+++ b/tests/unit/write-batcher.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
 import { createWriteBatcher } from '../../src/renderer/utils/write-batcher';
+import { isMouseReport } from '../../src/renderer/utils/repaint-nudge';
 
 /** Wait for all pending microtasks to drain. */
 const drainMicrotasks = () => new Promise<void>((resolve) => queueMicrotask(resolve));
@@ -98,5 +101,236 @@ describe('createWriteBatcher', () => {
     await drainMicrotasks();
 
     expect(write).toHaveBeenCalledWith('first\r\nsecond\r\nthird');
+  });
+
+  // writePaced exists because chunk boundaries are event boundaries to a
+  // fullscreen TUI, and a pipe preserves neither: coalesced or read-coalesced
+  // wheel reports become one multi-line jump whose differential frame
+  // intermittently mis-assembles. Each report must be its own write AND the
+  // writes must be paced to a physical-wheel cadence, in arrival order with
+  // everything else. (Ack-clocking to the consumer's answers was tried and
+  // reverted: it capped scrolling at the TUI's own ~10Hz idle frame clock.)
+  describe('writePaced', () => {
+    const PACE_MS = 16;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('writes the first report immediately as its own payload', () => {
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS);
+
+      batcher.writePaced('\x1b[<64;10;5M');
+      expect(write).toHaveBeenCalledTimes(1);
+      expect(write).toHaveBeenCalledWith('\x1b[<64;10;5M');
+    });
+
+    it('a synchronous burst drains one report per pace interval, never joined', () => {
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS);
+
+      batcher.writePaced('r1');
+      batcher.writePaced('r2');
+      batcher.writePaced('r3');
+      expect(write.mock.calls).toEqual([['r1']]);
+
+      vi.advanceTimersByTime(PACE_MS);
+      expect(write.mock.calls).toEqual([['r1'], ['r2']]);
+
+      vi.advanceTimersByTime(PACE_MS);
+      expect(write.mock.calls).toEqual([['r1'], ['r2'], ['r3']]);
+    });
+
+    it('reports arriving slower than the pace write immediately', () => {
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS);
+
+      batcher.writePaced('r1');
+      vi.advanceTimersByTime(PACE_MS * 2);
+      batcher.writePaced('r2');
+
+      expect(write.mock.calls).toEqual([['r1'], ['r2']]);
+    });
+
+    it('typed bytes already queued drain before a paced report (arrival order holds)', async () => {
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS);
+
+      batcher.schedule('typed');
+      batcher.writePaced('\x1b[<64;10;5M');
+
+      expect(write.mock.calls).toEqual([['typed'], ['\x1b[<64;10;5M']]);
+
+      // schedule('typed') left a microtask queued that these synchronous
+      // assertions never let fire (fake timers do not fake microtasks).
+      // Draining it for real is a double-write guard: it proves the pending
+      // microtask finds an already-empty queue rather than re-writing 'typed'.
+      await drainMicrotasks();
+      expect(write.mock.calls).toEqual([['typed'], ['\x1b[<64;10;5M']]);
+    });
+
+    it('typed bytes arriving during a paced wait stay ordered behind the pending report', () => {
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS);
+
+      batcher.writePaced('r1');
+      batcher.writePaced('r2');
+      batcher.schedule('a');
+      expect(write.mock.calls).toEqual([['r1']]);
+
+      vi.advanceTimersByTime(PACE_MS);
+      expect(write.mock.calls).toEqual([['r1'], ['r2'], ['a']]);
+    });
+
+    it('a writePaced/schedule/writePaced interleave keeps strict arrival order', () => {
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS);
+
+      batcher.writePaced('r1');
+      batcher.schedule('a');
+      batcher.writePaced('r2');
+
+      // r1 writes immediately (nothing paced ahead of it). writePaced('r2')
+      // drains synchronously, which flushes the already-queued batched 'a'
+      // first - r2 itself is still under the pace floor r1 set, so it stays
+      // queued rather than writing here too.
+      expect(write.mock.calls).toEqual([['r1'], ['a']]);
+
+      vi.advanceTimersByTime(PACE_MS);
+      expect(write.mock.calls).toEqual([['r1'], ['a'], ['r2']]);
+    });
+
+    it('flush drops pending paced reports but keeps batched bytes', async () => {
+      // Pending reports at teardown are scroll intents for a dying view, and
+      // writing them joined would recreate the exact coalesced chunk this
+      // path exists to prevent.
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS);
+
+      batcher.writePaced('r1');
+      batcher.writePaced('r2');
+      batcher.schedule('typed');
+      batcher.flush();
+
+      expect(write.mock.calls).toEqual([['r1'], ['typed']]);
+
+      vi.advanceTimersByTime(PACE_MS * 4);
+      expect(write.mock.calls).toEqual([['r1'], ['typed']]);
+
+      // schedule('typed') queued a microtask before flush() ran. Draining it
+      // for real is a double-write guard: it proves flush() already emptied
+      // the queue, rather than leaving 'typed' to be re-written once the
+      // microtask fires.
+      await drainMicrotasks();
+      expect(write.mock.calls).toEqual([['r1'], ['typed']]);
+    });
+  });
+
+  // Nothing today fails if useTerminal.ts's onData routing line is deleted or
+  // inverted: repaint-nudge.test.ts only pins isMouseReport's return value in
+  // isolation, and every test above only drives writePaced/schedule directly.
+  // This block closes that gap in two halves, the same split as
+  // repaint-nudge.test.ts's 'isUserInputData wired into createRepaintNudge':
+  // a tripwire that pins the SOURCE TEXT of the routing line (a copy of the
+  // expression living only in this test file cannot detect a change to the
+  // real one), and a harness that reproduces that same expression against a
+  // real createWriteBatcher to pin its SEMANTICS. Neither half alone is the
+  // pin - the tripwire cannot see a wiring bug in the expression it does not
+  // parse, and the harness's own copy of the expression cannot see a change
+  // to the source.
+  describe('isMouseReport routing wired into createWriteBatcher (useTerminal.ts onData)', () => {
+    it('useTerminal.ts onData routes isMouseReport(data) to writePaced and everything else to schedule', () => {
+      const useTerminalPath = path.resolve(__dirname, '../../src/renderer/hooks/useTerminal.ts');
+      const source = fs.readFileSync(useTerminalPath, 'utf-8');
+
+      // Two independent regexes rather than one exact literal, so this survives
+      // a benign reformat (e.g. the single-statement if/else growing braces)
+      // without going soft on the thing that actually matters: which branch
+      // each call sits in. Each still requires the literal call to sit right
+      // after its guard, so a deletion or an inversion of the routing fails
+      // both - there is no other isMouseReport(data)/batcher.schedule(data)
+      // pairing anywhere else in this file for either to accidentally match.
+      const mouseReportRoutesToWritePaced =
+        /if\s*\(\s*isMouseReport\(data\)\s*\)\s*\{?\s*batcher\.writePaced\(data\)/;
+      const elseRoutesToSchedule = /else\s*\{?\s*batcher\.schedule\(data\)/;
+
+      expect(source).toMatch(mouseReportRoutesToWritePaced);
+      expect(source).toMatch(elseRoutesToSchedule);
+    });
+
+    describe('routing semantics against a real batcher', () => {
+      const PACE_MS = 16;
+
+      beforeEach(() => {
+        vi.useFakeTimers();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      // Reproduces the routing expression pinned by the tripwire above, so
+      // the assertions below are checking what that exact expression DOES,
+      // not just that its text is present.
+      const routeOnData = (batcher: ReturnType<typeof createWriteBatcher>, data: string): void => {
+        if (isMouseReport(data)) batcher.writePaced(data);
+        else batcher.schedule(data);
+      };
+
+      it('routes a single SGR wheel report through writePaced: written synchronously, un-joined', () => {
+        const write = vi.fn<[string], void>();
+        const batcher = createWriteBatcher(write, PACE_MS);
+
+        routeOnData(batcher, '\x1b[<64;10;5M');
+
+        // writePaced drains synchronously; schedule would need a microtask.
+        // Asserting before any await is what would catch an inversion (mouse
+        // report routed to schedule instead): that variant leaves write
+        // uncalled at this point.
+        expect(write).toHaveBeenCalledTimes(1);
+        expect(write).toHaveBeenCalledWith('\x1b[<64;10;5M');
+      });
+
+      it('routes typed bytes through schedule: not written until the microtask drains', async () => {
+        const write = vi.fn<[string], void>();
+        const batcher = createWriteBatcher(write, PACE_MS);
+
+        routeOnData(batcher, 'a');
+
+        // schedule() never writes synchronously. If routing were inverted
+        // (typed bytes -> writePaced), write would already have been called
+        // by this point.
+        expect(write).not.toHaveBeenCalled();
+
+        await drainMicrotasks();
+
+        expect(write).toHaveBeenCalledTimes(1);
+        expect(write).toHaveBeenCalledWith('a');
+      });
+
+      it('an SGR report and a typed byte in the same burst land as two separate writes, in arrival order', async () => {
+        const write = vi.fn<[string], void>();
+        const batcher = createWriteBatcher(write, PACE_MS);
+
+        routeOnData(batcher, '\x1b[<64;10;5M');
+        routeOnData(batcher, 'a');
+
+        // The mouse report drains synchronously (writePaced); the typed byte
+        // is still sitting in schedule's microtask queue. An inverted routing
+        // (mouse report -> schedule) would leave write uncalled here instead.
+        expect(write.mock.calls).toEqual([['\x1b[<64;10;5M']]);
+
+        await drainMicrotasks();
+
+        // And it must never have joined into one payload - that would mean
+        // the report went through schedule too.
+        expect(write.mock.calls).toEqual([['\x1b[<64;10;5M'], ['a']]);
+      });
+    });
   });
 });

--- a/tests/unit/write-batcher.test.ts
+++ b/tests/unit/write-batcher.test.ts
@@ -229,6 +229,61 @@ describe('createWriteBatcher', () => {
       await drainMicrotasks();
       expect(write.mock.calls).toEqual([['r1'], ['typed']]);
     });
+
+    it('clamps the pace wait against a backward wall-clock jump (NTP, sleep/resume skew)', () => {
+      // Without the `Math.min(..., paceMs)` clamp, `lastPacedWriteAt + paceMs
+      // - Date.now()` can come out far larger than paceMs once the clock has
+      // jumped backward, scheduling one long stall instead of the intended
+      // per-report floor.
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS);
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+      batcher.writePaced('r1'); // writes immediately; sets lastPacedWriteAt
+      const baseTime = Date.now();
+
+      // Simulate an NTP-style correction: the wall clock jumps backward by
+      // many pace intervals' worth of time.
+      vi.setSystemTime(baseTime - PACE_MS * 20);
+
+      batcher.writePaced('r2');
+
+      const scheduledDelay = setTimeoutSpy.mock.calls.at(-1)?.[1];
+      expect(scheduledDelay).toBe(PACE_MS);
+    });
+
+    it('a synchronous drain that finds an already-due paced head clears the still-pending timer instead of leaving it stale', () => {
+      // The head's own paceTimer is scheduled by the first writePaced('r2')
+      // call below. A second, independent writePaced call can reach drain()
+      // synchronously once real elapsed time has already cleared that head's
+      // deadline but before the timer's OWN callback has run - the timer
+      // bookkeeping must clear the stale reference right there, not leave it
+      // dangling once the head it was scheduled for has already been consumed.
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS);
+      const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+      batcher.writePaced('r1'); // writes immediately, no timer touched
+      batcher.writePaced('r2'); // under the pace floor: schedules a paceTimer
+      expect(clearTimeoutSpy).not.toHaveBeenCalled();
+
+      // The wall clock reaches r2's deadline without that scheduled timer's
+      // own callback having run yet.
+      vi.setSystemTime(Date.now() + PACE_MS);
+
+      // This call reaches drain() synchronously and finds r2 already due.
+      batcher.writePaced('r3');
+
+      // r2 wrote through this synchronous path, not the (now-stale) timer's
+      // own callback, and the stale reference was cleared exactly once.
+      expect(write.mock.calls).toEqual([['r1'], ['r2']]);
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+
+      // r3 still gets its own fresh pace-floor timer - the clear did not also
+      // skip scheduling the next one.
+      vi.advanceTimersByTime(PACE_MS);
+      expect(write.mock.calls).toEqual([['r1'], ['r2'], ['r3']]);
+    });
   });
 
   // Nothing today fails if useTerminal.ts's onData routing line is deleted or


### PR DESCRIPTION
## What

Two terminal-input fixes, with the tests and docs that pin them:

- `write-batcher.ts`: mouse reports are no longer joined into microtask batches. They drain
  through a new `writePaced` path, one write per 16ms floor, strictly ordered with typed bytes,
  with pending reports dropped at teardown. `useTerminal` routes every report (`isMouseReport`,
  exported from `repaint-nudge.ts`) through it.
- `pty-spawn.ts`: `buildSpawnEnv`'s `CLAUDE_CODE_*` strip keeplists `CLAUDE_CODE_SCROLL_SPEED`
  (alongside the existing full-repaint flag) so a user's exported tuning survives. Deliberately
  no default value.

## Why

Claude Code's fullscreen TUI processes an input chunk as one batch: wheel reports coalesced into
one write become one multi-line jump, and the TUI's differential frame for a multi-line jump
intermittently splices stale rows (the missing-entries family, claude-code#83714). Verified by
controlled injection against an idle session: ten spaced reports rendered ten clean frames
(~29KB); the same ten in one chunk rendered a single ~2.3KB frame with a spliced row. The
batcher was therefore manufacturing a corruption trigger native terminals never produce.

The keeplist closes the mirror-image footgun: without it, the identity-marker strip silently
deletes a user's own scroll-speed export from every spawned agent. A default of 3 was shipped
and reverted the same day (its JSDoc records why): it tripled every scroll jump past the
renderer's mis-assembly threshold.

The defect itself is upstream, reproduced natively in PowerShell by wheel-scrolling deep into a
large resumed session; every host-side workaround site carries an `UNWIND(claude-code#83714)`
marker so the sweep is a grep once upstream fixes the renderer.

## How

One ordered queue with two item kinds inside the existing batcher: batch items keep the original
one-write-per-burst join; paced items release at a 16ms floor with timer bookkeeping hardened
against wall-clock jumps. `flush()` (teardown) writes batch items and drops paced ones, since
writing stale scroll intents joined would recreate the exact chunk shape the path exists to
prevent. Trade-offs considered and rejected are documented in the module header (ack-clocking
capped scrolling at the TUI's own frame clock; jump size per report belongs to
`CLAUDE_CODE_SCROLL_SPEED`).

## Breaking changes

None.

## Tests

- `tests/unit/write-batcher.test.ts`: pacing cadence, arrival-order across the two paths,
  teardown drop semantics, timer bookkeeping.
- `tests/unit/repaint-nudge.test.ts`: `isMouseReport` classification (SGR, X10, motion, wheel,
  negatives).
- `tests/unit/pty-spawn.test.ts`: no-default on every platform, keeplist survival through the
  strip.
- CI: typecheck, lint, unit, UI shards, Linux Electron E2E shards.

Generated with [Claude Code](https://claude.com/claude-code)
