### PR TITLE
fix(changes): clamp a restored diff scroll position to the current layout

### DIFF
--- a/src/renderer/components/dialogs/task-detail/changes/DiffViewer.tsx
+++ b/src/renderer/components/dialogs/task-detail/changes/DiffViewer.tsx
@@ -11,6 +11,7 @@ import { formatRelativeTime } from '../../../../lib/datetime';
 import { NAMED_THEMES } from '../../../../../shared/types';
 import type { GitBlameLine, GitDiffStatus } from '../../../../../shared/types';
 import {
+  clampDiffScrollTop,
   getSavedDiffScroll,
   makeDiffScrollKey,
   resolveDiffScrollAction,
@@ -393,7 +394,19 @@ export function DiffViewer({
     const modifiedEditor = diffEditor.getModifiedEditor();
     pendingRevealRef.current = null;
     if (action.kind === 'restore') {
-      modifiedEditor.setScrollTop(action.position.scrollTop);
+      // Never hand Monaco an offset the current layout cannot reach. A diff
+      // editor's height depends on the alignment view zones, so the same file
+      // is shorter before its diff is computed and shorter again once
+      // unchanged regions fold - a position saved against a taller layout
+      // saturates at the bottom instead. scrollLeft is left unclamped: it does
+      // not feed the visible-line-range computation this guards.
+      modifiedEditor.setScrollTop(
+        clampDiffScrollTop(
+          action.position.scrollTop,
+          modifiedEditor.getScrollHeight(),
+          modifiedEditor.getLayoutInfo().height,
+        ),
+      );
       modifiedEditor.setScrollLeft(action.position.scrollLeft);
     } else if (action.kind === 'revealLineInCenter') {
       modifiedEditor.revealLineInCenter(action.lineNumber, monacoRef.current?.editor.ScrollType.Immediate);

--- a/src/renderer/utils/diff-scroll-memory.ts
+++ b/src/renderer/utils/diff-scroll-memory.ts
@@ -56,6 +56,34 @@ export function saveDiffScroll(key: string, position: DiffScrollPosition): void 
 }
 
 /**
+ * Clamp a saved scrollTop to what the editor's CURRENT layout can actually
+ * scroll to.
+ *
+ * A diff editor's modified-side scroll height is not a property of the file: it
+ * includes the alignment view zones that pad the modified side against the
+ * original's inserted/deleted lines. Those zones only exist once the diff has
+ * been computed, so between a model swap and the diff result the same file is
+ * measurably shorter than it will be. Handing Monaco an offset past the end
+ * leaves the scroll state disagreeing with the view model's line count, and the
+ * next alignment-zone update resolves it into a line past the last one
+ * ("Illegal value for lineNumber", Sentry DESKTOP-8).
+ *
+ * Restoring past the end saturates at the bottom. A non-finite input (a
+ * disposed or never-laid-out editor reporting NaN) degrades to the top.
+ */
+export function clampDiffScrollTop(
+  scrollTop: number,
+  scrollHeight: number,
+  viewportHeight: number,
+): number {
+  if (!Number.isFinite(scrollTop) || !Number.isFinite(scrollHeight) || !Number.isFinite(viewportHeight)) {
+    return 0;
+  }
+  const maxScrollTop = Math.max(0, scrollHeight - viewportHeight);
+  return Math.min(Math.max(0, scrollTop), maxScrollTop);
+}
+
+/**
  * Decide how to position a file's diff when its content first becomes visible.
  *
  * - A saved position always wins (revisit): restore it.

--- a/tests/ui/changes-diff-scroll-memory.spec.ts
+++ b/tests/ui/changes-diff-scroll-memory.spec.ts
@@ -127,13 +127,28 @@ async function scrollModifiedToBottom(target: Page): Promise<void> {
   });
 }
 
-/** Toggle the "Collapse unchanged" option through the diff view-options menu. */
-async function toggleCollapseUnchanged(target: Page): Promise<void> {
+/**
+ * Drive "Collapse unchanged" to an explicit state through the diff view-options
+ * menu.
+ *
+ * Set-to-a-state rather than toggle, and therefore idempotent: the preference is
+ * GLOBAL, so a test that leaves it on poisons every sibling in this shared-page
+ * file (cross-platform-parity.md forbids that cascade). A blind toggle in a
+ * cleanup path cannot be made safe, because it has no way to tell "the test
+ * enabled this" from "the enabling click itself threw before it landed" and
+ * would switch the preference ON while trying to restore it.
+ */
+async function setCollapseUnchanged(target: Page, enabled: boolean): Promise<void> {
   const optionsTrigger = target.locator('[data-testid="diff-view-options"]');
   const optionsMenu = target.locator('[data-testid="diff-view-options-menu"]');
   await optionsTrigger.click();
   await optionsMenu.waitFor({ state: 'visible', timeout: 5000 });
-  await optionsMenu.locator('[data-testid="diff-collapse-unchanged"]').click();
+  const collapseItem = optionsMenu.locator('[data-testid="diff-collapse-unchanged"]');
+  await collapseItem.waitFor({ state: 'visible', timeout: 5000 });
+  if ((await collapseItem.getAttribute('aria-checked')) !== String(enabled)) {
+    await collapseItem.click();
+    await expect(collapseItem).toHaveAttribute('aria-checked', String(enabled), { timeout: 5000 });
+  }
   // The menu is a checklist and stays open after a check, so close it through
   // its own trigger rather than Escape, which the task-detail window also uses.
   await optionsTrigger.click();
@@ -355,12 +370,11 @@ test.describe('Changes view: diff scroll memory', () => {
     // next visit restores a position saved against the expanded layout onto a
     // folded one that is a fraction of the height.
     //
-    // From here the global collapse preference is ON, so the restore below runs
-    // inside try/finally: an assertion that throws must still hand the shared
-    // page back with the preference off, or it leaks into every test added to
-    // this file later (cross-platform-parity.md forbids that cascade).
-    await toggleCollapseUnchanged(page);
+    // The enable is INSIDE the try, so a throw part-way through it is still
+    // followed by the cleanup below. That is only safe because the helper sets
+    // an explicit state instead of toggling.
     try {
+      await setCollapseUnchanged(page, true);
       await page.locator('button', { hasText: 'delta.ts' }).click();
       await page.locator('.view-line', { hasText: 'delta' }).first().waitFor({ state: 'visible', timeout: 10000 });
 
@@ -393,7 +407,7 @@ test.describe('Changes view: diff scroll memory', () => {
       expect(getPageErrors()).toHaveLength(0);
     } finally {
       // Leave the shared page as this test found it for any later spec run.
-      await toggleCollapseUnchanged(page);
+      await setCollapseUnchanged(page, false);
     }
     await page.keyboard.press('Control+Shift+W');
     await expect(dialog).not.toBeVisible({ timeout: 8000 });

--- a/tests/ui/changes-diff-scroll-memory.spec.ts
+++ b/tests/ui/changes-diff-scroll-memory.spec.ts
@@ -6,6 +6,10 @@
  * the file is virtualized away), and that switching away and back restores the
  * previous scroll position instead of re-revealing the first change.
  *
+ * The second test covers the shorter-layout case: a position saved against the
+ * expanded diff, restored after unchanged regions were folded away, must stay
+ * inside the scrollable range rather than leaving an offset past the end.
+ *
  * Monaco virtualizes lines: only visible lines exist as `.view-line` DOM nodes,
  * so DOM presence of a token is a proxy for "scrolled to that region". The diff
  * is computed client-side from the mock's original/modified strings, so no real
@@ -14,7 +18,7 @@
 import { test, expect } from '@playwright/test';
 import { chromium, type Browser, type Page } from '@playwright/test';
 import path from 'node:path';
-import { waitForViteReady } from './helpers';
+import { waitForViteReady, collectPageErrors } from './helpers';
 
 const MOCK_SCRIPT = path.join(__dirname, 'mock-electron-api.js');
 const VITE_URL = `http://localhost:${process.env.PLAYWRIGHT_VITE_PORT || '5173'}`;
@@ -27,6 +31,14 @@ const TOP_TOKEN = 'TOP_OF_FILE_TOKEN_AAA';
 const MID_TOKEN = 'MID_CHANGE_TOKEN_ZZZ';
 const TOTAL_LINES = 200;
 const CHANGE_LINE = 100;
+
+// delta.ts is long and almost entirely unchanged, with its single change near
+// the top. Collapsing unchanged regions therefore removes nearly all of its
+// height, which is what turns a position saved against the expanded layout into
+// an offset past the end of the folded one.
+const DELTA_TAIL_TOKEN = 'DELTA_TAIL_TOKEN_QQQ';
+const DELTA_TOTAL_LINES = 3000;
+const DELTA_CHANGE_LINE = 5;
 
 // Build a long file whose only change sits deep in the middle (line 100), with a
 // recognizable token on line 1 so we can tell whether the viewport is at the top.
@@ -43,14 +55,89 @@ function buildFixtureScript(): string {
       var modifiedLines = lines.slice();
       modifiedLines[${CHANGE_LINE} - 1] = 'const value = "${MID_TOKEN}";';
       var modified = modifiedLines.join('\\n');
+      var deltaLines = [];
+      for (var deltaLineNumber = 1; deltaLineNumber <= ${DELTA_TOTAL_LINES}; deltaLineNumber++) {
+        if (deltaLineNumber === ${DELTA_TOTAL_LINES}) { deltaLines.push('// ${DELTA_TAIL_TOKEN} ' + deltaLineNumber); }
+        else { deltaLines.push('// delta line ' + deltaLineNumber); }
+      }
+      var deltaOriginal = deltaLines.join('\\n');
+      var deltaModifiedLines = deltaLines.slice();
+      deltaModifiedLines[${DELTA_CHANGE_LINE} - 1] = 'const deltaChanged = true;';
+      var deltaModified = deltaModifiedLines.join('\\n');
+
       window.__mockGitDiff = {
         files: [
           { path: 'alpha.ts', status: 'M', insertions: 1, deletions: 1, original: original, modified: modified, language: 'typescript' },
           { path: 'beta.ts', status: 'M', insertions: 1, deletions: 0, original: 'const a = 1;', modified: 'const a = 1;\\nconst b = 2;', language: 'typescript' },
+          { path: 'delta.ts', status: 'M', insertions: 1, deletions: 1, original: deltaOriginal, modified: deltaModified, language: 'typescript' },
         ],
       };
     })();
   `;
+}
+
+interface ModifiedEditorHandle {
+  getScrollTop: () => number;
+  getScrollHeight: () => number;
+  getLayoutInfo: () => { height: number };
+  setScrollTop: (scrollTop: number) => void;
+}
+
+interface MonacoTestHandle {
+  editor: { getDiffEditors: () => { getModifiedEditor: () => ModifiedEditorHandle }[] };
+}
+
+interface ModifiedScrollState {
+  scrollTop: number;
+  scrollHeight: number;
+  viewportHeight: number;
+}
+
+/**
+ * Read the live modified-side scroll geometry through the dev-only monaco
+ * handle (`window.__monaco`, exposed by monacoConfig.ts in dev builds).
+ * Returns -1s when no diff editor is mounted so a poll can wait it out.
+ */
+async function readModifiedScrollState(target: Page): Promise<ModifiedScrollState> {
+  return target.evaluate(() => {
+    const monaco = (window as unknown as { __monaco?: MonacoTestHandle }).__monaco;
+    const diffEditors = monaco?.editor.getDiffEditors() ?? [];
+    if (diffEditors.length === 0) return { scrollTop: -1, scrollHeight: -1, viewportHeight: -1 };
+    const modifiedEditor = diffEditors[0].getModifiedEditor();
+    return {
+      scrollTop: modifiedEditor.getScrollTop(),
+      scrollHeight: modifiedEditor.getScrollHeight(),
+      viewportHeight: modifiedEditor.getLayoutInfo().height,
+    };
+  });
+}
+
+/**
+ * Drive the modified side to its bottom. Programmatic rather than Ctrl+End
+ * because a click to focus could land in either pane, and Monaco saturates an
+ * over-large offset at the real maximum for the current layout.
+ */
+async function scrollModifiedToBottom(target: Page): Promise<void> {
+  await target.evaluate(() => {
+    const monaco = (window as unknown as { __monaco?: MonacoTestHandle }).__monaco;
+    const diffEditors = monaco?.editor.getDiffEditors() ?? [];
+    if (diffEditors.length === 0) return;
+    const modifiedEditor = diffEditors[0].getModifiedEditor();
+    modifiedEditor.setScrollTop(modifiedEditor.getScrollHeight());
+  });
+}
+
+/** Toggle the "Collapse unchanged" option through the diff view-options menu. */
+async function toggleCollapseUnchanged(target: Page): Promise<void> {
+  const optionsTrigger = target.locator('[data-testid="diff-view-options"]');
+  const optionsMenu = target.locator('[data-testid="diff-view-options-menu"]');
+  await optionsTrigger.click();
+  await optionsMenu.waitFor({ state: 'visible', timeout: 5000 });
+  await optionsMenu.locator('[data-testid="diff-collapse-unchanged"]').click();
+  // The menu is a checklist and stays open after a check, so close it through
+  // its own trigger rather than Escape, which the task-detail window also uses.
+  await optionsTrigger.click();
+  await optionsMenu.waitFor({ state: 'hidden', timeout: 5000 });
 }
 
 const preConfig = `
@@ -199,6 +286,115 @@ test.describe('Changes view: diff scroll memory', () => {
     // Use Control+Shift+W (capture-phase) rather than Escape: Monaco captured
     // focus via the click+Ctrl+Home sequence, so the bubble-phase Escape listener
     // on the task-detail window can be intercepted by Monaco on CI Linux.
+    await page.keyboard.press('Control+Shift+W');
+    await expect(dialog).not.toBeVisible({ timeout: 8000 });
+  });
+
+  // Regression guard for Sentry DESKTOP-8 ("Illegal value for lineNumber"),
+  // NOT a reproduction of it. The reported throw comes from Monaco's own
+  // scroll-synchronisation autorun while it updates a diff's alignment view
+  // zones, and it could not be reproduced here: measured against this fixture,
+  // Monaco saturates a deep restore at the bottom of the collapsed layout
+  // (54000px of scroll height down to 528px) without throwing. What this test
+  // does pin is the app-side contract around that crash path - a position saved
+  // against the expanded layout, restored onto a folded one, must stay inside
+  // the scrollable range and must not surface a renderer error.
+  test('restoring a deep position onto a diff that folds stays in range and does not throw', async () => {
+    // Same chained-wait budget as the test above: dialog mount, panel mount,
+    // Monaco construction, three file switches and their diff recomputes.
+    test.slow();
+
+    // Registered here rather than in beforeAll so the preceding test's errors
+    // (if any) are not attributed to this one.
+    const getPageErrors = collectPageErrors(page);
+
+    const card = page
+      .locator('[data-swimlane-name="Code Review"]')
+      .locator('text=Diff Scroll Task')
+      .first();
+    await card.click();
+
+    const dialog = page.locator('[data-testid="task-detail-dialog"]');
+    await dialog.waitFor({ state: 'visible', timeout: 5000 });
+
+    // The Changes panel's open state survives the preceding test's dialog
+    // close, so toggle only when it did NOT come back open - an unconditional
+    // click would close it. Waiting first (rather than probing visibility)
+    // keeps this correct while the panel is still mounting.
+    const diffArea = page.locator('[data-testid="diff-editor-area"]');
+    try {
+      await diffArea.waitFor({ state: 'visible', timeout: 3000 });
+    } catch {
+      await page.locator('[data-testid="changes-toggle"]').click();
+      await diffArea.waitFor({ state: 'visible', timeout: 10000 });
+    }
+    await page.locator('.view-line').first().waitFor({ state: 'visible', timeout: 10000 });
+
+    // Open delta.ts expanded (collapse is off by default) and go to its bottom,
+    // which is only reachable while the unchanged bulk is shown.
+    await page.locator('button', { hasText: 'delta.ts' }).click();
+    await page.locator('.view-line', { hasText: 'delta line' }).first().waitFor({ state: 'visible', timeout: 10000 });
+
+    // Wait for the expanded layout before capturing: a file this long is far
+    // taller than the pane, so a real scroll range exists.
+    await expect
+      .poll(async () => (await readModifiedScrollState(page)).scrollHeight, { timeout: 10000 })
+      .toBeGreaterThan(DELTA_TOTAL_LINES * 5);
+
+    await scrollModifiedToBottom(page);
+    await expect(page.locator('.view-line', { hasText: DELTA_TAIL_TOKEN }).first()).toBeVisible({ timeout: 10000 });
+    await expect
+      .poll(async () => (await readModifiedScrollState(page)).scrollTop, { timeout: 10000 })
+      .toBeGreaterThan(1000);
+
+    // Switch away so the deep position is committed under delta.ts's key.
+    await page.locator('button', { hasText: 'beta.ts' }).click();
+    await expect(page.locator('.view-line', { hasText: 'const b = 2;' })).toBeVisible({ timeout: 10000 });
+
+    // Turn on "Collapse unchanged" while delta.ts is NOT the open file, so the
+    // next visit restores a position saved against the expanded layout onto a
+    // folded one that is a fraction of the height.
+    //
+    // From here the global collapse preference is ON, so the restore below runs
+    // inside try/finally: an assertion that throws must still hand the shared
+    // page back with the preference off, or it leaks into every test added to
+    // this file later (cross-platform-parity.md forbids that cascade).
+    await toggleCollapseUnchanged(page);
+    try {
+      await page.locator('button', { hasText: 'delta.ts' }).click();
+      await page.locator('.view-line', { hasText: 'delta' }).first().waitFor({ state: 'visible', timeout: 10000 });
+
+      // Wait for the fold to actually land. Monaco renders each folded unchanged
+      // region as a .diff-hidden-lines widget; without this the assertions below
+      // would run against the still-expanded layout and prove nothing.
+      await expect
+        .poll(async () => page.locator('.diff-hidden-lines').count(), { timeout: 10000 })
+        .toBeGreaterThan(0);
+
+      // Restoring past the end must saturate inside the folded layout rather than
+      // leaving an out-of-range offset for Monaco to resolve into a line past the
+      // model's end.
+      await expect
+        .poll(
+          async () => {
+            const state = await readModifiedScrollState(page);
+            if (state.scrollHeight < 0) return false;
+            const maxScrollTop = Math.max(0, state.scrollHeight - state.viewportHeight);
+            // One line of slack: the assertion is "inside the scrollable range",
+            // not a pixel-exact offset (cross-platform-parity.md).
+            return state.scrollTop <= maxScrollTop + 20;
+          },
+          { timeout: 10000 },
+        )
+        .toBe(true);
+
+      // monacoConfig's funnel only swallows the DiffEditor disposal error, so a
+      // genuine internal throw would still surface here.
+      expect(getPageErrors()).toHaveLength(0);
+    } finally {
+      // Leave the shared page as this test found it for any later spec run.
+      await toggleCollapseUnchanged(page);
+    }
     await page.keyboard.press('Control+Shift+W');
     await expect(dialog).not.toBeVisible({ timeout: 8000 });
   });

--- a/tests/unit/diff-scroll-memory.test.ts
+++ b/tests/unit/diff-scroll-memory.test.ts
@@ -14,6 +14,7 @@ import {
   getSavedDiffScroll,
   saveDiffScroll,
   resolveDiffScrollAction,
+  clampDiffScrollTop,
 } from '../../src/renderer/utils/diff-scroll-memory';
 
 describe('makeDiffScrollKey', () => {
@@ -81,5 +82,40 @@ describe('resolveDiffScrollAction', () => {
 
   it('scrolls to top when the diff computed but found no changes', () => {
     expect(resolveDiffScrollAction(undefined, [])).toEqual({ kind: 'scrollToTop' });
+  });
+});
+
+describe('clampDiffScrollTop', () => {
+  it('leaves a position the layout can reach untouched', () => {
+    expect(clampDiffScrollTop(300, 2000, 500)).toBe(300);
+  });
+
+  it('saturates at the bottom when the saved position overshoots a shorter layout', () => {
+    // The layout can scroll to 2000 - 500 = 1500; a position saved against a
+    // taller layout must land there rather than past the end.
+    expect(clampDiffScrollTop(4000, 2000, 500)).toBe(1500);
+  });
+
+  it('accepts a position exactly at the bottom', () => {
+    expect(clampDiffScrollTop(1500, 2000, 500)).toBe(1500);
+  });
+
+  it('returns 0 when the content is shorter than the viewport', () => {
+    expect(clampDiffScrollTop(800, 300, 500)).toBe(0);
+  });
+
+  it('returns 0 for an unlaid-out editor reporting zero dimensions', () => {
+    expect(clampDiffScrollTop(800, 0, 0)).toBe(0);
+  });
+
+  it('floors a negative saved position at the top', () => {
+    expect(clampDiffScrollTop(-40, 2000, 500)).toBe(0);
+  });
+
+  it('degrades to the top when any dimension is not finite', () => {
+    expect(clampDiffScrollTop(Number.NaN, 2000, 500)).toBe(0);
+    expect(clampDiffScrollTop(800, Number.NaN, 500)).toBe(0);
+    expect(clampDiffScrollTop(800, 2000, Number.NaN)).toBe(0);
+    expect(clampDiffScrollTop(Number.POSITIVE_INFINITY, 2000, 500)).toBe(0);
   });
 });


### PR DESCRIPTION
## What

Clamps the scroll position the Changes panel restores when a diff file is revisited, so it can never be an offset past the end of the current layout.

- `src/renderer/utils/diff-scroll-memory.ts` gains a pure `clampDiffScrollTop(scrollTop, scrollHeight, viewportHeight)`.
- `DiffViewer.tsx`'s `consumePendingReveal` runs the saved `scrollTop` through it before `setScrollTop`. `scrollLeft` is deliberately left unclamped: it does not feed the visible-line-range computation this guards.

## Why

Filed against Sentry DESKTOP-8, `Error: Illegal value for lineNumber` (1 event, 1 install, `Kangentic@0.38.0`).

**The task's stated diagnosis does not hold, and this PR does not claim to fix that crash.** The task attributed the throw to `consumePendingReveal` calling `setScrollTop` at `DiffViewer.tsx:396`. Pulling the actual event falsifies that: all 50 captured frames are inside the Monaco chunk, and the frame directly beneath the throwing `setScrollTop` is `Ma._runFn`, one of Monaco's own observable-autorun primitives. `consumePendingReveal` is nowhere in the stack. Read bottom-up, an observable transaction ends, `changeViewZones` updates the diff's alignment zones, `changeWhitespace` / `_updateHeight` / `setScrollDimensions` change the height, and Monaco's own original-to-modified scroll synchronisation then calls `setScrollTop` and resolves a line past the model's end.

Two consequences: clamping our restore never touches the throwing frame, and the throw happens synchronously *inside* the zone update, so nothing running after that call returns can help.

What this PR does keep is the underlying invariant, which is real: a diff editor's scroll height is not a property of the file. It includes the alignment view zones padding the modified side against the original, so the same file is shorter before its diff is computed, and shorter again once unchanged regions fold. Handing Monaco a position saved against a taller layout is something the app should simply not do.

## How

A pure helper plus one call site, so the arithmetic is unit-testable and the imperative path stays thin. `resolveDiffScrollAction` is untouched: it decides *what* to do, not *how far*.

The other half of the task's suggested direction, deferring the restore until the view zones settle, was **not** implemented, because measurement showed there is nothing to defer past: on a revisit Monaco reuses the cached diff, so the layout is already settled when the restore fires (modified scroll height read at 144036px only 8ms after the file switch).

Measured on monaco-editor 0.55.1, Monaco already handles the out-of-range cases gracefully:

| Scenario | Measurement | Result |
| --- | --- | --- |
| 460-line alignment zones | diff settled (h=8280) before the restore at ~40ms | no unsettled window |
| 8000-line alignment zones | h=144036 already at 8ms (cached diff on revisit) | no unsettled window |
| Collapse-unchanged shrink | 54000px scroll height collapsing to 528px, deep restore of 53472 | saturated to 0, no throw |

So this is defensive hygiene that makes the app's own contract explicit, not a proven fix.

## Breaking changes

None. No user-visible behaviour change: Monaco already clamped these offsets internally, so the clamp only moves that decision into the app.

## Tests

- **Unit, red-green** (`tests/unit/diff-scroll-memory.test.ts`): 7 new cases for `clampDiffScrollTop` covering in-range, overshoot saturating at the bottom, exactly-at-bottom, content shorter than the viewport, zero dimensions, negative input, and non-finite input in each argument position. 18/18 pass.
- **UI, scenario guard only** (`tests/ui/changes-diff-scroll-memory.spec.ts`): seeds a 3000-line mostly-unchanged file, scrolls to the bottom expanded, switches away, enables "Collapse unchanged", switches back, and asserts the restored position stays inside the scrollable range with no `pageerror`. **This test was verified to pass identically with the clamp reverted, so it does not cover the clamp** and is labelled as such in the file. No red-green UI test for the reported throw was achievable, per the measurements above.
- The spec's global "Collapse unchanged" preference handling was made idempotent (set-to-a-state, not toggle) so a mid-test failure cannot leak the preference into sibling tests in the same shared-page worker. Verified with `--repeat-each=2`.
- Local gate: typecheck and lint clean. The unit, UI, and Electron E2E tiers run as CI checks on this PR.

## Residual risk

The reported crash is **not** addressed: a Monaco-internal race in the diff scroll-sync autorun on monaco-editor 0.55.1. Two candidate follow-ups, neither done here:

1. Check whether a later 0.55.x fixes it upstream.
2. Reduce the app-caused view-zone churn in `applyCollapseFold`'s unfold/refold cycle (`DiffViewer.tsx:297-303`), which is the only app-scheduled `setTimeout` that mutates view zones and so fits the event's `auto.browser.browserapierrors.setTimeout` mechanism.

Two unrelated observations worth their own tasks: `PopOutChangesFileRoot.tsx:169` passes an unqualified `params.taskId` as `scrollKey` where `ChangesPanel.tsx:1116` deliberately qualifies by scope and commit, and the scroll-memory map has no eviction path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bsxt6bHiWvWyvkoYVe74xV
