### PR TITLE
fix(terminal): bound the paced wheel-report queue with a lane cap and reversal supersede

### DIFF
--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -911,7 +911,15 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   frame. So `useTerminal` routes every mouse report (`isMouseReport`) through `writePaced`: an
   ordered queue that writes each report as its own payload at a 16ms-per-report floor, restoring
   the physical-wheel cadence a native terminal delivers; typed bytes keep arrival order across
-  the two paths, and teardown drops pending reports rather than writing them joined.
+  the two paths, and teardown drops pending reports rather than writing them joined. The paced
+  queue is bounded as well as paced: wheel reports carry a direction lane (`mouseWheelLane`),
+  pending same-lane depth is capped at 8 so a high-resolution flick's post-stop tail is bounded
+  near 128ms instead of scaling with wheel resolution, and a same-axis, same-modifier reversal
+  drops the pending opposite-direction reports as stale intent (the same philosophy as
+  teardown); clicks, releases, and motion are laneless, never capped or superseded (teardown
+  still drops them like any pending report). The 16ms floor itself stays
+  deliberately: the cap changes how many writes queue, not the per-write cadence the TUI's read
+  loop needs to catch each report individually.
   (Ack-clocking each report to the TUI's answer was tried and reverted: the TUI coalesces
   repaints onto its own frame clock, so input-clocking capped scrolling at ~10Hz.) The jump a
   coalesced read still produces is bounded by keeping `CLAUDE_CODE_SCROLL_SPEED` at the CLI

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -17,7 +17,7 @@ import {
   registerDevtoolsTerminal,
   traceTerminalRenderer,
 } from '../utils/terminal-grid-registry';
-import { createRepaintNudge, isUserInputData, isMouseReport, type RepaintNudgeController } from '../utils/repaint-nudge';
+import { createRepaintNudge, isUserInputData, isMouseReport, mouseWheelLane, type RepaintNudgeController } from '../utils/repaint-nudge';
 import { registerMountedTerminal } from '../utils/terminal-mount-registry';
 import { registerTerminalAnchor } from '../utils/terminal-anchor-registry';
 import type { PtyResizeOrigin, TerminalColorOverrides } from '../../shared/types';
@@ -950,15 +950,22 @@ export function useTerminal(options: UseTerminalOptions) {
         // jump whose differential frame intermittently splices stale rows
         // (the missing-entries family). So reports are PACED, not just
         // unbatched: one write per MOUSE_REPORT_PACE_MS restores the
-        // physical-wheel cadence a native terminal delivers. The jump each
+        // physical-wheel cadence a native terminal delivers. Wheel reports
+        // additionally carry a direction lane (mouseWheelLane) so the
+        // batcher can cap their pending depth (a high-resolution flick
+        // otherwise queues far past the hand stopping) and drop pending
+        // opposite-direction reports on a same-axis, same-modifier reversal;
+        // clicks, releases, and motion are laneless, never capped or
+        // superseded (teardown flush still drops them like any pending
+        // paced item). The jump each
         // single report produces is CLAUDE_CODE_SCROLL_SPEED's territory, not
         // this path's - see write-batcher.ts for the schemes tried and
         // rejected. Ordering against typed bytes holds.
-        if (isMouseReport(data)) batcher.writePaced(data);
+        if (isMouseReport(data)) batcher.writePaced(data, mouseWheelLane(data));
         else batcher.schedule(data);
       });
 
