### PR TITLE
feat(titlebar): mark dev builds as "Kangentic (dev)" in the wordmark and OS title

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -48,7 +48,7 @@ import { PATHS } from './config/paths';
 // one-shot marker there - so a module-scope load() breaks this too.
 const configFileExistedAtLaunch = fs.existsSync(PATHS.configFile);
 import { initStartupTimer, mark, phase, endPhase, finishStartupTimer } from './startup-timer';
-import { resolveBackgroundColor, resolveIconPath, resolveWindowBounds, resolveRendererIndexPath } from './window-utils';
+import { resolveBackgroundColor, resolveIconPath, resolveWindowBounds, resolveRendererIndexPath, computeWindowTitle } from './window-utils';
 import { popOutWindowManager } from './pop-out/pop-out-window-manager';
 import { destroyAllLanes } from './browser/browser-lane-manager';
 import { sweepOrphanedBrowserPartitions } from './browser/browser-partition-cleanup';
@@ -1044,42 +1044,27 @@ const createWindow = () => {
     mark('did_finish_load');
 
     // Set the window title so the taskbar entry says which build this is and, for a
-    // worktree run, which worktree. One computed string, one setTitle call, so the
-    // dev marker cannot drift between the worktree and non-worktree paths.
+    // worktree run, which worktree. One computed string (computeWindowTitle,
+    // window-utils.ts), one setTitle call, so the dev marker cannot drift between the
+    // worktree and non-worktree paths. A dev build marks itself here the same way the
+    // in-app wordmark does, so the taskbar entry and the window chrome agree about which
+    // instance this is when a packaged build is open alongside `npm start`.
+    //
+    // The __KANGENTIC_DEV__ ternary stays INLINE here rather than moving into
+    // computeWindowTitle: esbuild only folds this reference (and drops the "(dev)"
+    // string literal from the production bundle via dead-code elimination) at the
+    // point __KANGENTIC_DEV__ itself is referenced. Passing a boolean into a separate
+    // module's function would ship the literal, dead but present, in every prod build.
+    // For the MAIN bundle __KANGENTIC_DEV__ means "dev tooling compiled in"
+    // (scripts/dev.js sets it; scripts/build.js only under KANGENTIC_BUILD_DEV=1).
+    //
+    // Set from `did-finish-load`, after Chromium has applied index.html's <title>, so
+    // this wins. The main window does not preventDefault() on 'page-title-updated'
+    // (unlike window-open-policy.ts for popups), so a renderer-side document.title write
+    // would silently clobber it. Nothing in the main-window tree writes one.
     if (mainWindow) {
-      // A dev build marks itself here the same way the in-app wordmark does, so the
-      // taskbar entry and the window chrome agree about which instance this is when a
-      // packaged build is open alongside `npm start`. Folded away in production by
-      // __KANGENTIC_DEV__, which for the MAIN bundle means "dev tooling compiled in"
-      // (scripts/dev.js sets it; scripts/build.js only under KANGENTIC_BUILD_DEV=1).
       const appLabel = __KANGENTIC_DEV__ ? 'Kangentic (dev)' : 'Kangentic';
-      // Outside a worktree this is the whole title, and in production it restates the
-      // string index.html's <title> already produced, so that path stays a no-op.
-      let windowTitle = appLabel;
-      const worktreeMatch = cwd ? cwd.replace(/\\/g, '/').match(/\.kangentic\/worktrees\/([^/]+)/) : null;
-      if (worktreeMatch) {
-        // A preview window gets the task's own `#<id> - <title>` label, with no
-        // app-name prefix: Windows already groups these thumbnails under
-        // Kangentic, so repeating it only pushed the part that identifies the
-        // window past the edge of the thumbnail. The number alone was not enough
-        // either - it still meant scanning the board to learn which task it was.
-        // Same string the title-bar pill renders, so the two cannot drift.
-        //
-        // Outside preview (or when resolution missed), keep the app-name form:
-        // there the title is the only thing distinguishing a worktree run from
-        // the main window. Current worktree folders are the task's display_id;
-        // folders created before that scheme keep their `<slug>-<shortId>` name,
-        // so prefix the numeric form to stop it reading as a window index.
-        const folderName = worktreeMatch[1];
-        const folderLabel = /^\d+$/.test(folderName) ? `#${folderName}` : folderName;
-        const previewLabel = getPreviewTaskTitle();
-        windowTitle = previewLabel ?? `${appLabel} - ${folderLabel}`;
-      }
-      // Set from `did-finish-load`, after Chromium has applied index.html's <title>,
-      // so this wins. The main window does not preventDefault() on 'page-title-updated'
-      // (unlike window-open-policy.ts for popups), so a renderer-side document.title
-      // write would silently clobber it. Nothing in the main-window tree writes one.
-      mainWindow.setTitle(windowTitle);
+      mainWindow.setTitle(computeWindowTitle(appLabel, cwd, getPreviewTaskTitle));
     }
 
     // Await the preload that started during createWindow -- typically already resolved

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1043,10 +1043,20 @@ const createWindow = () => {
   mainWindow.webContents.on('did-finish-load', async () => {
     mark('did_finish_load');
 
-    // Set window title to include worktree name so the taskbar entry
-    // is distinguishable from the main project window.
-    if (cwd && mainWindow) {
-      const worktreeMatch = cwd.replace(/\\/g, '/').match(/\.kangentic\/worktrees\/([^/]+)/);
+    // Set the window title so the taskbar entry says which build this is and, for a
+    // worktree run, which worktree. One computed string, one setTitle call, so the
+    // dev marker cannot drift between the worktree and non-worktree paths.
+    if (mainWindow) {
+      // A dev build marks itself here the same way the in-app wordmark does, so the
+      // taskbar entry and the window chrome agree about which instance this is when a
+      // packaged build is open alongside `npm start`. Folded away in production by
+      // __KANGENTIC_DEV__, which for the MAIN bundle means "dev tooling compiled in"
+      // (scripts/dev.js sets it; scripts/build.js only under KANGENTIC_BUILD_DEV=1).
+      const appLabel = __KANGENTIC_DEV__ ? 'Kangentic (dev)' : 'Kangentic';
+      // Outside a worktree this is the whole title, and in production it restates the
+      // string index.html's <title> already produced, so that path stays a no-op.
+      let windowTitle = appLabel;
+      const worktreeMatch = cwd ? cwd.replace(/\\/g, '/').match(/\.kangentic\/worktrees\/([^/]+)/) : null;
       if (worktreeMatch) {
         // A preview window gets the task's own `#<id> - <title>` label, with no
         // app-name prefix: Windows already groups these thumbnails under
@@ -1063,8 +1073,13 @@ const createWindow = () => {
         const folderName = worktreeMatch[1];
         const folderLabel = /^\d+$/.test(folderName) ? `#${folderName}` : folderName;
         const previewLabel = getPreviewTaskTitle();
-        mainWindow.setTitle(previewLabel ?? `Kangentic - ${folderLabel}`);
+        windowTitle = previewLabel ?? `${appLabel} - ${folderLabel}`;
       }
+      // Set from `did-finish-load`, after Chromium has applied index.html's <title>,
+      // so this wins. The main window does not preventDefault() on 'page-title-updated'
+      // (unlike window-open-policy.ts for popups), so a renderer-side document.title
+      // write would silently clobber it. Nothing in the main-window tree writes one.
+      mainWindow.setTitle(windowTitle);
     }
 
     // Await the preload that started during createWindow -- typically already resolved

--- a/src/main/window-utils.ts
+++ b/src/main/window-utils.ts
@@ -40,6 +40,48 @@ export function resolveRendererIndexPath(viteName: string): string {
   return fs.existsSync(standalonePath) ? standalonePath : legacyPath;
 }
 
+/**
+ * Compute the main window's OS/taskbar title.
+ *
+ * Pure: the caller resolves `appLabel` ("Kangentic (dev)" vs "Kangentic") from the
+ * build-time `__KANGENTIC_DEV__` constant AT THE CALL SITE, not in here. Two reasons:
+ * that identifier is an esbuild `define` and does not exist as a runtime global under
+ * vitest; and, more load-bearingly, esbuild's dead-code elimination folds a direct
+ * `__KANGENTIC_DEV__ ? 'Kangentic (dev)' : 'Kangentic'` reference to the `false` branch
+ * and drops the "(dev)" string literal from the production bundle entirely - but only
+ * at the reference site itself. Moving that ternary in here would make it read a plain
+ * `boolean` parameter instead, which esbuild cannot fold across the module boundary, so
+ * the literal would ship (dead, unreachable, but present) in every production build.
+ * Keep the ternary inline at the call site in index.ts; this function only composes the
+ * already-resolved label with the worktree/preview logic.
+ *
+ * `resolvePreviewTaskTitle` is a thunk so it is invoked only when a worktree is actually
+ * detected, preserving the original call site's laziness (that resolver does a real, if
+ * best-effort, DB lookup).
+ *
+ * Outside a worktree, the title is just `appLabel` - in production that already matches
+ * what index.html's static <title> shows, so setTitle restates rather than changes that
+ * case.
+ *
+ * Inside a worktree, a resolved preview task label (`#<id> - <title>`) wins outright with
+ * NO `appLabel` prefix - Windows already groups the thumbnail under the Kangentic taskbar
+ * group, so repeating the app name there only pushes the part that identifies the window
+ * past the edge of the thumbnail. Otherwise it falls back to "<appLabel> - <folderLabel>",
+ * where a purely-numeric worktree folder (the task's display_id) reads as "#<id>" instead
+ * of a bare number, and a legacy `<slug>-<shortId>` folder is used verbatim.
+ */
+export function computeWindowTitle(
+  appLabel: string,
+  cwd: string | null,
+  resolvePreviewTaskTitle: () => string | null,
+): string {
+  const worktreeMatch = cwd ? cwd.replace(/\\/g, '/').match(/\.kangentic\/worktrees\/([^/]+)/) : null;
+  if (!worktreeMatch) return appLabel;
+  const folderName = worktreeMatch[1];
+  const folderLabel = /^\d+$/.test(folderName) ? `#${folderName}` : folderName;
+  return resolvePreviewTaskTitle() ?? `${appLabel} - ${folderLabel}`;
+}
+
 /** Read saved window bounds from config, with screen-boundary validation. */
 export function resolveWindowBounds(): { x: number; y: number; width: number; height: number; maximized: boolean } | null {
   try {

--- a/src/renderer/components/layout/TitleBar.tsx
+++ b/src/renderer/components/layout/TitleBar.tsx
@@ -118,7 +118,18 @@ export function TitleBar({
       {/* Branding -- logo + app name */}
       <div className="flex items-center gap-1.5 flex-shrink-0">
         <BrandMark className="w-5 h-5 text-fg-secondary" />
-        <span className="text-sm font-semibold text-fg-secondary">Kangentic</span>
+        <span className="text-sm font-semibold text-fg-secondary">
+          Kangentic
+          {/*
+            Dev-only marker so a `npm start` window is distinguishable from a packaged build
+            when both are open. Nested INSIDE the wordmark span rather than beside it, so it
+            inherits the wordmark's size/weight/tone and is separated by exactly one space
+            instead of the parent flex row's gap. Built out of prod by __KANGENTIC_DEV__, the
+            same gate the preview pill below uses, so nothing ships in a packaged build. A
+            preview window is a dev window, so it gets this too, on top of its pill.
+          */}
+          {__KANGENTIC_DEV__ && <span data-testid="titlebar-dev-badge">{' (dev)'}</span>}
+        </span>
         {/*
           Dev-only (preview): the original task's `#<id> - <title>` label after the
           wordmark, in a muted pill (raised surface + edge border) so it stands out without

--- a/tests/captures/features/walkthrough.capture.ts
+++ b/tests/captures/features/walkthrough.capture.ts
@@ -11,6 +11,7 @@ import { chromium, type Page } from '@playwright/test';
 import path from 'node:path';
 import fs from 'node:fs';
 import { getOutputDir } from '../helpers/output-dir';
+import { hideDevOnlyChrome } from '../helpers/capture-page';
 
 const OUTPUT_DIR = getOutputDir('walkthrough');
 const MOCK_SCRIPT = path.join(__dirname, '..', '..', 'ui', 'mock-electron-api.js');
@@ -133,6 +134,10 @@ test('full product walkthrough', async () => {
   `);
 
   await page.addInitScript({ path: MOCK_SCRIPT });
+
+  // This capture builds its own page instead of using launchCapturePage, so it needs
+  // its own call. Without it the walkthrough video and chapter PNGs show the dev badge.
+  await hideDevOnlyChrome(page);
 
   // Enable session spawn in the mock (normally throws in UI tests).
   // Uses __mockPreConfigure to capture internal state references,

--- a/tests/captures/helpers/capture-page.ts
+++ b/tests/captures/helpers/capture-page.ts
@@ -37,6 +37,37 @@ export interface CapturePage {
 }
 
 /**
+ * Hide dev-only title-bar chrome from marketing assets.
+ *
+ * Captures render against the shared Vite dev server (playwright.config.ts's
+ * `webServer`), so `__KANGENTIC_DEV__` is true and the title-bar wordmark carries
+ * its "(dev)" badge. Every capture is a full-viewport screenshot or screencast that
+ * includes the title bar, and marketing assets must show the shipped wordmark.
+ *
+ * addInitScript, not addStyleTag: an injected <style> does not survive the
+ * `page.goto` that follows, and the walkthrough capture navigates after its setup.
+ * Call this from every capture page setup, not just `launchCapturePage`;
+ * `tests/unit/capture-dev-chrome-parity.test.ts` fails the build if one forgets.
+ *
+ * Scope is the wordmark badge alone. TitleBar's other `__KANGENTIC_DEV__` element,
+ * the preview-task pill, needs no rule here: it renders only when
+ * `window.electronAPI.dev.previewTaskTitle` is set, and the capture mock defines no
+ * `dev` key at all. A third dev-only element would need its selector added below.
+ */
+export async function hideDevOnlyChrome(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const injectStyle = () => {
+      const style = document.createElement('style');
+      style.textContent = '[data-testid="titlebar-dev-badge"] { display: none; }';
+      document.head.appendChild(style);
+    };
+    // Init scripts run at document start, where <head> may not exist yet.
+    if (document.head) injectStyle();
+    else document.addEventListener('DOMContentLoaded', injectStyle, { once: true });
+  });
+}
+
+/**
  * Launch a Chromium page pre-configured for marketing captures.
  * Sets viewport, device scale, theme, injects mock + fixture data,
  * disables animations, and waits for the board to render.
@@ -84,6 +115,8 @@ export async function launchCapturePage(options: CaptureOptions): Promise<Captur
 
   // Inject the mock Electron API
   await page.addInitScript({ path: MOCK_SCRIPT });
+
+  await hideDevOnlyChrome(page);
 
   // Inject the marketing fixture data
   await page.addInitScript(options.preConfigScript);

--- a/tests/ui/app.spec.ts
+++ b/tests/ui/app.spec.ts
@@ -48,6 +48,10 @@ test.describe('App Launch', () => {
 
   test('title bar displays Kangentic branding', async () => {
     await expect(page.locator('.font-semibold:has-text("Kangentic")')).toBeVisible();
+    // The UI tier serves the renderer from `vite` with no --mode production, so
+    // __KANGENTIC_DEV__ is true and the wordmark carries its dev badge. A packaged
+    // build drops it entirely via dead-code elimination.
+    await expect(page.locator('[data-testid="titlebar-dev-badge"]')).toHaveText('(dev)');
   });
 
   test('status bar exists', async () => {

--- a/tests/unit/capture-dev-chrome-parity.test.ts
+++ b/tests/unit/capture-dev-chrome-parity.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Capture dev-chrome parity guard.
+ *
+ * TitleBar.tsx renders a `[data-testid="titlebar-dev-badge"]` "(dev)" badge
+ * whenever `__KANGENTIC_DEV__` is true. Marketing captures under
+ * tests/captures/ render against the shared Vite dev server
+ * (playwright.config.ts's `webServer`), so `__KANGENTIC_DEV__` is always true
+ * there and the badge WOULD appear in every screenshot and video unless a
+ * capture explicitly hides it via `hideDevOnlyChrome` (capture-page.ts).
+ * `launchCapturePage` calls it for every capture routed through it, but a
+ * capture that builds its OWN Chromium page - the way
+ * walkthrough.capture.ts does - has to call it separately, and nothing forces
+ * that call to stay in place.
+ *
+ * tests/captures/** has no other gate that would catch a missing or deleted
+ * call: tsconfig.json's `include` only covers src/** and
+ * packages/protocol/src/**, so this tree is never typechecked; `npm run
+ * lint` only runs eslint against src/ and packages/protocol/src/; and
+ * .github/workflows/ci.yml has no captures tier. So a bespoke-page capture
+ * that forgets the call, or a deleted call in an existing one, ships a
+ * marketing screenshot/video with a raw "(dev)" badge and nothing fails.
+ *
+ * This test (pure source analysis, no Vite server or browser needed - runs
+ * in CI via the unit tier) makes that regression unmergeable: every file
+ * under tests/captures/** that constructs its own Playwright page
+ * (chromium.launch / .newContext / .newPage) must also call
+ * hideDevOnlyChrome(...) somewhere in that same file.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const CAPTURES_DIR = path.join(REPO_ROOT, 'tests/captures');
+
+const PAGE_CONSTRUCTION_PATTERNS = [/chromium\.launch\(/, /\.newContext\(/, /\.newPage\(/];
+const HIDE_CALL_PATTERN = /hideDevOnlyChrome\(/;
+
+function collectSourceFiles(directory: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath));
+    } else if (path.extname(entry.name) === '.ts') {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function toRelative(filePath: string): string {
+  return path.relative(REPO_ROOT, filePath).replace(/\\/g, '/');
+}
+
+/** Every tests/captures/**\/*.ts file that constructs its own Playwright
+ *  page, i.e. matches at least one of PAGE_CONSTRUCTION_PATTERNS. */
+const pageConstructingFiles = collectSourceFiles(CAPTURES_DIR)
+  .filter((filePath) => {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    return PAGE_CONSTRUCTION_PATTERNS.some((pattern) => pattern.test(content));
+  })
+  .map(toRelative)
+  .sort();
+
+describe('capture dev-chrome parity: scan is not vacuous', () => {
+  it('finds both known bespoke-page capture files', () => {
+    // If a future Playwright/Chromium refactor renames chromium.launch /
+    // newContext / newPage, PAGE_CONSTRUCTION_PATTERNS would silently stop
+    // matching anything and the check below would vacuously pass over zero
+    // files. Pinning the two known offenders means that refactor fails here
+    // instead of shipping a badge with nobody watching for it.
+    expect(pageConstructingFiles).toContain('tests/captures/helpers/capture-page.ts');
+    expect(pageConstructingFiles).toContain('tests/captures/features/walkthrough.capture.ts');
+    expect(pageConstructingFiles.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('capture dev-chrome parity: every bespoke-page capture hides the dev badge', () => {
+  it('every file that constructs its own page also calls hideDevOnlyChrome(...)', () => {
+    const offenders = pageConstructingFiles.filter((relativePath) => {
+      const content = fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf-8');
+      return !HIDE_CALL_PATTERN.test(content);
+    });
+    expect(
+      offenders,
+      `These tests/captures files construct their own Playwright page `
+        + `(chromium.launch / .newContext / .newPage) but never call `
+        + `hideDevOnlyChrome(page) (tests/captures/helpers/capture-page.ts). `
+        + `Without that call the title bar's "(dev)" badge `
+        + `([data-testid="titlebar-dev-badge"]) renders against the dev `
+        + `server and ships in the marketing screenshot or video. Add `
+        + `\`await hideDevOnlyChrome(page);\` right after the page is `
+        + `created:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/window-utils.test.ts
+++ b/tests/unit/window-utils.test.ts
@@ -38,7 +38,7 @@ vi.mock('electron', () => ({
 
 import fs from 'node:fs';
 import { screen } from 'electron';
-import { resolveIconPath, resolvePopOutBounds, savePopOutBounds } from '../../src/main/window-utils';
+import { computeWindowTitle, resolveIconPath, resolvePopOutBounds, savePopOutBounds } from '../../src/main/window-utils';
 
 interface FakeDisplay {
   id: number;
@@ -206,6 +206,82 @@ describe('savePopOutBounds', () => {
     // Highest-value assertion: a save for 'changes' must not drop the sibling 'stats'
     // entry (read-merge-write), regardless of AppConfig's dictionary merge semantics.
     expect(savedConfig.popOutBounds?.stats).toEqual(previousStats);
+  });
+});
+
+describe('computeWindowTitle', () => {
+  // Pure string logic - no fs/electron access, so none of the module-level mocks above
+  // apply here. `appLabel` is always passed in as an already-resolved string ("Kangentic
+  // (dev)" or "Kangentic") rather than a boolean read from `__KANGENTIC_DEV__`: that
+  // identifier is an esbuild `define`, resolved (and its "(dev)" string literal folded
+  // away by dead-code elimination in production) only at the call site in index.ts. See
+  // the doc comment on computeWindowTitle for why the ternary must stay there instead of
+  // moving into this function.
+  const noPreviewTitle = () => null;
+
+  it('non-worktree: the app label alone, with no cwd at all', () => {
+    expect(computeWindowTitle('Kangentic (dev)', null, noPreviewTitle)).toBe('Kangentic (dev)');
+  });
+
+  it('non-worktree, dev label, real (non-worktree) cwd: "Kangentic (dev)" - the core new behavior', () => {
+    // This is the case the whole feature exists for: a dogfooding `npm start` window,
+    // NOT running out of a .kangentic/worktrees/ checkout, distinguishable from a
+    // packaged build in the taskbar.
+    expect(computeWindowTitle('Kangentic (dev)', 'C:\\Users\\dev\\projects\\kangentic', noPreviewTitle)).toBe(
+      'Kangentic (dev)',
+    );
+  });
+
+  it('non-worktree, production label: plain "Kangentic" - restates index.html\'s <title>, no badge', () => {
+    expect(computeWindowTitle('Kangentic', 'C:\\Users\\dev\\projects\\kangentic', noPreviewTitle)).toBe('Kangentic');
+  });
+
+  it('worktree, numeric folder (display_id), dev label, no resolved preview label: "Kangentic (dev) - #<id>"', () => {
+    expect(
+      computeWindowTitle('Kangentic (dev)', 'C:\\Users\\dev\\kangentic\\.kangentic\\worktrees\\566', noPreviewTitle),
+    ).toBe('Kangentic (dev) - #566');
+  });
+
+  it('worktree, numeric folder, production label, no resolved preview label: "Kangentic - #<id>"', () => {
+    expect(
+      computeWindowTitle('Kangentic', 'C:\\Users\\dev\\kangentic\\.kangentic\\worktrees\\566', noPreviewTitle),
+    ).toBe('Kangentic - #566');
+  });
+
+  it('worktree, legacy <slug>-<shortId> folder: used verbatim, no leading "#"', () => {
+    expect(
+      computeWindowTitle(
+        'Kangentic (dev)',
+        'C:\\Users\\dev\\kangentic\\.kangentic\\worktrees\\my-feature-a1b2c3d4',
+        noPreviewTitle,
+      ),
+    ).toBe('Kangentic (dev) - my-feature-a1b2c3d4');
+  });
+
+  it('worktree with a resolved preview task label: the label wins OUTRIGHT - no "Kangentic" prefix, no "(dev)" suffix', () => {
+    // Highest-value case: this is the one place the app-name/dev marker deliberately
+    // does NOT appear, because Windows already groups the thumbnail under the
+    // Kangentic taskbar group. A future edit that "helpfully" prepends the app label
+    // here would push the part that actually identifies the window off the thumbnail.
+    expect(
+      computeWindowTitle(
+        'Kangentic (dev)',
+        'C:\\Users\\dev\\kangentic\\.kangentic\\worktrees\\566',
+        () => '#566 - Some task',
+      ),
+    ).toBe('#566 - Some task');
+  });
+
+  it('accepts a forward-slash cwd (POSIX) identically to a backslash one', () => {
+    expect(
+      computeWindowTitle('Kangentic (dev)', '/home/dev/kangentic/.kangentic/worktrees/566', noPreviewTitle),
+    ).toBe('Kangentic (dev) - #566');
+  });
+
+  it('does not invoke the preview-title resolver at all outside a worktree (preserves laziness)', () => {
+    const resolvePreviewTaskTitle = vi.fn(() => null);
+    computeWindowTitle('Kangentic (dev)', 'C:\\Users\\dev\\projects\\kangentic', resolvePreviewTaskTitle);
+    expect(resolvePreviewTaskTitle).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## What

The title bar wordmark reads **Kangentic (dev)** instead of **Kangentic** in dev builds, and the OS/taskbar title carries the same marker.

- `src/renderer/components/layout/TitleBar.tsx` - the wordmark span gains a nested `<span data-testid="titlebar-dev-badge"> (dev)</span>`.
- `src/main/index.ts` + `src/main/window-utils.ts` - the `did-finish-load` handler composes one title string and makes one `setTitle` call.
- `tests/captures/**` - marketing captures hide the badge.

## Why

The team dogfoods Kangentic from `npm start` while a packaged build is often open at the same time. Both windows drew an identical wordmark and an identical taskbar entry, so the only way to tell which was the dev instance was to click into one.

There is precedent for marking dev at the OS level: dev mode already runs under a separate AppUserModelID (`com.kangentic.dev`, `docs/cross-platform.md`).

CLAUDE.md's "dev mode must be indistinguishable from a production boot" is about HMR-induced drift inside a session, not intentional dev chrome. Nothing else about dev-mode appearance or behavior changes.

## How

Both markers are gated on the existing build-time `__KANGENTIC_DEV__` flag, so production drops them via dead-code elimination.

**Wordmark.** The suffix is nested inside the wordmark span rather than placed beside it, so it inherits the wordmark's size, weight, and tone and is separated by exactly one space instead of the parent flex row's `gap-1.5`. Nesting also keeps `.font-semibold:has-text("Kangentic")` resolving to a single element, so Playwright strict mode is unaffected.

**OS title.** `setTitle` previously ran *only* for worktree windows (it required a `--cwd=` matching `.kangentic/worktrees/`), so a normal dev window inherited `Kangentic` from `index.html` and got no marker at all. The block now always runs and computes one string via `computeWindowTitle`. In production the non-worktree branch restates the string the document title already produced, so that path is an idempotent no-op.

**Three decisions worth a reviewer's attention:**

1. **Preview windows.** A `/preview` window is a dev window, so it gets the wordmark suffix *on top of* its existing `#<id> - <title>` pill. The preview label still wins the OS title outright. The comment above the old `setTitle` warns against the *pill* and the OS title drifting; that pairing is untouched, since both still come from `getPreviewTaskTitle()`. The wordmark is separate chrome and is not part of that pairing.

2. **The `__KANGENTIC_DEV__` ternary stays inline in `index.ts`, not in the extracted helper.** esbuild folds the constant only where it is directly referenced. Passing a boolean across the module boundary ships the `"(dev)"` literal into every production bundle as dead-but-present code. This was caught by a bundle grep during review and is documented at both sites.

3. **Accepted asymmetry.** `npm run build` always builds the renderer in Vite's default `production` mode, so an E2E build run with `KANGENTIC_BUILD_DEV=1` gets `(dev)` in the OS title but not the wordmark. That build is E2E-only, no human runs it, and `(dev)` is arguably correct for it since its main process does carry dev tooling. Gating on `MAIN_WINDOW_VITE_DEV_SERVER_URL` instead would remove the divergence but repurposes a "where do I load the renderer from" constant as a build-identity flag.

**Marketing captures.** `tests/captures` renders against the shared Vite dev server, so `__KANGENTIC_DEV__` is true there and every full-viewport screenshot and the walkthrough video would have shipped a `(dev)` wordmark to the website. A new `hideDevOnlyChrome(page)` helper suppresses it, injected with `addInitScript` rather than `addStyleTag` so it survives the `page.goto` that follows. `walkthrough.capture.ts` builds its own Playwright page and needs its own call.

## Breaking changes

None. Production output is byte-identical in the marker's absence, verified below.

## Tests

- `tests/unit/window-utils.test.ts` - 9 new tests for `computeWindowTitle`: dev and production labels, non-worktree, numeric and legacy worktree folders, both path separators, the preview-label override, and that the preview resolver is not invoked outside a worktree.
- `tests/unit/capture-dev-chrome-parity.test.ts` - new static scan: every file under `tests/captures/**` that constructs its own Playwright page must also call `hideDevOnlyChrome`, with a non-vacuity guard pinning both known files. That tree is neither typechecked, linted, nor run in CI, so nothing else would catch a missing call.
- `tests/ui/app.spec.ts` - asserts the badge renders in the UI tier, which serves the renderer in dev mode.

Verified locally: typecheck and lint clean; `tests/ui/app.spec.ts` 37/37 and `tests/unit/window-utils.test.ts` 21/21, both after the rebase.

Dead-code elimination checked against a presence control so the absence cannot pass vacuously: in `.vite/build`, `Kangentic (dev)` and `titlebar-dev-badge` each appear 0 times while a known-shipped string appears 3 times and the production `Kangentic - ` path is still present.

Both capture paths were verified by cropping the produced PNGs rather than by the tests passing: the wordmark reads `Kangentic`.

Not verified locally: the main-process `setTitle` at runtime. E2E cannot run in this worktree because npm blocked Electron's postinstall, so the binary is absent. CI's Linux `e2e-shards` job does run it.

Generated with [Claude Code](https://claude.com/claude-code)
