### PR TITLE
fix(terminal): motion-flood scroll lag, unfocused paste settling, and the dev instance-lock trap

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -177,6 +177,8 @@ Flags:
 - `--ephemeral` - isolated data directory, auto-cleaned on exit (used for worktree previews). The data directory is wiped on every boot, so a previous (possibly crashed) preview's clones never persist. Because the wipe also takes the markers that say what the user has already seen, the boot seeds them back: `hasCompletedFirstRun`, `lastWhatsNewShownVersion`, and every announcement in the committed `announcements.json` stamped read and dismissed. Without that last one the megaphone badge and the announcement banner returned on every preview launch.
 - `--fresh` - ephemeral preview with NO project pre-cloned or auto-opened, so the app starts on the Welcome Screen. Use it to exercise the first-launch experience (pick a folder, land on the board, onboarding checklist). Implies the same wipe as `--ephemeral`, but deliberately gets NONE of the seeded markers above, so onboarding, What's New, and unread announcements all present as they would to a real first-time user.
 
+**Single-instance lock warning:** a non-ephemeral launch whose Electron process exits almost immediately with code 0 means another Kangentic instance (usually the installed app) already holds the single-instance lock -- the loser exits silently and the holder's window is focused, which looks exactly like a successful dev launch while you are actually using the other build. `dev.js` detects that signature (non-ephemeral, exit 0, under 5s from spawn) and prints an unmissable warning: quit the other instance (including its tray icon and any background processes in Task Manager), then run `npm start` again. Ephemeral previews skip the lock and can never trigger it.
+
 ### Production (`npm run build` / `scripts/build.js`)
 
 1. `tsc --noEmit` (type check)

--- a/docs/embedded-browser.md
+++ b/docs/embedded-browser.md
@@ -67,7 +67,7 @@ Captures live under the session directory so they're cleaned up by existing life
 
 Per-adapter verification is exposed via each `AgentAdapter`'s `getSubmissionVerifier(contextType: 'paste' | 'command-injection')` method. `BROWSER_CAPTURE_SEND` calls `TerminalSubmit.submitContent` (paste path) which looks up the session's adapter via `agentRegistry.get(sessionManager.getSessionAgentName(sessionId))` and passes `getSubmissionVerifier('paste')` to `pasteAndSubmit` as the optional `verifier` callback. Slash-command bursts route through `TerminalSubmit.submitKeystrokes` and use `getSubmissionVerifier('command-injection')` for the JSONL polling path. Adapters may return `null` to fall back to the activity/data-byte signals. Engine code itself never branches on agent name.
 
-**Caller contract:** the session must be subscribed to (in `SessionManager.focusedSessionIds`) when the engine is invoked. Both the Browser pane and `TerminalSubmitScheduler` run alongside an active terminal panel that subscribes via `TERMINAL_SUBSCRIBE`, so they satisfy this naturally.
+**No subscription requirement:** the engine observes PTY output through `SessionManager`'s unconditional `data-tap` event (settle, submission evidence, and the paste-mode monitor alike), so it behaves identically for focused and background sessions. The old caller contract (session must be in `focusedSessionIds`) is gone: MCP session-send and mobile-bridge messages routinely target sessions no renderer is subscribed to, and under the renderer-gated `data` event those callers silently degraded to the wall-clock cap with a dead paste-mode guard.
 
 ### Capture and Drawing
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -912,11 +912,17 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   ordered queue that writes each report as its own payload at a 16ms-per-report floor, restoring
   the physical-wheel cadence a native terminal delivers; typed bytes keep arrival order across
   the two paths, and teardown drops pending reports rather than writing them joined. The paced
-  queue is bounded as well as paced: wheel reports carry a direction lane (`mouseWheelLane`),
+  queue is bounded as well as paced: wheel reports carry a direction lane (`mouseReportLane`),
   pending same-lane depth is capped at 8 so a high-resolution flick's post-stop tail is bounded
   near 128ms instead of scaling with wheel resolution, and a same-axis, same-modifier reversal
   drops the pending opposite-direction reports as stale intent (the same philosophy as
-  teardown); clicks, releases, and motion are laneless, never capped or superseded (teardown
+  teardown). Motion reports (drift and drags) carry a single self-superseding lane that keeps
+  only the newest pointer position: motion generates at display refresh rate, above the 16ms
+  floor's 62.5/s drain, so a laneless motion stream grew the queue whenever refresh outpaced
+  the floor (measured 2026-08-28 on a 143Hz display: a two-second cursor traverse left 117
+  motion reports pending), and since the queue is FIFO, every wheel report and click landing
+  after a traverse waited out that stale backlog - the flick-after-move lag the wheel cap
+  alone could not fix. Clicks and releases are laneless, never capped or superseded (teardown
   still drops them like any pending report). The 16ms floor itself stays
   deliberately: the cap changes how many writes queue, not the per-write cadence the TUI's read
   loop needs to catch each report individually.

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -326,8 +326,28 @@ async function start() {
     env: spawnEnv,
   });
 
