### PR TITLE
perf(ci): one checks job, 11 UI shards, drop the redundant npm cache

### DIFF
--- a/.github/workflows/ci-experiment.yml
+++ b/.github/workflows/ci-experiment.yml
@@ -1,0 +1,302 @@
+name: CI (experiment)
+
+# TEMPORARY measurement pipeline. Delete once its shape is promoted into ci.yml.
+#
+# This is ci.yml with three changes under test (task: CI bottleneck analysis):
+#   1a. lint + typecheck + build collapsed into ONE job with independently
+#       reporting steps.
+#   1b. UI shards 9 -> 11.
+#   1c. `cache: npm` dropped from every setup-node (it restores ~/.npm, which
+#       only `npm ci` reads, and `npm ci` only runs on a node_modules cache MISS,
+#       so on the warm path it is ~5.3s of dead weight on the critical path).
+#
+# Two properties are load-bearing and must not be "tidied up":
+#
+# - It NEVER fires on a normal branch. The ~20 concurrent-job cap is ACCOUNT-WIDE,
+#   so this run (21 jobs) firing alongside a live ci.yml run (21 jobs) would put
+#   42 jobs against a cap of 20 and badly distort BOTH measurements. Hence: no
+#   `pull_request`, and a `push` filter restricted to a dedicated `ci-exp/**`
+#   namespace that no feature branch uses. `workflow_dispatch` is listed too, but
+#   it only becomes usable once this file is on the DEFAULT branch (GitHub only
+#   surfaces workflow_dispatch for workflows present on the default branch), which
+#   is why the `ci-exp/**` push trigger is what actually drives measurement today.
+# - Every job `name:` is prefixed `Exp:`. Status-check contexts are keyed by
+#   name; an un-prefixed name here would report into main's branch protection
+#   (`Lint (ESLint)`, `Build (production bundle)`, ... are required contexts).
+#
+# Its own concurrency group, so a measurement run never cancels a real CI run.
+#
+# Measure by branching a `ci-exp/**` branch off the exact commit of a known
+# ci.yml baseline run and adding ONLY this file. The test content is then
+# identical to the baseline, so the comparison is paired.
+
+on:
+  push:
+    branches: ['ci-exp/**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-experiment-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # 1a. lint + typecheck + build, serially, behind ONE checkout/setup/cache.
+  #
+  # Every step carries `if: ${{ !cancelled() }}` and an `id:`, and the final step
+  # aggregates the outcomes. Without that, a lint failure would abort the job and
+  # HIDE a typecheck failure, so the PR fix loop would need one CI round-trip per
+  # broken check even though the run itself got shorter.
+  #
+  # Two couplings this job now owns (see ci.yml notes when promoting):
+  # - Dropping the standalone build job is only safe while all 5 e2e-shards keep
+  #   running `npm run build` UNCONDITIONALLY; they are what prove the app bundle.
+  # - `npm run build -w packages/protocol` is the old build job's genuinely unique
+  #   contribution (the E2E shards do not build the package) and lives here now.
+  checks:
+    name: "Exp: Checks (lint, typecheck, build)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+      - name: Install dependencies (npm ci)
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Lint (ESLint)
+        id: lint
+        if: ${{ !cancelled() }}
+        run: npm run lint
+      - name: Type check (tsc)
+        id: typecheck
+        if: ${{ !cancelled() }}
+        run: npm run typecheck
+      - name: Build (production bundle)
+        id: build
+        if: ${{ !cancelled() }}
+        run: npm run build
+      - name: Build @kangentic/protocol package
+        id: build_protocol
+        if: ${{ !cancelled() }}
+        run: npm run build -w packages/protocol
+      - name: Summarize check results
+        if: ${{ !cancelled() }}
+        run: |
+          status=0
+          check() {
+            if [ "$2" != "success" ]; then
+              echo "FAILED: $1 ($2)"
+              status=1
+            else
+              echo "passed: $1"
+            fi
+          }
+          check "Lint (ESLint)" "${{ steps.lint.outcome }}"
+          check "Type check (tsc)" "${{ steps.typecheck.outcome }}"
+          check "Build (production bundle)" "${{ steps.build.outcome }}"
+          check "Build @kangentic/protocol" "${{ steps.build_protocol.outcome }}"
+          exit $status
+
+  unit-shards:
+    name: "Exp: Unit Test (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3]
+        shardTotal: [3]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+      - name: Install dependencies (npm ci)
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Unit tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+        run: npx vitest run tests/unit --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --reporter=blob --reporter=default --outputFile.blob=.vitest/blob/blob-${{ matrix.shardIndex }}.json
+      - name: Upload blob report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit-blob-${{ matrix.shardIndex }}
+          path: .vitest/blob/
+          retention-days: 1
+
+  unit:
+    name: "Exp: Unit tests (Vitest)"
+    needs: [unit-shards]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+      - name: Install dependencies (npm ci)
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Download shard blob reports
+        uses: actions/download-artifact@v8
+        with:
+          pattern: unit-blob-*
+          merge-multiple: true
+          path: .vitest/blob
+      - name: Merge blob reports into one Vitest summary
+        run: npx vitest --merge-reports=.vitest/blob --reporter=github-actions --reporter=default
+      - name: Fail if any unit shard job did not succeed
+        if: ${{ needs.unit-shards.result != 'success' }}
+        run: exit 1
+
+  # 1b. 11 shards, up from 9. The UI tier is the run's pole and the only tier on
+  # the critical path: every other job is done by ~115s while the pole runs ~270s,
+  # so ~11 of the ~20 slots sit idle for the last ~150s of a run.
+  #
+  # Playwright balances shards by TEST COUNT, but per-test cost varies ~5x across
+  # this suite, so at 9 shards the per-shard WORK spread was 1.88x (297s to 558s)
+  # while the count spread was 1.06x. The 2 slots freed by collapsing lint /
+  # typecheck / build are what pay for shards 10 and 11 without taking the run to
+  # 23 jobs (see the budget note on the `ui` gate below).
+  playwright-shards:
+    name: "Exp: UI Test (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        shardTotal: [11]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+      - name: Install dependencies (npm ci)
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-playwright-
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium
+      - name: Run UI tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+        run: npx playwright test --project=ui --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+
+  # Concurrency budget under test: UI 11 + E2E 5 + unit 3 = 19 shards, plus the
+  # single `checks` job + the CLA workflow = 21. Identical to today's 21, so the
+  # accepted over-cap-by-one and its ~6-15s queue behaviour are unchanged.
+  #
+  # 21 is a CEILING here, not a target. Collapsing the three always-on jobs also
+  # removed the three EARLIEST slot releasers (typecheck 37s, lint 41s, build
+  # 51s) and replaced them with one ~140s job. At 21 that is harmless because the
+  # CLA check frees a slot at 10-17s, but no cheap early releaser remains: at 22+
+  # jobs the first release becomes a ~70s unit shard, and a queued UI shard would
+  # start that late.
+  ui:
+    name: "Exp: UI tests (Playwright)"
+    needs: [playwright-shards]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Gate on shard results
+        run: |
+          if [ "${{ needs.playwright-shards.result }}" != "success" ]; then
+            echo "One or more Playwright shards did not succeed (result: ${{ needs.playwright-shards.result }})"
+            exit 1
+          fi
+          echo "All Playwright shards passed."
+
+  # Still 5 shards, still building unconditionally. That `npm run build` is what
+  # proves the app bundle now that the standalone build job is gone - do not make
+  # it conditional without restoring a dedicated bundle check.
+  #
+  # Deliberately NOT deduplicated: the 5 builds cost ~21s each (~105s of runner
+  # minutes), but E2E finishes at ~115s against a ~240s pole, so it is nowhere
+  # near the critical path, and sharing one bundle via an artifact costs ~20s of
+  # upload plus ~20s of download per shard - no wall-clock win.
+  e2e-shards:
+    name: "Exp: E2E Test (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4, 5]
+        shardTotal: [5]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      - name: Cache node_modules (native build + Electron binary)
+        id: cache-node-modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+      - name: Install dependencies (npm ci, full native build)
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Build (production bundle)
+        run: npm run build
+      - name: Run E2E tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+        run: xvfb-run -a npx playwright test --project=electron --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+
+  e2e:
+    name: "Exp: E2E tests (Electron)"
+    needs: [e2e-shards]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Gate on shard results
+        run: |
+          if [ "${{ needs.e2e-shards.result }}" != "success" ]; then
+            echo "One or more E2E shards did not succeed (result: ${{ needs.e2e-shards.result }})"
+            exit 1
+          fi
+          echo "All E2E shards passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,37 +15,83 @@ concurrency:
   cancel-in-progress: true
 
 # CI architecture:
-# - Standalone checks (lint, typecheck, build) each run as their own top-level
-#   job, always-visible in the checks list. None consume another's output (build
-#   is a "does it bundle" gate; the UI tier runs the Vite dev server, not build).
+# - ONE always-on `checks` job runs lint, typecheck and build serially, with each
+#   step reporting independently (see the job for why that wiring is required).
 # - The three test tiers (unit / UI / E2E) are sharded matrices, each behind a
 #   thin gate job whose `name:` is the required status check ("Unit tests
 #   (Vitest)", "UI tests (Playwright)", "E2E tests (Electron)"). The shards are
 #   an implementation detail; the gate is the required check.
 #
-# Concurrency budget (GitHub Free caps concurrent jobs at ~20): shard counts are
-# sized so the test shards plus the always-on jobs fit the cap with NO queueing
-# (queueing, not shard count, was the real wall-clock bottleneck). Current
-# budget: UI 9 + E2E 5 + unit 3 = 17 shards, plus lint + typecheck + build + the
-# CLA workflow = 4, totalling 21 - one over the cap, deliberately: the CLA check
-# finishes in ~10-17s and frees its slot, so the single over-cap shard queues
-# only that briefly (far under its ~70-90s runtime) and still lands inside the
-# envelope. node_modules is cached under one shared lockfile-keyed key, so npm ci
-# runs only on a lockfile change. The thin gates run AFTER their shards (`needs`),
-# so they do not consume a shard-phase slot. To scale as the suites grow: either
-# rebalance the shard counts (UI is test-count-bound and wants the most shards;
-# E2E is launch-bound and one-waves at workers=8 so ~5 suffices; unit is npm-ci-
-# floored once cached, so a few shards suffice), or raise the ceiling by upgrading
-# the GitHub plan (Team = 60 concurrent).
+# THE UI TIER IS THE ONLY THING ON THE CRITICAL PATH. Measured 2026-08-29: every
+# other job finishes by ~115s while the UI pole runs ~226s, so ~11 of the ~20
+# slots sit idle for the last ~150s of a run. Two consequences that mislead
+# people who tune this file:
+#   1. Freeing a concurrency slot buys ~0s of wall clock BY ITSELF. Collapsing
+#      lint/typecheck/build was never a speedup - it is what PAYS for UI shards
+#      10 and 11 while keeping the run at 21 jobs instead of 23.
+#   2. Sharding is balanced by TEST COUNT, not cost. Playwright's filterForShard
+#      walks test groups in file order and cuts them into equal-COUNT windows, so
+#      an expensive file makes its window expensive and no amount of splitting a
+#      spec file moves it (splitting keeps the tests contiguous at the same
+#      cumulative indices). At 9 shards this left a 1.88x work spread (297-558s)
+#      across shards whose counts differed by only 1.06x. 11 shards cut the
+#      heaviest shard's work 558s -> ~495s and the pole 304s -> ~226s.
+#
+# Concurrency budget (GitHub Free caps concurrent jobs at ~20): UI 11 + E2E 5 +
+# unit 3 = 19 shards, plus the `checks` job + the CLA workflow (a separate
+# workflow, so it never appears in this run's own job list) = 21 - one over the
+# cap, deliberately: the CLA check finishes in ~10-17s and frees its slot, so the
+# single over-cap job queues only that briefly. Measured max queue delay on an
+# uncontended run: 3s.
+#
+# 21 IS A CEILING, NOT A TARGET. Collapsing the three always-on jobs also removed
+# the three EARLIEST slot releasers (they finished at 37s, 41s and 51s) and
+# replaced them with one ~65s job. At 21 that is harmless because CLA is the
+# release valve, but no cheap early releaser remains: at 22+ jobs the first
+# release becomes a ~70s unit shard, and a queued UI shard would start that late
+# and blow past the pole. The cap is also ACCOUNT-wide, so a concurrent release
+# or publish-protocol run eats into it.
+#
+# node_modules is cached under one shared lockfile-keyed key, so npm ci runs only
+# on a lockfile change. setup-node deliberately does NOT set `cache: npm`: that
+# restores a ~366 MB ~/.npm tree which only `npm ci` reads, and `npm ci` only runs
+# on a node_modules cache MISS, so on the warm path it was ~5.3s of dead weight
+# per job (~106s of runner time per run) sitting on the pole's critical path.
+# The thin gates run AFTER their shards (`needs`), so they do not consume a
+# shard-phase slot.
+#
+# To scale as the suites grow: E2E is launch-bound and one-waves at workers=8 so
+# ~5 suffices; unit is npm-ci-floored once cached. UI is the tier that matters,
+# and since its imbalance is cost-vs-count rather than count, more shards help
+# only until the pole shard's own heavy files dominate. Past that the levers are
+# PWTEST_SHARD_WEIGHTS (internal, needs a guard test) or a paid plan (Team = 60
+# concurrent).
 #
 # The job `name:` is the status-check context used by branch protection - keep
 # these in sync with main's required checks if you rename one.
 
 jobs:
-  lint:
-    name: Lint (ESLint)
+  # lint + typecheck + build, serially, behind ONE checkout/setup/cache. Measured
+  # 62-66s total, against a ~226s UI pole, so it is nowhere near the critical
+  # path. It replaced three separate jobs (72s + 71s + 71s) whose only reason to
+  # be separate was independent reporting, which the step wiring below preserves.
+  #
+  # Every step carries `if: ${{ !cancelled() }}` and an `id:`, and the final step
+  # aggregates the outcomes. WITHOUT that, a lint failure aborts the job and
+  # HIDES a typecheck failure, costing one CI round-trip per broken check.
+  #
+  # Two couplings this job now owns:
+  # - Collapsing the standalone build job is only safe while all 5 e2e-shards
+  #   keep running `npm run build` UNCONDITIONALLY. They are what prove the app
+  #   bundle on every PR. If that ever becomes conditional, restore a dedicated
+  #   bundle check.
+  # - `npm run build -w packages/protocol` was the old build job's genuinely
+  #   unique contribution (the E2E shards do not build the package, and
+  #   publish-protocol.yml only runs on a protocol-v* tag) and lives here now.
+  checks:
+    name: Checks (lint, typecheck, build)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -53,7 +99,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: npm
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v5
@@ -64,31 +109,38 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
       - name: Lint (ESLint)
+        id: lint
+        if: ${{ !cancelled() }}
         run: npm run lint
-
-  typecheck:
-    name: Type check (tsc)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v5
-      - name: Set up Node.js 22
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: npm
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v5
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
-      - name: Install dependencies (npm ci)
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci
       - name: Type check (tsc)
+        id: typecheck
+        if: ${{ !cancelled() }}
         run: npm run typecheck
+      - name: Build (production bundle)
+        id: build
+        if: ${{ !cancelled() }}
+        run: npm run build
+      - name: Build @kangentic/protocol package
+        id: build_protocol
+        if: ${{ !cancelled() }}
+        run: npm run build -w packages/protocol
+      - name: Summarize check results
+        if: ${{ !cancelled() }}
+        run: |
+          status=0
+          check() {
+            if [ "$2" != "success" ]; then
+              echo "FAILED: $1 ($2)"
+              status=1
+            else
+              echo "passed: $1"
+            fi
+          }
+          check "Lint (ESLint)" "${{ steps.lint.outcome }}"
+          check "Type check (tsc)" "${{ steps.typecheck.outcome }}"
+          check "Build (production bundle)" "${{ steps.build.outcome }}"
+          check "Build @kangentic/protocol" "${{ steps.build_protocol.outcome }}"
+          exit $status
 
   # Unit tier, sharded across ubuntu runners like the UI/E2E tiers (Vitest
   # `--shard`). The suite is volume-bound (~360 files, no single long pole), and
@@ -113,7 +165,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: npm
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v5
@@ -153,7 +204,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: npm
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v5
@@ -175,45 +225,12 @@ jobs:
         if: ${{ needs.unit-shards.result != 'success' }}
         run: exit 1
 
-  build:
-    name: Build (production bundle)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v5
-      - name: Set up Node.js 22
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: npm
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v5
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
-      - name: Install dependencies (npm ci)
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci
-      - name: Build (production bundle)
-        run: npm run build
-      # @kangentic/protocol publishes through its own independent workflow
-      # (publish-protocol.yml), not this one -- but that workflow only runs
-      # at publish time (a protocol-v* tag push), so without this step a
-      # broken package build (a declaration-emit error, an esbuild config
-      # regression) would go undetected until an actual release attempt.
-      # This proves `npm run build -w packages/protocol` still succeeds on
-      # every PR, same as the app bundle above.
-      - name: Build @kangentic/protocol package
-        run: npm run build -w packages/protocol
-
   # UI tier, sharded across parallel ubuntu runners (Playwright `--shard`). Each
   # shard prints its own per-test results via the `list` reporter (visible in the
   # shard's job log) - there is NO blob upload or merged-report job, so the run is
-  # not gated by a serial merge. npm ci uses --ignore-scripts (the headless UI
-  # tests never load node-pty/better-sqlite3/electron) then rebuilds just esbuild,
-  # which the Vite dev server needs. Chromium's system libs already ship on
+  # not gated by a serial merge. Install is the same plain `npm ci` as every other
+  # tier, restored from the one shared node_modules cache (see the inline note on
+  # the cache step). Chromium's system libs already ship on
   # ubuntu-latest, so the browser install needs no --with-deps; the binary is
   # cached. The single required status check is the thin `ui` gate below.
   playwright-shards:
@@ -223,8 +240,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        shardTotal: [9]
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        shardTotal: [11]
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -232,7 +249,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: npm
       # Shared node_modules cache (keyed on the lockfile, same key as every tier):
       # on a hit the shard skips install entirely; on a miss it runs a full
       # npm ci. The native modules go unused by the headless UI tests, but keeping
@@ -320,7 +336,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: npm
       - name: Cache node_modules (native build + Electron binary)
         id: cache-node-modules
         uses: actions/cache@v5

--- a/tests/unit/ci-required-checks.test.ts
+++ b/tests/unit/ci-required-checks.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * A job's `name:` in a workflow file IS its branch-protection status-check
+ * context. Renaming or removing one silently desynchronizes `main`'s required
+ * check list: the old context stops reporting, so every PR sits forever on
+ * "Expected - Waiting for status to be reported" and cannot merge through the
+ * normal gate. Nothing in CI catches that, because CI itself is green.
+ *
+ * This bit during the 2026-08-29 CI consolidation, which merged the `Lint
+ * (ESLint)` / `Type check (tsc)` / `Build (production bundle)` jobs into one
+ * `Checks (lint, typecheck, build)` job and had to update branch protection in
+ * the same change.
+ *
+ * So this test pins the contract in BOTH directions:
+ *   1. Every context that main requires still exists as a job `name:`.
+ *   2. Every always-on job is explicitly classified as required or not, so
+ *      adding a job forces a conscious decision about whether it should gate.
+ *
+ * When this test fails, update the list below AND main's branch protection
+ * together:
+ *   gh api repos/Kangentic/kangentic/branches/main/protection   # snapshot first
+ *   gh api -X PATCH repos/Kangentic/kangentic/branches/main/protection/required_status_checks \
+ *     -f 'checks[][context]=<new name>' ...
+ */
+
+const REPO_ROOT = join(__dirname, '..', '..');
+
+/**
+ * The status-check contexts branch protection requires on `main`, minus `cla`
+ * (which is owned by cla.yml, a separate `pull_request_target` workflow that
+ * never appears in a ci.yml run's own job list).
+ *
+ * Verified against the live API on 2026-08-29.
+ */
+const REQUIRED_CONTEXTS_FROM_CI = [
+  'Checks (lint, typecheck, build)',
+  'Unit tests (Vitest)',
+  'UI tests (Playwright)',
+  'E2E tests (Electron)',
+];
+
+/**
+ * Jobs that deliberately do NOT gate: the sharded matrices. Their names carry
+ * `${{ matrix... }}` templates, so they could never be stable contexts anyway.
+ * Each tier gates through its thin `needs`-gated summary job above instead.
+ */
+const DELIBERATELY_NOT_REQUIRED = [
+  'Unit Test (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})',
+  'UI Test (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})',
+  'E2E Test (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})',
+];
+
+function readWorkflow(file: string): string {
+  return readFileSync(join(REPO_ROOT, '.github', 'workflows', file), 'utf8');
+}
+
+/**
+ * Collect every top-level job's `name:` value. Deliberately a line scan rather
+ * than a YAML parse: no YAML parser is a declared dependency of this repo, and
+ * the shape being asserted (two indent levels, one `name:` per job) is fixed by
+ * the Actions schema.
+ */
+function jobNames(source: string): string[] {
+  const names: string[] = [];
+  const lines = source.split(/\r?\n/);
+  let insideJob = false;
+  for (const line of lines) {
+    if (/^ {2}[A-Za-z_][\w-]*:\s*$/.test(line)) {
+      insideJob = true;
+      continue;
+    }
+    if (/^\S/.test(line)) insideJob = false;
+    if (!insideJob) continue;
+    const nameMatch = /^ {4}name:\s*(.+?)\s*$/.exec(line);
+    if (nameMatch) {
+      names.push(nameMatch[1].replace(/^["']|["']$/g, ''));
+      insideJob = false;
+    }
+  }
+  return names;
+}
+
+describe('CI status-check contexts stay in sync with branch protection', () => {
+  const ciNames = jobNames(readWorkflow('ci.yml'));
+
+  it('finds every job in ci.yml', () => {
+    // Guards the line scan itself: if the parse silently stopped matching, every
+    // other assertion here would vacuously pass.
+    expect(ciNames.length).toBe(
+      REQUIRED_CONTEXTS_FROM_CI.length + DELIBERATELY_NOT_REQUIRED.length,
+    );
+  });
+
+  it.each(REQUIRED_CONTEXTS_FROM_CI)(
+    'still defines the required context %s',
+    (context) => {
+      expect(ciNames).toContain(context);
+    },
+  );
+
+  it('classifies every ci.yml job as required or deliberately not required', () => {
+    const classified = new Set([
+      ...REQUIRED_CONTEXTS_FROM_CI,
+      ...DELIBERATELY_NOT_REQUIRED,
+    ]);
+    const unclassified = ciNames.filter((name) => !classified.has(name));
+    expect(unclassified).toEqual([]);
+  });
+
+  it('keeps the cla context in its own workflow', () => {
+    // `cla` is required on main but lives in cla.yml, which is why a job count
+    // taken from a ci.yml run is always one short of the real concurrency load.
+    expect(readWorkflow('cla.yml')).toMatch(/^\s{2}cla:\s*$/m);
+  });
+});


### PR DESCRIPTION
## What this does

Collapses `lint` / `typecheck` / `build` into one `Checks (lint, typecheck, build)` job, takes UI shards from 9 to 11, and drops the redundant `cache: npm` from every `setup-node`.

## Measured, not estimated

Three runs of a throwaway experiment pipeline against baseline run `33187044735`, **all on the identical commit** (`8dc8661c`), so this is a paired comparison rather than a time-separated one.

| | baseline | run 1 | run 2\* | run 3 |
|---|---|---|---|---|
| run total | 314s | **235s** | 301s | **230s** |
| pole job | 304s | **226s** | 225s | **219s** |
| max shard work | 558s | 495s | 518s | 479s |
| max queue delay | n/a | 3s | **68s** | 6s |

\*Run 2 was contended by a concurrent PR run, so its wall clock is discarded.

**Clean-run medians: run total -26%, pole -27%.** The decision metric is max shard work, which is immune to queueing: the heaviest shard's share of total suite work drops from 14.7% to ~12.9% (an even split would be 9.1%).

## Why the consolidation is not the speedup

Every non-UI job already finished by ~115s while the pole ran 226-304s, so ~11 of the ~20 concurrency slots sat idle for the last ~150s of every run. Freeing a slot buys ~0s by itself.

What it actually buys is the two extra UI shards **without** taking the run to 23 jobs. At 23 the three over-cap jobs queue behind the first finishers, and a queued UI shard starts up to 41s late and gives most of the gain back, non-deterministically. Consolidated, the run stays at 21 jobs, exactly where it was.

## Why 11 shards helps at all

Playwright's `filterForShard` walks test groups in file order and cuts them into equal **count** windows. Cost is never consulted. So per-shard work spread 1.88x (297-558s) while counts spread only 1.06x. More shards move the window boundaries, which is the only lever that does not require touching test files.

This also rules out the obvious follow-up: splitting a heavy spec file cannot help, because the split keeps the same tests contiguous at the same cumulative indices, so every test lands on the shard it already lands on.

## The npm cache

`setup-node`'s `cache: npm` restores a ~366 MB `~/.npm` tree that only `npm ci` reads, and `npm ci` only runs on a `node_modules` cache **miss**. On the warm path it was ~5.3s of dead weight per job sitting on the pole's critical path (~106s of runner time per run). Cold runs on a lockfile change pay a slower `npm ci`, which is the intended trade.

## Branch protection

`Lint (ESLint)`, `Type check (tsc)` and `Build (production bundle)` are required contexts on `main` today, so they will never report on this PR and it cannot go green through the normal gate until protection swaps them for `Checks (lint, typecheck, build)`. `UI Test (N/9)` was never required, so the shard count needs no protection edit.

The pre-existing `.kangentic/protection-checks.json` template is stale (it predates `E2E tests (Electron)` becoming required), so a fresh snapshot was taken rather than reusing it.

## New guard

`tests/unit/ci-required-checks.test.ts` pins workflow job names against the required-context list in both directions, so a future rename fails a test instead of silently wedging every PR on "Expected - Waiting for status to be reported". Verified red-green.

## Also included

`.github/workflows/ci-experiment.yml`, the measurement rig. It fires only on `workflow_dispatch` or a push to `ci-exp/**`, so it costs nothing at rest, and its header documents the account-wide concurrency trap that makes two pipelines running at once unmeasurable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
