### PR TITLE
fix(pty): stop a deleted directory's fs.watch from pinning a CPU core

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -622,6 +622,18 @@ Two watchers per session, reading files written by bridge scripts:
 
 Events watcher uses byte offset tracking to only read new lines (no full re-read). Activity state (thinking/idle) is derived from event types -- see [Activity Detection](activity-detection.md).
 
+Both go through `FileWatcher` (`src/main/pty/readers/file-watcher.ts`), which pairs an `fs.watch`
+fast path with a 1s poll that runs unconditionally as the fallback. Two behaviors are load-bearing
+on Windows, where a directory `fs.watch` whose target is deleted emits `rename` at roughly 150k
+events/sec forever, with no `error` event, until `close()`:
+
+- Both files are created (empty) before their watcher is constructed, so each watcher arms on the
+  FILE. When a watcher has to fall back to watching the parent DIRECTORY (the file does not exist
+  yet), it counts raw events ahead of its filename filter and disarms itself on a flood, dropping
+  to the poll and re-arming on the file once it appears.
+- Deleting a live session's directory is therefore survivable: the watcher releases its handle,
+  `repairMissingEventsDir` recreates the directory, and the poll picks the file back up.
+
 ### Shell Resolution
 
 Platform-specific detection order in `src/main/pty/spawn/shell-resolver.ts`:

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -105,7 +105,10 @@ src/
     pty/                   # Terminal session management
       paste-engine.ts      # Bracketed-paste primitive (driven by TerminalSubmit.submitContent)
       pty-buffer-manager.ts # Output buffering, scrollback ring buffer (512KB)
-      session-file-watcher.ts # fs.watch for status.json and events.jsonl
+      readers/             # Telemetry file readers
+        file-watcher.ts    # fs.watch fast path + polling fallback, with a storm guard
+        status-file-reader.ts # Watches status.json + events.jsonl for a session
+        session-history-reader.ts # Tails an agent's native history file
       session-manager.ts   # PTY spawn, output streaming, lifecycle
       session-queue.ts     # Concurrency limiter with reentrancy-safe promotion
       shell-resolver.ts    # Cross-platform shell detection

--- a/docs/worktree-strategy.md
+++ b/docs/worktree-strategy.md
@@ -400,13 +400,28 @@ App reopened
 
 ## Cleanup
 
-### Adapter notification on removal
+### Notification on removal
+
+Two listeners bracket a removal, and they are deliberately NOT symmetric in placement.
 
 Some agent CLIs record per-directory state in a GLOBAL config file, keyed by absolute path. That state outlives the worktree: Kangentic creates one worktree per task, so an adapter keyed this way accumulates a dead entry per task with nothing to clean it up. Codex is the case that forced this (its directory trust in `~/.codex/config.toml` reached 473 dead entries on one machine); Gemini's `trustedFolders.json` and Grok's `~/.grok/trusted_folders.toml` have the same shape (Grok accumulates entries only for worktrees under an undecided project root, since its trust cascades from a decided ancestor).
 
 `WorktreeManager.removeWorktree` is therefore the single notification point: on a successful removal it calls the listener registered at startup (`setWorktreeRemovedListener` in `src/main/index.ts`), which fans out to every adapter's optional `onWorktreeRemoved` (see [Agent Integration](agent-integration.md)). The listener is registered rather than imported so this git module never reaches into the agent registry.
 
-Notifying from the chokepoint is deliberate. Worktree removal is hand-copied across seven call sites (Done move, task delete, archive, MCP delete, project close, startup retry, branch-switch cleanup); an earlier attempt that notified at each site leaked from the ones it missed. The one path that deliberately does NOT notify is `createWorktree`'s husk-clear, which calls the internal removal directly because it is about to reuse the same path rather than vacate it.
+Notifying from the chokepoint is deliberate. Worktree removal is hand-copied across seven call sites (Done move, task delete, archive, MCP delete, project close, startup retry, branch-switch cleanup); an earlier attempt that notified at each site leaked from the ones it missed. The one path that deliberately does NOT fire the REMOVED listener is `createWorktree`'s husk-clear, which calls the internal removal directly because it is about to reuse the same path rather than vacate it.
+
+**Before** a removal is attempted, `removeWorktreeInternal` fires a second listener,
+`setWorktreeRemovingListener` (also wired in `src/main/index.ts`). Its contract is "drop any OS
+handle you hold under this path, I am about to delete it", and it releases both `DiffWatcher`
+instances for that prefix (`IpcContext`'s and the bridge-owned one, see
+[Mobile Bridge](mobile-bridge.md)).
+
+It hangs off the *internal* method rather than the public one precisely because the husk-clear
+above must also fire it: that path's failure mode is a directory that could not be deleted because
+something still held it open, and our own recursive `fs.watch` is one of those holders. It also
+runs ahead of the `existsSync` bail, since an already-gone path is exactly the case where a watcher
+left armed on it is spinning. On Windows a directory `fs.watch` whose target is deleted emits
+`rename` at roughly 150k events/sec forever, with no `error` event, until `close()`.
 
 ### On Project Open
 

--- a/src/main/git/diff-watcher.ts
+++ b/src/main/git/diff-watcher.ts
@@ -4,6 +4,22 @@ import simpleGit from 'simple-git';
 import { replacePathPrefix } from '../../shared/paths';
 
 const DEBOUNCE_MS = 500;