+  const electronLaunchedAt = Date.now();
   electronProc.on('close', (code) => {
     console.log(`[dev] Electron exited with code ${code}`);
+    // A near-instant code-0 exit from a NON-ephemeral launch is almost always
+    // the single-instance lock: another Kangentic (usually the installed app)
+    // already holds it, so main/index.ts calls app.exit(0) silently and the
+    // second-instance handler FOCUSES that other instance. To the person who
+    // just ran npm start, that looks exactly like a successful dev launch
+    // while they are actually using the other build (2026-08-28: days of
+    // "dogfooding main" happened on the 08-23 installed build this way, which
+    // is how already-fixed terminal regressions kept being reported as
+    // unfixed). Ephemeral previews skip the lock, so this branch cannot fire
+    // for them.
+    if (!ephemeral && code === 0 && Date.now() - electronLaunchedAt < 5000) {
+      console.error('');
+      console.error('[dev] *** Electron exited immediately: another Kangentic instance');
+      console.error('[dev] *** (usually the installed app) holds the single-instance lock.');
+      console.error('[dev] *** The window that just came to the foreground is THAT instance,');
+      console.error('[dev] *** NOT this dev build. Quit it first (check the tray and Task');
+      console.error('[dev] *** Manager background processes), then run npm start again.');
+      console.error('');
+    }
     cleanup(code || 0);
   });
 }