-      // Debounced PTY resize -- coalesces rapid dimension changes so the
+      // Debounced PTY resize - coalesces rapid dimension changes so the
       // TUI only redraws once after resizing settles.
       const sid = options.sessionId;
       terminal.onResize(({ cols, rows }) => {
@@ -1124,7 +1131,7 @@ export function useTerminal(options: UseTerminalOptions) {
       // REGISTERED here, so this is where the beat the long frame measures ends.
       traceInitTiming('session');
     } else {
-      // No session -- just fit immediately
+      // No session - just fit immediately
       const fitStartedAt = readClock();
       fitAddon.fit();
       fitElapsedMs = readClock() - fitStartedAt;

--- a/src/renderer/utils/repaint-nudge.ts
+++ b/src/renderer/utils/repaint-nudge.ts
@@ -39,6 +39,8 @@
  * with its useTerminal wiring and tests.
  */
 
+import type { PacedLane } from './write-batcher';
+
 /** FocusOut then FocusIn. Costs the TUI one render and moves no cursor. */
 export const REPAINT_NUDGE_BYTES = '\x1b[O\x1b[I';
 
@@ -76,6 +78,9 @@ const SGR_MOUSE_REPORT_PATTERN = /^\x1b\[<(\d+);\d+;\d+[Mm]$/;
 const X10_MOUSE_REPORT_PATTERN = /^\x1b\[M([\s\S])[\s\S]{2}$/;
 /** Bit 5 of a mouse report's button byte marks motion (drift or drag). */
 const MOUSE_MOTION_BIT = 32;
+/** Bit 6 of a mouse report's button code marks a wheel event: 64=up, 65=down,
+ *  66=left, 67=right, with modifier bits (4 shift, 8 meta, 16 ctrl) added on. */
+const MOUSE_WHEEL_BIT = 64;
 
 /**
  * True when `data` is something the USER did, rather than a report xterm
@@ -107,6 +112,51 @@ export function isUserInputData(data: string): boolean {
  */
 export function isMouseReport(data: string): boolean {
   return SGR_MOUSE_REPORT_PATTERN.test(data) || X10_MOUSE_REPORT_PATTERN.test(data);
+}
+
+/**
+ * The paced-write lane for a wheel report, or undefined for everything else
+ * (clicks, releases, motion, non-reports), which must never be capped or
+ * superseded. Lane keys use the DECODED button code, so X10 wheel bytes
+ * (96/97 on the wire) share lanes with their SGR twins (64/65): they are the
+ * same physical wheel. This deliberately re-runs the anchored patterns
+ * isMouseReport just tested; two anchored regex executions per wheel tick are
+ * negligible and keep the routing line's tripwire shape simple.
+ *
+ * The supersede target is `buttonCode ^ 1`: the low bit is direction within
+ * an axis, so 64/65 (up/down), 66/67 (left/right), and modifier-shifted
+ * pairs like ctrl+wheel 80/81 supersede only each other. Cross-axis and
+ * cross-modifier lanes never purge one another: a trackpad diagonal scroll
+ * interleaves vertical and horizontal reports, and a stray horizontal tick
+ * must not eat the pending vertical queue.
+ *
+ * UNWIND(claude-code#83714): lanes bound the paced queue that workaround
+ * introduces; delete this with writePaced.
+ */
+export function mouseWheelLane(data: string): PacedLane | undefined {
+  let buttonCode: number;
+  const sgrReport = SGR_MOUSE_REPORT_PATTERN.exec(data);
+  if (sgrReport !== null) {
+    // Wheel events are press-encoded only (final byte M). A wheel-shaped
+    // code with a release final is nonstandard; leave it laneless rather
+    // than risk dropping a release.
+    if (!data.endsWith('M')) return undefined;
+    buttonCode = Number(sgrReport[1]);
+  } else {
+    const x10Report = X10_MOUSE_REPORT_PATTERN.exec(data);
+    if (x10Report === null) return undefined;
+    buttonCode = x10Report[1].charCodeAt(0) - 32;
+  }
+  // Real button codes stay below 256 (base + modifier + extension bits). A
+  // larger value, reachable only from a synthetic or pasted chunk, can pass
+  // the bitwise checks via ToInt32 wrapping while laneKey keeps the raw
+  // number and supersedesLaneKey the wrapped one (4294967360 ^ 1 is 65) - an
+  // inconsistent pair that could purge a legitimate lane. Laneless is the
+  // safe reading, and it also covers Number() overflowing to Infinity.
+  if (buttonCode > 255) return undefined;
+  if ((buttonCode & MOUSE_WHEEL_BIT) === 0) return undefined;
+  if ((buttonCode & MOUSE_MOTION_BIT) !== 0) return undefined;
+  return { laneKey: `wheel:${buttonCode}`, supersedesLaneKey: `wheel:${buttonCode ^ 1}` };
 }
 
 /**

--- a/src/renderer/utils/write-batcher.ts
+++ b/src/renderer/utils/write-batcher.ts
@@ -23,11 +23,46 @@
  *  that is CLAUDE_CODE_SCROLL_SPEED's job (the CLI default of 1
  *  matches the native terminals verified clean).
  *
- *  UNWIND(claude-code#83714): writePaced and the isMouseReport routing
- *  exist because the fullscreen renderer mis-assembles multi-line-jump
- *  frames. When upstream fixes that, revert mouse reports to plain
- *  schedule() and delete writePaced.
+ *  The paced queue is BOUNDED, not just paced. A flick on a
+ *  high-resolution wheel emits reports faster than the floor drains
+ *  them, so an uncapped queue keeps feeding the TUI scroll commands
+ *  after the hand has stopped, and its depth scales with wheel
+ *  resolution rather than requested travel. Wheel reports therefore
+ *  carry a lane (one wheel direction, supplied by the caller via
+ *  mouseWheelLane): pending same-lane depth is capped at
+ *  MOUSE_WHEEL_LANE_MAX_DEPTH, bounding the post-stop tail near
+ *  depth * paceMs at the deliberate price of truncated travel on very
+ *  large flicks, and a same-axis reversal drops the pending
+ *  opposite-direction reports as stale intent (the same philosophy as
+ *  flush). Laneless paced items (clicks, releases, motion) are never
+ *  counted, capped, or superseded (a dropped release would stick a
+ *  button); teardown flush still drops every pending paced item,
+ *  laneless included, as it always has. The
+ *  16ms floor itself stays as is: the cap changes how many writes
+ *  queue, not the per-write cadence the TUI's read loop needs to
+ *  catch each report individually, and lowering the floor would
+ *  re-open the read-coalescing window the pacing exists to close.
+ *
+ *  UNWIND(claude-code#83714): writePaced, the isMouseReport routing,
+ *  and the lane cap/supersede exist because the fullscreen renderer
+ *  mis-assembles multi-line-jump frames. When upstream fixes that,
+ *  revert mouse reports to plain schedule() and delete writePaced.
  */
+
+/** Marks a paced item as a member of a lane of interchangeable intents
+ *  (one wheel direction). The batcher stays encoding-agnostic: callers
+ *  decide both keys (see mouseWheelLane in repaint-nudge.ts).
+ *  UNWIND(claude-code#83714): lanes bound the paced queue the workaround
+ *  introduces; they go when writePaced goes. */
+export interface PacedLane {
+  /** Pending paced items sharing this key count toward one capped pool. */
+  laneKey: string;
+  /** Pending paced items with THIS key are removed unwritten the moment an
+   *  item in laneKey arrives: a same-axis wheel reversal makes the queued
+   *  opposite-direction scroll stale intent. */
+  supersedesLaneKey?: string;
+}
+
 export interface WriteBatcher {
   /** Push data into the queue and schedule a microtask flush if not already scheduled. */
   schedule: (data: string) => void;
@@ -40,8 +75,16 @@ export interface WriteBatcher {
    *  per paceMs. Ordering against `schedule` data always holds: items drain
    *  strictly in arrival order, whichever path they came in through. A call
    *  drains synchronously, so batched bytes already queued flush immediately
-   *  rather than waiting for their microtask. */
-  writePaced: (data: string) => void;
+   *  rather than waiting for their microtask.
+   *
+   *  With a `lane`, the item joins that lane's pending pool: an arrival
+   *  finding maxPacedLaneDepth same-lane items already pending is dropped
+   *  (same-lane reports are interchangeable scroll intent, and bounded lag
+   *  beats full travel on a large flick), and pending items in
+   *  lane.supersedesLaneKey are removed unwritten (a same-axis reversal
+   *  makes them stale). Laneless items are never counted, capped, or
+   *  superseded. */
+  writePaced: (data: string, lane?: PacedLane) => void;
 }
 
 /** One frame at 60Hz: long enough that the TUI's read loop usually catches
@@ -49,14 +92,23 @@ export interface WriteBatcher {
  *  still lands within a couple hundred milliseconds. */
 const MOUSE_REPORT_PACE_MS = 16;
 
+/** Cap on PENDING same-lane paced reports. Bounds the post-flick lag tail
+ *  near depth * paceMs (128ms at defaults) while keeping short scrolls
+ *  exact: a gesture only loses reports while its lane is saturated. Module
+ *  private like MOUSE_REPORT_PACE_MS; tests inject a small cap through the
+ *  factory param, and production stays tunable without test churn. */
+const MOUSE_WHEEL_LANE_MAX_DEPTH = 8;
+
 interface QueueItem {
   data: string;
   paced: boolean;
+  laneKey?: string;
 }
 
 export function createWriteBatcher(
   write: (payload: string) => void,
   paceMs: number = MOUSE_REPORT_PACE_MS,
+  maxPacedLaneDepth: number = MOUSE_WHEEL_LANE_MAX_DEPTH,
 ): WriteBatcher {
   const queue: QueueItem[] = [];
   let microtaskScheduled = false;
@@ -112,8 +164,44 @@ export function createWriteBatcher(
     }
   };
 
-  const writePaced = (data: string): void => {
-    queue.push({ data, paced: true });
+  const writePaced = (data: string, lane?: PacedLane): void => {
+    // UNWIND(claude-code#83714): the supersede and cap below are part of the
+    // same workaround as the pacing itself and go with it. Neither needs
+    // drain() changes: a pending paceTimer's deadline is the global pace
+    // floor, not a property of the head it was scheduled for, so it validly
+    // delivers whatever the head is when it fires.
+    if (lane !== undefined) {
+      if (lane.supersedesLaneKey !== undefined) {
+        const keptItems = queue.filter(
+          (item) => !(item.paced && item.laneKey === lane.supersedesLaneKey),
+        );
+        if (keptItems.length !== queue.length) {
+          queue.length = 0;
+          queue.push(...keptItems);
+        }
+      }
+      // Within an axis, pending items hold only one direction (each arrival
+      // purges its opposite above), so a supersede that actually removed
+      // items implies this lane had nothing pending and the cap below
+      // cannot also act on the same arrival.
+      let pendingSameLaneCount = 0;
+      for (const item of queue) {
+        if (item.paced && item.laneKey === lane.laneKey) pendingSameLaneCount += 1;
+      }
+      if (pendingSameLaneCount >= maxPacedLaneDepth) {
+        // Drop the INCOMING report, not the oldest: under SUSTAINED
+        // saturation both converge on the same write stream (a finite
+        // burst differs only in which interchangeable same-lane reports
+        // survive, as the cap tests pin), and every drain frees a slot the
+        // next fresh-coordinate arrival fills, so a stale-coordinate window
+        // self-heals within depth * paceMs. Drop-oldest would add a
+        // mid-queue removal path for no observable gain. Still drain,
+        // holding the documented "a call drains synchronously" contract.
+        drain();
+        return;
+      }
+    }
+    queue.push({ data, paced: true, laneKey: lane?.laneKey });
     drain();
   };
 

--- a/tests/unit/repaint-nudge.test.ts
+++ b/tests/unit/repaint-nudge.test.ts
@@ -18,6 +18,7 @@ import {
   diffViewportRows,
   isUserInputData,
   isMouseReport,
+  mouseWheelLane,
   REPAINT_NUDGE_BYTES,
   type RepaintNudgeGate,
 } from '../../src/renderer/utils/repaint-nudge';
@@ -192,6 +193,94 @@ describe('isMouseReport', () => {
     ['a multi-character paste', 'hello world', false],
   ])('%s', (_label, data, expected) => {
     expect(isMouseReport(data as string)).toBe(expected as boolean);
+  });
+});
+
+describe('mouseWheelLane', () => {
+  // Wheel reports get a paced-write lane so the batcher can cap their pending
+  // depth and drop pending opposite-direction reports on a same-axis reversal
+  // (write-batcher.ts). Everything else stays laneless (undefined), which the
+  // batcher treats as never-cap, never-supersede: dropping a click release
+  // would stick a button. The supersede target is buttonCode ^ 1, so only
+  // same-axis, same-modifier pairs purge each other: a trackpad diagonal
+  // scroll interleaves vertical and horizontal reports, and a stray
+  // horizontal tick must not eat the pending vertical queue.
+  const x10WheelUpBytes = String.fromCharCode(32 + 64, 40, 40);
+  const x10WheelDownBytes = String.fromCharCode(32 + 65, 40, 40);
+  const x10MotionBytes = String.fromCharCode(32 + 35, 40, 40);
+  const x10ClickBytes = String.fromCharCode(32 + 0, 40, 40);
+
+  it.each([
+    [
+      'SGR wheel up (64) pairs with wheel down',
+      '\x1b[<64;10;5M',
+      { laneKey: 'wheel:64', supersedesLaneKey: 'wheel:65' },
+    ],
+    [
+      'SGR wheel down (65) pairs with wheel up',
+      '\x1b[<65;10;5M',
+      { laneKey: 'wheel:65', supersedesLaneKey: 'wheel:64' },
+    ],
+    [
+      'ctrl+wheel up (80) pairs with ctrl+wheel down, not the plain lanes',
+      '\x1b[<80;10;5M',
+      { laneKey: 'wheel:80', supersedesLaneKey: 'wheel:81' },
+    ],
+    [
+      'ctrl+wheel down (81) pairs with ctrl+wheel up, not the plain lanes',
+      '\x1b[<81;10;5M',
+      { laneKey: 'wheel:81', supersedesLaneKey: 'wheel:80' },
+    ],
+    [
+      'wheel left (66) pairs with wheel right, never the vertical lanes',
+      '\x1b[<66;10;5M',
+      { laneKey: 'wheel:66', supersedesLaneKey: 'wheel:67' },
+    ],
+    [
+      'wheel right (67) pairs with wheel left, never the vertical lanes',
+      '\x1b[<67;10;5M',
+      { laneKey: 'wheel:67', supersedesLaneKey: 'wheel:66' },
+    ],
+    // X10 wheel bytes are the SGR codes offset by 32 on the wire; the lane
+    // uses the DECODED code, so both encodings share one lane per direction:
+    // they are the same physical wheel.
+    [
+      'X10 wheel up (byte 96) shares the SGR wheel-up lane',
+      '\x1b[M' + x10WheelUpBytes,
+      { laneKey: 'wheel:64', supersedesLaneKey: 'wheel:65' },
+    ],
+    [
+      'X10 wheel down (byte 97) shares the SGR wheel-down lane',
+      '\x1b[M' + x10WheelDownBytes,
+      { laneKey: 'wheel:65', supersedesLaneKey: 'wheel:64' },
+    ],
+    ['SGR motion (35)', '\x1b[<35;10;5M', undefined],
+    ['SGR drag (32)', '\x1b[<32;10;5M', undefined],
+    ['SGR click press (0)', '\x1b[<0;10;5M', undefined],
+    ['SGR click release (0, lowercase m)', '\x1b[<0;10;5m', undefined],
+    ['a wheel-shaped code with a release final (lowercase m) stays laneless', '\x1b[<64;10;5m', undefined],
+    ['a code with both wheel and motion bits (96) stays laneless', '\x1b[<96;10;5M', undefined],
+    // Codes past 255 never come from a real wheel; letting one through would
+    // pair a raw-number laneKey with a ToInt32-wrapped supersedesLaneKey
+    // (4294967360 ^ 1 is 65), able to purge a legitimate lane.
+    [
+      'an SGR code past 255 that ToInt32-wraps onto the wheel bit stays laneless',
+      '\x1b[<4294967360;10;5M',
+      undefined,
+    ],
+    [
+      'an SGR code overflowing Number to Infinity stays laneless',
+      '\x1b[<' + '9'.repeat(400) + ';10;5M',
+      undefined,
+    ],
+    ['X10 motion', '\x1b[M' + x10MotionBytes, undefined],
+    ['X10 click', '\x1b[M' + x10ClickBytes, undefined],
+    ['two SGR reports joined into one chunk', '\x1b[<64;10;5M\x1b[<65;10;5M', undefined],
+    ['an SGR report with trailing bytes', '\x1b[<64;10;5Mhello', undefined],
+    ['a FocusIn report', '\x1b[I', undefined],
+    ['an ordinary typed character', 'a', undefined],
+  ])('%s', (_label, data, expected) => {
+    expect(mouseWheelLane(data as string)).toEqual(expected);
   });
 });
 

--- a/tests/unit/write-batcher.test.ts
+++ b/tests/unit/write-batcher.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { createWriteBatcher } from '../../src/renderer/utils/write-batcher';
-import { isMouseReport } from '../../src/renderer/utils/repaint-nudge';
+import { isMouseReport, mouseWheelLane } from '../../src/renderer/utils/repaint-nudge';
 
 /** Wait for all pending microtasks to drain. */
 const drainMicrotasks = () => new Promise<void>((resolve) => queueMicrotask(resolve));
@@ -286,6 +286,264 @@ describe('createWriteBatcher', () => {
     });
   });
 
+  // Lanes bound the paced queue. A high-resolution wheel emits reports faster
+  // than the pace floor drains them, so without a cap the queue keeps feeding
+  // scroll commands after the hand stops, and its depth scales with wheel
+  // resolution rather than requested travel. A lane marks same-direction
+  // wheel reports as interchangeable intent: pending same-lane depth is
+  // capped (drop the INCOMING arrival), and an arrival removes pending items
+  // in its declared supersede target (a same-axis reversal makes them stale).
+  // Laneless paced items (clicks, releases, motion) are exempt from both: a
+  // dropped release would stick a button.
+  describe('writePaced lanes (cap + reversal supersede)', () => {
+    const PACE_MS = 16;
+    const LANE_CAP = 3;
+    const wheelDown = { laneKey: 'wheel:65', supersedesLaneKey: 'wheel:64' };
+    const wheelUp = { laneKey: 'wheel:64', supersedesLaneKey: 'wheel:65' };
+    const wheelLeft = { laneKey: 'wheel:66', supersedesLaneKey: 'wheel:67' };
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('drops same-lane arrivals beyond the pending cap (drop-incoming: earliest survivors write)', () => {
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS, LANE_CAP);
+
+      batcher.writePaced('r1', wheelDown); // writes immediately, not pending
+      batcher.writePaced('r2', wheelDown);
+      batcher.writePaced('r3', wheelDown);
+      batcher.writePaced('r4', wheelDown); // pending depth now at the cap
+      batcher.writePaced('r5', wheelDown); // dropped
+      batcher.writePaced('r6', wheelDown); // dropped
+
+      expect(write.mock.calls).toEqual([['r1']]);
+
+      // The exact survivor list pins drop-incoming: drop-oldest would have
+      // written r4..r6 instead.
+      vi.advanceTimersByTime(PACE_MS * 10);
+      expect(write.mock.calls).toEqual([['r1'], ['r2'], ['r3'], ['r4']]);
+    });
+
+    it('the default lane cap of 8 applies when maxPacedLaneDepth is not passed to the factory', () => {
+      // Every cap test above injects LANE_CAP (3) as the third factory arg,
+      // and none of them sends more than 3 same-lane reports, so deleting
+      // the production default (MOUSE_WHEEL_LANE_MAX_DEPTH = 8) would leave
+      // maxPacedLaneDepth undefined - where `count >= undefined` is always
+      // false and the cap silently never fires - and this whole suite would
+      // still pass. This test omits the factory arg entirely, pinning that
+      // the default itself, not just an explicitly-injected cap, bounds the
+      // queue in production.
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS);
+
+      for (let index = 1; index <= 10; index += 1) {
+        batcher.writePaced(`r${index}`, wheelDown);
+      }
+
+      // r1 writes immediately (nothing pending ahead of it, never counted).
+      // r2..r9 each see a pending same-lane depth below the default cap (0
+      // through 7) and are accepted; r10 is the first arrival to see depth 8
+      // and is dropped.
+      expect(write.mock.calls).toEqual([['r1']]);
+
+      vi.advanceTimersByTime(PACE_MS * 20);
+      expect(write.mock.calls).toEqual([
+        ['r1'],
+        ['r2'],
+        ['r3'],
+        ['r4'],
+        ['r5'],
+        ['r6'],
+        ['r7'],
+        ['r8'],
+        ['r9'],
+      ]);
+    });
+
+    it('a drained slot readmits the next same-lane arrival', () => {
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS, LANE_CAP);
+
+      batcher.writePaced('r1', wheelDown);
+      batcher.writePaced('r2', wheelDown);
+      batcher.writePaced('r3', wheelDown);
+      batcher.writePaced('r4', wheelDown);
+      batcher.writePaced('r5', wheelDown); // dropped at the cap, and stays dropped
+
+      vi.advanceTimersByTime(PACE_MS); // r2 writes, freeing one slot
+      batcher.writePaced('r6', wheelDown); // readmitted into the freed slot
+
+      vi.advanceTimersByTime(PACE_MS * 10);
+      expect(write.mock.calls).toEqual([['r1'], ['r2'], ['r3'], ['r4'], ['r6']]);
+    });
+
+    it('a cap-drop disturbs neither the pace floor nor the pending timer', () => {
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS, LANE_CAP);
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+      batcher.writePaced('r1', wheelDown); // immediate, sets the floor
+      batcher.writePaced('r2', wheelDown); // schedules the one pace timer
+      batcher.writePaced('r3', wheelDown);
+      batcher.writePaced('r4', wheelDown);
+      batcher.writePaced('r5', wheelDown); // dropped
+
+      // Only r2's arrival scheduled a timer; the later arrivals (dropped one
+      // included) found it pending and left it alone.
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(PACE_MS - 1);
+      expect(write.mock.calls).toEqual([['r1']]);
+      vi.advanceTimersByTime(1);
+      expect(write.mock.calls).toEqual([['r1'], ['r2']]);
+    });
+
+    it('a cap-drop still calls drain() synchronously, delivering an already-due pending head', () => {
+      // Mirrors the vi.setSystemTime technique used above for the
+      // already-due head (the writePaced describe's "a synchronous drain
+      // that finds an already-due paced head..." test). In every other cap
+      // test in this file the head is not yet due at drop time, so the drop
+      // path's drain() call (write-batcher.ts, the cap branch) is a no-op
+      // either way - deleting that call would still pass the whole suite.
+      // This test forces the head to be due, via a system-time jump, before
+      // the scheduled paceTimer's own callback has run, then drops an
+      // arrival at the cap. drain() firing on the drop path is the only
+      // thing that can deliver the due head at this point: without it, r2
+      // would sit pending until the fake timer is advanced, which is what
+      // makes asserting synchronously here mutation-detectable.
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS, LANE_CAP);
+
+      batcher.writePaced('r1', wheelDown); // immediate, sets the floor
+      batcher.writePaced('r2', wheelDown); // pending; schedules the pace timer
+      batcher.writePaced('r3', wheelDown); // pending
+      batcher.writePaced('r4', wheelDown); // pending depth now at the cap
+
+      // The wall clock reaches r2's deadline without that scheduled timer's
+      // own callback having run yet.
+      vi.setSystemTime(Date.now() + PACE_MS);
+
+      batcher.writePaced('r5', wheelDown); // cap-dropped: pending depth is 3
+
+      // Asserted BEFORE any vi.advanceTimersByTime: the dropped arrival's
+      // own drain() call is what delivered the due head synchronously.
+      expect(write.mock.calls).toEqual([['r1'], ['r2']]);
+
+      vi.advanceTimersByTime(PACE_MS * 5);
+      expect(write.mock.calls).toEqual([['r1'], ['r2'], ['r3'], ['r4']]);
+      expect(write.mock.calls.flat()).not.toContain('r5');
+    });
+
+    it('laneless paced items are never capped', () => {
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS, LANE_CAP);
+
+      for (const payload of ['k1', 'k2', 'k3', 'k4', 'k5', 'k6']) {
+        batcher.writePaced(payload);
+      }
+
+      vi.advanceTimersByTime(PACE_MS * 10);
+      expect(write.mock.calls).toEqual([['k1'], ['k2'], ['k3'], ['k4'], ['k5'], ['k6']]);
+    });
+
+    it('laneless paced items do not count toward a lane\'s pending depth', () => {
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS, LANE_CAP);
+
+      batcher.writePaced('down1', wheelDown); // immediate
+      batcher.writePaced('click1'); // keyless, pending
+      batcher.writePaced('click2'); // keyless, pending
+      batcher.writePaced('down2', wheelDown); // lane depth 0: accepted
+      batcher.writePaced('down3', wheelDown); // lane depth 1: accepted
+      batcher.writePaced('down4', wheelDown); // lane depth 2: accepted
+      batcher.writePaced('down5', wheelDown); // lane depth at cap: dropped
+
+      vi.advanceTimersByTime(PACE_MS * 10);
+      expect(write.mock.calls).toEqual([
+        ['down1'],
+        ['click1'],
+        ['click2'],
+        ['down2'],
+        ['down3'],
+        ['down4'],
+      ]);
+    });
+
+    it('supersede removes only the declared target lane; laneless and cross-axis items survive in order', () => {
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS, LANE_CAP);
+
+      batcher.writePaced('down1', wheelDown); // immediate
+      batcher.writePaced('down2', wheelDown); // pending, removed by the reversal
+      batcher.writePaced('click'); // keyless: survives
+      batcher.writePaced('left1', wheelLeft); // cross-axis lane: survives
+      batcher.writePaced('down3', wheelDown); // pending, removed by the reversal
+      batcher.writePaced('up1', wheelUp); // the reversal
+
+      vi.advanceTimersByTime(PACE_MS * 10);
+      expect(write.mock.calls).toEqual([['down1'], ['click'], ['left1'], ['up1']]);
+    });
+
+    it('supersede under a pending timer: the exposed unpaced run writes now, the reused timer delivers the survivor', async () => {
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS, LANE_CAP);
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+      const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+      batcher.writePaced('down1', wheelDown); // immediate; sets the floor
+      batcher.writePaced('down2', wheelDown); // schedules the pace timer for the head
+      batcher.schedule('typed'); // unpaced, queued behind down2
+      batcher.writePaced('up1', wheelUp); // removes down2; queue is now [typed, up1]
+
+      // The drain inside writePaced wrote the exposed unpaced run immediately
+      // (arrival order for typed bytes), while up1 stays under down1's floor.
+      expect(write.mock.calls).toEqual([['down1'], ['typed']]);
+
+      // The pending timer's deadline is the global pace floor, not a property
+      // of the removed head, so the supersede neither cleared nor replaced it.
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+      expect(clearTimeoutSpy).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(PACE_MS);
+      expect(write.mock.calls).toEqual([['down1'], ['typed'], ['up1']]);
+
+      // schedule('typed') queued a microtask that these synchronous
+      // assertions never let fire. Draining it for real proves it finds an
+      // already-empty queue rather than re-writing 'typed'.
+      await drainMicrotasks();
+      expect(write.mock.calls).toEqual([['down1'], ['typed'], ['up1']]);
+    });
+
+    it('flush still drops pending laned reports along with laneless ones', () => {
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS, LANE_CAP);
+
+      batcher.writePaced('down1', wheelDown);
+      batcher.writePaced('down2', wheelDown);
+      // Laneless paced item, pending behind down2. The title claims
+      // laneless coverage, but until this line the body only ever queued a
+      // laned pending item plus an unpaced schedule() item - it never
+      // proved a PACED laneless item is dropped by flush too.
+      batcher.writePaced('release1');
+      batcher.schedule('typed');
+      batcher.flush();
+
+      expect(write.mock.calls).toEqual([['down1'], ['typed']]);
+      // release1 was pending and laneless: flush drops it exactly like the
+      // laned down2, not merely omits it from the exact-array check above.
+      expect(write.mock.calls.flat()).not.toContain('release1');
+
+      vi.advanceTimersByTime(PACE_MS * 4);
+      expect(write.mock.calls).toEqual([['down1'], ['typed']]);
+      expect(write.mock.calls.flat()).not.toContain('release1');
+    });
+  });
+
   // Nothing today fails if useTerminal.ts's onData routing line is deleted or
   // inverted: repaint-nudge.test.ts only pins isMouseReport's return value in
   // isolation, and every test above only drives writePaced/schedule directly.
