### PR TITLE
feat(analytics): adopt Sentry error reporting and expand the event set

### DIFF
--- a/.claude/skills/sentry/SKILL.md
+++ b/.claude/skills/sentry/SKILL.md
@@ -1,0 +1,119 @@
+---
+description: Investigate a Sentry issue - retrieve the issue, latest event, stack trace, tags, and breadcrumbs from kangentic.sentry.io and diagnose it. Use when a task or the user says to investigate/look at/diagnose a Sentry issue or link, or to check what errors are arriving.
+---
+
+# Sentry
+
+Retrieve and diagnose issues from the `kangentic` Sentry org (`kangentic.sentry.io`). Two
+projects live there: `desktop` (this Electron app, numeric id `4511996066660352`) and `mobile`
+(the React Native app, numeric id `4511808149651456`). Desktop error reporting is wired in
+`src/main/analytics/error-reporting.ts`; docs/analytics.md ("Error Reporting") describes what
+gets captured and how.
+
+## Auth (never print the token)
+
+Requests need a bearer token. Resolution order (Kangentic-scoped on purpose, so another
+repo's generic `SENTRY_AUTH_TOKEN` is never picked up by mistake):
+
+1. `KANGENTIC_SENTRY_TOKEN` environment variable, if set.
+2. On Windows, the User-level registry value for the same name (covers a process tree started
+   before the variable was set): `[Environment]::GetEnvironmentVariable('KANGENTIC_SENTRY_TOKEN','User')`.
+3. The `token = ...` line in `~/.sentryclirc` (usually the CI upload token; reads 403 on it).
+
+Read the token into a shell variable and pass it as a header in the SAME command; never echo
+it, never write it to a file, never include it in a reply.
+
+A persisted token doubles as a build switch: `scripts/build.js` and `vite.config.mts` activate
+release sourcemap upload whenever `KANGENTIC_SENTRY_TOKEN` (or `SENTRY_AUTH_TOKEN`) is present
+at build time. A Windows User-level value survives into every later `npm run build`, so store
+the token that way only if local production builds attempting an upload is acceptable;
+otherwise set it per-session.
+
+Scopes: reading issues/events needs `event:read` + `project:read` + `org:read` (a User Auth
+Token from Settings > Account > API > Auth Tokens; resolving issues additionally needs
+`event:write`). A `403` from every endpoint means the stored token is a CI-scoped one
+(`org:ci` - it can only upload sourcemaps): stop and ask the user to mint a read-scoped token
+rather than retrying.
+
+## Retrieval
+
+Parse the issue id from a pasted URL: `https://kangentic.sentry.io/issues/<ISSUE_ID>/?...`
+(the `project=` query param is the numeric project id, useful for list queries).
+
+PowerShell pattern (one call per request; substitute the endpoint):
+
+```powershell
+$token = $env:KANGENTIC_SENTRY_TOKEN; if (-not $token) { $token = [Environment]::GetEnvironmentVariable('KANGENTIC_SENTRY_TOKEN','User') }; if (-not $token) { $token = ((Get-Content "$env:USERPROFILE\.sentryclirc") | Where-Object { $_ -match '^token\s*=' }) -replace '^token\s*=\s*','' }; Invoke-RestMethod -Uri 'https://sentry.io/api/0/organizations/kangentic/issues/<ISSUE_ID>/' -Headers @{ Authorization = "Bearer $token" } | ConvertTo-Json -Depth 8
+```
+
+macOS/Linux (Bash, one command): `curl -s -H "Authorization: Bearer $KANGENTIC_SENTRY_TOKEN" <url>`.
+
+The endpoints that matter:
+
+| What | Endpoint |
+|---|---|
+| Issue summary (title, culprit, count, userCount, firstSeen/lastSeen, level, substatus) | `GET /api/0/organizations/kangentic/issues/<ISSUE_ID>/` |
+| Latest event (stack trace, tags, breadcrumbs, contexts, release) | `GET /api/0/organizations/kangentic/issues/<ISSUE_ID>/events/latest/` |
+| All events for the issue | `GET /api/0/organizations/kangentic/issues/<ISSUE_ID>/events/` |
+| Search issues (e.g. new unresolved desktop issues) | `GET /api/0/organizations/kangentic/issues/?project=4511996066660352&query=is:unresolved&statsPeriod=14d` |
+
+The latest-event payload is large; extract what you need rather than dumping it: `entries`
+with `type: "exception"` carries the stack frames, `type: "breadcrumbs"` the trail, `tags`
+carries `source`/`reason` (stamped by `reportHandledError` for handled forwards), release,
+environment, and the anonymous install id under `user.id` (non-reversible; `userCount` on the
+issue = affected installs).
+
+## Diagnosis
+
+- **Mechanism first.** `mechanism` on the exception says how it was caught: `onunhandledrejection`
+  / `onerror` (renderer globals), `generic` via `captureException` (a boundary or
+  `reportHandledError` - check the `source` tag: `updater`, `pty_spawn`, `spawn`).
+- **Symbolication caveat:** packaged-release events resolve to real file/line only once a
+  release build uploaded sourcemaps (`SENTRY_AUTH_TOKEN` set during `npm run build`). A dev
+  event's renderer frames are unminified module URLs (readable); a packaged event without
+  uploaded maps shows minified positions - lean on message, mechanism, tags, and breadcrumbs.
+- **Environment tag** separates `development` (forced-on dev/preview runs) from `production`
+  (packaged installs). Do not chase dev-only test events (`Kangentic telemetry verification:` is
+  the preview rig's own test error).
+- **Cross-reference locally:** the same failure usually has a local trail - `.kangentic/logs/`
+  (crash JSONs, main console), `kangentic_tail_logs`, and the Aptabase `app_error` /
+  `spawn_failed` counts are the volume view of the same signal.
+
+## Typical requests
+
+**"Any new issues?" (triage scan).** Query each project (or the one named) for what needs
+eyes, newest first:
+
+```
+GET /api/0/organizations/kangentic/issues/?project=4511996066660352&query=is:unresolved is:for_review&statsPeriod=14d&sort=date
+```
+
+Run it for both project ids unless the user scoped to one. Report a compact per-issue line:
+shortId, title, count, userCount (affected installs), firstSeen, environment, and the link
+(`https://kangentic.sentry.io/issues/<id>/`). Two filters keep the report honest:
+
+- Treat `environment: development` events as dev/preview noise (the
+  `Kangentic telemetry verification:` issues are the rig's own test errors) - list them
+  separately or not at all, never alongside production issues without saying so.
+- "New" means new to the user: if an issue's shortId already appears in an existing board task
+  (`kangentic_search_tasks` for the shortId), say it is already tracked instead of re-reporting
+  it as new.
+
+**"Investigate this issue / create a follow-up task."** Retrieve the issue and latest event,
+diagnose (below), then - when asked for a task - create ONE task via the kangentic MCP tools,
+routed by project: a DESKTOP-* issue goes on the `kangentic` board; a MOBILE-* issue (or a
+REACT-NATIVE-* one - issues created before the 2026-08 slug rename keep their old prefix) on
+`kangentic-mobile`. First search for an existing task carrying the shortId so a re-report never
+duplicates. Title: `Fix DESKTOP-N: <issue title, trimmed>`. Description: the Sentry link,
+shortId, level, event/affected-install counts, environment + release, the diagnosis, and the
+few stack frames or tags that carry it. Default to To Do; the user decides when it spawns.
+
+## Boundaries
+
+- Diagnose and report; fix only when the task asks for a fix.
+- Create a follow-up board task only when asked ("create a follow up task" style requests):
+  include the Sentry link, shortId, affected-install count, and your diagnosis in the
+  description.
+- Do not resolve/archive issues in Sentry unless explicitly asked (needs `event:write`).
+- Never paste the token or a full raw event dump into a task, commit, or reply; quote the
+  frames and fields that carry the diagnosis.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,22 +1,42 @@
 # Analytics
 
-Kangentic collects anonymous usage statistics to understand adoption and improve the product.
+Kangentic collects anonymous usage statistics to understand adoption and improve the product,
+and crash/error reports to diagnose bugs. Two vendors, two jobs: [Aptabase](https://aptabase.com)
+counts product events; [Sentry](https://sentry.io) groups and symbolicates errors. Both share
+the same kill switch (below).
 
-## What We Collect
+## What We Collect (Aptabase)
 
-Nine event types are tracked, all on critical-path actions only:
+Seventeen event types are tracked, all on critical-path actions only:
 
 | Event | When | Properties |
 |-------|------|------------|
 | `app_launch` | App starts (when analytics is enabled) | platform, arch, clientId |
 | `app_heartbeat` | Every 30 minutes while at least one agent session is active; skipped when idle. Also fires once right before system sleep if a session is active | activeSessions, suspendedSessions, queuedSessions, totalSessions |
 | `app_close` | Graceful quit, Ctrl+C, SIGTERM, or OS shutdown/reboot/log-off | durationSeconds |
-| `app_error` | Uncaught exception, unhandled rejection, renderer crash, or React ErrorBoundary | source, message (sanitized), reason (renderer crashes), exitCode (renderer crashes), boundary / panel / components (renderer errors) |
+| `app_error` | Uncaught exception, unhandled rejection, renderer crash, React ErrorBoundary, updater failure, or PTY spawn failure | source, message (sanitized); see per-source extras below |
 | `project_create` | User creates a project | (none) |
-| `task_complete` | Task moves to Done | agent, model, durationSeconds, costUsd, inputTokens, outputTokens, toolCalls |
-| `session_spawn` | Agent session reaches running state (board or transient) | agent, isTransient |
-| `session_exit` | Agent session finishes | exitCode, durationSeconds, agent, model, costUsd, toolCalls |
+| `project_move` | User relocates a project folder via the Locate Folder dialog (move mode) | (none) |
+| `project_relocate` | Same dialog, relocate mode | (none) |
+| `task_complete` | Task moves to Done | agent, model, permissionMode, durationSeconds, costUsd, inputTokens, outputTokens, toolCalls |
+| `session_spawn` | Agent session reaches running state (board or transient) | agent, isTransient, permissionMode, worktree |
+| `session_exit` | Agent session finishes | exitCode, durationSeconds, agent, model, costUsd, toolCalls, intentional |
 | `transient_session_spawn` | Transient session launched from command bar | agent |
+| `onboarding_milestone` | Once per install per funnel step | step (`first_project`, `first_task`, `first_spawn`, `first_task_complete`) |
+| `feature_first_use` | Once per install per curated feature | feature |
+| `feature_used` | Once per curated feature per UTC day | feature |
+| `board_snapshot` | Once per project per app run, on cold project open | columns, customColumns, taskBucket (`0` / `1-9` / `10-49` / `50-199` / `200+`), profiles |
+| `update_outcome` | Next launch after the app version changed | result (`applied` / `rolled_back`), fromVersion, toVersion |
+| `spawn_failed` | An agent spawn failed (born-into-column create, MCP auto-spawn, board resume, startup recovery) | agent, reason (`create_spawn`, `auto_spawn`, `resume`, `unknown_agent`, `cli_not_found`) |
+
+The curated `feature` vocabulary is `ANALYTICS_FEATURES` in `src/main/analytics/usage.ts`:
+`command_terminal`, `worktree_session`, `board_profile`, `popout_window`, `browser_pane`,
+`mcp_server`, `mobile_bridge`, `usage_dashboard`, `quick_find`, `settings`. Each feature adds at
+most one `feature_used` event per user per day, so the list is a budget decision, not a free
+enum. Renderer-reported features cross one IPC channel (`analytics:trackFeatureUsed`) and are
+re-validated against this list in the main process. Onboarding milestones and feature first-use
+flags persist in `<configDir>/analytics-usage.json`, alongside the last-run version that powers
+`update_outcome`.
 
 `agent` is the adapter id from a fixed allowlist (`claude`, `codex`, `gemini`, `qwen`, `opencode`, `aider`, `cursor`, `warp`, `copilot`, `kimi`, `droid`, `ollama`, `grok`, `antigravity`). `model` is the CLI-level model identifier the agent itself reports through its status output (e.g. `claude-opus-4-7`, `gpt-5-codex`, `gemini-2.5-pro`).
 
@@ -24,29 +44,49 @@ Nine event types are tracked, all on critical-path actions only:
 
 For Claude sessions, `model` is normalized to its base id via `parseModelId` (`src/shared/model-id.ts`) before being attached, so the 1M-context opt-in suffix and a dated pin no longer fragment the model breakdown: `claude-opus-4-8[1m]` -> `claude-opus-4-8`, `claude-haiku-4-5-20251001` -> `claude-haiku-4-5`. This is a display-layer grouping only - the exact spawnable id is unaffected.
 
+`permissionMode` on `session_spawn` / `task_complete` is the RESOLVED mode the session record
+actually spawned under (from `resolveEffectivePermissionMode`), not the task's raw override
+(which is null for most tasks, meaning "inherit"). `worktree` says whether the session ran in a
+git worktree. `intentional` on `session_exit` distinguishes a deliberate kill/suspend (tagged by
+the session manager) from a genuine agent-side exit, closing the crash-versus-intentional blind
+spot.
+
 `costUsd`, `inputTokens`, `outputTokens`, and `toolCalls` are cumulative session metrics, omitted when not yet available (e.g. a session that exited before any usage was recorded). `session_exit` carries `costUsd`/`toolCalls` only, since its token counts would otherwise be a point-in-time context-window snapshot rather than a cumulative total; `task_complete` is the source for cumulative token counts.
 
 The `app_launch` event also carries `clientId`, an anonymous id Kangentic generates and attaches (see "Unique Installs" below). It is attached only to `app_launch` (the one authoritative per-launch install signal), not to every event, to avoid inflating high-cardinality string-prop volume on events like `app_heartbeat` where it adds no install-counting value.
+
+`board_snapshot` sends counts only: the number of columns, whether the board deviates from the
+seeded default (compared against `DEFAULT_SWIMLANES` in `src/main/db/migrations/default-data.ts`
+by count and name-set), a bucketed task count (never the exact figure), and the number of Board
+Profiles. Column names and task content never leave the machine.
+
+### app_error sources
+
+`source` discriminates the failure path: `uncaughtException`, `unhandledRejection`,
+`render-process-gone` (extras: `reason`, `exitCode`), `error_boundary` (extras: `boundary`,
+`panel`, `components`), `updater`, `pty_spawn` (extras: `shell`, `shellArgs`, `cwdExists`,
+`shellExists`, `errno`, `platform`, `arch`), and `pty_spawn_cwd_missing` (extra: `platform`).
 
 Renderer errors (`source: error_boundary`) carry three extra properties that say *where* the error
 happened, since a message alone is rarely enough to locate one. `boundary` is `root`, `panel`, or
 `unhandled_rejection` and identifies which of the three reporters caught it; `panel` is the
 failing panel's static label; `components` is a trail of React component names, innermost first.
-The raw component stack is never sent: a production stack frame embeds a `file://` URL containing
-the user's home directory, so main reduces it to component names, which cannot contain a path.
+The raw component stack is never sent to Aptabase: a production stack frame embeds a `file://`
+URL containing the user's home directory, so main reduces it to component names, which cannot
+contain a path. (Sentry receives the real stack instead, with paths normalized - see Error
+Reporting below.)
 
 `boundary` and `panel` read directly. `components` does not: React takes frame names from
 `fn.name` and the packaged renderer bundle is minified, so the trail arrives mangled. It still
-distinguishes one code path from another, and a matching build's sourcemap resolves it, but it is
-not readable on its own. `boundary` is the field to reach for first.
+distinguishes one code path from another, but Sentry is now the place to read a symbolicated
+stack; `boundary` is the field to reach for first on the Aptabase side.
 
-Aptabase truncates any string property at 180 characters server-side, so `panel` and `components`
-are capped at that length rather than sending text that would be silently cut. `message` is the
-exception: `sanitizeErrorMessage` caps it at 200, so a message longer than 180 is still cut
-server-side.
+Aptabase truncates any string property at 180 characters server-side, so `message`, `panel`, and
+`components` are all capped at that length locally (`MAX_ANALYTICS_STRING_LENGTH`) rather than
+sending text that would be silently cut.
 
 `boundary` classifies only `source: error_boundary` events. The other `app_error` sources
-(`uncaughtException`, `unhandledRejection`, `render-process-gone`, all raised in the main process)
+(all raised in the main process)
 never carry it, and they are separate from the local crash-log system under
 `.kangentic/logs/crashes/`, which records its own JSON files and never reaches Aptabase.
 
@@ -61,18 +101,65 @@ Aptabase's own identity model rotates daily (see "How It Works" below), so it ca
 - **Fallback:** if the OS machine-id source is unavailable (e.g. a hardened or containerized environment), Kangentic falls back to a random id persisted locally; that id does not survive a reinstall.
 - **Control:** `clientId` is on by default and shares the same `KANGENTIC_TELEMETRY` control as every other event below - there is no separate opt-out.
 
+## Error Reporting (Sentry)
+
+Crash and error monitoring is separate from product analytics: Aptabase's `app_error` stays as a
+coarse error-rate pulse on the product dashboard, while Sentry (`@sentry/electron`) provides
+grouping, deduplication, symbolicated stack traces, and alerting. Desktop and mobile issues land
+in one Sentry org, one triage surface.
+
+- **Initialization** (`src/main/analytics/error-reporting.ts`): the SDK initializes in the main
+  process (next to `initAnalytics`, before app-ready) and in the renderer
+  (`src/renderer/error-reporting.ts`). The renderer SDK has no network path of its own - every
+  renderer event transports to the main process over the SDK's internal IPC, and main's
+  offline-capable transport is the single point of egress. The renderer init is gated on a boot
+  flag (`--kangentic-error-reporting` in `additionalArguments`) that mirrors main's single
+  decision, so the two processes can never disagree.
+- **Scrubbing is the SDK's and Sentry's job, not custom code:** the SDK's default
+  `normalizePathsIntegration` rewrites stack-frame paths and URLs relative to the app root (the
+  user's home directory never reaches Sentry for app code), `sendDefaultPii` stays `false`, and
+  Sentry's server-side data scrubbing is on by default. Any further rule belongs in the Sentry
+  UI (Advanced Data Scrubbing), not in a `beforeSend` here.
+- **Errors only:** release-health session tracking (the SDK's `MainProcessSession` integration,
+  on by default) is filtered out, and tracing and session replay are never enabled.
+- **Boundary-caught errors** never reach the SDK's global handlers (React swallows them), so
+  both error boundaries hand the real `Error` to `captureException` explicitly, alongside the
+  existing Aptabase funnel.
+- **Handled errors are forwarded too** (`reportHandledError`): the deliberate catch sites that
+  otherwise emit only a sanitized count - updater structural failures (`source: updater`), PTY
+  spawn failures (`source: pty_spawn`), and the silent agent-spawn catches (`source: spawn`,
+  with a `reason` tag) - send the real error to Sentry so hidden issues are diagnosable, not
+  just counted.
+- **Affected-install counts:** the same anonymous, non-reversible `clientId` documented under
+  "Unique Installs" is attached as the Sentry user id, so an issue's Users column means
+  "installs affected." It contains no personal data and shares the same kill switches.
+- **Investigating an issue:** the `/sentry` skill (`.claude/skills/sentry/SKILL.md`) teaches an
+  agent to retrieve and diagnose issues from the org via the API.
+- **Sourcemaps** upload at release time only: `@sentry/vite-plugin` (renderer) and
+  `@sentry/esbuild-plugin` (main/preload) activate when an upload token is present
+  (`KANGENTIC_SENTRY_TOKEN`, or the conventional `SENTRY_AUTH_TOKEN` as a CI fallback), generate
+  hidden maps, upload them with debug IDs, and delete them from the output. Nothing ships in the
+  artifact; resolution is entirely server-side. The DSN in source is a public routing
+  identifier by design, not a secret. `KANGENTIC_SENTRY_TOKEN` is also what the `/sentry`
+  skill reads for issue retrieval, so one scoped variable serves both.
+
 ## What We Don't Collect
 
 - Task titles, descriptions, or any user-generated content
-- File paths, project names, or code
+- File paths, project names, or code (stack-frame paths are normalized to the app root before
+  they leave the machine)
 - Usernames, emails, or any personally identifiable information
 - Task creation, task start, or mid-board task moves (only done-entry is tracked)
+- Per-feature content: `feature_used` says a feature was touched that day, never what it was
+  used for
 
 ## Why
 
 - Understand how many people use Kangentic and on which platforms
 - Measure product effectiveness (task completion rates, agent success rates)
 - Prioritize development based on actual usage patterns
+- See where new installs stall (the onboarding funnel) and which features earn their keep
+- Diagnose crashes with actionable, grouped, symbolicated reports instead of truncated strings
 
 ## How It Works
 
@@ -86,17 +173,24 @@ Kangentic uses [Aptabase](https://aptabase.com), a privacy-first, open-source an
 
 Kangentic separately attaches its own anonymous, non-reversible `clientId` to the `app_launch` event so we can count unique installs ourselves - see "Unique Installs" above. It contains no personal data and is not an Aptabase feature.
 
-All analytics run in the main process only -- the renderer never sends analytics events.
+All telemetry egress happens in the main process. Renderer errors reach it over IPC (the
+`analytics:trackRendererError` funnel for Aptabase, the Sentry SDK's internal IPC transport for
+error reports); the renderer never opens a network path of its own.
 
-## KANGENTIC_TELEMETRY Environment Variable
+## Environment Variables
 
-The `KANGENTIC_TELEMETRY` environment variable controls analytics:
+`KANGENTIC_TELEMETRY` is the superset kill switch (it predates error reporting and its
+documented promise - "disables analytics entirely" - is honored: `0` disables Aptabase AND
+Sentry). `KANGENTIC_ERROR_REPORTING` controls Sentry alone:
 
-| Value | Behavior |
-|-------|----------|
-| `0` or `false` | Analytics disabled (opt-out) |
-| `1` or `true` | Analytics enabled, even in dev builds (for local debugging) |
-| *(unset)* | Analytics enabled in production only (default) |
+| Variable | Value | Behavior |
+|----------|-------|----------|
+| `KANGENTIC_TELEMETRY` | `0` or `false` | ALL telemetry disabled: analytics and error reporting (opt-out) |
+| `KANGENTIC_TELEMETRY` | `1` or `true` | Telemetry enabled, even in dev builds (for local debugging) |
+| `KANGENTIC_TELEMETRY` | *(unset)* | Enabled in production only (default) |
+| `KANGENTIC_ERROR_REPORTING` | `0` or `false` | Error reporting disabled; analytics unaffected |
+| `KANGENTIC_ERROR_REPORTING` | `1` or `true` | Error reporting enabled, even in dev builds (unless `KANGENTIC_TELEMETRY=0`) |
+| `KANGENTIC_ERROR_REPORTING` | *(unset)* | Inherits the `KANGENTIC_TELEMETRY` behavior |
 
 ### Opt-out examples
 
@@ -117,4 +211,5 @@ Add the export to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.) to make it 
 
 ## Data Retention
 
-Data retention follows [Aptabase's privacy policy](https://aptabase.com/legal/privacy).
+Analytics retention follows [Aptabase's privacy policy](https://aptabase.com/legal/privacy).
+Error reports follow the Sentry organization's plan retention (30 days on the current plan).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -390,10 +390,11 @@ Detach a registered UI surface (usage stats, git changes, a single changed file'
 | `popOut:listOpen` | invoke | List the instance keys of every currently-open pop-out window |
 | `popOut:changed` | on | Event: the set of open pop-out windows changed; pushed to the main window only. Handled by `renderer/pop-out/pop-out-changed.ts`, which mirrors the set into `pop-out-store.ts` (so in-app triggers - title bar, headers - flip between "open" and "focus") and then applies the effects a window CLOSING implies: a closed `changes` window leaves its task's inline Changes panel CLOSED rather than reclaiming the split. Those effects hang off this push and NOT off `pop-out-store.setOpen()`, which `popOut:listOpen` also drives on mount and on every HMR re-sync; `browser` masks its pane the same way but deliberately still reclaims on close |
 
-### Analytics (1 channel)
+### Analytics (2 channels)
 | Channel | Pattern | Purpose |
 |---------|---------|---------|
 | `analytics:trackRendererError` | send | Report a renderer-side error to main, with a `RendererErrorContext` (`boundary`, `panel?`, `componentStack?`) saying where it came from. See [Analytics](analytics.md). |
+| `analytics:trackFeatureUsed` | send | Report one use of a curated adoption feature; main re-validates against `ANALYTICS_FEATURES` and dedups to once per feature per day. See [Analytics](analytics.md). |
 
 ### App (1 channel)
 | Channel | Pattern | Purpose |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -444,7 +444,7 @@ The Mobile Devices tab hosts the desktop half of the mobile companion app's pair
 
 ### Privacy
 
-The Privacy tab is informational only. It displays what anonymous analytics Kangentic collects (app launches, platform, crash reports, task/session counts) and what it does not collect (task content, file paths, usernames, code). Analytics are powered by Aptabase (no cookies, no persistent identifiers, GDPR-compliant). Set `KANGENTIC_TELEMETRY=0` as an environment variable to opt out. It points to the Memory tab for the (fully local) conversation-search controls. Global-only (per-machine).
+The Privacy tab is informational only. It displays what anonymous telemetry Kangentic collects (app launches, platform, crash reports, task/session counts, daily feature-usage counts) and what it does not collect (task content, file paths, usernames, code). Usage analytics are powered by Aptabase (no cookies, GDPR-compliant, plus one anonymous non-reversible install id for unique-install counting); crash and error reports go to Sentry with machine-specific paths removed from stack traces. Set `KANGENTIC_TELEMETRY=0` as an environment variable to disable all telemetry, or `KANGENTIC_ERROR_REPORTING=0` to disable only error reporting (see [analytics.md](analytics.md)). It points to the Memory tab for the (fully local) conversation-search controls. Global-only (per-machine).
 
 ### Developer
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -647,7 +647,7 @@ The Mobile section closes with **How to install and pair**, which opens the [Kan
 
 ### Privacy
 
-The Privacy tab shows what anonymous analytics Kangentic collects and how to opt out. Analytics are powered by Aptabase (no cookies, no persistent identifiers, GDPR-compliant). Set `KANGENTIC_TELEMETRY=0` as an environment variable to disable analytics entirely. It also lists `support@kangentic.com` for questions about what is collected. This tab is informational only - there are no configurable settings.
+The Privacy tab shows what anonymous telemetry Kangentic collects and how to opt out. Usage analytics are powered by Aptabase (no cookies, GDPR-compliant, plus one anonymous non-reversible install id used only to count unique installs); crash and error reports go to Sentry with machine-specific paths removed from stack traces. Set `KANGENTIC_TELEMETRY=0` as an environment variable to disable all telemetry, or `KANGENTIC_ERROR_REPORTING=0` to disable only error reporting. It also lists `support@kangentic.com` for questions about what is collected. This tab is informational only - there are no configurable settings.
 
 ### Developer
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@aptabase/electron": "^0.3.1",
         "@huggingface/transformers": "^4.2.0",
         "@monaco-editor/react": "^4.7.0",
+        "@sentry/electron": "^7.17.0",
         "@tanstack/react-virtual": "^3.14.2",
         "@xterm/headless": "6.0.0",
         "better-sqlite3": "^12.10.0",
@@ -48,6 +49,8 @@
         "@kangentic/branding": "^2.8.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@playwright/test": "^1.60.0",
+        "@sentry/esbuild-plugin": "^5.4.0",
+        "@sentry/vite-plugin": "^5.4.0",
         "@tailwindcss/postcss": "^4.3.0",
         "@tailwindcss/vite": "^4.3.0",
         "@types/better-sqlite3": "^7.6.13",
@@ -105,6 +108,49 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
+      "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.4.tgz",
+      "integrity": "sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.1",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apm-js-collab/tracing-hooks": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "debug": "^4.4.1",
+        "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@aptabase/electron": {
@@ -2489,7 +2535,6 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2742,6 +2787,119 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -3115,6 +3273,560 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.70.0.tgz",
+      "integrity": "sha512-IK6+J+8H06tZe+A8L37TT5ZxxwNtyQatW8zl5RYYJ/e9CsjrM8fPi8I1OT7uquTw8UtjqFHt7bEef/Vy63ksPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.70.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/feedback": "10.70.0",
+        "@sentry/replay": "10.70.0",
+        "@sentry/replay-canvas": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.70.0.tgz",
+      "integrity": "sha512-IvjhafF5NFXrPCg5EHbAPGDwIhHxgUcLlHTklZ3DAdA6ky88BJYMfevbcnOEmgavf4nylhCaquRUFNB5+szj+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugins/-/bundler-plugins-10.72.0.tgz",
+      "integrity": "sha512-r9A2xZ/JlXuN/B6mfov+jn5RPrpz/35WqMtbns/WzwBDjMKQ5ZbsBUNFC/zXZ4VGEdhZCn0/gFFpl0yvt5NYiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/cli": "^2.58.6",
+        "@sentry/core": "10.72.0",
+        "dotenv": "^17.4.2",
+        "find-up": "^5.0.0",
+        "glob": "^13.0.6",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "rollup": ">=3.2.0",
+        "webpack": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/core": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.72.0.tgz",
+      "integrity": "sha512-UJMHZfbjP4qk+g4AQhZmzosMdICC2D9p0/hLrm1LofPsp+WBfcSnv9jsY1a9TfmpS4WCAmTx8nANYTIXifcBjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.6.tgz",
+      "integrity": "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.6",
+        "@sentry/cli-linux-arm": "2.58.6",
+        "@sentry/cli-linux-arm64": "2.58.6",
+        "@sentry/cli-linux-i686": "2.58.6",
+        "@sentry/cli-linux-x64": "2.58.6",
+        "@sentry/cli-win32-arm64": "2.58.6",
+        "@sentry/cli-win32-i686": "2.58.6",
+        "@sentry/cli-win32-x64": "2.58.6"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz",
+      "integrity": "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==",
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz",
+      "integrity": "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz",
+      "integrity": "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz",
+      "integrity": "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz",
+      "integrity": "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz",
+      "integrity": "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz",
+      "integrity": "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz",
+      "integrity": "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@sentry/cli/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.70.0.tgz",
+      "integrity": "sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/electron": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry/electron/-/electron-7.17.0.tgz",
+      "integrity": "sha512-7U0njOjLnBFEZRYXKdQzIcN6dPGtI1ngku4zTx76DXiGh7uZnw9Cy71QqpEm/aMAw4hD2hMQovp34yy+BwEKMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.70.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/node": "10.70.0"
+      },
+      "peerDependencies": {
+        "@sentry/node-native": "10.70.0"
+      },
+      "peerDependenciesMeta": {
+        "@sentry/node-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/esbuild-plugin": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/esbuild-plugin/-/esbuild-plugin-5.4.0.tgz",
+      "integrity": "sha512-ACn/W1j1GUqVjfZvqtGfMRAhtgXAKKzJGBEgt4LrazQYoTh+rtrZy1JwfRKzGTsA3XgE+p5gXtFdU32Jc8fY7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugins": "^10.64.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.70.0.tgz",
+      "integrity": "sha512-6VQn2ETJjHkk4QQDdx/587/JDfXsk3yBTLZ3UZOMtBVrkmwgk+1FJZ8ULJ3ud1xZcuh2icunIkc7tGVv2axdnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.70.0.tgz",
+      "integrity": "sha512-SPOOVxmKTVIEtqvOKkQT163e/pOwucjS7OPsCHyRs8sFR4nfBNu0EThplyqnvqd5BWBMTPH6WTBQfo+QWHV+HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/node-core": "10.70.0",
+        "@sentry/opentelemetry": "10.70.0",
+        "@sentry/server-utils": "10.70.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.70.0.tgz",
+      "integrity": "sha512-oPOEVVNxv5WHtckx2i06Wi9FLWyvOg/1DUeX732jZ4iqT2nupINaMH4nF4f4kSvUThFnxkFSRQxwqOxgzMKhKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/opentelemetry": "10.70.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.70.0.tgz",
+      "integrity": "sha512-UNV/2tqypcUK6FDzerAsFJn1Km/c4VZCYkUZDNbnV5S0cwAq2BYKMo4M5vovaLDBQlxA+Wk9ovbxi5wYjjl9fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.70.0.tgz",
+      "integrity": "sha512-xMnSGzJn9Xd29rYd32lkx/gFW+5mtgqADJ2FiZvis0MBGZuDlNRwPn0/Cs1xA3JNXKV3NGfhdmmvs90w4dHSmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.70.0",
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.70.0.tgz",
+      "integrity": "sha512-irzpw22bK5CF3jbecDa0gBUcfjv7tgeUoLAvtIfeHOP5ajmf3o4Cp99a9RQqkfgvkcMeRZBUwE91SQhp6Ank+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.70.0",
+        "@sentry/replay": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.70.0.tgz",
+      "integrity": "sha512-rzegZjMFFgCp3o+N8+XU13rfSvz4B+f8rU0ijBGrQcHdMNyfsFDTu1UTm262JofmrV2u+s+D0u0vFTnqtOGkbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "meriyah": "^6.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.4.0.tgz",
+      "integrity": "sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugins": "^10.64.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/@simple-git/args-pathspec": {
       "version": "1.0.3",
@@ -4735,6 +5447,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "dev": true,
@@ -5316,6 +6037,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -6606,8 +7333,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "dev": true,
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -6966,7 +7694,6 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -6988,7 +7715,6 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -8124,6 +8850,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "dev": true,
@@ -9241,7 +9981,6 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -9582,6 +10321,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/micromark": {
@@ -10303,6 +11051,12 @@
       "version": "0.5.3",
       "license": "MIT"
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/monaco-editor": {
       "version": "0.55.1",
       "license": "MIT",
@@ -10399,6 +11153,27 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-gyp": {
@@ -11216,6 +11991,13 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "license": "MIT",
@@ -11733,6 +12515,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -11989,6 +12784,12 @@
     "node_modules/scheduler": {
       "version": "0.27.0",
       "license": "MIT"
+    },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "license": "Apache-2.0"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -12468,7 +13269,6 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -13050,6 +13850,13 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -13719,6 +14526,24 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "@kangentic/branding": "^2.8.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/test": "^1.60.0",
+    "@sentry/esbuild-plugin": "^5.4.0",
+    "@sentry/vite-plugin": "^5.4.0",
     "@tailwindcss/postcss": "^4.3.0",
     "@tailwindcss/vite": "^4.3.0",
     "@types/better-sqlite3": "^7.6.13",
@@ -119,6 +121,7 @@
     "@aptabase/electron": "^0.3.1",
     "@huggingface/transformers": "^4.2.0",
     "@monaco-editor/react": "^4.7.0",
+    "@sentry/electron": "^7.17.0",
     "@tanstack/react-virtual": "^3.14.2",
     "@xterm/headless": "6.0.0",
     "better-sqlite3": "^12.10.0",
@@ -137,5 +140,17 @@
     "sqlite-vec": "^0.1.9",
     "turndown": "^7.2.4",
     "turndown-plugin-gfm": "^1.0.2"
+  },
+  "allowScripts": {
+    "electron": true,
+    "better-sqlite3": true,
+    "node-pty": true,
+    "esbuild": true,
+    "electron-winstaller": true,
+    "onnxruntime-node": true,
+    "protobufjs": true,
+    "sharp": true,
+    "fsevents": true,
+    "@sentry/cli": true
   }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -13,6 +13,35 @@ const projectDir = path.resolve(__dirname, '..');
 // must be physically present in the binary the test launches.
 const keepDevtools = process.env.KANGENTIC_BUILD_DEV === '1';
 
+// Sentry sourcemap upload for the main + preload bundles, release-only: it
+// activates only when an upload token is present (a CI/release secret; the
+// renderer half lives in vite.config.mts behind the same gate).
+// KANGENTIC_SENTRY_TOKEN is the scoped name; SENTRY_AUTH_TOKEN stays accepted
+// as the conventional CI fallback. Maps are generated as separate files
+// (esbuild 'external' = no sourceMappingURL comment), uploaded with debug
+// IDs, then deleted, so nothing ships.
+const sentryAuthToken = process.env.KANGENTIC_SENTRY_TOKEN ?? process.env.SENTRY_AUTH_TOKEN;
+const uploadSourcemaps = Boolean(sentryAuthToken);
+
+// The uploadSourcemaps guard gates the require below (the function itself runs
+// eagerly at module load), so unit tests that require this module for
+// assertVendorChunksLazy never load the Sentry toolchain when no token is set.
+function resolveSentryEsbuildPlugins() {
+  if (!uploadSourcemaps) return [];
+  const { sentryEsbuildPlugin } = require('@sentry/esbuild-plugin');
+  return [
+    sentryEsbuildPlugin({
+      org: 'kangentic',
+      project: 'desktop',
+      authToken: sentryAuthToken,
+      telemetry: false,
+      sourcemaps: {
+        filesToDeleteAfterUpload: ['.vite/build/*.map'],
+      },
+    }),
+  ];
+}
+
 /**
  * Fails the build unless the two heavy lazy-only vendors (recharts behind
  * LazyStatsDashboard, monaco behind the lazy ChangesPanel) stayed OUT of the
@@ -120,8 +149,9 @@ const esbuildCommon = {
     // via esbuild's dead-code elimination. See scripts/dev.js for the dev value.
     '__KANGENTIC_DEV__': keepDevtools ? 'true' : 'false',
   },
-  sourcemap: false,
+  sourcemap: uploadSourcemaps ? 'external' : false,
   minify: true,
+  plugins: resolveSentryEsbuildPlugins(),
 };
 
 async function build() {

--- a/src/main/agent/mcp-http-server.ts
+++ b/src/main/agent/mcp-http-server.ts
@@ -66,6 +66,7 @@ import {
 import { registerDevtoolsMcpTools } from '../../devtools/mcp/register';
 import { buildServerInstructions } from './mcp-http/server-instructions';
 import { logMcpToolArguments, createToolArgumentNotices, type ToolArgumentNotices } from './mcp-http/tool-call-logging';
+import { trackFeatureUsed } from '../analytics/usage';
 import type { RequestResolver } from './mcp-http/project-resolver';
 
 const SERVER_NAME = 'kangentic';
@@ -484,6 +485,15 @@ async function handleHttpRequest(
       }
       // Diagnostics must never break dispatch.
       try { logMcpToolArguments(parsedBody, toolArgumentNotices); } catch { /* ignore logging failure */ }
+      // Adoption signal: an `initialize` handshake means an MCP client
+      // actually connected (each client sends exactly one per session).
+      // Deliberately not per tool call; trackFeatureUsed dedups to once/day.
+      try {
+        const rpcMessages = Array.isArray(parsedBody) ? parsedBody : [parsedBody];
+        if (rpcMessages.some((message) => (message as { method?: unknown } | null)?.method === 'initialize')) {
+          trackFeatureUsed('mcp_server');
+        }
+      } catch { /* never break dispatch */ }
       await transport.handleRequest(req, res, parsedBody);
     } else {
       // GET (SSE stream) and DELETE (session teardown) carry no JSON body.

--- a/src/main/analytics/analytics.ts
+++ b/src/main/analytics/analytics.ts
@@ -82,13 +82,15 @@ export function trackEvent(eventName: string, props?: Record<string, string | nu
 
 /**
  * Strip file paths from error messages to avoid leaking PII (usernames in paths).
- * Truncates to 200 chars.
+ * Truncates to MAX_ANALYTICS_STRING_LENGTH (180), matching Aptabase's
+ * server-side cap so what we send is what lands (a 200-char local cap
+ * previously let messages 180-200 chars long be silently cut server-side).
  */
 export function sanitizeErrorMessage(message: string): string {
   return message
     .replace(/[A-Z]:\\[^\s:;,)]+/gi, '<path>')       // Windows paths: C:\Users\...
     .replace(/\/(?:home|Users|tmp|var|etc|root|opt)\/[^\s:;,)]+/g, '<path>') // Unix paths
-    .slice(0, 200);
+    .slice(0, MAX_ANALYTICS_STRING_LENGTH);
 }
 
 /**

--- a/src/main/analytics/error-reporting.ts
+++ b/src/main/analytics/error-reporting.ts
@@ -1,0 +1,134 @@
+import { app } from 'electron';
+import * as Sentry from '@sentry/electron/main';
+
+/**
+ * Sentry DSN for the Kangentic desktop project (kangentic.sentry.io, project
+ * `desktop`). A DSN is a public routing identifier by design (like
+ * APTABASE_APP_KEY in analytics.ts), not a secret. An empty string would make
+ * initErrorReporting() a no-op and keep the renderer flag off, so the wiring
+ * ships inert if this is ever cleared.
+ */
+const SENTRY_DSN =
+  'https://6368bfbd74782d122cb321b26799bddd@o4511808143556608.ingest.us.sentry.io/4511996066660352';
+
+let active = false;
+
+/**
+ * Decide whether Sentry error reporting should be enabled, as a pure function
+ * of the two env switches and the packaged state.
+ *
+ * The contract (docs/analytics.md):
+ * - KANGENTIC_TELEMETRY=0/false is the superset kill switch: it disables ALL
+ *   telemetry egress, Aptabase and Sentry both. Users who set it were promised
+ *   "disables analytics entirely" before Sentry existed; that promise holds.
+ * - KANGENTIC_ERROR_REPORTING=0/false disables Sentry alone (Aptabase unaffected).
+ * - KANGENTIC_ERROR_REPORTING=1/true force-enables Sentry (e.g. in dev), unless
+ *   the superset kill switch is set.
+ * - Unset inherits the analytics default: KANGENTIC_TELEMETRY=1/true forces on,
+ *   otherwise on in packaged builds only.
+ */
+export function resolveErrorReportingEnabled(
+  telemetryValue: string | undefined,
+  errorReportingValue: string | undefined,
+  isPackaged: boolean
+): boolean {
+  if (telemetryValue === '0' || telemetryValue === 'false') return false;
+  if (errorReportingValue === '0' || errorReportingValue === 'false') return false;
+  if (errorReportingValue === '1' || errorReportingValue === 'true') return true;
+  if (telemetryValue === '1' || telemetryValue === 'true') return true;
+  return isPackaged;
+}
+
+/**
+ * Whether Sentry actually initialized this run. Read by createWindow to pass
+ * the --kangentic-error-reporting flag to the renderer, which gates the
+ * renderer-side Sentry.init() on the same single decision made here.
+ */
+export function isErrorReportingActive(): boolean {
+  return active;
+}
+
+/**
+ * Attach the anonymous, non-reversible install id (the same clientId
+ * analytics attaches to app_launch - see analytics/client-id.ts) as the
+ * Sentry user id. This is what makes the per-issue "Users" count real
+ * (how many installs an issue affects), with no new data class: the id is
+ * already disclosed in docs/analytics.md and contains no personal data.
+ */
+export function setErrorReportingUser(clientId: string): void {
+  if (!active) return;
+  try {
+    Sentry.setUser({ id: clientId });
+  } catch {
+    // Never disrupt startup for telemetry
+  }
+}
+
+/**
+ * Forward a HANDLED error to Sentry with its real stack. The SDK's global
+ * handlers only see UNCAUGHT errors, so the deliberate catch sites that today
+ * emit only a sanitized app_error count (updater structural failures, PTY
+ * spawn failures, the silent agent-spawn catches) would stay invisible as
+ * diagnosable issues - exactly the "hidden issue" class error reporting
+ * exists for. Tags are for grouping/filtering; never put content in them.
+ */
+export function reportHandledError(error: unknown, tags: Record<string, string> = {}): void {
+  if (!active) return;
+  try {
+    Sentry.withScope((scope) => {
+      for (const [tagKey, tagValue] of Object.entries(tags)) scope.setTag(tagKey, tagValue);
+      Sentry.captureException(error instanceof Error ? error : new Error(String(error)));
+    });
+  } catch {
+    // Error reporting must never cascade into the failing path itself
+  }
+}
+
+/**
+ * Initialize Sentry error reporting. Must be called BEFORE app.whenReady(),
+ * next to initAnalytics() (the SDK wires its renderer IPC/protocol transport
+ * during init).
+ *
+ * Scrubbing is deliberately Sentry's job, not ours: the SDK's default
+ * normalizePathsIntegration rewrites stack-frame paths and URLs relative to
+ * the app root (so the user's home directory never reaches Sentry for app
+ * code), sendDefaultPii stays false, and Sentry's server-side data scrubbing
+ * is on by default. Any further rule belongs in the Sentry UI (Advanced Data
+ * Scrubbing), not in a custom beforeSend here.
+ *
+ * Errors only: release-health session tracking (the MainProcessSession
+ * integration, on by default) is filtered out, and tracing/replay are never
+ * enabled. Aptabase's app_error stays as the coarse error-rate pulse on the
+ * product dashboard; Sentry is the diagnostic tool.
+ */
+export function initErrorReporting(): void {
+  if (!SENTRY_DSN) return;
+  if (
+    !resolveErrorReportingEnabled(
+      process.env.KANGENTIC_TELEMETRY,
+      process.env.KANGENTIC_ERROR_REPORTING,
+      app.isPackaged
+    )
+  ) {
+    return;
+  }
+
+  try {
+    Sentry.init({
+      dsn: SENTRY_DSN,
+      sendDefaultPii: false,
+      integrations: (defaultIntegrations) =>
+        defaultIntegrations.filter(
+          (integration) => integration.name !== 'MainProcessSession'
+        ),
+      // The known-benign Windows `npm start` TTY write artifacts that
+      // index.ts's isSuppressibleUncaughtError filters for Aptabase. Sentry's
+      // own global handlers would otherwise report them as crashes.
+      ignoreErrors: ['write EAGAIN', 'write EPIPE'],
+    });
+    active = true;
+  } catch (error) {
+    console.error('[ANALYTICS] Failed to initialize error reporting:', error);
+    active = false;
+  }
+}

--- a/src/main/analytics/usage.ts
+++ b/src/main/analytics/usage.ts
@@ -1,0 +1,212 @@
+import { promises as fsPromises, readFileSync } from 'node:fs';
+import { trackEvent } from './analytics';
+
+/**
+ * The curated feature vocabulary for adoption tracking. Deliberately small:
+ * each feature adds up to one `feature_used` event per user per day, so the
+ * list is a budget decision, not a free enum (see docs/analytics.md's event
+ * budget). Renderer-reported features arrive over IPC and are validated
+ * against this list, so a compromised or drifted renderer cannot invent
+ * event vocabulary.
+ */
+export const ANALYTICS_FEATURES = [
+  'command_terminal',
+  'worktree_session',
+  'board_profile',
+  'popout_window',
+  'browser_pane',
+  'mcp_server',
+  'mobile_bridge',
+  'usage_dashboard',
+  'quick_find',
+  'settings',
+] as const;
+
+export type AnalyticsFeature = (typeof ANALYTICS_FEATURES)[number];
+
+const featureSet: ReadonlySet<string> = new Set(ANALYTICS_FEATURES);
+
+/** Type guard for renderer-supplied feature names crossing the IPC boundary. */
+export function isKnownAnalyticsFeature(value: string): value is AnalyticsFeature {
+  return featureSet.has(value);
+}
+
+/**
+ * Onboarding funnel steps, each fired at most once per install so the funnel
+ * reads as install counts per step (where do new installs stall?).
+ * `first_project` rides the project_create path; the rest ride the first task
+ * create / agent spawn / done-move.
+ */
+export const ONBOARDING_MILESTONES = [
+  'first_project',
+  'first_task',
+  'first_spawn',
+  'first_task_complete',
+] as const;
+
+export type OnboardingMilestone = (typeof ONBOARDING_MILESTONES)[number];
+
+interface UsageFlags {
+  milestones: Partial<Record<OnboardingMilestone, true>>;
+  featureFirstUse: Partial<Record<AnalyticsFeature, true>>;
+  /** The app version of the previous run, for update_outcome detection. */
+  lastRunVersion?: string;
+}
+
+/**
+ * Lifetime once-per-install flags, persisted beside analytics-client-id.json
+ * in the global config dir (NOT per-project: milestones describe the install).
+ * Null until initUsageAnalytics runs; while null, lifetime-once events
+ * (feature_first_use, onboarding_milestone) are skipped entirely rather than
+ * fired unbounded, and only the in-memory daily-deduped feature_used flows.
+ *
+ * Deliberately NOT gated on whether analytics is enabled: trackEvent already
+ * no-ops when disabled, and a dev/opted-out install burning its lifetime flags
+ * sends nothing either way. Dev machines are not real installs; an opted-out
+ * user stays opted out.
+ */
+let usageFlags: UsageFlags | null = null;
+let usageFlagsPath: string | null = null;
+
+/** In-memory once-per-UTC-day dedup for feature_used. Resets on app restart,
+ *  which can only under-dedup (an extra event after a same-day restart), never
+ *  inflate past one per feature per app run per day. */
+const featureUsedDay = new Map<AnalyticsFeature, string>();
+
+function currentUtcDay(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Serializes flag writes: two milestones landing in the same tick would
+ *  otherwise race unordered writeFile calls on one path and can leave the
+ *  file holding the OLDER state (or interleaved garbage). The chain keeps
+ *  order; each payload is a full snapshot, so the last write wins whole. */
+let pendingFlagsWrite: Promise<void> = Promise.resolve();
+
+function persistUsageFlags(): void {
+  if (!usageFlags || !usageFlagsPath) return;
+  const targetPath = usageFlagsPath;
+  const payload = JSON.stringify(usageFlags, null, 2);
+  // Fire-and-forget like every other analytics write: losing a flag write
+  // means at worst one duplicate lifetime event on a later run.
+  pendingFlagsWrite = pendingFlagsWrite
+    .then(() => fsPromises.writeFile(targetPath, payload, 'utf-8'))
+    .catch(() => {});
+}
+
+/** A JSON object (not array/primitive) usable as a flag record; anything else
+ *  falls back to empty. Field-level, because a syntactically valid file with
+ *  the wrong shape (a string where a record belongs) would otherwise flow
+ *  through an `as` cast and make trackMilestone's property write throw a
+ *  TypeError out of its call sites (project create, startup). */
+function asFlagRecord<FlagKey extends string>(value: unknown): Partial<Record<FlagKey, true>> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Partial<Record<FlagKey, true>>)
+    : {};
+}
+
+/**
+ * Load (or create) the lifetime usage flags. Called once at startup from
+ * index.ts with a path under the global config dir. Sync read: the file is a
+ * few hundred bytes and startup already does sync config reads.
+ */
+export function initUsageAnalytics(flagsFilePath: string): void {
+  usageFlagsPath = flagsFilePath;
+  try {
+    const parsed = JSON.parse(readFileSync(flagsFilePath, 'utf-8')) as Record<string, unknown> | null;
+    const lastRunVersion = parsed?.lastRunVersion;
+    usageFlags = {
+      milestones: asFlagRecord<OnboardingMilestone>(parsed?.milestones),
+      featureFirstUse: asFlagRecord<AnalyticsFeature>(parsed?.featureFirstUse),
+      lastRunVersion: typeof lastRunVersion === 'string' ? lastRunVersion : undefined,
+    };
+  } catch {
+    // Missing or corrupt file: start fresh. Worst case is one repeated
+    // lifetime event, not data loss.
+    usageFlags = { milestones: {}, featureFirstUse: {} };
+  }
+}
+
+/**
+ * Record one use of a curated feature. Emits `feature_used` at most once per
+ * feature per UTC day, and `feature_first_use` at most once per install.
+ * Fire-and-forget from any main-process call site; renderer surfaces reach
+ * this through the analytics:trackFeatureUsed IPC funnel.
+ */
+export function trackFeatureUsed(feature: AnalyticsFeature): void {
+  const day = currentUtcDay();
+  if (featureUsedDay.get(feature) !== day) {
+    featureUsedDay.set(feature, day);
+    trackEvent('feature_used', { feature });
+  }
+  if (usageFlags && !usageFlags.featureFirstUse[feature]) {
+    usageFlags.featureFirstUse[feature] = true;
+    trackEvent('feature_first_use', { feature });
+    persistUsageFlags();
+  }
+}
+
+/**
+ * Record an onboarding funnel step, at most once per install. No-op until
+ * initUsageAnalytics has loaded the lifetime flags.
+ */
+export function trackMilestone(step: OnboardingMilestone): void {
+  if (!usageFlags || usageFlags.milestones[step]) return;
+  usageFlags.milestones[step] = true;
+  trackEvent('onboarding_milestone', { step });
+  persistUsageFlags();
+}
+
+/**
+ * Bucket an absolute task count for board_snapshot, so board size reads as a
+ * distribution without ever sending an exact per-user count.
+ */
+export function bucketTaskCount(count: number): string {
+  if (count === 0) return '0';
+  if (count <= 9) return '1-9';
+  if (count <= 49) return '10-49';
+  if (count <= 199) return '50-199';
+  return '200+';
+}
+
+/** Numeric-tuple compare of dotted versions; non-numeric segments compare 0. */
+function isVersionDowngrade(fromVersion: string, toVersion: string): boolean {
+  const fromParts = fromVersion.split('.').map((part) => Number.parseInt(part, 10) || 0);
+  const toParts = toVersion.split('.').map((part) => Number.parseInt(part, 10) || 0);
+  const length = Math.max(fromParts.length, toParts.length);
+  for (let index = 0; index < length; index += 1) {
+    const fromSegment = fromParts[index] ?? 0;
+    const toSegment = toParts[index] ?? 0;
+    if (toSegment < fromSegment) return true;
+    if (toSegment > fromSegment) return false;
+  }
+  return false;
+}
+
+/**
+ * Detect an applied update (or rollback) by comparing this run's version with
+ * the persisted previous run's. Fired once per launch from index.ts. A failed
+ * update never reaches here; it reports through app_error `source: 'updater'`
+ * (and Sentry). First run ever just records the baseline.
+ */
+export function trackUpdateOutcome(currentVersion: string): void {
+  if (!usageFlags) return;
+  const previousVersion = usageFlags.lastRunVersion;
+  if (previousVersion === currentVersion) return;
+  if (previousVersion) {
+    trackEvent('update_outcome', {
+      result: isVersionDowngrade(previousVersion, currentVersion) ? 'rolled_back' : 'applied',
+      fromVersion: previousVersion,
+      toVersion: currentVersion,
+    });
+  }
+  usageFlags.lastRunVersion = currentVersion;
+  persistUsageFlags();
+}
+
+/** Reset module state between unit tests (vitest shares module instances). */
+export function resetUsageAnalyticsForTests(): void {
+  usageFlags = null;
+  usageFlagsPath = null;
+  featureUsedDay.clear();
+}

--- a/src/main/browser/browser-pane-registry.ts
+++ b/src/main/browser/browser-pane-registry.ts
@@ -1,6 +1,7 @@
 import { webContents as electronWebContents, type WebContents } from 'electron';
 import { randomUUID } from 'node:crypto';
 import { detachDebugger, isDebuggerAttached } from './cdp/cdp';
+import { trackFeatureUsed } from '../analytics/usage';
 import type { BrowserPaneVisibility } from '../../shared/types';
 
 /**
@@ -364,6 +365,10 @@ export class BrowserPaneRegistry {
         `task=${entry.taskId.slice(0, 8)} wc=${entry.webContentsId} kind=${entry.kind}` +
         (entry.handoff ? ' handoff' : ''),
     );
+    // Adoption signal for user-visible panes only: offscreen lanes are the
+    // driver's plumbing, not a user opening the Browser pane. New-entry branch
+    // only, so a rebind of the same guest never re-counts.
+    if (entry.kind === 'pane') trackFeatureUsed('browser_pane');
     this.announceRegistered(entry);
     return entry;
   }

--- a/src/main/db/migrations/default-data.ts
+++ b/src/main/db/migrations/default-data.ts
@@ -2,6 +2,23 @@ import type Database from 'better-sqlite3';
 import { v4 as uuidv4 } from 'uuid';
 
 /**
+ * The seeded default board. Exported (not just function-local) so the
+ * board_snapshot analytics event can classify a board as customized against
+ * the same literal the seeder writes, with no second copy to drift.
+ * Readonly (as const): a consumer mutating the shared array would corrupt
+ * every later seed in this process, so mutation must fail at compile time.
+ */
+export const DEFAULT_SWIMLANES = [
+  { name: 'To Do', role: 'todo', color: '#6b7280', icon: 'layers', archived: 0, permission_mode: null, auto_spawn: 0, auto_command: null },
+  { name: 'Planning', role: null, color: '#8b5cf6', icon: 'map', archived: 0, permission_mode: 'plan', auto_spawn: 1, auto_command: null },
+  { name: 'Executing', role: null, color: '#3b82f6', icon: 'square-terminal', archived: 0, permission_mode: null, auto_spawn: 1, auto_command: null },
+  { name: 'Code Review', role: null, color: '#f59e0b', icon: 'code', archived: 0, permission_mode: null, auto_spawn: 1, auto_command: null },
+  { name: 'Testing', role: null, color: '#06b6d4', icon: 'flask-conical', archived: 0, permission_mode: null, auto_spawn: 1, auto_command: null },
+  { name: 'Merge', role: null, color: '#f97316', icon: 'merge', archived: 0, permission_mode: null, auto_spawn: 1, auto_command: null },
+  { name: 'Done', role: 'done', color: '#10b981', icon: 'circle-check-big', archived: 1, permission_mode: null, auto_spawn: 0, auto_command: null },
+] as const;
+
+/**
  * Seed default swimlanes, actions, and transitions for a new project database.
  * Called from project-schema.ts when the swimlanes table is empty.
  */
@@ -10,15 +27,7 @@ export function seedDefaultSwimlanes(db: Database.Database): void {
   const insertLane = db.prepare(
     'INSERT INTO swimlanes (id, name, role, position, color, icon, is_archived, permission_mode, auto_spawn, auto_command, plan_exit_target_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
   );
-  const defaults = [
-    { name: 'To Do', role: 'todo', color: '#6b7280', icon: 'layers', archived: 0, permission_mode: null, auto_spawn: 0, auto_command: null },
-    { name: 'Planning', role: null, color: '#8b5cf6', icon: 'map', archived: 0, permission_mode: 'plan', auto_spawn: 1, auto_command: null },
-    { name: 'Executing', role: null, color: '#3b82f6', icon: 'square-terminal', archived: 0, permission_mode: null, auto_spawn: 1, auto_command: null },
-    { name: 'Code Review', role: null, color: '#f59e0b', icon: 'code', archived: 0, permission_mode: null, auto_spawn: 1, auto_command: null },
-    { name: 'Testing', role: null, color: '#06b6d4', icon: 'flask-conical', archived: 0, permission_mode: null, auto_spawn: 1, auto_command: null },
-    { name: 'Merge', role: null, color: '#f97316', icon: 'merge', archived: 0, permission_mode: null, auto_spawn: 1, auto_command: null },
-    { name: 'Done', role: 'done', color: '#10b981', icon: 'circle-check-big', archived: 1, permission_mode: null, auto_spawn: 0, auto_command: null },
-  ];
+  const defaults = DEFAULT_SWIMLANES;
 
   const tx = db.transaction(() => {
     const laneIds: string[] = [];

--- a/src/main/db/repositories/task-repository.ts
+++ b/src/main/db/repositories/task-repository.ts
@@ -509,6 +509,18 @@ export class TaskRepository {
   }
 
   /**
+   * Total task count, active plus archived, as a bare COUNT(*). For callers
+   * that need only the number (board_snapshot's bucketed count): list() would
+   * materialize every row plus the attachment-count join just to take .length.
+   */
+  countAll(): number {
+    const { count } = this.db
+      .prepare('SELECT COUNT(*) AS count FROM tasks')
+      .get() as { count: number };
+    return count;
+  }
+
+  /**
    * The newest `limit` archived tasks plus the total archived count. Lets the
    * board hydrate the Done column's count + inline preview without fetching the
    * whole archive (which can be many MB once hundreds of tasks accumulate). The

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,6 +26,8 @@ import { isShuttingDown, setShuttingDown } from './shutdown-state';
 import { isBenignStreamWriteError } from './diagnostics/benign-stream-error';
 const windowConfigManager = new ConfigManager();
 import { initAnalytics, trackEvent, sanitizeErrorMessage, shouldEmitHeartbeat, setAnalyticsClientId } from './analytics/analytics';
+import { initErrorReporting, isErrorReportingActive, setErrorReportingUser } from './analytics/error-reporting';
+import { initUsageAnalytics, trackUpdateOutcome } from './analytics/usage';
 import { resolveClientId } from './analytics/client-id';
 import { PATHS } from './config/paths';
 // Whether this launch found an existing global config.json. Read at module
@@ -207,6 +209,13 @@ import { ensureSpawnHelperPermissions } from './pty/spawn/spawn-helper-permissio
 // to register protocol schemes. The analytics module decides whether to activate
 // based on app.isPackaged and the KANGENTIC_TELEMETRY env var.
 initAnalytics();
+
+// Initialize Sentry error reporting beside it (also pre-ready: the SDK wires
+// its renderer IPC/protocol transport during init). Gated by the same
+// KANGENTIC_TELEMETRY superset kill switch plus KANGENTIC_ERROR_REPORTING;
+// scrubbing and event hygiene are the SDK's and Sentry's job, not ours
+// (see analytics/error-reporting.ts).
+initErrorReporting();
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string;
 declare const MAIN_WINDOW_VITE_NAME: string;
@@ -743,20 +752,24 @@ const createWindow = () => {
       // Enable <webview> for the embedded browser side-pane in the task-detail
       // window. Hardened via the will-attach-webview hook below.
       webviewTag: true,
-      // Surface the ephemeral-preview flag (and, when resolvable, the original task
-      // title) to the renderer (read in preload via process.argv). Set ONLY in
+      // Surface boot flags to the renderer (read in preload via process.argv).
+      // --kangentic-error-reporting mirrors main's single Sentry decision so the
+      // renderer-side Sentry.init() can never disagree with it. The ephemeral-preview
+      // flag (and, when resolvable, the original task title) is set ONLY in
       // dev-preview mode (`--ephemeral`), so the dev TestHarness and the preview title
       // stay out of the regular `npm start` dogfood. The title is base64-encoded so a
       // value with spaces / `:` / `/` survives command-line round-tripping intact.
-      additionalArguments:
-        __KANGENTIC_DEV__ && isEphemeral
+      additionalArguments: [
+        ...(isErrorReportingActive() ? ['--kangentic-error-reporting'] : []),
+        ...(__KANGENTIC_DEV__ && isEphemeral
           ? [
               '--kangentic-ephemeral',
               ...(previewTaskTitle
                 ? [`--kangentic-preview-task-title=${Buffer.from(previewTaskTitle, 'utf-8').toString('base64')}`]
                 : []),
             ]
-          : [],
+          : []),
+      ],
     },
   });
 
@@ -1236,6 +1249,17 @@ app.whenReady().then(async () => {
     return isFirstPartyPermissionAllowed(permission);
   });
 
+  // Lifetime usage flags (onboarding milestones, feature first-use, last-run
+  // version) live beside the client-id file in the global config dir. Loaded
+  // BEFORE createWindow(): registerAllIpc (inside it) attaches the
+  // session-changed listener whose trackMilestone('first_spawn') silently
+  // no-ops until these flags load, and startup session recovery can reach
+  // 'running' before post-window init would have run. Loading also arms
+  // update_outcome: an applied update or rollback is detected as a version
+  // change between runs.
+  initUsageAnalytics(path.join(PATHS.configDir, 'analytics-usage.json'));
+  trackUpdateOutcome(app.getVersion());
+
   createWindow();
   initUpdater(mainWindow!);
   initAnnouncements(mainWindow!);
@@ -1278,6 +1302,9 @@ app.whenReady().then(async () => {
     path.join(PATHS.configDir, 'analytics-client-id.json')
   );
   setAnalyticsClientId(clientId);
+  // Same anonymous id as the Sentry user id, so issues carry an affected-
+  // installs count (no-op unless error reporting initialized).
+  setErrorReportingUser(clientId);
 
   // Fire app_launch event (analytics initialized before app.whenReady above).
   // trackEvent is a no-op if analytics is disabled, so no guard needed here.

--- a/src/main/ipc/handlers/projects.ts
+++ b/src/main/ipc/handlers/projects.ts
@@ -19,6 +19,8 @@ import { applyRuntimeConfig } from '../../config/apply-runtime-config';
 import { ensureGitignore } from '../helpers';
 import { searchProjectEntries } from '../helpers/project-entry-search';
 import { trackEvent } from '../../analytics/analytics';
+import { trackMilestone, bucketTaskCount } from '../../analytics/usage';
+import { DEFAULT_SWIMLANES } from '../../db/migrations/default-data';
 import { isShuttingDown } from '../../shutdown-state';
 import { runWithProjectLogContext } from '../../diagnostics/project-log-context';
 import { prRefreshScheduler } from '../../pr/pr-refresh-scheduler';
@@ -608,6 +610,7 @@ export function registerProjectHandlers(context: IpcContext): void {
     const defaults = getLastProjectOverrides(context.projectRepo, context.configManager, project.path);
     context.configManager.saveProjectOverrides(project.path, defaults);
     trackEvent('project_create');
+    trackMilestone('first_project');
     return project;
   });
 
@@ -681,6 +684,26 @@ export function registerProjectHandlers(context: IpcContext): void {
           const taskRepo = new TaskRepository(db);
           const sessionRepo = new SessionRepository(db);
           const swimlaneRepo = new SwimlaneRepository(db);
+
+          // Analytics: one board-shape snapshot per cold open (the
+          // recoveredProjects guard above makes this once per project per app
+          // run). Counts only - names and content never leave the machine;
+          // the task count is bucketed so no exact figure is sent.
+          try {
+            const lanes = swimlaneRepo.list();
+            const defaultNames = new Set<string>(DEFAULT_SWIMLANES.map((lane) => lane.name));
+            const taskCount = taskRepo.countAll();
+            trackEvent('board_snapshot', {
+              columns: lanes.length,
+              customColumns:
+                lanes.length !== DEFAULT_SWIMLANES.length ||
+                lanes.some((lane) => !defaultNames.has(lane.name)),
+              taskBucket: bucketTaskCount(taskCount),
+              profiles: context.boardConfigManager.getBoardProfiles(project.path).length,
+            });
+          } catch {
+            // Snapshot must never interfere with recovery below
+          }
 
           // Ordering contract (see pruneOrphanedWorktreeTasks): the prune
           // completes before session recovery reads the DB; the slow

--- a/src/main/ipc/handlers/sessions.ts
+++ b/src/main/ipc/handlers/sessions.ts
@@ -12,6 +12,7 @@ import { applyProfileToLane } from '../../transition-engine/column-strategy';
 import { loadTaskProfile } from '../helpers/task-profile';
 import { handleTaskMove } from './task-move';
 import { trackEvent } from '../../analytics/analytics';
+import { trackFeatureUsed, trackMilestone } from '../../analytics/usage';
 import { parseModelId } from '../../../shared/model-id';
 import { captureSessionMetrics, refineTranscriptTokens, refineTranscriptToolCounts } from './session-metrics';
 import { captureGitChurn, resolveDefaultBaseBranch } from './git-stats-capture';
@@ -506,15 +507,41 @@ export function registerSessionHandlers(context: IpcContext): void {
 
       // Analytics: track spawn intent on the first running transition. Model
       // is not known yet (arrives later via status.json) and is omitted here -
-      // session_exit / task_complete carry the model.
+      // session_exit / task_complete carry the model. permissionMode (the
+      // resolved mode the session record spawned under, not the task's raw
+      // override) and worktree ride the same event as budget-neutral props.
+      // This listener sees EVERY spawn path (board move, create, recovery,
+      // transient), which also makes it the one chokepoint for the
+      // worktree/profile adoption signals and the first_spawn milestone.
       if (!sessionSpawnAnalyticsFired.has(sessionId)) {
         sessionSpawnAnalyticsFired.add(sessionId);
         const spawnAgentName = context.sessionManager.getSessionAgentName(sessionId);
         if (spawnAgentName) {
-          trackEvent('session_spawn', {
+          const spawnProps: Record<string, string | number | boolean> = {
             agent: spawnAgentName,
             isTransient: !!session.transient,
-          });
+          };
+          try {
+            const spawnProjectId = context.sessionManager.getSessionProjectId(sessionId);
+            // Not during shutdown: getProjectDb silently REOPENS a just-closed
+            // project DB (close deletes the cache entry, so the next call
+            // constructs a fresh connection nothing ever closes again).
+            if (!isShuttingDown() && spawnProjectId && session.taskId) {
+              const database = getProjectDb(spawnProjectId);
+              const spawnRecord = new SessionRepository(database).getLatestForTask(session.taskId);
+              if (spawnRecord?.permission_mode) spawnProps.permissionMode = spawnRecord.permission_mode;
+              const taskRow = new TaskRepository(database).getById(session.taskId);
+              if (taskRow) {
+                spawnProps.worktree = !!taskRow.worktree_path;
+                if (taskRow.worktree_path) trackFeatureUsed('worktree_session');
+                if (taskRow.profile_id) trackFeatureUsed('board_profile');
+              }
+            }
+          } catch {
+            // Enrichment is best-effort; the base props still send
+          }
+          trackEvent('session_spawn', spawnProps);
+          if (!session.transient) trackMilestone('first_spawn');
         }
       }
 
@@ -602,6 +629,10 @@ export function registerSessionHandlers(context: IpcContext): void {
         exitProps.costUsd = Math.round(usageForExit.cost.totalCostUsd * 10000) / 10000;
       }
       exitProps.toolCalls = context.sessionManager.getToolCallCount(sessionId);
+      // Crash-vs-deliberate: kill()/suspend tag the exit intentional (see
+      // session-spawn-flow.ts); undefined means a genuine agent-side exit, so
+      // compare === true like every other consumer of the flag.
+      exitProps.intentional = intentional === true;
       trackEvent('session_exit', exitProps);
       sessionStartTimes.delete(sessionId);
       sessionSpawnAnalyticsFired.delete(sessionId);

--- a/src/main/ipc/handlers/task-crud.ts
+++ b/src/main/ipc/handlers/task-crud.ts
@@ -17,6 +17,9 @@ import {
   spawnAgent,
 } from '../helpers';
 import { resolveProjectContext } from '../helpers/project-repos';
+import { trackEvent } from '../../analytics/analytics';
+import { reportHandledError } from '../../analytics/error-reporting';
+import { trackMilestone } from '../../analytics/usage';
 import { linkPR } from '../../pr/pr-linking';
 import { applyProfileToLane } from '../../transition-engine/column-strategy';
 import { createProgressCallback, clearSpawnProgress } from '../../transition-engine/spawn-progress';
@@ -95,6 +98,7 @@ export function registerTaskCrudHandlers(context: IpcContext): void {
     const { tasks, swimlanes, actions, attachments } = getProjectRepos(context, resolvedProjectId);
     const { pendingAttachments, ...taskInput } = input;
     const task = tasks.create(taskInput);
+    trackMilestone('first_task');
 
     // Save any pending attachments from the dialog
     if (pendingAttachments?.length && resolvedProjectPath) {
@@ -158,6 +162,11 @@ export function registerTaskCrudHandlers(context: IpcContext): void {
             await spawnAgent({ context, engine, tasks, sessionRepo, task, fromSwimlaneId: '*', toLane, projectId, projectPath, attachments });
           } catch (err) {
             console.error('[TASK_CREATE] Failed to start session:', err);
+            // The resolved agent lives inside spawnAgent and is not returned;
+            // the override chain is the best available approximation here.
+            const failedAgent = task.agent_override ?? toLane.agent_override ?? 'default';
+            trackEvent('spawn_failed', { agent: failedAgent, reason: 'create_spawn' });
+            reportHandledError(err, { source: 'spawn', reason: 'create_spawn', agent: failedAgent });
           }
         } finally {
           clearSpawnProgress(context.mainWindow, task.id);

--- a/src/main/ipc/handlers/task-move.ts
+++ b/src/main/ipc/handlers/task-move.ts
@@ -22,6 +22,7 @@ import { sendToRenderer } from '../send-to-renderer';
 import { resolveProjectContext } from '../helpers/project-repos';
 import { interpolateTaskTemplate, resolveTaskTemplateVars } from '../../agent/shared';
 import { trackEvent } from '../../analytics/analytics';
+import { trackMilestone } from '../../analytics/usage';
 import { getDevPortForTask } from '../../dev-ports/dev-port-allocator';
 import { parseModelId } from '../../../shared/model-id';
 import { captureSessionMetrics, refineTranscriptTokens, refineTranscriptToolCounts } from './session-metrics';
@@ -356,6 +357,11 @@ export async function handleTaskMove(
         if (latestSessionRecord?.model_id) {
           completeProps.model = parseModelId(latestSessionRecord.model_id).baseId;
         }
+        // The resolved mode the last session actually ran under (the task's
+        // own permission_mode is a raw override, null = inherit).
+        if (latestSessionRecord?.permission_mode) {
+          completeProps.permissionMode = latestSessionRecord.permission_mode;
+        }
         const lifetimeSummary = sessionRepo.getSummaryForTask(task.id);
         if (lifetimeSummary) {
           completeProps.durationSeconds = Math.round(lifetimeSummary.durationMs / 1000);
@@ -365,6 +371,7 @@ export async function handleTaskMove(
           completeProps.toolCalls = lifetimeSummary.toolCallCount;
         }
         trackEvent('task_complete', completeProps);
+        trackMilestone('first_task_complete');
       }
 
       // --- Priority 1: TARGET IS TO DO → full reset (kill session, remove worktree, delete branch) ---

--- a/src/main/ipc/handlers/transient-sessions.ts
+++ b/src/main/ipc/handlers/transient-sessions.ts
@@ -7,6 +7,7 @@ import { IPC } from '../../../shared/ipc-channels';
 import { resolveProjectRoot } from '../../../shared/git-utils';
 import { fetchIfStale } from '../../git/fetch-throttle';
 import { trackEvent } from '../../analytics/analytics';
+import { trackFeatureUsed } from '../../analytics/usage';
 import { agentRegistry } from '../../agent/agent-registry';
 import { DEFAULT_AGENT } from '../../../shared/types';
 import type {
@@ -128,6 +129,7 @@ export function registerTransientSessionHandlers(context: IpcContext): void {
     });
 
     trackEvent('transient_session_spawn', { agent: adapter.name });
+    trackFeatureUsed('command_terminal');
     return { session, branch, checkoutError };
   });
 

--- a/src/main/ipc/helpers/agent-spawn.ts
+++ b/src/main/ipc/helpers/agent-spawn.ts
@@ -7,6 +7,8 @@ import { HandoffRepository } from '../../db/repositories/handoff-repository';
 import { TransitionEngine } from '../../transition-engine/transition-engine';
 import { getProjectDb } from '../../db/database';
 import { interpolateTaskTemplate, resolveTaskTemplateVars } from '../../agent/shared';
+import { trackEvent } from '../../analytics/analytics';
+import { reportHandledError } from '../../analytics/error-reporting';
 import { resolveDefaultBaseBranch } from '../handlers/git-stats-capture';
 import { getDevPortForTask } from '../../dev-ports/dev-port-allocator';
 import { agentRegistry } from '../../agent/agent-registry';
@@ -455,6 +457,10 @@ export async function spawnAgent(options: AgentSpawnOptions): Promise<void> {
   } catch (error) {
     if (isAbortError(error)) throw error;
     console.error('[spawnAgent] Failed to start session:', error);
+    // The deepest silent failure on the board path: nothing reaches the user,
+    // so at least the failure-rate signal must not stay blind.
+    trackEvent('spawn_failed', { agent: targetAgent, reason: 'resume' });
+    reportHandledError(error, { source: 'spawn', reason: 'resume', agent: targetAgent });
     return;
   }
 
@@ -598,6 +604,17 @@ export async function autoSpawnForTask(
       }
     } catch (err) {
       console.error('[MCP auto-spawn] Failed:', err);
+      // fullTask/toLane are declared inside the try, so re-read the row here;
+      // its override is the best approximation of the agent on this path.
+      let failedAgent = 'default';
+      try {
+        failedAgent =
+          getProjectRepos(context, projectId).tasks.getById(task.id)?.agent_override ?? 'default';
+      } catch {
+        // DB may be closed; keep the placeholder
+      }
+      trackEvent('spawn_failed', { agent: failedAgent, reason: 'auto_spawn' });
+      reportHandledError(err, { source: 'spawn', reason: 'auto_spawn', agent: failedAgent });
     }
     };
     return logProjectName ? runWithProjectLogContext(logProjectName, run) : run();

--- a/src/main/ipc/register-all.ts
+++ b/src/main/ipc/register-all.ts
@@ -7,6 +7,7 @@ import {
   summarizeComponentStack,
   MAX_ANALYTICS_STRING_LENGTH,
 } from '../analytics/analytics';
+import { trackFeatureUsed, isKnownAnalyticsFeature } from '../analytics/usage';
 import { ProjectRepository } from '../db/repositories/project-repository';
 import { ProjectGroupRepository } from '../db/repositories/project-group-repository';
 import { SessionManager } from '../pty/session-manager';
@@ -280,6 +281,16 @@ export function registerAllIpc(mainWindow: BrowserWindow, mcpServerHandle: McpHt
       trackEvent('app_error', props);
     }
   );
+
+  // Analytics: renderer feature-adoption reporting (fire-and-forget). The
+  // feature name is re-validated at RUNTIME against the curated allowlist
+  // (usage.ts) because the string is erased at the IPC boundary; an unknown
+  // value is dropped so the renderer cannot invent event vocabulary. Dedup
+  // (once per feature per day, first-use lifetime) lives in trackFeatureUsed.
+  ipcMain.on(IPC.TRACK_FEATURE_USED, (_event, feature: string) => {
+    if (typeof feature !== 'string' || !isKnownAnalyticsFeature(feature)) return;
+    trackFeatureUsed(feature);
+  });
 }
 
 // Thin wrappers -- same signatures as before, zero changes in index.ts

--- a/src/main/mobile-bridge/mobile-bridge-service.ts
+++ b/src/main/mobile-bridge/mobile-bridge-service.ts
@@ -14,6 +14,7 @@ import {
   type ShortAuthenticationString,
 } from '@kangentic/protocol';
 import { isGenuineEncryptionAvailable } from '../boards/shared/auth';
+import { trackFeatureUsed } from '../analytics/usage';
 import { validateRelayUrl } from '../../shared/relay';
 import type { MobileBridgeStatus, MobileBridgeTransportState, MobileDeviceConnectionState } from '../../shared/types';
 import { DevQuickPair } from './dev-quick-pair';
@@ -418,6 +419,11 @@ export class MobileBridgeService extends EventEmitter {
     this.wireSessionListeners(session);
     session.start();
     this.sessions.set(device.deviceId, session);
+    // Adoption signal: fires when the bridge is enabled with a paired device
+    // (startup sync, reconcile, or a fresh pairing). Deliberately NOT on the
+    // transport's 'connected' edge, which re-fires on every reconnect and
+    // ~2-minute re-handshake; trackFeatureUsed dedups to once per day anyway.
+    trackFeatureUsed('mobile_bridge');
     // A roster session is persistent: the first dial can fail outright (a
     // local relay that is not up yet - the desktop-launched-before-relay
     // case), and RelayClient keeps re-dialing with capped backoff while

--- a/src/main/pop-out/pop-out-window-manager.ts
+++ b/src/main/pop-out/pop-out-window-manager.ts
@@ -4,6 +4,8 @@ import { resolveBackgroundColor, resolveIconPath, resolveRendererIndexPath, reso
 import { POP_OUT_SURFACES, POPOUT_ARG_PREFIX, popOutInstanceKey, resolveSurfaceTitle } from '../../shared/pop-out';
 import type { PopOutChangesFileParams, PopOutDescriptor, PopOutKind, PopOutParams, PopOutTaskParams } from '../../shared/pop-out';
 import { cascadePopOutPosition } from './cascade';
+import { trackFeatureUsed } from '../analytics/usage';
+import { isErrorReportingActive } from '../analytics/error-reporting';
 
 const BOUNDS_SAVE_DEBOUNCE_MS = 500;
 
@@ -114,7 +116,14 @@ export class PopOutWindowManager {
         contextIsolation: true,
         nodeIntegration: false,
         webviewTag: meta.needsWebview,
-        additionalArguments: [`${POPOUT_ARG_PREFIX}${encodedDescriptor}`],
+        additionalArguments: [
+          `${POPOUT_ARG_PREFIX}${encodedDescriptor}`,
+          // Mirrors createWindow() in index.ts: preload derives
+          // analytics.errorReportingEnabled per-window from this flag, so a
+          // window factory that omits it silently disables renderer Sentry
+          // for every window it creates.
+          ...(isErrorReportingActive() ? ['--kangentic-error-reporting'] : []),
+        ],
       },
     });
 
@@ -122,6 +131,10 @@ export class PopOutWindowManager {
     // sufficient (createWindow() in index.ts sets it explicitly for the same reason).
     // macOS uses the app bundle / dock icon, so it is skipped there.
     if (process.platform !== 'darwin') win.setIcon(iconImage);
+
+    // Adoption signal on genuine creation only (the focus/cap early returns
+    // above never reach here); trackFeatureUsed dedups to once per day.
+    trackFeatureUsed('popout_window');
 
     // Saved bounds are keyed by KIND, so every additional live window of this kind
     // would restore exactly stacked on the first. Cascade it down-right instead.

--- a/src/main/pty/spawn/pty-spawn.ts
+++ b/src/main/pty/spawn/pty-spawn.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import { isUncPath, isCmdShell } from '../../../shared/paths';
 import { trackEvent, sanitizeErrorMessage } from '../../analytics/analytics';
+import { reportHandledError } from '../../analytics/error-reporting';
 
 /** Shell executable + args, split from a user-facing shell spec. */
 export interface ShellInvocation {
@@ -339,5 +340,15 @@ export function recordSpawnFailure(params: {
     errno: params.diagnostic.errno,
     platform: process.platform,
     arch: process.arch,
+  });
+  // Handled failure: forward to Sentry with the diagnostic as tags so spawn
+  // failures group by errno/shell and are diagnosable beyond a count. The
+  // message is the sanitized form (paths already stripped upstream of Sentry's
+  // own normalization, since this string is hand-assembled, not a stack).
+  reportHandledError(new Error(sanitizeErrorMessage(params.diagnostic.errorMessage)), {
+    source: 'pty_spawn',
+    errno: params.diagnostic.errno ?? 'none',
+    shellExists: String(params.diagnostic.shellExists),
+    cwdExists: String(params.diagnostic.cwdExists),
   });
 }

--- a/src/main/transition-engine/session-startup/prepare-spawn.ts
+++ b/src/main/transition-engine/session-startup/prepare-spawn.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { agentRegistry } from '../../agent/agent-registry';
+import { trackEvent } from '../../analytics/analytics';
 import type { AgentAdapter } from '../../agent/agent-adapter';
 import type { McpHttpServerHandle } from '../../agent/mcp-http-server';
 import { appendCallerSession } from '../../agent/mcp-http/caller-url';
@@ -148,7 +149,10 @@ export async function prepareAgentSpawn(input: {
     tasks: input.tasks,
   });
   const adapter = agentRegistry.get(agent);
-  if (!adapter) return { ok: false, reason: 'unknown-agent' };
+  if (!adapter) {
+    trackEvent('spawn_failed', { agent, reason: 'unknown_agent' });
+    return { ok: false, reason: 'unknown-agent' };
+  }
 
   // Model/effort ids are adapter-specific, so the project-level default only
   // applies when this spawn actually runs the project's default agent.
@@ -156,7 +160,10 @@ export async function prepareAgentSpawn(input: {
 
   const cliPathOverride = config.agent.cliPaths[agent] ?? null;
   const detection = await adapter.detect(cliPathOverride);
-  if (!detection.found || !detection.path) return { ok: false, reason: 'cli-not-found' };
+  if (!detection.found || !detection.path) {
+    trackEvent('spawn_failed', { agent, reason: 'cli_not_found' });
+    return { ok: false, reason: 'cli-not-found' };
+  }
 
   await adapter.ensureTrust(cwd);
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -4,6 +4,7 @@ import { app, BrowserWindow, ipcMain } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import { IPC } from '../shared/ipc-channels';
 import { trackEvent, sanitizeErrorMessage } from './analytics/analytics';
+import { reportHandledError } from './analytics/error-reporting';
 import { normalizeReleaseNotes } from './updater-release-notes';
 
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
@@ -220,6 +221,9 @@ export function initUpdater(mainWindow: BrowserWindow): void {
       source: 'updater',
       message: sanitizeErrorMessage(error.message),
     });
+    // Handled, so Sentry's global handlers never see it; forward the real
+    // error so structural updater failures are diagnosable, not just counted.
+    reportHandledError(error, { source: 'updater' });
   });
 
   // Schedule checks

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -486,6 +486,12 @@ const api: ElectronAPI = {
   analytics: {
     trackRendererError: (message: string, context?: RendererErrorContext) =>
       ipcRenderer.send(IPC.TRACK_RENDERER_ERROR, message, context),
+    trackFeatureUsed: (feature: string) =>
+      ipcRenderer.send(IPC.TRACK_FEATURE_USED, feature),
+    // Appended to additionalArguments by main only when Sentry actually
+    // initialized there (isErrorReportingActive), so the renderer-side
+    // Sentry.init() follows main's single decision.
+    errorReportingEnabled: process.argv.includes('--kangentic-error-reporting'),
   },
 
   app: {

--- a/src/renderer/components/ErrorBoundary.tsx
+++ b/src/renderer/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { RefreshCw } from 'lucide-react';
+import { reportBoundaryError } from '../error-reporting';
 
 interface Props {
   children: React.ReactNode;
@@ -22,6 +23,10 @@ export class ErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, info: React.ErrorInfo): void {
     console.error('ErrorBoundary caught:', error, info.componentStack);
+    // Boundary-caught errors never reach Sentry's global handlers (React
+    // swallows them), so hand the real Error over explicitly; the IPC funnel
+    // below keeps Aptabase's coarse app_error pulse alongside it.
+    reportBoundaryError(error);
     window.electronAPI?.analytics?.trackRendererError(error.message, {
       boundary: 'root',
       componentStack: info.componentStack ?? undefined,

--- a/src/renderer/components/PanelErrorBoundary.tsx
+++ b/src/renderer/components/PanelErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { RefreshCw } from 'lucide-react';
 import { isChunkLoadError } from '../utils/chunk-load-error';
+import { reportBoundaryError } from '../error-reporting';
 
 interface PanelErrorBoundaryProps {
   children: React.ReactNode;
@@ -48,6 +49,9 @@ export class PanelErrorBoundary extends React.Component<
 
   componentDidCatch(error: Error, info: React.ErrorInfo): void {
     console.error('PanelErrorBoundary caught:', error, info.componentStack);
+    // Boundary-caught errors never reach Sentry's global handlers (React
+    // swallows them); see ErrorBoundary.componentDidCatch.
+    reportBoundaryError(error);
     window.electronAPI?.analytics?.trackRendererError(error.message, {
       boundary: 'panel',
       panel: this.props.label,

--- a/src/renderer/components/settings/SettingsPanel.tsx
+++ b/src/renderer/components/settings/SettingsPanel.tsx
@@ -53,6 +53,12 @@ export function SettingsPanel() {
     setLastSettingsTab(activeTab);
   }, [activeTab, setLastSettingsTab]);
 
+  // Adoption signal, on mount so every open path counts (gear icon,
+  // openProjectSettings, keybinding); main dedups to once per day.
+  useEffect(() => {
+    window.electronAPI?.analytics?.trackFeatureUsed('settings');
+  }, []);
+
   useEffect(() => {
     window.electronAPI.shell.getAvailable().then(setShells).catch(() => {});
     window.electronAPI.font.getAvailable().then(setFonts).catch(() => {});

--- a/src/renderer/components/settings/tabs/PrivacyTab.tsx
+++ b/src/renderer/components/settings/tabs/PrivacyTab.tsx
@@ -16,9 +16,10 @@ export function PrivacyTab() {
       <SectionHeader label="What We Collect" />
       <ul className="list-disc list-inside text-sm text-fg-muted space-y-1 ml-1">
         <li>App launches, platform, and architecture</li>
-        <li>App crashes and errors (sanitized, no file paths)</li>
+        <li>App crashes and errors (stack traces with machine-specific paths removed from app code)</li>
         <li>Task and project creation counts</li>
         <li>Agent session starts, exit codes, and duration</li>
+        <li>Which features get used, as daily counts (never their content)</li>
       </ul>
 
       <SectionHeader label="What We Don't Collect" />
@@ -30,9 +31,15 @@ export function PrivacyTab() {
 
       <SectionHeader label="How It Works" />
       <p className="text-sm text-fg-muted leading-relaxed">
-        Analytics are powered by Aptabase, a privacy-first platform.
-        No cookies or persistent identifiers. IP addresses are used
-        for geographic lookup only, then discarded. GDPR-compliant by design.
+        Usage analytics are powered by Aptabase, a privacy-first platform.
+        No cookies. IP addresses are used for geographic lookup only, then
+        discarded. A single anonymous, non-reversible install id counts unique
+        installs; it contains no personal data. GDPR-compliant by design.
+      </p>
+      <p className="text-sm text-fg-muted leading-relaxed">
+        Crash and error reports go to Sentry so bugs can be diagnosed and
+        fixed. Stack traces are recorded with machine-specific paths removed
+        from app code; no task content, code, or personal data is attached.
       </p>
 
       <SectionHeader label="Conversation Search" />
@@ -44,7 +51,10 @@ export function PrivacyTab() {
 
       <SectionHeader label="How to Opt Out" />
       <p className="text-sm text-fg-muted leading-relaxed">
-        Set <code className="font-mono">KANGENTIC_TELEMETRY=0</code> as an environment variable to disable analytics.
+        Set <code className="font-mono">KANGENTIC_TELEMETRY=0</code> as an environment variable to
+        disable all telemetry (analytics and error reporting). Set{' '}
+        <code className="font-mono">KANGENTIC_ERROR_REPORTING=0</code> to disable only error
+        reporting while keeping anonymous analytics.
       </p>
 
       <SectionHeader label="Questions" />

--- a/src/renderer/error-reporting.ts
+++ b/src/renderer/error-reporting.ts
@@ -1,0 +1,40 @@
+import { init as sentryInit, captureException } from '@sentry/electron/renderer';
+
+/**
+ * Renderer half of Sentry error reporting. The renderer SDK has NO network
+ * path of its own: every event it captures is forwarded to the main process
+ * over the SDK's internal IPC and leaves through main's transport, so the
+ * documented invariant that all telemetry egress happens in the main process
+ * holds with this initialized (docs/analytics.md).
+ *
+ * Init is gated on `analytics.errorReportingEnabled`, a synchronous boot value
+ * preload reads from additionalArguments that mirrors main's single decision
+ * (KANGENTIC_TELEMETRY / KANGENTIC_ERROR_REPORTING / packaged, plus a DSN
+ * actually being configured) - so the renderer can never initialize when main
+ * did not. Options stay empty per the SDK docs: renderer config is inherited
+ * from the main process.
+ */
+export function initRendererErrorReporting(): void {
+  if (!window.electronAPI?.analytics?.errorReportingEnabled) return;
+  try {
+    sentryInit();
+  } catch (error) {
+    console.error('[ANALYTICS] Failed to initialize renderer error reporting:', error);
+  }
+}
+
+/**
+ * Report an error a React error boundary caught. Boundary-caught errors never
+ * reach the SDK's global handlers (React swallows them), so the boundaries
+ * hand them over explicitly. captureException is a safe no-op when the SDK
+ * did not initialize, so call sites need no gate of their own. The existing
+ * trackRendererError IPC funnel stays alongside this: Aptabase keeps the
+ * coarse app_error pulse, Sentry gets the real stack.
+ */
+export function reportBoundaryError(error: unknown): void {
+  try {
+    captureException(error);
+  } catch {
+    // Error reporting must never cascade into the boundary's own render path.
+  }
+}

--- a/src/renderer/hooks/useSearchPalette.ts
+++ b/src/renderer/hooks/useSearchPalette.ts
@@ -47,7 +47,11 @@ export function useSearchPalette(options: UseSearchPaletteOptions = {}) {
     _lastIsOpen = isOpen;
   }, [isOpen]);
 
-  const open = useCallback(() => setIsOpen(true), []);
+  const open = useCallback(() => {
+    setIsOpen(true);
+    // Adoption signal; main dedups to once per day (fire-and-forget).
+    window.electronAPI?.analytics?.trackFeatureUsed('quick_find');
+  }, []);
   const close = useCallback(() => setIsOpen(false), []);
 
   // Ctrl/Cmd+Shift+F always toggles the palette.

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -4,8 +4,13 @@ import { App } from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { readPopOutDescriptor } from './pop-out/read-descriptor';
 import { PopOutSurfaceRoot } from './pop-out/PopOutSurfaceRoot';
+import { initRendererErrorReporting } from './error-reporting';
 import faviconHref from '@kangentic/branding/assets/brandmark-small.svg?url';
 import './index.css';
+
+// Before any listener or render, so the SDK's global handlers see everything.
+// No-op unless main initialized Sentry (see error-reporting.ts).
+initRendererErrorReporting();
 
 window.addEventListener('unhandledrejection', (event) => {
   const message = event.reason instanceof Error ? event.reason.message : String(event.reason);

--- a/src/renderer/stores/usage-dashboard-store.ts
+++ b/src/renderer/stores/usage-dashboard-store.ts
@@ -175,6 +175,8 @@ function createUsageDashboardStore() {
     open: () => {
       if (get().statsOpen) return;
       set({ statsOpen: true });
+      // Adoption signal; main dedups to once per day (fire-and-forget).
+      window.electronAPI?.analytics?.trackFeatureUsed('usage_dashboard');
       // Fetch AFTER the flip so the shell paints first (never block first paint).
       void get().loadDashboardStats();
     },

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -213,6 +213,7 @@ export const IPC = {
 
   // Analytics
   TRACK_RENDERER_ERROR: 'analytics:trackRendererError',
+  TRACK_FEATURE_USED: 'analytics:trackFeatureUsed',
 
   // App
   APP_GET_VERSION: 'app:getVersion',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4972,6 +4972,13 @@ export interface ElectronAPI {
   // Analytics
   analytics: {
     trackRendererError: (message: string, context?: RendererErrorContext) => void;
+    /** Report one use of a curated adoption feature (fire-and-forget; main
+     *  validates against ANALYTICS_FEATURES and dedups to once per day). */
+    trackFeatureUsed: (feature: string) => void;
+    /** Synchronous boot value mirroring main's single Sentry decision (read
+     *  from additionalArguments in preload): gates the renderer-side
+     *  Sentry.init() so the two processes can never disagree. */
+    errorReportingEnabled: boolean;
   };
 
   // App

--- a/tests/fixtures/aptabase-electron-main-stub.ts
+++ b/tests/fixtures/aptabase-electron-main-stub.ts
@@ -1,0 +1,20 @@
+/**
+ * Unit-tier stand-in for `@aptabase/electron/main`, wired via the alias in
+ * vitest.config.ts.
+ *
+ * Why it exists: the real package ships ESM whose top level does
+ * `import { app, ipcMain, net, protocol } from 'electron'`. Under plain-node
+ * vitest the `electron` package is its CJS stub (a string export), and Node's
+ * ESM linker rejects those named imports at LINK time - so any test whose
+ * import graph merely reaches `src/main/analytics/analytics.ts` fails before
+ * it runs. Suites that assert on analytics behavior keep their own
+ * `vi.mock('@aptabase/electron/main', ...)`, which overrides this alias; this
+ * stub only keeps the import graph loadable for everyone else.
+ */
+export function initialize(): Promise<void> {
+  return Promise.resolve();
+}
+
+export function trackEvent(): Promise<void> {
+  return Promise.resolve();
+}

--- a/tests/fixtures/sentry-electron-stub.ts
+++ b/tests/fixtures/sentry-electron-stub.ts
@@ -1,0 +1,23 @@
+/**
+ * Unit-tier stand-in for `@sentry/electron/main` and `@sentry/electron/renderer`,
+ * wired via the aliases in vitest.config.ts for the same reason as the
+ * Aptabase stub beside it: the real package's ESM build named-imports from
+ * 'electron', which Node's ESM linker rejects against the CJS electron stub
+ * under plain-node vitest. Suites that assert on error-reporting behavior
+ * keep their own `vi.mock('@sentry/electron/main', ...)`, which overrides
+ * this alias; this stub only keeps the import graph loadable for everyone
+ * else. Every export is a no-op mirroring the calls the app makes.
+ */
+type ScopeLike = { setTag: (key: string, value: string) => void };
+
+export function init(): void {}
+
+export function captureException(): string {
+  return '';
+}
+
+export function setUser(): void {}
+
+export function withScope(callback: (scope: ScopeLike) => void): void {
+  callback({ setTag: () => {} });
+}

--- a/tests/ui/feature-usage-telemetry.spec.ts
+++ b/tests/ui/feature-usage-telemetry.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * UI coverage for the renderer-side feature-usage telemetry call sites.
+ *
+ * Three renderer call sites report feature adoption over IPC via
+ * window.electronAPI.analytics.trackFeatureUsed(<feature>):
+ *   - SettingsPanel.tsx fires 'settings' on mount.
+ *   - useSearchPalette.ts's open() fires 'quick_find'.
+ *   - usage-dashboard-store.ts's open() fires 'usage_dashboard'.
+ *
+ * The headless mock (mock-electron-api.js) records every call into
+ * window.__mockTrackFeatureUsedCalls, but nothing read it back: a typo'd
+ * feature string at any call site ships silently, since main-process
+ * validation just drops an unrecognized name (isKnownAnalyticsFeature in
+ * src/main/analytics/usage.ts) rather than throwing. Each test below opens
+ * the surface through its real user-facing trigger and asserts the exact
+ * literal was recorded.
+ *
+ * Each test launches its own browser/project (no cross-test state), so the
+ * file opts into parallel mode like search-palette.spec.ts and
+ * usage-dashboard.spec.ts.
+ */
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { launchPage, createProject } from './helpers';
+
+test.describe.configure({ mode: 'parallel' });
+
+/** Read the mock's feature-usage call log (empty array if nothing fired yet). */
+async function getTrackedFeatures(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const mockWindow = window as unknown as { __mockTrackFeatureUsedCalls?: string[] };
+    return mockWindow.__mockTrackFeatureUsedCalls ?? [];
+  });
+}
+
+test.describe('Feature usage telemetry', () => {
+  test('opening Settings records the settings feature usage', async () => {
+    const { browser, page } = await launchPage();
+    try {
+      await createProject(page, `Telemetry Settings ${Date.now()}`);
+
+      await page.locator('[data-testid="settings-button"]').click();
+      await page.locator('h2:has-text("Settings")').waitFor({ state: 'visible', timeout: 3000 });
+
+      await expect
+        .poll(async () => getTrackedFeatures(page), { timeout: 5000 })
+        .toContain('settings');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('opening Quick Find records the quick_find feature usage', async () => {
+    const { browser, page } = await launchPage();
+    try {
+      await createProject(page, `Telemetry Quick Find ${Date.now()}`);
+
+      await page.keyboard.press('Control+Shift+F');
+      await page.getByTestId('search-palette').waitFor({ state: 'visible', timeout: 3000 });
+
+      await expect
+        .poll(async () => getTrackedFeatures(page), { timeout: 5000 })
+        .toContain('quick_find');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  test('opening the usage dashboard records the usage_dashboard feature usage', async () => {
+    const { browser, page } = await launchPage();
+    try {
+      await createProject(page, `Telemetry Usage Dashboard ${Date.now()}`);
+
+      await page.locator('[data-testid="usage-stats-button"]').click();
+      await page.locator('[data-testid="stats-page"]').waitFor({ state: 'visible', timeout: 5000 });
+
+      await expect
+        .poll(async () => getTrackedFeatures(page), { timeout: 5000 })
+        .toContain('usage_dashboard');
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -2676,6 +2676,12 @@
         window.__mockTrackRendererErrorCalls = window.__mockTrackRendererErrorCalls || [];
         window.__mockTrackRendererErrorCalls.push({ message: message, context: context });
       },
+      trackFeatureUsed: function (feature) {
+        window.__mockTrackFeatureUsedCalls = window.__mockTrackFeatureUsedCalls || [];
+        window.__mockTrackFeatureUsedCalls.push(feature);
+      },
+      // Sentry never initializes under the UI harness.
+      errorReportingEnabled: false,
     },
 
     app: {

--- a/tests/unit/analytics-usage.test.ts
+++ b/tests/unit/analytics-usage.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const mocks = vi.hoisted(() => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('../../src/main/analytics/analytics', () => ({
+  trackEvent: mocks.trackEvent,
+}));
+
+import {
+  ANALYTICS_FEATURES,
+  ONBOARDING_MILESTONES,
+  isKnownAnalyticsFeature,
+  initUsageAnalytics,
+  trackFeatureUsed,
+  trackMilestone,
+  trackUpdateOutcome,
+  bucketTaskCount,
+  resetUsageAnalyticsForTests,
+} from '../../src/main/analytics/usage';
+
+let tempDir: string;
+let flagsPath: string;
+
+beforeEach(() => {
+  mocks.trackEvent.mockClear();
+  resetUsageAnalyticsForTests();
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kng-usage-'));
+  flagsPath = path.join(tempDir, 'analytics-usage.json');
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+/** persistUsageFlags is fire-and-forget (fs.promises); yield so writes land. */
+async function flushWrites(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+describe('isKnownAnalyticsFeature', () => {
+  it('accepts every curated feature and rejects unknown vocabulary', () => {
+    for (const feature of ANALYTICS_FEATURES) {
+      expect(isKnownAnalyticsFeature(feature)).toBe(true);
+    }
+    expect(isKnownAnalyticsFeature('made_up_feature')).toBe(false);
+    expect(isKnownAnalyticsFeature('')).toBe(false);
+  });
+});
+
+describe('trackFeatureUsed', () => {
+  it('emits feature_used once per feature per day, plus feature_first_use once per install', () => {
+    initUsageAnalytics(flagsPath);
+    trackFeatureUsed('quick_find');
+    trackFeatureUsed('quick_find');
+    trackFeatureUsed('settings');
+
+    const eventNames = mocks.trackEvent.mock.calls.map((call) => call[0]);
+    expect(eventNames.filter((name) => name === 'feature_used')).toHaveLength(2);
+    expect(eventNames.filter((name) => name === 'feature_first_use')).toHaveLength(2);
+    expect(mocks.trackEvent).toHaveBeenCalledWith('feature_used', { feature: 'quick_find' });
+    expect(mocks.trackEvent).toHaveBeenCalledWith('feature_first_use', { feature: 'settings' });
+  });
+
+  it('remembers first-use across restarts via the flags file', async () => {
+    initUsageAnalytics(flagsPath);
+    trackFeatureUsed('browser_pane');
+    await flushWrites();
+
+    // Simulate a restart: fresh module state, same flags file.
+    resetUsageAnalyticsForTests();
+    mocks.trackEvent.mockClear();
+    initUsageAnalytics(flagsPath);
+    trackFeatureUsed('browser_pane');
+
+    const eventNames = mocks.trackEvent.mock.calls.map((call) => call[0]);
+    // The daily dedup map is in-memory, so the restarted run sends one
+    // feature_used again, but never a second feature_first_use.
+    expect(eventNames).toContain('feature_used');
+    expect(eventNames).not.toContain('feature_first_use');
+  });
+
+  it('skips lifetime-once events entirely when initUsageAnalytics never ran, but still sends the daily feature_used', () => {
+    trackFeatureUsed('mcp_server');
+    trackFeatureUsed('mcp_server');
+
+    const eventNames = mocks.trackEvent.mock.calls.map((call) => call[0]);
+    expect(eventNames).toEqual(['feature_used']);
+  });
+});
+
+describe('trackMilestone', () => {
+  it('fires each step at most once per install, persisted across restarts', async () => {
+    initUsageAnalytics(flagsPath);
+    trackMilestone('first_task');
+    trackMilestone('first_task');
+    trackMilestone('first_spawn');
+    await flushWrites();
+
+    resetUsageAnalyticsForTests();
+    initUsageAnalytics(flagsPath);
+    trackMilestone('first_task');
+
+    const milestoneCalls = mocks.trackEvent.mock.calls.filter(
+      (call) => call[0] === 'onboarding_milestone'
+    );
+    expect(milestoneCalls).toEqual([
+      ['onboarding_milestone', { step: 'first_task' }],
+      ['onboarding_milestone', { step: 'first_spawn' }],
+    ]);
+  });
+
+  it('is a no-op before initUsageAnalytics (never fires unbounded)', () => {
+    trackMilestone('first_project');
+    expect(mocks.trackEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('trackUpdateOutcome', () => {
+  it('records a baseline on first run without emitting', async () => {
+    initUsageAnalytics(flagsPath);
+    trackUpdateOutcome('1.2.3');
+    expect(mocks.trackEvent).not.toHaveBeenCalled();
+    await flushWrites();
+    expect(JSON.parse(fs.readFileSync(flagsPath, 'utf-8')).lastRunVersion).toBe('1.2.3');
+  });
+
+  it('emits applied on an upgrade and rolled_back on a downgrade, once per version change', async () => {
+    initUsageAnalytics(flagsPath);
+    trackUpdateOutcome('1.2.3');
+    await flushWrites();
+
+    resetUsageAnalyticsForTests();
+    initUsageAnalytics(flagsPath);
+    trackUpdateOutcome('1.3.0');
+    expect(mocks.trackEvent).toHaveBeenCalledWith('update_outcome', {
+      result: 'applied',
+      fromVersion: '1.2.3',
+      toVersion: '1.3.0',
+    });
+    trackUpdateOutcome('1.3.0');
+    expect(mocks.trackEvent).toHaveBeenCalledTimes(1);
+    await flushWrites();
+
+    resetUsageAnalyticsForTests();
+    mocks.trackEvent.mockClear();
+    initUsageAnalytics(flagsPath);
+    trackUpdateOutcome('1.2.9');
+    expect(mocks.trackEvent).toHaveBeenCalledWith('update_outcome', {
+      result: 'rolled_back',
+      fromVersion: '1.3.0',
+      toVersion: '1.2.9',
+    });
+  });
+});
+
+describe('initUsageAnalytics survives a wrong-shaped flags file', () => {
+  it('does not throw on field-level type mismatches, and downstream calls stay functional', () => {
+    // Syntactically valid JSON, but every field has the wrong shape: a
+    // string where a milestone record belongs, an array where a
+    // feature-first-use record belongs, an object where the version string
+    // belongs. asFlagRecord() must fall back to {} per-field rather than
+    // letting an `as` cast carry the wrong runtime type into usageFlags.
+    fs.writeFileSync(
+      flagsPath,
+      JSON.stringify({ milestones: 'x', featureFirstUse: [1], lastRunVersion: { a: 1 } })
+    );
+
+    expect(() => initUsageAnalytics(flagsPath)).not.toThrow();
+
+    // Reverting asFlagRecord's validation (a plain `as` cast) would leave
+    // usageFlags.milestones holding the string "x" at runtime. ES modules
+    // are strict mode, so `usageFlags.milestones[step] = true` then throws
+    // "Cannot create property ... on string" - this assertion is the red
+    // signal for that regression.
+    expect(() => trackMilestone('first_project')).not.toThrow();
+    const milestoneCalls = mocks.trackEvent.mock.calls.filter(
+      (call) => call[0] === 'onboarding_milestone'
+    );
+    expect(milestoneCalls).toEqual([['onboarding_milestone', { step: 'first_project' }]]);
+
+    // lastRunVersion fell back to undefined (object is not a string), so
+    // this is a first-run baseline: must not throw, and must not emit.
+    expect(() => trackUpdateOutcome('1.0.0')).not.toThrow();
+    expect(mocks.trackEvent).not.toHaveBeenCalledWith('update_outcome', expect.anything());
+  });
+
+  it('the featureFirstUse array guard actually holds: a wrong-shaped array does not silently swallow the first-use flag', async () => {
+    // The `!Array.isArray(value)` half of asFlagRecord's guard is otherwise
+    // untested by the assertion above (trackMilestone never touches
+    // featureFirstUse). Assigning a named property to an array does not
+    // throw - `([1] as any).quick_find = true` is legal JS - so a partial
+    // revert dropping only Array.isArray would stay green against a
+    // not-throw assertion. Prove the flag actually PERSISTS instead: if the
+    // guard were dropped, the write would land on the throwaway array
+    // instead of a real record, JSON.stringify would drop it, and the
+    // restarted run below would re-fire feature_first_use.
+    fs.writeFileSync(
+      flagsPath,
+      JSON.stringify({ milestones: 'x', featureFirstUse: [1], lastRunVersion: { a: 1 } })
+    );
+    initUsageAnalytics(flagsPath);
+    trackFeatureUsed('quick_find');
+    await flushWrites();
+
+    resetUsageAnalyticsForTests();
+    mocks.trackEvent.mockClear();
+    initUsageAnalytics(flagsPath);
+    trackFeatureUsed('quick_find');
+
+    const eventNames = mocks.trackEvent.mock.calls.map((call) => call[0]);
+    expect(eventNames).not.toContain('feature_first_use');
+  });
+});
+
+describe('ONBOARDING_MILESTONES vocabulary parity', () => {
+  it('every declared milestone actually fires onboarding_milestone, in declaration order, when tracked', () => {
+    initUsageAnalytics(flagsPath);
+    for (const step of ONBOARDING_MILESTONES) {
+      trackMilestone(step);
+    }
+
+    const milestoneSteps = mocks.trackEvent.mock.calls
+      .filter((call) => call[0] === 'onboarding_milestone')
+      .map((call) => (call[1] as { step: string }).step);
+    expect(milestoneSteps).toEqual([...ONBOARDING_MILESTONES]);
+  });
+});
+
+describe('bucketTaskCount', () => {
+  it('buckets counts without ever exposing an exact figure', () => {
+    expect(bucketTaskCount(0)).toBe('0');
+    expect(bucketTaskCount(1)).toBe('1-9');
+    expect(bucketTaskCount(9)).toBe('1-9');
+    expect(bucketTaskCount(10)).toBe('10-49');
+    expect(bucketTaskCount(49)).toBe('10-49');
+    expect(bucketTaskCount(50)).toBe('50-199');
+    expect(bucketTaskCount(199)).toBe('50-199');
+    expect(bucketTaskCount(200)).toBe('200+');
+    expect(bucketTaskCount(5000)).toBe('200+');
+  });
+});

--- a/tests/unit/browser-pane-registry.test.ts
+++ b/tests/unit/browser-pane-registry.test.ts
@@ -22,9 +22,13 @@ vi.mock('../../src/main/browser/cdp/cdp', () => ({
   detachDebugger: vi.fn(),
   isDebuggerAttached: vi.fn(() => false),
 }));
+vi.mock('../../src/main/analytics/usage', () => ({
+  trackFeatureUsed: vi.fn(),
+}));
 
 import { webContents } from 'electron';
 import { detachDebugger, isDebuggerAttached } from '../../src/main/browser/cdp/cdp';
+import { trackFeatureUsed } from '../../src/main/analytics/usage';
 import { BrowserPaneRegistry, type RegisterSurfaceInput } from '../../src/main/browser/browser-pane-registry';
 
 interface FakeGuest {
@@ -71,6 +75,33 @@ describe('BrowserPaneRegistry', () => {
     expect(registry.get('pane_aaaaaaaa')?.ownerSessionId).toBe('sess-a');
     expect(registry.get('pane_aaaaaaaa')?.url).toBe('http://localhost:4200');
     expect(registry.get('pane_aaaaaaaa')).toMatchObject({ kind: 'pane', handoff: false });
+  });
+
+  /**
+   * `trackFeatureUsed('browser_pane')` is the adoption signal added alongside
+   * this registry (see browser-pane-registry.ts's `register()`). It has two
+   * ways to be wrong: counting an offscreen lane (the driver's own plumbing,
+   * never a user opening the Browser pane) as adoption, and re-counting a
+   * rebind of an already-known guest (a `/clear` session rotation) as a new
+   * adoption event.
+   */
+  describe('adoption signal (trackFeatureUsed)', () => {
+    it('fires browser_pane for a new pane registration', () => {
+      registry.register(REGISTER_A);
+      expect(vi.mocked(trackFeatureUsed)).toHaveBeenCalledWith('browser_pane');
+    });
+
+    it('does NOT fire for a lane registration (offscreen driver plumbing, not a user pane)', () => {
+      registry.register(ISOLATED_LANE);
+      expect(vi.mocked(trackFeatureUsed)).not.toHaveBeenCalled();
+    });
+
+    it('does NOT re-fire when the SAME guest re-registers (a rebind, not a new entry)', () => {
+      registry.register(REGISTER_A);
+      vi.mocked(trackFeatureUsed).mockClear();
+      registry.register({ ...REGISTER_A, handle: undefined, ownerSessionId: 'sess-a2' });
+      expect(vi.mocked(trackFeatureUsed)).not.toHaveBeenCalled();
+    });
   });
 
   it('unregisters by handle and by webContentsId', () => {

--- a/tests/unit/error-reporting-renderer.test.ts
+++ b/tests/unit/error-reporting-renderer.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit coverage for the renderer half of Sentry error reporting
+ * (src/renderer/error-reporting.ts). This project's vitest config has no
+ * jsdom environment (see tests/unit/panel-error-boundary.test.ts's header
+ * for the established rationale), so `window` is stubbed directly via
+ * vi.stubGlobal - the same pattern that file uses for window.electronAPI.
+ *
+ * Neither function under test caches module-level state: each call reads
+ * window.electronAPI fresh, so unlike error-reporting-switch.test.ts's
+ * main-process counterpart, no vi.resetModules() dance is needed here.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+vi.mock('@sentry/electron/renderer', () => ({
+  init: mocks.init,
+  captureException: mocks.captureException,
+}));
+
+import { initRendererErrorReporting, reportBoundaryError } from '../../src/renderer/error-reporting';
+
+describe('initRendererErrorReporting', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    mocks.init.mockClear();
+  });
+
+  it('calls @sentry/electron/renderer init() when electronAPI.analytics.errorReportingEnabled is true', () => {
+    vi.stubGlobal('window', { electronAPI: { analytics: { errorReportingEnabled: true } } });
+
+    initRendererErrorReporting();
+
+    expect(mocks.init).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call init() when errorReportingEnabled is false', () => {
+    vi.stubGlobal('window', { electronAPI: { analytics: { errorReportingEnabled: false } } });
+
+    initRendererErrorReporting();
+
+    expect(mocks.init).not.toHaveBeenCalled();
+  });
+
+  it('does not call init() when window.electronAPI is entirely absent', () => {
+    vi.stubGlobal('window', {});
+
+    initRendererErrorReporting();
+
+    expect(mocks.init).not.toHaveBeenCalled();
+  });
+});
+
+describe('reportBoundaryError', () => {
+  afterEach(() => {
+    mocks.captureException.mockReset();
+  });
+
+  it('forwards the error to Sentry.captureException', () => {
+    const error = new Error('boundary caught this');
+
+    reportBoundaryError(error);
+
+    expect(mocks.captureException).toHaveBeenCalledTimes(1);
+    expect(mocks.captureException).toHaveBeenCalledWith(error);
+  });
+
+  it('never throws even when captureException itself throws', () => {
+    mocks.captureException.mockImplementation(() => {
+      throw new Error('sentry transport exploded');
+    });
+
+    expect(() => reportBoundaryError(new Error('boundary caught this'))).not.toThrow();
+  });
+});

--- a/tests/unit/error-reporting-switch.test.ts
+++ b/tests/unit/error-reporting-switch.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const setTagSpy = vi.fn();
+  return {
+    electronMock: { app: { isPackaged: true } },
+    setTagSpy,
+    sentryMock: {
+      init: vi.fn(),
+      setUser: vi.fn(),
+      captureException: vi.fn(),
+      withScope: vi.fn(
+        (callback: (scope: { setTag: (key: string, value: string) => void }) => void) => {
+          callback({ setTag: setTagSpy });
+        }
+      ),
+    },
+  };
+});
+
+vi.mock('electron', () => ({ app: mocks.electronMock.app }));
+vi.mock('@sentry/electron/main', () => mocks.sentryMock);
+
+import { resolveErrorReportingEnabled } from '../../src/main/analytics/error-reporting';
+
+describe('resolveErrorReportingEnabled', () => {
+  it('KANGENTIC_TELEMETRY=0/false is the superset kill switch: disables Sentry regardless of the error-reporting switch', () => {
+    expect(resolveErrorReportingEnabled('0', undefined, true)).toBe(false);
+    expect(resolveErrorReportingEnabled('false', undefined, true)).toBe(false);
+    expect(resolveErrorReportingEnabled('0', '1', true)).toBe(false);
+    expect(resolveErrorReportingEnabled('false', 'true', true)).toBe(false);
+  });
+
+  it('KANGENTIC_ERROR_REPORTING=0/false disables Sentry alone', () => {
+    expect(resolveErrorReportingEnabled(undefined, '0', true)).toBe(false);
+    expect(resolveErrorReportingEnabled(undefined, 'false', true)).toBe(false);
+    expect(resolveErrorReportingEnabled('1', '0', true)).toBe(false);
+  });
+
+  it('KANGENTIC_ERROR_REPORTING=1/true force-enables (dev), unless the superset switch is off', () => {
+    expect(resolveErrorReportingEnabled(undefined, '1', false)).toBe(true);
+    expect(resolveErrorReportingEnabled(undefined, 'true', false)).toBe(true);
+    expect(resolveErrorReportingEnabled('0', '1', false)).toBe(false);
+  });
+
+  it('unset inherits the analytics default: telemetry force-on wins, else packaged only', () => {
+    expect(resolveErrorReportingEnabled('1', undefined, false)).toBe(true);
+    expect(resolveErrorReportingEnabled('true', undefined, false)).toBe(true);
+    expect(resolveErrorReportingEnabled(undefined, undefined, true)).toBe(true);
+    expect(resolveErrorReportingEnabled(undefined, undefined, false)).toBe(false);
+  });
+});
+
+/**
+ * `active` (the opt-out promise gate) is module-scoped with no exported
+ * reset helper, unlike usage.ts's resetUsageAnalyticsForTests(). Isolating
+ * it between cases needs vi.resetModules() + a dynamic re-import per case,
+ * the same pattern tests/unit/announcements-init-guard.test.ts uses for its
+ * own module-scoped state. The hoisted `mocks.sentryMock` fn instances are
+ * stable across resets (same object reference returned by the mock
+ * factory), so call history is inspected via those, cleared per test below.
+ */
+async function importFreshErrorReporting() {
+  vi.resetModules();
+  return import('../../src/main/analytics/error-reporting');
+}
+
+describe('error reporting runtime behavior (module-state gated)', () => {
+  const originalTelemetry = process.env.KANGENTIC_TELEMETRY;
+  const originalErrorReporting = process.env.KANGENTIC_ERROR_REPORTING;
+
+  beforeEach(() => {
+    mocks.sentryMock.init.mockClear();
+    mocks.sentryMock.setUser.mockClear();
+    mocks.sentryMock.captureException.mockClear();
+    mocks.sentryMock.withScope.mockClear();
+    mocks.setTagSpy.mockClear();
+    mocks.electronMock.app.isPackaged = true;
+    delete process.env.KANGENTIC_TELEMETRY;
+    // Force the switch ON regardless of packaged state, so initErrorReporting
+    // actually activates in every case below unless a test deliberately
+    // skips calling it.
+    process.env.KANGENTIC_ERROR_REPORTING = '1';
+  });
+
+  afterEach(() => {
+    if (originalTelemetry === undefined) delete process.env.KANGENTIC_TELEMETRY;
+    else process.env.KANGENTIC_TELEMETRY = originalTelemetry;
+    if (originalErrorReporting === undefined) delete process.env.KANGENTIC_ERROR_REPORTING;
+    else process.env.KANGENTIC_ERROR_REPORTING = originalErrorReporting;
+  });
+
+  describe('reportHandledError', () => {
+    it('forwards to Sentry.withScope/captureException and sets each provided tag once initErrorReporting ran with the switch ON', async () => {
+      const errorReporting = await importFreshErrorReporting();
+      errorReporting.initErrorReporting();
+
+      const error = new Error('spawn failed');
+      errorReporting.reportHandledError(error, { source: 'pty', component: 'spawn' });
+
+      expect(mocks.sentryMock.withScope).toHaveBeenCalledTimes(1);
+      expect(mocks.sentryMock.captureException).toHaveBeenCalledTimes(1);
+      expect(mocks.sentryMock.captureException).toHaveBeenCalledWith(error);
+      expect(mocks.setTagSpy).toHaveBeenCalledWith('source', 'pty');
+      expect(mocks.setTagSpy).toHaveBeenCalledWith('component', 'spawn');
+    });
+
+    it('makes ZERO Sentry calls when the module was never initialized (the opt-out promise gate)', async () => {
+      const errorReporting = await importFreshErrorReporting();
+      // Deliberately do NOT call initErrorReporting() - this is the
+      // fresh-module, never-activated state a fully opted-out install stays
+      // in for its whole run.
+      errorReporting.reportHandledError(new Error('spawn failed'), { source: 'pty' });
+
+      expect(mocks.sentryMock.withScope).not.toHaveBeenCalled();
+      expect(mocks.sentryMock.captureException).not.toHaveBeenCalled();
+      expect(mocks.setTagSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('initErrorReporting respects the switch (the state a real opted-out user is actually in)', () => {
+    // index.ts always calls initErrorReporting() unconditionally at startup;
+    // an opted-out user's real runtime state is "init WAS called, the switch
+    // resolved OFF, initErrorReporting bails before touching Sentry.init".
+    // That is a different code path than "init was never called" above, and
+    // it is the one production actually exercises for an opted-out install.
+    it('does not call Sentry.init, active stays false, and reportHandledError stays inert when the superset kill switch is OFF - even in a packaged build', async () => {
+      mocks.electronMock.app.isPackaged = true;
+      process.env.KANGENTIC_TELEMETRY = '0';
+
+      const errorReporting = await importFreshErrorReporting();
+      errorReporting.initErrorReporting();
+
+      expect(mocks.sentryMock.init).not.toHaveBeenCalled();
+      expect(errorReporting.isErrorReportingActive()).toBe(false);
+
+      errorReporting.reportHandledError(new Error('spawn failed'), { source: 'pty' });
+      expect(mocks.sentryMock.captureException).not.toHaveBeenCalled();
+    });
+
+    it('does not call Sentry.init when KANGENTIC_ERROR_REPORTING alone is OFF', async () => {
+      process.env.KANGENTIC_ERROR_REPORTING = '0';
+
+      const errorReporting = await importFreshErrorReporting();
+      errorReporting.initErrorReporting();
+
+      expect(mocks.sentryMock.init).not.toHaveBeenCalled();
+      expect(errorReporting.isErrorReportingActive()).toBe(false);
+    });
+  });
+
+  describe('setErrorReportingUser', () => {
+    it('calls Sentry.setUser({ id }) only when active', async () => {
+      const errorReporting = await importFreshErrorReporting();
+      errorReporting.initErrorReporting();
+      errorReporting.setErrorReportingUser('client-abc-123');
+
+      expect(mocks.sentryMock.setUser).toHaveBeenCalledTimes(1);
+      expect(mocks.sentryMock.setUser).toHaveBeenCalledWith({ id: 'client-abc-123' });
+    });
+
+    it('makes no call when the module was never initialized', async () => {
+      const errorReporting = await importFreshErrorReporting();
+      errorReporting.setErrorReportingUser('client-abc-123');
+
+      expect(mocks.sentryMock.setUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('initErrorReporting Sentry.init option shape', () => {
+    it('passes sendDefaultPii: false, filters MainProcessSession out of integrations while keeping others, and ignores the known-benign write errors', async () => {
+      const errorReporting = await importFreshErrorReporting();
+      errorReporting.initErrorReporting();
+
+      expect(mocks.sentryMock.init).toHaveBeenCalledTimes(1);
+      const options = mocks.sentryMock.init.mock.calls[0][0] as {
+        sendDefaultPii: boolean;
+        integrations: (defaultIntegrations: Array<{ name: string }>) => Array<{ name: string }>;
+        ignoreErrors: string[];
+      };
+
+      expect(options.sendDefaultPii).toBe(false);
+      expect(options.ignoreErrors).toContain('write EAGAIN');
+      expect(options.ignoreErrors).toContain('write EPIPE');
+
+      const syntheticDefaultIntegrations = [
+        { name: 'MainProcessSession' },
+        { name: 'Console' },
+        { name: 'FunctionToString' },
+      ];
+      const filtered = options.integrations(syntheticDefaultIntegrations);
+      expect(filtered.map((integration) => integration.name)).toEqual([
+        'Console',
+        'FunctionToString',
+      ]);
+    });
+  });
+});

--- a/tests/unit/mcp-http-server-track-feature-used.test.ts
+++ b/tests/unit/mcp-http-server-track-feature-used.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Guards the `mcp_server` adoption signal in `handleHttpRequest`
+ * (src/main/agent/mcp-http-server.ts): a POST body whose parsed JSON-RPC
+ * message(s) include `method: 'initialize'` fires
+ * `trackFeatureUsed('mcp_server')` exactly once per matching request. This is
+ * the "an MCP client actually connected" signal - deliberately not fired for
+ * every tool call, and deliberately gated on the JSON-RPC method name rather
+ * than any other request shape (the body is parsed once and handed straight
+ * to the SDK transport, so a broken `.some(...)` scan would silently stop
+ * classifying requests without touching dispatch at all).
+ *
+ * Drives real request bodies through a real `startMcpHttpServer` instance via
+ * `node:http`, mirroring the harness in mcp-http-server-steering-lifecycle
+ * .test.ts and mcp-server-network-config.test.ts (both already prove this
+ * dispatch path is drivable without restructuring source). `analytics/usage`
+ * is left real (unmocked) so the actual `.some(...)` classification in
+ * mcp-http-server.ts is exercised end to end; only the underlying
+ * `analytics/analytics` trackEvent sink is mocked (its own module pulls in
+ * `@aptabase/electron/main`, which cannot load outside a real Electron
+ * process - see the identical note in register-all-idempotency.test.ts).
+ *
+ * Heavy leaf modules are stubbed so mcp-http-server imports under node
+ * (mirrors the sibling mcp-http-server-*.test.ts files).
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import * as http from 'node:http';
+
+vi.mock('electron', () => ({
+  webContents: { fromId: () => null },
+  app: { getPath: () => '/tmp', isPackaged: false },
+}));
+vi.mock('../../src/main/agent/commands', () => ({ commandHandlers: {} }));
+vi.mock('../../src/main/agent/mcp-project-context', () => ({
+  buildCommandContextForProject: vi.fn(() => null),
+}));
+vi.mock('../../src/main/search/search-core', () => ({ runSearchEverything: vi.fn() }));
+vi.mock('../../src/main/diagnostics/process-metrics', () => ({ getProcessMetrics: vi.fn() }));
+vi.mock('../../src/main/git/worktree-list', () => ({ enumerateWorktrees: vi.fn() }));
+vi.mock('../../src/main/browser/browser-pane-driver', () => ({
+  withGuest: vi.fn(),
+  validateNavigationUrl: vi.fn(),
+}));
+vi.mock('../../src/main/browser/browser-pane-registry', () => ({
+  browserPaneRegistry: { list: () => [] },
+}));
+vi.mock('../../src/main/browser/cdp/cdp', () => ({
+  clickAtCenterOfSelector: vi.fn(),
+  dispatchMouseEvent: vi.fn(),
+  dispatchKeyEvent: vi.fn(),
+  dispatchKeypress: vi.fn(),
+  dragFromTo: vi.fn(),
+  getOuterHtml: vi.fn(),
+  getBoundingBox: vi.fn(),
+  getConsoleEntries: vi.fn(),
+  getLayoutMetrics: vi.fn(),
+  queryAllElements: vi.fn(),
+  runtimeEvaluate: vi.fn(),
+  typeText: vi.fn(),
+}));
+vi.mock('../../src/main/browser/cdp/screenshot', () => ({
+  captureScreenshotWithBudget: vi.fn(),
+  captureElementClip: vi.fn(),
+}));
+vi.mock('../../src/devtools/mcp/register', () => ({ registerDevtoolsMcpTools: vi.fn() }));
+
+// analytics.ts module-level-imports '@aptabase/electron/main', a real
+// node_modules package that cannot load outside a real Electron process (see
+// the identical note in register-all-idempotency.test.ts). trackFeatureUsed
+// (analytics/usage.ts) is left REAL so the source's own `.some(...)`
+// initialize-detection is what's under test, not a stand-in for it.
+const mockTrackEvent = vi.fn();
+vi.mock('../../src/main/analytics/analytics', () => ({
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}));
+
+import { startMcpHttpServer, type McpHttpServerHandle } from '../../src/main/agent/mcp-http-server';
+import { RequestResolver } from '../../src/main/agent/mcp-http/project-resolver';
+import { resetUsageAnalyticsForTests } from '../../src/main/analytics/usage';
+import type { IpcContext } from '../../src/main/ipc/ipc-context';
+import type { CommandContext } from '../../src/main/agent/commands/types';
+
+function makeResolver(): RequestResolver {
+  const fakeIpcContext = { projectRepo: { list: () => [] } } as unknown as IpcContext;
+  const fakeCommandContext = {} as unknown as CommandContext;
+  return new RequestResolver({
+    ipcContext: fakeIpcContext,
+    defaultContext: fakeCommandContext,
+    defaultProjectId: 'proj-1',
+    defaultProjectName: 'Test Project',
+  });
+}
+
+/** POSTs an arbitrary (possibly malformed) JSON body to the running server. */
+function postBody(
+  port: number,
+  token: string,
+  rawBody: string,
+): Promise<{ statusCode: number }> {
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: '/mcp/proj-1',
+        method: 'POST',
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          'Content-Type': 'application/json',
+          'X-Kangentic-Token': token,
+        },
+      },
+      (response) => {
+        response.resume();
+        response.on('end', () => resolve({ statusCode: response.statusCode ?? 0 }));
+      },
+    );
+    request.on('error', reject);
+    request.end(rawBody);
+  });
+}
+
+function featureUsedCalls(): unknown[][] {
+  return mockTrackEvent.mock.calls.filter((call) => call[0] === 'feature_used');
+}
+
+describe('mcp-http-server - mcp_server adoption tracking on initialize', () => {
+  let handle: McpHttpServerHandle | undefined;
+
+  beforeEach(() => {
+    mockTrackEvent.mockClear();
+    // trackFeatureUsed dedups 'feature_used' to once per feature per UTC day
+    // via a module-level Map in usage.ts, which persists across tests in this
+    // file (vitest shares module instances within one file). Without this
+    // reset, only the FIRST test in this describe block would ever observe a
+    // 'feature_used' call - every later test's real trackFeatureUsed call
+    // would silently no-op against the same-day dedup, which looks identical
+    // to "initialize detection is broken" from the outside.
+    resetUsageAnalyticsForTests();
+  });
+
+  afterEach(() => {
+    handle?.close();
+    handle = undefined;
+  });
+
+  it('fires trackFeatureUsed(\'mcp_server\') for a single {method: "initialize"} body', async () => {
+    const resolver = makeResolver();
+    handle = await startMcpHttpServer(
+      (projectId) => (projectId === 'proj-1' ? resolver : null),
+      () => ({ enabled: false, allowInteraction: false, allowNavigation: false, allowEval: false, restrictNavigationToLocalhost: false }),
+      { bindAddress: '127.0.0.1' },
+    );
+    const port = Number(new URL(handle.baseUrl).port);
+
+    await postBody(port, handle.token, JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }));
+
+    // Red: removing the `rpcMessages.some(...)` check (or the trackFeatureUsed
+    // call it guards) in handleHttpRequest leaves this at 0 matching calls.
+    expect(featureUsedCalls()).toEqual([['feature_used', { feature: 'mcp_server' }]]);
+  });
+
+  it('fires trackFeatureUsed(\'mcp_server\') for an ARRAY body containing an initialize message', async () => {
+    const resolver = makeResolver();
+    handle = await startMcpHttpServer(
+      (projectId) => (projectId === 'proj-1' ? resolver : null),
+      () => ({ enabled: false, allowInteraction: false, allowNavigation: false, allowEval: false, restrictNavigationToLocalhost: false }),
+      { bindAddress: '127.0.0.1' },
+    );
+    const port = Number(new URL(handle.baseUrl).port);
+
+    // Batched JSON-RPC: an array of messages, one of which is initialize.
+    await postBody(port, handle.token, JSON.stringify([
+      { jsonrpc: '2.0', method: 'notifications/other', params: {} },
+      { jsonrpc: '2.0', method: 'initialize', id: 1 },
+    ]));
+
+    // Red: reverting the `Array.isArray(parsedBody) ? parsedBody : [parsedBody]`
+    // normalization to a bare `[parsedBody]` would scan the whole array as one
+    // opaque message (no `.method` on an array), and this would read 0 calls.
+    expect(featureUsedCalls()).toEqual([['feature_used', { feature: 'mcp_server' }]]);
+  });
+
+  it('does NOT fire trackFeatureUsed for a {method: "tools/call"} body', async () => {
+    const resolver = makeResolver();
+    handle = await startMcpHttpServer(
+      (projectId) => (projectId === 'proj-1' ? resolver : null),
+      () => ({ enabled: false, allowInteraction: false, allowNavigation: false, allowEval: false, restrictNavigationToLocalhost: false }),
+      { bindAddress: '127.0.0.1' },
+    );
+    const port = Number(new URL(handle.baseUrl).port);
+
+    await postBody(port, handle.token, JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: 'kangentic_list_tasks', arguments: {} },
+      id: 1,
+    }));
+
+    expect(featureUsedCalls()).toEqual([]);
+  });
+
+  it('does not throw and does not fire trackFeatureUsed for a null-parsed body', async () => {
+    const resolver = makeResolver();
+    handle = await startMcpHttpServer(
+      (projectId) => (projectId === 'proj-1' ? resolver : null),
+      () => ({ enabled: false, allowInteraction: false, allowNavigation: false, allowEval: false, restrictNavigationToLocalhost: false }),
+      { bindAddress: '127.0.0.1' },
+    );
+    const port = Number(new URL(handle.baseUrl).port);
+
+    // `JSON.parse('null')` succeeds and yields the value `null`, so this
+    // reaches the initialize-detection block with parsedBody === null - unlike
+    // a malformed/unparseable body, which the earlier catch already handles
+    // and never reaches this code at all.
+    const response = await postBody(port, handle.token, 'null');
+
+    expect(response.statusCode).not.toBe(0);
+    expect(featureUsedCalls()).toEqual([]);
+  });
+});

--- a/tests/unit/pop-out-window-manager.test.ts
+++ b/tests/unit/pop-out-window-manager.test.ts
@@ -13,7 +13,7 @@ import type { PopOutChangesFileParams } from '../../src/shared/pop-out';
 // vi.mock() calls are hoisted above every other statement in this file, so any
 // outer variable a factory references must be declared through vi.hoisted() -
 // otherwise the factory would run before its own `const` initializer.
-const { mockResolveBackgroundColor, mockResolveIconPath, mockResolveRendererIndexPath, mockResolvePopOutBounds, mockSavePopOutBounds } = vi.hoisted(() => ({
+const { mockResolveBackgroundColor, mockResolveIconPath, mockResolveRendererIndexPath, mockResolvePopOutBounds, mockSavePopOutBounds, mockTrackFeatureUsed, mockIsErrorReportingActive } = vi.hoisted(() => ({
   mockResolveBackgroundColor: vi.fn(() => '#18181b'),
   mockResolveIconPath: vi.fn(() => '/mock/icon.png'),
   mockResolveRendererIndexPath: vi.fn(() => '/mock/renderer/index.html'),
@@ -21,6 +21,8 @@ const { mockResolveBackgroundColor, mockResolveIconPath, mockResolveRendererInde
     (): { x: number; y: number; width: number; height: number; maximized: boolean } | null => null,
   ),
   mockSavePopOutBounds: vi.fn(),
+  mockTrackFeatureUsed: vi.fn(),
+  mockIsErrorReportingActive: vi.fn(() => false),
 }));
 
 vi.mock('../../src/main/window-utils', () => ({
@@ -29,6 +31,12 @@ vi.mock('../../src/main/window-utils', () => ({
   resolveRendererIndexPath: mockResolveRendererIndexPath,
   resolvePopOutBounds: mockResolvePopOutBounds,
   savePopOutBounds: mockSavePopOutBounds,
+}));
+vi.mock('../../src/main/analytics/usage', () => ({
+  trackFeatureUsed: mockTrackFeatureUsed,
+}));
+vi.mock('../../src/main/analytics/error-reporting', () => ({
+  isErrorReportingActive: mockIsErrorReportingActive,
 }));
 
 const { MOCK_WORK_AREA, MOCK_DEFAULT_POSITION } = vi.hoisted(() => ({
@@ -105,7 +113,7 @@ vi.mock('electron', () => {
 });
 
 import { PopOutWindowManager } from '../../src/main/pop-out/pop-out-window-manager';
-import { POP_OUT_SURFACES, resolveSurfaceTitle } from '../../src/shared/pop-out';
+import { POP_OUT_SURFACES, POPOUT_ARG_PREFIX, resolveSurfaceTitle } from '../../src/shared/pop-out';
 import { cascadePopOutPosition } from '../../src/main/pop-out/cascade';
 
 /** Shape of the mocked BrowserWindow beyond the real Electron interface, so
@@ -144,6 +152,7 @@ describe('PopOutWindowManager.open()', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockResolvePopOutBounds.mockReturnValue(null);
+    mockIsErrorReportingActive.mockReturnValue(false);
     manager = new PopOutWindowManager();
     const openContext: Parameters<typeof manager.configure>[0] = {
       devServerUrl: null,
@@ -224,5 +233,73 @@ describe('PopOutWindowManager.open()', () => {
     // dedicated guard were removed, so a bare `.toThrow()` would pass either
     // way and prove nothing about the guard itself.
     expect(() => manager.open('changes-file', paramsWithoutFilePath)).toThrow(/requires a filePath param/);
+  });
+
+  /**
+   * `--kangentic-error-reporting` is how the renderer's Sentry.init() call
+   * agrees with main's single Sentry decision (mirrors createWindow() in
+   * index.ts). A pop-out window that omits it while error reporting is
+   * active would silently ship with no renderer Sentry.
+   */
+  describe('renderer boot flags (additionalArguments)', () => {
+    function additionalArgumentsOf(win: unknown): string[] {
+      const options = asMockWindow(win).options as { webPreferences?: { additionalArguments?: string[] } };
+      return options.webPreferences?.additionalArguments ?? [];
+    }
+
+    it('includes --kangentic-error-reporting when Sentry is active, alongside the descriptor arg', () => {
+      mockIsErrorReportingActive.mockReturnValue(true);
+      const params = makeChangesFileParams({ filePath: 'src/error-reporting-on.tsx' });
+      const win = manager.open('changes-file', params);
+
+      const args = additionalArgumentsOf(win);
+      expect(args).toContain('--kangentic-error-reporting');
+      // The flag must not clobber the existing descriptor argument the pop-out
+      // renderer reads its kind/params from.
+      expect(args.some((arg) => arg.startsWith(POPOUT_ARG_PREFIX))).toBe(true);
+    });
+
+    it('omits the flag when Sentry did not initialize', () => {
+      mockIsErrorReportingActive.mockReturnValue(false);
+      const params = makeChangesFileParams({ filePath: 'src/error-reporting-off.tsx' });
+      const win = manager.open('changes-file', params);
+
+      const args = additionalArgumentsOf(win);
+      expect(args).not.toContain('--kangentic-error-reporting');
+      expect(args.some((arg) => arg.startsWith(POPOUT_ARG_PREFIX))).toBe(true);
+    });
+  });
+
+  /**
+   * `trackFeatureUsed('popout_window')` is the adoption signal added
+   * alongside this manager. It must fire on a genuine new-window creation
+   * only, never on the focus-existing or cap-blocked early returns above it.
+   */
+  describe('adoption signal (trackFeatureUsed)', () => {
+    it('fires popout_window on a genuine new-window creation', () => {
+      const params = makeChangesFileParams({ filePath: 'src/adoption.tsx' });
+      manager.open('changes-file', params);
+      expect(mockTrackFeatureUsed).toHaveBeenCalledWith('popout_window');
+    });
+
+    it('does NOT re-fire when focusing an already-open window of the same key', () => {
+      const params = makeChangesFileParams({ filePath: 'src/adoption-refocus.tsx' });
+      manager.open('changes-file', params);
+      mockTrackFeatureUsed.mockClear();
+
+      manager.open('changes-file', params); // same key -> focuses the existing window
+      expect(mockTrackFeatureUsed).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire when the maxInstances cap blocks a new window', () => {
+      for (let fileIndex = 0; fileIndex < 8; fileIndex += 1) {
+        manager.open('changes-file', makeChangesFileParams({ filePath: `src/cap-${fileIndex}.tsx` }));
+      }
+      mockTrackFeatureUsed.mockClear();
+
+      const blocked = manager.open('changes-file', makeChangesFileParams({ filePath: 'src/cap-9th.tsx' }));
+      expect(blocked).toBeNull();
+      expect(mockTrackFeatureUsed).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/unit/prepare-agent-spawn.test.ts
+++ b/tests/unit/prepare-agent-spawn.test.ts
@@ -87,6 +87,15 @@ vi.mock('../../src/main/agent/agent-registry', () => ({
   agentRegistry: { get: (...args: unknown[]) => agentRegistryGetMock(...(args as [string])) },
 }));
 
+// trackEvent no-ops in the real analytics.ts unless `enabled` was flipped by
+// initAnalytics (never called in this suite), so a spawn_failed call would be
+// silently swallowed by the real module. Mocked as a plain spy so the
+// unknown-agent / cli-not-found tests below can assert on it directly.
+const mockTrackEvent = vi.fn();
+vi.mock('../../src/main/analytics/analytics', () => ({
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}));
+
 // ---------------------------------------------------------------------------
 // Import the module under test AFTER all mocks are declared.
 // ---------------------------------------------------------------------------
@@ -511,6 +520,9 @@ describe('prepareAgentSpawn - extraEnv field', () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('Expected ok:false');
     expect(result.reason).toBe('unknown-agent');
+    // resolveTargetAgent is mocked to always resolve 'opencode' (see the
+    // module mock above), so that is the agent tag this failure carries.
+    expect(mockTrackEvent).toHaveBeenCalledWith('spawn_failed', { agent: 'opencode', reason: 'unknown_agent' });
   });
 
   it('returns ok:false with reason "cli-not-found" when adapter.detect returns found:false', async () => {
@@ -526,6 +538,7 @@ describe('prepareAgentSpawn - extraEnv field', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('Expected ok:false');
+    expect(mockTrackEvent).toHaveBeenCalledWith('spawn_failed', { agent: 'opencode', reason: 'cli_not_found' });
     expect(result.reason).toBe('cli-not-found');
   });
 

--- a/tests/unit/project-open-lifecycle.test.ts
+++ b/tests/unit/project-open-lifecycle.test.ts
@@ -166,10 +166,39 @@ vi.mock('../../src/main/retrieval/retrieval-service', () => ({
   retrievalService: { startForProject: vi.fn(), stop: vi.fn(), reconcileEmbedWorker: vi.fn() },
 }));
 
+// The board_snapshot analytics block (registerProjectHandlers' PROJECT_OPEN
+// cold-open) is the ONE place in this file's exercised code paths that calls
+// swimlaneRepo.list() / taskRepo.countAll() directly rather than merely
+// passing the repo instance to an already-mocked function - every other
+// consumer (pruneOrphanedWorktreeTasks, cleanupStaleResourcesAsync,
+// resumeSuspendedSessions, autoSpawnTasks) is itself mocked and never invokes
+// a method on the repo it's handed. Left as the REAL trivial-constructor
+// class (per the file header's rationale), swimlaneRepo.list()/
+// taskRepo.countAll() would call `db.prepare(...)` against the fake `{}` db
+// object from the database mock above and throw, silently swallowed by the
+// snapshot block's own try/catch - which is exactly why trackEvent has never
+// been asserted to receive a 'board_snapshot' call in this file until now.
+const mockSwimlaneList = vi.fn(() => [] as Array<{ name: string }>);
+const mockTaskCountAll = vi.fn(() => 0);
+
+vi.mock('../../src/main/db/repositories/swimlane-repository', () => ({
+  SwimlaneRepository: class {
+    list = (...args: unknown[]) => mockSwimlaneList(...args);
+  },
+}));
+
+vi.mock('../../src/main/db/repositories/task-repository', () => ({
+  TaskRepository: class {
+    countAll = (...args: unknown[]) => mockTaskCountAll(...args);
+  },
+}));
+
 // ---------------------------------------------------------------------------
 // Import under test (after all vi.mock declarations)
 // ---------------------------------------------------------------------------
 
+import { trackEvent } from '../../src/main/analytics/analytics';
+import { DEFAULT_SWIMLANES } from '../../src/main/db/migrations/default-data';
 import {
   registerProjectHandlers,
   openProjectByPath,
@@ -279,6 +308,11 @@ beforeEach(() => {
   state.cleanupGate = null;
   state.resumeError = null;
   state.autoSpawnError = null;
+  // mockReturnValue persists across tests (vi.clearAllMocks() resets call
+  // history, not implementation), so reset both to their neutral defaults
+  // here rather than letting one test's override leak into the next.
+  mockSwimlaneList.mockReturnValue([]);
+  mockTaskCountAll.mockReturnValue(0);
 });
 
 // ---------------------------------------------------------------------------
@@ -419,6 +453,88 @@ describe('PROJECT_OPEN cold-open block (registerProjectHandlers)', () => {
       'resumeSuspendedSessions',
       'autoSpawnTasks',
     ]);
+  });
+
+  // -------------------------------------------------------------------------
+  // 2b. board_snapshot analytics (fired once per cold open, inside the same
+  //     deferred setImmediate block, BEFORE pruneOrphanedTasksAndNotify).
+  // -------------------------------------------------------------------------
+
+  function getBoardSnapshotProps(): Record<string, string | number | boolean> {
+    const call = vi.mocked(trackEvent).mock.calls.find((args) => args[0] === 'board_snapshot');
+    if (!call) throw new Error('board_snapshot was never tracked');
+    return call[1] as Record<string, string | number | boolean>;
+  }
+
+  it('reports customColumns:false for the exact default 7-lane board', async () => {
+    mockSwimlaneList.mockReturnValue(DEFAULT_SWIMLANES.map((lane) => ({ name: lane.name })));
+
+    const context = createMockContext();
+    const project = makeProject();
+    await registerAndOpen(context, project);
+
+    await vi.waitFor(() => {
+      expect(state.callOrder).toContain('autoSpawnTasks');
+    }, { timeout: 2000 });
+
+    expect(getBoardSnapshotProps().customColumns).toBe(false);
+  });
+
+  it('reports customColumns:true when a default-named lane was renamed', async () => {
+    const renamedLanes = DEFAULT_SWIMLANES.map((lane) => ({ name: lane.name }));
+    renamedLanes[0] = { name: 'Backlog' }; // 'To Do' renamed
+    mockSwimlaneList.mockReturnValue(renamedLanes);
+
+    const context = createMockContext();
+    const project = makeProject();
+    await registerAndOpen(context, project);
+
+    await vi.waitFor(() => {
+      expect(state.callOrder).toContain('autoSpawnTasks');
+    }, { timeout: 2000 });
+
+    expect(getBoardSnapshotProps().customColumns).toBe(true);
+  });
+
+  it('reports customColumns:true when an 8th lane was added, even if it duplicates a default name', async () => {
+    // Duplicating an existing default name (rather than adding a novel one)
+    // isolates the LENGTH half of the customColumns check: every lane's name
+    // is still present in the default-name Set, so a name-only comparison
+    // would read this board as non-custom. Only the `lanes.length !==
+    // DEFAULT_SWIMLANES.length` half catches the extra lane.
+    const extraLanes = [
+      ...DEFAULT_SWIMLANES.map((lane) => ({ name: lane.name })),
+      { name: DEFAULT_SWIMLANES[0].name },
+    ];
+    mockSwimlaneList.mockReturnValue(extraLanes);
+
+    const context = createMockContext();
+    const project = makeProject();
+    await registerAndOpen(context, project);
+
+    await vi.waitFor(() => {
+      expect(state.callOrder).toContain('autoSpawnTasks');
+    }, { timeout: 2000 });
+
+    expect(getBoardSnapshotProps().customColumns).toBe(true);
+  });
+
+  it('buckets taskCount from TaskRepository.countAll() into taskBucket', async () => {
+    mockSwimlaneList.mockReturnValue(DEFAULT_SWIMLANES.map((lane) => ({ name: lane.name })));
+    mockTaskCountAll.mockReturnValue(12);
+
+    const context = createMockContext();
+    const project = makeProject();
+    await registerAndOpen(context, project);
+
+    await vi.waitFor(() => {
+      expect(state.callOrder).toContain('autoSpawnTasks');
+    }, { timeout: 2000 });
+
+    // Red: reverting to a stale count source (e.g. `tasks.list().length`, the
+    // full-row scan countAll replaced) or dropping the countAll() call
+    // entirely would leave taskCount at 0 and this at '0' instead of '10-49'.
+    expect(getBoardSnapshotProps().taskBucket).toBe('10-49');
   });
 });
 

--- a/tests/unit/register-all-idempotency.test.ts
+++ b/tests/unit/register-all-idempotency.test.ts
@@ -570,4 +570,65 @@ describe('registerAllIpc idempotency', () => {
       expect(props?.panel).toHaveLength(MAX_ANALYTICS_STRING_LENGTH);
     }, 30000);
   });
+
+  describe('TRACK_FEATURE_USED analytics handler', () => {
+    // register-all.ts wires a second direct `ipcMain.on(...)` call alongside
+    // TRACK_RENDERER_ERROR: a renderer-reported feature name is re-validated
+    // against the curated allowlist (isKnownAnalyticsFeature) before being
+    // forwarded to trackFeatureUsed, since the string is erased at the IPC
+    // boundary and a compromised or drifted renderer could otherwise invent
+    // event vocabulary. `analytics/usage` is left REAL (not mocked) so this
+    // exercises the actual allowlist check, not a stand-in for it; only the
+    // underlying `analytics/analytics` trackEvent sink (which usage.ts's
+    // trackFeatureUsed calls into) is mocked.
+    type TrackFeatureUsedCallback = (event: unknown, feature: string) => void;
+
+    function getTrackFeatureUsedCallback(): TrackFeatureUsedCallback {
+      const entry = mockOn.mock.calls.find((call) => call[0] === IPC.TRACK_FEATURE_USED);
+      if (!entry) {
+        throw new Error('ipcMain.on was never called with IPC.TRACK_FEATURE_USED');
+      }
+      return entry[1] as TrackFeatureUsedCallback;
+    }
+
+    it('forwards a known feature name to trackFeatureUsed', async () => {
+      const { registerAllIpc } = await import('../../src/main/ipc/register-all');
+      const { trackEvent } = await import('../../src/main/analytics/analytics');
+      registerAllIpc(makeMockWindow(1));
+
+      const callback = getTrackFeatureUsedCallback();
+      callback({}, 'quick_find');
+
+      // Red: removing the `isKnownAnalyticsFeature` guard or the
+      // `trackFeatureUsed` call in register-all.ts's TRACK_FEATURE_USED
+      // handler leaves this at 0 matching calls - trackFeatureUsed's own
+      // once-per-day dedup (usage.ts) is real here, so a single call is the
+      // correct expectation for a fresh module instance.
+      expect(vi.mocked(trackEvent)).toHaveBeenCalledWith('feature_used', { feature: 'quick_find' });
+    }, 30000);
+
+    it('drops a non-string feature value with zero forwarding', async () => {
+      const { registerAllIpc } = await import('../../src/main/ipc/register-all');
+      const { trackEvent } = await import('../../src/main/analytics/analytics');
+      registerAllIpc(makeMockWindow(1));
+
+      const callback = getTrackFeatureUsedCallback();
+      callback({}, 123 as unknown as string);
+
+      const featureUsedCalls = vi.mocked(trackEvent).mock.calls.filter((call) => call[0] === 'feature_used');
+      expect(featureUsedCalls).toEqual([]);
+    }, 30000);
+
+    it('drops an unknown feature name with zero forwarding', async () => {
+      const { registerAllIpc } = await import('../../src/main/ipc/register-all');
+      const { trackEvent } = await import('../../src/main/analytics/analytics');
+      registerAllIpc(makeMockWindow(1));
+
+      const callback = getTrackFeatureUsedCallback();
+      callback({}, 'made_up_feature');
+
+      const featureUsedCalls = vi.mocked(trackEvent).mock.calls.filter((call) => call[0] === 'feature_used');
+      expect(featureUsedCalls).toEqual([]);
+    }, 30000);
+  });
 });

--- a/tests/unit/sanitize-error-message.test.ts
+++ b/tests/unit/sanitize-error-message.test.ts
@@ -28,8 +28,8 @@ describe('sanitizeErrorMessage', () => {
     expect(result).toBe('Failed at <path>: Cannot read properties of undefined');
   });
 
-  it('truncates to 200 characters', () => {
+  it('truncates to the Aptabase server-side cap (180 characters)', () => {
     const longMessage = 'A'.repeat(300);
-    expect(sanitizeErrorMessage(longMessage)).toHaveLength(200);
+    expect(sanitizeErrorMessage(longMessage)).toHaveLength(180);
   });
 });

--- a/tests/unit/session-spawn-analytics.test.ts
+++ b/tests/unit/session-spawn-analytics.test.ts
@@ -42,7 +42,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Session, SessionRecord } from '../../src/shared/types';
+import type { Session, SessionRecord, Task } from '../../src/shared/types';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks (must be declared before any imports of the mocked modules)
@@ -77,9 +77,11 @@ vi.mock('../../src/main/db/repositories/session-repository', () => ({
   },
 }));
 
+const mockTaskGetById = vi.fn(() => null as Task | null);
+
 vi.mock('../../src/main/db/repositories/task-repository', () => ({
   TaskRepository: class {
-    getById = vi.fn(() => null);
+    getById = mockTaskGetById;
   },
 }));
 
@@ -103,6 +105,17 @@ vi.mock('../../src/main/transition-engine/spawn-progress', () => ({
 // The module under test: trackEvent is what we assert against.
 vi.mock('../../src/main/analytics/analytics', () => ({
   trackEvent: vi.fn(),
+}));
+
+// trackFeatureUsed/trackMilestone are mocked as plain spies (rather than
+// leaving usage.ts real) so the enrichment/milestone assertions below aren't
+// entangled with usage.ts's own once-per-day / once-per-install dedup state,
+// which persists across tests within this file (vitest shares module
+// instances per file) and would make only the FIRST matching test in the
+// file observe a call.
+vi.mock('../../src/main/analytics/usage', () => ({
+  trackFeatureUsed: vi.fn(),
+  trackMilestone: vi.fn(),
 }));
 
 vi.mock('../../src/main/ipc/handlers/session-metrics', () => ({
@@ -159,6 +172,7 @@ vi.mock('../../src/main/ipc/helpers', () => ({
 // Import the module under test AFTER all vi.mock declarations.
 import { registerSessionHandlers } from '../../src/main/ipc/handlers/sessions';
 import { trackEvent } from '../../src/main/analytics/analytics';
+import { trackFeatureUsed, trackMilestone } from '../../src/main/analytics/usage';
 
 // ---------------------------------------------------------------------------
 // Shared fixture factory
@@ -300,6 +314,173 @@ describe('session-changed listener - session_spawn fires exactly once per sessio
 });
 
 // ---------------------------------------------------------------------------
+// #1b - Enrichment branch: permissionMode/worktree props + trackFeatureUsed
+// ---------------------------------------------------------------------------
+//
+// The `sessionSpawnAnalyticsFired` fire-once branch performs a best-effort DB
+// read (SessionRepository.getLatestForTask + TaskRepository.getById) to
+// enrich session_spawn's props and fire trackFeatureUsed for worktree/profile
+// adoption. Every test above this point leaves both repository mocks at their
+// declared default (getLatestForTask -> null, TaskRepository.getById -> null),
+// so `if (spawnRecord?.permission_mode)` / `if (taskRow) {...}` never execute
+// and this whole branch is untested - the exact-match `toHaveBeenCalledWith`
+// assertions above pass only because the enrichment adds nothing. Red-green:
+// deleting the enrichment block from sessions.ts would leave
+// `session_spawn`'s props at the bare `{ agent, isTransient }` shape and this
+// test would fail on the missing permissionMode/worktree keys.
+
+describe('session-changed listener - enrichment reads permission mode, worktree, and profile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedIpcHandlers.clear();
+    capturedSessionEventHandlers.clear();
+    mockGetLatestForTask.mockReturnValue(null);
+    mockTaskGetById.mockReturnValue(null);
+
+    mockGetProjectRepos.mockReturnValue({
+      tasks: { getById: vi.fn(() => null), update: vi.fn() },
+      swimlanes: { getById: vi.fn(() => null) },
+      actions: { getTransitionsFor: vi.fn(() => []) },
+      attachments: { add: vi.fn(), listForTask: vi.fn(() => []) },
+    });
+  });
+
+  it('adds permissionMode + worktree:true to session_spawn props and fires trackFeatureUsed for worktree_session and board_profile', () => {
+    const sessionId = 'analytics-enrichment-full-unique-id-010';
+    mockGetLatestForTask.mockReturnValue({ permission_mode: 'plan' } as unknown as SessionRecord);
+    mockTaskGetById.mockReturnValue({
+      id: 'task-analytics-001',
+      worktree_path: '/mock/project/.kangentic/worktrees/task',
+      profile_id: 'profile-1',
+    } as unknown as Task);
+
+    const context = createMockContext(sessionId, 'claude');
+    registerSessionHandlers(context as never);
+
+    const sessionChangedHandler = capturedSessionEventHandlers.get('session-changed');
+    if (!sessionChangedHandler) throw new Error('session-changed handler was not registered');
+
+    sessionChangedHandler(sessionId, makeRunningSession(sessionId));
+
+    expect(vi.mocked(trackEvent)).toHaveBeenCalledWith('session_spawn', {
+      agent: 'claude',
+      isTransient: false,
+      permissionMode: 'plan',
+      worktree: true,
+    });
+    expect(vi.mocked(trackFeatureUsed)).toHaveBeenCalledWith('worktree_session');
+    expect(vi.mocked(trackFeatureUsed)).toHaveBeenCalledWith('board_profile');
+  });
+
+  it('omits permissionMode, reports worktree:false, and does not fire trackFeatureUsed when the record has no permission_mode and the task has no worktree/profile', () => {
+    const sessionId = 'analytics-enrichment-empty-unique-id-011';
+    mockGetLatestForTask.mockReturnValue(null);
+    mockTaskGetById.mockReturnValue({
+      id: 'task-analytics-001',
+      worktree_path: null,
+      profile_id: null,
+    } as unknown as Task);
+
+    const context = createMockContext(sessionId, 'claude');
+    registerSessionHandlers(context as never);
+
+    const sessionChangedHandler = capturedSessionEventHandlers.get('session-changed');
+    if (!sessionChangedHandler) throw new Error('session-changed handler was not registered');
+
+    sessionChangedHandler(sessionId, makeRunningSession(sessionId));
+
+    // `worktree` is unconditionally set to `!!taskRow.worktree_path` once a
+    // task row is found (unlike `permissionMode`, which is only added when
+    // truthy) - so a found task with no worktree still reports worktree:false.
+    expect(vi.mocked(trackEvent)).toHaveBeenCalledWith('session_spawn', {
+      agent: 'claude',
+      isTransient: false,
+      worktree: false,
+    });
+    expect(vi.mocked(trackFeatureUsed)).not.toHaveBeenCalled();
+  });
+
+  it('omits both permissionMode and worktree when no task row is found at all', () => {
+    const sessionId = 'analytics-enrichment-no-task-unique-id-017';
+    mockGetLatestForTask.mockReturnValue(null);
+    mockTaskGetById.mockReturnValue(null);
+
+    const context = createMockContext(sessionId, 'claude');
+    registerSessionHandlers(context as never);
+
+    const sessionChangedHandler = capturedSessionEventHandlers.get('session-changed');
+    if (!sessionChangedHandler) throw new Error('session-changed handler was not registered');
+
+    sessionChangedHandler(sessionId, makeRunningSession(sessionId));
+
+    expect(vi.mocked(trackEvent)).toHaveBeenCalledWith('session_spawn', {
+      agent: 'claude',
+      isTransient: false,
+    });
+    expect(vi.mocked(trackFeatureUsed)).not.toHaveBeenCalled();
+  });
+
+  // A dedicated "isShuttingDown() === true skips the enrichment reads" case
+  // was considered and deliberately skipped: proving it would require
+  // vi.resetModules() + re-importing sessions.ts (plus every mock it closes
+  // over) mid-file so the real, unmocked shutdown-state module's flag could
+  // be flipped without leaking `true` into every other test in this file
+  // (the flag has no reset export). That is not cheap, and the module-reset
+  // gymnastics risk destabilizing the rest of this shared-mock suite for a
+  // branch that is already covered indirectly: every OTHER test in this file
+  // exercises the isShuttingDown()===false path by construction (the module
+  // default), which is the state that matters for production behavior.
+});
+
+// ---------------------------------------------------------------------------
+// #1c - trackMilestone('first_spawn') fires for a real (non-transient) spawn
+// ---------------------------------------------------------------------------
+
+describe('session-changed listener - trackMilestone("first_spawn")', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedIpcHandlers.clear();
+    capturedSessionEventHandlers.clear();
+    mockGetLatestForTask.mockReturnValue(null);
+    mockTaskGetById.mockReturnValue(null);
+
+    mockGetProjectRepos.mockReturnValue({
+      tasks: { getById: vi.fn(() => null), update: vi.fn() },
+      swimlanes: { getById: vi.fn(() => null) },
+      actions: { getTransitionsFor: vi.fn(() => []) },
+      attachments: { add: vi.fn(), listForTask: vi.fn(() => []) },
+    });
+  });
+
+  it('fires trackMilestone("first_spawn") for a non-transient running transition', () => {
+    const sessionId = 'analytics-milestone-nontransient-unique-id-014';
+    const context = createMockContext(sessionId, 'claude');
+    registerSessionHandlers(context as never);
+
+    const sessionChangedHandler = capturedSessionEventHandlers.get('session-changed');
+    if (!sessionChangedHandler) throw new Error('session-changed handler was not registered');
+
+    sessionChangedHandler(sessionId, makeRunningSession(sessionId));
+
+    expect(vi.mocked(trackMilestone)).toHaveBeenCalledWith('first_spawn');
+  });
+
+  it('does NOT fire trackMilestone("first_spawn") for a transient running transition', () => {
+    const sessionId = 'analytics-milestone-transient-unique-id-015';
+    const context = createMockContext(sessionId, 'claude');
+    registerSessionHandlers(context as never);
+
+    const sessionChangedHandler = capturedSessionEventHandlers.get('session-changed');
+    if (!sessionChangedHandler) throw new Error('session-changed handler was not registered');
+
+    const transientRunningSession: Session = { ...makeRunningSession(sessionId), transient: true };
+    sessionChangedHandler(sessionId, transientRunningSession);
+
+    expect(vi.mocked(trackMilestone)).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // #2 - Cleanup-on-exit: Set entry deleted so re-spawn can fire analytics again
 // ---------------------------------------------------------------------------
 
@@ -310,6 +491,7 @@ describe('exit listener - session_spawn Set entry is cleared so re-spawn fires a
     capturedSessionEventHandlers.clear();
 
     mockGetLatestForTask.mockReturnValue(null);
+    mockTaskGetById.mockReturnValue(null);
 
     mockGetProjectRepos.mockReturnValue({
       tasks: { getById: vi.fn(() => null), update: vi.fn() },
@@ -380,6 +562,7 @@ describe('exit listener - session_exit attaches costUsd/toolCalls from the usage
     capturedSessionEventHandlers.clear();
 
     mockGetLatestForTask.mockReturnValue(null);
+    mockTaskGetById.mockReturnValue(null);
 
     mockGetProjectRepos.mockReturnValue({
       tasks: { getById: vi.fn(() => null), update: vi.fn() },
@@ -395,13 +578,15 @@ describe('exit listener - session_exit attaches costUsd/toolCalls from the usage
    * never tracked (e.g. because sessionStartTimes was never populated).
    * `liveToolCallCount` seeds `sessionManager.getToolCallCount` - the source
    * `toolCalls` reads from directly (not the usage cache's stamped
-   * `toolCallCount`, which this listener no longer reads).
+   * `toolCallCount`, which this listener no longer reads). `intentional` is
+   * forwarded as the exit listener's third positional arg (crash-vs-deliberate).
    */
   function fireRunningThenExit(
     sessionId: string,
     agentName: string,
     usageCacheEntry: Record<string, unknown> | undefined,
     liveToolCallCount = 0,
+    intentional?: boolean,
   ): Record<string, string | number | boolean> {
     const context = createMockContext(sessionId, agentName);
     context.sessionManager.getUsageCache.mockReturnValue(
@@ -420,12 +605,30 @@ describe('exit listener - session_exit attaches costUsd/toolCalls from the usage
     sessionChangedHandler(sessionId, makeRunningSession(sessionId));
     vi.mocked(trackEvent).mockClear();
 
-    exitHandler(sessionId, 0);
+    exitHandler(sessionId, 0, intentional);
 
     const exitCall = vi.mocked(trackEvent).mock.calls.find((call) => call[0] === 'session_exit');
     if (!exitCall) throw new Error('session_exit was never tracked');
     return exitCall[1] as Record<string, string | number | boolean>;
   }
+
+  it('marks session_exit intentional:true when the exit listener\'s third arg is true', () => {
+    // kill()/suspend tag the exit intentional (session-spawn-flow.ts); a
+    // force-killed or user-stopped session must not read as a crash.
+    const sessionId = 'analytics-exit-intentional-true-012';
+
+    const props = fireRunningThenExit(sessionId, 'claude', undefined, 0, true);
+
+    expect(props.intentional).toBe(true);
+  });
+
+  it('marks session_exit intentional:false when the exit listener receives no third arg (genuine agent-side exit)', () => {
+    const sessionId = 'analytics-exit-intentional-false-013';
+
+    const props = fireRunningThenExit(sessionId, 'claude', undefined, 0, undefined);
+
+    expect(props.intentional).toBe(false);
+  });
 
   it('attaches costUsd (rounded to 4 decimals) and toolCalls from the live counter', () => {
     const sessionId = 'analytics-exit-usage-populated-005';

--- a/tests/unit/spawn-agent-lock-overrides.test.ts
+++ b/tests/unit/spawn-agent-lock-overrides.test.ts
@@ -29,6 +29,19 @@ vi.mock('../../src/main/agent/agent-registry', () => ({
   agentRegistry: { get: vi.fn(() => ({ sessionType: 'claude_agent' })) },
 }));
 
+// agent-spawn.ts imports ONLY `trackEvent` from analytics/analytics (not
+// sanitizeErrorMessage or any other export), so this mock is a complete
+// replacement, not a partial one that would silently drop an export the
+// other describe blocks in this file rely on.
+const mockTrackEvent = vi.fn();
+vi.mock('../../src/main/analytics/analytics', () => ({
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}));
+const mockReportHandledError = vi.fn();
+vi.mock('../../src/main/analytics/error-reporting', () => ({
+  reportHandledError: (...args: unknown[]) => mockReportHandledError(...args),
+}));
+
 import { spawnAgent } from '../../src/main/ipc/helpers/agent-spawn';
 
 const TASK_ID = 'task-lock-001';
@@ -432,5 +445,57 @@ describe('spawnAgent lock-Advanced-overrides-on-first-spawn -- project model/eff
       effort_override: 'xhigh',
       permission_mode: 'auto',
     });
+  });
+});
+
+/**
+ * spawnAgent's fallback resume is "the deepest silent failure on the board
+ * path" (see the comment at its call site): nothing else reaches the user
+ * when it throws, so the analytics/error-reporting instrumentation there is
+ * the only signal that a resume failed at all. Two things can silently
+ * regress: the `isAbortError` guard moving BELOW the new instrumentation
+ * (which would report a user cancellation as a failure and page Sentry for
+ * it), and the instrumentation being dropped from the non-abort path
+ * entirely (which would make resume failures invisible again).
+ */
+describe('spawnAgent - resume failure analytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports spawn_failed and forwards the handled error when resumeSuspendedSession rejects, without letting it propagate', async () => {
+    const task = makeTask({ model_override: 'fable-5' });
+    const deps = makeDeps({ latestSession: undefined, task });
+    const resumeError = new Error('CLI exited unexpectedly');
+    deps.engine.resumeSuspendedSession = vi.fn(async () => {
+      throw resumeError;
+    });
+
+    // Must resolve (not reject) - the catch swallows the error.
+    await runSpawn(task, makeDestinationLane(), deps);
+
+    expect(mockTrackEvent).toHaveBeenCalledWith('spawn_failed', { agent: 'claude', reason: 'resume' });
+    expect(mockReportHandledError).toHaveBeenCalledWith(resumeError, {
+      source: 'spawn',
+      reason: 'resume',
+      agent: 'claude',
+    });
+  });
+
+  it('rethrows an AbortError WITHOUT reporting spawn_failed or forwarding to Sentry', async () => {
+    // The ordering contract: `if (isAbortError(error)) throw error;` sits
+    // ABOVE the trackEvent/reportHandledError calls. A user-cancelled spawn
+    // (project close, task deleted mid-spawn) must never count as a failure.
+    const task = makeTask({ model_override: 'fable-5' });
+    const deps = makeDeps({ latestSession: undefined, task });
+    const abortError = new DOMException('The operation was aborted', 'AbortError');
+    deps.engine.resumeSuspendedSession = vi.fn(async () => {
+      throw abortError;
+    });
+
+    await expect(runSpawn(task, makeDestinationLane(), deps)).rejects.toBe(abortError);
+
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+    expect(mockReportHandledError).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/task-create-handler.test.ts
+++ b/tests/unit/task-create-handler.test.ts
@@ -136,6 +136,21 @@ vi.mock('../../src/main/ipc/handlers/task-move', () => ({
   handleTaskMove: vi.fn(async () => {}),
 }));
 
+const mockTrackEvent = vi.fn();
+vi.mock('../../src/main/analytics/analytics', () => ({
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}));
+
+const mockTrackMilestone = vi.fn();
+vi.mock('../../src/main/analytics/usage', () => ({
+  trackMilestone: (...args: unknown[]) => mockTrackMilestone(...args),
+}));
+
+const mockReportHandledError = vi.fn();
+vi.mock('../../src/main/analytics/error-reporting', () => ({
+  reportHandledError: (...args: unknown[]) => mockReportHandledError(...args),
+}));
+
 // ---------------------------------------------------------------------------
 // Capture handlers registered by ipcMain.handle
 // ---------------------------------------------------------------------------
@@ -386,6 +401,27 @@ describe('TASK_CREATE handler', () => {
     expect(mockSpawnAgent).not.toHaveBeenCalled();
   });
 
+  it('fires trackMilestone("first_task") on every create, regardless of auto_spawn', async () => {
+    const noSpawnLane = createMockSwimlane('lane-backlog', { auto_spawn: false });
+    swimlaneRepo = createMockSwimlaneRepo([noSpawnLane]);
+    const noSpawnTask = createMockTask('task-no-spawn', { swimlane_id: 'lane-backlog' });
+    taskRepo = createMockTaskRepo(noSpawnTask);
+
+    mockGetProjectRepos.mockReturnValue({
+      tasks: taskRepo,
+      swimlanes: swimlaneRepo,
+      actions: { getTransitionsFor: vi.fn(() => []) },
+      attachments: attachmentRepo,
+    });
+
+    await callCreateHandler(context, {
+      swimlane_id: 'lane-backlog',
+      title: 'No spawn task',
+    });
+
+    expect(mockTrackMilestone).toHaveBeenCalledWith('first_task');
+  });
+
   it('skips lock block when currentProjectPath is null', async () => {
     context.currentProjectPath = null;
     capturedHandlers.clear();
@@ -538,6 +574,30 @@ describe('TASK_CREATE handler', () => {
     });
 
     expect(result).toMatchObject({ id: 'task-new' });
+  });
+
+  it('tracks spawn_failed and reports the handled error, tagged with the resolved agent, when spawnAgent rejects', async () => {
+    const spawnError = new Error('CLI not found');
+    mockSpawnAgent.mockRejectedValueOnce(spawnError);
+
+    await callCreateHandler(context, {
+      swimlane_id: 'lane-doing',
+      title: 'Spawn failure task',
+    });
+
+    // The resolved agent lives inside spawnAgent and is never returned, so
+    // the handler approximates it from the override chain
+    // (task.agent_override ?? toLane.agent_override ?? 'default'); neither
+    // fixture sets an override here, so 'default' is the expected tag.
+    expect(mockTrackEvent).toHaveBeenCalledWith('spawn_failed', { agent: 'default', reason: 'create_spawn' });
+    // reportHandledError's agent tag is a just-applied fix (pinned here so a
+    // regression to the untagged two-arg call form is caught): the SAME
+    // resolved agent that trackEvent above receives.
+    expect(mockReportHandledError).toHaveBeenCalledWith(spawnError, {
+      source: 'spawn',
+      reason: 'create_spawn',
+      agent: 'default',
+    });
   });
 
   // =========================================================================

--- a/tests/unit/task-move-complete-analytics.test.ts
+++ b/tests/unit/task-move-complete-analytics.test.ts
@@ -62,6 +62,9 @@ vi.mock('../../src/main/git/worktree-manager', () => ({
 const mockTrackEvent = vi.fn();
 vi.mock('../../src/main/analytics/analytics', () => ({ trackEvent: (...args: unknown[]) => mockTrackEvent(...args) }));
 
+const mockTrackMilestone = vi.fn();
+vi.mock('../../src/main/analytics/usage', () => ({ trackMilestone: (...args: unknown[]) => mockTrackMilestone(...args) }));
+
 vi.mock('../../src/main/transition-engine/session-lifecycle', () => ({
   markRecordExited: vi.fn(),
   markRecordSuspended: vi.fn(),
@@ -312,5 +315,51 @@ describe('handleTaskMove task_complete analytics', () => {
 
     const props = getTaskCompleteProps();
     expect(props.costUsd).toBe(0.1235);
+  });
+
+  it('reports the resolved permissionMode the last session actually ran under', async () => {
+    hoisted.latestRecord = {
+      id: 'rec-1',
+      model_id: 'claude-opus-4-8',
+      agent_session_id: null,
+      status: 'suspended',
+      session_type: 'claude_agent',
+      permission_mode: 'acceptEdits',
+    } as unknown as SessionRecord;
+    hoisted.summary = null;
+
+    const task = makeTask({ swimlane_id: DOING_LANE_ID, session_id: null, worktree_path: null, agent: 'claude' });
+    await moveTaskToDone(task);
+
+    const props = getTaskCompleteProps();
+    // Red: reading this from the task's raw permission_mode (an override,
+    // null = inherit) instead of the session record's resolved value would
+    // leave this key absent even though the record carries one.
+    expect(props.permissionMode).toBe('acceptEdits');
+  });
+
+  it('omits permissionMode when the latest session record has none', async () => {
+    hoisted.latestRecord = {
+      id: 'rec-1',
+      model_id: 'claude-opus-4-8',
+      agent_session_id: null,
+      status: 'suspended',
+      session_type: 'claude_agent',
+      permission_mode: null,
+    } as unknown as SessionRecord;
+    hoisted.summary = null;
+
+    const task = makeTask({ swimlane_id: DOING_LANE_ID, session_id: null, worktree_path: null, agent: 'claude' });
+    await moveTaskToDone(task);
+
+    const props = getTaskCompleteProps();
+    expect(props).not.toHaveProperty('permissionMode');
+  });
+
+  it('fires trackMilestone("first_task_complete") on the Done move', async () => {
+    const task = makeTask({ swimlane_id: DOING_LANE_ID, session_id: null, worktree_path: null });
+    await moveTaskToDone(task);
+
+    expect(mockTrackMilestone).toHaveBeenCalledWith('first_task_complete');
   });
 });

--- a/tests/unit/updater-retry.test.ts
+++ b/tests/unit/updater-retry.test.ts
@@ -6,9 +6,12 @@
  *   - checkWithRetry(): flag transitions, retry call count, error logging
  *   - downloadWithRetry(): flag transitions, retry call count, error logging
  *   - autoUpdater.on('error') handler branches:
- *       1. checkRetrying || downloadRetrying in-flight -- no trackEvent
- *       2. isTransientUpdaterError -- no trackEvent, console.log suppression message
- *       3. structural error -- trackEvent('app_error', ...) called
+ *       1. checkRetrying || downloadRetrying in-flight - no trackEvent, no reportHandledError
+ *       2. isTransientUpdaterError - no trackEvent, no reportHandledError, console.log suppression message
+ *       3. structural error - trackEvent('app_error', ...) AND reportHandledError(error, { source: 'updater' })
+ *          called, gated identically (reportHandledError sits after the same two early
+ *          returns, so a regression that moves it above either guard would page Sentry
+ *          for a transient or in-flight-retry error)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -23,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   autoUpdaterOn: vi.fn(),
   trackEvent: vi.fn(),
   sanitizeErrorMessage: vi.fn((message: string) => message),
+  reportHandledError: vi.fn(),
   // initUpdater() now guards on the presence of app-update.yml; force the
   // guard to pass so the full wiring path (including the `error` listener
   // these tests target) is executed.
@@ -53,6 +57,10 @@ vi.mock('electron-updater', () => ({
 vi.mock('../../src/main/analytics/analytics', () => ({
   trackEvent: mocks.trackEvent,
   sanitizeErrorMessage: mocks.sanitizeErrorMessage,
+}));
+
+vi.mock('../../src/main/analytics/error-reporting', () => ({
+  reportHandledError: mocks.reportHandledError,
 }));
 
 vi.mock('fs', async () => {
@@ -267,6 +275,11 @@ describe("autoUpdater.on('error') listener", () => {
       message: 'sanitized message',
     });
     expect(mocks.sanitizeErrorMessage).toHaveBeenCalledWith(structuralError.message);
+    // reportHandledError forwards the REAL error (not the sanitized message
+    // trackEvent gets), so a structural updater failure is diagnosable in
+    // Sentry beyond a bare count.
+    expect(mocks.reportHandledError).toHaveBeenCalledTimes(1);
+    expect(mocks.reportHandledError).toHaveBeenCalledWith(structuralError, { source: 'updater' });
   });
 
   it('does NOT call trackEvent for a transient error when not retrying', () => {
@@ -281,6 +294,9 @@ describe("autoUpdater.on('error') listener", () => {
       expect.stringContaining('[UPDATER] Suppressing transient error telemetry:'),
       expect.any(String),
     );
+    // A transient error must never reach Sentry either - it shares the same
+    // early return as the trackEvent suppression above.
+    expect(mocks.reportHandledError).not.toHaveBeenCalled();
 
     consoleLogSpy.mockRestore();
   });
@@ -301,6 +317,7 @@ describe("autoUpdater.on('error') listener", () => {
 
     // The in-flight guard returned early - no trackEvent should have fired.
     expect(mocks.trackEvent).not.toHaveBeenCalled();
+    expect(mocks.reportHandledError).not.toHaveBeenCalled();
 
     // Clean up: advance past the retry delay and resolve the pending promise.
     mocks.checkForUpdates.mockResolvedValueOnce(undefined);
@@ -319,6 +336,7 @@ describe("autoUpdater.on('error') listener", () => {
     errorListener(structuralError);
 
     expect(mocks.trackEvent).not.toHaveBeenCalled();
+    expect(mocks.reportHandledError).not.toHaveBeenCalled();
 
     mocks.downloadUpdate.mockResolvedValueOnce(undefined);
     await vi.advanceTimersByTimeAsync(30_000);

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
+import { sentryVitePlugin } from '@sentry/vite-plugin';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import rendererOptimizeDeps from './scripts/renderer-optimize-deps.json';
@@ -9,6 +10,17 @@ import rendererOptimizeDeps from './scripts/renderer-optimize-deps.json';
 // bundled/evaluated as ESM.
 const configDir = path.dirname(fileURLToPath(import.meta.url));
 const isWorktree = configDir.replace(/\\/g, '/').includes('.kangentic/worktrees/');
+
+// Sentry sourcemap upload is a RELEASE-ONLY build step: it activates only when
+// an upload token is present (a CI/release secret, never committed - the repo
+// is public). KANGENTIC_SENTRY_TOKEN is the scoped name (matching the
+// KANGENTIC_TELEMETRY convention, and immune to another repo's generic env);
+// SENTRY_AUTH_TOKEN stays accepted as the conventional CI fallback. Everything
+// is server-side after upload: hidden sourcemaps are generated, uploaded with
+// debug IDs, then deleted from the output, so nothing ships in the artifact
+// and there is zero runtime or bundle cost (docs/analytics.md, "Error Reporting").
+const sentryAuthToken = process.env.KANGENTIC_SENTRY_TOKEN ?? process.env.SENTRY_AUTH_TOKEN;
+const uploadSourcemaps = Boolean(sentryAuthToken);
 
 export default defineConfig(({ mode }) => ({
   // Worktree checkouts share the main repo's physical node_modules via a
@@ -35,7 +47,23 @@ export default defineConfig(({ mode }) => ({
   define: {
     __KANGENTIC_DEV__: JSON.stringify(mode !== 'production'),
   },
-  plugins: [tailwindcss(), react()],
+  plugins: [
+    tailwindcss(),
+    react(),
+    ...(uploadSourcemaps && mode === 'production'
+      ? [
+          sentryVitePlugin({
+            org: 'kangentic',
+            project: 'desktop',
+            authToken: sentryAuthToken,
+            telemetry: false,
+            sourcemaps: {
+              filesToDeleteAfterUpload: ['.vite/build/renderer/**/*.map'],
+            },
+          }),
+        ]
+      : []),
+  ],
   resolve: {
     alias: {
       '@shared': '/src/shared',
@@ -66,6 +94,9 @@ export default defineConfig(({ mode }) => ({
     include: rendererOptimizeDeps,
   },
   build: {
+    // Hidden maps (no sourceMappingURL comment) exist only long enough for the
+    // Sentry plugin above to upload and delete them; see uploadSourcemaps.
+    ...(uploadSourcemaps && mode === 'production' ? { sourcemap: 'hidden' as const } : {}),
     // Electron loads from disk, so large DOWNLOAD sizes are not a concern -
     // but parse/eval at cold start is. Named vendor chunks serve two goals:
     // keep the always-loaded xterm out of the main bundle, and give

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,19 @@ export default defineConfig({
     // than reaching into its internals via deep relative paths.
     alias: {
       '@kangentic/protocol': path.join(configDir, 'packages/protocol/src'),
+      // The Aptabase SDK's ESM build named-imports from 'electron', which
+      // Node's ESM linker rejects against the CJS electron stub under
+      // plain-node vitest - so any suite whose import graph reaches
+      // src/main/analytics/analytics.ts would fail at link time. This stub
+      // keeps the graph loadable; suites that assert on analytics still
+      // vi.mock the SDK or the analytics module, which overrides the alias.
+      '@aptabase/electron/main': path.join(
+        configDir,
+        'tests/fixtures/aptabase-electron-main-stub.ts'
+      ),
+      // Same ESM-link problem, same cure (see the stub's header comment).
+      '@sentry/electron/main': path.join(configDir, 'tests/fixtures/sentry-electron-stub.ts'),
+      '@sentry/electron/renderer': path.join(configDir, 'tests/fixtures/sentry-electron-stub.ts'),
     },
   },
   // Match the build-time constant used by esbuild (scripts/{dev,build}.js)


### PR DESCRIPTION
## What

Adopts Sentry (`@sentry/electron`, new `desktop` project in the existing org) for error and crash monitoring, and expands the Aptabase product-analytics event set per the approved telemetry evaluation. Touches the analytics module and its call sites across main, the renderer error boundaries, the settings Privacy tab, both build configs (sourcemap upload), the docs, and adds a `/sentry` skill for agent-driven issue triage.

## Why

Aptabase's `app_error` is a truncated string counter: no stacks, grouping, dedup, release health, or alerting, while the mobile app already has all of that in Sentry. The telemetry evaluation (task #574) decided errors go to Sentry (one org, one triage feed for desktop + mobile, $0 on the current plan), analytics stays on Aptabase, and sized an event-expansion budget (~30 to ~36 events/user/day, ceiling ~180 DAU on the 200k plan). This PR implements that decision.

## How

- **Sentry, dual init with main-only egress:** main initializes beside `initAnalytics` (pre-app-ready); the renderer SDK has no network path and transports over the SDK's internal IPC, so the documented "all telemetry egress happens in the main process" invariant holds. The renderer init is gated on a boot flag in `additionalArguments` mirroring main's single decision. Errors only: the `MainProcessSession` release-health integration is filtered out; no tracing or replay.
- **Scrubbing is vendor-native:** the SDK's default `normalizePathsIntegration` rewrites frame paths relative to the app root, `sendDefaultPii` stays false, server-side scrubbing stays on. No custom scrubber code.
- **Kill switches:** `KANGENTIC_TELEMETRY=0` disables both vendors (the pre-existing documented promise); new `KANGENTIC_ERROR_REPORTING` controls Sentry alone.
- **Hidden-issue capture:** `reportHandledError` forwards the deliberate catch sites (updater structural failures, PTY spawn failures, silent agent-spawn catches) with real stacks and tags; the existing anonymous install id rides as the Sentry user id so issues carry affected-install counts.
- **Event expansion:** `onboarding_milestone`, `feature_first_use`, `feature_used` (once per feature per day, curated 10-feature vocabulary, renderer reports validated against the allowlist over one new IPC channel), `board_snapshot` (COUNT(*), bucketed), `update_outcome`, `spawn_failed`; prop enrichment on `session_spawn` (`permissionMode`, `worktree`), `session_exit` (`intentional`), `task_complete` (`permissionMode`). Lifetime flags persist with serialized writes and field-level validation.
- **Sourcemaps at release only:** `@sentry/vite-plugin` + `@sentry/esbuild-plugin` activate on `KANGENTIC_SENTRY_TOKEN` (or `SENTRY_AUTH_TOKEN`), upload hidden maps with debug IDs, and delete them; nothing ships in the artifact.
- **Unit-tier stubs:** vitest aliases `@aptabase/electron/main` and `@sentry/electron/*` to no-op stubs (their ESM builds named-import from `electron`, which Node's linker rejects against the CJS electron stub under plain-node vitest); per-suite `vi.mock`s still override.

Trade-offs a reviewer should weigh: raw (path-normalized) stack traces now leave the machine, a deliberate re-decision from the previous strip-everything posture, disclosed in the Privacy tab and docs alongside the corrected "no persistent identifiers" copy; and the Sentry DSN is hardcoded in source, which is by design (a DSN is a public routing identifier, like the Aptabase app key beside it).

## Breaking changes

None. `KANGENTIC_TELEMETRY=0` keeps its documented meaning (now covering both vendors); `KANGENTIC_ERROR_REPORTING` is new and optional.

## Tests

CI checks (lint, typecheck, unit, build, UI shards, Linux E2E shards), plus in this PR: switch truth-table and runtime-gating tests for the Sentry module, dedup/persistence/corruption-guard tests for the usage module, the review pass's ~900 lines (feature-usage UI spec, MCP track-feature tests, renderer error-reporting tests, expansions across the spawn/task suites), and a coverage-audit commit pinning the four remaining instrumentation decision points (each red-green proven). Verified live in a dev preview: Sentry ingestion (issues DESKTOP-1/2, install id attached), the renderer feature funnel, and flag persistence end to end.

Generated with [Claude Code](https://claude.com/claude-code)
