### PR TITLE
feat(changes): keep the Changes panel closed after its pop-out closes

### DIFF
--- a/.claude/rules/pop-out-surface-registry.md
+++ b/.claude/rules/pop-out-surface-registry.md
@@ -57,6 +57,22 @@ pop-outs, and do not conflate the two layers.
   dialog / embedded pane) must not also be mounted. Guard the in-app mount site and add a
   `<PopOutButton kind=... params=.../>` to its header/toolbar.
 
+  **Guarding the mount site only SUPPRESSES the render; it does not decide what happens when the
+  window closes.** The in-app open flag survives detachment, so by default the surface RECLAIMS
+  its in-app slot the moment the window closes. Whether that is right is per-surface, and either
+  answer needs a deliberate choice:
+  - `stats` and `monitor` clear their in-app store when the pop-out OPENS
+    (`AppLayout.tsx`), so reopening later starts from a clean closed state.
+  - `changes` clears on CLOSE instead (`renderer/pop-out/pop-out-changed.ts`), because its trigger
+    is a stateful pill reading the same flag: clearing on open would leave the pill inactive over
+    a live detached window.
+
+  A close-driven effect belongs on the `popOut:changed` PUSH, never in `pop-out-store.setOpen()` -
+  `loadOpen()` also calls that on mount and on every HMR `vite:afterUpdate`, so an effect placed
+  there rides a re-sync path and a Fast Refresh could close a user's panel. The push carries the
+  whole open-key set with no per-key close event, so derive the disappearance by diffing the sets
+  and read the vanished key back with `parsePopOutInstanceKey`.
+
   **Carve-out: an ADDITIVE surface declares `inAppSurface: null`.** `changes-file` is a detached
   read of ONE file's diff, opened FROM the inline diff pane - suppressing that pane would defeat
   the surface, so it has no exclusive in-app counterpart and its origin stays mounted while its
@@ -76,6 +92,13 @@ pop-outs, and do not conflate the two layers.
   `Object.values(IPC)`. Runs in CI via `npm run test:unit`.
 - **Test:** `tests/unit/hmr-resync.test.ts` covers the renderer half of Pattern B/E for
   `pop-out-store.ts` (the store mirroring which windows are open).
