### PR TITLE
fix(startup): gate the macOS launch-time activate behind startup

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,6 +23,7 @@ import { createRequestResolver } from './agent/mcp-project-context';
 import { IPC, PROJECT_PATH_MISSING_PREFIX } from '../shared/ipc-channels';
 import { ConfigManager } from './config/config-manager';
 import { isShuttingDown, setShuttingDown } from './shutdown-state';
+import { isStartupComplete, markStartupComplete, shouldCreateWindowOnActivate } from './startup-gate';
 import { isBenignStreamWriteError } from './diagnostics/benign-stream-error';
 const windowConfigManager = new ConfigManager();
 import { initAnalytics, trackEvent, sanitizeErrorMessage, shouldEmitHeartbeat, setAnalyticsClientId } from './analytics/analytics';
@@ -631,6 +632,13 @@ if (!isEphemeral && !isE2ETest) {
 let mainWindow: BrowserWindow | null = null;
 let activateAllProjectsTimer: ReturnType<typeof setTimeout> | null = null;
 let mcpServerHandle: McpHttpServerHandle | null = null;
+// Whether the whenReady body has finished DECIDING mcpServerHandle. The handle
+// itself is null both before startup runs startMcpHttpServer and after that
+// call fails, so "unresolved" is not observable from the value alone. Only this
+// flag separates the two, and createWindow must never run while it is false:
+// registerAllIpc would build an IpcContext that can never reach the MCP server,
+// and only repairs itself if some later call passes a truthy handle.
+let mcpServerSettled = false;
 let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
 
 // Parse --cwd=<path> from command line args
@@ -724,6 +732,30 @@ function showTerminalAwareContextMenu(
 }
 
 const createWindow = () => {
+  // Unreachable while the startup gate holds: the only two call sites are the
+  // whenReady body (once) and the activate handler, which the gate limits to a
+  // zero window count. Kept because the failure it prevents is severe and
+  // silent - a second BrowserWindow orphans the first, which holds
+  // getAllWindows() above zero forever, so window-all-closed never fires,
+  // before-quit never runs, and syncShutdownCleanup never kills PTYs, suspends
+  // session records, or closes DBs (the same trap described at the 'closed'
+  // handler below). Report rather than throw, and sit above phase() so the
+  // early return cannot leave a startup phase unclosed.
+  //
+  // Returning without assigning mainWindow is safe for both callers, which
+  // dereference it as mainWindow! on the very next line: this branch is taken
+  // only WHEN a live window exists, so that non-null assertion still holds and
+  // they simply re-point the updater/announcements refs at the window they
+  // already had.
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    console.error('[APP] createWindow called with a live main window; ignoring');
+    trackEvent('app_error', {
+      source: 'duplicateCreateWindow',
+      message: 'createWindow called while a live main window already existed',
+    });
+    return;
+  }
+
   phase('createWindow');
   const isTest = process.env.NODE_ENV === 'test';
 
@@ -889,6 +921,20 @@ const createWindow = () => {
   // Register IPC handlers early so speculative preloading (below) can use them.
   // Idempotent: on macOS dock re-activation, the guard in registerAllIpc()
   // updates the window reference without re-registering handlers.
+  //
+  // The handle must have SETTLED first, or the context is built with no route
+  // to the MCP server. The startup gate guarantees that on every normal path;
+  // the one exception is the degraded-startup escape hatch (the whenReady
+  // .catch below), where a throw before the MCP block leaves it unsettled.
+  // Report rather than throw: throwing here would destroy the very escape
+  // hatch that produced this window.
+  if (!mcpServerSettled) {
+    console.error('[APP] createWindow ran before the MCP server handle settled');
+    trackEvent('app_error', {
+      source: 'createWindowBeforeMcpSettled',
+      message: 'createWindow ran before startMcpHttpServer settled',
+    });
+  }
   registerAllIpc(mainWindow, mcpServerHandle);
 
   // Native right-click context menu (Copy / Paste / Select All).
@@ -1229,6 +1275,9 @@ app.whenReady().then(async () => {
     // Continue without it -- agents will see "Unauthorized" or "Connection
     // refused" but the rest of the app stays functional.
   }
+  // Settled either way: a handle on success, a deliberate null on failure.
+  // Set once here, after the try/catch, so both paths are covered in one place.
+  mcpServerSettled = true;
 
   // Grant the first-party renderer the web-platform permissions it actually uses:
   // 'media' (getUserMedia microphone access for voice-to-text dictation) and the
@@ -1260,9 +1309,20 @@ app.whenReady().then(async () => {
   initUsageAnalytics(path.join(PATHS.configDir, 'analytics-usage.json'));
   trackUpdateOutcome(app.getVersion());
 
+  // These four lines MUST stay one unbroken synchronous block. createWindow()
+  // calls mainWindow.loadURL() internally, so the renderer starts loading
+  // before initUpdater/initAnnouncements have registered their channels; only
+  // the absence of an await here guarantees the renderer cannot reach its first
+  // invoke until they have. Adding an await in this span re-opens DESKTOP-3/4
+  // from the whenReady path itself, which the static scan in
+  // tests/unit/startup-gate.test.ts exists to catch.
   createWindow();
   initUpdater(mainWindow!);
   initAnnouncements(mainWindow!);
+  // Open the gate: from here an activate event may rebuild the window. Before
+  // this point the module-scope activate handler is a no-op, so a macOS
+  // launch-time activate can no longer race ahead of the registrations above.
+  markStartupComplete();
 
   // Windows has no powerMonitor 'shutdown' event (Linux/macOS only). An OS
   // shutdown/restart/log-off there is signaled via this BrowserWindow event
@@ -1384,6 +1444,39 @@ app.whenReady().then(async () => {
       .catch((err) => console.warn('[browser-partition] startup sweep failed:', err))
       .finally(() => { endPhase('sweepBrowserPartitions'); });
   }
+}).catch((error) => {
+  // Degraded-startup escape hatch. This body has several unguarded SYNCHRONOUS
+  // fs writes before createWindow (ensureSpawnHelperPermissions, the config
+  // save, initUsageAnalytics), and a read-only config dir or a full disk
+  // reaches them. Before the startup gate, an early throw still produced a
+  // window by accident, because the ungated activate handler fired on launch
+  // and saw a zero window count. The gate closes that path deliberately, so
+  // re-open it here or a startup failure becomes a dead dock icon.
+  //
+  // This catch intercepts the rejection before process.on('unhandledRejection')
+  // can, so the suppression filter has to be reapplied here or a benign stdio
+  // write error is echoed to the very TTY that produced it (see the comment on
+  // isSuppressibleUncaughtError). The source tag is deliberately distinct from
+  // that handler's, so a startup failure stays separable from an ambient one.
+  if (!isSuppressibleUncaughtError(error)) {
+    console.error('[APP] Startup failed:', error);
+    if (!isShuttingDown()) {
+      trackEvent('app_error', {
+        source: 'startupFailure',
+        message: sanitizeErrorMessage(error instanceof Error ? error.message : String(error)),
+      });
+    }
+  }
+  // Recovery is not automatic: the launch-time activate has already been
+  // dropped, so the window arrives on the user's next dock click. If the throw
+  // landed before createWindow, that window gets the bulk of its channels
+  // (registerAllIpc runs inside createWindow) but NOT the updater or
+  // announcements ones - neither init is idempotent, so they cannot be
+  // retried from here. A throw after initAnnouncements recovers fully.
+  //
+  // Unconditional, suppressed errors included: a gate left shut is a dock icon
+  // that never opens anything, which is worse than the error we just dropped.
+  markStartupComplete();
 });
 
 app.on('window-all-closed', () => {
@@ -1392,13 +1485,22 @@ app.on('window-all-closed', () => {
   }
 });
 
+// macOS fires 'activate' during LAUNCH as well as on a dock click, so this
+// handler is gated on the startup sequence having finished. Acting on the
+// launch-time event is what built the window mid-startup and let the renderer
+// invoke announcements channels that initAnnouncements had not registered yet
+// (Sentry DESKTOP-3 / DESKTOP-4). Dropping it loses nothing: the whenReady body
+// creates the window unconditionally.
 app.on('activate', () => {
-  if (isShuttingDown()) return;
-  if (BrowserWindow.getAllWindows().length === 0) {
-    createWindow();
-    updateUpdaterWindow(mainWindow!);
-    updateAnnouncementsWindow(mainWindow!);
-  }
+  const shouldCreate = shouldCreateWindowOnActivate({
+    shuttingDown: isShuttingDown(),
+    startupComplete: isStartupComplete(),
+    openWindowCount: BrowserWindow.getAllWindows().length,
+  });
+  if (!shouldCreate) return;
+  createWindow();
+  updateUpdaterWindow(mainWindow!);
+  updateAnnouncementsWindow(mainWindow!);
 });
 
 /** Send a heartbeat event with current session counts. Skipped when no

--- a/src/main/startup-gate.ts
+++ b/src/main/startup-gate.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared startup-gate state module.
+ *
+ * macOS fires `app.on('activate')` during launch, before the `app.whenReady()`
+ * body has finished. The module-scope activate handler in index.ts creates the
+ * main window whenever the window count is zero, so it used to win that race
+ * and build the window while whenReady was still parked on
+ * `await startMcpHttpServer(...)`. The renderer then loaded and invoked
+ * `announcements:get` / `announcements:getHistory` before
+ * `initAnnouncements(mainWindow)` had called `ipcMain.handle`, and the invoke
+ * rejected with "No handler registered" (Sentry DESKTOP-3 / DESKTOP-4). The
+ * same race also left `registerAllIpc` holding an unsettled `mcpServerHandle`,
+ * and produced a SECOND BrowserWindow once whenReady reached its own
+ * `createWindow()` call.
+ *
+ * The gate closes all three: the activate handler is a no-op until the startup
+ * sequence has created the window and registered its handlers.
+ *
+ * Mirrors shutdown-state.ts - one module-level flag, read through a function so
+ * every caller observes the same value.
+ */
+
+let startupComplete = false;
+
+export function isStartupComplete(): boolean {
+  return startupComplete;
+}
+
+export function markStartupComplete(): void {
+  startupComplete = true;
+}
+
+/** The inputs `shouldCreateWindowOnActivate` decides on. */
+export interface ActivateWindowState {
+  shuttingDown: boolean;
+  startupComplete: boolean;
+  openWindowCount: number;
+}
+
+/**
+ * Whether an `activate` event should build the main window.
+ *
+ * Pure, and deliberately not inlined into the handler: src/main/index.ts makes
+ * top-level `electron` calls and so cannot be imported by a unit test (see the
+ * headers of tests/unit/developer-flag-defaults.test.ts and
+ * tests/unit/config-manager.test.ts). Keeping the decision here is what makes
+ * the launch-time ordering testable at all.
+ */
+export function shouldCreateWindowOnActivate(state: ActivateWindowState): boolean {
+  if (state.shuttingDown) return false;
+  // The launch-time activate. The whenReady body creates the window
+  // unconditionally, so dropping this event loses nothing - acting on it is
+  // what raced ahead of IPC registration.
+  if (!state.startupComplete) return false;
+  return state.openWindowCount === 0;
+}

--- a/tests/unit/startup-gate.test.ts
+++ b/tests/unit/startup-gate.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Unit tests for the startup gate (src/main/startup-gate.ts) and its wiring
+ * into src/main/index.ts.
+ *
+ * Regression cover for Sentry DESKTOP-3 / DESKTOP-4: on a cold macOS launch,
+ * `app.on('activate')` fires DURING launch. The old handler saw a zero window
+ * count and called createWindow() while the whenReady body was still parked on
+ * `await startMcpHttpServer(...)`. createWindow() calls mainWindow.loadURL()
+ * internally, so the renderer mounted and invoked `announcements:get` /
+ * `announcements:getHistory` before `initAnnouncements(mainWindow)` had run
+ * `ipcMain.handle` - and the invoke rejected with "No handler registered".
+ *
+ * The suite has two halves. The behavioural half exercises the decision
+ * directly. The static half scans src/main/index.ts, because that file makes
+ * top-level `electron` calls and cannot be imported by a unit test - the same
+ * constraint documented in tests/unit/developer-flag-defaults.test.ts and
+ * tests/unit/config-manager.test.ts, and the same scan approach already used by
+ * tests/unit/window-open-policy.test.ts and
+ * tests/unit/pop-out-surface-registry.test.ts.
+ *
+ * tests/unit/register-all-idempotency.test.ts covers the neighbouring macOS
+ * re-activate invariant, but only by calling registerAllIpc directly; it never
+ * goes through the activate handler. This suite closes that gap.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { shouldCreateWindowOnActivate } from '../../src/main/startup-gate';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const INDEX_SOURCE = fs.readFileSync(path.join(REPO_ROOT, 'src/main/index.ts'), 'utf-8');
+
+/**
+ * A named region of index.ts, so a failing scan reports the handful of lines it
+ * looked at instead of dumping the whole 1500-line file into the CI log.
+ */
+function sliceAfter(marker: string, length: number): string {
+  const start = INDEX_SOURCE.indexOf(marker);
+  if (start === -1) throw new Error(`src/main/index.ts no longer contains ${marker}`);
+  return INDEX_SOURCE.slice(start, start + length);
+}
+
+describe('shouldCreateWindowOnActivate', () => {
+  it('refuses the launch-time activate that fires before startup completes', () => {
+    // The DESKTOP-3/4 case exactly: macOS fires activate during launch, no
+    // window exists yet, and the whenReady body has not registered IPC.
+    expect(
+      shouldCreateWindowOnActivate({
+        shuttingDown: false,
+        startupComplete: false,
+        openWindowCount: 0,
+      }),
+      'an activate arriving before the whenReady body finished must NOT build a window: it would load a renderer that can invoke announcements/updater channels nobody has registered yet, and leave registerAllIpc holding an unsettled mcpServerHandle',
+    ).toBe(false);
+  });
+
+  it('builds the window for a normal dock re-activation after startup', () => {
+    expect(
+      shouldCreateWindowOnActivate({
+        shuttingDown: false,
+        startupComplete: true,
+        openWindowCount: 0,
+      }),
+      'once startup has completed, an activate with no open windows is the macOS dock-click path and must still rebuild the window',
+    ).toBe(true);
+  });
+
+  it('does nothing when a window is already open', () => {
+    expect(
+      shouldCreateWindowOnActivate({
+        shuttingDown: false,
+        startupComplete: true,
+        openWindowCount: 1,
+      }),
+      'a second BrowserWindow orphans the first, which holds getAllWindows() above zero forever and blocks window-all-closed -> before-quit -> syncShutdownCleanup',
+    ).toBe(false);
+  });
+
+  it('does nothing while shutting down, even with no windows left', () => {
+    expect(
+      shouldCreateWindowOnActivate({
+        shuttingDown: true,
+        startupComplete: true,
+        openWindowCount: 0,
+      }),
+      'rebuilding a window during shutdown resurrects the app mid-teardown',
+    ).toBe(false);
+  });
+
+  it('keeps the shutdown check ahead of the startup check', () => {
+    // Shutdown before startup completed is reachable: a quit during a slow
+    // startup. Neither input alone may authorize a window.
+    expect(
+      shouldCreateWindowOnActivate({
+        shuttingDown: true,
+        startupComplete: false,
+        openWindowCount: 0,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('the startup-complete flag', () => {
+  beforeEach(() => {
+    // The flag is module-level state. vi.resetModules + a fresh dynamic import
+    // is this repo's idiom for clearing it (see importFreshModule() in
+    // tests/unit/announcements-init-guard.test.ts), which is why the module
+    // ships no test-only reset export.
+    vi.resetModules();
+  });
+
+  it('starts closed, so a launch-time activate is dropped by default', async () => {
+    const gate = await import('../../src/main/startup-gate');
+    expect(
+      gate.isStartupComplete(),
+      'the gate must default to closed: the whole fix rests on the launch-time activate finding it shut',
+    ).toBe(false);
+  });
+
+  it('opens once marked, and stays open', async () => {
+    const gate = await import('../../src/main/startup-gate');
+    gate.markStartupComplete();
+    expect(gate.isStartupComplete()).toBe(true);
+    gate.markStartupComplete();
+    expect(gate.isStartupComplete()).toBe(true);
+  });
+
+  it('is fresh state per module instance', async () => {
+    const first = await import('../../src/main/startup-gate');
+    first.markStartupComplete();
+    expect(first.isStartupComplete()).toBe(true);
+
+    vi.resetModules();
+    const second = await import('../../src/main/startup-gate');
+    expect(
+      second.isStartupComplete(),
+      'a re-imported module must start closed again, or the tests above leak into each other',
+    ).toBe(false);
+  });
+});
+
+/**
+ * The gate is only worth anything if index.ts actually reads it, and only SAFE
+ * while nothing suspends between building the window and opening the gate.
+ * Each scan below names the bug it prevents.
+ */
+describe('the startup gate is wired into src/main/index.ts', () => {
+  it('routes the activate handler through the gate predicate', () => {
+    // Anchored on the full call, not just "app.on('activate'": an unrelated
+    // comment upstream mentions the event by name, and indexOf finds that first.
+    const handler = sliceAfter("app.on('activate', () => {", 400);
+    expect(
+      handler,
+      "src/main/index.ts must decide app.on('activate') with shouldCreateWindowOnActivate(...); an inline getAllWindows().length === 0 check alone is what raced ahead of IPC registration on a cold macOS launch (DESKTOP-3/4)",
+    ).toContain('shouldCreateWindowOnActivate(');
+
+    // Calling the predicate is not the same as obeying it. Matched as a pattern
+    // rather than the literal `if (!shouldCreate) return;` so that renaming the
+    // local does not fail a test that has nothing to say about its name.
+    expect(
+      /if \(!\w+\) return;/.test(handler),
+      'the activate handler must ACT on the predicate: calling shouldCreateWindowOnActivate and then building the window regardless still contains the call, and is still the DESKTOP-3/4 race',
+    ).toBe(true);
+  });
+
+  it('creates the window from exactly two call sites', () => {
+    // `const createWindow = () =>` is the definition and does not match.
+    const callSites = INDEX_SOURCE.match(/createWindow\(\);/g) ?? [];
+    expect(
+      callSites.length,
+      'createWindow() must be invoked from exactly two places - the whenReady body and the gated activate handler. A third caller is a third chance to build a duplicate window, which the gate does not cover.',
+    ).toBe(2);
+  });
+
+  it('opens the gate with no suspension point after creating the window', () => {
+    // THE load-bearing assertion. createWindow() calls loadURL() internally, so
+    // the renderer is already booting when it returns; only the absence of an
+    // await between there and the gate/registrations guarantees the renderer
+    // cannot invoke before initUpdater and initAnnouncements have run.
+    const windowIndex = INDEX_SOURCE.indexOf('createWindow();');
+    expect(windowIndex, 'no createWindow() call site found').toBeGreaterThan(-1);
+
+    const gateIndex = INDEX_SOURCE.indexOf('markStartupComplete();', windowIndex);
+    expect(gateIndex, 'no markStartupComplete() call found after createWindow()').toBeGreaterThan(-1);
+
+    const span = INDEX_SOURCE.slice(windowIndex, gateIndex);
+
+    // Anchor check: markStartupComplete() appears twice (the in-body gate open
+    // and the degraded-startup .catch escape hatch). Proving initAnnouncements
+    // sits inside the span is what pins this to the in-body one deliberately,
+    // rather than relying on the .catch happening to come later in the file.
+    // Pin BOTH ends of the span. Containing only one registration call would
+    // still pass if a future edit moved the other out of the block, and it is
+    // the pair that has to sit inside it.
+    expect(
+      span,
+      'the span measured must be the in-body startup sequence (it has to contain the initUpdater call), not the whenReady .catch escape hatch',
+    ).toContain('initUpdater(');
+    expect(
+      span,
+      'the span measured must be the in-body startup sequence (it has to contain the initAnnouncements call), not the whenReady .catch escape hatch',
+    ).toContain('initAnnouncements(');
+
+    expect(
+      span.includes('await'),
+      'nothing may await between createWindow() and markStartupComplete(): createWindow calls loadURL, so an await here lets the renderer mount and invoke announcements:get / announcements:getHistory before initAnnouncements registers them - exactly the DESKTOP-3/4 rejection, reintroduced from the whenReady path itself',
+    ).toBe(false);
+  });
+
+  it('keeps the degraded-startup escape hatch that also opens the gate', () => {
+    // A count scan, not a proximity regex: the whenReady body already contains
+    // unrelated .catch( calls (pruneStaleWorktreeProjects,
+    // sweepOrphanedBrowserPartitions), so a loose match can bind to the wrong
+    // one and fail confusingly.
+    const gateOpens = INDEX_SOURCE.match(/markStartupComplete\(\);/g) ?? [];
+    expect(
+      gateOpens.length,
+      'markStartupComplete() must be called from exactly two places: the in-body gate open after initAnnouncements, and the whenReady .catch escape hatch. Without the catch, a synchronous throw early in startup (the fs writes before createWindow) leaves the gate shut forever and every dock click is a no-op - a dead icon instead of a recoverable window.',
+    ).toBe(2);
+
+    // The count alone does not prove either call is the escape hatch: moving
+    // both into the try body satisfies it. Slice the .catch block marker to
+    // marker (no fixed character budget, so comment growth cannot push the
+    // call out of the window) and prove one of them lives inside it.
+    const catchStart = INDEX_SOURCE.indexOf('}).catch((error) => {');
+    expect(catchStart, 'no whenReady .catch escape hatch found in src/main/index.ts').toBeGreaterThan(-1);
+    const catchEnd = INDEX_SOURCE.indexOf('\n});', catchStart);
+    expect(catchEnd, 'the whenReady .catch block is never closed at column 0').toBeGreaterThan(catchStart);
+
+    expect(
+      INDEX_SOURCE.slice(catchStart, catchEnd),
+      'one markStartupComplete() must sit INSIDE the whenReady .catch. A startup throw that leaves the gate shut strands the user on a dock icon that opens nothing, which is the failure this escape hatch exists to prevent.',
+    ).toContain('markStartupComplete();');
+  });
+
+  it('checks that the MCP handle settled before registering IPC', () => {
+    expect(
+      sliceAfter('if (!mcpServerSettled) {', 600),
+      'the mcpServerSettled check must sit immediately before registerAllIpc(...): mcpServerHandle is null both before startup decides and after it fails, so only the flag distinguishes an unresolved handle from a deliberate one',
+    ).toContain('registerAllIpc(');
+  });
+
+  it('settles the MCP flag on both the success and failure paths', () => {
+    expect(
+      INDEX_SOURCE.includes('mcpServerSettled = true;'),
+      'mcpServerSettled must be set after the startMcpHttpServer try/catch so a swallowed failure still counts as settled; setting it only inside the try leaves the failure path indistinguishable from "startup has not run yet"',
+    ).toBe(true);
+  });
+
+  it('guards createWindow against building a second live window', () => {
+    expect(
+      INDEX_SOURCE.includes('mainWindow && !mainWindow.isDestroyed()'),
+      'createWindow() must bail when a live mainWindow already exists. A second BrowserWindow orphans the first; the orphan holds getAllWindows() above zero, so window-all-closed never fires, before-quit never runs, and syncShutdownCleanup never kills PTYs, suspends session records, or closes DBs.',
+    ).toBe(true);
+
+    // Presence of the condition is not the guard. Anchored on the guard's own
+    // telemetry source, which is unique in the file: the bare condition text
+    // appears three times, because two IPC broadcast guards share its shape.
+    expect(
+      sliceAfter("source: 'duplicateCreateWindow'", 200),
+      'the duplicate-window guard must RETURN, not merely report. A log-only branch falls straight through and builds the second BrowserWindow anyway, which is the orphan described above.',
+    ).toContain('return;');
+  });
+});

--- a/tests/unit/startup-gate.test.ts
+++ b/tests/unit/startup-gate.test.ts
@@ -163,6 +163,15 @@ describe('the startup gate is wired into src/main/index.ts', () => {
       /if \(!\w+\) return;/.test(handler),
       'the activate handler must ACT on the predicate: calling shouldCreateWindowOnActivate and then building the window regardless still contains the call, and is still the DESKTOP-3/4 race',
     ).toBe(true);
+
+    // Calling the predicate with the wrong inputs is not the same as obeying
+    // it either: hardcoding `startupComplete: true` (or feeding it a stale
+    // local) keeps both assertions above green while fully reintroducing the
+    // launch-time race, because the gate would then never actually close.
+    expect(
+      handler,
+      'the activate handler must read the LIVE gate value via isStartupComplete(), not a literal or a cached local - anything else defeats the gate while leaving the predicate call and its `if (!...) return;` guard in place',
+    ).toContain('startupComplete: isStartupComplete()');
   });
 
   it('creates the window from exactly two call sites', () => {
@@ -229,10 +238,25 @@ describe('the startup gate is wired into src/main/index.ts', () => {
     const catchEnd = INDEX_SOURCE.indexOf('\n});', catchStart);
     expect(catchEnd, 'the whenReady .catch block is never closed at column 0').toBeGreaterThan(catchStart);
 
+    const catchBody = INDEX_SOURCE.slice(catchStart, catchEnd);
     expect(
-      INDEX_SOURCE.slice(catchStart, catchEnd),
+      catchBody,
       'one markStartupComplete() must sit INSIDE the whenReady .catch. A startup throw that leaves the gate shut strands the user on a dock icon that opens nothing, which is the failure this escape hatch exists to prevent.',
     ).toContain('markStartupComplete();');
+
+    // Presence inside the catch is not enough: the call must be UNCONDITIONAL.
+    // The catch already contains an `if (!isShuttingDown())` around the
+    // analytics report, and it would be an easy edit to tuck the gate open
+    // inside it, or to add some other "only reopen on a real failure" guard.
+    // Any of those makes recovery conditional on a predicate that has nothing
+    // to do with whether the user can still open a window. Anchored on the
+    // 2-space indentation of the catch body's own top level rather than by
+    // brace-balancing, consistent with this file's other exact-text anchors.
+    // Newline-anchored, so it holds under a CRLF checkout too.
+    expect(
+      catchBody,
+      'markStartupComplete() must sit at the TOP LEVEL of the .catch body, not nested inside its isShuttingDown reporting guard or any other condition: the escape hatch has to reopen the gate on every startup failure, or a dock click opens nothing',
+    ).toContain('\n  markStartupComplete();');
   });
 
   it('checks that the MCP handle settled before registering IPC', () => {


### PR DESCRIPTION
## What

Serializes main-window creation against the `app.whenReady()` startup sequence, so IPC handlers are
always registered before the renderer's first invoke.

- **`src/main/startup-gate.ts`** (new) - `isStartupComplete()` / `markStartupComplete()` plus a pure
  `shouldCreateWindowOnActivate()` predicate. Mirrors the existing `src/main/shutdown-state.ts`.
- **`src/main/index.ts`** - the `activate` handler routes through the predicate; the gate opens right
  after `initAnnouncements`; the `whenReady` chain gains a `.catch` escape hatch; a new
  `mcpServerSettled` flag; and a `createWindow()` re-entrancy guard.
- **`tests/unit/startup-gate.test.ts`** (new) - 15 tests.

## Why

Fixes Sentry **DESKTOP-3** (`announcements:get`) and **DESKTOP-4** (`announcements:getHistory`):
unhandled renderer rejections on `Kangentic@0.38.0`, macOS 26.5.1, both firing in the same second on
two separate cold launches.

macOS fires `app.on('activate')` during **launch**, not only on a dock click. The handler saw
`getAllWindows().length === 0` and called `createWindow()` while the `whenReady` body was still
parked on `await startMcpHttpServer(...)`. `createWindow()` calls `loadURL()` internally, so the
renderer mounted and invoked the announcements channels before `initAnnouncements` had called
`ipcMain.handle` - rejecting with `No handler registered`.

`src/main/announcements.ts` already registers those handlers above every bail-out on purpose. That
intent was right; the ordering it silently depended on is what broke.

Announcements was the cheapest symptom. The same race also:

- handed `registerAllIpc` an unsettled `mcpServerHandle` (it only overwrites the handle on re-entry
  when truthy), so the IPC context had no route to the MCP server; and
- since `createWindow()` had **no re-entrancy guard**, let `whenReady` go on to build a **second**
  window. That orphan holds `getAllWindows()` above zero forever, so `window-all-closed` never
  fires, `before-quit` never runs, and `syncShutdownCleanup` never kills PTYs, suspends session
  records, or closes DBs. This is the exact failure mode already documented at the `closed` handler.

## How

The gate makes the module-scope `activate` handler a no-op until startup has created the window and
registered its handlers. Dropping the launch-time event loses nothing: `whenReady` creates the window
unconditionally.

Three points worth a reviewer's attention:

1. **Gating `activate` removes an accidental safety net.** The `whenReady` body has unguarded
   synchronous fs writes before `createWindow` (`ensureSpawnHelperPermissions`, the config save,
   `initUsageAnalytics`), and today an early throw there *still* produces a window precisely because
   the ungated handler fires on launch. So the chain gains a `.catch` that reports through the same
   shape `process.on('unhandledRejection')` already uses (observability is unchanged) and then opens
   the gate. Accepted limitation, documented at the call site: if the throw lands before
   `createWindow`, the recovered window lacks the updater and announcements channels (neither init is
   idempotent), and it arrives on the next dock click rather than automatically.

2. **`mcpServerSettled` is a separate flag, not a type widening.** `mcpServerHandle` is `null` both
   before startup decides and after it fails, so "unresolved" is not observable from the value.
   Widening to `| undefined` does not work: it collapses back to `null` at `registerAllIpc`'s
   `= null` default parameter. Both the settled check and the re-entrancy guard **report rather than
   throw**, because throwing would destroy the very escape hatch that produced the window.

3. **Lines 1313-1319 of `index.ts` must stay one await-free block.** `createWindow()` starts the
   renderer loading, so only the absence of a suspension point guarantees the renderer cannot invoke
   before `initUpdater` / `initAnnouncements` have run. A static scan enforces this.

## Breaking changes

None.

## Tests

`src/main/index.ts` cannot be imported by a unit test (top-level `electron` calls), so this follows
the repo's established convention: extract the decision into an importable module, unit-test that,
and static-scan `index.ts` for the wiring.

- A behavioural table over `shouldCreateWindowOnActivate` (the launch-time case, normal dock
  re-activation, window-already-open, shutting-down) plus the flag lifecycle.
- Seven static wiring scans. The load-bearing one slices `index.ts` between `createWindow()` and the
  gate opening and asserts the span contains no `await`.
- Red-green verified by mutation: inserting an `await` in that span, reverting the handler to its old
  inline form, hardcoding `startupComplete: true`, and nesting the escape hatch inside a guard each
  failed exactly its own assertion and left the rest green.

**Empirical repro on Windows.** `activate` is an ordinary EventEmitter event, so the race reproduces
off-platform. Emitting a synthetic launch-time `activate` at the top of the `whenReady` body, with a
positive control confirming it fired:

```
[GATE-PROBE] emitting synthetic launch-time activate
[GATE-PROBE] activate decision { shouldCreate: false, startupComplete: false, windows: 0 }
```

`startupComplete: false, windows: 0` is exactly the state that previously called `createWindow()`.
The gate declined, the app booted to a rendered board, the renderer console was clean, and there were
zero errors or warnings across the whole boot. The probe was removed before commit.

CI covers lint, typecheck, unit, build, and the UI and Linux Electron E2E shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHi3NyRb2UJvdCut6TfHjV
