### PR TITLE
fix(activity-marks): stop a clickable mark from dropping the click

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,11 +225,19 @@ won't be found.
   `ActivityMark` can reach. Every such icon renders each of its branches through
   `components/IconSlot.tsx`, a fixed-size `<span>` that all branches share: React reconciles the
   one span in place across the swap, so the node under the pointer survives, and the span
-  absorbs the pointer on the glyph's behalf. The three sites are `StopButtonIcon`,
-  `PauseButtonIcon`, and `MonitorCard`'s `StateGlyph` - the last is why the neutralization is
-  scoped to the glyph rather than put on the button, since its clickable is a whole card
-  carrying other interactive children. `tests/ui/command-terminal.spec.ts` covers both variants
-  (a mark flip and an element-type swap) with red-green mouse-level tests. There is no `-rest` mark: rest is the `-idle` geometry in a muted
+  absorbs the pointer on the glyph's behalf. Each site wraps ONCE around the icon its branching
+  produced, never per branch, so a future branch cannot silently opt out. The sites
+  fixed so far are `StopButtonIcon`, `PauseButtonIcon`, and `MonitorCard`'s `StateGlyph` - the
+  last is why the neutralization is scoped to the glyph rather than put on the button, since
+  its clickable is a whole card carrying other interactive children. That list is what has been
+  ADOPTED, not where the hazard exists: `MonitorTable`'s `StateCell` (inside `DataTable`'s
+  clickable `<tr>`) and `TerminalPanel`'s session-tab glyph have the same element-type swap and
+  are still unwrapped. A slot also neutralizes the element it wraps, so a mark inside one must
+  label itself with `aria-label` - a native `<title>` child would be inert, which is why
+  `TaskCard` (tooltip-bearing, and a mark FLIP only) is not a slot candidate.
+  `tests/ui/command-terminal.spec.ts` covers both variants (a mark flip and an element-type
+  swap) with red-green mouse-level tests, but only for `StopButtonIcon`; the other two adoptions
+  ride on the shared component. There is no `-rest` mark: rest is the `-idle` geometry in a muted
   tone. `data-rest` on the root is the reduced-motion strategy (`static` / `keep-dash` /
   `drop-dash`), NOT a tone; test selectors key off `data-mark`. The set's grid is a WIDTH
   KEYLINE, not a square ink box: each mark fills its slot's width and takes the height its form

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,23 @@ won't be found.
   with a blinking chip in the same sidebar row. Marks are `currentColor` only, so the
   CALL SITE supplies `text-active` / `text-attention` / `text-fg-muted` - never hardcode a hex,
   since `--kng-active` / `--kng-attention` are desktop-only values that mobile and web