@@ -311,7 +569,7 @@ describe('createWriteBatcher', () => {
       // both - there is no other isMouseReport(data)/batcher.schedule(data)
       // pairing anywhere else in this file for either to accidentally match.
       const mouseReportRoutesToWritePaced =
-        /if\s*\(\s*isMouseReport\(data\)\s*\)\s*\{?\s*batcher\.writePaced\(data\)/;
+        /if\s*\(\s*isMouseReport\(data\)\s*\)\s*\{?\s*batcher\.writePaced\(data,\s*mouseWheelLane\(data\)\)/;
       const elseRoutesToSchedule = /else\s*\{?\s*batcher\.schedule\(data\)/;
 
       expect(source).toMatch(mouseReportRoutesToWritePaced);
@@ -333,7 +591,7 @@ describe('createWriteBatcher', () => {
       // the assertions below are checking what that exact expression DOES,
       // not just that its text is present.
       const routeOnData = (batcher: ReturnType<typeof createWriteBatcher>, data: string): void => {
-        if (isMouseReport(data)) batcher.writePaced(data);
+        if (isMouseReport(data)) batcher.writePaced(data, mouseWheelLane(data));
         else batcher.schedule(data);
       };
 
@@ -385,6 +643,21 @@ describe('createWriteBatcher', () => {
         // And it must never have joined into one payload - that would mean
         // the report went through schedule too.
         expect(write.mock.calls).toEqual([['\x1b[<64;10;5M'], ['a']]);
+      });
+
+      it('a wheel reversal supersedes the pending opposite-direction report end-to-end', () => {
+        const write = vi.fn<[string], void>();
+        const batcher = createWriteBatcher(write, PACE_MS);
+
+        routeOnData(batcher, '\x1b[<65;10;5M'); // wheel down: immediate
+        routeOnData(batcher, '\x1b[<65;10;5M'); // wheel down: queued under the floor
+        routeOnData(batcher, '\x1b[<64;10;5M'); // wheel up: supersedes the pending down
+
+        expect(write.mock.calls).toEqual([['\x1b[<65;10;5M']]);
+
+        // The queued down report never writes; the reversal is what drains.
+        vi.advanceTimersByTime(PACE_MS * 4);
+        expect(write.mock.calls).toEqual([['\x1b[<65;10;5M'], ['\x1b[<64;10;5M']]);
       });
     });
   });

--- a/tests/unit/write-batcher.test.ts
+++ b/tests/unit/write-batcher.test.ts
@@ -542,6 +542,42 @@ describe('createWriteBatcher', () => {
       expect(write.mock.calls).toEqual([['down1'], ['typed']]);
       expect(write.mock.calls.flat()).not.toContain('release1');
     });
+
+    it('flush empties a saturated lane so the next burst is not permanently capped', () => {
+      // Lane depth is recomputed by re-scanning `queue` on every arrival, so
+      // flush()'s queue.length = 0 already empties the pool as a side effect
+      // today. That is exactly the property a later perf pass (a persistent
+      // Map<laneKey, count> incremented on push / decremented on drain,
+      // instead of a per-arrival recount) would be tempted to change - and
+      // could easily forget to also clear on flush, leaving the lane
+      // permanently saturated for the rest of the batcher's lifetime. No
+      // existing test drives writePaced after a flush that left a lane at
+      // the cap, so that regression would pass the whole suite silently.
+      const write = vi.fn<[string], void>();
+      const batcher = createWriteBatcher(write, PACE_MS, LANE_CAP);
+
+      batcher.writePaced('d1', wheelDown); // immediate
+      batcher.writePaced('d2', wheelDown); // pending
+      batcher.writePaced('d3', wheelDown); // pending, lane now at the cap
+      batcher.writePaced('d4', wheelDown); // dropped
+      batcher.flush(); // drops d2 and d3 unwritten; lane pool must empty too
+
+      expect(write.mock.calls).toEqual([['d1']]);
+
+      // lastPacedWriteAt survives flush (it is not queue state), so the next
+      // arrival must still clear the pace floor before it writes immediately.
+      vi.advanceTimersByTime(PACE_MS);
+
+      batcher.writePaced('e1', wheelDown); // immediate: the pace floor cleared
+      batcher.writePaced('e2', wheelDown); // pending
+      batcher.writePaced('e3', wheelDown); // pending
+      batcher.writePaced('e4', wheelDown); // pending, lane at the cap again
+      batcher.writePaced('e5', wheelDown); // dropped: proves the cap still works post-flush
+
+      vi.advanceTimersByTime(PACE_MS * 10);
+      expect(write.mock.calls).toEqual([['d1'], ['e1'], ['e2'], ['e3'], ['e4']]);
+      expect(write.mock.calls.flat()).not.toContain('e5');
+    });
   });
 
   // Nothing today fails if useTerminal.ts's onData routing line is deleted or


### PR DESCRIPTION
## What

Bounds the terminal input batcher's paced mouse-report queue. Wheel reports now carry a direction lane: pending same-lane depth is capped at 8, and a same-axis direction reversal removes the pending opposite-direction reports unwritten. Touches `write-batcher.ts` (lane cap + supersede), `repaint-nudge.ts` (new `mouseWheelLane` classifier), the `useTerminal` onData routing line, and the session-lifecycle doc.

## Why

In a fullscreen (alt-screen) agent terminal the TUI owns scrolling, so every wheel tick becomes an SGR mouse report that drains through `writePaced` at one PTY write per 16ms (the claude-code#83714 workaround: a chunk of joined reports becomes one multi-line jump whose differential frame mis-assembles). That queue was unbounded and uncoalesced: a fast flick on a high-resolution wheel emits reports faster than 62.5/sec, so scrolling kept running after the hand stopped and the first visible response lagged by however deep the queue already was.

## How

The batcher stays encoding-agnostic: `writePaced(data, lane?)` takes an optional `PacedLane { laneKey, supersedesLaneKey }`, and all mouse semantics live in `repaint-nudge.ts` next to the report patterns. `mouseWheelLane` pairs directions via `buttonCode ^ 1`, so 64/65, 66/67, and modifier-shifted pairs like ctrl+wheel 80/81 supersede only each other; a trackpad diagonal scroll's stray horizontal ticks cannot purge the pending vertical queue. Clicks, releases, and motion stay laneless and are never counted or dropped (a dropped release would stick a button). The cap drops the incoming report, deliberately truncating travel on very large flicks: the post-stop tail is bounded near 128ms instead of scaling with wheel resolution. The 16ms floor is kept: the cap changes how many writes queue, not the per-write cadence the TUI's read loop needs to catch each report individually. All new logic carries UNWIND(claude-code#83714) markers so it is swept together with the pacing when upstream fixes the renderer.

## Breaking changes

None.

## Tests

Unit coverage added in `tests/unit/write-batcher.test.ts` (lane cap with drop-incoming pinned by the survivor list, drained-slot readmission, cap-drop leaving the pace timer alone, laneless exemption and non-counting, supersede scoped to its declared target lane, supersede under a pending timer, flush dropping laned items, and flush resetting a saturated lane) and `tests/unit/repaint-nudge.test.ts` (a `mouseWheelLane` classification table across SGR, X10, modifiers, motion, clicks, and malformed shapes). The routing-line tripwire and semantics harness were updated to the new call shape. Also verified in vivo against a live preview renderer via the IPC log: a 30-report synchronous burst delivers exactly 9 paced writes at 16ms cadence, a 5-down-1-up reversal delivers 2, and a 50-event flick over 200ms stops writing 130ms after the last event.

Generated with [Claude Code](https://claude.com/claude-code)