--- a/src/main/pty/buffer/headless-frame.ts
+++ b/src/main/pty/buffer/headless-frame.ts
@@ -210,9 +210,19 @@ export class HeadlessFrameBuffer {
    * defaulting TERM=xterm-256color into every PTY child: still
    * `DECSTBM: gated (TMUX=unset ZELLIJ=unset TERM_PROGRAM=unset
    * TERM=xterm-256color)` behind the same XTVERSION no-reply, so the gate keys
-   * on the handshake, not on TERM alone. It can still reopen on any upgrade,
+   * on the handshake, not on TERM alone. Re-measured 2026-08-28 (claude
+   * 2.1.250): identical gate line. It can still reopen on any upgrade,
    * silently, and the resulting bug is expensive to re-diagnose - hence the
    * guard. The origin-mode branch below is NOT dormant.
+   *
+   * The same missing XTVERSION reply also makes the CLI log
+   * `DECRQM(2026): skipped (no XTVERSION reply) -> sync unsupported`, even
+   * though xterm 6.x implements DEC 2026 and the CLI emits balanced
+   * `?2026h/l` wrappers regardless (measured 2026-08-28, ~25 pairs per 256KB
+   * of live stream). Do NOT "fix" this by registering a CSI > q handler that
+   * answers XTVERSION on xterm's behalf: the one handshake gates BOTH
+   * behaviors, so unlocking sync-awareness would simultaneously ungate
+   * DECSTBM and make the replay scroll-region gap live.
    *
    * Order is load-bearing, twice over:
    *

--- a/src/main/pty/buffer/pty-buffer-manager.ts
+++ b/src/main/pty/buffer/pty-buffer-manager.ts
@@ -678,7 +678,12 @@ export class PtyBufferManager {
       // A replay snapshot is mid-sample: hold this tick (re-arm, do not emit)
       // so no flush lands between the sample's drain and its reply. The
       // sample's tail fold delivers whatever is buffered; anything left on its
-      // degraded paths rides the re-armed tick once the counter drops.
+      // degraded paths rides the re-armed tick once the counter drops. Worst
+      // case this holds LIVE delivery for REPLAY_SERIALIZE_MAX_WAIT_MS (the
+      // serialize deadline caps how long the counter can stay up); the
+      // 2026-08-28 fidelity audit observed zero deadline hits through a
+      // mass-resume boot, so this is a bounded correctness guard, not a
+      // live-path tax.
       if (current.replaySamplesInFlight > 0) {
         this.scheduleFlush(sessionId, current);
         return;

--- a/src/main/pty/paste-engine.ts
+++ b/src/main/pty/paste-engine.ts
@@ -29,19 +29,19 @@ import { waitForOutputSettle, type OutputSettleResult } from './output-settle';
  * kernel read as `\e[201~` the submit handler can read stale closure
  * state. The settle wait + floor guarantees React commits before Enter.
  *
- * CALLER CONTRACT: the session must be subscribed (in
- * `SessionManager.focusedSessionIds`) before invoking. The `'data'` event
- * is gated on subscription for IPC-bandwidth reasons, so settle (step 3)
- * and evidence (step 5) only resolve via the data path when the session
- * is focused. Both fall back to wall-clock floors and activity events
- * respectively, but the engine is meaningfully slower and less
- * deterministic without subscription. Browser pane and the keystroke
- * delivery path (TerminalSubmit) both run alongside an active terminal
- * panel that subscribes via `TERMINAL_SUBSCRIBE`, so they satisfy this
- * naturally. The gate is default-closed (an empty focused set forwards
- * NOTHING - e.g. a mobile-bridge paste while the desktop shows the Backlog
- * view), in which case the engine degrades to those wall-clock/activity
- * fallbacks: slower, still correct.
+ * The engine observes PTY output via the UNCONDITIONAL `'data-tap'` event,
+ * not the renderer-gated `'data'` event, so settle (step 3), evidence
+ * (step 5), and the bracketed-paste-mode monitor all work identically for
+ * focused and background sessions. This matters because two real callers
+ * routinely target sessions no renderer is subscribed to - MCP
+ * session-send (agent-to-agent messages) and the mobile bridge (a phone
+ * message while the desktop shows another view). Under the old `'data'`
+ * subscription those callers silently degraded to the wall-clock cap with
+ * no early settle, and the paste-mode modal guard never fired for them at
+ * all (found by the 2026-08-28 fidelity audit; output-settle.ts's header
+ * warns about exactly this trap). For a focused session `'data-tap'` and
+ * `'data'` are emitted back-to-back in the same synchronous fan-out for
+ * the same bytes, so focused-caller timing is unchanged.
  */
 
 export interface PasteOptions {
@@ -171,11 +171,11 @@ type SettleResult = OutputSettleResult;
  * window, or capMs fallback if data never arrives. The floor keeps
  * fast-render small payloads from racing past React's commit cycle.
  *
- * Delegates to the shared `waitForOutputSettle` primitive. Stays on the
- * renderer-gated `'data'` event (not `'data-tap'`) to preserve this engine's
- * documented caller contract: the browser pane and dictation paths run
- * alongside a subscribed terminal, and widening the seam here would change
- * paste timing for reasons unrelated to this change.
+ * Delegates to the shared `waitForOutputSettle` primitive, observing the
+ * unconditional `'data-tap'` event so an unfocused session (MCP
+ * session-send, mobile bridge) settles on real output instead of riding
+ * capMs. Focused-session timing is identical: `'data-tap'` and `'data'`
+ * fire back-to-back in the same fan-out for the same bytes.
  */
 function waitForPasteSettle(
   sessionManager: SessionManager,
@@ -185,7 +185,7 @@ function waitForPasteSettle(
 ): Promise<SettleResult> {
   const capMs = Math.max(SETTLE_CAP_MIN_MS, Math.round(packetLength * SETTLE_CAP_PER_BYTE_MS) + SETTLE_CAP_MIN_MS);
   return waitForOutputSettle(sessionManager, sessionId, {
-    event: 'data',
+    event: 'data-tap',
     idleMs: OUTPUT_SETTLE_IDLE_MS,
     capMs,
     floorMs: MIN_GAP_MS,
@@ -249,7 +249,7 @@ function waitForSubmissionEvidence(
     let postWriteBytes = 0;
 
     const cleanup = (): void => {
-      sessionManager.off('data', onData);
+      sessionManager.off('data-tap', onData);
       sessionManager.off('activity', onActivity);
       signal.removeEventListener('abort', onAbort);
       clearTimeout(timer);
@@ -294,7 +294,7 @@ function waitForSubmissionEvidence(
       reject(new PasteSubmitError('aborted', 'paste-engine: aborted during evidence wait'));
     };
 
-    sessionManager.on('data', onData);
+    sessionManager.on('data-tap', onData);
     sessionManager.on('activity', onActivity);
     signal.addEventListener('abort', onAbort, { once: true });
     const timer = setTimeout(() => finish('timeout'), timeoutMs);
@@ -360,7 +360,7 @@ export function createPasteEngine(sessionManager: SessionManager): PasteEngine {
         if (offIdx > onIdx) pasteModeOff = true;
         else if (onIdx > offIdx) pasteModeOff = false;
       };
-      sessionManager.on('data', monitorPasteMode);
+      sessionManager.on('data-tap', monitorPasteMode);
 
       try {
         await sessionManager.drain(sessionId);
@@ -435,7 +435,7 @@ export function createPasteEngine(sessionManager: SessionManager): PasteEngine {
         }
         throw caughtError;
       } finally {
-        sessionManager.off('data', monitorPasteMode);
+        sessionManager.off('data-tap', monitorPasteMode);
         clearTimeout(timeoutTimer);
         disposeLink();
       }

--- a/src/main/pty/spawn/pty-spawn.ts
+++ b/src/main/pty/spawn/pty-spawn.ts
@@ -127,6 +127,10 @@ export const FULL_REPAINT_ENV_KEY = 'CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT';
  * clean under controlled injection, coalesced multiples spliced rows). The
  * CLI default of 1 matches the native terminals verified clean. Non-Claude
  * agents ignore the var, the same argument the strip itself relies on.
+ * UNWIND(claude-code#83714): the keeplist entry itself stays (a user's
+ * exported value must always survive the strip), but the no-default stance
+ * exists because of the same upstream mis-assembly - re-evaluate a default
+ * alongside the rest of the unwind when upstream fixes the renderer.
  */
 export const SCROLL_SPEED_ENV_KEY = 'CLAUDE_CODE_SCROLL_SPEED';
 

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -17,7 +17,7 @@ import {
   registerDevtoolsTerminal,
   traceTerminalRenderer,
 } from '../utils/terminal-grid-registry';
-import { createRepaintNudge, isUserInputData, isMouseReport, mouseWheelLane, type RepaintNudgeController } from '../utils/repaint-nudge';
+import { createRepaintNudge, isUserInputData, isMouseReport, mouseReportLane, type RepaintNudgeController } from '../utils/repaint-nudge';
 import { registerMountedTerminal } from '../utils/terminal-mount-registry';
 import { registerTerminalAnchor } from '../utils/terminal-anchor-registry';
 import type { PtyResizeOrigin, TerminalColorOverrides } from '../../shared/types';
@@ -951,17 +951,20 @@ export function useTerminal(options: UseTerminalOptions) {
         // (the missing-entries family). So reports are PACED, not just
         // unbatched: one write per MOUSE_REPORT_PACE_MS restores the
         // physical-wheel cadence a native terminal delivers. Wheel reports
-        // additionally carry a direction lane (mouseWheelLane) so the
+        // additionally carry a direction lane (mouseReportLane) so the
         // batcher can cap their pending depth (a high-resolution flick
         // otherwise queues far past the hand stopping) and drop pending
         // opposite-direction reports on a same-axis, same-modifier reversal;
-        // clicks, releases, and motion are laneless, never capped or
-        // superseded (teardown flush still drops them like any pending
-        // paced item). The jump each
+        // motion reports carry a self-superseding lane keeping only the
+        // newest position (motion generates at display refresh rate, above
+        // the pace floor's drain rate, and everything queued behind a
+        // motion backlog waits it out); clicks and releases are laneless,
+        // never capped or superseded (teardown flush still drops them like
+        // any pending paced item). The jump each
         // single report produces is CLAUDE_CODE_SCROLL_SPEED's territory, not
         // this path's - see write-batcher.ts for the schemes tried and
         // rejected. Ordering against typed bytes holds.
-        if (isMouseReport(data)) batcher.writePaced(data, mouseWheelLane(data));
+        if (isMouseReport(data)) batcher.writePaced(data, mouseReportLane(data));
         else batcher.schedule(data);
       });
 

--- a/src/renderer/utils/incoming-write-queue.ts
+++ b/src/renderer/utils/incoming-write-queue.ts
@@ -68,6 +68,13 @@ export interface IncomingWriteQueueOptions {
    * and no bytes are acked, so main-side backpressure naturally throttles the
    * PTY at the source. Used to stop mid-drag xterm parsing (a board drag).
    * Resume via `kick()`. Distinct from `shouldDrop`, which acks-and-discards.
+   *
+   * Worst-case hold duration is the CALLER's release signal, not anything
+   * bounded here. useTerminal's replay hold (`scrollbackPendingRef`) is the
+   * long pole: if a replay dies mid-flight, the only unconditional release is
+   * the scrollback watchdog (5s) forcing settleScrollback. The 2026-08-28
+   * fidelity audit observed zero watchdog releases through a mass-resume
+   * boot, so this is a documented bound, not an observed cost.
    */
   shouldHold?: () => boolean;
   /** Report `bytes` consumed (written or dropped) to main's flow control. */

--- a/src/renderer/utils/repaint-nudge.ts
+++ b/src/renderer/utils/repaint-nudge.ts
@@ -114,32 +114,57 @@ export function isMouseReport(data: string): boolean {
   return SGR_MOUSE_REPORT_PATTERN.test(data) || X10_MOUSE_REPORT_PATTERN.test(data);
 }
 
+/** The one lane every motion report (drift or drag, any button, any
+ *  modifier) joins. It supersedes ITSELF: each arrival purges every pending
+ *  motion report, so at most the newest pointer position ever waits in the
+ *  queue. Superseding across button/modifier variants is deliberate - a
+ *  click, release, or wheel report carries its own coordinates, so a stale
+ *  intermediate position serves no consumer. */
+const MOTION_LANE: PacedLane = { laneKey: 'motion', supersedesLaneKey: 'motion' };
+
 /**
- * The paced-write lane for a wheel report, or undefined for everything else
- * (clicks, releases, motion, non-reports), which must never be capped or
- * superseded. Lane keys use the DECODED button code, so X10 wheel bytes
- * (96/97 on the wire) share lanes with their SGR twins (64/65): they are the
- * same physical wheel. This deliberately re-runs the anchored patterns
- * isMouseReport just tested; two anchored regex executions per wheel tick are
- * negligible and keep the routing line's tripwire shape simple.
+ * The paced-write lane for a mouse report, or undefined for reports that
+ * must never be capped or superseded (clicks, releases, non-reports:
+ * dropping a release would stick a button). Lane keys use the DECODED
+ * button code, so X10 wheel bytes (96/97 on the wire) share lanes with
+ * their SGR twins (64/65): they are the same physical wheel. This
+ * deliberately re-runs the anchored patterns isMouseReport just tested; two
+ * anchored regex executions per report are negligible and keep the routing
+ * line's tripwire shape simple.
  *
- * The supersede target is `buttonCode ^ 1`: the low bit is direction within
- * an axis, so 64/65 (up/down), 66/67 (left/right), and modifier-shifted
- * pairs like ctrl+wheel 80/81 supersede only each other. Cross-axis and
- * cross-modifier lanes never purge one another: a trackpad diagonal scroll
- * interleaves vertical and horizontal reports, and a stray horizontal tick
- * must not eat the pending vertical queue.
+ * WHEEL reports get a per-direction lane. The supersede target is
+ * `buttonCode ^ 1`: the low bit is direction within an axis, so 64/65
+ * (up/down), 66/67 (left/right), and modifier-shifted pairs like ctrl+wheel
+ * 80/81 supersede only each other. Cross-axis and cross-modifier lanes
+ * never purge one another: a trackpad diagonal scroll interleaves vertical
+ * and horizontal reports, and a stray horizontal tick must not eat the
+ * pending vertical queue.
+ *
+ * MOTION reports (bit 5, drift and drags alike) share the single
+ * self-superseding MOTION_LANE. Motion generates at the display's refresh
+ * rate while the paced queue drains at most one report per pace interval,
+ * so a laneless motion stream GROWS the queue whenever refresh outpaces the
+ * floor - measured 2026-08-28 on a 143Hz display: a two-second cursor
+ * traverse left 117 motion reports pending, nearly two seconds of stale
+ * drain. The queue is FIFO, so every wheel report and click arriving after
+ * the traverse waited out that whole backlog (the flick-after-move lag the
+ * wheel lane cap could not fix, since the cap bounds wheel COUNT, not wheel
+ * position behind motion). Keeping only the newest position restores
+ * near-native latency for everything queued behind motion, and is
+ * semantics-safe: a TUI tracking hover or a drag selection only acts on the
+ * latest position, and the press/release events that bound a drag are
+ * laneless and always delivered.
  *
  * UNWIND(claude-code#83714): lanes bound the paced queue that workaround
  * introduces; delete this with writePaced.
  */
-export function mouseWheelLane(data: string): PacedLane | undefined {
+export function mouseReportLane(data: string): PacedLane | undefined {
   let buttonCode: number;
   const sgrReport = SGR_MOUSE_REPORT_PATTERN.exec(data);
   if (sgrReport !== null) {
-    // Wheel events are press-encoded only (final byte M). A wheel-shaped
-    // code with a release final is nonstandard; leave it laneless rather
-    // than risk dropping a release.
+    // Wheel and motion events are press-encoded only (final byte M). A
+    // report with a release final (lowercase m) stays laneless rather than
+    // risk dropping a release.
     if (!data.endsWith('M')) return undefined;
     buttonCode = Number(sgrReport[1]);
   } else {
@@ -154,9 +179,14 @@ export function mouseWheelLane(data: string): PacedLane | undefined {
   // inconsistent pair that could purge a legitimate lane. Laneless is the
   // safe reading, and it also covers Number() overflowing to Infinity.
   if (buttonCode > 255) return undefined;
-  if ((buttonCode & MOUSE_WHEEL_BIT) === 0) return undefined;
-  if ((buttonCode & MOUSE_MOTION_BIT) !== 0) return undefined;
-  return { laneKey: `wheel:${buttonCode}`, supersedesLaneKey: `wheel:${buttonCode ^ 1}` };
+  if ((buttonCode & MOUSE_WHEEL_BIT) !== 0) {
+    // A code with both wheel and motion bits is nonstandard; laneless is
+    // the conservative reading.
+    if ((buttonCode & MOUSE_MOTION_BIT) !== 0) return undefined;
+    return { laneKey: `wheel:${buttonCode}`, supersedesLaneKey: `wheel:${buttonCode ^ 1}` };
+  }
+  if ((buttonCode & MOUSE_MOTION_BIT) !== 0) return MOTION_LANE;
+  return undefined;
 }
 
 /**

--- a/src/renderer/utils/write-batcher.ts
+++ b/src/renderer/utils/write-batcher.ts
@@ -29,15 +29,23 @@
  *  after the hand has stopped, and its depth scales with wheel
  *  resolution rather than requested travel. Wheel reports therefore
  *  carry a lane (one wheel direction, supplied by the caller via
- *  mouseWheelLane): pending same-lane depth is capped at
+ *  mouseReportLane): pending same-lane depth is capped at
  *  MOUSE_WHEEL_LANE_MAX_DEPTH, bounding the post-stop tail near
  *  depth * paceMs at the deliberate price of truncated travel on very
  *  large flicks, and a same-axis reversal drops the pending
  *  opposite-direction reports as stale intent (the same philosophy as
- *  flush). Laneless paced items (clicks, releases, motion) are never
- *  counted, capped, or superseded (a dropped release would stick a
- *  button); teardown flush still drops every pending paced item,
- *  laneless included, as it always has. The
+ *  flush). MOTION reports carry a single SELF-superseding lane: motion
+ *  generates at display refresh rate, which outpaces the floor's drain
+ *  rate on high-refresh displays, and the queue is FIFO, so a laneless
+ *  motion backlog delayed every wheel report and click queued behind
+ *  it (measured 2026-08-28: 117 pending motion reports on a 143Hz
+ *  display, roughly two seconds of stale drain ahead of the next
+ *  flick). Each motion arrival replaces every pending motion report,
+ *  keeping only the newest position - the only one any consumer acts
+ *  on. Laneless paced items (clicks, releases) are never counted,
+ *  capped, or superseded (a dropped release would stick a button);
+ *  teardown flush still drops every pending paced item, laneless
+ *  included, as it always has. The
  *  16ms floor itself stays as is: the cap changes how many writes
  *  queue, not the per-write cadence the TUI's read loop needs to
  *  catch each report individually, and lowering the floor would
@@ -50,8 +58,9 @@
  */
 
 /** Marks a paced item as a member of a lane of interchangeable intents
- *  (one wheel direction). The batcher stays encoding-agnostic: callers
- *  decide both keys (see mouseWheelLane in repaint-nudge.ts).
+ *  (one wheel direction, or all pointer motion). The batcher stays
+ *  encoding-agnostic: callers decide both keys (see mouseReportLane in
+ *  repaint-nudge.ts).
  *  UNWIND(claude-code#83714): lanes bound the paced queue the workaround
  *  introduces; they go when writePaced goes. */
 export interface PacedLane {
@@ -59,7 +68,9 @@ export interface PacedLane {
   laneKey: string;
   /** Pending paced items with THIS key are removed unwritten the moment an
    *  item in laneKey arrives: a same-axis wheel reversal makes the queued
-   *  opposite-direction scroll stale intent. */
+   *  opposite-direction scroll stale intent. May equal laneKey itself: a
+   *  self-superseding lane keeps only its newest arrival (pointer motion,
+   *  where only the latest position means anything). */
   supersedesLaneKey?: string;
 }
 
@@ -180,10 +191,12 @@ export function createWriteBatcher(
           queue.push(...keptItems);
         }
       }
-      // Within an axis, pending items hold only one direction (each arrival
-      // purges its opposite above), so a supersede that actually removed
-      // items implies this lane had nothing pending and the cap below
-      // cannot also act on the same arrival.
+      // A purge that actually removed items leaves this lane empty either
+      // way, so the cap below never also acts on the same arrival: a wheel
+      // arrival purges its OPPOSITE direction, and within an axis pending
+      // items hold only one direction, so its own lane had nothing pending;
+      // a self-superseding arrival (motion) just emptied its own lane
+      // directly.
       let pendingSameLaneCount = 0;
       for (const item of queue) {
         if (item.paced && item.laneKey === lane.laneKey) pendingSameLaneCount += 1;

--- a/tests/unit/paste-engine.test.ts
+++ b/tests/unit/paste-engine.test.ts
@@ -751,6 +751,35 @@ describe('PasteEngine.pasteAndSubmit submission verifier (per-adapter)', () => {
     await expect(promise).resolves.toBeUndefined();
   });
 
+  it("no verifier: evidence resolves via 'data-tap'-only bytes for an UNFOCUSED session (MCP and mobile senders)", async () => {
+    // Regression guard for the 'data' -> 'data-tap' rename in
+    // waitForSubmissionEvidence. MockSessionManager.emitData() fires
+    // 'data-tap' and 'data' back-to-back (mirroring a FOCUSED session), so
+    // every other evidence test in this file would still pass even if the
+    // listener reverted to 'data' - both events carry the same bytes. An
+    // unfocused session (MCP session-send, mobile bridge) never emits
+    // 'data' at all, only the unconditional 'data-tap' fan-out, so this
+    // test emits 'data-tap' alone to prove evidence really resolves off
+    // that event and not the sibling one. (The settle-phase equivalent is
+    // the "UNFOCUSED session settles on 'data-tap'" test above; that
+    // listener is independent of this one and doesn't cover this path.)
+    const promise = engine.pasteAndSubmit('s1', 'hello', { timeoutMs: 30000 });
+    await reachEvidenceWait();
+
+    // Below the floor - engine must still be waiting.
+    mockSessionManager.emit('data-tap', 's1', 'a'.repeat(20));
+    await tick();
+    mockSessionManager.emit('data-tap', 's1', 'b'.repeat(20));
+    await tick();
+    // 40 bytes accumulated - still below the 50-byte floor.
+
+    // Crossing the floor (50 bytes total) resolves the wait, via 'data-tap' alone.
+    mockSessionManager.emit('data-tap', 's1', 'c'.repeat(15));
+    await tick();
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
   it('verifier wins when it resolves true even though activity has not fired', async () => {
     let resolveVerifier: (value: boolean) => void;
     const verifierPromise = new Promise<boolean>((resolve) => {

--- a/tests/unit/paste-engine.test.ts
+++ b/tests/unit/paste-engine.test.ts
@@ -49,6 +49,11 @@ class MockSessionManager extends EventEmitter {
   }
 
   emitData(sessionId: string, chunk: string): void {
+    // Mirror the real SessionManager fan-out for a FOCUSED session: the
+    // unconditional 'data-tap' first, then the renderer-gated 'data',
+    // back-to-back for the same bytes (session-manager.ts onFlush). The
+    // engine listens on 'data-tap'; the unfocused test emits it alone.
+    this.emit('data-tap', sessionId, chunk);
     this.emit('data', sessionId, chunk);
   }
 
@@ -148,6 +153,47 @@ describe('PasteEngine.pasteAndSubmit', () => {
     await reachEvidenceWait();
     await emitEvidence();
 
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("an UNFOCUSED session settles on 'data-tap' instead of riding the cap (MCP and mobile senders)", async () => {
+    // A background session's bytes reach main only on the unconditional
+    // 'data-tap' fan-out; the renderer-gated 'data' event never fires for it.
+    // Before the settle listened on 'data-tap', every MCP session-send and
+    // mobile-bridge message to an unfocused session rode the full capMs
+    // (payload-scaled, ~3s here) before \r instead of settling at the 1000ms
+    // floor. The 4000-byte payload makes cap (3000ms) clearly distinguishable
+    // from the floor.
+    const big = 'y'.repeat(4000);
+    const promise = engine.pasteAndSubmit('s1', big);
+
+    await tick();
+    mockSessionManager.flushDrain();
+    await tick();
+    // 4000 + 12 markers = 4012 bytes -> 4 chunks; first is synchronous, the
+    // remaining three each need a setImmediate yield.
+    await flushSetImmediate();
+    await tick();
+    await flushSetImmediate();
+    await tick();
+    await flushSetImmediate();
+    await tick();
+    expect(mockSessionManager.writeRawCalls).toHaveLength(4);
+
+    // The TUI's paste-placeholder redraw, arriving on data-tap ONLY.
+    mockSessionManager.emit('data-tap', 's1', '\x1b[K[Pasted text +0 lines]');
+    await tick();
+    vi.advanceTimersByTime(250); // idle window after the burst
+    await tick();
+    vi.advanceTimersByTime(750); // complete the 1000ms React-commit floor
+    await tick();
+
+    // \r must already be queued at the floor, not at the ~3000ms cap.
+    expect(mockSessionManager.writeCalls).toHaveLength(1);
+    expect(mockSessionManager.writeCalls[0].data).toBe('\r');
+
+    await reachEvidenceWait();
+    await emitEvidence();
     await expect(promise).resolves.toBeUndefined();
   });
 

--- a/tests/unit/repaint-nudge.test.ts
+++ b/tests/unit/repaint-nudge.test.ts
@@ -18,7 +18,7 @@ import {
   diffViewportRows,
   isUserInputData,
   isMouseReport,
-  mouseWheelLane,
+  mouseReportLane,
   REPAINT_NUDGE_BYTES,
   type RepaintNudgeGate,
 } from '../../src/renderer/utils/repaint-nudge';
@@ -196,15 +196,20 @@ describe('isMouseReport', () => {
   });
 });
 
-describe('mouseWheelLane', () => {
+describe('mouseReportLane', () => {
   // Wheel reports get a paced-write lane so the batcher can cap their pending
   // depth and drop pending opposite-direction reports on a same-axis reversal
-  // (write-batcher.ts). Everything else stays laneless (undefined), which the
-  // batcher treats as never-cap, never-supersede: dropping a click release
-  // would stick a button. The supersede target is buttonCode ^ 1, so only
+  // (write-batcher.ts). The supersede target is buttonCode ^ 1, so only
   // same-axis, same-modifier pairs purge each other: a trackpad diagonal
   // scroll interleaves vertical and horizontal reports, and a stray
-  // horizontal tick must not eat the pending vertical queue.
+  // horizontal tick must not eat the pending vertical queue. Motion reports
+  // (drift and drags, any modifier) share ONE self-superseding lane so only
+  // the newest pointer position ever waits in the queue: motion generates at
+  // display refresh rate, above the pace floor's drain rate, and a laneless
+  // motion backlog delayed every wheel report and click queued behind it.
+  // Clicks and releases stay laneless (undefined), which the batcher treats
+  // as never-cap, never-supersede: dropping a click release would stick a
+  // button.
   const x10WheelUpBytes = String.fromCharCode(32 + 64, 40, 40);
   const x10WheelDownBytes = String.fromCharCode(32 + 65, 40, 40);
   const x10MotionBytes = String.fromCharCode(32 + 35, 40, 40);
@@ -254,8 +259,21 @@ describe('mouseWheelLane', () => {
       '\x1b[M' + x10WheelDownBytes,
       { laneKey: 'wheel:65', supersedesLaneKey: 'wheel:64' },
     ],
-    ['SGR motion (35)', '\x1b[<35;10;5M', undefined],
-    ['SGR drag (32)', '\x1b[<32;10;5M', undefined],
+    [
+      'SGR motion (35) joins the single self-superseding motion lane',
+      '\x1b[<35;10;5M',
+      { laneKey: 'motion', supersedesLaneKey: 'motion' },
+    ],
+    [
+      'SGR drag (32) shares the motion lane: only the newest position matters',
+      '\x1b[<32;10;5M',
+      { laneKey: 'motion', supersedesLaneKey: 'motion' },
+    ],
+    [
+      'SGR shift+drag (36) shares the motion lane across modifiers',
+      '\x1b[<36;10;5M',
+      { laneKey: 'motion', supersedesLaneKey: 'motion' },
+    ],
     ['SGR click press (0)', '\x1b[<0;10;5M', undefined],
     ['SGR click release (0, lowercase m)', '\x1b[<0;10;5m', undefined],
     ['a wheel-shaped code with a release final (lowercase m) stays laneless', '\x1b[<64;10;5m', undefined],
@@ -273,14 +291,18 @@ describe('mouseWheelLane', () => {
       '\x1b[<' + '9'.repeat(400) + ';10;5M',
       undefined,
     ],
-    ['X10 motion', '\x1b[M' + x10MotionBytes, undefined],
+    [
+      'X10 motion shares the SGR motion lane',
+      '\x1b[M' + x10MotionBytes,
+      { laneKey: 'motion', supersedesLaneKey: 'motion' },
+    ],
     ['X10 click', '\x1b[M' + x10ClickBytes, undefined],
     ['two SGR reports joined into one chunk', '\x1b[<64;10;5M\x1b[<65;10;5M', undefined],
     ['an SGR report with trailing bytes', '\x1b[<64;10;5Mhello', undefined],
     ['a FocusIn report', '\x1b[I', undefined],
     ['an ordinary typed character', 'a', undefined],
   ])('%s', (_label, data, expected) => {
-    expect(mouseWheelLane(data as string)).toEqual(expected);
+    expect(mouseReportLane(data as string)).toEqual(expected);
   });
 });
 

--- a/tests/unit/write-batcher.test.ts
+++ b/tests/unit/write-batcher.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { createWriteBatcher } from '../../src/renderer/utils/write-batcher';
-import { isMouseReport, mouseWheelLane } from '../../src/renderer/utils/repaint-nudge';
+import { isMouseReport, mouseReportLane } from '../../src/renderer/utils/repaint-nudge';
 
 /** Wait for all pending microtasks to drain. */
 const drainMicrotasks = () => new Promise<void>((resolve) => queueMicrotask(resolve));
@@ -605,7 +605,7 @@ describe('createWriteBatcher', () => {
       // both - there is no other isMouseReport(data)/batcher.schedule(data)
       // pairing anywhere else in this file for either to accidentally match.
       const mouseReportRoutesToWritePaced =
-        /if\s*\(\s*isMouseReport\(data\)\s*\)\s*\{?\s*batcher\.writePaced\(data,\s*mouseWheelLane\(data\)\)/;
+        /if\s*\(\s*isMouseReport\(data\)\s*\)\s*\{?\s*batcher\.writePaced\(data,\s*mouseReportLane\(data\)\)/;
       const elseRoutesToSchedule = /else\s*\{?\s*batcher\.schedule\(data\)/;
 
       expect(source).toMatch(mouseReportRoutesToWritePaced);
@@ -627,7 +627,7 @@ describe('createWriteBatcher', () => {
       // the assertions below are checking what that exact expression DOES,
       // not just that its text is present.
       const routeOnData = (batcher: ReturnType<typeof createWriteBatcher>, data: string): void => {
-        if (isMouseReport(data)) batcher.writePaced(data, mouseWheelLane(data));
+        if (isMouseReport(data)) batcher.writePaced(data, mouseReportLane(data));
         else batcher.schedule(data);
       };
 
@@ -694,6 +694,49 @@ describe('createWriteBatcher', () => {
         // The queued down report never writes; the reversal is what drains.
         vi.advanceTimersByTime(PACE_MS * 4);
         expect(write.mock.calls).toEqual([['\x1b[<65;10;5M'], ['\x1b[<64;10;5M']]);
+      });
+
+      it('a wheel flick after a motion flood is not delayed behind stale positions', () => {
+        // The 143Hz regression (2026-08-28): motion generates at display
+        // refresh rate, above the 62.5/s the floor drains, and the queue is
+        // FIFO - so before motion had a self-superseding lane, a cursor
+        // traverse left a backlog of stale positions and the NEXT flick
+        // waited out all of them (measured: 117 pending, ~2s). With the
+        // lane, only the newest position survives, so the flick clears
+        // within two pace intervals instead of backlog * PACE_MS.
+        const write = vi.fn<[string], void>();
+        const batcher = createWriteBatcher(write, PACE_MS);
+
+        for (let step = 0; step < 20; step += 1) {
+          routeOnData(batcher, `\x1b[<35;${10 + step};5M`);
+        }
+        routeOnData(batcher, '\x1b[<64;40;5M'); // the flick, right after the hand stops
+
+        vi.advanceTimersByTime(PACE_MS * 2);
+        const payloads = write.mock.calls.flat();
+        expect(payloads[0]).toBe('\x1b[<35;10;5M'); // first motion wrote immediately
+        expect(payloads).toContain('\x1b[<64;40;5M'); // the flick is already through
+        // Only the first (already written) and the newest motion survive;
+        // the 18 stale intermediate positions were purged unwritten.
+        expect(payloads.filter((payload) => payload.includes('<35;'))).toHaveLength(2);
+        expect(payloads).toContain('\x1b[<35;29;5M');
+      });
+
+      it('motion purging never removes a click or release sitting between motions', () => {
+        const write = vi.fn<[string], void>();
+        const batcher = createWriteBatcher(write, PACE_MS);
+
+        routeOnData(batcher, '\x1b[<35;10;5M'); // motion: immediate
+        routeOnData(batcher, '\x1b[<35;11;5M'); // motion: pending
+        routeOnData(batcher, '\x1b[<0;12;5m'); // click release: laneless, pending
+        routeOnData(batcher, '\x1b[<35;13;5M'); // motion: purges only the pending motion
+
+        vi.advanceTimersByTime(PACE_MS * 4);
+        expect(write.mock.calls).toEqual([
+          ['\x1b[<35;10;5M'],
+          ['\x1b[<0;12;5m'],
+          ['\x1b[<35;13;5M'],
+        ]);
       });
     });
   });


### PR DESCRIPTION
## What

Four fixes and their documentation from the terminal render fidelity audit:

- **Mouse motion gets a self-superseding paced lane** (`mouseReportLane`, renamed from `mouseWheelLane`). Motion reports generate at the display's refresh rate (measured 143Hz) while the paced writer drains at most 62.5/s, and motion was deliberately laneless, so the FIFO queue grew ~80 reports/second whenever the cursor moved over a terminal (117 pending measured from dogfooding logs). Every wheel flick and click landing after a cursor traverse queued behind seconds of stale positions; the wheel lane cap bounds wheel count, not wheel position behind motion. Each motion arrival now purges all pending motion, keeping only the newest position. Clicks and releases stay laneless and are never dropped.
- **The paste engine observes `data-tap` instead of the renderer-gated `data` event** for all three of its PTY listeners (output settle, submission evidence, bracketed-paste-mode monitor). MCP session-send and mobile-bridge messages target sessions no renderer is subscribed to; under `data` those callers rode the payload-scaled settle cap (seconds) with no early settle, and the modal-safety guard never armed for them. Focused-caller timing is unchanged: both events fire back-to-back in the same fan-out for the same bytes.
- **`dev.js` warns loudly when `npm start` loses the single-instance lock.** The losing instance exits silently while the holder's window is focused, which is indistinguishable from a successful dev launch and led to days of dogfooding the wrong build.
- **Comment-only records** of audited worst-case bounds (the incoming-write-queue's 5s hold watchdog, the buffer manager's replay flush hold) and the DECSTBM gate re-verification at CLI 2.1.250, plus the UNWIND marker the SCROLL_SPEED keeplist was missing.

## Why

Terminal fidelity is the product's core feature, and scroll feel had measurably degraded. The audit traced the felt regressions to the motion flood (this PR), the unbounded wheel queue (fixed previously, unreleased), and a build-identity trap (the dev.js warning). The paste-engine fix fell out of the same investigation: `output-settle.ts`'s own header warns about exactly the focus-gating trap it had.

## How

The motion lane needs zero write-batcher logic changes: self-supersede falls out of the existing purge-then-count order, so the change is classification (`mouseReportLane`) plus documentation. Dropping stale motion is semantically safe because clicks, releases, and wheel reports carry their own coordinates, and a TUI acts only on the latest position. The paste-engine switch is safe for focused callers because `data-tap` and `data` are emitted back-to-back synchronously for identical bytes.

## Breaking changes

None.

## Tests

- New unit tests pin the motion lane end to end: classifier rows (SGR drift, drag, modifier drag, X10), the flick-after-motion-flood latency regression (write queued at the pace floor, not behind stale positions), and that motion purging never removes a laneless click or release.
- New unit tests pin both unfocused paste paths red-green: settle resolves at the floor instead of riding the cap on `data-tap`-only bytes, and the evidence phase resolves via `data-tap`-only bytes (the mock now mirrors the real two-event fan-out, so a silent revert to the gated event fails the suite).
- CI runs the full unit, UI, and Electron E2E tiers on this PR.

Generated with [Claude Code](https://claude.com/claude-code)