+
+/**
+ * Longest a pending run may be held before the callbacks fire regardless.
+ *
+ * The debounce below is trailing with no natural ceiling: every event clears
+ * and re-arms it, so a stream arriving faster than DEBOUNCE_MS never lets it
+ * expire and the subscribers hear NOTHING for as long as the stream lasts.
+ * More than two file events per second clears that bar, which a running dev
+ * server, a test run, or an install inside the worktree does easily - so the
+ * Changes panel would sit frozen for the whole build and read as broken.
+ *
+ * Capping the run keeps the coalescing (the point of the debounce) while
+ * guaranteeing forward progress.
+ */
+const MAX_DEBOUNCE_WAIT_MS = 2000;
+
 const IGNORED_SEGMENTS = new Set(['.git', 'node_modules', '.kangentic']);
 
 /**
@@ -17,6 +33,9 @@ const GIT_META_FILES = new Set(['index', 'HEAD', 'ORIG_HEAD', 'MERGE_HEAD', 'pac
 interface WatcherEntry {
   watchers: fs.FSWatcher[];
   debounceTimer: ReturnType<typeof setTimeout> | null;
+  /** When the current pending run started, for the MAX_DEBOUNCE_WAIT_MS cap.
+   *  Only meaningful while `debounceTimer` is non-null. */
+  pendingSince: number;
   /**
    * Every subscriber's callback for this path. The renderer's git-diff panel
    * is single-subscriber-per-path, but the mobile bridge fans out one live
@@ -42,6 +61,10 @@ interface WatcherEntry {
  */
 export class DiffWatcher {
   private readonly watchers = new Map<string, WatcherEntry>();
+  /** worktree path -> resolved absolute git dir. Survives subscribe/unsubscribe
+   *  cycles; invalidated only by `releaseUnder`, which means the path is going
+   *  away for real. */
+  private readonly gitDirCache = new Map<string, string>();
 
   /**
    * Register a change callback for a path, returning a teardown that removes
@@ -56,18 +79,41 @@ export class DiffWatcher {
       return () => this.removeCallback(worktreePath, callback);
     }
 
-    const entry: WatcherEntry = { watchers: [], debounceTimer: null, callbacks: new Set([callback]) };
+    const entry: WatcherEntry = {
+      watchers: [],
+      debounceTimer: null,
+      pendingSince: 0,
+      callbacks: new Set([callback]),
+    };
     this.watchers.set(worktreePath, entry);
 
+    const dispatch = () => {
+      for (const registeredCallback of entry.callbacks) registeredCallback();
+    };
+
     // Debounce: reset the shared timer on each change from any watcher, then
-    // fan the single fire out to every registered callback.
+    // fan the single fire out to every registered callback. Capped at
+    // MAX_DEBOUNCE_WAIT_MS so a continuous event stream cannot starve it.
     const fire = () => {
       const current = this.watchers.get(worktreePath);
       if (current !== entry) return; // unsubscribed/replaced while debouncing
-      if (entry.debounceTimer !== null) clearTimeout(entry.debounceTimer);
+
+      const now = Date.now();
+      if (entry.debounceTimer === null) {
+        entry.pendingSince = now;
+      } else {
+        clearTimeout(entry.debounceTimer);
+        if (now - entry.pendingSince >= MAX_DEBOUNCE_WAIT_MS) {
+          // Held long enough. Fire now and let the next event open a new run.
+          entry.debounceTimer = null;
+          dispatch();
+          return;
+        }
+      }
+
       entry.debounceTimer = setTimeout(() => {
         entry.debounceTimer = null;
-        for (const registeredCallback of entry.callbacks) registeredCallback();
+        dispatch();
       }, DEBOUNCE_MS);
     };
 
@@ -112,41 +158,74 @@ export class DiffWatcher {
    * or watch the git dir leaves the working-tree watch (1) fully functional.
    */
   private watchGitMetadata(worktreePath: string, entry: WatcherEntry, fire: () => void): void {
+    // Resolving the git dir costs a git subprocess (~50-100ms on Windows), and
+    // it is paid again every time the last subscriber for a path leaves and a
+    // new one arrives - which is exactly what clicking between tasks does. The
+    // answer is stable for the life of a worktree, so cache it and let the
+    // removing-listener drop it when the worktree is actually deleted.
+    const cachedGitDir = this.gitDirCache.get(worktreePath);
+    if (cachedGitDir !== undefined) {
+      this.armGitMetadataWatches(worktreePath, cachedGitDir, entry, fire);
+      return;
+    }
+
     simpleGit(worktreePath)
       .raw(['rev-parse', '--absolute-git-dir'])
       .then((output) => {
         const gitDir = output.trim();
-        // The subscription may have been torn down while git resolved.
-        if (!gitDir || this.watchers.get(worktreePath) !== entry) return;
-
-        // Top-level git dir: index (staging), HEAD, ORIG_HEAD, MERGE_HEAD,
-        // packed-refs. Non-recursive, so objects/ is never descended.
-        try {
-          const metaWatcher = fs.watch(gitDir, { recursive: false }, (_eventType, filename) => {
-            if (filename && GIT_META_FILES.has(path.basename(filename.toString()))) fire();
-          });
-          entry.watchers.push(metaWatcher);
-        } catch {
-          // ignore: a single missing watch must not break the rest
-        }
-
-        // logs/HEAD moves on every commit / checkout / reset. It lives one level
-        // down, so watch the logs/ directory itself (non-recursive).
-        const logsDir = path.join(gitDir, 'logs');
-        if (fs.existsSync(logsDir)) {
-          try {
-            const logsWatcher = fs.watch(logsDir, { recursive: false }, (_eventType, filename) => {
-              if (filename && path.basename(filename.toString()) === 'HEAD') fire();
-            });
-            entry.watchers.push(logsWatcher);
-          } catch {
-            // ignore
-          }
-        }
+        if (!gitDir) return;
+        // Liveness gates the CACHE WRITE, not just the arming below. A
+        // `releaseUnder` that lands while this subprocess is still in flight
+        // has already dropped the entry AND the cache; re-populating it here
+        // would silently undo that invalidation, and every later subscribe for
+        // this path would take the cache-hit branch against a git dir that
+        // `git worktree remove` has since deleted.
+        if (this.watchers.get(worktreePath) !== entry) return;
+        this.gitDirCache.set(worktreePath, gitDir);
+        this.armGitMetadataWatches(worktreePath, gitDir, entry, fire);
       })
       .catch(() => {
         // Not a git repo, or git unavailable: the working-tree watch still applies.
       });
+  }
+
+  /**
+   * Arm the two git-metadata watches. Split out of `watchGitMetadata` so the
+   * cache hit can take the same path synchronously.
+   */
+  private armGitMetadataWatches(
+    worktreePath: string,
+    gitDir: string,
+    entry: WatcherEntry,
+    fire: () => void,
+  ): void {
+    // The subscription may have been torn down while git resolved.
+    if (this.watchers.get(worktreePath) !== entry) return;
+
+    // Top-level git dir: index (staging), HEAD, ORIG_HEAD, MERGE_HEAD,
+    // packed-refs. Non-recursive, so objects/ is never descended.
+    try {
+      const metaWatcher = fs.watch(gitDir, { recursive: false }, (_eventType, filename) => {
+        if (filename && GIT_META_FILES.has(path.basename(filename.toString()))) fire();
+      });
+      entry.watchers.push(metaWatcher);
+    } catch {
+      // ignore: a single missing watch must not break the rest
+    }
+
+    // logs/HEAD moves on every commit / checkout / reset. It lives one level
+    // down, so watch the logs/ directory itself (non-recursive).
+    const logsDir = path.join(gitDir, 'logs');
+    if (fs.existsSync(logsDir)) {
+      try {
+        const logsWatcher = fs.watch(logsDir, { recursive: false }, (_eventType, filename) => {
+          if (filename && path.basename(filename.toString()) === 'HEAD') fire();
+        });
+        entry.watchers.push(logsWatcher);
+      } catch {
+        // ignore
+      }
+    }
   }
 
   unsubscribe(worktreePath: string): void {
@@ -178,6 +257,15 @@ export class DiffWatcher {
     for (const worktreePath of [...this.watchers.keys()]) {
       if (replacePathPrefix(worktreePath, pathPrefix, pathPrefix) !== null) {
         this.unsubscribe(worktreePath);
+      }
+    }
+    // The path is being moved or deleted, so any resolved git dir under it is
+    // now stale. Keyed separately from `watchers` because the cache outlives a
+    // subscription; unsubscribe alone must NOT drop it, or the cache would
+    // never survive the subscribe/unsubscribe cycle it exists to skip.
+    for (const worktreePath of [...this.gitDirCache.keys()]) {
+      if (replacePathPrefix(worktreePath, pathPrefix, pathPrefix) !== null) {
+        this.gitDirCache.delete(worktreePath);
       }
     }
   }

--- a/src/main/git/worktree-manager.ts
+++ b/src/main/git/worktree-manager.ts
@@ -885,6 +885,13 @@ export class WorktreeManager {
     options?: { timeoutMs?: number; removalProfile?: WorktreeRemovalProfile },
   ): Promise<boolean> {
     assertRemovableWorktreePath(this.projectPath, worktreePath);
+
+    // Release our own OS handles under this path first. Deliberately ahead of
+    // the existsSync bail: a path that is ALREADY gone is exactly the case
+    // where a watcher left armed on it is spinning right now, so that is the
+    // one call we least want to skip.
+    await notifyWorktreeRemoving(worktreePath);
+
     if (!fs.existsSync(worktreePath)) return true;
 
     const timeoutMs = options?.timeoutMs ?? GIT_REMOVAL_TIMEOUT_MS;
@@ -1215,5 +1222,48 @@ async function notifyWorktreeRemoved(worktreePath: string): Promise<void> {
     // Best-effort: the worktree is already gone, and a failure here only
     // leaves a stale entry behind. It must never fail the removal.
     console.warn('[WORKTREE] worktree-removed listener failed (non-fatal):', error);
+  }
+}
+
+/**
+ * Notified BEFORE any removal attempt, from `removeWorktreeInternal`.
+ *
+ * The contract is "drop any OS handle you hold under this path, I am about to
+ * delete it", which is why it is deliberately paired with the *internal*
+ * method rather than the public one: unlike the removed-listener above, it is
+ * also correct for the husk clear inside `createWorktree`, whose own failure
+ * path blames "a process holding it" for the husks it leaves behind. We are one
+ * of those holders.
+ *
+ * Two concrete consumers, both measured:
+ *  - `DiffWatcher` keeps a RECURSIVE `fs.watch` on the worktree root plus two
+ *    on `<mainRepo>/.git/worktrees/<name>`, which `git worktree remove --force`
+ *    also deletes. On Windows a directory watch whose target is deleted emits
+ *    `rename` at ~150k events/sec forever, with no `error` event, stopping only
+ *    on close(). Nothing released those handles on removal; only project
+ *    relocation ever called `releaseUnder`.
+ *  - An open handle inside the tree is what the retry, process-reap and husk
+ *    machinery below exists to fight.
+ *
+ * Registered by the main process at startup for the same dependency-direction
+ * reason as the removed-listener: this module must not reach up into the IPC
+ * context or the mobile bridge to find their watchers.
+ */
+type WorktreeRemovingListener = (worktreePath: string) => Promise<void>;
+
+let worktreeRemovingListener: WorktreeRemovingListener | null = null;
+
+export function setWorktreeRemovingListener(listener: WorktreeRemovingListener | null): void {
+  worktreeRemovingListener = listener;
+}
+
+async function notifyWorktreeRemoving(worktreePath: string): Promise<void> {
+  if (!worktreeRemovingListener) return;
+  try {
+    await worktreeRemovingListener(worktreePath);
+  } catch (error) {
+    // Best-effort: failing to release a handle must never block the removal.
+    // The worst case is the pre-existing behaviour.
+    console.warn('[WORKTREE] worktree-removing listener failed (non-fatal):', error);
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -58,7 +58,7 @@ import { prRefreshScheduler } from './pr/pr-refresh-scheduler';
 import { retrievalService } from './retrieval/retrieval-service';
 import { lineCountClient } from './git/line-count/line-count-client';
 import { setProjectDbInitializer } from './db/database';
-import { setWorktreeRemovedListener } from './git/worktree-manager';
+import { setWorktreeRemovedListener, setWorktreeRemovingListener } from './git/worktree-manager';
 import { notifyAdaptersWorktreeRemoved } from './ipc/helpers/task-cleanup';
 import { loadVecExtension } from './retrieval/vec-extension';
 import { restoreShellEnv } from './shell-env';
@@ -1116,6 +1116,21 @@ app.whenReady().then(async () => {
   // into the agent registry. Wired here, before any project opens, so no
   // removal path can run un-notified.
   setWorktreeRemovedListener(notifyAdaptersWorktreeRemoved);
+
+  // Symmetric BEFORE hook: release every fs.watch handle we hold under a
+  // worktree ahead of deleting it. On Windows a directory watch whose target is
+  // deleted emits `rename` at ~150k events/sec forever, with no `error` event,
+  // stopping only on close() - and an open handle inside the tree is also what
+  // the removal retry / process-reap / husk machinery exists to fight.
+  //
+  // Both DiffWatcher instances have to be released: the bridge deliberately
+  // owns one separate from the IPC context's, so releasing either alone leaves
+  // half the handles armed over a deleted directory.
+  setWorktreeRemovingListener(async (worktreePath: string) => {
+    const removalContext = getOptionalIpcContext();
+    removalContext?.diffWatcher.releaseUnder(worktreePath);
+    removalContext?.mobileBridgeService.releaseDiffHandlesUnder(worktreePath);
+  });
 
   // Redundant AUMID call inside whenReady -- ensures the ID is set even if
   // Electron clears it during app initialization on some Windows versions.

--- a/src/main/mobile-bridge/mobile-bridge-service.ts
+++ b/src/main/mobile-bridge/mobile-bridge-service.ts
@@ -808,4 +808,19 @@ export class MobileBridgeService extends EventEmitter {
     this.disposeAllSessions();
     this.diffWatcher.closeAll();
   }
+
+  /**
+   * Release this service's `fs.watch` handles at or under `pathPrefix`, ahead
+   * of that directory being deleted.
+   *
+   * Exists because the bridge deliberately owns a DiffWatcher separate from
+   * `IpcContext.diffWatcher` (see the field's comment), so releasing only the
+   * IPC one before a worktree removal would leave half the handles armed over
+   * a deleted directory - which on Windows spins a CPU core until close().
+   * A phone left on a task's diff view holds such a subscription with no
+   * renderer involvement at all.
+   */
+  releaseDiffHandlesUnder(pathPrefix: string): void {
+    this.diffWatcher.releaseUnder(pathPrefix);
+  }
 }

--- a/src/main/pty/lifecycle/session-file-manager.ts
+++ b/src/main/pty/lifecycle/session-file-manager.ts
@@ -99,9 +99,18 @@ export class SessionFileManager {
    * too - callers must be sure the session is never coming back.
    */
   detachAndDelete(sessionId: string): void {
-    this.cleanupAndRemoveFiles(sessionId);
+    // Close the watchers BEFORE removing the directory they watch. Both halves
+    // are synchronous today, so no watcher event is delivered in between and
+    // the old order was harmless - but an fs.watch left armed over its own
+    // target's deletion is precisely the shape that pins a CPU core on Windows
+    // (see the storm guard in readers/file-watcher.ts). Ordering it correctly
+    // keeps that true if either half ever grows an await.
+    //
+    // End state is unchanged: statusFileReader.detach unlinks status.json and
+    // events.jsonl, then the recursive+force rm removes the directory.
     this.sessionHistoryReader.detach(sessionId);
     this.statusFileReader.detach(sessionId);
+    this.cleanupAndRemoveFiles(sessionId);
   }
 
   /**

--- a/src/main/pty/readers/file-watcher.ts
+++ b/src/main/pty/readers/file-watcher.ts
@@ -1,5 +1,37 @@
 import fs from 'node:fs';
 
+/**
+ * Raw native events, arriving inside STORM_WINDOW_MS with no dispatch in
+ * between, that mark an fs.watch handle as stuck rather than busy.
+ *
+ * On Windows, once the DIRECTORY backing an fs.watch handle is deleted the
+ * handle emits `rename` in a tight loop and never stops. Measured on
+ * node 24 / Windows 11: 145k to 155k events/sec, roughly 85% of it kernel
+ * time, identically for a plain, a `recursive: true`, and a `recursive: false`
+ * directory watch. No `error` event is emitted, recreating the path does not
+ * stop it, and only close() does.
+ *
+ * The flood's `filename` is the watched directory's OWN absolute path in
+ * extended-length (`\\?\C:\...`) form, so it never equals the file we are
+ * looking for. That is why the count runs BEFORE the filename filter in
+ * setupWatcher: nothing downstream of that filter ever observes a single storm
+ * event, so accounting placed there would sit at zero while a core burns.
+ *
+ * A watch on a FILE whose parent directory is deleted does NOT flood. It emits
+ * `error` (EPERM) and goes quiet, which attachErrorHandler covers instead.
+ *
+ * Both guards below are load-bearing:
+ *  - Reset-on-dispatch covers a legitimate write burst, which always settles
+ *    within debounceMs and therefore dispatches, zeroing the count.
+ *  - The time window covers the directory arm, whose count also advances on
+ *    unrelated SIBLING files that never dispatch. BoardConfigManager watches a
+ *    project root for a usually-absent kangentic.json, where .git, build output
+ *    and lockfiles churn constantly; a bare count with no window would cross the
+ *    threshold during an ordinary hour of work and disarm a healthy watcher.
+ */
+const STORM_EVENT_THRESHOLD = 1000;
+const STORM_WINDOW_MS = 1000;
+
 interface FileWatcherOptions {
   filePath: string;
   onChange: () => void;
@@ -28,6 +60,10 @@ export class FileWatcher {
    *  changes, so a broken watcher (only the poll fires) still falls back to
    *  full polling. Used to skip the redundant stat while fs.watch is healthy. */
   private lastWatcherNativeFireTime = 0;
+  /** Raw native events since the last dispatch, and when that run started.
+   *  See STORM_EVENT_THRESHOLD. */
+  private nativeEventCount = 0;
+  private nativeEventWindowStart = 0;
   private closed = false;
 
   private readonly filePath: string;
@@ -81,6 +117,9 @@ export class FileWatcher {
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
     this.debounceTimer = setTimeout(() => {
       this.debounceTimer = null;
+      // A dispatch proves the handle is delivering usable events rather than
+      // spinning, so the storm run starts over.
+      this.nativeEventCount = 0;
       this.onChange();
     }, this.debounceMs);
   };
@@ -93,36 +132,140 @@ export class FileWatcher {
     this.onFileChange();
   };
 
-  private setupWatcher(): void {
-    try {
-      const watcher = fs.watch(this.filePath, this.onWatcherEvent);
-      watcher.on('error', () => {
-        // fs.watch broke - polling will cover it silently
-      });
-      this.watcher = watcher;
-    } catch {
-      // File may not exist yet; try watching the parent directory instead
-      const directory = this.filePath.replace(/[/\\][^/\\]+$/, '');
-      const expectedFilename = this.filePath.replace(/^.*[/\\]/, '');
-      try {
-        const watcher = fs.watch(directory, (_eventType, filename) => {
-          if (filename === expectedFilename) {
-            this.onWatcherEvent();
-          }
-        });
-        watcher.on('error', () => {
-          // fs.watch broke - polling will cover it silently
-        });
-        this.watcher = watcher;
-      } catch {
-        // Can't watch directory either - polling fallback will still work
-      }
+  /**
+   * Every native fs.watch delivery, counted before any filename filter so a
+   * flood that the filter drops entirely is still visible. See
+   * STORM_EVENT_THRESHOLD for why both the count and the window are needed.
+   */
+  private onRawWatcherEvent = (): void => {
+    // A queued completion can still arrive after close() or a disarm.
+    if (this.closed || !this.watcher) return;
+
+    this.nativeEventCount += 1;
+    if (this.nativeEventCount === 1) {
+      this.nativeEventWindowStart = Date.now();
+      return;
     }
+    if (this.nativeEventCount < STORM_EVENT_THRESHOLD) return;
+
+    if (Date.now() - this.nativeEventWindowStart <= STORM_WINDOW_MS) {
+      this.disarmWatcher();
+      return;
+    }
+    // Slow accumulation across a long span is ordinary sibling churn, not a
+    // storm. Start a fresh run rather than disarming a healthy watcher.
+    this.nativeEventCount = 0;
+  };
+
+  private setupWatcher(): void {
+    if (this.armFileWatcher()) return;
+
+    // File may not exist yet; try watching the parent directory instead.
+    const directory = this.filePath.replace(/[/\\][^/\\]+$/, '');
+    const expectedFilename = this.filePath.replace(/^.*[/\\]/, '');
+    try {
+      const watcher = fs.watch(directory, (_eventType, filename) => {
+        this.onRawWatcherEvent();
+        if (filename === expectedFilename) {
+          this.onWatcherEvent();
+        }
+      });
+      this.attachErrorHandler(watcher);
+      this.watcher = watcher;
+      this.nativeEventCount = 0;
+    } catch {
+      // Can't watch directory either - polling fallback will still work
+    }
+  }
+
+  /**
+   * Arm a watch on the file itself. False when fs.watch throws (the file is
+   * absent, or its directory is gone).
+   *
+   * Deliberately never falls back to the directory: the poll's re-arm calls
+   * this directly and must not silently recreate the directory watch, which is
+   * the arm that floods.
+   */
+  private armFileWatcher(): boolean {
+    try {
+      const watcher = fs.watch(this.filePath, () => {
+        this.onRawWatcherEvent();
+        this.onWatcherEvent();
+      });
+      this.attachErrorHandler(watcher);
+      this.watcher = watcher;
+      this.nativeEventCount = 0;
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * fs.watch broke - polling covers it silently. Windows raises EPERM here when
+   * the watched FILE's directory is deleted.
+   *
+   * Close and release the handle rather than leaving a dead FSWatcher in
+   * `this.watcher`: that would block the poll's re-arm, and a leaked FSWatcher
+   * is the handle class that once held the libuv loop open past a clean quit.
+   * Identity-checked because a re-arm may already have replaced it, and nulling
+   * the CURRENT handle from a stale handle's error would orphan a live watcher.
+   */
+  private attachErrorHandler(watcher: fs.FSWatcher): void {
+    watcher.on('error', () => {
+      try { watcher.close(); } catch { /* already released */ }
+      if (this.watcher !== watcher) return;
+      this.watcher = null;
+      this.nativeEventCount = 0;
+      this.lastWatcherNativeFireTime = 0;
+    });
+  }
+
+  /**
+   * Release a stuck fs.watch handle and fall back to polling.
+   *
+   * Deliberately does NOT set `closed` and does NOT touch pollTimer or
+   * debounceTimer: the instance stays alive on its polling fallback, and the
+   * poll re-arms a file watch once the target exists again.
+   *
+   * Zeroing lastWatcherNativeFireTime keeps the very next poll tick from
+   * skipping its isStale() check on the strength of the departed watcher's own
+   * timestamps.
+   */
+  private disarmWatcher(): void {
+    if (this.watcher) {
+      try { this.watcher.close(); } catch { /* already released */ }
+      this.watcher = null;
+      console.warn(
+        `[file-watcher] released a flooding fs.watch handle for ${this.filePath} - falling back to polling`,
+      );
+    }
+    this.nativeEventCount = 0;
+    this.nativeEventWindowStart = 0;
+    this.lastWatcherNativeFireTime = 0;
+  }
+
+  /**
+   * Re-arm a watch that a storm or an error released.
+   *
+   * Runs above the poll's early returns because an actively-written file keeps
+   * a debounce pending, which would starve a re-arm placed later in the body.
+   *
+   * Two limits. FILE watch only, since the directory arm is the one that
+   * floods. And only when the file exists, which keeps a disarmed watcher from
+   * throwing inside fs.watch once per second for the rest of its life.
+   */
+  private rearmFileWatcherIfDisarmed(): void {
+    if (this.watcher) return;
+    if (!fs.existsSync(this.filePath)) return;
+    this.armFileWatcher();
   }
 
   private startPolling(): void {
     this.pollTimer = setInterval(() => {
-      if (this.closed || this.debounceTimer) return;
+      if (this.closed) return;
+      this.rearmFileWatcherIfDisarmed();
+      if (this.debounceTimer) return;
       // fs.watch delivered an OS event within the last interval: it is healthy
       // and already pushing changes, so skip the redundant stat entirely. This
       // removes the per-interval statSync precisely during active streaming

--- a/src/main/pty/readers/status-file-reader.ts
+++ b/src/main/pty/readers/status-file-reader.ts
@@ -51,7 +51,7 @@ export interface StatusFileAttachOptions {
   /**
    * Adapter-supplied hook (from `runtime.statusFile`) used to decode
    * status.json and events.jsonl content. Optional: when null, the
-   * reader still performs startup file cleanup (delete stale
+   * reader still performs startup file cleanup (truncate stale
    * status.json, truncate stale events.jsonl) but skips watcher setup
    * since there's nothing to parse. This is used by sessions whose
    * adapter does not opt into the hook telemetry pipeline (Codex,
@@ -101,9 +101,10 @@ export class StatusFileReader {
    * paths are optional - a session with neither is a no-op (the
    * adapter isn't using Kangentic's statusline/hook pipeline).
    *
-   * Deletes any stale status.json and truncates any stale events.jsonl
-   * from a prior run with the same path, so the watcher doesn't emit
-   * cached data from the previous session.
+   * Truncates any stale status.json and events.jsonl from a prior run
+   * with the same path, so the watcher doesn't emit cached data from
+   * the previous session. Truncated rather than unlinked so the watcher
+   * arms on the FILE - see the inline note on the truncate below.
    */
   attach(options: StatusFileAttachOptions): void {
     const { sessionId, statusOutputPath, eventsOutputPath, statusFileHook } = options;
@@ -120,11 +121,24 @@ export class StatusFileReader {
       firstStatusDelivered: false,
     };
 
-    // Delete stale status.json so the watcher doesn't emit cached data
+    // Truncate stale status.json so the watcher doesn't emit cached data
     // from a previous session run. Runs regardless of whether a parser
     // is provided - file cleanup is not parser-dependent.
+    //
+    // TRUNCATE, not unlink, and that distinction is load-bearing. Unlinking
+    // left the file absent at the moment FileWatcher was constructed a line
+    // later, so `fs.watch(statusOutputPath)` always threw and the watcher
+    // always fell back to watching the SESSION DIRECTORY, for the whole life of
+    // the session. On Windows a directory watch whose target is deleted then
+    // spins a CPU core forever (see readers/file-watcher.ts). Creating the file
+    // empty puts the watcher on the file itself, which does not have that
+    // failure mode - and matches what the events file below already does.
+    //
+    // Every adapter's parseStatus returns null for '' (Claude's JSON.parse is
+    // wrapped in try/catch; the rest return null unconditionally), so an empty
+    // file emits nothing and cannot satisfy the firstStatusDelivered handoff.
     if (statusOutputPath) {
-      try { fs.unlinkSync(statusOutputPath); } catch { /* may not exist */ }
+      try { fs.writeFileSync(statusOutputPath, ''); } catch { /* dir may not exist */ }
 
       // Only install the watcher when we have a status-file hook to
       // decode changes. Sessions without a hook still need the file

--- a/tests/unit/diff-watcher-gitdir-cache-race.test.ts
+++ b/tests/unit/diff-watcher-gitdir-cache-race.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit test closing a red-green coverage hole for an in-flight
+ * releaseUnder() race in DiffWatcher.watchGitMetadata
+ * (src/main/git/diff-watcher.ts): a releaseUnder() that lands while
+ * `git rev-parse --absolute-git-dir` is still resolving must leave
+ * gitDirCache genuinely empty, not silently repopulated by the late
+ * resolution.
+ *
+ * The fix is the entry-liveness guard immediately before the cache write in
+ * watchGitMetadata's `.then()`:
+ *   if (this.watchers.get(worktreePath) !== entry) return;
+ *   this.gitDirCache.set(worktreePath, gitDir);
+ *
+ * The two existing 'git dir cache' tests in tests/unit/diff-watcher.test.ts
+ * both fully `await` the rev-parse promise before calling releaseUnder, so
+ * neither one exercises the in-flight case this guard protects. This test
+ * drives the promise on a manually-controlled schedule so releaseUnder can
+ * land WHILE it is still pending.
+ *
+ * Mirrors tests/unit/diff-watcher.test.ts's node:fs / simple-git / node:path
+ * mocking style rather than importing from it, since each spec file owns its
+ * own `vi.mock(...)` factories.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Mocks (mirrors tests/unit/diff-watcher.test.ts) ─────────────────────────
+
+/** Per-path close spies, keyed by the watched path. */
+const mockCloseFns = new Map<string, ReturnType<typeof vi.fn>>();
+
+vi.mock('node:fs', () => ({
+  default: {
+    watch: vi.fn((watchPath: string, _options: unknown, _callback: (eventType: string, filename: string | null) => void) => {
+      const closeFn = vi.fn();
+      mockCloseFns.set(watchPath, closeFn);
+      return { close: closeFn };
+    }),
+    existsSync: vi.fn(() => true),
+  },
+}));
+
+// Mock simple-git so the test can control rev-parse resolution timing.
+const mockGitRaw = vi.fn<(args: string[]) => Promise<string>>();
+const mockGitInstance = { raw: mockGitRaw };
+
+vi.mock('simple-git', () => ({
+  default: vi.fn(() => mockGitInstance),
+}));
+
+// Extend the real path module: pin sep to '/' for cross-platform consistency
+// (DiffWatcher splits filenames by path.sep; on CI Linux sep is already '/'),
+// but keep the real `relative`, `isAbsolute`, and `join` so releaseUnder's
+// replacePathPrefix works correctly.
+vi.mock('node:path', async () => {
+  const actual = await vi.importActual<typeof import('node:path')>('node:path');
+  return {
+    default: {
+      ...actual,
+      sep: '/',
+    },
+  };
+});
+
+import { DiffWatcher } from '../../src/main/git/diff-watcher';
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/** A promise this test resolves on its own schedule, standing in for the
+ *  in-flight `git rev-parse` subprocess. */
+function createDeferredGitRawResult(): {
+  promise: Promise<string>;
+  resolve: (resolvedGitDir: string) => void;
+} {
+  let resolvePromise!: (resolvedGitDir: string) => void;
+  const promise = new Promise<string>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('DiffWatcher git dir cache in-flight release race', () => {
+  let watcher: DiffWatcher;
+
+  beforeEach(() => {
+    mockCloseFns.clear();
+    mockGitRaw.mockReset();
+    // Default: git is not a real repo, so rev-parse rejects and
+    // watchGitMetadata no-ops (mirrors tests/unit/diff-watcher.test.ts). The
+    // one test in this file overrides this with its own controlled
+    // resolution.
+    mockGitRaw.mockRejectedValue(new Error('not a git repository'));
+    watcher = new DiffWatcher();
+  });
+
+  afterEach(() => {
+    watcher.closeAll();
+  });
+
+  it('re-resolves the git dir when releaseUnder lands while rev-parse is still in flight', async () => {
+    // Catches the fix's guard being removed. Without
+    // `if (this.watchers.get(worktreePath) !== entry) return;` in
+    // watchGitMetadata's .then(), the late resolution below would silently
+    // repopulate gitDirCache with a git dir that releaseUnder already
+    // declared gone, the second subscribe would take the cache-hit branch,
+    // and mockGitRaw would be called only once total instead of twice - this
+    // assertion goes red.
+    const worktreePath = '/mock/race';
+    const fakeGitDir = '/mock/race/.git';
+
+    const firstRevParseResolution = createDeferredGitRawResult();
+    mockGitRaw.mockReturnValueOnce(firstRevParseResolution.promise);
+
+    // Subscribe #1: cache miss, kicks off the in-flight rev-parse.
+    watcher.subscribe(worktreePath, vi.fn());
+    expect(mockGitRaw).toHaveBeenCalledTimes(1);
+
+    // The worktree is deleted (or a task's isolation is released) while
+    // rev-parse is still pending.
+    watcher.releaseUnder(worktreePath);
+
+    // NOW the subprocess finally resolves, racing the release.
+    firstRevParseResolution.resolve(`${fakeGitDir}\n`);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Subscribe #2: if the cache was genuinely left empty by the release,
+    // this is a fresh miss and rev-parse is called again.
+    mockGitRaw.mockResolvedValueOnce(`${fakeGitDir}\n`);
+    watcher.subscribe(worktreePath, vi.fn());
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockGitRaw).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/diff-watcher.test.ts
+++ b/tests/unit/diff-watcher.test.ts
@@ -479,4 +479,103 @@ describe('DiffWatcher', () => {
       expect(mockGitRaw).toHaveBeenCalledWith(['rev-parse', '--absolute-git-dir']);
     });
   });
+
+  // ── Debounce max wait ────────────────────────────────────────────────────
+  //
+  // The debounce is trailing with no natural ceiling, so a stream arriving
+  // faster than DEBOUNCE_MS re-arms it forever and subscribers hear nothing.
+  // A dev server or test run inside the worktree clears that bar easily.
+
+  describe('debounce max wait', () => {
+    it('still fires under a continuous stream faster than the debounce', () => {
+      const callback = vi.fn();
+      watcher.subscribe('/project', callback);
+
+      // An event every 400ms never lets the 500ms trailing timer expire.
+      // Without the 2000ms cap this loop produces ZERO callbacks.
+      for (let tick = 0; tick < 6; tick++) {
+        watchCallback!('change', 'src/file.ts');
+        vi.advanceTimersByTime(400);
+      }
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire early: a normal burst still coalesces on the trailing edge', () => {
+      const callback = vi.fn();
+      watcher.subscribe('/project', callback);
+
+      watchCallback!('change', 'src/file.ts');
+      vi.advanceTimersByTime(100);
+      watchCallback!('change', 'src/other.ts');
+
+      // Still inside the debounce window, and nowhere near the cap.
+      vi.advanceTimersByTime(400);
+      expect(callback).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(100);
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens a fresh run after a capped dispatch', () => {
+      const callback = vi.fn();
+      watcher.subscribe('/project', callback);
+
+      for (let tick = 0; tick < 6; tick++) {
+        watchCallback!('change', 'src/file.ts');
+        vi.advanceTimersByTime(400);
+      }
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      // A later quiet change is debounced normally, not dispatched instantly.
+      watchCallback!('change', 'src/file.ts');
+      expect(callback).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(500);
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── git dir cache ────────────────────────────────────────────────────────
+
+  describe('git dir cache', () => {
+    const worktreePath = '/mock/cached';
+    const fakeGitDir = '/mock/cached/.git';
+
+    async function subscribeAndFlush(): Promise<() => void> {
+      const unsubscribe = watcher.subscribe(worktreePath, vi.fn());
+      await Promise.resolve();
+      await Promise.resolve();
+      return unsubscribe;
+    }
+
+    it('resolves the git dir once across subscribe/unsubscribe cycles', async () => {
+      mockGitRaw.mockResolvedValue(`${fakeGitDir}\n`);
+
+      const unsubscribe = await subscribeAndFlush();
+      expect(mockGitRaw).toHaveBeenCalledTimes(1);
+
+      // Clicking away from a task and back tears the subscription down and
+      // rebuilds it. That must not spawn a second git process.
+      unsubscribe();
+      await subscribeAndFlush();
+
+      expect(mockGitRaw).toHaveBeenCalledTimes(1);
+      // The metadata watches are still armed off the cached value.
+      expect(watchCallbacksByPath.has(fakeGitDir)).toBe(true);
+    });
+
+    it('drops the cached git dir when the path is released', async () => {
+      mockGitRaw.mockResolvedValue(`${fakeGitDir}\n`);
+
+      await subscribeAndFlush();
+      expect(mockGitRaw).toHaveBeenCalledTimes(1);
+
+      // releaseUnder means the worktree is being deleted or moved, so the
+      // resolved git dir is no longer trustworthy.
+      watcher.releaseUnder(worktreePath);
+
+      await subscribeAndFlush();
+      expect(mockGitRaw).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/tests/unit/file-watcher-recovery.test.ts
+++ b/tests/unit/file-watcher-recovery.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Real-filesystem recovery tests for FileWatcher.
+ *
+ * Separate from file-watcher.test.ts, which mocks `node:fs` wholesale.
+ *
+ * The Windows event flood that motivated the storm guard is platform-specific
+ * (a directory watch whose target is deleted emits `rename` at ~150k/sec
+ * forever, stopping only on close). These tests therefore assert the BEHAVIOUR
+ * that has to hold on every platform - the watcher keeps reporting changes
+ * across a delete and recreate of its directory - rather than any event count.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { FileWatcher } from '../../src/main/pty/readers/file-watcher';
+
+describe('FileWatcher recovery on a real filesystem', () => {
+  let tempDir: string;
+  const openWatchers: FileWatcher[] = [];
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'file-watcher-recovery-'));
+  });
+
+  afterEach(() => {
+    for (const watcher of openWatchers) watcher.close();
+    openWatchers.length = 0;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (predicate()) return;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    throw new Error('timed out waiting for the expected change');
+  }
+
+  it('keeps reporting changes after its directory is deleted and recreated', async () => {
+    const sessionDirectory = path.join(tempDir, 'session');
+    const statusPath = path.join(sessionDirectory, 'status.json');
+    fs.mkdirSync(sessionDirectory, { recursive: true });
+    fs.writeFileSync(statusPath, '');
+
+    let changeCount = 0;
+    const watcher = new FileWatcher({
+      filePath: statusPath,
+      onChange: () => { changeCount += 1; },
+      debounceMs: 10,
+      pollIntervalMs: 50,
+    });
+    openWatchers.push(watcher);
+
+    fs.writeFileSync(statusPath, '{"first":1}');
+    await waitFor(() => changeCount > 0);
+    const changesBeforeDelete = changeCount;
+
+    // The directory vanishes under a live watcher: a prune sweep, a project
+    // delete, or an external rm. On Windows this is what floods.
+    fs.rmSync(sessionDirectory, { recursive: true, force: true });
+
+    // repairMissingEventsDir does exactly this for a live session, and the
+    // agent's next write recreates the file.
+    fs.mkdirSync(sessionDirectory, { recursive: true });
+    fs.writeFileSync(statusPath, '{"second":2}');
+
+    await waitFor(() => changeCount > changesBeforeDelete);
+    expect(changeCount).toBeGreaterThan(changesBeforeDelete);
+  });
+
+  it('reports the file appearing when it did not exist at construction', async () => {
+    // This is the directory-fallback arm: the file is absent, so fs.watch on it
+    // throws and the watcher falls back to the parent directory.
+    const sessionDirectory = path.join(tempDir, 'late-session');
+    const statusPath = path.join(sessionDirectory, 'status.json');
+    fs.mkdirSync(sessionDirectory, { recursive: true });
+
+    let changeCount = 0;
+    const watcher = new FileWatcher({
+      filePath: statusPath,
+      onChange: () => { changeCount += 1; },
+      debounceMs: 10,
+      pollIntervalMs: 50,
+      // The default mtime isStale cannot see a file that does not exist yet,
+      // so mirror what StatusFileReader's events watcher does.
+      isStale: () => fs.existsSync(statusPath),
+    });
+    openWatchers.push(watcher);
+
+    fs.writeFileSync(statusPath, '{"late":true}');
+
+    await waitFor(() => changeCount > 0);
+    expect(changeCount).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/file-watcher-storm-guard.test.ts
+++ b/tests/unit/file-watcher-storm-guard.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests closing two red-green coverage holes in FileWatcher's
+ * storm-disarm logic (src/main/pty/readers/file-watcher.ts). Each hole was
+ * empirically proven by a source mutation that left the full
+ * tests/unit/file-watcher.test.ts suite green:
+ *
+ *  - HOLE A: the storm threshold boundary (file-watcher.ts:149,
+ *    `if (this.nativeEventCount < STORM_EVENT_THRESHOLD) return;`) is
+ *    unpinned. Every existing test fires STORM_EVENT_THRESHOLD + 1 events (or,
+ *    in the slow-churn test, 500 per burst), so none of them sits exactly at
+ *    the boundary. Changing `<` to `<=` leaves the whole suite green.
+ *
+ *  - HOLE B: disarmWatcher's `this.lastWatcherNativeFireTime = 0;`
+ *    (file-watcher.ts:245) is unpinned. Deleting that line also leaves the
+ *    whole suite green, because the existing 'lets the very next poll run
+ *    isStale after a disarm' test uses the FILE arm, where armFileWatcher's
+ *    callback runs onWatcherEvent unconditionally right after the zeroing,
+ *    setting the timestamp straight back to Date.now() - so the existing
+ *    test cannot tell a real zero from a stale timestamp that happens to
+ *    land on the same arithmetic result one full pollIntervalMs later.
+ *
+ * This file mirrors tests/unit/file-watcher.test.ts's node:fs mock and helper
+ * shapes rather than importing from it, since each spec file owns its own
+ * `vi.mock('node:fs', ...)` factory.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Mocks (mirrors tests/unit/file-watcher.test.ts) ─────────────────────────
+
+const mockWatcherClose = vi.fn();
+const mockWatcherOn = vi.fn();
+
+// Captured callbacks from fs.watch calls (in order).
+let watchCallbacks: Array<(...args: unknown[]) => void> = [];
+// The path each fs.watch call targeted, in order.
+let watchPaths: string[] = [];
+let watchShouldThrow = false;
+const mockStatSync = vi.fn(() => ({ mtimeMs: 0, size: 0 }));
+const mockExistsSync = vi.fn(() => false);
+
+vi.mock('node:fs', () => ({
+  default: {
+    watch: vi.fn((watchPath: string, callback: (...args: unknown[]) => void) => {
+      if (watchShouldThrow) {
+        watchShouldThrow = false;
+        throw new Error('ENOENT');
+      }
+      watchPaths.push(watchPath);
+      watchCallbacks.push(callback);
+      return { close: mockWatcherClose, on: mockWatcherOn };
+    }),
+    statSync: (...args: unknown[]) => mockStatSync(...args),
+    existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  },
+}));
+
+import { FileWatcher } from '../../src/main/pty/readers/file-watcher';
+
+// ── Helpers (mirrors tests/unit/file-watcher.test.ts) ───────────────────────
+
+/** Simulate fs.watch firing for the most recent (file) watcher. */
+function fireWatcher(): void {
+  const lastCallback = watchCallbacks[watchCallbacks.length - 1];
+  if (lastCallback) lastCallback();
+}
+
+function fireWatcherTimes(count: number): void {
+  for (let eventIndex = 0; eventIndex < count; eventIndex++) fireWatcher();
+}
+
+/** Simulate fs.watch firing for the most recent directory watcher. */
+function fireDirWatcher(eventType: string, filename: string | null): void {
+  const lastCallback = watchCallbacks[watchCallbacks.length - 1];
+  if (lastCallback) lastCallback(eventType, filename);
+}
+
+function fireDirWatcherTimes(count: number, eventType: string, filename: string | null): void {
+  for (let eventIndex = 0; eventIndex < count; eventIndex++) fireDirWatcher(eventType, filename);
+}
+
+/** The storm threshold in file-watcher.ts. Declared locally rather than
+ *  exported, mirroring tests/unit/file-watcher.test.ts's own local constant. */
+const STORM_EVENT_THRESHOLD = 1000;
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('FileWatcher storm-disarm coverage holes', () => {
+  let onChange: ReturnType<typeof vi.fn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    watchCallbacks = [];
+    watchPaths = [];
+    watchShouldThrow = false;
+    mockStatSync.mockReturnValue({ mtimeMs: 0, size: 0 });
+    mockExistsSync.mockReturnValue(false);
+    onChange = vi.fn();
+    // A disarm warns once, by design (mirrors the 'storm disarm' describe
+    // block in file-watcher.test.ts): silence it so the suite output stays clean.
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  function createWatcher(overrides: Record<string, unknown> = {}): FileWatcher {
+    return new FileWatcher({
+      filePath: '/test/dir/status.json',
+      onChange,
+      ...overrides,
+    } as ConstructorParameters<typeof FileWatcher>[0]);
+  }
+
+  describe('HOLE A: storm threshold boundary (file-watcher.ts:149)', () => {
+    it('does not disarm at exactly STORM_EVENT_THRESHOLD - 1 (999) raw events', () => {
+      // Pins the lower side of the boundary. Catches a threshold check that
+      // trips one event early, e.g. file-watcher.ts:149 changed to
+      // `if (this.nativeEventCount < STORM_EVENT_THRESHOLD - 1) return;`: at
+      // the 999th event, `999 < 999` is false, so it falls through, and the
+      // elapsed time is 0ms (synchronous), which is <= STORM_WINDOW_MS, so it
+      // would disarm here - this assertion goes red. (This is not the
+      // specific `<=` mutation named for this task - that one is caught by
+      // the next test below - but it establishes the other side of the same
+      // boundary so a shift in either direction is caught.)
+      const watcher = createWatcher({ debounceMs: 50, pollIntervalMs: 100000 });
+
+      fireWatcherTimes(STORM_EVENT_THRESHOLD - 1);
+
+      expect(mockWatcherClose).not.toHaveBeenCalled();
+      watcher.close();
+    });
+
+    it('disarms at exactly STORM_EVENT_THRESHOLD (1000) raw events', () => {
+      // Catches the proven mutation: changing file-watcher.ts:149's
+      // `if (this.nativeEventCount < STORM_EVENT_THRESHOLD) return;` to `<=`.
+      // At the 1000th event, `1000 <= 1000` is true under the mutation, so the
+      // function returns before ever reaching the disarm check below it, and
+      // close() is never called - this assertion goes red (0 calls, not 1)
+      // until the 1001st event arrives. With the real `<`, `1000 < 1000` is
+      // false, so it falls through to the disarm check; the elapsed time
+      // since the window opened is 0ms (all 1000 events fire synchronously,
+      // no timer advance between them), which is <= STORM_WINDOW_MS, so it
+      // disarms on exactly the 1000th event.
+      const watcher = createWatcher({ debounceMs: 50, pollIntervalMs: 100000 });
+
+      fireWatcherTimes(STORM_EVENT_THRESHOLD);
+
+      expect(mockWatcherClose).toHaveBeenCalledTimes(1);
+      watcher.close();
+    });
+  });
+
+  describe('HOLE B: disarmWatcher must zero lastWatcherNativeFireTime (file-watcher.ts:245)', () => {
+    it('lets the very next poll run isStale after a directory-arm disarm with a short gap', () => {
+      // Catches the proven mutation: deleting
+      // `this.lastWatcherNativeFireTime = 0;` from disarmWatcher(). This test
+      // deliberately uses the DIRECTORY arm (not the file arm the existing
+      // 'lets the very next poll run isStale after a disarm' test uses),
+      // because on the directory arm a storm's non-matching events never
+      // call onWatcherEvent, so a genuine zeroing survives to the poll tick
+      // instead of being immediately overwritten. The gap between the last
+      // MATCHING event and the poll tick is shaped shorter than
+      // pollIntervalMs, which is what makes a non-zeroed timestamp
+      // discriminating.
+      watchShouldThrow = true; // file arm throws -> falls back to directory watch
+      const isStale = vi.fn().mockReturnValue(false);
+      const watcher = createWatcher({
+        debounceMs: 50,
+        pollIntervalMs: 1000,
+        isStale,
+      });
+      expect(watchPaths).toEqual(['/test/dir']);
+
+      // t=500: one event whose filename MATCHES the watched file -> runs
+      // onWatcherEvent, setting lastWatcherNativeFireTime = 500.
+      vi.advanceTimersByTime(500);
+      fireDirWatcher('change', 'status.json');
+
+      // Let the debounce settle: onChange fires once, and the dispatch resets
+      // nativeEventCount to 0 (a fresh storm-count run starts after this).
+      vi.advanceTimersByTime(50);
+      expect(onChange).toHaveBeenCalledTimes(1);
+
+      // t=600: a burst of NON-matching events. Each runs onRawWatcherEvent
+      // (counting toward the storm) but never onWatcherEvent (filename
+      // mismatch), so lastWatcherNativeFireTime is untouched by this burst -
+      // whatever disarmWatcher does to it from here on is the only thing that
+      // can change it.
+      vi.advanceTimersByTime(50);
+      fireDirWatcherTimes(STORM_EVENT_THRESHOLD, 'rename', 'unrelated.log');
+      expect(mockWatcherClose).toHaveBeenCalledTimes(1);
+
+      // t=1000: the first poll tick. The gap between the poll tick (t=1000)
+      // and the matching event's timestamp (t=500) is 500ms, well under the
+      // 1000ms pollIntervalMs - discriminating only if disarmWatcher actually
+      // zeroed the timestamp out from under it.
+      isStale.mockClear();
+      vi.advanceTimersByTime(400);
+
+      // With the zeroing: lastWatcherNativeFireTime is 0, so Date.now() - 0 is
+      // the full fake-timer epoch value (real wall-clock start plus the 1000ms
+      // advanced), astronomically greater than pollIntervalMs (1000). The
+      // poll's native-fire-time guard does not early-return, and isStale runs.
+      // Without it (the mutation): lastWatcherNativeFireTime is still the t=500
+      // timestamp, so Date.now() - lastWatcherNativeFireTime = 500, which IS
+      // < 1000 - the poll early-returns and isStale is never called. This
+      // assertion goes red.
+      expect(isStale).toHaveBeenCalled();
+
+      watcher.close();
+    });
+  });
+});

--- a/tests/unit/file-watcher.test.ts
+++ b/tests/unit/file-watcher.test.ts
@@ -6,24 +6,36 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
 const mockWatcherClose = vi.fn();
-const mockWatcherOn = vi.fn();
+
+// Handlers registered via watcher.on('error', ...), oldest first. Captured
+// rather than discarded so the error path can be driven from a test.
+let watchErrorHandlers: Array<() => void> = [];
+const mockWatcherOn = vi.fn((eventName: string, handler: () => void) => {
+  if (eventName === 'error') watchErrorHandlers.push(handler);
+});
 
 // Captured callbacks from fs.watch calls (in order)
 let watchCallbacks: Array<(...args: unknown[]) => void> = [];
+// The path each fs.watch call targeted, in order. Lets a test assert that a
+// re-arm went to the file and not back to the directory.
+let watchPaths: string[] = [];
 let watchShouldThrow = false;
 const mockStatSync = vi.fn(() => ({ mtimeMs: 0, size: 0 }));
+const mockExistsSync = vi.fn(() => false);
 
 vi.mock('node:fs', () => ({
   default: {
-    watch: vi.fn((_path: string, callback: (...args: unknown[]) => void) => {
+    watch: vi.fn((watchPath: string, callback: (...args: unknown[]) => void) => {
       if (watchShouldThrow) {
         watchShouldThrow = false;
         throw new Error('ENOENT');
       }
+      watchPaths.push(watchPath);
       watchCallbacks.push(callback);
       return { close: mockWatcherClose, on: mockWatcherOn };
     }),
     statSync: (...args: unknown[]) => mockStatSync(...args),
+    existsSync: (...args: unknown[]) => mockExistsSync(...args),
   },
 }));
 
@@ -43,6 +55,23 @@ function fireDirWatcher(eventType: string, filename: string | null): void {
   if (lastCallback) lastCallback(eventType, filename);
 }
 
+/** The storm threshold in file-watcher.ts. Exceed it to trip a disarm. */
+const STORM_EVENT_THRESHOLD = 1000;
+
+function fireWatcherTimes(count: number): void {
+  for (let index = 0; index < count; index++) fireWatcher();
+}
+
+function fireDirWatcherTimes(count: number, eventType: string, filename: string | null): void {
+  for (let index = 0; index < count; index++) fireDirWatcher(eventType, filename);
+}
+
+/** Invoke the most recently registered 'error' handler. */
+function fireWatcherError(): void {
+  const lastHandler = watchErrorHandlers[watchErrorHandlers.length - 1];
+  if (lastHandler) lastHandler();
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe('FileWatcher', () => {
@@ -52,8 +81,12 @@ describe('FileWatcher', () => {
     vi.useFakeTimers();
     vi.clearAllMocks();
     watchCallbacks = [];
+    watchPaths = [];
+    watchErrorHandlers = [];
     watchShouldThrow = false;
     mockStatSync.mockReturnValue({ mtimeMs: 0, size: 0 });
+    // Default false so no existing test gains a re-arm; storm tests opt in.
+    mockExistsSync.mockReturnValue(false);
     onChange = vi.fn();
   });
 
@@ -280,6 +313,179 @@ describe('FileWatcher', () => {
       fireWatcher();
       vi.advanceTimersByTime(50);
       expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('storm disarm', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      // A disarm warns once, by design. Silence it so the suite output stays clean.
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('disarms a flooding directory watcher, and polling still delivers', () => {
+      watchShouldThrow = true;
+      const isStale = vi.fn().mockReturnValue(false);
+      const watcher = createWatcher({
+        filePath: '/test/dir/status.json',
+        debounceMs: 50,
+        pollIntervalMs: 1000,
+        isStale,
+      });
+      expect(watchPaths).toEqual(['/test/dir']);
+
+      // The real Windows flood carries the watched directory's own absolute
+      // path, which never equals the expected filename - so the filter drops
+      // every event and nothing downstream of it ever sees the storm.
+      fireDirWatcherTimes(STORM_EVENT_THRESHOLD + 1, 'rename', '\\\\?\\C:\\test\\dir');
+
+      expect(mockWatcherClose).toHaveBeenCalledTimes(1);
+      expect(onChange).not.toHaveBeenCalled();
+
+      // The poll fallback is untouched by the disarm.
+      isStale.mockReturnValue(true);
+      vi.advanceTimersByTime(1000);
+      vi.advanceTimersByTime(50);
+      expect(onChange).toHaveBeenCalledTimes(1);
+
+      watcher.close();
+    });
+
+    it('disarms a flooding file watcher that never settles its debounce', () => {
+      const watcher = createWatcher({ debounceMs: 50, pollIntervalMs: 100000 });
+
+      // No timer advance: each event clears and re-arms the debounce, so
+      // onChange never fires and the run never resets.
+      fireWatcherTimes(STORM_EVENT_THRESHOLD + 1);
+
+      expect(mockWatcherClose).toHaveBeenCalledTimes(1);
+      expect(onChange).not.toHaveBeenCalled();
+      watcher.close();
+    });
+
+    it('does not disarm on slow sibling churn spread across windows', () => {
+      watchShouldThrow = true;
+      const isStale = vi.fn().mockReturnValue(false);
+      const watcher = createWatcher({
+        filePath: '/test/dir/status.json',
+        debounceMs: 50,
+        pollIntervalMs: 100000,
+        isStale,
+      });
+
+      // Five times the threshold in total, but no single window holds enough.
+      // This is the BoardConfigManager case: a project root where .git, build
+      // output and lockfiles churn while kangentic.json never appears, so
+      // nothing ever dispatches to reset the count.
+      for (let burst = 0; burst < 5; burst++) {
+        fireDirWatcherTimes(500, 'change', 'unrelated.log');
+        vi.advanceTimersByTime(1001);
+      }
+
+      expect(mockWatcherClose).not.toHaveBeenCalled();
+      watcher.close();
+      expect(mockWatcherClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not disarm while events keep dispatching', () => {
+      const watcher = createWatcher({ debounceMs: 50, pollIntervalMs: 100000 });
+
+      // Twice the threshold overall, but every batch settles and dispatches.
+      for (let batch = 0; batch < 10; batch++) {
+        fireWatcherTimes(200);
+        vi.advanceTimersByTime(50);
+      }
+
+      expect(onChange).toHaveBeenCalledTimes(10);
+      expect(mockWatcherClose).not.toHaveBeenCalled();
+      watcher.close();
+    });
+
+    it('re-arms a FILE watch from the poll, never the directory', () => {
+      watchShouldThrow = true;
+      const isStale = vi.fn().mockReturnValue(false);
+      const watcher = createWatcher({
+        filePath: '/test/dir/status.json',
+        debounceMs: 50,
+        pollIntervalMs: 1000,
+        isStale,
+      });
+      expect(watchPaths).toEqual(['/test/dir']);
+
+      fireDirWatcherTimes(STORM_EVENT_THRESHOLD + 1, 'rename', '\\\\?\\C:\\test\\dir');
+      expect(mockWatcherClose).toHaveBeenCalledTimes(1);
+
+      // Target still missing: no re-arm, and no fs.watch throw once per second.
+      vi.advanceTimersByTime(1000);
+      expect(watchPaths).toEqual(['/test/dir']);
+
+      // Target back: re-armed on the file, never back onto the directory.
+      mockExistsSync.mockReturnValue(true);
+      vi.advanceTimersByTime(1000);
+      expect(watchPaths).toEqual(['/test/dir', '/test/dir/status.json']);
+
+      watcher.close();
+    });
+
+    it('lets the very next poll run isStale after a disarm', () => {
+      const isStale = vi.fn().mockReturnValue(false);
+      const watcher = createWatcher({ debounceMs: 50, pollIntervalMs: 1000, isStale });
+
+      // A file-arm storm advances lastWatcherNativeFireTime on every event,
+      // which would otherwise suppress the poll's stat for a full interval
+      // after the handle is already gone.
+      fireWatcherTimes(STORM_EVENT_THRESHOLD + 1);
+      expect(mockWatcherClose).toHaveBeenCalledTimes(1);
+      isStale.mockClear();
+
+      vi.advanceTimersByTime(1000);
+      expect(isStale).toHaveBeenCalled();
+
+      watcher.close();
+    });
+
+    it('does not double-close when closed after a disarm', () => {
+      const watcher = createWatcher({ debounceMs: 50, pollIntervalMs: 100000 });
+
+      fireWatcherTimes(STORM_EVENT_THRESHOLD + 1);
+      expect(mockWatcherClose).toHaveBeenCalledTimes(1);
+
+      watcher.close();
+      expect(mockWatcherClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('error handling', () => {
+    it('releases the handle on an error event and re-arms from the poll', () => {
+      const isStale = vi.fn().mockReturnValue(false);
+      const watcher = createWatcher({ pollIntervalMs: 1000, isStale });
+      expect(watchPaths).toEqual(['/test/status.json']);
+
+      // Windows raises EPERM here when a watched FILE's directory is deleted.
+      fireWatcherError();
+      expect(mockWatcherClose).toHaveBeenCalledTimes(1);
+
+      mockExistsSync.mockReturnValue(true);
+      vi.advanceTimersByTime(1000);
+      expect(watchPaths).toEqual(['/test/status.json', '/test/status.json']);
+
+      watcher.close();
+    });
+
+    it('does not re-arm after close', () => {
+      const watcher = createWatcher({ pollIntervalMs: 1000 });
+      mockExistsSync.mockReturnValue(true);
+
+      watcher.close();
+      const pathCountAtClose = watchPaths.length;
+
+      vi.advanceTimersByTime(5000);
+      expect(watchPaths).toHaveLength(pathCountAtClose);
     });
   });
 

--- a/tests/unit/fs-watch-sites-guard.test.ts
+++ b/tests/unit/fs-watch-sites-guard.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Guard: every raw `fs.watch` site in the main process is accounted for.
+ *
+ * Background. On Windows, an `fs.watch` pointed at a DIRECTORY keeps emitting
+ * `rename` forever once that directory is deleted - measured 145k to 155k
+ * events/sec, roughly 85% kernel time, for a plain, a `recursive: true` and a
+ * `recursive: false` watch alike. No `error` event fires, recreating the path
+ * does not stop it, and only `close()` does. One such handle pins a CPU core
+ * for the life of the app. (A watch on a FILE does not flood; it raises EPERM.)
+ *
+ * A new raw `fs.watch` is therefore a load-bearing decision, not a detail. It
+ * needs ONE of:
+ *   1. Route through `pty/readers/file-watcher.ts`, which carries the storm
+ *      guard, the polling fallback and the re-arm; or
+ *   2. Own a release path that closes the handle BEFORE anything deletes the
+ *      watched directory - the way `DiffWatcher.releaseUnder` is now driven by
+ *      the worktree-removing listener in `git/worktree-manager.ts`.
+ *
+ * This test does not judge which. It fails when the set of sites changes, so
+ * the decision is made deliberately instead of by omission - the same shape as
+ * esbuild-cjs-imports.test.ts and central-embedding-engine-boundary.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MAIN_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'src', 'main');
+
+/**
+ * Known raw `fs.watch` call sites, as repo-relative POSIX paths, with the
+ * number of calls in each file and why they are allowed to be raw.
+ */
+const ALLOWED_FS_WATCH_SITES: Record<string, { calls: number; reason: string }> = {
+  'pty/readers/file-watcher.ts': {
+    calls: 2,
+    reason:
+      'The wrapper itself: a file watch, plus the parent-directory fallback. '
+      + 'Owns the storm guard, the polling fallback and the file-only re-arm.',
+  },
+  'git/diff-watcher.ts': {
+    calls: 3,
+    reason:
+      'Working tree (recursive) plus the git dir and its logs/ dir. All three '
+      + 'sit on paths a worktree removal destroys, so they are released ahead of '
+      + 'the delete via releaseUnder, driven by setWorktreeRemovingListener.',
+  },
+  'mobile-bridge/dev-quick-pair.ts': {
+    calls: 1,
+    reason:
+      'Dev-only (constructed inside __KANGENTIC_DEV__, so it is absent from a '
+      + 'packaged build). Watches the repo-local mobile-dev-pairing directory, '
+      + 'which the module creates itself and no cleanup path deletes.',
+  },
+};
+
+function listTypeScriptFiles(directory: string): string[] {
+  const found: string[] = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...listTypeScriptFiles(entryPath));
+    } else if (entry.name.endsWith('.ts')) {
+      found.push(entryPath);
+    }
+  }
+  return found;
+}
+
+/** Count `fs.watch(` calls, ignoring `fs.watchFile(` and comment lines. */
+function countFsWatchCalls(source: string): number {
+  let count = 0;
+  for (const line of source.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('*') || trimmed.startsWith('//')) continue;
+    // `fs.watchFile(` cannot match: the pattern requires `(` right after
+    // `watch`, so there is nothing to exclude here.
+    count += (line.match(/\bfs\.watch\s*\(/g) ?? []).length;
+  }
+  return count;
+}
+
+describe('raw fs.watch sites in src/main', () => {
+  it('matches the reviewed allowlist', () => {
+    const actual: Record<string, number> = {};
+
+    for (const filePath of listTypeScriptFiles(MAIN_DIR)) {
+      const calls = countFsWatchCalls(fs.readFileSync(filePath, 'utf-8'));
+      if (calls === 0) continue;
+      const relativePath = path.relative(MAIN_DIR, filePath).split(path.sep).join('/');
+      actual[relativePath] = calls;
+    }
+
+    const expected = Object.fromEntries(
+      Object.entries(ALLOWED_FS_WATCH_SITES).map(([site, entry]) => [site, entry.calls]),
+    );
+
+    expect(
+      actual,
+      'A raw fs.watch site in src/main changed.\n\n'
+      + 'On Windows a directory fs.watch spins a CPU core forever once its target\n'
+      + 'is deleted, silently and until close(). Either route the watch through\n'
+      + 'pty/readers/file-watcher.ts (which carries the storm guard, the polling\n'
+      + 'fallback and the re-arm), or give it a release path that closes the handle\n'
+      + 'before the directory is deleted - see DiffWatcher.releaseUnder and\n'
+      + 'setWorktreeRemovingListener in git/worktree-manager.ts.\n\n'
+      + 'Then update ALLOWED_FS_WATCH_SITES in this file with the reason.',
+    ).toEqual(expected);
+  });
+
+  it('has no fs.watchFile usage, which has no such guard', () => {
+    const offenders: string[] = [];
+    for (const filePath of listTypeScriptFiles(MAIN_DIR)) {
+      if (/\bfs\.watchFile\s*\(/.test(fs.readFileSync(filePath, 'utf-8'))) {
+        offenders.push(path.relative(MAIN_DIR, filePath).split(path.sep).join('/'));
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/unit/remove-worktree.test.ts
+++ b/tests/unit/remove-worktree.test.ts
@@ -178,7 +178,7 @@ vi.mock('simple-git', () => ({
 // Import under test (after mocks)
 // ---------------------------------------------------------------------------
 
-import { WorktreeManager, setWorktreeRemovedListener } from '../../src/main/git/worktree-manager';
+import { WorktreeManager, setWorktreeRemovedListener, setWorktreeRemovingListener } from '../../src/main/git/worktree-manager';
 
 const WORKTREE_PATH = '/mock/project/.kangentic/worktrees/my-task-abcd1234';
 const PROJECT_PATH = '/mock/project';
@@ -546,6 +546,105 @@ describe('WorktreeManager.removeWorktree -- worktree-removed listener', () => {
 
     // No setWorktreeRemovedListener call - default state after the afterEach
     // reset above. Must not throw.
+    await expect(manager.removeWorktree(WORKTREE_PATH)).resolves.toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Worktree-removing listener: release OS handles BEFORE the delete
+// ---------------------------------------------------------------------------
+//
+// The contract is the mirror image of the removed-listener above: it fires
+// before any removal attempt, whether or not the removal goes on to succeed,
+// because its job is to drop handles we hold under the path. On Windows a
+// directory `fs.watch` whose target is deleted spins a CPU core until close(),
+// and an open handle in the tree is also what the retry / reap / husk machinery
+// fights. Also module-level mutable state, so it must be reset in afterEach.
+
+describe('WorktreeManager.removeWorktree - worktree-removing listener', () => {
+  let manager: WorktreeManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGitInstances.length = 0;
+    recordedSpawnCalls.length = 0;
+    spawnOverrides.length = 0;
+    mockReapProcessesForWorktree.mockResolvedValue([]);
+    manager = new WorktreeManager(PROJECT_PATH);
+  });
+
+  afterEach(() => {
+    setWorktreeRemovingListener(null);
+  });
+
+  it('fires BEFORE any git command or filesystem removal runs', async () => {
+    mockExistsSync.mockReturnValue(true);
+    let spawnCallsWhenNotified = -1;
+    let removeWithRetryCallsWhenNotified = -1;
+    const listener = vi.fn(async () => {
+      spawnCallsWhenNotified = recordedSpawnCalls.length;
+      removeWithRetryCallsWhenNotified = mockRemoveWithRetry.mock.calls.length;
+    });
+    setWorktreeRemovingListener(listener);
+
+    const result = await manager.removeWorktree(WORKTREE_PATH);
+
+    expect(result).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(WORKTREE_PATH);
+    // The whole point: nothing had touched the directory yet.
+    expect(spawnCallsWhenNotified).toBe(0);
+    expect(removeWithRetryCallsWhenNotified).toBe(0);
+  });
+
+  it('fires even when the path is already gone - that is the spinning-watcher case', async () => {
+    mockExistsSync.mockReturnValue(false);
+    const listener = vi.fn(async () => {});
+    setWorktreeRemovingListener(listener);
+
+    const result = await manager.removeWorktree(WORKTREE_PATH);
+
+    expect(result).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires even when the removal fails, unlike the removed-listener', async () => {
+    mockExistsSync.mockReturnValue(true);
+    spawnOverrides.push({
+      match: (args) => args[0] === 'worktree' && args[1] === 'remove',
+      behavior: { exitCode: 1, stderr: 'fatal: unable to remove worktree' },
+    });
+    mockRemoveWithRetry.mockRejectedValue(new Error('EPERM: operation not permitted'));
+    const listener = vi.fn(async () => {});
+    setWorktreeRemovingListener(listener);
+
+    const result = await manager.removeWorktree(WORKTREE_PATH);
+
+    expect(result).toBe(false);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('a listener that throws does not fail the removal (best-effort)', async () => {
+    mockExistsSync.mockReturnValue(true);
+    const listener = vi.fn(async () => {
+      throw new Error('diff watcher release blew up');
+    });
+    setWorktreeRemovingListener(listener);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await manager.removeWorktree(WORKTREE_PATH);
+
+    expect(result).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[WORKTREE] worktree-removing listener failed (non-fatal):',
+      expect.any(Error),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('is a no-op when no listener is registered', async () => {
+    mockExistsSync.mockReturnValue(true);
+
     await expect(manager.removeWorktree(WORKTREE_PATH)).resolves.toBe(true);
   });
 });

--- a/tests/unit/session-history-reader-cursor-branches.test.ts
+++ b/tests/unit/session-history-reader-cursor-branches.test.ts
@@ -62,6 +62,11 @@ vi.mock('node:fs', () => ({
       return { close: vi.fn(), on: vi.fn() };
     }),
     statSync: (...args: unknown[]) => mockStatSync(...args),
+    // FileWatcher's poll consults existsSync before re-arming a released
+    // handle. Unreachable here (this mock's watch never throws, so the handle
+    // is never null), but stubbed so a future change fails loudly instead of
+    // with a confusing TypeError.
+    existsSync: () => true,
     openSync: (...args: unknown[]) => mockOpenSync(...args),
     closeSync: (...args: unknown[]) => mockCloseSync(...args),
     readSync: (...args: unknown[]) => mockReadSync(...args),

--- a/tests/unit/session-respawn.test.ts
+++ b/tests/unit/session-respawn.test.ts
@@ -241,7 +241,7 @@ describe('Session respawn (column transition)', () => {
     expect(taskSessions[0].id).toBe(second.id);
   });
 
-  it('stale status.json is deleted on respawn to prevent cached usage emission', async () => {
+  it('stale status.json is truncated on respawn to prevent cached usage emission', async () => {
     const sessionDir = path.join(tmpDir, 'sessions', 'claude-session-1');
     fs.mkdirSync(sessionDir, { recursive: true });
     const statusPath = path.join(sessionDir, 'status.json');
@@ -260,7 +260,15 @@ describe('Session respawn (column transition)', () => {
     // Respawn with the same statusOutputPath (same claudeSessionId)
     await spawnForTask('task-11', { statusOutputPath: statusPath });
 
-    // Stale file should have been deleted before the usage watcher started
-    expect(fs.existsSync(statusPath)).toBe(false);
+    // The stale CONTENT must be gone before the usage watcher starts, which is
+    // what this test is really about: every parseStatus returns null for '',
+    // so an empty file emits nothing.
+    //
+    // Truncated rather than unlinked. Leaving the file absent meant
+    // fs.watch(statusOutputPath) threw and FileWatcher fell back to watching
+    // the session DIRECTORY - and on Windows a directory watch whose target is
+    // later deleted spins a CPU core until close(). See status-file-reader.ts.
+    expect(fs.existsSync(statusPath)).toBe(true);
+    expect(fs.readFileSync(statusPath, 'utf-8')).toBe('');
   });
 });

--- a/tests/unit/status-file-reader.test.ts
+++ b/tests/unit/status-file-reader.test.ts
@@ -97,8 +97,8 @@ describe('StatusFileReader', () => {
       statusFileHook: parser,
     });
 
-    // WAIT: attach() deletes stale status.json on setup, then the watcher
-    // triggers an initial read of the (now-deleted) file. So we need to
+    // WAIT: attach() truncates stale status.json on setup, then the watcher
+    // triggers an initial read of the (now-empty) file. So we need to
     // re-write content AFTER attach.
     fs.writeFileSync(statusPath, '{"fresh":"data"}');
 
@@ -106,13 +106,14 @@ describe('StatusFileReader', () => {
     // debounced watchers but this works for testing dispatch).
     reader.flushPendingEvents('session-1');
 
-    // The initial synchronous read in attach happened on the DELETED file
-    // (ENOENT), so no callback fired there. But we can still verify the
-    // attach lifecycle worked:
+    // The initial synchronous read in attach saw an EMPTY file. Every real
+    // parseStatus returns null for '', so production emits nothing there; this
+    // stub ignores its input, so it is not a useful assertion either way. What
+    // this test pins is the attach lifecycle:
     expect(reader.isAttached('session-1')).toBe(true);
   });
 
-  it('deletes stale status.json on attach so the watcher does not emit cached data', () => {
+  it('truncates stale status.json on attach so the watcher does not emit cached data', () => {
     const statusPath = path.join(tempDir, 'status.json');
     fs.writeFileSync(statusPath, '{"stale":"prev-run"}');
 
@@ -132,8 +133,13 @@ describe('StatusFileReader', () => {
       statusFileHook: parser,
     });
 
-    // File should be deleted by attach.
-    expect(fs.existsSync(statusPath)).toBe(false);
+    // File should exist but be empty, mirroring events.jsonl below. The stub
+    // parser above throws on stale content, so an empty read is what keeps
+    // this green. Truncating rather than unlinking is what puts FileWatcher on
+    // the FILE instead of falling back to watching the session DIRECTORY,
+    // which is the arm that spins a CPU core on Windows once it is deleted.
+    expect(fs.existsSync(statusPath)).toBe(true);
+    expect(fs.readFileSync(statusPath, 'utf-8')).toBe('');
   });
 
   it('truncates stale events.jsonl on attach', () => {


### PR DESCRIPTION
## What

Stops an `fs.watch` whose target directory has been deleted from pinning a CPU core for the rest
of the app's life.

- `src/main/pty/readers/file-watcher.ts` - storm detection, self-disarm, and file-only re-arm.
- `src/main/pty/readers/status-file-reader.ts` - truncate stale `status.json` instead of unlinking.
- `src/main/git/worktree-manager.ts` + `src/main/index.ts` - a `setWorktreeRemovingListener` hook
  that releases watcher handles before a worktree is deleted.
- `src/main/mobile-bridge/mobile-bridge-service.ts` - `releaseDiffHandlesUnder` so the
  bridge-owned `DiffWatcher` is released too.
- `src/main/git/diff-watcher.ts` - debounce max-wait + a git-dir resolution cache.
- `src/main/pty/lifecycle/session-file-manager.ts` - close readers before deleting their directory.

## Why

Found during the #568 performance review: a preview's main process sat at **98% of one core for
over an hour**. A CPU profile attributed it to `FSWatcher._handle.onchange`, and closing two
watchers dropped the process to 1.5%. The flooding watchers were named
`<project>/.kangentic/sessions/<sessionId>`, one per running session.

A standalone repro pinned the OS behavior on Windows across all four watch shapes this codebase
uses:

| shape | while deleted | after recreate | after close |
|---|---|---|---|
| `fs.watch(file)`, parent deleted | 0/s (emits `error` EPERM) | 0/s | 0/s |
| `fs.watch(dir)` | 150,809/s | 148,908/s | 0/s |
| `fs.watch(dir, { recursive: true })` | 145,011/s | 154,525/s | 0/s |
| `fs.watch(dir, { recursive: false })` | 150,098/s | 153,261/s | 0/s |

Roughly 85% of that is kernel time. No `error` event fires for the directory shapes, recreating
the path does not stop the flood, and only `close()` does. The flood's `filename` is the watched
directory's own absolute path in extended-length (`\\?\C:\...`) form, so it never matches the file
being looked for.

Two things made this reachable. `StatusFileReader.attach` unlinked `status.json` immediately
before constructing its `FileWatcher`, so the file never existed at construction and the watcher
always fell back to watching the session DIRECTORY - one flooding candidate per running session,
exactly what was observed. And `repairMissingEventsDir` recreates the vanished directory, which is
why it ran for an hour instead of being transient (and why `existsSync` is not a usable
"target gone" test).

## How

Two layers, because the deletions we cause and the ones we do not need different answers.

**Layer 1 - stop creating the condition.** Truncate `status.json` rather than unlinking it, so the
watcher arms on the FILE (which does not flood). Release our own handles before deleting a
worktree: `releaseUnder` previously had exactly one caller (project relocation), so worktree
removal released nothing, and for a linked worktree one subscription is three doomed handles since
`git worktree remove --force` also deletes the administrative git dir. The new hook hangs off
`removeWorktreeInternal` rather than `removeWorktree` so `createWorktree`'s husk-clear fires it
too - that path's failure mode is "a process still holds this directory", and we are one of those
holders.

**Layer 2 - survive a deletion we do not control** (an external `rm`, Explorer, another process).
`FileWatcher` counts raw native events BEFORE its filename filter, since the filter drops every
storm event and nothing downstream of it would otherwise see one. Detection needs both a count
(1000) and a window (1s): reset-on-dispatch alone false-positives on the directory arm, whose
count also advances on unrelated sibling files. `BoardConfigManager` watches a project ROOT for a
usually-absent `kangentic.json`, so a bare threshold would trip during an ordinary hour of git and
build activity - and the default `isStale` cannot detect file creation, so a spurious disarm would
leave board config permanently blind to that file appearing.

Two `DiffWatcher` issues surfaced while auditing the same code. Its 500ms debounce was trailing
with no maximum wait, so any stream faster than 500ms re-armed it forever and the callbacks never
fired at all - a dev server or test run inside a worktree left the Changes panel frozen for the
whole build. And `git rev-parse --absolute-git-dir` ran on every subscribe, so clicking between
tasks respawned a git subprocess each time.

## Breaking changes

None. `status.json` is now created empty rather than left absent between sessions; every adapter's
`parseStatus` returns null for `''`, so nothing is emitted and the `firstStatusDelivered` handoff
is unaffected.

## Tests

The CI checks, plus:

- `tests/unit/file-watcher.test.ts` - storm disarm on both arms, no false disarm on slow sibling
  churn, file-only re-arm, error-path release.
- `tests/unit/file-watcher-storm-guard.test.ts` - the threshold boundary and the
  `lastWatcherNativeFireTime` zeroing, both proven by source mutation.
- `tests/unit/file-watcher-recovery.test.ts` - real-filesystem recovery across a delete/recreate.
  Asserts recovery, never an event count, since the flood is Windows-specific.
- `tests/unit/diff-watcher.test.ts` - debounce max-wait (red-green verified: without the cap the
  callback fires 0 times) and the git-dir cache lifecycle.
- `tests/unit/diff-watcher-gitdir-cache-race.test.ts` - a `releaseUnder` landing while `rev-parse`
  is in flight must not leave a stale cache entry.
- `tests/unit/remove-worktree.test.ts` - the removing-listener fires before any git command or
  filesystem removal, including when the path is already gone or the removal fails.
- `tests/unit/fs-watch-sites-guard.test.ts` - pins the four known raw `fs.watch` sites with a
  per-site reason so a new one has to be a deliberate decision.

Full unit tier green locally (12,613 passing).

Also verified empirically against a running app rather than only in tests:

| scenario | before | after |
|---|---|---|
| live session directory deleted | 98% of a core, indefinitely | **1.46%**, feed self-healed |
| worktree removed with 3 live diff handles | unprotected | **0.50%**, no husk left |
| 3,000 project-root events across windows | would trip a bare counter | no disarm |
| 45s continuous write stream | panel frozen at 9 files | tracked live (214, then 231) |

Generated with [Claude Code](https://claude.com/claude-code)