-  deliberately diverge from. There is no `-rest` mark: rest is the `-idle` geometry in a muted
+  deliberately diverge from. The injected `<g>` is `pointer-events: none`, which is
+  load-bearing for any mark inside a button: re-assigning its `innerHTML` on a `mark` change
+  destroys the node the cursor is over, and Chromium then drops the click outright, which
+  shipped as "the first Stop click never registers" (measured: the injected ink covered 15% of
+  the pause button, and `control-stop`'s filled square covers the exact centre). Hits must land
+  on the React-authored `<svg>`, which survives a `mark` change - so the `none` never moves up
+  to the root, which `TaskCard`'s `<title>` tooltip needs hit-testable, and the `<g>` never gets
+  `key={mark}`. That covers a mark FLIP only; an icon that changes ELEMENT TYPE between states
+  (lucide at rest, `ActivityMark` when active) unmounts the `<svg>` too, which no change inside
+  `ActivityMark` can reach. Every such icon renders each of its branches through
+  `components/IconSlot.tsx`, a fixed-size `<span>` that all branches share: React reconciles the
+  one span in place across the swap, so the node under the pointer survives, and the span
+  absorbs the pointer on the glyph's behalf. The three sites are `StopButtonIcon`,
+  `PauseButtonIcon`, and `MonitorCard`'s `StateGlyph` - the last is why the neutralization is
+  scoped to the glyph rather than put on the button, since its clickable is a whole card
+  carrying other interactive children. `tests/ui/command-terminal.spec.ts` covers both variants
+  (a mark flip and an element-type swap) with red-green mouse-level tests. There is no `-rest` mark: rest is the `-idle` geometry in a muted
   tone. `data-rest` on the root is the reduced-motion strategy (`static` / `keep-dash` /
   `drop-dash`), NOT a tone; test selectors key off `data-mark`. The set's grid is a WIDTH
   KEYLINE, not a square ink box: each mark fills its slot's width and takes the height its form

--- a/src/renderer/components/ActivityMark.tsx
+++ b/src/renderer/components/ActivityMark.tsx
@@ -197,6 +197,26 @@ export interface ActivityMarkProps extends React.SVGProps<SVGSVGElement> {
  * reduced-motion dash rule is `svg[data-rest="drop-dash"] *`, so all of them still match one level
  * deeper. It is also harmless to compositing: the animated element is the packaged inner `<g>`,
  * and an extra static ancestor does not stop Blink from promoting it.
+ *
+ * That `<g>` is `pointer-events: none`, and it is LOAD-BEARING for any mark inside a button.
+ * Re-assigning `innerHTML` destroys every child of the `<g>` and builds new ones, so a `mark`
+ * change tears out whatever node the cursor is over. Chromium then drops the click outright:
+ * press the glyph, the agent's activity flips mid-press, and the button does nothing until you
+ * click a second time. It reached users as "the first Stop click never registers". Making the
+ * injected subtree non-hit-testable puts every hit on the React-authored `<svg>`, which survives
+ * a `mark` change because React only updates its attributes. Measured before the fix: the ink
+ * inside the `<g>` covered 15% of the twin pause button, and `control-stop`'s filled square
+ * covers the exact centre, which is where people click.
+ *
+ * Two shapes that look equivalent and are not. `pointer-events: none` must NOT move up to the
+ * `<svg>` root, which has to stay hit-testable for `TaskCard`'s native `<title>` tooltip; and the
+ * `<g>` must NOT get `key={mark}`, which replaces the `<g>` itself (the same teardown one level
+ * up) and discards the `anchorMarkMotionToTimeline` phase anchor. An inline style rather than a
+ * Tailwind class because the packaged `activity.css` arrives unlayered and outranks utilities.
+ *
+ * This covers a mark FLIP. A call site whose icon changes ELEMENT TYPE between states (a lucide
+ * glyph at rest, an ActivityMark when active) unmounts the `<svg>` too, which no change here can
+ * prevent; those buttons neutralize their own children instead. See `StopButtonIcon`.
  */
 export function ActivityMark({
   mark,
@@ -235,7 +255,7 @@ export function ActivityMark({
       role={isLabelled ? 'img' : undefined}
       aria-hidden={isLabelled ? undefined : true}
     >
-      <g ref={markGroupRef} dangerouslySetInnerHTML={{ __html: MARK_INNER[mark] }} />
+      <g ref={markGroupRef} style={{ pointerEvents: 'none' }} dangerouslySetInnerHTML={{ __html: MARK_INNER[mark] }} />
       {children}
     </svg>
   );

--- a/src/renderer/components/IconSlot.tsx
+++ b/src/renderer/components/IconSlot.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from 'react';
 
 interface IconSlotProps {
-  /** Box width and height in px. Pass what the glyph inside already draws at, so
-   *  adopting a slot changes no layout: the slot is a hit target, not a resize. */
+  /** Box width and height in px. ONE value for the whole icon, not one per branch:
+   *  see the `size` note below for why a constant box is the point. */
   size: number;
   /** Appended after the base classes (e.g. `shrink-0` in a flex row). */
   className?: string;
@@ -22,29 +22,44 @@ interface IconSlotProps {
  *
  * Two properties do the work, and both are load-bearing:
  *
- *  1. The contents are `pointer-events: none`, so hits land on this `<span>` rather than
- *     on whatever glyph currently occupies it.
- *  2. Every branch of a swapping icon returns THIS component at the same position, so
- *     React reconciles one `<span>` in place across the swap - the DOM node survives even
- *     when the icon inside changes element type entirely (a lucide glyph to an
- *     `ActivityMark`, say). Only its attributes update.
+ *  1. `[&>*]:pointer-events-none` sets the property on the slot's DIRECT children. Since
+ *     `pointer-events` inherits, the whole subtree below them is non-hit-testable too -
+ *     unless some descendant sets its own explicit value, which would silently punch a
+ *     hole in the guarantee. Hits therefore land on this `<span>` rather than on whatever
+ *     glyph currently occupies it.
+ *  2. Wrap ONCE, around the icon the branching produced - never separately inside each
+ *     branch. One `<span>` at one JSX position is what lets React reconcile the same DOM
+ *     node across the swap, even when the icon inside changes element type entirely (a
+ *     lucide glyph to an `ActivityMark`, say). Only its attributes update. Wrapping per
+ *     branch happens to work, but it puts the invariant back in every future branch's
+ *     hands, and a single branch that forgets the wrapper silently restores the bug.
  *
  * That is why the fix belongs HERE and not on the button: scoping the neutralization to
  * the glyph works inside a clickable that has other interactive children, where
  * neutralizing the whole clickable's children is not available. `MonitorCard`'s state
  * glyph is exactly that case.
  *
- * `size` is per-branch on purpose. The branches of a real icon rarely draw at one size
- * (the Stop control is a 20px mark but an 18px lucide glyph at rest), and forcing them to
- * agree would resize the control in some states. Passing each branch's existing size keeps
- * the rendering identical to before while still handing every branch the same stable node.
+ * `size` is per ICON, not per branch. The branches of a real icon rarely draw at one size
+ * (the Stop control is a 20px mark but an 18px lucide glyph at rest), and letting the box
+ * follow each branch would resize the control every time the state flipped - the jitter
+ * this component exists to remove, since a box that changes size is also a box the
+ * pointer can fall out of. So the slot takes the largest size the icon draws at and holds
+ * it across every state: the glyph inside keeps its own size, and a smaller branch simply
+ * sits centred in a slightly larger box. Adopting a slot therefore CAN grow a given
+ * branch's footprint by a pixel or two versus an unwrapped glyph. That is deliberate.
+ *
+ * One trap. The slot neutralizes the element it wraps, which for an `<ActivityMark>` is
+ * that component's `<svg>` root - the very node `ActivityMark` documents as having to
+ * stay hit-testable, because a native `<title>` child renders its tooltip only while the
+ * element itself can receive the pointer (see `TaskCard`, which relies on exactly that).
+ * A mark inside a slot must therefore label itself with `aria-label`, not a `<title>`
+ * child; a `<title>` there would be silently inert, with no test to catch it.
  */
 export function IconSlot({ size, className, children }: IconSlotProps) {
   return (
     <span
       className={`grid place-items-center [&>*]:pointer-events-none ${className ?? ''}`}
       style={{ width: size, height: size }}
-      data-icon-slot=""
     >
       {children}
     </span>

--- a/src/renderer/components/IconSlot.tsx
+++ b/src/renderer/components/IconSlot.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react';
+
+interface IconSlotProps {
+  /** Box width and height in px. Pass what the glyph inside already draws at, so
+   *  adopting a slot changes no layout: the slot is a hit target, not a resize. */
+  size: number;
+  /** Appended after the base classes (e.g. `shrink-0` in a flex row). */
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * A fixed-size box that keeps the POINTER TARGET stable while the icon inside it swaps.
+ *
+ * Chromium drops a click outright when the node that received `mousedown` is destroyed
+ * before `mouseup`. An icon driven by session activity can be replaced at any instant by
+ * a push from the main process, so a press landing on the glyph races a state change it
+ * has no relationship to: the handler never runs, and the user sees nothing happen until
+ * they click a second time. It shipped twice - as "a button on a background window needs
+ * two clicks" and again as "the first Stop click never registers" - and both times it
+ * read as a focus bug, because the click event simply never exists to trace.
+ *
+ * Two properties do the work, and both are load-bearing:
+ *
+ *  1. The contents are `pointer-events: none`, so hits land on this `<span>` rather than
+ *     on whatever glyph currently occupies it.
+ *  2. Every branch of a swapping icon returns THIS component at the same position, so
+ *     React reconciles one `<span>` in place across the swap - the DOM node survives even
+ *     when the icon inside changes element type entirely (a lucide glyph to an
+ *     `ActivityMark`, say). Only its attributes update.
+ *
+ * That is why the fix belongs HERE and not on the button: scoping the neutralization to
+ * the glyph works inside a clickable that has other interactive children, where
+ * neutralizing the whole clickable's children is not available. `MonitorCard`'s state
+ * glyph is exactly that case.
+ *
+ * `size` is per-branch on purpose. The branches of a real icon rarely draw at one size
+ * (the Stop control is a 20px mark but an 18px lucide glyph at rest), and forcing them to
+ * agree would resize the control in some states. Passing each branch's existing size keeps
+ * the rendering identical to before while still handing every branch the same stable node.
+ */
+export function IconSlot({ size, className, children }: IconSlotProps) {
+  return (
+    <span
+      className={`grid place-items-center [&>*]:pointer-events-none ${className ?? ''}`}
+      style={{ width: size, height: size }}
+      data-icon-slot=""
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -21,6 +21,7 @@ import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } fro
 import type { ReactNode } from 'react';
 import { CircleStop, FolderOpen, FolderGit, GitBranch, GitCompare, Loader2, Maximize2, Minimize2, PictureInPicture2, SquareChevronRight, Zap } from 'lucide-react';
 import { ActivityMark } from '../ActivityMark';
+import { IconSlot } from '../IconSlot';
 import { BranchPicker } from '../dialogs/BranchPicker';
 import { LaunchOverlay } from '../LaunchOverlay';
 import { HeaderActionButton } from '../HeaderActionButton';
@@ -32,7 +33,7 @@ import { useKeybinding, useFormattedCombo } from '../../hooks/useKeybinding';
 import { ContextBar } from '../terminal/ContextBar';
 import { CommandTerminalPane, type TerminalGridGetter } from './CommandTerminalPane';
 import { useSessionStore } from '../../stores/session-store';
-import { transientKey } from '../../stores/session-store/transient-session-slice';
+import { transientKey, type TransientKillOutcome } from '../../stores/session-store/transient-session-slice';
 import { commandTerminalChangesEntityId } from '../../stores/session-store/task-changes-panel-slice';
 import { useBoardStore } from '../../stores/board-store';
 import { useConfigStore } from '../../stores/config-store';
@@ -63,20 +64,31 @@ const ChangesPanel = lazy(() => import('../dialogs/task-detail/changes/ChangesPa
  * Ring and square are one packaged mark, so the hand-computed `47 16` dash that used to be
  * duplicated here and in `TaskDetailHeader` is gone. See `PauseButtonIcon` for why 20 is the
  * size that reproduces the old glyph exactly.
+ *
+ * These branches return DIFFERENT element types, so activity changing swaps the whole subtree
+ * rather than re-rendering one, and a node destroyed mid-press makes Chromium drop the click.
+ * Every branch renders through `IconSlot`, which is the one element the swap does NOT destroy
+ * and which absorbs the pointer on the glyph's behalf. `PauseButtonIcon` has the same shape
+ * over five branches and does the same.
  */
-function StopButtonIcon({ isThinking, isIdle }: { isThinking: boolean; isIdle: boolean }): ReactNode {
+function StopButtonIcon({ isThinking, isIdle, stopping }: { isThinking: boolean; isIdle: boolean; stopping: boolean }): ReactNode {
+  // One slot size across every branch: the box is the hit target, while each glyph keeps
+  // the size it already drew at (the 20px mark reads level with the 18px lucide glyphs).
+  if (stopping) {
+    return <IconSlot size={20}><Loader2 size={18} className="animate-spin" /></IconSlot>;
+  }
   if (isThinking || isIdle) {
     return (
-      <span className="grid place-items-center w-5 h-5">
+      <IconSlot size={20}>
         <ActivityMark
           mark={isThinking ? 'control-stop-working' : 'control-stop-idle'}
           size={20}
           className={isThinking ? 'text-active' : 'text-attention'}
         />
-      </span>
+      </IconSlot>
     );
   }
-  return <CircleStop size={18} />;
+  return <IconSlot size={20}><CircleStop size={18} /></IconSlot>;
 }
 
 interface CommandTerminalWindowProps {
@@ -109,6 +121,19 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [branch, setBranch] = useState<string | null>(null);
   const [showCommandPalette, setShowCommandPalette] = useState(false);
+  // Stop is async (kill IPC, then close). Without a pending state the button looks
+  // inert for the duration, which is exactly how a DROPPED click presented, so the
+  // two were indistinguishable to the user.
+  const [stopping, setStopping] = useState(false);
+  // Set inside an effect, not at ref init: StrictMode remounts synthetically in dev
+  // and a ref-init value alone stays false after the synthetic cleanup.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
   const config = useConfigStore((s) => s.config);
   const rawProjectPath = useProjectStore((s) => s.currentProject?.path ?? null);
   // Also the source for CommandTerminalPane's own pasteImageTemplate lookup
@@ -319,17 +344,36 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
   // Stop = destroy THIS terminal's PTY and close its window. The layer's count
   // bridge hides the whole layer when the last window closes. Hiding the layer
   // (the X / Ctrl+Shift+P / backdrop) is separate and keeps every PTY alive.
+  //
+  // The window closes on EVERY path, including a kill that found nothing to kill:
+  // the user asked for this terminal to go away. Only a kill that actually failed
+  // is surfaced, because then a PTY may still be running with nothing pointing at
+  // it. All three outcomes used to be silent, so a kill that quietly did nothing
+  // looked exactly like the dropped click this button was also suffering from.
   const handleTerminate = useCallback(async () => {
+    if (stopping) return;
+    setStopping(true);
     const currentProjectId = useProjectStore.getState().currentProject?.id ?? null;
+    let outcome: TransientKillOutcome = 'no-session';
     try {
       if (currentProjectId) {
-        await useSessionStore.getState().killTransientSessionBySlot(currentProjectId, slot);
+        outcome = await useSessionStore.getState().killTransientSessionBySlot(currentProjectId, slot);
       }
     } catch {
-      // Best-effort cleanup.
+      outcome = 'failed';
+    }
+    if (outcome === 'failed') {
+      useToastStore.getState().addToast({
+        message: 'Could not stop the terminal. Its process may still be running.',
+        variant: 'error',
+      });
     }
     closeWindow(windowId);
-  }, [closeWindow, windowId, slot]);
+    // Normally unreachable - closing this window unmounts the component. It matters
+    // when the close is a no-op (an id the store no longer holds), which would
+    // otherwise strand the button disabled with a spinner and no way back.
+    if (mountedRef.current) setStopping(false);
+  }, [closeWindow, windowId, slot, stopping]);
 
   const handleCommandSelect = useCallback((command: AgentCommand) => {
     setShowCommandPalette(false);
@@ -367,16 +411,19 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
       <div ref={headerRef} className="flex items-center gap-3 px-4 h-[54px] border-b border-edge flex-shrink-0 select-none min-w-0">
         {/* Leading cluster: Stop (protected, measured as one unit). */}
         <div ref={leadingRef} className="flex items-center flex-shrink-0">
+          {/* StopButtonIcon's branches all render through IconSlot, so the node under the
+              pointer survives an activity change mid-press (see IconSlot). */}
           <button
             onClick={handleTerminate}
-            className={`inline-flex items-center justify-center p-1 rounded-full transition-colors flex-shrink-0 ${
-              showActivityRing ? 'hover:bg-surface-hover' : 'text-red-400 hover:bg-red-400/10'
+            disabled={stopping}
+            className={`inline-flex items-center justify-center p-1 rounded-full transition-colors flex-shrink-0 disabled:cursor-not-allowed ${
+              stopping ? 'text-fg-muted' : showActivityRing ? 'hover:bg-surface-hover' : 'text-red-400 hover:bg-red-400/10'
             }`}
-            title="Stop terminal"
+            title={stopping ? 'Stopping...' : 'Stop terminal'}
             aria-label="Stop terminal"
             data-testid="command-bar-terminate-button"
           >
-            <StopButtonIcon isThinking={isThinking} isIdle={isIdle} />
+            <StopButtonIcon isThinking={isThinking} isIdle={isIdle} stopping={stopping} />
           </button>
         </div>
 
@@ -514,8 +561,9 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
                   <KebabMenuDivider />
                   <KebabMenuItem
                     icon={<CircleStop size={14} />}
-                    label="Stop terminal"
+                    label={stopping ? 'Stopping...' : 'Stop terminal'}
                     onClick={() => { close(); handleTerminate(); }}
+                    disabled={stopping}
                     destructive
                     data-testid="command-bar-kebab-stop"
                   />

--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -67,28 +67,29 @@ const ChangesPanel = lazy(() => import('../dialogs/task-detail/changes/ChangesPa
  *
  * These branches return DIFFERENT element types, so activity changing swaps the whole subtree
  * rather than re-rendering one, and a node destroyed mid-press makes Chromium drop the click.
- * Every branch renders through `IconSlot`, which is the one element the swap does NOT destroy
- * and which absorbs the pointer on the glyph's behalf. `PauseButtonIcon` has the same shape
- * over five branches and does the same.
+ * The single `IconSlot` below the branching is the one element the swap does NOT destroy, and
+ * it absorbs the pointer on the glyph's behalf. Wrapping once rather than inside each branch
+ * is what makes that structural: a future branch cannot forget it. `PauseButtonIcon` has the
+ * same shape over five branches and does the same.
  */
 function StopButtonIcon({ isThinking, isIdle, stopping }: { isThinking: boolean; isIdle: boolean; stopping: boolean }): ReactNode {
-  // One slot size across every branch: the box is the hit target, while each glyph keeps
-  // the size it already drew at (the 20px mark reads level with the 18px lucide glyphs).
-  if (stopping) {
-    return <IconSlot size={20}><Loader2 size={18} className="animate-spin" /></IconSlot>;
-  }
+  // The slot is 20 across every state, while each glyph keeps the size it already drew at
+  // (the 20px mark reads level with the 18px lucide glyphs), so the button never resizes.
+  return <IconSlot size={20}>{stopGlyph({ isThinking, isIdle, stopping })}</IconSlot>;
+}
+
+function stopGlyph({ isThinking, isIdle, stopping }: { isThinking: boolean; isIdle: boolean; stopping: boolean }): ReactNode {
+  if (stopping) return <Loader2 size={18} className="animate-spin" />;
   if (isThinking || isIdle) {
     return (
-      <IconSlot size={20}>
-        <ActivityMark
-          mark={isThinking ? 'control-stop-working' : 'control-stop-idle'}
-          size={20}
-          className={isThinking ? 'text-active' : 'text-attention'}
-        />
-      </IconSlot>
+      <ActivityMark
+        mark={isThinking ? 'control-stop-working' : 'control-stop-idle'}
+        size={20}
+        className={isThinking ? 'text-active' : 'text-attention'}
+      />
     );
   }
-  return <IconSlot size={20}><CircleStop size={18} /></IconSlot>;
+  return <CircleStop size={18} />;
 }
 
 interface CommandTerminalWindowProps {
@@ -326,7 +327,18 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
     // guaranteed to happen after that unmount commits.
     const grid = gridGetterRef.current?.() ?? undefined;
     try {
-      await useSessionStore.getState().killTransientSessionBySlot(currentProjectId, slot);
+      // Act on the outcome here too, not just in handleTerminate: this path scrubs the
+      // slot and immediately spawns a replacement on it, so a kill that failed leaves the
+      // old PTY running and unreachable while a new one starts under a fresh checkout.
+      // Warn rather than abort - the user asked for the branch switch, and the respawn is
+      // still the useful half of it.
+      const killOutcome = await useSessionStore.getState().killTransientSessionBySlot(currentProjectId, slot);
+      if (killOutcome === 'failed') {
+        useToastStore.getState().addToast({
+          message: 'Could not stop the old terminal. Its process may still be running.',
+          variant: 'warning',
+        });
+      }
       setSessionId(null);
       setTerminalReady(false);
       const result = await useSessionStore.getState().spawnTransientSession(slot, resolvedBranch, grid);
@@ -346,10 +358,19 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
   // (the X / Ctrl+Shift+P / backdrop) is separate and keeps every PTY alive.
   //
   // The window closes on EVERY path, including a kill that found nothing to kill:
-  // the user asked for this terminal to go away. Only a kill that actually failed
-  // is surfaced, because then a PTY may still be running with nothing pointing at
-  // it. All three outcomes used to be silent, so a kill that quietly did nothing
-  // looked exactly like the dropped click this button was also suffering from.
+  // the user asked for this terminal to go away. All three outcomes used to be
+  // silent, so a kill that quietly did nothing looked exactly like the dropped
+  // click this button was also suffering from.
+  //
+  // Only 'failed' is surfaced. 'no-session' is deliberately quiet even though it
+  // carries the same "a PTY may still be running" risk, because in the case that
+  // actually reaches it the window is genuinely all there is to close. The one
+  // known gap: Stop clicked while the initial spawn IPC is still in flight finds
+  // no map entry yet (spawnTransientSession inserts it only after the await), so
+  // the spawn completes unattended and the next layer-open reconciles a window
+  // back for it. Closing the spawn race needs cancellation plumbed through the
+  // mount effect; until then this path cannot tell that case apart from a slot
+  // that never had a PTY, which is why it stays silent rather than crying wolf.
   const handleTerminate = useCallback(async () => {
     if (stopping) return;
     setStopping(true);
@@ -369,9 +390,12 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
       });
     }
     closeWindow(windowId);
-    // Normally unreachable - closing this window unmounts the component. It matters
-    // when the close is a no-op (an id the store no longer holds), which would
-    // otherwise strand the button disabled with a spinner and no way back.
+    // This runs on essentially every Stop, not just the rare path: closeWindow is a
+    // plain Zustand set(), so React cannot commit the unmount between these two
+    // statements. Usually it is a harmless setState just ahead of that unmount. It
+    // is load-bearing only when the close is a no-op (an id the store no longer
+    // holds, which closeWindow returns early on), where no unmount ever follows and
+    // the button would otherwise be stranded disabled with a spinner and no way back.
     if (mountedRef.current) setStopping(false);
   }, [closeWindow, windowId, slot, stopping]);
 
@@ -420,7 +444,10 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
               stopping ? 'text-fg-muted' : showActivityRing ? 'hover:bg-surface-hover' : 'text-red-400 hover:bg-red-400/10'
             }`}
             title={stopping ? 'Stopping...' : 'Stop terminal'}
-            aria-label="Stop terminal"
+            // Tracks `stopping` like the title and the kebab item's label: an explicit
+            // aria-label wins the accessible-name computation, so leaving it static would
+            // hide the pending state from exactly the users who cannot see the spinner.
+            aria-label={stopping ? 'Stopping terminal' : 'Stop terminal'}
             data-testid="command-bar-terminate-button"
           >
             <StopButtonIcon isThinking={isThinking} isIdle={isIdle} stopping={stopping} />

--- a/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
+++ b/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
@@ -7,6 +7,7 @@ import { getSwimlaneIcon } from '../../../utils/swimlane-icons';
 import { ICON_REGISTRY } from '../../../utils/swimlane-icons';
 import { ActivityMark } from '../../ActivityMark';
 import { HeaderActionButton } from '../../HeaderActionButton';
+import { IconSlot } from '../../IconSlot';
 import { IsolatedBadge } from '../../IsolatedBadge';
 import { KebabMenu, KebabMenuItem, KebabMenuDivider } from '../../KebabMenu';
 import { CommandSearchList } from './CommandSearchList';
@@ -45,7 +46,13 @@ function PauseButtonIcon({
   isIdle: boolean;
   isSessionActive: boolean;
 }): ReactNode {
-  if (toggling) return <Loader2 size={18} className="animate-spin" />;
+  // Every branch renders through IconSlot: these branches return different element types,
+  // so a state change mid-press would otherwise destroy the node the press landed on and
+  // Chromium would drop the click (see IconSlot). Clicking here also flips `toggling`, so
+  // this button swaps its own icon by design.
+  if (toggling) {
+    return <IconSlot size={20}><Loader2 size={18} className="animate-spin" /></IconSlot>;
+  }
 
   // Active and idle/permission share one packaged mark, differing only by color and motion
   // (a rotating dashed arc vs a static ring), so the two states read as one visual language.
@@ -57,25 +64,25 @@ function PauseButtonIcon({
   // should be reintroduced, since ring and bars are now one SVG that scales together.
   if (isThinking || isIdle) {
     return (
-      <span className="grid place-items-center w-5 h-5">
+      <IconSlot size={20}>
         <ActivityMark
           mark={isThinking ? 'control-pause-working' : 'control-pause-idle'}
           size={20}
           className={isThinking ? 'text-active' : 'text-attention'}
         />
-      </span>
+      </IconSlot>
     );
   }
 
-  if (isQueued) return <Clock size={18} />;
+  if (isQueued) return <IconSlot size={20}><Clock size={18} /></IconSlot>;
   // Launching (preparing/initializing): a muted grey spinner matching the board
   // card's loading indicator. The agent has not started yet, so it is NOT active-green;
   // once the session is running the engine seeds 'thinking' and this flips to the
   // active ring. Suspended -> the resume control.
   if (isSessionActive) {
-    return <Loader2 size={18} className="animate-spin text-fg-muted" />;
+    return <IconSlot size={20}><Loader2 size={18} className="animate-spin text-fg-muted" /></IconSlot>;
   }
-  return <CirclePlay size={18} />;
+  return <IconSlot size={20}><CirclePlay size={18} /></IconSlot>;
 }
 
 interface TaskDetailHeaderProps {

--- a/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
+++ b/src/renderer/components/dialogs/task-detail/TaskDetailHeader.tsx
@@ -46,13 +46,27 @@ function PauseButtonIcon({
   isIdle: boolean;
   isSessionActive: boolean;
 }): ReactNode {
-  // Every branch renders through IconSlot: these branches return different element types,
-  // so a state change mid-press would otherwise destroy the node the press landed on and
-  // Chromium would drop the click (see IconSlot). Clicking here also flips `toggling`, so
-  // this button swaps its own icon by design.
-  if (toggling) {
-    return <IconSlot size={20}><Loader2 size={18} className="animate-spin" /></IconSlot>;
-  }
+  // One IconSlot wraps whatever the branching produces: these branches return different
+  // element types, so a state change mid-press would otherwise destroy the node the press
+  // landed on and Chromium would drop the click (see IconSlot). Clicking here also flips
+  // `toggling`, so this button swaps its own icon by design.
+  return <IconSlot size={20}>{pauseGlyph({ toggling, isThinking, isQueued, isIdle, isSessionActive })}</IconSlot>;
+}
+
+function pauseGlyph({
+  toggling,
+  isThinking,
+  isQueued,
+  isIdle,
+  isSessionActive,
+}: {
+  toggling: boolean;
+  isThinking: boolean;
+  isQueued: boolean;
+  isIdle: boolean;
+  isSessionActive: boolean;
+}): ReactNode {
+  if (toggling) return <Loader2 size={18} className="animate-spin" />;
 
   // Active and idle/permission share one packaged mark, differing only by color and motion
   // (a rotating dashed arc vs a static ring), so the two states read as one visual language.
@@ -64,25 +78,23 @@ function PauseButtonIcon({
   // should be reintroduced, since ring and bars are now one SVG that scales together.
   if (isThinking || isIdle) {
     return (
-      <IconSlot size={20}>
-        <ActivityMark
-          mark={isThinking ? 'control-pause-working' : 'control-pause-idle'}
-          size={20}
-          className={isThinking ? 'text-active' : 'text-attention'}
-        />
-      </IconSlot>
+      <ActivityMark
+        mark={isThinking ? 'control-pause-working' : 'control-pause-idle'}
+        size={20}
+        className={isThinking ? 'text-active' : 'text-attention'}
+      />
     );
   }
 
-  if (isQueued) return <IconSlot size={20}><Clock size={18} /></IconSlot>;
+  if (isQueued) return <Clock size={18} />;
   // Launching (preparing/initializing): a muted grey spinner matching the board
   // card's loading indicator. The agent has not started yet, so it is NOT active-green;
   // once the session is running the engine seeds 'thinking' and this flips to the
   // active ring. Suspended -> the resume control.
   if (isSessionActive) {
-    return <IconSlot size={20}><Loader2 size={18} className="animate-spin text-fg-muted" /></IconSlot>;
+    return <Loader2 size={18} className="animate-spin text-fg-muted" />;
   }
-  return <IconSlot size={20}><CirclePlay size={18} /></IconSlot>;
+  return <CirclePlay size={18} />;
 }
 
 interface TaskDetailHeaderProps {

--- a/src/renderer/components/monitor/MonitorCard.tsx
+++ b/src/renderer/components/monitor/MonitorCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { CirclePause, Check, GitBranch } from 'lucide-react';
 import { ActivityMark } from '../ActivityMark';
+import { IconSlot } from '../IconSlot';
 import type { MonitorSessionRow } from '../../../shared/types';
 import { LabelPills, Pill } from '../Pill';
 import { PrLink } from '../PrLink';
@@ -42,7 +43,14 @@ interface MonitorCardProps {
   hideProject?: boolean;
 }
 
-/** The state glyph, matching TaskCard's vocabulary exactly. */
+/**
+ * The state glyph, matching TaskCard's vocabulary exactly.
+ *
+ * Every branch renders through `IconSlot`. The card is a `role="button"` carrying other
+ * interactive children, so the glyph cannot be protected by neutralizing the card's
+ * children wholesale - the slot scopes that to the glyph itself, which is exactly the
+ * case it exists for.
+ */
 function StateGlyph({ row }: { row: MonitorSessionRow }) {
   const title = row.activityReason ? formatActivityReasonText(row.activityReason) : undefined;
   const bucket = bucketOf(row);
@@ -71,23 +79,31 @@ function StateGlyph({ row }: { row: MonitorSessionRow }) {
     // would unmount one and mount the other, restarting the march from zero
     // (the lesson pinned for TaskCard in tests/unit/activity-mark.test.ts).
     return (
-      <ActivityMark
-        mark={mark}
-        size={15}
-        className={`${needsYou ? 'text-attention' : 'text-active'} shrink-0`}
-        aria-label={title ?? (needsYou ? 'Needs you' : 'Working')}
-      />
+      <IconSlot size={15} className="shrink-0">
+        <ActivityMark
+          mark={mark}
+          size={15}
+          className={needsYou ? 'text-attention' : 'text-active'}
+          aria-label={title ?? (needsYou ? 'Needs you' : 'Working')}
+        />
+      </IconSlot>
     );
   }
   if (bucket === 'finished') {
-    return <Check size={14} className="text-fg-disabled shrink-0" aria-label="Finished" />;
+    return (
+      <IconSlot size={15} className="shrink-0">
+        <Check size={14} className="text-fg-disabled" aria-label="Finished" />
+      </IconSlot>
+    );
   }
   return (
-    <CirclePause
-      size={14}
-      className="text-fg-faint shrink-0"
-      aria-label={row.status === 'queued' ? 'Waiting to start' : 'Paused'}
-    />
+    <IconSlot size={15} className="shrink-0">
+      <CirclePause
+        size={14}
+        className="text-fg-faint"
+        aria-label={row.status === 'queued' ? 'Waiting to start' : 'Paused'}
+      />
+    </IconSlot>
   );
 }
 

--- a/src/renderer/components/monitor/MonitorCard.tsx
+++ b/src/renderer/components/monitor/MonitorCard.tsx
@@ -46,12 +46,20 @@ interface MonitorCardProps {
 /**
  * The state glyph, matching TaskCard's vocabulary exactly.
  *
- * Every branch renders through `IconSlot`. The card is a `role="button"` carrying other
- * interactive children, so the glyph cannot be protected by neutralizing the card's
- * children wholesale - the slot scopes that to the glyph itself, which is exactly the
- * case it exists for.
+ * One `IconSlot` wraps whatever the branching produces. The card is a `role="button"`
+ * carrying other interactive children, so the glyph cannot be protected by neutralizing the
+ * card's children wholesale - the slot scopes that to the glyph itself, which is exactly the
+ * case it exists for. Wrapping once rather than per branch is what stops a future branch
+ * from silently opting out.
+ *
+ * The slot is 15 in every state, one px wider than the two lucide branches draw at, so the
+ * glyph column no longer jitters between 15 and 14 as a session finishes.
  */
 function StateGlyph({ row }: { row: MonitorSessionRow }) {
+  return <IconSlot size={15} className="shrink-0">{stateGlyphContent(row)}</IconSlot>;
+}
+
+function stateGlyphContent(row: MonitorSessionRow) {
   const title = row.activityReason ? formatActivityReasonText(row.activityReason) : undefined;
   const bucket = bucketOf(row);
 
@@ -78,32 +86,26 @@ function StateGlyph({ row }: { row: MonitorSessionRow }) {
     // siblings: React reconciles siblings positionally, so an idle/working flip
     // would unmount one and mount the other, restarting the march from zero
     // (the lesson pinned for TaskCard in tests/unit/activity-mark.test.ts).
+    // Labelled with aria-label, never a <title> child: inside an IconSlot the mark's own
+    // <svg> root is not hit-testable, so a native tooltip would never appear (see IconSlot).
     return (
-      <IconSlot size={15} className="shrink-0">
-        <ActivityMark
-          mark={mark}
-          size={15}
-          className={needsYou ? 'text-attention' : 'text-active'}
-          aria-label={title ?? (needsYou ? 'Needs you' : 'Working')}
-        />
-      </IconSlot>
+      <ActivityMark
+        mark={mark}
+        size={15}
+        className={needsYou ? 'text-attention' : 'text-active'}
+        aria-label={title ?? (needsYou ? 'Needs you' : 'Working')}
+      />
     );
   }
   if (bucket === 'finished') {
-    return (
-      <IconSlot size={15} className="shrink-0">
-        <Check size={14} className="text-fg-disabled" aria-label="Finished" />
-      </IconSlot>
-    );
+    return <Check size={14} className="text-fg-disabled" aria-label="Finished" />;
   }
   return (
-    <IconSlot size={15} className="shrink-0">
-      <CirclePause
-        size={14}
-        className="text-fg-faint"
-        aria-label={row.status === 'queued' ? 'Waiting to start' : 'Paused'}
-      />
-    </IconSlot>
+    <CirclePause
+      size={14}
+      className="text-fg-faint"
+      aria-label={row.status === 'queued' ? 'Waiting to start' : 'Paused'}
+    />
   );
 }
 

--- a/src/renderer/stores/session-store/transient-session-slice.ts
+++ b/src/renderer/stores/session-store/transient-session-slice.ts
@@ -30,7 +30,11 @@ export interface TransientSessionEntry {
  *
  * `'no-session'` means the slot held no map entry, so no IPC was issued at all. It is
  * NOT a quiet success: the PTY, if one exists, is still running and now unreachable
- * from this slot.
+ * from this slot. The way that actually happens is a Stop landing before the initial
+ * spawn resolves, since `spawnTransientSession` inserts the entry only after its await;
+ * the spawn then completes unattended and the next layer-open reconciles a window back
+ * for it. `handleTerminate` still closes the window on this outcome and stays silent
+ * about it - see the reasoning there before making it louder.
  */
 export type TransientKillOutcome = 'killed' | 'no-session' | 'failed';
 

--- a/src/renderer/stores/session-store/transient-session-slice.ts
+++ b/src/renderer/stores/session-store/transient-session-slice.ts
@@ -25,6 +25,15 @@ export interface TransientSessionEntry {
   label?: string;
 }
 
+/**
+ * What a kill request actually did.
+ *
+ * `'no-session'` means the slot held no map entry, so no IPC was issued at all. It is
+ * NOT a quiet success: the PTY, if one exists, is still running and now unreachable
+ * from this slot.
+ */
+export type TransientKillOutcome = 'killed' | 'no-session' | 'failed';
+
 /** Composite map key. One Command Terminal window owns one (project, slot) PTY. */
 export function transientKey(projectId: string, slot: string): string {
   return `${projectId}::${slot}`;
@@ -152,8 +161,14 @@ export interface TransientSessionSlice {
     branch?: string,
     grid?: { cols: number; rows: number },
   ) => Promise<{ session: Session; branch: string; checkoutError?: string }>;
-  /** Kill one slot's transient PTY (IPC) and scrub its renderer state. */
-  killTransientSessionBySlot: (projectId: string, slot: string) => Promise<void>;
+  /** Kill one slot's transient PTY (IPC) and scrub its renderer state.
+   *
+   *  Reports which of the three things actually happened, because they are not
+   *  interchangeable and used to be indistinguishable: a missing map entry issued no
+   *  IPC at all and a rejected kill was swallowed, so both resolved exactly like a
+   *  successful kill. A caller that surfaces "stopped" on every path tells the user a
+   *  PTY died when it may still be running. The renderer state is scrubbed either way. */
+  killTransientSessionBySlot: (projectId: string, slot: string) => Promise<TransientKillOutcome>;
   /** Remove a transient session's renderer state by session id, no IPC (the PTY
    *  already exited naturally). Drops its (project, slot) map entry too. */
   clearTransientSessionById: (sessionId: string) => void;
@@ -230,13 +245,19 @@ export function createTransientSessionSlice(preserved: {
 
     killTransientSessionBySlot: async (projectId, slot) => {
       const entry = get().transientSessions[transientKey(projectId, slot)];
-      if (!entry) return;
+      // No entry means no PTY to address. Nothing was killed, and saying so is the
+      // point: this path issues no IPC and the caller cannot otherwise tell.
+      if (!entry) return 'no-session';
+      let outcome: TransientKillOutcome = 'killed';
       try {
         await window.electronAPI.sessions.killTransient(entry.sessionId);
       } catch {
-        // Best-effort cleanup.
+        // Still scrub below - the renderer must not keep pointing at a PTY it can no
+        // longer address - but report the failure rather than passing as a kill.
+        outcome = 'failed';
       }
       get().clearTransientSessionById(entry.sessionId);
+      return outcome;
     },
 
     clearTransientSessionById: (sessionId) => {

--- a/tests/ui/command-terminal.spec.ts
+++ b/tests/ui/command-terminal.spec.ts
@@ -2228,12 +2228,20 @@ test.describe('Command Terminal', () => {
 
     test('Stop still fires when the icon changes ELEMENT TYPE mid-press', async () => {
       // The harder half of the same bug class, and the one IconSlot exists for.
-      // Going from a running session to no activity swaps StopButtonIcon's whole
-      // branch - an <ActivityMark> subtree becomes a lucide <CircleStop> - so React
-      // unmounts the <svg> the press landed on entirely. Making the injected <g>
+      // StopButtonIcon's branches return different ELEMENT TYPES, so crossing between
+      // them makes React unmount the whole subtree the press landed on - a lucide
+      // <CircleStop> becomes an <ActivityMark> <svg>. Making the injected <g>
       // non-hit-testable cannot help here: the node carrying that style is itself
       // destroyed. Only a stable ancestor that every branch renders through survives,
       // which is IconSlot.
+      //
+      // Driven in the lucide -> mark direction on purpose. A session that has started
+      // but not yet reported activity leaves `activity` undefined, so isThinking and
+      // isIdle are both false and the lucide branch is what renders; seeding 'thinking'
+      // then crosses to the mark. The reverse direction has no legal drive: every member
+      // of ActivityState ('thinking' | 'idle' | 'permission') maps to one of the two
+      // branches, so leaving the mark would mean feeding updateActivity a string outside
+      // its own union and relying on the classifier's undefined lookup falling through.
       const { browser, page } = await launchWithState(
         ringBasePreConfig() + deterministicSpawn
       );
@@ -2241,31 +2249,23 @@ test.describe('Command Terminal', () => {
         await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
         await openOverlayAndMarkSessionReady(page);
 
-        await page.evaluate((sessionId) => {
-          const stores = (window as unknown as {
-            __zustandStores?: { session?: { getState: () => { updateActivity: (id: string, next: string) => void } } };
-          }).__zustandStores;
-          stores?.session?.getState().updateActivity(sessionId, 'thinking');
-        }, RING_SESSION_ID);
-
         const stopButton = page.getByTestId('command-bar-terminate-button');
-        await expect(stopButton.locator('[data-mark="control-stop-working"]')).toBeVisible({ timeout: 3000 });
+        await expect(stopButton.locator('.lucide-circle-stop')).toBeVisible({ timeout: 3000 });
 
         const box = await stopButton.boundingBox();
         if (!box) throw new Error('stop button has no bounding box');
         await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
         await page.mouse.down();
 
-        // Drop the session's readiness so sessionRunning goes false: the mark branch
-        // is abandoned for the plain lucide glyph. Awaiting the lucide class is the
-        // commit barrier, so the swap has definitely landed before mouseup.
+        // Cross to the mark branch mid-press. Awaiting the data-mark is the commit
+        // barrier, so the element-type swap has definitely landed before mouseup.
         await page.evaluate((sessionId) => {
           const stores = (window as unknown as {
-            __zustandStores?: { session?: { getState: () => { clearFirstOutput?: (id: string) => void; updateActivity: (id: string, next: string) => void } } };
+            __zustandStores?: { session?: { getState: () => { updateActivity: (id: string, next: string) => void } } };
           }).__zustandStores;
-          stores?.session?.getState().updateActivity(sessionId, 'exited');
+          stores?.session?.getState().updateActivity(sessionId, 'thinking');
         }, RING_SESSION_ID);
-        await expect(stopButton.locator('.lucide-circle-stop')).toBeVisible({ timeout: 3000 });
+        await expect(stopButton.locator('[data-mark="control-stop-working"]')).toBeVisible({ timeout: 3000 });
 
         await page.mouse.up();
 
@@ -2355,10 +2355,22 @@ test.describe('Command Terminal', () => {
         await openOverlayAndMarkSessionReady(page);
 
         const stopButton = page.getByTestId('command-bar-terminate-button');
+
+        // Seed a live activity mark FIRST, so the "marks are gone" assertion below is
+        // about `stopping` pre-empting the ring rather than about a ring that was never
+        // rendered. Without this the count-0 assertion passes vacuously.
+        await page.evaluate((sessionId) => {
+          const stores = (window as unknown as {
+            __zustandStores?: { session?: { getState: () => { updateActivity: (id: string, next: string) => void } } };
+          }).__zustandStores;
+          stores?.session?.getState().updateActivity(sessionId, 'thinking');
+        }, RING_SESSION_ID);
+        await expect(stopButton.locator('[data-mark="control-stop-working"]')).toBeVisible({ timeout: 3000 });
+
         await stopButton.click();
 
-        // In flight: disabled, spinner, and the activity marks are gone (the pending
-        // branch pre-empts them).
+        // In flight: disabled, spinner, and the activity mark is gone (the pending
+        // branch pre-empts it).
         await expect(stopButton).toBeDisabled({ timeout: 3000 });
         await expect(stopButton.locator('.lucide-loader-circle')).toBeVisible();
         await expect(stopButton.locator('[data-mark^="control-stop-"]')).toHaveCount(0);
@@ -2369,6 +2381,62 @@ test.describe('Command Terminal', () => {
           const resolve = (window as unknown as { __resolveKill?: () => void }).__resolveKill;
           if (resolve) resolve();
         });
+        await expect(page.getByTestId('command-terminal-window')).toHaveCount(0, { timeout: 5000 });
+
+        // A successful kill is silent - the error toast below is the OTHER outcome's
+        // signal (see "Stop shows an error toast when the kill fails" just below), and
+        // this is the negative half that pairs with it: nothing here reruns the mock's
+        // kill IPC to fail, so a broadened `if (outcome === 'failed')` (e.g. dropped to
+        // always show) would still slip past this file undetected without this
+        // assertion.
+        //
+        // This is a fixed, non-polling read, not `expect(...).toHaveCount(0)`: a real
+        // toast's own auto-dismiss lifecycle (config default 4s) sits inside
+        // Playwright's default 5s assertion-retry window, so a polling assertion would
+        // pass vacuously by waiting out an ACTUAL wrongly-fired toast rather than
+        // proving one was never shown (this was verified empirically - a broadened,
+        // unconditional `addToast` call still passed a polling `toHaveCount(0)` here).
+        // The window's disappearance is the ordering barrier instead: addToast and
+        // closeWindow are consecutive synchronous statements in handleTerminate with no
+        // await between them, so once the window is confirmed gone above, any toast
+        // this Stop click was going to add has already committed to the DOM - a single
+        // synchronous count read is enough.
+        const failureToastCount = await page.getByTestId('toast').filter({
+          hasText: 'Could not stop the terminal. Its process may still be running.',
+        }).count();
+        expect(failureToastCount).toBe(0);
+      } finally {
+        await browser.close();
+      }
+    });
+
+    test('Stop shows an error toast when the kill fails, but still closes the window', async () => {
+      // handleTerminate surfaces a toast only when killTransientSessionBySlot
+      // resolves 'failed' (the kill IPC rejected). The window closes on every
+      // outcome regardless - the user asked for this terminal to go away - so
+      // the toast is the only observable signal that something went wrong.
+      // Deleting the `if (outcome === 'failed')` block in CommandTerminalWindow.tsx
+      // currently fails no test; this pins both halves of that behavior.
+      const rejectKill = `
+        window.electronAPI.sessions.killTransient = function () {
+          return Promise.reject(new Error('kill failed'));
+        };
+      `;
+      const { browser, page } = await launchWithState(
+        ringBasePreConfig() + deterministicSpawn + rejectKill
+      );
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+        await openOverlayAndMarkSessionReady(page);
+
+        const stopButton = page.getByTestId('command-bar-terminate-button');
+        await stopButton.click();
+
+        const errorToast = page.getByTestId('toast').filter({
+          hasText: 'Could not stop the terminal. Its process may still be running.',
+        });
+        await expect(errorToast).toBeVisible({ timeout: 5000 });
+
         await expect(page.getByTestId('command-terminal-window')).toHaveCount(0, { timeout: 5000 });
       } finally {
         await browser.close();

--- a/tests/ui/command-terminal.spec.ts
+++ b/tests/ui/command-terminal.spec.ts
@@ -2225,6 +2225,155 @@ test.describe('Command Terminal', () => {
         await browser.close();
       }
     });
+
+    test('Stop still fires when the icon changes ELEMENT TYPE mid-press', async () => {
+      // The harder half of the same bug class, and the one IconSlot exists for.
+      // Going from a running session to no activity swaps StopButtonIcon's whole
+      // branch - an <ActivityMark> subtree becomes a lucide <CircleStop> - so React
+      // unmounts the <svg> the press landed on entirely. Making the injected <g>
+      // non-hit-testable cannot help here: the node carrying that style is itself
+      // destroyed. Only a stable ancestor that every branch renders through survives,
+      // which is IconSlot.
+      const { browser, page } = await launchWithState(
+        ringBasePreConfig() + deterministicSpawn
+      );
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+        await openOverlayAndMarkSessionReady(page);
+
+        await page.evaluate((sessionId) => {
+          const stores = (window as unknown as {
+            __zustandStores?: { session?: { getState: () => { updateActivity: (id: string, next: string) => void } } };
+          }).__zustandStores;
+          stores?.session?.getState().updateActivity(sessionId, 'thinking');
+        }, RING_SESSION_ID);
+
+        const stopButton = page.getByTestId('command-bar-terminate-button');
+        await expect(stopButton.locator('[data-mark="control-stop-working"]')).toBeVisible({ timeout: 3000 });
+
+        const box = await stopButton.boundingBox();
+        if (!box) throw new Error('stop button has no bounding box');
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await page.mouse.down();
+
+        // Drop the session's readiness so sessionRunning goes false: the mark branch
+        // is abandoned for the plain lucide glyph. Awaiting the lucide class is the
+        // commit barrier, so the swap has definitely landed before mouseup.
+        await page.evaluate((sessionId) => {
+          const stores = (window as unknown as {
+            __zustandStores?: { session?: { getState: () => { clearFirstOutput?: (id: string) => void; updateActivity: (id: string, next: string) => void } } };
+          }).__zustandStores;
+          stores?.session?.getState().updateActivity(sessionId, 'exited');
+        }, RING_SESSION_ID);
+        await expect(stopButton.locator('.lucide-circle-stop')).toBeVisible({ timeout: 3000 });
+
+        await page.mouse.up();
+
+        await expect(page.getByTestId('command-terminal-window')).toHaveCount(0, { timeout: 5000 });
+      } finally {
+        await browser.close();
+      }
+    });
+
+    test('Stop still fires when the activity mark changes mid-press', async () => {
+      // Regression guard for a dropped first click. ActivityMark injects the packaged
+      // mark with dangerouslySetInnerHTML on an inner <g>, so changing `mark` destroys
+      // every child of that <g>. control-stop's geometry is a FILLED rect covering the
+      // centre of the button, so a press landing where people actually click has its
+      // mousedown target torn out the moment activity flips, and Chromium drops the
+      // click: the handler never runs, no kill IPC is issued, and the window stays open.
+      //
+      // The fix makes the injected subtree non-hit-testable, so the surviving
+      // React-authored <svg> is the event target across a mark change. Without it this
+      // test fails on the final assertion.
+      const { browser, page } = await launchWithState(
+        ringBasePreConfig() + deterministicSpawn
+      );
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+        await openOverlayAndMarkSessionReady(page);
+
+        const setActivity = (activityState: string) => page.evaluate(({ sessionId, activityState }) => {
+          const stores = (window as unknown as {
+            __zustandStores?: {
+              session?: { getState: () => { updateActivity: (id: string, next: string) => void } };
+            };
+          }).__zustandStores;
+          stores?.session?.getState().updateActivity(sessionId, activityState);
+        }, { sessionId: RING_SESSION_ID, activityState });
+
+        const stopButton = page.getByTestId('command-bar-terminate-button');
+
+        await setActivity('thinking');
+        await expect(stopButton.locator('[data-mark="control-stop-working"]')).toBeVisible({ timeout: 3000 });
+
+        // Press dead centre, which is inside the mark's filled stop square.
+        const box = await stopButton.boundingBox();
+        if (!box) throw new Error('stop button has no bounding box');
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await page.mouse.down();
+
+        // Flip the mark mid-press. Awaiting the new data-mark is the commit barrier:
+        // the attribute and the <g>'s innerHTML are written in the same React commit,
+        // so once the attribute is observable the injected children have been replaced
+        // underneath the cursor. Never swap this await for a fixed wait - it is what
+        // makes the race deterministic rather than intermittent.
+        await setActivity('idle');
+        await expect(stopButton.locator('[data-mark="control-stop-idle"]')).toBeVisible({ timeout: 3000 });
+
+        await page.mouse.up();
+
+        // Stop destroys this terminal and closes its window. It was the only one, so
+        // the layer hides with it.
+        await expect(page.getByTestId('command-terminal-window')).toHaveCount(0, { timeout: 5000 });
+      } finally {
+        await browser.close();
+      }
+    });
+
+    test('Stop shows a pending state while the kill is in flight, then closes', async () => {
+      // Stop awaits a kill IPC before closing. With no pending state the button looked
+      // inert for that whole window, which is indistinguishable from the dropped click
+      // above - that is why the bug read as "nothing happened" rather than as an error.
+      //
+      // The kill is held open here so the in-between state is observable at all; the real
+      // one measured ~10ms. This also covers the recovery ordering in handleTerminate: the
+      // `stopping` flag is cleared after closeWindow so a close that does not unmount
+      // cannot strand the button disabled with a spinner and no way back.
+      const holdKill = `
+        window.__resolveKill = null;
+        window.electronAPI.sessions.killTransient = function () {
+          return new Promise(function (resolve) { window.__resolveKill = resolve; });
+        };
+      `;
+      const { browser, page } = await launchWithState(
+        ringBasePreConfig() + deterministicSpawn + holdKill
+      );
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+        await openOverlayAndMarkSessionReady(page);
+
+        const stopButton = page.getByTestId('command-bar-terminate-button');
+        await stopButton.click();
+
+        // In flight: disabled, spinner, and the activity marks are gone (the pending
+        // branch pre-empts them).
+        await expect(stopButton).toBeDisabled({ timeout: 3000 });
+        await expect(stopButton.locator('.lucide-loader-circle')).toBeVisible();
+        await expect(stopButton.locator('[data-mark^="control-stop-"]')).toHaveCount(0);
+        await expect(page.getByTestId('command-terminal-window')).toHaveCount(1);
+
+        // Releasing the kill lets the close run.
+        await page.evaluate(() => {
+          const resolve = (window as unknown as { __resolveKill?: () => void }).__resolveKill;
+          if (resolve) resolve();
+        });
+        await expect(page.getByTestId('command-terminal-window')).toHaveCount(0, { timeout: 5000 });
+      } finally {
+        await browser.close();
+      }
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/activity-mark-render.test.ts
+++ b/tests/unit/activity-mark-render.test.ts
@@ -133,6 +133,33 @@ describe('ActivityMark <title> child renders alongside the injected mark geometr
   });
 });
 
+describe('ActivityMark keeps the injected geometry out of hit testing', () => {
+  // Re-assigning the <g>'s innerHTML on a `mark` change destroys every child under
+  // the cursor, and Chromium drops a click whose target chain is torn down
+  // mid-gesture. That shipped as "the first Stop click never registers": a press on
+  // the glyph, an activity flip during the press, and the button did nothing.
+  //
+  // The behavioral guard is tests/ui/command-terminal.spec.ts ("Stop still fires when
+  // the activity mark changes mid-press"), which drives real mousedown/mouseup in real
+  // Chromium - this tier cannot observe the bug at all, since there is no DOM here and
+  // jsdom never synthesizes a click from mousedown/mouseup anyway. What this asserts is
+  // only that the prop the fix depends on is still present.
+  it('marks the injected <g> non-hit-testable, leaving the <svg> root hittable', () => {
+    const output = ActivityMark({ mark: 'control-stop-working' });
+    if (!isElementLike(output)) throw new Error('ActivityMark did not return an element');
+
+    const markGroup = Array.isArray(output.props.children) ? output.props.children[0] : output.props.children;
+    if (!isElementLike(markGroup)) throw new Error('expected the first child to be the injected <g>');
+    expect(markGroup.type).toBe('g');
+    expect(markGroup.props.style).toEqual({ pointerEvents: 'none' });
+
+    // The root must stay hit-testable: TaskCard hangs a <title> off it for the native
+    // hover tooltip, which needs the <svg> itself to receive the pointer.
+    const rootStyle = output.props.style as { pointerEvents?: string } | undefined;
+    expect(rootStyle?.pointerEvents).toBeUndefined();
+  });
+});
+
 describe('CommandTerminalIcon showPlus precedence', () => {
   it('renders terminal-new even when tone is thinking (showPlus wins over the working mark)', () => {
     const iconElement = CommandTerminalIcon({ tone: 'thinking', showPlus: true });

--- a/tests/unit/icon-slot.test.ts
+++ b/tests/unit/icon-slot.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit coverage for IconSlot's own contract, pinned once at the unit tier instead of
+ * with a slow browser test per adoption site. IconSlot is adopted at three places
+ * (StopButtonIcon in CommandTerminalWindow.tsx, PauseButtonIcon in
+ * TaskDetailHeader.tsx, StateGlyph in MonitorCard.tsx), but only StopButtonIcon's
+ * adoption is exercised end-to-end (tests/ui/command-terminal.spec.ts, "Stop still
+ * fires when the activity mark changes mid-press"). PauseButtonIcon's and
+ * StateGlyph's adoptions would fail no test if reverted. This file asserts the
+ * mechanism itself is intact, independent of any one call site.
+ *
+ * Same rationale and pattern as activity-mark-render.test.ts: this project's vitest
+ * config has no jsdom environment and no @testing-library/react dependency (see
+ * panel-error-boundary.test.ts and dialog-form-primitives.test.ts for the
+ * established rationale), so IconSlot is called directly as a plain function and its
+ * real `React.createElement` output (`{ type, props }`) is walked without a
+ * renderer. IconSlot takes no hooks, so unlike activity-mark-render.test.ts this
+ * file needs no `react` hook stubbing.
+ */
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { IconSlot } from '../../src/renderer/components/IconSlot';
+
+interface ElementLike {
+  type: unknown;
+  props: Record<string, unknown>;
+}
+
+function isElementLike(node: unknown): node is ElementLike {
+  return typeof node === 'object' && node !== null && 'props' in node;
+}
+
+describe('IconSlot', () => {
+  it('renders a <span>', () => {
+    const output = IconSlot({ size: 20, children: React.createElement('svg') });
+    if (!isElementLike(output)) throw new Error('IconSlot did not return an element');
+
+    expect(output.type).toBe('span');
+  });
+
+  it('sizes both width and height in style to the size prop, not a hardcoded default', () => {
+    // 37 is a deliberately distinctive value: a hardcoded default (18 or 20, the
+    // two sizes the real call sites use) would fail this assertion, whereas a
+    // coincidental match at 18 or 20 would not prove the prop is actually wired.
+    const output = IconSlot({ size: 37, children: React.createElement('svg') });
+    if (!isElementLike(output)) throw new Error('IconSlot did not return an element');
+
+    expect(output.props.style).toEqual({ width: 37, height: 37 });
+  });
+
+  it('carries [&>*]:pointer-events-none - the property that puts hits on the span instead of the glyph - and appends the caller className', () => {
+    const output = IconSlot({ size: 20, className: 'shrink-0', children: React.createElement('svg') });
+    if (!isElementLike(output)) throw new Error('IconSlot did not return an element');
+
+    const className = output.props.className;
+    if (typeof className !== 'string') throw new Error('expected className to be a string');
+    expect(className).toContain('[&>*]:pointer-events-none');
+    expect(className).toContain('shrink-0');
+  });
+
+  it('passes children through untouched', () => {
+    const child = React.createElement('svg', { 'data-mark': 'control-stop-idle' });
+    const output = IconSlot({ size: 20, children: child });
+    if (!isElementLike(output)) throw new Error('IconSlot did not return an element');
+
+    expect(output.props.children).toBe(child);
+  });
+});

--- a/tests/unit/transient-debugger-wiring.test.ts
+++ b/tests/unit/transient-debugger-wiring.test.ts
@@ -429,10 +429,12 @@ describe('killTransientSessionBySlot', () => {
     killTransientMock.mockReset();
   });
 
-  it('is a no-op when no entry exists for the (project, slot) pair', async () => {
+  it('reports no-session (not a silent success) when no entry exists for the (project, slot) pair', async () => {
     const { slice, getState } = makeSliceStore();
-    // No entries at all - should return without calling IPC or mutating state.
-    await slice.killTransientSessionBySlot('proj-1', 'slot-1');
+    // No entries at all - no IPC, no state mutation, and the caller is TOLD so.
+    // Reporting this apart from 'killed' is the point: a caller that cannot tell the
+    // difference will claim it stopped a PTY that may still be running.
+    await expect(slice.killTransientSessionBySlot('proj-1', 'slot-1')).resolves.toBe('no-session');
     expect(killTransientMock).not.toHaveBeenCalled();
     expect(getState().transientSessions).toEqual({});
   });
@@ -453,7 +455,7 @@ describe('killTransientSessionBySlot', () => {
       },
     );
 
-    await slice.killTransientSessionBySlot(FAKE_PROJECT_ID, 'slot-1');
+    await expect(slice.killTransientSessionBySlot(FAKE_PROJECT_ID, 'slot-1')).resolves.toBe('killed');
 
     expect(killTransientMock).toHaveBeenCalledWith(session.id);
     expect(getState().transientSessions[transientKey(FAKE_PROJECT_ID, 'slot-1')]).toBeUndefined();
@@ -476,8 +478,9 @@ describe('killTransientSessionBySlot', () => {
       },
     );
 
-    // Must not throw even though IPC rejects.
-    await expect(slice.killTransientSessionBySlot(FAKE_PROJECT_ID, 'slot-1')).resolves.toBeUndefined();
+    // Must not throw even though IPC rejects, but must report 'failed' rather than
+    // passing the rejection off as a completed kill.
+    await expect(slice.killTransientSessionBySlot(FAKE_PROJECT_ID, 'slot-1')).resolves.toBe('failed');
 
     // Cleanup must still have run despite the IPC failure.
     expect(getState().transientSessions[transientKey(FAKE_PROJECT_ID, 'slot-1')]).toBeUndefined();


### PR DESCRIPTION
## What

Fixes a dropped click on any control whose icon is driven by session activity. The reported
symptom was the Command Terminal's Stop button doing nothing until a second click.

- `ActivityMark` - the injected `<g>` is now `pointer-events: none`.
- `IconSlot` (new) - a fixed-size box every branch of a swapping icon renders through.
- Adopted at `StopButtonIcon`, `PauseButtonIcon`, and `MonitorCard`'s `StateGlyph`.
- `killTransientSessionBySlot` now reports its outcome instead of returning `void`.
- The Stop button gains a pending state, and `handleBranchChange` acts on the kill outcome.

## Why

Chromium drops a click outright when the node that received `mousedown` is destroyed before
`mouseup`. Two independent mechanisms did that here, and both race the user because the condition
is pushed from the main process at any instant:

1. **Mark re-injection.** `ActivityMark` writes the packaged mark via `dangerouslySetInnerHTML` on
   an inner `<g>`, so a `mark` change destroys every child of that group. Measured before the fix:
   the injected ink covered 15% of the pause button, and `control-stop`'s filled square covers the
   exact centre, which is where people click.
2. **Element-type swap.** `StopButtonIcon`, `PauseButtonIcon`, and `StateGlyph` return different
   element TYPES per branch (a lucide glyph at rest, an `ActivityMark` when active), so a state
   change unmounts the `<svg>` itself. No change inside `ActivityMark` can reach this.

Only (1) was in the original report. (2) was found while building the shared component, and was a
second live dropped click that the first fix did not cover.

The failure was invisible rather than obvious because the Stop path had no pending state and
`killTransientSessionBySlot` collapsed three outcomes (killed / no map entry / IPC threw) into an
indistinguishable `void`, so a kill that quietly did nothing looked exactly like a dropped click.

Closes #577

## How

Fix (1) makes the injected subtree non-hit-testable, so hits land on the React-authored `<svg>`,
which survives a `mark` change. Two deliberate non-choices, both load-bearing: the `none` does NOT
move up to the root, which `TaskCard`'s `<title>` tooltip needs hit-testable, and the `<g>` never
gets `key={mark}`, which would be the same teardown one level up plus the loss of the motion-phase
anchor.

Fix (2) is `IconSlot`: one `<span>` all branches share, so React reconciles it in place across the
swap and it absorbs the pointer on the glyph's behalf. Scoping the neutralization to the glyph
rather than the button is what lets `MonitorCard` use it, since that clickable is a card carrying
other interactive children.

Two scope notes worth a reviewer's attention:

- `MonitorCard` was checked and is **not** vulnerable in practice - its glyph is a 15px corner
  icon, not the click target. `IconSlot` there is defensive consistency, not a repair. A test
  written for it passed with both protections stripped, so it was deleted rather than kept as
  non-discriminating coverage.
- The three adopting sites are where the fix was ADOPTED, not the full extent of the hazard.
  `MonitorTable`'s `StateCell` and `TerminalPanel`'s session-tab glyph have the same swap and are
  still unwrapped.

A separate workspace-saver dedupe was built and then dropped: it was correct and unit-tested, but
driving the live app showed every no-op gesture produced zero store notifications, so there was
nothing for it to skip. Unmeasured benefit on shared persistence code was not worth the risk.

## Breaking changes

None. `killTransientSessionBySlot`'s return type widens from `Promise<void>` to
`Promise<TransientKillOutcome>`; both call sites are updated and the type is renderer-internal.

## Tests

- `tests/ui/command-terminal.spec.ts` - mark-flip and element-type-swap mid-press tests, the
  pending state, and the failed-kill toast. The two mid-press tests were verified **red 3/3
  against the unfixed component and green 3/3 after**.
- `tests/unit/icon-slot.test.ts` - pins `IconSlot`'s contract.
- `tests/unit/activity-mark-render.test.ts` - pins that the `<g>` carries the prop and the root
  does not.
- `tests/unit/transient-debugger-wiring.test.ts` - updated for the three kill outcomes.
- Verified in a real Electron build: one click on Stop killed the PTY, closed the window, and hid
  the layer.

Local runs are Windows-only; the Linux CI checks are the authority. The three new tests do
mouse-level `boundingBox` positioning, which `.claude/rules/cross-platform-parity.md` flags as
CI-fragile - they use real condition waits and no pixel-exact assertions, but that is the thing to
watch if a check goes red.

Generated with [Claude Code](https://claude.com/claude-code)