+- **Test:** `tests/unit/pop-out-changed.test.ts` pins the push-vs-`setOpen` split above: it
+  asserts a raw `setOpen([])` (the shape `loadOpen()` and the HMR re-sync take) leaves the
+  panel open, while the same disappearance arriving through the push closes it. Folding the
+  close effect back into `setOpen` turns it red.
+- **Test:** `tests/unit/pop-out.test.ts` round-trips `popOutInstanceKey` against
+  `parsePopOutInstanceKey` for every task-scoped kind, so the key a close path reads back
+  cannot drift from the one the open path wrote.
 - **Review:** `/code-review` flags a new `new BrowserWindow(` outside the manager, or a new
   in-app surface added without its mutual-exclusivity guard.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -388,7 +388,7 @@ Detach a registered UI surface (usage stats, git changes, a single changed file'
 | `popOut:focus` | invoke | Focus (and restore if minimized) a surface's pop-out window |
 | `popOut:isOpen` | invoke | Whether a surface's pop-out window is currently open |
 | `popOut:listOpen` | invoke | List the instance keys of every currently-open pop-out window |
-| `popOut:changed` | on | Event: the set of open pop-out windows changed; pushed to the main window only, mirrored into `pop-out-store.ts` so in-app triggers (title bar, headers) flip between "open" and "focus" |
+| `popOut:changed` | on | Event: the set of open pop-out windows changed; pushed to the main window only. Handled by `renderer/pop-out/pop-out-changed.ts`, which mirrors the set into `pop-out-store.ts` (so in-app triggers - title bar, headers - flip between "open" and "focus") and then applies the effects a window CLOSING implies: a closed `changes` window leaves its task's inline Changes panel CLOSED rather than reclaiming the split. Those effects hang off this push and NOT off `pop-out-store.setOpen()`, which `popOut:listOpen` also drives on mount and on every HMR re-sync; `browser` masks its pane the same way but deliberately still reclaims on close |
 
 ### Analytics (1 channel)
 | Channel | Pattern | Purpose |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -234,6 +234,8 @@ Right-click a file in the tree for **View history**, a popover listing the commi
 
 The panel persists its expanded/collapsed state, selected file, selected commit, and divider positions across dialog reopens.
 
+The whole panel can also detach into its own OS window - click the pop-out icon in its header - not just a single file's diff. Unlike the properties above, this is not preserved through a close: while the window is open the header pill still reads **Hide changes**, but closing the window leaves the panel closed instead of restoring it inline; click **Show changes** again to reopen it.
+
 The Changes panel is available for all tasks, whether or not worktrees are enabled. It uses `git merge-base` to show only branch-specific changes, excluding upstream commits.
 
 When the dialog is open, it claims the terminal session and the bottom panel drops that task's tab. Any other running session keeps its tab and its live terminal; the panel only collapses once nothing is left in it. Closing the dialog returns the tab, still selected.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -15,6 +15,7 @@ import { useAnnouncementsStore } from './stores/announcements-store';
 import { useUsageDashboardStore } from './stores/usage-dashboard-store';
 import { useMonitorStore } from './stores/monitor-store';
 import { usePopOutStore } from './stores/pop-out-store';
+import { receivePopOutOpenSet } from './pop-out/pop-out-changed';
 import { useDictationStore } from './stores/dictation-store';
 import { useProjectSwitchEffect } from './hooks/useProjectSwitchEffect';
 import { useAgentDrivenInvalidation } from './hooks/useAgentDrivenInvalidation';
@@ -118,9 +119,7 @@ export function App() {
     // live via the popOut:changed push. Only meaningful in the main window (a
     // pop-out window never reads this store); see stores/pop-out-store.ts.
     void usePopOutStore.getState().loadOpen();
-    const cleanupPopOutChanged = window.electronAPI.popOut?.onChanged((openInstanceKeys) => {
-      usePopOutStore.getState().setOpen(openInstanceKeys);
-    });
+    const cleanupPopOutChanged = window.electronAPI.popOut?.onChanged(receivePopOutOpenSet);
 
     // Listen for auto-update downloaded notification
     const cleanupUpdateListener = window.electronAPI.updater?.onUpdateDownloaded((info) => {

--- a/src/renderer/pop-out/pop-out-changed.ts
+++ b/src/renderer/pop-out/pop-out-changed.ts
@@ -1,0 +1,45 @@
+import { parsePopOutInstanceKey } from '../../shared/pop-out';
+import { usePopOutStore } from '../stores/pop-out-store';
+import { useSessionStore } from '../stores/session-store';
+
+/**
+ * Handler for the main process's `popOut:changed` push: mirror the new open set
+ * into the pop-out store, then apply the side effects a window CLOSING implies.
+ *
+ * Why this is not `pop-out-store.setOpen()` itself: `setOpen` is also the target
+ * of `loadOpen()`, which App.tsx calls at mount and again on every HMR
+ * `vite:afterUpdate` re-sync. Those are re-syncs, not lifetime events, and
+ * hanging a cross-store write (plus its debounced DB save) off them would mean a
+ * Fast Refresh could silently close a user's panel. The push is the only signal
+ * that means "a window's lifetime ended", so the effects live here and `setOpen`
+ * stays a plain setter.
+ *
+ * Why App level rather than an effect inside the task-detail body: nothing closes
+ * a task's pop-outs when its task-detail window closes, so a `changes` pop-out
+ * outlives the component that spawned it. A component-local effect would miss
+ * exactly that case, and the panel would be back on the task's next open.
+ *
+ * The push carries the whole open-key set and no per-key close event, so the
+ * disappearance is derived by diffing against the previous set.
+ */
+export function receivePopOutOpenSet(openInstanceKeys: string[]): void {
+  const previousKeys = usePopOutStore.getState().openInstanceKeys;
+  usePopOutStore.getState().setOpen(openInstanceKeys);
+
+  const stillOpen = new Set(openInstanceKeys);
+  for (const key of Object.keys(previousKeys)) {
+    if (stillOpen.has(key)) continue;
+    const closed = parsePopOutInstanceKey(key);
+    // Only the task-detail Changes view reclaims its in-app split on close, and
+    // leaving it open there is the unwanted extra step this clears. The two
+    // deliberate omissions:
+    //   - 'changes-file' is an ADDITIVE per-file read opened FROM the inline
+    //     panel, so closing one must leave that panel exactly as it was.
+    //   - 'browser' masks its pane identically (browserOpenTasks) but is
+    //     deliberately left alone; reclaiming is still its behavior.
+    if (closed?.kind !== 'changes') continue;
+    // Clear against the key's OWN project, never the ambient one: the window can
+    // outlive a board switch, and the panel state is persisted per task.
+    useSessionStore.getState().setChangesOpen(closed.taskId, false, closed.projectId);
+  }
+}

--- a/src/renderer/stores/session-store/task-changes-panel-slice.ts
+++ b/src/renderer/stores/session-store/task-changes-panel-slice.ts
@@ -120,6 +120,19 @@ export interface TaskChangesPanelSlice {
    */
   hydratedDetailViewTasks: Set<string>;
   toggleChangesOpen: (taskId: string) => void;
+  /**
+   * Set an entity's Changes panel open state explicitly. `toggleChangesOpen`
+   * delegates here, and the pop-out close path drives it: when a `changes`
+   * pop-out window disappears from the `popOut:changed` open set, the panel is
+   * left CLOSED rather than reclaiming the in-app split (see
+   * renderer/pop-out/pop-out-changed.ts), where a toggle would be wrong.
+   *
+   * `projectId` is for a caller that already knows the task's project (the
+   * pop-out key carries it) and so must not depend on which board happens to be
+   * open when the window closes; it defaults to the current project like every
+   * other setter here.
+   */
+  setChangesOpen: (taskId: string, open: boolean, projectId?: string) => void;
   setChangesSelectedFile: (taskId: string, filePath: string | null) => void;
   setChangesScope: (taskId: string, scope: GitDiffScope) => void;
   setChangesFileTreeWidth: (taskId: string, width: number) => void;
@@ -250,10 +263,15 @@ function isNonTaskDetailViewId(entityId: string): boolean {
  * Schedule a debounced persist of a task's detail-view layout. Captures the
  * project id at interaction time (project-scoped-ipc rule) and the latest blob.
  * Sentinel (non-task) ids are ignored - they have no `tasks` row to write.
+ *
+ * `projectIdOverride` is for a caller that already knows the task's project and
+ * so must not read the ambient one: a `changes` pop-out can be closed after the
+ * user has switched boards, and the ambient read would then write the task's
+ * blob into the wrong project's database.
  */
-function scheduleDetailViewSave(taskId: string, get: () => SessionStore): void {
+function scheduleDetailViewSave(taskId: string, get: () => SessionStore, projectIdOverride?: string): void {
   if (isNonTaskDetailViewId(taskId)) return;
-  const projectId = useProjectStore.getState().currentProject?.id ?? null;
+  const projectId = projectIdOverride ?? useProjectStore.getState().currentProject?.id ?? null;
   detailViewPendingSaves.set(taskId, { state: buildDetailViewBlob(get(), taskId), projectId });
   const existing = detailViewSaveTimers.get(taskId);
   if (existing) clearTimeout(existing);
@@ -294,17 +312,25 @@ export const createTaskChangesPanelSlice: StateCreator<SessionStore, [], [], Tas
   hydratedDetailViewTasks: new Set<string>(),
 
   toggleChangesOpen: (taskId) => {
-    const next = new Set(get().changesOpenTasks);
+    get().setChangesOpen(taskId, !get().changesOpenTasks.has(taskId));
+  },
+
+  setChangesOpen: (taskId, open, projectId) => {
+    const current = get().changesOpenTasks;
+    if (current.has(taskId) === open) return; // idempotent: no churn, no save
+    const next = new Set(current);
+    // The view mode rides the open flag: opening seeds the default split, closing
+    // drops the entry so the next open is not resurrected as 'expanded'.
     const viewMode = { ...get().changesViewMode };
-    if (next.has(taskId)) {
-      next.delete(taskId);
-      delete viewMode[taskId];
-    } else {
+    if (open) {
       next.add(taskId);
       viewMode[taskId] = 'split';
+    } else {
+      next.delete(taskId);
+      delete viewMode[taskId];
     }
     set({ changesOpenTasks: next, changesViewMode: viewMode });
-    scheduleDetailViewSave(taskId, get);
+    scheduleDetailViewSave(taskId, get, projectId);
   },
 
   toggleBrowserOpen: (taskId) => {

--- a/src/shared/pop-out.ts
+++ b/src/shared/pop-out.ts
@@ -117,6 +117,29 @@ export function popOutInstanceKey<K extends PopOutKind>(kind: K, params: PopOutP
   return taskKey;
 }
 
+/**
+ * Inverse of {@link popOutInstanceKey} for the TASK-SCOPED kinds: recover which kind
+ * and task a key belongs to. Returns null for a global surface (which carries no task),
+ * an unknown kind, or a malformed key.
+ *
+ * Exists because `popOut:changed` pushes the whole open-key SET with no per-key close
+ * event, so a consumer that needs to react to one window disappearing has to diff the
+ * sets and then read the vanished key back. Lives beside the builder so the two cannot
+ * drift; tests/unit/pop-out.test.ts round-trips them.
+ */
+export function parsePopOutInstanceKey(
+  key: string,
+): { kind: PopOutKind; projectId: string; taskId: string } | null {
+  // Segments 1 and 2 are always projectId/taskId, including for 'changes-file' - its
+  // filePath is deliberately the LAST segment, so extra segments never shift these two.
+  const segments = key.split(':');
+  if (segments.length < 3) return null;
+  const [kind, projectId, taskId] = segments;
+  if (!isPopOutKind(kind) || isGlobalPopOutKind(kind)) return null;
+  if (!projectId || !taskId) return null;
+  return { kind, projectId, taskId };
+}
+
 export interface PopOutSurfaceMeta {
   kind: PopOutKind;
   scope: 'global' | 'task';

--- a/tests/e2e/agent-activity-special-modes.spec.ts
+++ b/tests/e2e/agent-activity-special-modes.spec.ts
@@ -29,12 +29,13 @@ import {
   cleanupTestDataDir,
   mockAgentPath,
   setProjectDefaultAgent,
-  waitForScrollback,
+  waitForTaskScrollback,
   getTaskIdByTitle,
   getSwimlaneIds,
   moveTaskIpc,
   closeApp,
   type AgentName,
+  type TaskScrollbackResult,
 } from './helpers';
 import type { ElectronApplication, Page } from '@playwright/test';
 import type { ActivityState } from '../../src/shared/types';
@@ -46,9 +47,10 @@ const runId = Date.now();
 const PROJECT_NAME = `Activity Special Modes ${runId}`;
 
 test.describe('Agent activity detection - special TUI / output modes', () => {
-  // Each test pairs a 15s spawn-marker wait with a 20s idle-poll, exceeding
-  // the 30s electron default; bump the describe timeout instead of marking
-  // every test slow individually.
+  // Each test pairs a 30s spawn-marker wait (see spawnAndWaitForMarker's doc
+  // comment for why every test gets that budget, not just whichever runs
+  // first) with a 20s idle-poll, exceeding the 30s electron default; bump
+  // the describe timeout instead of marking every test slow individually.
   test.describe.configure({ timeout: 60_000 });
 
   let app: ElectronApplication;
@@ -98,57 +100,93 @@ test.describe('Agent activity detection - special TUI / output modes', () => {
     cleanupTestDataDir(TEST_NAME);
   });
 
-  async function spawnAndWaitForMarker(agent: AgentName, marker: string): Promise<string> {
+  /**
+   * Spawns a task for `agent` and waits for `marker` in THAT task's own
+   * session scrollback (never any other live session's - see
+   * waitForTaskScrollback's doc comment for why that distinction matters in
+   * a file that shares one Electron app across four tests).
+   *
+   * The task title includes `test.info().retry`, which is 0 on the initial
+   * attempt and increments on every CI retry. Without this, a retried test
+   * re-creates a task with the SAME title as the failed attempt's task,
+   * `getTaskIdByTitle` can resolve back onto that stale (still-Planning,
+   * already-spawned) task instead of the freshly created one, and the retry
+   * ends up observing the leftover session's now-warmed-up state rather than
+   * testing a real spawn.
+   *
+   * markerTimeoutMs defaults to 30s (double waitForTaskScrollback's own
+   * 15s default): the renderer reload inside setProjectDefaultAgent plus a
+   * first worktree + PTY spawn is a real cold-start cost on a CI runner
+   * where the electron project's workers (8 on Linux CI) are all launching
+   * Electron apps concurrently against a shared, small vCPU budget. Which
+   * of the four tests in this file actually pays that cold cost is NOT
+   * fixed to "whichever runs first" - CI splits specs into shards by
+   * cumulative test index, so a shard boundary can land mid-file and make
+   * Cursor, Copilot, or Warp the first spawn in that shard's copy of the
+   * app instead of Codex. Giving every call the same headroom (rather than
+   * only the literally-first test) is what actually fixes that. Still a
+   * condition poll (waitForTaskScrollback), never a bare sleep - cost on
+   * the warm path is zero, since the poll returns as soon as the marker
+   * lands.
+   */
+  async function spawnAndWaitForMarker(
+    agent: AgentName,
+    marker: string,
+    markerTimeoutMs = 30000,
+  ): Promise<TaskScrollbackResult & { taskId: string }> {
     await setProjectDefaultAgent(page, agent);
 
-    const taskTitle = `${agent} special ${runId}`;
+    const taskTitle = `${agent} special ${runId}-r${test.info().retry}`;
     await createTask(page, taskTitle, `Special-mode activity check for ${agent}`);
     const swimlaneIds = await getSwimlaneIds(page);
     const taskId = await getTaskIdByTitle(page, taskTitle);
 
     await moveTaskIpc(page, taskId, swimlaneIds.planning);
-    return waitForScrollback(page, marker);
+    const result = await waitForTaskScrollback(page, taskId, marker, markerTimeoutMs);
+    return { taskId, ...result };
   }
 
   test('Codex: settles to idle despite continuous TUI redraws', async () => {
-    await spawnAndWaitForMarker('codex', 'MOCK_CODEX_SESSION:');
+    const { sessionId } = await spawnAndWaitForMarker('codex', 'MOCK_CODEX_SESSION:');
     await expect.poll(async () => {
       const activity = await page.evaluate(() => window.electronAPI.sessions.getActivity());
-      return Object.values(activity as Record<string, ActivityState>);
+      return (activity as Record<string, ActivityState>)[sessionId];
     }, {
       timeout: 20000,
       message: 'Codex session should reach idle despite TUI redraw stream',
-    }).toContain('idle');
+    }).toBe('idle');
   });
 
   test('Cursor: settles to idle despite continuous TUI redraws', async () => {
-    await spawnAndWaitForMarker('cursor', 'MOCK_CURSOR_SESSION:');
+    const { sessionId } = await spawnAndWaitForMarker('cursor', 'MOCK_CURSOR_SESSION:');
     await expect.poll(async () => {
       const activity = await page.evaluate(() => window.electronAPI.sessions.getActivity());
-      return Object.values(activity as Record<string, ActivityState>);
+      return (activity as Record<string, ActivityState>)[sessionId];
     }, {
       timeout: 20000,
       message: 'Cursor session should reach idle despite TUI redraw stream',
-    }).toContain('idle');
+    }).toBe('idle');
   });
 
   test('Copilot: PTY status bar containing GPT-5 mini appears in scrollback', async () => {
-    await spawnAndWaitForMarker('copilot', 'MOCK_COPILOT_SESSION:');
+    const { taskId } = await spawnAndWaitForMarker('copilot', 'MOCK_COPILOT_SESSION:');
     // The status bar string is in raw PTY scrollback (with ANSI codes).
     // What matters is that it reaches the scrollback at all - that proves
     // the streamOutput -> session-manager -> scrollback wiring is intact.
-    const scrollback = await waitForScrollback(page, 'GPT-5 mini', 15000);
+    // Scoped to this task's own session (not waitForScrollback's all-session
+    // join) for the same reason as spawnAndWaitForMarker above.
+    const { scrollback } = await waitForTaskScrollback(page, taskId, 'GPT-5 mini', 15000);
     expect(scrollback).toContain('GPT-5 mini');
   });
 
   test('Warp: settles to idle after active output stops', async () => {
-    await spawnAndWaitForMarker('warp', 'MOCK_WARP_SESSION:');
+    const { sessionId } = await spawnAndWaitForMarker('warp', 'MOCK_WARP_SESSION:');
     await expect.poll(async () => {
       const activity = await page.evaluate(() => window.electronAPI.sessions.getActivity());
-      return Object.values(activity as Record<string, ActivityState>);
+      return (activity as Record<string, ActivityState>)[sessionId];
     }, {
       timeout: 20000,
       message: 'Warp session should reach idle after active output stops',
-    }).toContain('idle');
+    }).toBe('idle');
   });
 });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -593,6 +593,55 @@ export async function waitForScrollback(page: Page, marker: string, timeoutMs = 
   throw new Error(`Timed out waiting for scrollback containing: ${marker}`);
 }
 
+/** Result of {@link waitForTaskScrollback}: the session that produced the
+ *  marker, and the scrollback text that satisfied it. */
+export interface TaskScrollbackResult {
+  sessionId: string;
+  scrollback: string;
+}
+
+/**
+ * Poll ONE task's own session for scrollback containing marker, rather than
+ * joining every live session the way {@link waitForScrollback} does.
+ *
+ * Scoping to the specific task's session is required whenever a spec's
+ * Electron app (and therefore its set of live PTY sessions) is shared across
+ * multiple tests or attempts in one file. Without it, a CI retry that reuses
+ * the same worker - and therefore the same still-alive app - can be
+ * satisfied by a DIFFERENT session's marker: a sibling test's session, or
+ * (worse) the failed attempt's OWN leftover session, which has simply had
+ * more wall-clock time to warm up in the background while later tests in the
+ * file ran. That leftover-session risk is compounded whenever the caller
+ * reuses the same task title across attempts, since `tasks.list()` can then
+ * resolve a lookup back onto the stale task instead of the freshly created
+ * one - callers should give each attempt a title that is unique per retry
+ * (e.g. include `test.info().retry`) so this never happens.
+ *
+ * Returns both the session id (so a follow-up assertion, e.g. an
+ * activity-state poll, can stay scoped to the same session) and the
+ * scrollback text that satisfied the marker.
+ */
+export async function waitForTaskScrollback(
+  page: Page,
+  taskId: string,
+  marker: string,
+  timeoutMs = 15000,
+): Promise<TaskScrollbackResult> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const result = await page.evaluate(async (id) => {
+      const sessions: Session[] = await window.electronAPI.sessions.list();
+      const session = sessions.find((candidate) => candidate.taskId === id);
+      if (!session) return null;
+      const scrollback = await window.electronAPI.sessions.getScrollback(session.id);
+      return { sessionId: session.id, scrollback };
+    }, taskId);
+    if (result && result.scrollback.includes(marker)) return result;
+    await page.waitForTimeout(500);
+  }
+  throw new Error(`Timed out waiting for task ${taskId}'s session scrollback containing: ${marker}`);
+}
+
 /** Wait until at least one session reports status='running' via IPC. */
 export async function waitForRunningSession(page: Page, timeoutMs = 15000): Promise<void> {
   await page.waitForFunction(async () => {

--- a/tests/ui/diff-view-mode-preference.spec.ts
+++ b/tests/ui/diff-view-mode-preference.spec.ts
@@ -281,6 +281,8 @@ test.describe('diffViewMode: Changes settings tab reflects and drives the same v
 
     // Open Settings panel.
     await page.locator('[data-testid="settings-button"]').click();
+    const settingsPanel = page.locator('[data-testid="settings-panel"]');
+    await settingsPanel.waitFor({ state: 'visible', timeout: 3000 });
     await page.locator('h2:has-text("Settings")').waitFor({ state: 'visible', timeout: 3000 });
 
     // Navigate to the Changes tab.
@@ -297,8 +299,25 @@ test.describe('diffViewMode: Changes settings tab reflects and drives the same v
     await diffViewSelect.selectOption('split');
     await expect.poll(() => getDiffViewMode(), { timeout: 3000 }).toBe('split');
 
-    // Close the settings panel via Escape.
-    await page.keyboard.press('Escape');
-    await page.locator('h2:has-text("Settings")').waitFor({ state: 'hidden', timeout: 2000 });
+    // Close the settings panel by driving the config store directly, instead
+    // of `page.keyboard.press('Escape')`. Escape's dismissal goes through
+    // `SettingsPanelShell`'s document-level handler -> `useOverlayPhase`'s
+    // `requestClose()` -> the 150ms `overlay-panel-out` CSS animation ->
+    // `animationend` -> `onClose()`. Under CI's sharded-worker contention that
+    // `animationend` dispatch can stall well past the animation's own
+    // duration (observed: CI run 33273015411, "waiting for locator to be
+    // hidden" timing out at 2000ms after every real assertion in this test
+    // had already passed - a pure cleanup-step flake, not a behavior bug).
+    // `setSettingsOpen(false)` unmounts `<SettingsPanel />` on the very next
+    // React commit (`AppLayout.tsx` gates it on `{settingsOpen &&
+    // <SettingsPanel />}`), bypassing the exit-animation path entirely, so
+    // there is nothing left in the wait for a stalled main thread to starve.
+    await page.evaluate(() => {
+      const stores = (window as unknown as {
+        __zustandStores?: { config?: { getState: () => { setSettingsOpen: (open: boolean) => void } } };
+      }).__zustandStores;
+      stores?.config?.getState().setSettingsOpen(false);
+    });
+    await settingsPanel.waitFor({ state: 'hidden', timeout: 3000 });
   });
 });

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -61,6 +61,28 @@
   // OS window. See window.__mockPopOut below.
   let popOutCalls = [];
   let popOutOpenResult = true;
+  // Which pop-out instance keys main currently reports as open, plus the
+  // popOut:changed push subscribers. A spec drives both through
+  // window.__mockFirePopOutChanged below, which is the ONLY way to exercise the
+  // real push path (App.tsx subscribes onChanged at mount).
+  let popOutOpenKeys = [];
+  let popOutChangedSubscribers = [];
+
+  /**
+   * Mirror of shared/pop-out.ts popOutInstanceKey, for the mock's isOpen(). This file is
+   * loaded via addInitScript as plain browser JS, so it cannot import the real builder and
+   * has to hand-copy it. Two things drift silently if pop-out.ts changes: the global-kind
+   * list below duplicates GLOBAL_KINDS, and the segment order duplicates the builder's.
+   * Update both together. Nothing catches a drift today because electronAPI.popOut.isOpen()
+   * has no caller in src/ - the renderer reads openness off pop-out-store instead - so this
+   * mirror is only here to keep the fake API self-consistent with listOpen().
+   */
+  function popOutKeyOf(kind, params) {
+    if (kind === 'stats' || kind === 'monitor') return kind;
+    const taskKey = kind + ':' + (params && params.projectId) + ':' + (params && params.taskId);
+    if (kind === 'changes-file') return taskKey + ':' + (params && params.filePath);
+    return taskKey;
+  }
   // Call log for window.electronAPI.window.* (minimize/maximize/close), so a
   // test can assert a title-bar / pop-out-frame control invoked the right verb
   // without a real OS window. See window.__mockWindowControls below.
@@ -3577,9 +3599,18 @@
       open: function (kind, params) { popOutCalls.push({ type: 'open', kind: kind, params: params }); return Promise.resolve(popOutOpenResult); },
       close: function (kind, params) { popOutCalls.push({ type: 'close', kind: kind, params: params }); return Promise.resolve(); },
       focus: function (kind, params) { popOutCalls.push({ type: 'focus', kind: kind, params: params }); return Promise.resolve(); },
-      isOpen: function (/* kind, params */) { return Promise.resolve(false); },
-      listOpen: function () { return Promise.resolve([]); },
-      onChanged: function (/* callback(openInstanceKeys) */) { return noop; },
+      isOpen: function (kind, params) { return Promise.resolve(popOutOpenKeys.indexOf(popOutKeyOf(kind, params)) !== -1); },
+      // Resolves the same set __mockFirePopOutChanged last pushed, so App.tsx's
+      // mount-time loadOpen() (and its HMR re-sync) cannot land late and clobber
+      // a simulated open set.
+      listOpen: function () { return Promise.resolve(popOutOpenKeys.slice()); },
+      onChanged: function (callback) {
+        popOutChangedSubscribers.push(callback);
+        return function () {
+          var index = popOutChangedSubscribers.indexOf(callback);
+          if (index !== -1) popOutChangedSubscribers.splice(index, 1);
+        };
+      },
       descriptor: null,
     },
 
@@ -4012,12 +4043,13 @@
   };
 
   /**
-   * Test hook: inspect the pop-out engine's open/close/focus call log. The
-   * renderer's pop-out store itself is driven directly via
-   * window.__zustandStores.popOut (exposed dev-only in App.tsx) - a test sets
-   * openInstanceKeys there to simulate "a surface just detached", the same
-   * shape the real popOut:changed push delivers. This hook is only for
-   * asserting which verb a trigger (title-bar button, PopOutButton) called.
+   * Test hook: inspect the pop-out engine's open/close/focus call log. This hook
+   * is only for asserting which verb a trigger (title-bar button, PopOutButton)
+   * called. To simulate a surface actually detaching or its window closing, fire
+   * window.__mockFirePopOutChanged below - it drives the real popOut:changed
+   * push, so the renderer's own side effects run. (Older specs poke
+   * window.__zustandStores.popOut directly, which mirrors the store but skips
+   * those effects.)
    */
   /**
    * Test hook: simulate a task detail being hosted in a DIFFERENT renderer (the
@@ -4035,6 +4067,12 @@
     reset: function () {
       popOutCalls = [];
       popOutOpenResult = true;
+      // The open SET is reset too, not just the call log: a shared-page suite
+      // that fires a push would otherwise leave a surface reported as detached
+      // for every later test in the file. Registered onChanged subscribers are
+      // deliberately NOT dropped - App.tsx subscribes once at mount, so
+      // clearing them would silently make every later push a no-op.
+      popOutOpenKeys = [];
     },
     getCalls: function () {
       return popOutCalls.slice();
@@ -4043,6 +4081,28 @@
     setOpenResult: function (value) {
       popOutOpenResult = value;
     },
+  };
+
+  /**
+   * Test hook: fire main's popOut:changed push with the given open-instance-key
+   * set, e.g. window.__mockFirePopOutChanged(['changes:p1:t1']) to detach a
+   * task's Changes view and then ([]) to close that window.
+   *
+   * Drives the REAL renderer path (App.tsx's onChanged subscription), not just
+   * the pop-out store, which is what makes the push's side effects observable -
+   * closing a `changes` window leaves its in-app panel closed rather than
+   * reclaiming the split. Also updates what listOpen() resolves, so the
+   * mount-time loadOpen() cannot land afterwards and undo the pushed set.
+   *
+   * Deliberately not cleared by __mockPopOut.reset(): App.tsx subscribes once at
+   * mount, and dropping the subscriber would silently make every later push a
+   * no-op.
+   */
+  window.__mockFirePopOutChanged = function (openInstanceKeys) {
+    popOutOpenKeys = (openInstanceKeys || []).slice();
+    popOutChangedSubscribers.slice().forEach(function (callback) {
+      callback(popOutOpenKeys.slice());
+    });
   };
 
   /**

--- a/tests/ui/task-detail-changes-popout-close.spec.ts
+++ b/tests/ui/task-detail-changes-popout-close.spec.ts
@@ -1,0 +1,235 @@
+/**
+ * UI tests for: closing the `changes` pop-out leaves the inline Changes panel CLOSED.
+ *
+ * Detaching only suppresses the inline render (`showChanges` masks on
+ * changesPopOut.isOpen), so the open flag used to survive and the panel reclaimed
+ * the split the moment the window closed. By then the user has already reviewed
+ * the files in the bigger window, so that reclaim is an extra step to undo.
+ *
+ * Pop-out windows are real OS windows and never open in this tier, so both the
+ * detach and the close are driven through window.__mockFirePopOutChanged, which
+ * fires the real popOut:changed push into App.tsx's subscription (not just the
+ * pop-out store) so the renderer's own side effects run.
+ *
+ * Per-test browser rather than a shared page: the pop-out store is global, and
+ * .claude/rules/cross-platform-parity.md bans cross-test state leakage.
+ */
+import { test, expect } from '@playwright/test';
+import { chromium, type Browser, type Page } from '@playwright/test';
+import path from 'node:path';
+import { waitForViteReady } from './helpers';
+
+const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
+const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
+
+const PROJECT_ID = 'proj-changes-popout';
+const TASK_ID = 'task-changes-popout';
+const SESSION_ID = 'sess-changes-popout';
+const TASK_TITLE = 'Changes Popout Task';
+
+/** popOutInstanceKey('changes', ...) is kind:projectId:taskId - project FIRST. */
+const CHANGES_POPOUT_KEY = `changes:${PROJECT_ID}:${TASK_ID}`;
+
+const preConfig = `
+  window.__mockPreConfigure(function (state) {
+    var ts = new Date().toISOString();
+
+    state.projects.push({
+      id: '${PROJECT_ID}',
+      name: 'Changes Popout Test',
+      path: '/mock/changes-popout-test',
+      github_url: null,
+      default_agent: 'claude',
+      last_opened: ts,
+      created_at: ts,
+    });
+
+    var laneIds = {};
+    state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+      var id = 'lane-' + s.name.toLowerCase().replace(/\\s+/g, '-');
+      laneIds[s.name] = id;
+      state.swimlanes.push(Object.assign({}, s, { id: id, position: i, created_at: ts }));
+    });
+
+    // Running session so displayState.kind === 'running' -> the dialog opens in
+    // non-editing mode and TaskDetailHeader (with the Changes pill) renders.
+    state.sessions.push({
+      id: '${SESSION_ID}',
+      taskId: '${TASK_ID}',
+      projectId: '${PROJECT_ID}',
+      pid: 9999,
+      status: 'running',
+      shell: 'bash',
+      cwd: '/mock/changes-popout-test',
+      startedAt: ts,
+      exitCode: null,
+    });
+
+    state.tasks.push({
+      id: '${TASK_ID}',
+      title: '${TASK_TITLE}',
+      description: 'Task used for the Changes pop-out close test',
+      swimlane_id: laneIds['Code Review'],
+      position: 0,
+      agent: 'claude',
+      session_id: '${SESSION_ID}',
+      worktree_path: '/mock/worktrees/changes-popout',
+      branch_name: 'feature/changes-popout',
+      pr_number: null,
+      pr_url: null,
+      base_branch: 'main',
+      archived_at: null,
+      created_at: ts,
+      updated_at: ts,
+    });
+
+    return { currentProjectId: '${PROJECT_ID}' };
+  });
+`;
+
+async function launchWithState(): Promise<{ browser: Browser; page: Page }> {
+  await waitForViteReady(VITE_URL);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  await page.addInitScript({ path: MOCK_SCRIPT });
+  await page.addInitScript(preConfig);
+
+  await page.goto(VITE_URL);
+  await page.waitForLoadState('load');
+  await page.waitForSelector('text=Kangentic', { timeout: 15000 });
+  await page.locator('[data-swimlane-name="Code Review"]').waitFor({ state: 'visible', timeout: 10000 });
+
+  return { browser, page };
+}
+
+/** Open the task detail from its board card and wait for the window. */
+async function openTaskDetail(page: Page) {
+  await page.locator('[data-swimlane-name="Code Review"]').locator(`text=${TASK_TITLE}`).first().click();
+  const dialog = page.locator('[data-testid="task-detail-dialog"]');
+  await dialog.waitFor({ state: 'visible', timeout: 5000 });
+  return dialog;
+}
+
+/** Fire main's popOut:changed push with the given open-key set. */
+async function firePopOutChanged(page: Page, keys: string[]): Promise<void> {
+  await page.evaluate((openKeys) => {
+    (window as unknown as { __mockFirePopOutChanged: (k: string[]) => void }).__mockFirePopOutChanged(openKeys);
+  }, keys);
+}
+
+/**
+ * The entity ids the session store currently marks as having an open Changes
+ * panel. This is what separates a real clear from a second render mask: the
+ * panel is suppressed either way while the window is detached.
+ */
+async function changesOpenEntityIds(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const stores = (window as unknown as {
+      __zustandStores?: { session?: { getState: () => { changesOpenTasks: Set<string> } } };
+    }).__zustandStores;
+    return Array.from(stores?.session?.getState().changesOpenTasks ?? new Set<string>());
+  });
+}
+
+test.describe('Changes pop-out close does not reclaim the inline panel', () => {
+  test('closing the pop-out leaves the panel closed and the pill inactive', async () => {
+    const { browser, page } = await launchWithState();
+    try {
+      await openTaskDetail(page);
+
+      const changesPill = page.locator('[data-testid="changes-toggle"]');
+      const changesPanel = page.locator('[data-testid="changes-expand"]');
+
+      // Open Changes inline. On CI Linux the re-render after the pill click can
+      // take several seconds, so give the state update a full budget.
+      await changesPill.click();
+      await expect(changesPanel).toBeVisible({ timeout: 10000 });
+      expect(await changesOpenEntityIds(page)).toContain(TASK_ID);
+
+      // Detach. The panel is suppressed, but the pill must keep reading active:
+      // the pill is the only control that can close it, and a pill reading
+      // "Show changes" over a detached window would be a lie.
+      await firePopOutChanged(page, [CHANGES_POPOUT_KEY]);
+      await expect(changesPanel).not.toBeVisible({ timeout: 10000 });
+      await expect(changesPill).toHaveAttribute('title', /^Hide changes/);
+      expect(await changesOpenEntityIds(page)).toContain(TASK_ID);
+
+      // Close the pop-out: the panel must NOT come back.
+      await firePopOutChanged(page, []);
+      await expect(changesPill).toHaveAttribute('title', /^Show changes/, { timeout: 10000 });
+      await expect(changesPanel).not.toBeVisible();
+      expect(await changesOpenEntityIds(page)).not.toContain(TASK_ID);
+
+      // The pill still works: one click re-opens the panel.
+      await changesPill.click();
+      await expect(changesPanel).toBeVisible({ timeout: 10000 });
+    } finally {
+      await browser.close();
+    }
+  });
+
+  /**
+   * Nothing closes a task's pop-outs when its task-detail window closes, so a
+   * changes pop-out outlives the window that spawned it. The clear has to happen
+   * anyway, or reopening the task shows the panel again.
+   */
+  test('a pop-out that outlives its task-detail window still clears the flag', async () => {
+    const { browser, page } = await launchWithState();
+    try {
+      const dialog = await openTaskDetail(page);
+      const changesPill = page.locator('[data-testid="changes-toggle"]');
+      const changesPanel = page.locator('[data-testid="changes-expand"]');
+
+      await changesPill.click();
+      await expect(changesPanel).toBeVisible({ timeout: 10000 });
+
+      await firePopOutChanged(page, [CHANGES_POPOUT_KEY]);
+      await expect(changesPanel).not.toBeVisible({ timeout: 10000 });
+
+      // Close the task-detail window with the pop-out still open. Control+Shift+W
+      // (capture phase) rather than Escape: the window has a running session, so
+      // the bubble-phase Escape can be intercepted on CI Linux.
+      await page.keyboard.press('Control+Shift+W');
+      await expect(dialog).not.toBeVisible({ timeout: 8000 });
+
+      // The pop-out closes with no task-detail window mounted to observe it.
+      await firePopOutChanged(page, []);
+      await expect.poll(() => changesOpenEntityIds(page), { timeout: 10000 }).not.toContain(TASK_ID);
+
+      // Reopening the task shows the panel closed.
+      await openTaskDetail(page);
+      await expect(changesPill).toHaveAttribute('title', /^Show changes/, { timeout: 10000 });
+      await expect(changesPanel).not.toBeVisible();
+    } finally {
+      await browser.close();
+    }
+  });
+
+  /**
+   * A per-file diff window is ADDITIVE: it is opened FROM the inline panel, which
+   * stays mounted behind it. Closing one must leave that panel exactly as it was.
+   */
+  test('closing a per-file "changes-file" pop-out leaves the inline panel open', async () => {
+    const { browser, page } = await launchWithState();
+    try {
+      await openTaskDetail(page);
+      const changesPill = page.locator('[data-testid="changes-toggle"]');
+      const changesPanel = page.locator('[data-testid="changes-expand"]');
+
+      await changesPill.click();
+      await expect(changesPanel).toBeVisible({ timeout: 10000 });
+
+      const fileKey = `changes-file:${PROJECT_ID}:${TASK_ID}:src/a b/c.ts`;
+      await firePopOutChanged(page, [fileKey]);
+      await firePopOutChanged(page, []);
+
+      await expect(changesPanel).toBeVisible();
+      await expect(changesPill).toHaveAttribute('title', /^Hide changes/);
+      expect(await changesOpenEntityIds(page)).toContain(TASK_ID);
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/unit/hmr-resync.test.ts
+++ b/tests/unit/hmr-resync.test.ts
@@ -92,6 +92,11 @@ describe('HMR store re-sync', () => {
   it('top-level mutable module state has HMR preservation or opt-out', () => {
     const UTILS_DIR = path.resolve(__dirname, '../../src/renderer/utils');
     const WINDOW_MANAGER_DIR = path.resolve(__dirname, '../../src/renderer/window-manager');
+    // src/renderer/pop-out/ holds renderer modules too (the surface registry, the
+    // popOut:changed consumer). Nothing in it needs preservation today, but it was
+    // outside this scan until a push handler landed there, so the next module-scope
+    // let/Map added would have shipped with no Pattern A guard.
+    const POP_OUT_DIR = path.resolve(__dirname, '../../src/renderer/pop-out');
     const sourceFiles: string[] = [];
     const collect = (dir: string) => {
       for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -103,6 +108,7 @@ describe('HMR store re-sync', () => {
     collect(STORES_DIR);
     collect(UTILS_DIR);
     collect(WINDOW_MANAGER_DIR);
+    collect(POP_OUT_DIR);
 
     // Match any top-level `let` declaration (column-0 = module scope, since
     // intra-function locals are indented). The dispose-block check and the

--- a/tests/unit/pop-out-changed.test.ts
+++ b/tests/unit/pop-out-changed.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for src/renderer/pop-out/pop-out-changed.ts: the `popOut:changed`
+ * push handler that mirrors the open set into the pop-out store and closes the
+ * in-app Changes panel for any `changes` window that just disappeared.
+ *
+ * The load-bearing property here is the SPLIT between the two entry points.
+ * `pop-out-store.setOpen()` is also reached from `loadOpen()`, which App.tsx
+ * calls at mount and on every HMR `vite:afterUpdate`, so it must stay a plain
+ * setter with no cross-store effects; only the push may close a panel. Folding
+ * the diff into `setOpen` would look like a tidy simplification and would make a
+ * Fast Refresh close the user's panel, so both halves are asserted.
+ *
+ * window.electronAPI is stubbed before importing the stores, mirroring
+ * pop-out-store.test.ts's pattern for a Node (non-jsdom) test environment.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const listOpenMock = vi.fn<() => Promise<string[]>>();
+const setDetailViewStateMock = vi.fn();
+
+(globalThis as Record<string, unknown>).window = {
+  electronAPI: {
+    popOut: { listOpen: listOpenMock },
+    tasks: { setDetailViewState: setDetailViewStateMock },
+  },
+};
+
+import { receivePopOutOpenSet } from '../../src/renderer/pop-out/pop-out-changed';
+import { usePopOutStore } from '../../src/renderer/stores/pop-out-store';
+import { useSessionStore } from '../../src/renderer/stores/session-store';
+import { useProjectStore } from '../../src/renderer/stores/project-store';
+
+const CHANGES_KEY = 'changes:p1:t1';
+
+/** Seed "the Changes panel is open for t1, detached into its own window". */
+function seedDetachedChangesPanel(): void {
+  useSessionStore.setState({
+    changesOpenTasks: new Set(['t1']),
+    changesViewMode: { t1: 'split' },
+  });
+  usePopOutStore.setState({ openInstanceKeys: { [CHANGES_KEY]: true } });
+}
+
+describe('receivePopOutOpenSet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usePopOutStore.setState({ openInstanceKeys: {} });
+    useSessionStore.setState({
+      changesOpenTasks: new Set<string>(),
+      browserOpenTasks: new Set<string>(),
+      changesViewMode: {},
+    });
+  });
+
+  it('mirrors the pushed open set into the pop-out store', () => {
+    receivePopOutOpenSet(['stats', CHANGES_KEY]);
+
+    expect(usePopOutStore.getState().openInstanceKeys).toEqual({ stats: true, [CHANGES_KEY]: true });
+  });
+
+  describe('the setOpen / push split', () => {
+    it('the raw setOpen (and therefore loadOpen and the HMR re-sync) never closes the panel', () => {
+      seedDetachedChangesPanel();
+
+      usePopOutStore.getState().setOpen([]);
+
+      expect([...useSessionStore.getState().changesOpenTasks]).toEqual(['t1']);
+    });
+
+    it('the push DOES close the panel when the changes window disappears', () => {
+      seedDetachedChangesPanel();
+
+      receivePopOutOpenSet([]);
+
+      expect([...useSessionStore.getState().changesOpenTasks]).toEqual([]);
+    });
+  });
+
+  it('drops the task view mode along with the open flag, so the next open is not resurrected as expanded', () => {
+    seedDetachedChangesPanel();
+    useSessionStore.setState({ changesViewMode: { t1: 'expanded' } });
+
+    receivePopOutOpenSet([]);
+
+    expect(useSessionStore.getState().changesViewMode).not.toHaveProperty('t1');
+  });
+
+  it('leaves the panel open while the changes window is still in the pushed set', () => {
+    seedDetachedChangesPanel();
+
+    receivePopOutOpenSet([CHANGES_KEY, 'stats']);
+
+    expect([...useSessionStore.getState().changesOpenTasks]).toEqual(['t1']);
+  });
+
+  it('closes only the task whose window disappeared', () => {
+    useSessionStore.setState({ changesOpenTasks: new Set(['t1', 't2']) });
+    usePopOutStore.setState({ openInstanceKeys: { 'changes:p1:t1': true, 'changes:p1:t2': true } });
+
+    receivePopOutOpenSet(['changes:p1:t2']);
+
+    expect([...useSessionStore.getState().changesOpenTasks]).toEqual(['t2']);
+  });
+
+  /**
+   * A per-file diff window is ADDITIVE: it is opened FROM the inline panel and
+   * that panel stays mounted behind it, so closing one must leave the panel
+   * exactly as it was.
+   */
+  it('a closing "changes-file" window leaves the inline Changes panel open', () => {
+    useSessionStore.setState({ changesOpenTasks: new Set(['t1']) });
+    usePopOutStore.setState({ openInstanceKeys: { 'changes-file:p1:t1:src/a b/c.ts': true } });
+
+    receivePopOutOpenSet([]);
+
+    expect([...useSessionStore.getState().changesOpenTasks]).toEqual(['t1']);
+  });
+
+  /** The Browser pane reclaims the same way; it is deliberately left alone. */
+  it('a closing "browser" window leaves browserOpenTasks untouched', () => {
+    useSessionStore.setState({ browserOpenTasks: new Set(['t1']) });
+    usePopOutStore.setState({ openInstanceKeys: { 'browser:p1:t1': true } });
+
+    receivePopOutOpenSet([]);
+
+    expect([...useSessionStore.getState().browserOpenTasks]).toEqual(['t1']);
+  });
+
+  it('a closing global "stats" window closes no panel', () => {
+    useSessionStore.setState({ changesOpenTasks: new Set(['t1']) });
+    usePopOutStore.setState({ openInstanceKeys: { stats: true } });
+
+    receivePopOutOpenSet([]);
+
+    expect([...useSessionStore.getState().changesOpenTasks]).toEqual(['t1']);
+  });
+
+  /**
+   * The window can outlive a board switch, so the closed state must be persisted
+   * against the project named by the KEY, not whichever board is open now.
+   */
+  describe('persistence', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+    afterEach(() => useProjectStore.setState({ currentProject: null }));
+
+    it('saves the task blob against the project id carried by the closed key', () => {
+      seedDetachedChangesPanel();
+
+      receivePopOutOpenSet([]);
+      vi.runAllTimers();
+
+      expect(setDetailViewStateMock).toHaveBeenCalledTimes(1);
+      const [taskId, blob, projectId] = setDetailViewStateMock.mock.calls[0];
+      expect(taskId).toBe('t1');
+      expect(projectId).toBe('p1');
+      expect(blob).not.toHaveProperty('changesOpen');
+    });
+
+    it('still saves against the closed key project id when the ambient project is a different one', () => {
+      // The test above only proves the override beats an ABSENT ambient
+      // project: useProjectStore's currentProject defaults to null, and the
+      // override wins over null even by accident (`projectIdOverride ??
+      // null`). Seeding a real, DIFFERENT current project here is what
+      // actually exercises why projectIdOverride exists: a `changes` pop-out
+      // can close after the user has switched boards, and the write must
+      // still land on the task's own project (the one named by the closed
+      // key), never whichever project is on screen when the window closes.
+      useProjectStore.setState({
+        currentProject: { id: 'p2', name: 'Other Project', path: '/mock/other-project' },
+      });
+      seedDetachedChangesPanel();
+
+      receivePopOutOpenSet([]);
+      vi.runAllTimers();
+
+      expect(setDetailViewStateMock).toHaveBeenCalledTimes(1);
+      const [taskId, , projectId] = setDetailViewStateMock.mock.calls[0];
+      expect(taskId).toBe('t1');
+      expect(projectId).toBe('p1'); // the closed key's project, not the ambient 'p2'
+    });
+  });
+});

--- a/tests/unit/pop-out.test.ts
+++ b/tests/unit/pop-out.test.ts
@@ -7,7 +7,7 @@
  * collapse to a single key.
  */
 import { describe, it, expect } from 'vitest';
-import { popOutInstanceKey, isPopOutKind, resolveSurfaceTitle, formatTaskAnchor, POP_OUT_SURFACES, POPOUT_KINDS } from '../../src/shared/pop-out';
+import { popOutInstanceKey, parsePopOutInstanceKey, isPopOutKind, resolveSurfaceTitle, formatTaskAnchor, POP_OUT_SURFACES, POPOUT_KINDS } from '../../src/shared/pop-out';
 import { IPC } from '../../src/shared/ipc-channels';
 
 describe('POPOUT_KINDS / POP_OUT_SURFACES parity', () => {
@@ -118,6 +118,46 @@ describe('POP_OUT_SURFACES fan-out declarations', () => {
     const changesKey = popOutInstanceKey('changes', { taskId: 't1', projectId: 'p1' });
     const browserKey = popOutInstanceKey('browser', { taskId: 't1', projectId: 'p1' });
     expect(changesKey).not.toBe(browserKey);
+  });
+});
+
+/**
+ * parsePopOutInstanceKey is the inverse used by the `popOut:changed` consumer:
+ * the push carries the whole open-key set with no per-key close event, so a key
+ * that vanished has to be read back to learn which task's panel to close. It
+ * must therefore agree with the builder for every task-scoped kind.
+ */
+describe('parsePopOutInstanceKey', () => {
+  const taskScopedKinds = POPOUT_KINDS.filter((kind) => POP_OUT_SURFACES[kind].scope === 'task');
+
+  it('covers every task-scoped kind (guards against a new kind slipping past the round-trip)', () => {
+    expect(taskScopedKinds).toEqual(expect.arrayContaining(['changes', 'browser', 'changes-file']));
+  });
+
+  it.each(taskScopedKinds)('round-trips a "%s" key back to its kind, project, and task', (kind) => {
+    // changes-file needs a filePath; the extra param is ignored by the other kinds.
+    const key = popOutInstanceKey(kind, { taskId: 't1', projectId: 'p1', filePath: 'src/a/b.ts' });
+
+    expect(parsePopOutInstanceKey(key)).toEqual({ kind, projectId: 'p1', taskId: 't1' });
+  });
+
+  it('reads the task off a "changes-file" key whose path carries slashes and a space', () => {
+    const key = popOutInstanceKey('changes-file', { taskId: 't1', projectId: 'p1', filePath: 'src/a b/c.ts' });
+
+    expect(parsePopOutInstanceKey(key)).toEqual({ kind: 'changes-file', projectId: 'p1', taskId: 't1' });
+  });
+
+  it('returns null for a global surface, which carries no task', () => {
+    expect(parsePopOutInstanceKey(popOutInstanceKey('stats', {}))).toBeNull();
+    expect(parsePopOutInstanceKey(popOutInstanceKey('monitor', {}))).toBeNull();
+  });
+
+  it('returns null for an unknown kind or a malformed key', () => {
+    expect(parsePopOutInstanceKey('bogus:p1:t1')).toBeNull();
+    expect(parsePopOutInstanceKey('changes:p1')).toBeNull();
+    expect(parsePopOutInstanceKey('changes::t1')).toBeNull();
+    expect(parsePopOutInstanceKey('changes:p1:')).toBeNull();
+    expect(parsePopOutInstanceKey('')).toBeNull();
   });
 });
 

--- a/tests/unit/task-changes-panel-slice.test.ts
+++ b/tests/unit/task-changes-panel-slice.test.ts
@@ -7,7 +7,7 @@
  * browser, Electron, or ipcRenderer binding is required.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // The slice imports `useProjectStore` (to stamp the project id on its debounced
 // detail-view-state saves). project-store imports session-store, which eagerly
 // creates its store from the slices - so importing the slice DIRECTLY as the
@@ -241,6 +241,54 @@ describe('toggleBrowserOpen', () => {
       const after = getState().browserGuestTasks;
       actions.clearBrowserGuest('task-1', 52);
       expect(getState().browserGuestTasks).toBe(after); // idempotent
+    });
+  });
+
+  describe('setChangesOpen is idempotent', () => {
+    // Scoped to its own describe (rather than calling vi.useFakeTimers()
+    // inline in the test body) so a failing assertion still runs
+    // vi.useRealTimers() in afterEach and never leaks fake timers into the
+    // other 36 tests in this file.
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('a redundant call changes no state and schedules no save', () => {
+      // The pop-out close path (pop-out-changed.ts) drives this directly on
+      // every `popOut:changed` push, including pushes where the panel was
+      // already closed. The early return is what makes a repeated push a
+      // genuine no-op rather than a fresh Set plus a debounced persistence
+      // write on every diff. Set-reference identity DOES catch a dropped
+      // guard (proven below), but `vi.getTimerCount()` would not: a
+      // redundant call that lost the guard still reaches
+      // `scheduleDetailViewSave`, which clears the existing debounce timer
+      // and immediately re-sets a new one, leaving the PENDING count
+      // unchanged even though a fresh save was genuinely scheduled. Spying
+      // on setTimeout's call count (not the pending count) is what actually
+      // observes that absence of work, independent of the identity check.
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+      const { actions, getState } = createTestStore();
+
+      actions.setChangesOpen('task-1', true);
+      const afterFirstOpen = getState().changesOpenTasks;
+      const callsAfterFirstOpen = setTimeoutSpy.mock.calls.length;
+      expect(callsAfterFirstOpen).toBeGreaterThan(0); // the genuine open scheduled a save
+
+      actions.setChangesOpen('task-1', true);
+      expect(setTimeoutSpy.mock.calls.length).toBe(callsAfterFirstOpen); // no new debounce timer: no save
+      expect(getState().changesOpenTasks).toBe(afterFirstOpen); // same reference: no churn
+      expect(getState().changesOpenTasks.has('task-1')).toBe(true);
+
+      actions.setChangesOpen('task-1', false);
+      const callsAfterClose = setTimeoutSpy.mock.calls.length;
+      expect(callsAfterClose).toBeGreaterThan(callsAfterFirstOpen); // the genuine close scheduled a save
+      expect(getState().changesOpenTasks.has('task-1')).toBe(false);
+      const afterClose = getState().changesOpenTasks;
+
+      actions.setChangesOpen('task-1', false);
+      expect(setTimeoutSpy.mock.calls.length).toBe(callsAfterClose); // redundant close scheduled nothing
+      expect(getState().changesOpenTasks).toBe(afterClose);
+
+      setTimeoutSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## What

Closing the task-detail `changes` pop-out now leaves the inline Changes panel **closed** instead of reclaiming the task-detail split.

- `src/shared/pop-out.ts` - `parsePopOutInstanceKey`, the inverse of `popOutInstanceKey` for task-scoped kinds, placed beside it so the two cannot drift.
- `src/renderer/pop-out/pop-out-changed.ts` (new) - `receivePopOutOpenSet`, the `popOut:changed` push handler.
- `src/renderer/stores/session-store/task-changes-panel-slice.ts` - `setChangesOpen` set-form, mirroring the existing `setBrowserOpen`; `toggleChangesOpen` delegates to it.
- `src/renderer/App.tsx` - the `onChanged` subscription calls the new handler.

`TaskDetailBody` and `TaskDetailHeader` are unchanged.

## Why

Popping the Changes view out only SUPPRESSED the inline panel:

```ts
const showChanges = changesOpen && !showBrowser && !changesPopOut.isOpen;
```

`changesOpenTasks` survived detachment, so the moment the pop-out closed the mask lifted and the panel reclaimed the split. By then the user has already reviewed the files in the bigger window, so that reclaim is a step they have to undo by hand.

## How

The push carries the whole open-key set with no per-key close event, so a vanished window is derived by diffing against the previous set and reading the key back.

Two placement decisions, both pinned by tests:

- **On the push, not in `pop-out-store.setOpen()`.** `loadOpen()` also drives `setOpen` at mount and on every HMR `vite:afterUpdate`. An effect there would let a Fast Refresh close a user's panel, so `setOpen` stays a plain setter and the effects hang off the push.
- **At App level, not in `TaskDetailBody`.** Nothing closes a task's pop-outs when its task-detail window closes, so a changes pop-out outlives the component that spawned it. A component-local effect would miss exactly that case.

Deliberately clears on **close**, not on open. The stats/monitor precedent (`AppLayout.tsx`) clears on open, but the Changes trigger is a stateful pill reading the same flag: clearing on open would leave the pill inactive over a live detached window. While detached the pill still reads "Hide changes", exactly as before.

`setChangesOpen` takes an optional `projectId` because the pop-out key carries the task's real project and the window can outlive a board switch; the ambient read would persist into the wrong database.

Two surfaces are deliberately skipped: `changes-file` (additive, opened FROM the panel, which stays mounted behind it) and `browser` (identical masking, out of scope for this task).

## Breaking changes

None.

## Tests

- **Unit** - `parsePopOutInstanceKey` round-trip for every task-scoped kind plus null cases; `receivePopOutOpenSet` covering the load-bearing `setOpen`-vs-push split (raw `setOpen([])` must NOT close, the push must), view-mode drop, per-task isolation, the `changes-file` / `browser` / `stats` exclusions, and persistence against the closed key's own project with a different ambient project seeded.
- **UI** - `tests/ui/task-detail-changes-popout-close.spec.ts`, 3 tests driving the real `popOut:changed` push through `App.tsx`'s own subscription. `popOut.onChanged` was a no-op stub in the mock, so no spec could reach that path before; this adds `window.__mockFirePopOutChanged`. Verified inert for the 3 existing specs that use the pop-out mock.
- **Red-green verified** - reverting the wiring fails the two behavioral UI tests ("Received: Hide changes"); restoring it passes them.
- **Verified in a running app** - detached a real OS pop-out on a live session and closed it through the genuine `close()` -> `closed` -> `emitOpenSetChanged` path: the flag cleared, the pill went inactive, the panel did not reclaim, the outlive path worked with no detail window mounted, and the persisted blob came back without `changesOpen` under the right project.

Includes a `test(review)` commit from the Code Review column (idempotence guard + a widened HMR Pattern A scan).

Docs: the whole-panel Changes pop-out was never documented in the user guide (only the per-file diff window was); that gap is filled, and the `popOut:changed` row in `architecture.md` describes the new handler. The `pop-out-surface-registry` rule now records that close behavior is a per-surface choice and why `changes` differs from `stats`/`monitor`.

Generated with [Claude Code](https://claude.com/claude-code)
