### PR TITLE
fix(pty): key the geometry re-assert on alt-screen entry, not first output

### DIFF
--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -19,7 +19,7 @@ Every agent implements the `AgentAdapter` interface. Each adapter lives in `src/
 | `runtime` | `AdapterRuntimeStrategy` declaring activity detection + session ID capture (see below) |
 | `removeHooks(directory, taskId?)` | Remove the per-directory config an adapter injected, on cleanup. `taskId` lets shared-file adapters (Codex, Gemini, Droid) reference-count so concurrent sessions in the same cwd do not clobber each other. The payload is not only hooks: Gemini also strips its `mcpServers.kangentic` entry (which carries the per-launch token), and Droid's refcount guards `<cwd>/.factory/mcp.json` rather than a hooks file. |
 | `clearSettingsCache()` | Clear cached merged settings |
-| `detectFirstOutput(data)` | Detect when the agent TUI is ready (lifts shimmer overlay) |
+| `detectFirstOutput(data)` | Detect the adapter's readiness escape, which lifts the shimmer overlay. A heuristic, not proof the agent is up - see First-Output Detection below |
 | `getExitSequence()` | Return PTY write sequence for graceful exit |
 | `locateSessionHistoryFile(agentSessionId, cwd)` | Locate the agent's native session history file on disk |
 
@@ -183,7 +183,7 @@ When a task moves to a column, `resolveTargetAgent()` determines which agent to 
 
 ## First-Output Detection
 
-Each adapter implements `detectFirstOutput(data)` to signal when the agent's TUI is ready. This controls when the shimmer overlay lifts in the terminal UI.
+Each adapter implements `detectFirstOutput(data)` to spot the first output worth showing. This controls when the shimmer overlay lifts in the terminal UI.
 
 | Agent | Detection Strategy | Rationale |
 |-------|-------------------|-----------|
@@ -202,7 +202,16 @@ Each adapter implements `detectFirstOutput(data)` to signal when the agent's TUI
 | Grok Build | `\x1b[?25l` (cursor hide) | Rust alt-screen TUI; the cursor-hide arrives in the very first output chunk, before the alt-screen switch (verified via node-pty against grok 1.0.0) |
 | Antigravity CLI | `data.length > 0` | First paint (logo + welcome banner) arrives as one plain-text burst well under a second after spawn (verified against agy 1.1.13) |
 
-The `\x1b[?25l` (ANSI cursor hide) sequence fires after the shell prompt noise but before the TUI draws its startup banner. This keeps the shell command hidden behind the shimmer overlay.
+The `\x1b[?25l` (ANSI cursor hide) sequence usually fires after the shell prompt noise but before the TUI draws its startup banner, which keeps the shell command hidden behind the shimmer overlay.
+
+**It is a shimmer heuristic, never proof the agent is running.** A shell can emit the same
+escape during its own startup: pwsh 7.6's preamble carries `\x1b[?25l` (see
+`buildSpawnClearPrelude` in `src/shared/paths.ts`), so on PowerShell the latch trips on SHELL
+bytes tens of ms after spawn, seconds before the agent process exists. Anything needing "the
+agent is demonstrably driving the terminal" must key on the stream's first alt-screen entry
+instead (`PtyBufferManager`'s `onAltScreenEnter`) - misreading this latch as agent liveness is
+what made the task #573 spawn-race fix miss its target on PowerShell. See
+[session-lifecycle.md](session-lifecycle.md)'s "Post-boot geometry re-assert".
 
 ## Exit Sequences
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,7 +209,7 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 | `session:data` | on | Terminal output available (includes `projectId`) |
 | `session:drainAck` | send | Renderer-to-main flow-control ack for per-session PTY backpressure; fire-and-forget (no projectId) |
 | `session:ptyResized` | on | The PTY's grid actually changed (`cols`, `rows`, `PtyResizeOrigin`). Broadcast to every window; the mounted owner xterm uses it to detect and heal a width divergence (xterm re-sends dims only when its own size changes) |
-| `session:firstOutput` | on | Alternate screen buffer detected - TUI ready (includes `projectId`) |
+| `session:firstOutput` | on | The adapter's readiness escape matched (Claude: cursor-hide `\x1b[?25l`), lifting the shimmer overlay. A heuristic, not proof the agent is up - a shell preamble can carry the same escape (includes `projectId`) |
 | `session:exit` | on | Session exited (includes `projectId`) |
 | `session:status` | on | Session changed - pushes full `Session` object (includes `projectId`) |
 | `session:usage` | on | Usage data updated (includes `projectId`) |

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -745,7 +745,7 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   tag (`mount`/`flush`/`reload`/`echo-reassert`/`debounced-onResize`) and main traces every
   resize outcome (`resize-applied`/`resize-noop`/`resize-refused`/`resize-stash`/
   `resize-ignored`/`resize-invalid`, plus `resize-reassert`/`resize-reassert-failed` from the
-  post-first-output re-assert below), so `kangentic_devtools_terminal_state`'s merged trace
+  post-boot re-assert below), so `kangentic_devtools_terminal_state`'s merged trace
   names the trigger if a divergence ever recurs. A resize for a queued or suspended session
   stashes (including suspend's marked-but-alive teardown window, where the PTY is still
   non-null but must not be reshaped or re-echoed); one for a missing or exited session is
@@ -754,18 +754,28 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   `tests/ui/terminal-resize-echo-reassert.spec.ts` (real xterm wiring: re-assert, repair,
   self-echo no-op, budget bound), and `tests/e2e/terminal-width-drift-selfheal.spec.ts` (a real
   PTY driven to the incident by a rogue `sessions.resize`, healed back to the owner grid).
-- **Post-first-output geometry re-assert (the spawn-window race).** ConPTY only delivers a
+- **Post-boot geometry re-assert (the spawn-window race).** ConPTY only delivers a
   resize to a connected client, so a resize applied while the agent is still booting (the fit
   lands ~140ms after `pty.spawn`) can be lost, leaving the child composing at the 120-column
   spawn width inside the fitted grid while `ptyMatchesGrid`/`colsDrift` read healthy. `resize()`
-  arms `ManagedSession.resizeAppliedBeforeFirstOutput` when it applies a resize before the
-  first-output latch trips, and `consumeFirstOutput` then re-delivers the geometry as a jiggle
-  (`cols-1`, then `cols` back, traced `resize-reassert`) via direct `pty.resize()` calls -
+  arms `ManagedSession.resizeAppliedBeforeTuiReady` when it applies a resize while the stream is
+  not in the alt buffer - NOT keyed on the first-output latch, which a shell preamble can
+  trip seconds before the agent exists (pwsh 7.6's preamble carries the cursor-hide escape the
+  adapters match; this shipped as a live recurrence of task #573 on 2026-08-30). Two triggers
+  then re-deliver the geometry as a jiggle
+  (`cols-1`, then `cols` back, traced `resize-reassert` with its `trigger`): the first-output
+  latch (disarming only when the output provably came from the TUI) and the stream's first
+  alt-screen entry via `PtyBufferManager`'s `onAltScreenEnter` (which nothing but the TUI can
+  produce, always disarming). The arming criterion is the stream's CURRENT alt-screen state, not
+  a once-ever latch, so a booted TUI resized during a normal-buffer excursion (`\x1b[?1049l`, or
+  an RIS `\x1bc`) re-arms and re-jiggles on its next re-entry; that costs one redundant
+  re-delivery of geometry the child already holds, and is accepted rather than tracked. Both call
+  direct `pty.resize()` -
   deliberately bypassing `resize()`'s ladder, whose same-dims short-circuit would eat the
   restore leg and whose broadcasts would churn the echo budget, phone re-seeds, and settle for
   net-unchanged geometry. The third-layer diagnostic (`composedCols`/`composedMatchesPty` on
   `kangentic_devtools_terminal_state`) measures the width the child actually composes at from
-  its raw ring, alt-screen sessions only. Pinned by the `Post-first-output geometry re-assert`
+  its raw ring, alt-screen sessions only. Pinned by the `Post-boot geometry re-assert`
   block in `tests/unit/session-manager.test.ts` and the respawn latch-cleanup tests in
   `tests/unit/session-spawn-flow.test.ts`; the diagnostic is exercised by
   `tests/unit/composed-width.test.ts` and `tests/unit/devtools-terminal-state.test.ts`.

--- a/src/devtools/main/composed-width.ts
+++ b/src/devtools/main/composed-width.ts
@@ -204,19 +204,41 @@ function explainsCandidate(baseWidth: number, candidate: number): boolean {
   );
 }
 
-/** Score ties within this epsilon are treated as equal explanatory power. */
-const SCORE_TIE_EPSILON = 1e-9;
+/** Bases whose score is within this fraction of the best are treated as
+ *  equally supported, and the tie-break (reference-nearest, then larger)
+ *  chooses among them. A sub-width lattice base (40 under a true 120) always
+ *  explains a SUPERSET of the truth's candidates - every k*120 is a k'*40 -
+ *  plus whatever stray 40-column runs the frame carries, so it beats the
+ *  truth by a few percent on any additive score. Measured live 2026-08-30
+ *  (task #573's recurrence): a 120-composing child's frame folded to 46
+ *  under strict-max selection while the 120 rules carried 93% of the
+ *  evidence mass. The near-tie band lets the tie-break, not the noise
+ *  margin, decide.
+ *
+ *  Pinned from BOTH sides, which is why a tweak here breaks two unrelated
+ *  tests at once (measured 2026-08-30): raising it to 0.95 drops base 120
+ *  out of its own band in the structural-mass test and folds that frame to
+ *  40, while lowering it to 0.5 admits decisively-worse bases into the
+ *  tie-break and breaks three of the pre-existing reference tests. The
+ *  usable window is roughly 0.87 to 0.90. */
+const COMPOSED_WIDTH_NEAR_TIE_RATIO = 0.9;
 
 /**
  * Fold the candidate lengths to the best-supported base width (see the module
- * doc). A base's score is EXACTNESS-weighted (each explained candidate
- * contributes 1/(1+offset)), not a bare count: a small base has dense
- * multiples, so some multiple of it grazes almost any length at the edge of
- * the eligibility band, and count-scoring let base 44 "explain" the real
- * 210-column frame. An exact single-row hit outranks a grazing multiple.
- * `referenceCols` breaks ties between bases with equal scores - exact mutual
- * sub-multiples are indistinguishable on the evidence alone - and cannot
- * override evidence a reference-far base explains better.
+ * doc). A base's score is the EXACTNESS-WEIGHTED, SUB-LINEAR evidence mass it
+ * explains: each explained candidate contributes sqrt(candidate)/(1+offset).
+ * Exactness weighting keeps a small base's dense multiples from grazing their
+ * way past the truth (count-scoring let base 44 "explain" the real 210-column
+ * frame). Length weighting makes a 120-column rule outvote a 40-column indent
+ * run (bare counts let base 40's lattice beat a 120-composing child by sheer
+ * noise count, task #573's live histogram). The square root keeps that
+ * weighting from overshooting the other way: linear mass let a SINGLE
+ * 7x-concatenated 700 run outvote three corroborating 100-rules, so a run's
+ * weight grows with length but sub-linearly, and several independent rows
+ * always beat one long outlier. `referenceCols` chooses among near-tied
+ * bases - exact mutual sub-multiples are indistinguishable on the evidence
+ * alone - and cannot override evidence a reference-far base explains
+ * decisively better.
  */
 function resolveBaseWidth(
   candidates: number[],
@@ -244,7 +266,7 @@ function resolveBaseWidth(
       if (baseWidth >= COMPOSED_WIDTH_MIN_SIGNAL_COLUMNS) baseWidths.add(baseWidth);
     }
   }
-  let best: { baseWidth: number; explained: number; score: number } | null = null;
+  const scored: Array<{ baseWidth: number; explained: number; score: number }> = [];
   for (const baseWidth of baseWidths) {
     let explained = 0;
     let score = 0;
@@ -252,33 +274,42 @@ function resolveBaseWidth(
       if (!explainsCandidate(baseWidth, candidateValue)) continue;
       explained += occurrenceCount;
       const wrapMultiple = Math.round(candidateValue / baseWidth);
-      score += occurrenceCount / (1 + Math.abs(candidateValue - wrapMultiple * baseWidth));
+      score +=
+        (occurrenceCount * Math.sqrt(candidateValue)) /
+        (1 + Math.abs(candidateValue - wrapMultiple * baseWidth));
     }
-    if (explained === 0) continue;
-    if (!best || score > best.score + SCORE_TIE_EPSILON) {
-      best = { baseWidth, explained, score };
-      continue;
-    }
-    if (score < best.score - SCORE_TIE_EPSILON) continue;
-    // Tied explanatory power: prefer the base nearer the reference grid,
-    // falling back to the larger base (a sub-multiple over-folds).
-    if (referenceCols !== null) {
-      const currentDistance = Math.abs(best.baseWidth - referenceCols);
-      const candidateDistance = Math.abs(baseWidth - referenceCols);
-      if (candidateDistance < currentDistance) best = { baseWidth, explained, score };
-      else if (candidateDistance === currentDistance && baseWidth > best.baseWidth) {
-        best = { baseWidth, explained, score };
-      }
-    } else if (baseWidth > best.baseWidth) {
-      best = { baseWidth, explained, score };
-    }
+    if (explained > 0) scored.push({ baseWidth, explained, score });
   }
   // candidates is non-empty at every call site and every candidate explains
-  // its own k=1 base, so best is always set; the fallback satisfies the type
-  // system.
-  return best
-    ? { baseWidth: best.baseWidth, explained: best.explained }
-    : { baseWidth: candidates[0], explained: 1 };
+  // its own k=1 base, so scored is never empty; the fallback satisfies the
+  // type system.
+  if (scored.length === 0) return { baseWidth: candidates[0], explained: 1 };
+  const bestScore = Math.max(...scored.map((entry) => entry.score));
+  // Near-tie band, then tie-break: nearest the reference grid, then larger
+  // (a sub-multiple over-folds).
+  let best = scored[0];
+  let bestQualifies = false;
+  for (const entry of scored) {
+    if (entry.score < bestScore * COMPOSED_WIDTH_NEAR_TIE_RATIO) continue;
+    if (!bestQualifies) {
+      best = entry;
+      bestQualifies = true;
+      continue;
+    }
+    if (referenceCols !== null) {
+      const currentDistance = Math.abs(best.baseWidth - referenceCols);
+      const candidateDistance = Math.abs(entry.baseWidth - referenceCols);
+      if (
+        candidateDistance < currentDistance ||
+        (candidateDistance === currentDistance && entry.baseWidth > best.baseWidth)
+      ) {
+        best = entry;
+      }
+    } else if (entry.baseWidth > best.baseWidth) {
+      best = entry;
+    }
+  }
+  return { baseWidth: best.baseWidth, explained: best.explained };
 }
 
 /**

--- a/src/main/pty/buffer/pty-buffer-manager.ts
+++ b/src/main/pty/buffer/pty-buffer-manager.ts
@@ -316,6 +316,15 @@ interface PtyBufferManagerCallbacks {
    *  throw - a throw is caught and logged at the reportDrain chokepoint so
    *  it can never unwind a replay whose pending buffer is already emptied. */
   onDrain(sessionId: string, data: string): void;
+  /** Fired when a session's stream transitions INTO the alternate screen
+   *  buffer (inAltScreen false -> true during onData's mode parse) - the
+   *  moment a fullscreen TUI demonstrably composed its first frame. This is
+   *  the one boot signal a shell preamble cannot fake: pwsh 7.6's preamble
+   *  carries the cursor-hide escape that trips adapter first-output
+   *  detectors, but no shell enters the alt buffer. SessionManager keys the
+   *  post-boot geometry re-assert on it. Fires on EVERY entry (a TUI can
+   *  leave and re-enter); the listener's own arming makes repeats no-ops. */
+  onAltScreenEnter?(sessionId: string): void;
 }
 
 interface BufferState {
@@ -548,7 +557,11 @@ export class PtyBufferManager {
     }
     if (state.modeParseCarry || data.includes('\x1b')) {
       const combined = state.modeParseCarry + data;
+      const wasInAltScreen = state.inAltScreen;
       updateModeState(state, combined);
+      if (!wasInAltScreen && state.inAltScreen) {
+        this.callbacks.onAltScreenEnter?.(sessionId);
+      }
       // The TUI-takeover clear of a fresh session: the first NORMAL-buffer
       // full clear PRECEDED by printable output (ConPTY's escape-only startup
       // clear stays armed - see the field and stripAnsiSequences docs).
@@ -1053,10 +1066,18 @@ export class PtyBufferManager {
    * The geometry this session's PTY was last resized to, as the buffer manager
    * saw it, plus whether a post-resize repaint is still outstanding.
    *
-   * Dev diagnostics only. `lastCols`/`lastRows` are the geometry the bytes
-   * currently in the scrollback were DRAWN at, which is the number you need to
-   * explain a terminal whose content does not match its grid - the divergence
-   * is invisible from the renderer, which only knows its own xterm's size.
+   * `lastCols`/`lastRows` are the geometry the bytes currently in the
+   * scrollback were DRAWN at, which is the number you need to explain a
+   * terminal whose content does not match its grid - the divergence is
+   * invisible from the renderer, which only knows its own xterm's size.
+   *
+   * Mostly diagnostics, but NOT diagnostics-only any more: `inAltScreen` is
+   * read on two production paths in SessionManager (`resize`'s arming
+   * criterion and `consumeFirstOutput`'s disarm gate) as the boot signal a
+   * shell preamble cannot fake. Removing or gating this accessor behind
+   * `__KANGENTIC_DEV__` would silently break the spawn-window resize race
+   * fix, whose symptom is a child composing at the spawn width for a whole
+   * turn while every pty-vs-grid invariant reads healthy.
    */
   getDimensionState(sessionId: string): {
     lastCols: number;
@@ -1211,8 +1232,9 @@ export class PtyBufferManager {
    * geometry gate, for performSpawn's carry-over (captured alongside
    * getRawScrollback, BEFORE removeSession). Lets initSession keep the gate
    * accurate across a respawn instead of conservatively marking every carried
-   * ring geometry-suspect. A production accessor by design - not
-   * getDimensionState, which is pinned as dev-diagnostics-only.
+   * ring geometry-suspect. Purpose-built for the respawn carry-over, rather
+   * than widening getDimensionState: this returns exactly the two fields
+   * performSpawn needs, captured at one point in the teardown.
    */
   getCarryoverGeometry(sessionId: string): CarryoverGeometry | null {
     const state = this.buffers.get(sessionId);

--- a/src/main/pty/lifecycle/first-output-tracker.ts
+++ b/src/main/pty/lifecycle/first-output-tracker.ts
@@ -4,12 +4,21 @@
  * overlay in the renderer and to clear the `resuming` flag on resumed
  * sessions.
  *
- * What counts as meaningful is adapter-specific. Claude waits for the
- * alternate-screen-buffer escape (`\x1b[?1049h`) because its shell prompt
- * renders before the CLI actually boots. Other agents default to any
- * non-empty data. The decision is delegated to the agent adapter via the
- * `detectFirstOutput` callback passed to `consume()`; when no detector is
- * given, any non-empty chunk qualifies.
+ * What counts as meaningful is adapter-specific. Claude matches the
+ * cursor-hide escape (`\x1b[?25l` - see ClaudeAdapter.detectFirstOutput), as
+ * do several other TUI adapters. The decision is delegated to the agent
+ * adapter via the `detectFirstOutput` callback passed to `consume()`; when no
+ * detector is given, any non-empty chunk qualifies.
+ *
+ * CAUTION: this latch is a shimmer-overlay heuristic, not proof the AGENT is
+ * up. Shell preambles can carry the very escapes the detectors match (pwsh
+ * 7.6 emits `\x1b[?25l` at startup - see buildSpawnClearPrelude in
+ * src/shared/paths.ts), so on such shells the latch trips on SHELL bytes
+ * tens of ms after spawn. Anything that needs "the agent is demonstrably
+ * driving the terminal" must key on the stream's alt-screen entry instead
+ * (PtyBufferManager's onAltScreenEnter) - misreading this latch as an
+ * agent-liveness signal is how the task #573 spawn-race fix initially
+ * missed its target.
  *
  * The tracker holds only a set of session IDs. Call `removeSession()`
  * when a session is fully cleaned up, or `clear()` during killAll().

--- a/src/main/pty/session-manager.ts
+++ b/src/main/pty/session-manager.ts
@@ -302,6 +302,16 @@ export class SessionManager extends EventEmitter {
         this.consumeFirstOutput(sessionId, data);
         this.emit('data-tap', sessionId, data);
       },
+      onAltScreenEnter: (sessionId) => {
+        // The TUI's first composed frame: the one boot signal a shell
+        // preamble cannot fake (see the arming comment in resize()). This
+        // trigger always disarms - a child that just switched buffers is
+        // demonstrably parsing output, so the re-delivered geometry lands.
+        this.reassertGeometryForBootingChild(sessionId, {
+          trigger: 'alt-screen-enter',
+          disarm: true,
+        });
+      },
     });
 
     this.sessionIdManager = new SessionIdManager({
@@ -499,7 +509,19 @@ export class SessionManager extends EventEmitter {
       : undefined;
     if (this.firstOutputTracker.consume(sessionId, data, detector)) {
       this.emit('first-output', sessionId);
-      this.reassertGeometryAfterFirstOutput(sessionId);
+      // First-output can be tripped by a SHELL preamble, not the agent (see
+      // the arming comment in resize()), so this trigger DISARMS only when
+      // the stream is already in the alt buffer - the output provably came
+      // from the TUI. Otherwise the jiggle still fires (for an inline-mode
+      // agent this is the only trigger, and one extra repaint is harmless)
+      // but the flag stays armed for the alt-screen-entry trigger, which is
+      // what actually reaches a fullscreen agent that boots after the shell.
+      const tuiComposedThisOutput =
+        this.bufferManager.getDimensionState(sessionId)?.inAltScreen === true;
+      this.reassertGeometryForBootingChild(sessionId, {
+        trigger: 'first-output',
+        disarm: tuiComposedThisOutput,
+      });
       // Clear the resuming flag once the resumed CLI has actually
       // produced output. This unblocks card / overlay labels for
       // adapters (Codex, Gemini) that don't emit a usage statusline.
@@ -511,12 +533,19 @@ export class SessionManager extends EventEmitter {
   }
 
   /**
-   * Re-deliver the PTY's geometry once the agent has produced first output,
-   * when a resize was applied inside the spawn window (see
-   * `ManagedSession.resizeAppliedBeforeFirstOutput`). A resize applied to a
-   * RUNNING child reliably reaches it (verified live: a hand-resize healed a
-   * stuck frame mid-turn), so re-asserting here closes the spawn race for
-   * every trigger.
+   * Re-deliver the PTY's geometry to a child that was still booting when a
+   * resize was applied (see `ManagedSession.resizeAppliedBeforeTuiReady`).
+   * A resize applied to a RUNNING child reliably reaches it (verified live:
+   * a hand-resize healed a stuck frame mid-turn), so the whole question is
+   * WHEN the child is demonstrably up. Two triggers fire this, at most one
+   * jiggle each: the adapter's first-output latch (which a shell preamble
+   * can trip early - it disarms only when the output provably came from the
+   * TUI) and the stream's first alt-screen entry (which nothing but the TUI
+   * can produce, and which always disarms). Task #573's live recurrence
+   * (2026-08-30) is the case the second trigger exists for: pwsh's preamble
+   * tripped first-output ~80ms after spawn, the fit resize then read as
+   * post-first-output and never armed under the old criterion, and the
+   * agent booting seconds later composed at the spawn width all turn.
    *
    * The re-assert is a jiggle - cols-1, then cols back - because a same-dims
    * delivery can be deduplicated anywhere in the chain (our own resize() would
@@ -537,10 +566,13 @@ export class SessionManager extends EventEmitter {
    * at first output, and one ungated code path means CI's Linux unit tests
    * exercise exactly what Windows ships.
    */
-  private reassertGeometryAfterFirstOutput(sessionId: string): void {
+  private reassertGeometryForBootingChild(
+    sessionId: string,
+    { trigger, disarm }: { trigger: 'first-output' | 'alt-screen-enter'; disarm: boolean },
+  ): void {
     const session = this.registry.get(sessionId);
-    if (!session?.pty || !session.resizeAppliedBeforeFirstOutput) return;
-    session.resizeAppliedBeforeFirstOutput = false;
+    if (!session?.pty || !session.resizeAppliedBeforeTuiReady) return;
+    if (disarm) session.resizeAppliedBeforeTuiReady = false;
     const { cols, rows } = session.pty;
     const jiggleCols = Math.max(2, cols - 1);
     if (jiggleCols === cols) return;
@@ -549,18 +581,18 @@ export class SessionManager extends EventEmitter {
     } catch (error) {
       // node-pty can throw on a just-died ConPTY; the exit path owns cleanup.
       // Nothing landed, so the child still holds `cols`.
-      traceTerminal(sessionId, 'resize-reassert-failed', { leg: 'jiggle', message: String(error) });
+      traceTerminal(sessionId, 'resize-reassert-failed', { trigger, leg: 'jiggle', message: String(error) });
       return;
     }
     try {
       session.pty.resize(cols, rows);
-      traceTerminal(sessionId, 'resize-reassert', { cols, rows, jiggleCols });
+      traceTerminal(sessionId, 'resize-reassert', { trigger, cols, rows, jiggleCols });
     } catch (error) {
       // The narrow leg landed but the restore did not: node-pty caches dims
       // only on a successful resize, so the child sits at cols-1 until the
       // next real resize. The leg field lets forensics tell this stranded
       // case from the harmless jiggle-leg failure above.
-      traceTerminal(sessionId, 'resize-reassert-failed', { leg: 'restore', message: String(error) });
+      traceTerminal(sessionId, 'resize-reassert-failed', { trigger, leg: 'restore', message: String(error) });
     }
   }
 
@@ -1222,21 +1254,40 @@ export class SessionManager extends EventEmitter {
       return { colsChanged };
     }
     session.pty.resize(clampedCols, clampedRows);
-    // A resize applied while the agent has not yet produced output can be lost:
-    // ConPTY only delivers a resize to a connected client, and in the spawn
-    // window the child is still booting behind the shell (and, under WSL, two
-    // interop hops). Arm the post-first-output re-assert so the geometry is
-    // re-delivered once the child demonstrably exists. Any origin arms - the
-    // loss is about timing, not who asked.
-    const appliedBeforeFirstOutput = !this.firstOutputTracker.hasEmitted(sessionId);
-    if (appliedBeforeFirstOutput) {
-      session.resizeAppliedBeforeFirstOutput = true;
+    // A resize applied while the agent is still booting can be lost: ConPTY
+    // only delivers a resize to a connected client, and in the spawn window
+    // the child is still starting behind the shell (and, under WSL, two
+    // interop hops). Arm the post-boot re-assert so the geometry is
+    // re-delivered once the child demonstrably exists. The criterion is
+    // "the stream has not entered the alt buffer yet", NOT the first-output
+    // latch: pwsh 7.6's startup preamble carries the cursor-hide escape that
+    // adapter first-output detectors match (src/shared/paths.ts,
+    // buildSpawnClearPrelude), so on that shell the latch reads "agent up"
+    // within tens of ms of spawn while the agent is seconds away - exactly
+    // the window whose resize is lost (task #573's live recurrence,
+    // 2026-08-30). No shell enters the alt buffer, so a pre-alt-screen
+    // resize always arms.
+    //
+    // This reads the CURRENT alt-screen state, not a once-ever latch, so a
+    // booted TUI that drops to the normal buffer (`\x1b[?1049l`, or an RIS
+    // `\x1bc`) and is resized during that excursion re-arms too, and its
+    // next re-entry jiggles a child that was never booting. Deliberate: the
+    // cost is one redundant re-delivery of geometry the child already has,
+    // and a running child absorbs it, so it is not worth a second piece of
+    // sticky per-session state to suppress.
+    //
+    // An inline-mode session's mid-turn resize arms a flag no remaining
+    // trigger consumes - a dormant boolean that dies with the session, not a
+    // jiggle. Any origin arms - the loss is about timing, not who asked.
+    const preTuiReady = this.bufferManager.getDimensionState(sessionId)?.inAltScreen !== true;
+    if (preTuiReady) {
+      session.resizeAppliedBeforeTuiReady = true;
     }
     traceTerminal(sessionId, 'resize-applied', {
       origin,
       cols: clampedCols,
       rows: clampedRows,
-      preFirstOutput: appliedBeforeFirstOutput,
+      preTuiReady,
     });
     // Mark resize time so the dispatch can suppress idle->thinking
     // transitions during the redraw burst that follows.

--- a/src/main/pty/session-registry.ts
+++ b/src/main/pty/session-registry.ts
@@ -98,17 +98,29 @@ export interface ManagedSession {
    *  status: a hard reset stays 'exited', not 'suspended'. */
   intentionalExit?: boolean;
   /**
-   * True when a resize was APPLIED to the live PTY before the agent produced
-   * first output. ConPTY only delivers a resize to a connected client, so a
-   * resize landing in the spawn window (the fit lands ~140ms after pty.spawn,
-   * while the shell/interop chain is still booting the agent) can be lost: the
-   * child then composes rows at the spawn width for the whole turn while every
-   * pty-vs-grid invariant reads healthy. `consumeFirstOutput` reads this and
-   * re-asserts the geometry once the child is demonstrably up (it just
-   * emitted), which a running child cannot miss. Lazily set; dies with the
+   * True when a resize was APPLIED to the live PTY while the session's
+   * stream was NOT in the alternate screen buffer. ConPTY only delivers a
+   * resize to a connected client, so a resize landing in the spawn window
+   * (the fit lands ~140ms after pty.spawn, while the shell/interop chain is
+   * still booting the agent) can be lost: the child then composes rows at
+   * the spawn width for the whole turn while every pty-vs-grid invariant
+   * reads healthy. The criterion is alt-screen entry rather than the
+   * first-output latch because a shell preamble (pwsh 7.6 emits the
+   * cursor-hide escape adapters match) can trip first-output seconds before
+   * the agent exists. `reassertGeometryForBootingChild` consumes this from
+   * two triggers (first-output and alt-screen entry) and re-delivers the
+   * geometry, which a running child cannot miss. Lazily set; dies with the
    * registry entry.
+   *
+   * Note the criterion is the CURRENT alt-screen state, not a once-ever
+   * latch: a booted TUI that drops to the normal buffer (`\x1b[?1049l`, or
+   * an RIS `\x1bc`) and is resized during that excursion re-arms, and the
+   * next re-entry jiggles a child that was never booting. That costs one
+   * redundant repaint of geometry the child already has, so it is tolerated
+   * rather than tracked - but it is why this reads "was not in the alt
+   * buffer" rather than "had never entered" it.
    */
-  resizeAppliedBeforeFirstOutput?: boolean;
+  resizeAppliedBeforeTuiReady?: boolean;
   /**
    * Exit code to report INSTEAD of the one the OS gives, when Kangentic ends a
    * session on the agent's behalf. Named "override" rather than "reported"

--- a/tests/unit/composed-width.test.ts
+++ b/tests/unit/composed-width.test.ts
@@ -164,6 +164,30 @@ describe('measureComposedCols', () => {
     expect(measurement.sampleCount).toBe(5);
   });
 
+  it('structural mass names the true width against dense sub-width noise (task #573 live histogram)', () => {
+    // The 2026-08-30 recurrence: a child composing 120 inside a 306 PTY. Its
+    // measured ring carried 95 full-width rules at 120 alongside box borders
+    // and dividers at 40/47/73/80 and sub-width ECH spans (84/108/115).
+    // Count-scored folding named base 46, and the base-40 lattice explains
+    // every 120-multiple plus the stray indents, edging out the truth on any
+    // bare count. Sub-linear length weighting keeps the 40-lattice inside the
+    // near-tie band instead of ahead, and the reference tie-break then names
+    // 120 - the width carrying virtually all the structural evidence.
+    const stream =
+      ALT +
+      ('─'.repeat(120) + '\r\n').repeat(95) +
+      ('─'.repeat(47) + '\r\n').repeat(21) +
+      ('─'.repeat(73) + '\r\n').repeat(21) +
+      (' '.repeat(40) + 'indent\r\n').repeat(7) +
+      (' '.repeat(80) + 'indent\r\n').repeat(7) +
+      '\x1b[84X\r\n'.repeat(20) +
+      '\x1b[108X\r\n'.repeat(20) +
+      '\x1b[115X\r\n'.repeat(20);
+    const measurement = measureComposedCols(stream, 306);
+    expect(measurement.composedCols).toBe(120);
+    expect(measurement.sampleCount).toBe(95);
+  });
+
   it('returns null when nothing in the window qualifies', () => {
     const stream =
       ALT + '─'.repeat(COMPOSED_WIDTH_MIN_SIGNAL_COLUMNS - 1) + '\r\nplain prose text\r\n';

--- a/tests/unit/pty-buffer-manager.test.ts
+++ b/tests/unit/pty-buffer-manager.test.ts
@@ -1418,6 +1418,140 @@ describe('PtyBufferManager', () => {
     });
   });
 
+  describe('onAltScreenEnter callback (post-boot geometry re-assert trigger, task #573)', () => {
+    // The one boot signal a shell preamble cannot fake: SessionManager keys
+    // the spawn-window resize re-assert on this firing, so its edge cases
+    // (exactly-once per transition, re-firing after an exit/re-entry, the
+    // 47/1047 variants, a chunk-split entry, and RIS re-arming the next
+    // entry) are pinned directly here rather than only reached indirectly
+    // through SessionManager's own tests.
+    function createManagerWithAltScreenCallback() {
+      const onAltScreenEnter = vi.fn();
+      const manager = new PtyBufferManager({ onFlush: vi.fn(), onDrain: vi.fn(), onAltScreenEnter });
+      manager.initSession(SESSION, '', 80);
+      manager.onResize(SESSION, 80);
+      return { manager, onAltScreenEnter };
+    }
+
+    it('fires once on the false-to-true alt-screen transition (1049h)', () => {
+      vi.useFakeTimers();
+      const { manager, onAltScreenEnter } = createManagerWithAltScreenCallback();
+
+      manager.onData(SESSION, '\x1b[?1049h');
+
+      expect(onAltScreenEnter).toHaveBeenCalledTimes(1);
+      expect(onAltScreenEnter).toHaveBeenCalledWith(SESSION);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('does not fire again for a repeated 1049h while already in the alt buffer', () => {
+      vi.useFakeTimers();
+      const { manager, onAltScreenEnter } = createManagerWithAltScreenCallback();
+
+      manager.onData(SESSION, '\x1b[?1049h');
+      onAltScreenEnter.mockClear();
+
+      // A fullscreen TUI can re-clear/re-assert 1049 without ever leaving the
+      // alt buffer; wasInAltScreen is already true, so this is a no-op.
+      manager.onData(SESSION, '\x1b[?1049h');
+
+      expect(onAltScreenEnter).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('fires again after leaving (1049l) and re-entering the alt buffer', () => {
+      vi.useFakeTimers();
+      const { manager, onAltScreenEnter } = createManagerWithAltScreenCallback();
+
+      manager.onData(SESSION, '\x1b[?1049h');
+      onAltScreenEnter.mockClear();
+
+      // The exit transition (true -> false) must not fire.
+      manager.onData(SESSION, '\x1b[?1049l');
+      expect(onAltScreenEnter).not.toHaveBeenCalled();
+
+      // Re-entry is a fresh false -> true transition: fires again. There is
+      // no session-level "already fired once" latch - only the current vs.
+      // previous state matters.
+      manager.onData(SESSION, '\x1b[?1049h');
+      expect(onAltScreenEnter).toHaveBeenCalledTimes(1);
+      expect(onAltScreenEnter).toHaveBeenCalledWith(SESSION);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it.each([47, 1047])('fires on the %i alt-screen variant, not just 1049', (mode) => {
+      vi.useFakeTimers();
+      const { manager, onAltScreenEnter } = createManagerWithAltScreenCallback();
+
+      manager.onData(SESSION, `\x1b[?${mode}h`);
+
+      expect(onAltScreenEnter).toHaveBeenCalledTimes(1);
+      expect(onAltScreenEnter).toHaveBeenCalledWith(SESSION);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('fires when a DECSET alt-screen entry is split across two PTY chunks (modeParseCarry)', () => {
+      vi.useFakeTimers();
+      const { manager, onAltScreenEnter } = createManagerWithAltScreenCallback();
+
+      // \x1b[?1049h split as \x1b[?10 | 49h. The first chunk carries a
+      // partial sequence (no complete DECSET yet), so nothing fires; the
+      // second chunk completes it against the combined (carry + data) text.
+      manager.onData(SESSION, '\x1b[?10');
+      expect(onAltScreenEnter).not.toHaveBeenCalled();
+
+      manager.onData(SESSION, '49h');
+      expect(onAltScreenEnter).toHaveBeenCalledTimes(1);
+      expect(onAltScreenEnter).toHaveBeenCalledWith(SESSION);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('fires again after RIS (\\x1bc) clears the alt-screen flag mid-session', () => {
+      vi.useFakeTimers();
+      const { manager, onAltScreenEnter } = createManagerWithAltScreenCallback();
+
+      manager.onData(SESSION, '\x1b[?1049h');
+      onAltScreenEnter.mockClear();
+
+      // RIS returns to the normal buffer (clears inAltScreen without going
+      // through the 1049l DECRST arm), so the next entry must read as a fresh
+      // false -> true transition rather than staying suppressed.
+      manager.onData(SESSION, '\x1bc');
+      expect(onAltScreenEnter).not.toHaveBeenCalled();
+
+      manager.onData(SESSION, '\x1b[?1049h');
+      expect(onAltScreenEnter).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+
+    it('does not fire for a within-chunk alt-screen flash (enter and exit in the same chunk)', () => {
+      vi.useFakeTimers();
+      const { manager, onAltScreenEnter } = createManagerWithAltScreenCallback();
+
+      // wasInAltScreen is read BEFORE updateModeState parses the whole chunk,
+      // so a chunk that both enters and exits within itself starts and ends
+      // false -> the transition guard never sees a false-to-true edge.
+      manager.onData(SESSION, '\x1b[?1049h\x1b[?1049l');
+
+      expect(onAltScreenEnter).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(20);
+      vi.useRealTimers();
+    });
+  });
+
   describe('initSession geometry-gate carry-over', () => {
     it('marks a carried ring geometry-suspect when the prior drawn-at geometry is unknown', () => {
       const manager = new PtyBufferManager({ onFlush: vi.fn(), onDrain: vi.fn() });

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -34,10 +34,21 @@ vi.mock('../../src/main/analytics/analytics', () => ({
   sanitizeErrorMessage: (message: string) => message,
 }));
 
+// `traceTerminal` is gated on `__KANGENTIC_DEV__`, which vitest.config.ts
+// pins to `false` - the real implementation is a no-op in every test here.
+// Wrap it (not replace it) so the trace payload contract is observable via
+// `vi.mocked(traceTerminal).mock.calls` while every other test's behavior
+// (already a no-op today) stays byte-identical.
+vi.mock('../../src/main/pty/terminal-trace', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/main/pty/terminal-trace')>();
+  return { ...actual, traceTerminal: vi.fn(actual.traceTerminal) };
+});
+
 import * as pty from 'node-pty';
 import { SessionManager } from '../../src/main/pty/session-manager';
 import { ClaudeAdapter } from '../../src/main/agent/adapters/claude/claude-adapter';
 import { ClaudeSessionHistoryParser } from '../../src/main/agent/adapters/claude/session-history-parser';
+import { traceTerminal } from '../../src/main/pty/terminal-trace';
 
 const claudeAdapter = new ClaudeAdapter();
 import { EventType } from '../../src/shared/types';
@@ -3316,17 +3327,20 @@ describe('Resting grid restore', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Post-first-output geometry re-assert (spawn-race fix, task 573)
+// Post-boot geometry re-assert (spawn-race fix, task 573)
 // ---------------------------------------------------------------------------
 
-describe('Post-first-output geometry re-assert', () => {
+describe('Post-boot geometry re-assert', () => {
   // A resize applied inside the spawn window can be lost: ConPTY only delivers
   // a resize to a connected client, and the fit lands while the agent is still
-  // booting behind the shell. Once the agent produces first output it
-  // demonstrably exists, so the geometry is re-delivered as a jiggle (cols-1,
+  // booting behind the shell. The geometry is re-delivered as a jiggle (cols-1,
   // then cols back) via DIRECT pty.resize calls - two genuine changes nothing
   // in the chain can deduplicate, and no pty-resize broadcast that would burn
-  // the renderer's echo re-assert budget or re-seed phone frames.
+  // the renderer's echo re-assert budget or re-seed phone frames. Two triggers
+  // fire it: the adapter first-output latch (which a SHELL preamble can trip -
+  // pwsh 7.6 emits the cursor-hide escape Claude's detector matches - so it
+  // disarms only when the output provably came from the TUI) and the stream's
+  // first alt-screen entry, which nothing but the TUI can produce.
   let manager: SessionManager;
 
   beforeEach(() => {
@@ -3343,6 +3357,21 @@ describe('Post-first-output geometry re-assert', () => {
     vi.mocked(pty.spawn).mockReturnValue(mock.mockPty as unknown as pty.IPty);
     // No agent adapter, so ANY non-empty chunk counts as first output.
     const session = await manager.spawn({ taskId, command: '', cwd: tmpDir });
+    return { session, ...mock };
+  }
+
+  async function spawnClaudeSession(taskId: string) {
+    const mock = createMockPty();
+    vi.mocked(pty.spawn).mockReturnValue(mock.mockPty as unknown as pty.IPty);
+    // The REAL Claude adapter: its detectFirstOutput matches the cursor-hide
+    // escape, which pwsh 7.6's shell preamble also carries - the collision
+    // the preamble-ordering tests below pin.
+    const session = await manager.spawn({
+      taskId,
+      command: '',
+      cwd: tmpDir,
+      agentParser: claudeAdapter,
+    });
     return { session, ...mock };
   }
 
@@ -3403,13 +3432,16 @@ describe('Post-first-output geometry re-assert', () => {
     expect(mockPty.resize).not.toHaveBeenCalled();
   });
 
-  it('a resize applied after first output does not arm a jiggle', async () => {
+  it('a post-first-output resize lies dormant until an alt-screen entry consumes it', async () => {
     const { session, mockPty, feedData } = await spawnSession('task-reassert-late');
 
     feedData('first output');
     await settleFlush();
 
-    // A running child observes this directly (verified live); no re-assert needed.
+    // A running child observes this directly (verified live), and first-output
+    // is already spent, so nothing fires on further plain output - but the
+    // pre-TUI arm stays set (the stream never entered the alt buffer, so this
+    // could still be a shell whose agent has not booted).
     manager.resize(session.id, 306, 48);
     expect(mockPty.resize.mock.calls).toEqual([[306, 48]]);
     mockPty.resize.mockClear();
@@ -3417,6 +3449,68 @@ describe('Post-first-output geometry re-assert', () => {
     feedData('more output');
     await settleFlush();
     expect(mockPty.resize).not.toHaveBeenCalled();
+
+    // The TUI takeover consumes the dormant arm exactly once.
+    feedData('\x1b[?1049h');
+    expect(mockPty.resize.mock.calls).toEqual([[305, 48], [306, 48]]);
+  });
+
+  it('arms on a pre-TUI resize even when the shell preamble already tripped first-output (task #573 live shape)', async () => {
+    const { session, mockPty, feedData } = await spawnClaudeSession('task-reassert-preamble');
+
+    // pwsh 7.6's startup preamble carries the cursor-hide escape Claude's
+    // detector matches: the latch trips on SHELL bytes, ~tens of ms after
+    // spawn, seconds before the agent exists.
+    feedData('\x1b[?25l\x1b[2JPS preamble');
+    await settleFlush();
+    expect(mockPty.resize).not.toHaveBeenCalled();
+
+    // The fit resize lands after the preamble. Under the old first-output
+    // arming criterion this read as post-first-output and never armed - the
+    // 2026-08-30 live recurrence.
+    manager.resize(session.id, 306, 19);
+    expect(mockPty.resize.mock.calls).toEqual([[306, 19]]);
+    mockPty.resize.mockClear();
+    const broadcasts: unknown[] = [];
+    manager.on('pty-resize', (...args: unknown[]) => broadcasts.push(args));
+
+    // Plain shell output must not fire anything (first-output is spent).
+    feedData('shell prompt noise\r\n');
+    await settleFlush();
+    expect(mockPty.resize).not.toHaveBeenCalled();
+
+    // The alt-screen entry - the one signal a shell cannot fake - fires the
+    // jiggle synchronously, with no broadcast.
+    feedData('\x1b[?1049h\x1b[?25l frame');
+    expect(mockPty.resize.mock.calls).toEqual([[305, 19], [306, 19]]);
+    expect(broadcasts).toEqual([]);
+
+    // Disarmed: leaving and re-entering the alt buffer does not re-jiggle
+    // without a new pre-TUI resize.
+    mockPty.resize.mockClear();
+    feedData('\x1b[?1049l\x1b[?1049h');
+    await settleFlush();
+    expect(mockPty.resize).not.toHaveBeenCalled();
+  });
+
+  it('a preamble-tripped first output jiggles but keeps the arm for the real TUI takeover', async () => {
+    const { session, mockPty, feedData } = await spawnClaudeSession('task-reassert-two-stage');
+
+    // The other race ordering: the fit lands BEFORE the preamble, so the
+    // first-output trigger fires while the stream is still pre-TUI.
+    manager.resize(session.id, 306, 19);
+    mockPty.resize.mockClear();
+
+    feedData('\x1b[?25l\x1b[2JPS preamble');
+    await settleFlush();
+    // The jiggle fires (one harmless repaint at worst) but does NOT disarm:
+    // the output was not provably the TUI's, and the booting agent may still
+    // miss this delivery.
+    expect(mockPty.resize.mock.calls).toEqual([[305, 19], [306, 19]]);
+
+    mockPty.resize.mockClear();
+    feedData('\x1b[?1049h frame');
+    expect(mockPty.resize.mock.calls).toEqual([[305, 19], [306, 19]]);
   });
 
   it('swallows a resize failure from a just-died ConPTY', async () => {
@@ -3436,7 +3530,7 @@ describe('Post-first-output geometry re-assert', () => {
 
   it('swallows a resize failure on the restore leg after the jiggle leg lands', async () => {
     // Distinct from the case above: there the arming resize's own mock throws,
-    // so only the FIRST (jiggle) resize call inside reassertGeometryAfterFirstOutput
+    // so only the FIRST (jiggle) resize call inside reassertGeometryForBootingChild
     // is ever attempted. Here the jiggle leg succeeds and only the SECOND
     // (restore) call fails - the only case that exercises the function's
     // second try/catch, which the case above cannot reach.
@@ -3464,8 +3558,8 @@ describe('Post-first-output geometry re-assert', () => {
     // No unhandled throw escaped the flush callback; the session survives.
     expect(manager.getSession(session.id)).toBeDefined();
 
-    // The flag is cleared before either leg runs, so a later output does not
-    // retry the stranded restore (mirrors the at-most-once case above).
+    // First-output is a spent one-shot, so a later plain-output chunk does
+    // not retry the stranded restore (mirrors the at-most-once case above).
     mockPty.resize.mockClear();
     feedData('more output');
     await settleFlush();
@@ -3483,5 +3577,74 @@ describe('Post-first-output geometry re-assert', () => {
     await settleFlush();
 
     expect(mockPty.resize).not.toHaveBeenCalled();
+  });
+
+  /**
+   * ConPTY can deliver a single escape sequence split across two onData
+   * chunks - `modeParseCarry` (pty-buffer-manager.ts) exists specifically to
+   * reassemble that split before parsing modes. Every other alt-screen-enter
+   * case in this file feeds `\x1b[?1049h` whole in one `feedData` call, so
+   * the carry-reassembled path itself has no coverage without this test.
+   */
+  it('fires the alt-screen jiggle exactly once when the entry escape is split across two onData chunks', async () => {
+    const { session, mockPty, feedData } = await spawnSession('task-reassert-split-escape');
+
+    manager.resize(session.id, 306, 48);
+    expect(mockPty.resize.mock.calls).toEqual([[306, 48]]);
+    mockPty.resize.mockClear();
+
+    // Split mid-parameter: neither half alone carries a complete DECSET, so
+    // only the carry-reassembled `combined` string can detect the entry.
+    feedData('\x1b[?10');
+    expect(mockPty.resize).not.toHaveBeenCalled();
+
+    feedData('49h frame');
+    expect(mockPty.resize.mock.calls).toEqual([[305, 48], [306, 48]]);
+
+    // The alt-screen trigger always disarms, so further output never re-fires.
+    mockPty.resize.mockClear();
+    feedData('more output');
+    await settleFlush();
+    expect(mockPty.resize).not.toHaveBeenCalled();
+  });
+
+  /**
+   * `traceTerminal` carries the forensics contract docs/session-lifecycle.md
+   * promises ("names the trigger"), but it is otherwise unobserved anywhere
+   * in this file - its `__KANGENTIC_DEV__` gate is pinned off by
+   * vitest.config.ts's `define`, so the real implementation is a no-op here.
+   * Spying it directly is the only way to pin which trigger fired, and that
+   * `resize-applied`'s field is `preTuiReady`, not the old `preFirstOutput`.
+   */
+  it('records the trigger and preTuiReady fields in the trace payloads', async () => {
+    const { session, mockPty, feedData } = await spawnSession('task-reassert-trace');
+    const trace = vi.mocked(traceTerminal);
+
+    manager.resize(session.id, 306, 48);
+    const applied = trace.mock.calls.find(
+      ([tracedSessionId, event]) => tracedSessionId === session.id && event === 'resize-applied',
+    );
+    expect(applied?.[2]).toMatchObject({ preTuiReady: true });
+    expect(applied?.[2]).not.toHaveProperty('preFirstOutput');
+    trace.mockClear();
+    mockPty.resize.mockClear();
+
+    // First-output trigger: jiggles but (not yet in the alt buffer) does not
+    // disarm, so the flag survives for the alt-screen trigger below.
+    feedData('first output');
+    await settleFlush();
+    const firstOutputReassert = trace.mock.calls.find(
+      ([tracedSessionId, event]) => tracedSessionId === session.id && event === 'resize-reassert',
+    );
+    expect(firstOutputReassert?.[2]).toMatchObject({ trigger: 'first-output' });
+    trace.mockClear();
+    mockPty.resize.mockClear();
+
+    // Alt-screen trigger: the still-armed flag fires a second, independent jiggle.
+    feedData('\x1b[?1049h frame');
+    const altScreenReassert = trace.mock.calls.find(
+      ([tracedSessionId, event]) => tracedSessionId === session.id && event === 'resize-reassert',
+    );
+    expect(altScreenReassert?.[2]).toMatchObject({ trigger: 'alt-screen-enter' });
   });
 });


### PR DESCRIPTION
## What

Follow-up to #336, which shipped the spawn-window geometry re-assert and then failed in production the same day. This re-keys the mechanism on a signal a shell cannot fake, and corrects the false premise wherever it was written down.

- `src/main/pty/buffer/pty-buffer-manager.ts`: new optional `onAltScreenEnter(sessionId)` callback, fired from the existing mode parse when a session's stream transitions into the alternate screen buffer.
- `src/main/pty/session-manager.ts`: `resize()` now arms on "the stream has not entered the alt buffer yet" instead of the first-output latch (the `resize-applied` trace field is renamed `preFirstOutput` to `preTuiReady`). Two triggers consume the arm, each tagged in the `resize-reassert` trace.
- `src/main/pty/session-registry.ts`: the flag is renamed to `resizeAppliedBeforeTuiReady` and documents why.
- `src/main/pty/lifecycle/first-output-tracker.ts`, `docs/agent-integration.md`, `docs/architecture.md`: comment and prose corrections, below.
- `src/devtools/main/composed-width.ts`: fold-scoring fix so the diagnostic reads the stuck width correctly.

## Why

ConPTY only delivers a resize to a connected client, so a resize applied while the agent is still booting can be lost. #336 detected "the agent is up" with the adapter first-output latch. That premise is false on PowerShell: Claude's `detectFirstOutput` matches the cursor-hide escape `\x1b[?25l`, and pwsh 7.6's startup preamble emits that same escape (the repo already documented this collision in `buildSpawnClearPrelude`, for a different mitigation). So the latch trips on shell bytes tens of ms after spawn, seconds before the agent process exists.

The consequence, observed live on 2026-08-30 in a different project on this machine: the panel fit resize traced `preFirstOutput: false`, never armed, and the agent composed 120-column rows inside a 306-column PTY for the entire turn. The measured ring carried 95 rule runs of exactly 120. Every pty-vs-grid invariant read healthy, exactly as the original bug did.

This also explains why the original verification missed it: the A/B campaign ran under WSL, whose bash emits no cursor-hide before Claude does, so the latch there really did mean "the agent is up".

## How

Arming and the final re-assert key on the stream's first alt-screen entry. No shell enters the alternate buffer, so it is the earliest unfakeable "the TUI is composing" signal, and the buffer manager already parses it for the replay path (`BufferState.inAltScreen`) - the callback just reports the transition it already computes.

Two triggers call the re-assert, at most one jiggle each:

- **first-output** still fires (it is the only trigger an inline-mode agent ever gets), but it disarms only when the stream is already in the alt buffer, i.e. the output provably came from the TUI. Otherwise the jiggle happens anyway (one harmless repaint) and the arm survives for the real takeover.
- **alt-screen entry** always disarms.

The jiggle mechanics are unchanged from #336: direct `pty.resize()` cols-1 then cols, deliberately bypassing `resize()`'s ladder, so there is still no `pty-resize` broadcast, no echo-budget churn, no phone re-seed, and no repaint-settle stacking. Cost is unchanged for the common case and bounded at one extra repaint for a preamble-tripped boot.

The false premise was also stated in three places outside the fix, all corrected here: `first-output-tracker.ts`'s header claimed Claude latches on `\x1b[?1049h` (it does not, and that wrong comment is what made the original design look sound); `docs/agent-integration.md` said the latch signals "when the agent's TUI is ready" and assured the escape "fires after the shell prompt noise"; and `docs/architecture.md`'s `session:firstOutput` row described the event as "Alternate screen buffer detected", which was never its mechanism.

Separately, the composed-width diagnostic read the stuck session as 46 columns rather than 120, because a dense sub-width lattice explains a superset of the true width's evidence and won on additive scoring. Scoring is now exactness-weighted sub-linear length mass with a near-tie band, so structural full-width evidence outvotes short sub-width noise without letting one long outlier outvote several corroborating rows.

## Breaking changes

None. No IPC channel, event, or `@kangentic/protocol` surface changes. The renamed trace field (`preFirstOutput` to `preTuiReady`) and the renamed internal flag are dev-diagnostic and in-process only.

## Tests

- `tests/unit/session-manager.test.ts`, `Post-boot geometry re-assert` (10 cases). The new ones reproduce the production failure directly: a pwsh-preamble-shaped stream that trips first-output before the fit resize, which must still arm and must jiggle on the later alt-screen entry. Verified red against the old arming criterion (no jiggle, matching the live trace) and green with the fix. Also pinned: a preamble-tripped first-output jiggles but keeps the arm; a post-first-output resize lies dormant until an alt-screen entry consumes it; no re-jiggle on a later re-entry without a new pre-TUI resize.
- `tests/unit/composed-width.test.ts`: a regression case built from the stuck session's measured histogram (95 rules at 120 plus the sub-width noise it really carried), asserting the fold names 120.
- Live verification on the amended build: two probe spawns under the default PowerShell shell show the full healed sequence in the trace (`preTuiReady: true`, then `resize-reassert` on `first-output`, then on `alt-screen-enter`), both children composing at the fitted width.
- CI checks (typecheck, lint, unit, build, UI shards, Linux Electron E2E) as the full gate.

Generated with [Claude Code](https://claude.com/claude-code)
