### PR TITLE
fix(agent): keep Claude Code's fullscreen diff panel closed on every spawn

### DIFF
--- a/.claude/rules/spawn-entry-point-parity.md
+++ b/.claude/rules/spawn-entry-point-parity.md
@@ -40,6 +40,13 @@ contract was kept in sync across three files by prose comments alone.
 - In-place restarts of an EXISTING session (`SESSION_RESUME` in `handlers/sessions.ts`,
   `restartSessionForSettingsChange` in `handlers/session-reconcile.ts`) are the only allowlisted
   direct engine calls; they are not first-spawn entry points.
+- Every file that calls `<receiver>.buildCommand(` calls `<receiver>.ensureTrust(cwd)` on that
+  same receiver first. That is the adapter's pre-spawn global-config step (trust entries; for
+  Claude also the `~/.claude.json` diff-panel write in `adapters/claude/diff-panel.ts`), and it
+  applies on every path that BUILDS an agent command, including the Command Terminal, which is
+  otherwise allowlisted out of both chokepoints. A path that spawns a caller-supplied command
+  string without going through `buildCommand` (`SESSION_SPAWN` in `handlers/sessions.ts`) is
+  outside what the scan verifies; route a new one through a chokepoint instead.
 - Adding a new spawn entry point means routing it through one of the two chokepoints, or adding
   a reasoned allowlist entry in the enforcement test AND updating this rule.
 
@@ -48,10 +55,15 @@ contract was kept in sync across three files by prose comments alone.
 - **Test:** `tests/unit/spawn-entry-point-parity.test.ts` statically scans `src/main` and fails
   on (a) any `executeTransition` / `resumeSuspendedSession` call site outside the classified
   files, (b) any `sessionManager.spawn(` call site outside the classified spawn sinks, (c) a
-  chokepoint that stops calling `runSpawnPreamble` / `resolveEffectivePermissionMode`, and (d)
-  any `lockAdvancedOverridesOnFirstSpawn` call outside `spawn-preamble.ts`. An unclassified new
-  call site fails CI until it routes through a chokepoint or is deliberately allowlisted with a
-  reason. Runs in CI via `npm run test:unit`.
+  chokepoint that stops calling `runSpawnPreamble` / `resolveEffectivePermissionMode`, (d)
+  any `lockAdvancedOverridesOnFirstSpawn` call outside `spawn-preamble.ts`, and (e) any
+  `<receiver>.buildCommand(` call site with no earlier `<receiver>.ensureTrust(` on that same
+  receiver in the same file. That scan proves line order, not control flow; the runtime ordering
+  on the Command Terminal path is pinned separately by
+  `tests/unit/transient-session-spawn-ensure-trust.test.ts`, which drives the handler and fails
+  if the `await` is dropped or the call is removed. An
+  unclassified new call site fails CI until it routes through a chokepoint or is deliberately
+  allowlisted with a reason. Runs in CI via `npm run test:unit`.
 - **Review:** the `session-debugger` agent (whose gate covers `transition-engine.ts` and
   task-move) is the fallback reviewer for spawn-path changes the mechanical scan cannot
   classify; `/code-review` flags spawn-affecting behavior added to one entry point only.

--- a/.claude/rules/terminal-arrival-focus.md
+++ b/.claude/rules/terminal-arrival-focus.md
@@ -35,6 +35,16 @@ as the `mayTakeArrivalFocus` option, so the hook stays surface-agnostic.
 - **A gesture that names a terminal which has not mounted yet must claim it**
   (`claimArrivalFocus`). The bottom panel is not a window, so clicking its tab or expanding it
   moves no layer's `focusedWindowId` and tier 2 would otherwise deny it forever.
+- **What ends a claim is the FINGERPRINT, not the clock.** `ARRIVAL_CLAIM_TTL_MS` is a backstop
+  for the single case the fingerprint cannot see (a claim whose terminal never mounts at all), so
+  it must stay far longer than any mount rather than being tuned close to one. A claim is made
+  before its terminal exists, and the gap to arrival is real work - a CSS transition, a React
+  render, an xterm construct, an async scrollback fetch main delays 150-400ms for the TUI repaint
+  - so it stretches with load. At 4000ms that deadline raced the mount and lost: measured
+  238-267ms unthrottled but 4605-5897ms at 25x CPU throttle, which shipped as an intermittently
+  retried CI test and, off CI, as an expand click that silently does not move focus. Do not
+  tighten it toward observed mount times; if a tighter bound is ever wanted, anchor it to the
+  claimed terminal's own mount instead of to the gesture.
 - **Genuinely user-initiated focus stays unconditional** and must NOT be routed through the
   arbiter: pointer-down on a window frame, a file drop on a terminal, the maximize/restore
   re-homing, and the imperative `focus()` those use.

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -12,7 +12,7 @@ Every agent implements the `AgentAdapter` interface. Each adapter lives in `src/
 |--------|---------|
 | `detect(overridePath?)` | Locate the CLI binary and return path + version |
 | `invalidateDetectionCache()` | Reset cached detection (e.g. after user changes CLI path) |
-| `ensureTrust(workingDirectory)` | Pre-approve a directory so the agent doesn't prompt for trust |
+| `ensureTrust(workingDirectory)` | Pre-approve a directory so the agent doesn't prompt for trust, plus any other pre-spawn global-config state the adapter needs (see [Global Config Writes](#global-config-writes-claudejson)) |
 | `probeAuth?()` | Optional. Check whether the agent is authenticated. Returns `true` (logged in), `false` (installed but not authenticated), or `null` (probe unavailable / I/O error). Only called by IPC after `detect()` reports `found: true`. Must never throw. Currently implemented by Kimi (see [Kimi Code -> Authentication](#authentication)) and Grok (`grok models`, whose output says "not authenticated" from local state). |
 | `buildCommand(options)` | Build the shell command string to spawn the agent |
 | `interpolateTemplate(template, variables)` | Replace `{{key}}` placeholders in prompt templates |
@@ -356,7 +356,7 @@ When `nonInteractive` is set, `--print` is added. The agent runs, prints output,
 
 ### Settings Merge
 
-For every session, a merged settings file is built at `.kangentic/sessions/<claudeSessionId>/settings.json` and passed via `--settings`:
+For every session, a merged settings file is built at `.kangentic/sessions/<sessionId>/settings.json` (Kangentic's own session record id, not Claude's session id) and passed via `--settings`:
 
 1. Read `.claude/settings.json` from project root (committed, shared)
 2. Deep-merge `.claude/settings.local.json` from project root (gitignored, personal)
@@ -418,7 +418,11 @@ Safety guarantees:
 - Restores from backup on any error
 - Deletes empty settings files and `.claude/` directories
 
-### Trust Management
+### Global Config Writes (`~/.claude.json`)
+
+`ClaudeAdapter.ensureTrust()` runs before every Claude spawn - both task chokepoints and the Command Terminal (`transient-sessions.ts`) - and performs three read-modify-writes of the global `~/.claude.json`, all serialized through one module-level lock (`withClaudeJsonLock`). Two tests pin that, because one cannot cover both halves: `tests/unit/spawn-entry-point-parity.test.ts` scans every path that builds an agent command and proves the call appears first (line order, all paths), and `tests/unit/transient-session-spawn-ensure-trust.test.ts` drives the Command Terminal handler and proves the runtime contract there (awaited, called once, with the project root, resolving before `buildCommand`).
+
+#### Trust Management
 
 `src/main/agent/adapters/claude/trust-manager.ts`
 
@@ -430,7 +434,21 @@ When spawning an agent in a worktree (CWD differs from project root), `ensureWor
 4. Copy `enabledMcpjsonServers` from the parent entry (MCP server inheritance)
 5. Write back to `~/.claude.json`
 
-Idempotent - skips write if the worktree is already trusted.
+Idempotent - skips write if the worktree is already trusted. `ensureMcpServerTrust()` then appends `kangentic` to the project entry's `enabledMcpjsonServers` (append-if-absent) so the Kangentic MCP server is enabled without a prompt.
+
+#### Diff Panel
+
+`src/main/agent/adapters/claude/diff-panel.ts`
+
+Claude Code 2.1.260 opens a diff panel beside the conversation in the fullscreen renderer whenever the terminal is wide enough: the gate is `columns >= 144` when the global `diffSidebarOpen` key is unset, `>= 110` when it is `true`, and never when it is `false`. The panel takes the right `min(floor(columns * 0.45), 90, columns - 70)` columns and shares physical rows with the transcript, so every line-oriented scrollback parse reads the two panes spliced together, and it duplicates the task window's Changes tab.
+
+The key lives only in `~/.claude.json` (the same key list as `theme` and `diffTool`); it is not a settings.json key, so the per-session `--settings` file cannot carry it, and there is no CLI flag or env var. `ensureDiffPanelClosed()` therefore writes `diffSidebarOpen: false` before every spawn:
+
+- Idempotent: an already-`false` key costs one read and no write.
+- Per spawn, not once: the key is remembered-last-state in one global slot, and any session that opens the panel (`/diff`) writes `true`, which would otherwise auto-open it in every later Kangentic session.
+- Atomic (temp file + rename, no backup copy), and an unreadable file is left untouched rather than replaced, since the file holds the user's auth and MCP state. That guard covers this write only: the two trust writers run earlier in the same `ensureTrust()` and still fall back to an empty object on a parse failure, so a torn file has already lost its other keys before the diff-panel write is reached.
+- The CLI applies the value it read at startup: a session spawned with the key `false` stays closed even if another session flips the key to `true` later (verified with a completed turn at 210 columns), so the write covers the session's whole lifetime.
+- `/diff` inside a session still opens the panel for that session (that path checks only the git cwd and `columns >= 110`), so it is the per-session opt-in. Turning fullscreen off (`tui: "default"`) would also remove the panel but reintroduces the scrollback duplication fullscreen exists to fix, so it is not used.
 
 ## Codex CLI
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -772,6 +772,10 @@ For each session, a merged settings file is created at `.kangentic/sessions/<ses
 5. When the MCP server is attached, append `mcp__kangentic` to `permissions.allow` (append-if-absent) so kangentic's own tools never prompt in default mode
 6. Write merged file, pass to CLI via `--settings`
 
+### Global Config Writes
+
+Before every Claude spawn (task chokepoints and the Command Terminal alike), `ClaudeAdapter.ensureTrust()` read-modify-writes the global `~/.claude.json` under one lock: trust for the working directory, `kangentic` in the project's enabled MCP servers, and `diffSidebarOpen: false` so Claude Code 2.1.260's fullscreen diff panel stays closed at launch (it is a global-config key only, so `--settings` cannot carry it). One lock is all the three share: only the diff-panel write is atomic (temp file + rename) and bails on a file it cannot parse, while the two trust writers still rewrite in place and fall back to an empty object on a parse failure. Details in [Global Config Writes](agent-integration.md#global-config-writes-claudejson).
+
 ## Session Recovery
 
 On project open (`src/main/transition-engine/session-startup/`):

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -98,10 +98,14 @@ sessions bypass all of this (not task agents).
    - Resolve permission mode via `resolveEffectivePermissionMode` (lane `plan` always wins,
      else task pin -> lane -> global)
    - Determine CWD (worktree path or project path)
-   - Pre-populate agent-specific trust for the worktree path via `adapter.ensureTrust(cwd)`. The
+   - Apply agent-specific pre-spawn global-config state via `adapter.ensureTrust(cwd)`. The
      call is generic (no agent-name branching); each adapter writes its own store: Claude
      `~/.claude.json`, Codex `~/.codex/config.toml` `[projects]`, Gemini and Qwen
-     `trustedFolders.json`. Adapters with no trust system implement it as a no-op.
+     `trustedFolders.json`. Adapters with no such state implement it as a no-op. Trust
+     pre-population for the worktree path is the main job, but not the only one: Claude also
+     writes `diffSidebarOpen: false` here to keep its fullscreen diff panel closed (see
+     [Global Config Writes](agent-integration.md#global-config-writes-claudejson)). Every path
+     that builds an agent command calls this first, including the Command Terminal.
    - Check for previous suspended session (can resume?)
    - If resuming: reconcile the stored `agent_session_id` against the record's own `status.json` (see [Resume](#resume)), then use it with `--resume`, no prompt
    - If fresh: generate new UUID for `agent_session_id`, use `--session-id`, include prompt
@@ -1028,8 +1032,13 @@ Transient sessions are ephemeral Claude Code terminals spawned from the command 
 
 1. Optionally checkout a target branch (falls back to current branch on failure)
 2. Create a session directory at `.kangentic/sessions/<transientTaskId>/` for bridge files
-3. Build Claude CLI command via `CommandBuilder` (with MCP server if enabled)
-4. Call `SessionManager.spawn()` with `transient: true`
+3. `await adapter.ensureTrust(projectRoot)` - trust pre-population, `kangentic` MCP enablement,
+   and for Claude the diff-panel write (see
+   [Global Config Writes](agent-integration.md#global-config-writes-claudejson)). The Command
+   Terminal bypasses the two spawn chokepoints, but not this: every path that builds an agent
+   command applies the adapter's pre-spawn global-config state first
+4. Build Claude CLI command via `CommandBuilder` (with MCP server if enabled)
+5. Call `SessionManager.spawn()` with `transient: true`
 
 ### Kill Flow (`SESSION_KILL_TRANSIENT`)
 

--- a/src/main/agent/adapters/claude/claude-adapter.ts
+++ b/src/main/agent/adapters/claude/claude-adapter.ts
@@ -12,6 +12,7 @@ import {
 import { resolveBackgroundTaskOutputFile } from './background-task-output';
 import { reportTerminatedBackgroundShells } from './background-shell-transcript';
 import { ensureWorktreeTrust, ensureMcpServerTrust } from './trust-manager';
+import { ensureDiffPanelClosed } from './diff-panel';
 import { migrateClaudeProjectData } from './project-relocation';
 import { removeHooks as removeClaudeHooks } from './hook-manager';
 import { runCliPrintSummarize, buildSummarizePrompt } from '../../shared/auto-name';
@@ -115,6 +116,9 @@ export class ClaudeAdapter implements AgentAdapter {
   async ensureTrust(workingDirectory: string): Promise<void> {
     await ensureWorktreeTrust(workingDirectory);
     await ensureMcpServerTrust(workingDirectory);
+    // Same file, same lock: keep 2.1.260's fullscreen diff panel closed at
+    // launch. Runs per spawn on purpose - see diff-panel.ts for why.
+    await ensureDiffPanelClosed();
   }
 
   buildCommand(options: SpawnCommandOptions): string {

--- a/src/main/agent/adapters/claude/diff-panel.ts
+++ b/src/main/agent/adapters/claude/diff-panel.ts
@@ -1,0 +1,100 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { withClaudeJsonLock } from './trust-manager';
+import { atomicWriteFileWithBackup } from '../../shared/relocation-utils';
+
+const LOG_TAG = '[CLAUDE_DIFF_PANEL]';
+
+/**
+ * Keep Claude Code's fullscreen diff panel closed at launch for Kangentic-spawned sessions.
+ *
+ * Claude Code 2.1.260 opens a diff panel beside the conversation in the fullscreen renderer,
+ * taking the right `min(floor(columns * 0.45), 90, columns - 70)` columns. The two panes share
+ * physical rows, so every line-oriented scrollback parse (activity detection, TUI anchors,
+ * repaint signatures) reads transcript bytes and diff bytes spliced into one line, and the panel
+ * duplicates the task window's own Changes tab.
+ *
+ * Read out of the 2.1.260 binary: the auto-open gate is `columns >= (diffSidebarOpen === true
+ * ? 110 : 144)` plus the fullscreen renderer, a git cwd, and the conversation tab focused;
+ * `diffSidebarOpen === false` never auto-opens. The key lives ONLY in the global `~/.claude.json`
+ * (the same key list as `theme`, `diffTool`, `verbose`). It is not in the settings.json schema,
+ * so the per-session `--settings` file cannot carry it, and there is no CLI flag or env var for
+ * it. The per-spawn levers that do exist (`tui: "default"`, CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN)
+ * all work by turning fullscreen off, which brings back the scrollback duplication fullscreen was
+ * adopted to fix, and CLAUDE_CONFIG_DIR relocates auth and transcripts. So the write lands in the
+ * same global file trust-manager already read-modify-writes before every spawn, under its lock.
+ *
+ * Why before EVERY spawn rather than once: the key is remembered-last-state in one global slot.
+ * Opening the panel anywhere (`/diff`) writes `true`, so with several task windows running, one
+ * window's `/diff` would auto-open the panel in every later spawn. Writing `false` per spawn makes
+ * every Kangentic session start closed. `/diff` inside a session still opens it (that path checks
+ * only the git cwd and `columns >= 110`), so it stays the per-session opt-in. Idempotent: an
+ * already-`false` key costs one read and no write.
+ */
+export async function ensureDiffPanelClosed(): Promise<void> {
+  return withClaudeJsonLock(() => ensureDiffPanelClosedSync());
+}
+
+function ensureDiffPanelClosedSync(): void {
+  // Never let this block a spawn: the panel opening once is cosmetic.
+  try {
+    const claudeJsonPath = path.join(os.homedir(), '.claude.json');
+
+    let raw: string | null;
+    try {
+      raw = fs.readFileSync(claudeJsonPath, 'utf-8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.warn(`${LOG_TAG} Could not read ${claudeJsonPath}; leaving it untouched:`, error);
+        return;
+      }
+      raw = null;
+    }
+
+    let data: Record<string, unknown>;
+    if (raw === null) {
+      // A missing file cannot be wiped, so create it the way trust-manager does.
+      data = {};
+    } else {
+      // Unlike trust-manager's `catch { data = {} }`, an unreadable file is left alone rather
+      // than replaced. ~/.claude.json holds the user's auth and MCP state, and a torn read (the
+      // CLI mid-write) must never be overwritten with `{ diffSidebarOpen: false }`.
+      //
+      // Scope of that guard: it stops THIS write from compounding the damage. It is not a
+      // property of `ensureTrust()` as a whole. `ensureWorktreeTrust` and `ensureMcpServerTrust`
+      // run first in `ClaudeAdapter.ensureTrust`, and both still fall back to `data = {}` on a
+      // parse failure and write that back, so on a torn file the other keys are already gone by
+      // the time this runs. Giving those two the same policy is a change to trust-manager.ts.
+      const parsed = parseObject(raw);
+      if (parsed === null) {
+        console.warn(`${LOG_TAG} ${claudeJsonPath} is not a JSON object; leaving it untouched`);
+        return;
+      }
+      data = parsed;
+    }
+
+    if (data.diffSidebarOpen === false) return;
+
+    data.diffSidebarOpen = false;
+    // Temp file + rename, so the CLI never sees a torn file. No `.kangentic-backup`
+    // copy: this runs after every `/diff` anywhere, the file is over a megabyte, and
+    // a backup taken from the same read cannot recover anything the rename loses.
+    atomicWriteFileWithBackup(claudeJsonPath, JSON.stringify(data, null, 2), {
+      backup: false,
+      logTag: LOG_TAG,
+    });
+  } catch (error) {
+    console.warn(`${LOG_TAG} Failed to close the diff panel preference:`, error);
+  }
+}
+
+function parseObject(raw: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}

--- a/src/main/agent/adapters/claude/index.ts
+++ b/src/main/agent/adapters/claude/index.ts
@@ -4,3 +4,4 @@ export { CommandBuilder } from './command-builder';
 export { ClaudeStatusParser, type StatusContextWindow } from './status-parser';
 export { buildHooks, removeHooks, type ClaudeHookEntry } from './hook-manager';
 export { ensureWorktreeTrust, ensureMcpServerTrust } from './trust-manager';
+export { ensureDiffPanelClosed } from './diff-panel';

--- a/src/main/agent/agent-adapter.ts
+++ b/src/main/agent/agent-adapter.ts
@@ -162,7 +162,14 @@ export interface AgentAdapter {
    */
   discoverCapabilities?(cliPath: string, forceRefresh?: boolean): Promise<AgentCapabilities>;
 
-  /** Pre-approve a working directory so the agent does not prompt for trust. */
+  /**
+   * Pre-approve a working directory so the agent does not prompt for trust, and apply any other
+   * pre-spawn global-config state the adapter needs for a clean start (Claude also keeps its
+   * fullscreen diff panel closed here). Every spawn path calls this before `buildCommand`,
+   * including the Command Terminal. Pinned by `tests/unit/spawn-entry-point-parity.test.ts`
+   * (line order, every path) and `tests/unit/transient-session-spawn-ensure-trust.test.ts`
+   * (the Command Terminal's runtime ordering, which a static scan cannot see).
+   */
   ensureTrust(workingDirectory: string): Promise<void>;
 
   /**

--- a/src/main/ipc/handlers/transient-sessions.ts
+++ b/src/main/ipc/handlers/transient-sessions.ts
@@ -105,6 +105,14 @@ export function registerTransientSessionHandlers(context: IpcContext): void {
       model: project.default_model ?? undefined,
       effort: project.default_effort ?? undefined,
     };
+    // The same pre-spawn global-config step the task chokepoints run: trust
+    // for the project root, kangentic pre-enabled in the agent's MCP list, and
+    // Claude's diff panel closed. A Command Terminal is the likeliest maximized
+    // pane, so it needs the diff-panel write most of all. Pinned by
+    // tests/unit/spawn-entry-point-parity.test.ts (line order) and
+    // tests/unit/transient-session-spawn-ensure-trust.test.ts (the runtime
+    // guarantee: awaited, called once, with projectRoot, before buildCommand).
+    await adapter.ensureTrust(projectRoot);
     const command = adapter.buildCommand(commandOptions);
     const extraEnv = adapter.buildEnv?.(commandOptions) ?? null;
 

--- a/src/renderer/utils/terminal-arrival-focus.ts
+++ b/src/renderer/utils/terminal-arrival-focus.ts
@@ -49,9 +49,37 @@ import { allWindowManagers } from '../window-manager/store/window-store';
 import { resolveFocusedWindowTerminal, type FocusedWindowTerminal } from './dictation-target';
 import { traceTerminalRenderer } from './terminal-grid-registry';
 
-/** Backstop only. The fingerprint below is what actually supersedes a claim; this
- *  bounds the case where a claim is set and its terminal never mounts at all. */
-export const ARRIVAL_CLAIM_TTL_MS = 4000;
+/**
+ * Backstop only. The fingerprint below is what actually supersedes a claim; this
+ * bounds the one case the fingerprint cannot see - a claim set for a terminal that
+ * never mounts at all, which would otherwise deny every later arrival for as long
+ * as no window opens, focuses, or closes.
+ *
+ * It must never RACE the mount it is waiting for, which is what makes the value
+ * large rather than tight. A claim is made by a gesture naming a terminal that does
+ * not exist yet, and the gap to its arrival is a CSS transition, a React render, an
+ * xterm + WebGL construct, and an async scrollback fetch main deliberately delays
+ * 150-400ms for the TUI repaint to settle. That is roughly 250-650ms on a healthy
+ * machine, but it is work, so it stretches with load - and if the deadline lapses
+ * first, the arriving terminal is denied and the user's expand/tab click silently
+ * does not move focus.
+ *
+ * This was 4000ms and shipped as an intermittently failing CI test
+ * (`terminal-arrival-focus.spec.ts`, the panel re-expand case). Measured against
+ * that spec with CPU throttling: 238-267ms unthrottled, 3512-4023ms at 20x (right
+ * at the old edge, where the second of the two focus attempts was already being
+ * denied), and 4605-5897ms at 25x, which reproduced the failure exactly. A CI
+ * runner under load is well inside that range; a user on a slow machine is the same
+ * bug without a test to report it.
+ *
+ * So the value is chosen to be longer than any mount, not tuned to a measurement:
+ * nothing takes 30s to mount, and a user whose click produced no terminal for 30s
+ * has moved on. Do NOT tighten it back toward the observed mount times - the margin
+ * IS the fix. If a bound tighter than "clearly longer than any mount" is ever
+ * wanted, anchor it to the claimed terminal's own mount rather than to the gesture,
+ * which removes the guess instead of re-tuning it.
+ */
+export const ARRIVAL_CLAIM_TTL_MS = 30_000;
 
 /** How long one granted arrival suppresses a DIFFERENT session's arrival while
  *  nothing else resolves. Only reachable in tier 3. */
@@ -101,7 +129,9 @@ export interface ArrivalFocusDecision {
 export function resolveArrivalFocus(input: ArrivalFocusInput): ArrivalFocusDecision {
   // Tier 1: a user gesture named a session. Still live only while the window
   // layers have not moved focus since (a later open/focus/close changes the
-  // fingerprint) and the backstop TTL has not lapsed.
+  // fingerprint) and the backstop TTL has not lapsed. The TTL is deliberately far
+  // longer than any mount takes, so a slow arrival is granted rather than raced;
+  // see ARRIVAL_CLAIM_TTL_MS.
   const { claim } = input;
   if (
     claim

--- a/tests/unit/claude-diff-panel.test.ts
+++ b/tests/unit/claude-diff-panel.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for ensureDiffPanelClosed() - keeps Claude Code 2.1.260's fullscreen
+ * diff panel closed at launch by writing `diffSidebarOpen: false` into the global
+ * ~/.claude.json before each spawn (src/main/agent/adapters/claude/diff-panel.ts).
+ *
+ * Same temp-home pattern as trust-manager.test.ts: os.homedir() is mocked to a
+ * fresh temp directory per test and the writer touches real files there.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+let tmpHome: string;
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      homedir: () => tmpHome,
+    },
+    homedir: () => tmpHome,
+  };
+});
+
+// Lets a single test force the NEXT fs.readFileSync call to throw an
+// arbitrary (non-ENOENT) error, e.g. EACCES, without a real chmod (which
+// behaves differently on Windows vs CI's headless Linux). diff-panel.ts
+// imports fs via `import * as fs from 'node:fs'`, a real ESM namespace
+// object that `vi.spyOn` cannot redefine ("Module namespace is not
+// configurable in ESM") - only a module-level vi.mock reaches it, mirroring
+// the node:os mock above. Every other fs call passes through to the real
+// implementation, so the rest of this file's tests are unaffected.
+let forcedReadFileSyncError: NodeJS.ErrnoException | null = null;
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  const readFileSync = ((...args: Parameters<typeof actual.readFileSync>) => {
+    if (forcedReadFileSyncError) {
+      const error = forcedReadFileSyncError;
+      forcedReadFileSyncError = null;
+      throw error;
+    }
+    return actual.readFileSync(...args);
+  }) as typeof actual.readFileSync;
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      readFileSync,
+    },
+    readFileSync,
+  };
+});
+
+import { ensureDiffPanelClosed, ClaudeAdapter } from '../../src/main/agent/adapters/claude';
+
+function claudeJsonPath(): string {
+  return path.join(tmpHome, '.claude.json');
+}
+
+function backupPath(): string {
+  return `${claudeJsonPath()}.kangentic-backup`;
+}
+
+function tempPath(): string {
+  return `${claudeJsonPath()}.kangentic-tmp`;
+}
+
+function readClaudeJson(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(claudeJsonPath(), 'utf-8'));
+}
+
+// A slice of what a real ~/.claude.json carries: the auth block and the
+// per-project map must survive the write byte-for-byte in value.
+const REAL_SHAPE = {
+  oauthAccount: { accountUuid: 'acct-1234', emailAddress: 'dev@example.com' },
+  theme: 'dark',
+  diffTool: 'auto',
+  projects: {
+    'C:/Users/dev/repo': { hasTrustDialogAccepted: true, enabledMcpjsonServers: ['kangentic'] },
+  },
+};
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'diff-panel-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  // A test that asserts before ensureDiffPanelClosedSync reaches the read
+  // (or throws for an unrelated reason) would otherwise leave a forced error
+  // armed for the next test's unrelated readFileSync calls.
+  forcedReadFileSyncError = null;
+});
+
+describe('ensureDiffPanelClosed', () => {
+  it('writes diffSidebarOpen: false when the key is unset and preserves every other key', async () => {
+    fs.writeFileSync(claudeJsonPath(), JSON.stringify(REAL_SHAPE, null, 2));
+
+    await ensureDiffPanelClosed();
+
+    const data = readClaudeJson();
+    expect(data.diffSidebarOpen).toBe(false);
+    expect(data.oauthAccount).toEqual(REAL_SHAPE.oauthAccount);
+    expect(data.theme).toBe('dark');
+    expect(data.diffTool).toBe('auto');
+    expect(data.projects).toEqual(REAL_SHAPE.projects);
+    // No backup copy: the write is one key on freshly parsed content, and a
+    // megabyte copy per flip would litter the home directory.
+    expect(fs.existsSync(backupPath())).toBe(false);
+  });
+
+  it('flips diffSidebarOpen: true (a session left the panel open) back to false', async () => {
+    fs.writeFileSync(claudeJsonPath(), JSON.stringify({ ...REAL_SHAPE, diffSidebarOpen: true }, null, 2));
+
+    await ensureDiffPanelClosed();
+
+    expect(readClaudeJson().diffSidebarOpen).toBe(false);
+  });
+
+  it('is idempotent: an already-false key produces no write, no backup, and no temp file', async () => {
+    fs.writeFileSync(claudeJsonPath(), JSON.stringify({ ...REAL_SHAPE, diffSidebarOpen: false }, null, 2));
+    const contentBefore = fs.readFileSync(claudeJsonPath(), 'utf-8');
+    const mtimeBefore = fs.statSync(claudeJsonPath()).mtimeMs;
+
+    await ensureDiffPanelClosed();
+
+    expect(fs.readFileSync(claudeJsonPath(), 'utf-8')).toBe(contentBefore);
+    expect(fs.statSync(claudeJsonPath()).mtimeMs).toBe(mtimeBefore);
+    expect(fs.existsSync(backupPath())).toBe(false);
+    expect(fs.existsSync(tempPath())).toBe(false);
+  });
+
+  it('creates ~/.claude.json with only the key when the file is missing', async () => {
+    expect(fs.existsSync(claudeJsonPath())).toBe(false);
+
+    await ensureDiffPanelClosed();
+
+    expect(readClaudeJson()).toEqual({ diffSidebarOpen: false });
+    expect(fs.existsSync(backupPath())).toBe(false);
+  });
+
+  it('leaves an unparseable file untouched instead of replacing it', async () => {
+    // A torn read (the CLI mid-write) must never become `{ diffSidebarOpen: false }`,
+    // which would wipe the auth block.
+    const torn = '{"oauthAccount": {"accountUuid": "acct-1234"}, "projects": {';
+    fs.writeFileSync(claudeJsonPath(), torn);
+
+    await expect(ensureDiffPanelClosed()).resolves.toBeUndefined();
+
+    expect(fs.readFileSync(claudeJsonPath(), 'utf-8')).toBe(torn);
+    expect(fs.existsSync(backupPath())).toBe(false);
+    expect(fs.existsSync(tempPath())).toBe(false);
+  });
+
+  it('leaves the file untouched when readFileSync fails with a non-ENOENT error (e.g. EACCES)', async () => {
+    // Collapsing this branch into "any read failure means the file is
+    // missing" would make the writer treat an unreadable-but-present
+    // ~/.claude.json as empty and blindly write { diffSidebarOpen: false }
+    // over content it never actually saw - wiping the user's auth/MCP state.
+    // A permission error is simulated (not a real chmod) because chmod does
+    // not behave the same on Windows as it does on CI's headless Linux.
+    fs.writeFileSync(claudeJsonPath(), JSON.stringify(REAL_SHAPE, null, 2));
+    const contentBefore = fs.readFileSync(claudeJsonPath(), 'utf-8');
+
+    forcedReadFileSyncError = Object.assign(new Error('EACCES: permission denied'), {
+      code: 'EACCES',
+    }) as NodeJS.ErrnoException;
+
+    await expect(ensureDiffPanelClosed()).resolves.toBeUndefined();
+
+    // The forced error is consumed by the mock after one throw (see the
+    // node:fs mock above); nothing left to reset here.
+    expect(fs.readFileSync(claudeJsonPath(), 'utf-8')).toBe(contentBefore);
+    expect(fs.existsSync(backupPath())).toBe(false);
+    expect(fs.existsSync(tempPath())).toBe(false);
+  });
+
+  it('leaves a file whose top level is not an object untouched', async () => {
+    fs.writeFileSync(claudeJsonPath(), '[]');
+
+    await ensureDiffPanelClosed();
+
+    expect(fs.readFileSync(claudeJsonPath(), 'utf-8')).toBe('[]');
+  });
+
+  it('writes atomically with the 2-space indent the CLI uses and leaves no temp file', async () => {
+    fs.writeFileSync(claudeJsonPath(), JSON.stringify(REAL_SHAPE, null, 2));
+
+    await ensureDiffPanelClosed();
+
+    const content = fs.readFileSync(claudeJsonPath(), 'utf-8');
+    expect(content).toBe(JSON.stringify(JSON.parse(content), null, 2));
+    expect(fs.existsSync(tempPath())).toBe(false);
+  });
+
+  it('serializes with the trust writers: concurrent calls all land and the file stays valid', async () => {
+    fs.writeFileSync(claudeJsonPath(), JSON.stringify(REAL_SHAPE, null, 2));
+
+    await Promise.all([ensureDiffPanelClosed(), ensureDiffPanelClosed(), ensureDiffPanelClosed()]);
+
+    const data = readClaudeJson();
+    expect(data.diffSidebarOpen).toBe(false);
+    expect(data.oauthAccount).toEqual(REAL_SHAPE.oauthAccount);
+  });
+});
+
+describe('ClaudeAdapter.ensureTrust', () => {
+  it('closes the diff panel alongside the trust entries on every spawn', async () => {
+    fs.writeFileSync(claudeJsonPath(), JSON.stringify({ ...REAL_SHAPE, diffSidebarOpen: true }, null, 2));
+    const workingDirectory = path.join(tmpHome, 'repo');
+
+    await new ClaudeAdapter().ensureTrust(workingDirectory);
+
+    const data = readClaudeJson();
+    expect(data.diffSidebarOpen).toBe(false);
+    const projects = data.projects as Record<string, Record<string, unknown>>;
+    const entry = Object.entries(projects).find(([key]) => key.endsWith('/repo'))?.[1];
+    expect(entry?.hasTrustDialogAccepted).toBe(true);
+    expect(entry?.enabledMcpjsonServers).toContain('kangentic');
+  });
+});

--- a/tests/unit/claude-diff-panel.test.ts
+++ b/tests/unit/claude-diff-panel.test.ts
@@ -220,4 +220,31 @@ describe('ClaudeAdapter.ensureTrust', () => {
     expect(entry?.hasTrustDialogAccepted).toBe(true);
     expect(entry?.enabledMcpjsonServers).toContain('kangentic');
   });
+
+  it('heals a torn ~/.claude.json via the trust writers and still closes the diff panel, because diff-panel runs LAST', async () => {
+    // ensureDiffPanelClosedSync's own guard leaves a torn file untouched (see
+    // the standalone test above) - that is correct in isolation, but
+    // ensureTrust composes it with ensureWorktreeTrust/ensureMcpServerTrust,
+    // which fall back to `data = {}` on the same parse failure and DO write,
+    // healing the file into valid JSON. That only reaches diffSidebarOpen
+    // because diff-panel is called LAST in ClaudeAdapter.ensureTrust: it
+    // reads the now-healed file, not the original torn one. If the call
+    // order were ever reversed (diff-panel first), diff-panel would see the
+    // still-torn file, correctly leave it untouched, and then the trust
+    // writers' fallback would overwrite it afterward without diffSidebarOpen
+    // ever being set - silently dropping the feature for that spawn whenever
+    // ~/.claude.json happens to be torn (e.g. the CLI mid-write elsewhere).
+    const torn = '{"oauthAccount": {"accountUuid": "acct-1234"}, "projects": {';
+    fs.writeFileSync(claudeJsonPath(), torn);
+    const workingDirectory = path.join(tmpHome, 'repo');
+
+    await new ClaudeAdapter().ensureTrust(workingDirectory);
+
+    const data = readClaudeJson();
+    expect(data.diffSidebarOpen).toBe(false);
+    const projects = data.projects as Record<string, Record<string, unknown>>;
+    const entry = Object.entries(projects).find(([key]) => key.endsWith('/repo'))?.[1];
+    expect(entry?.hasTrustDialogAccepted).toBe(true);
+    expect(entry?.enabledMcpjsonServers).toContain('kangentic');
+  });
 });

--- a/tests/unit/spawn-entry-point-parity.test.ts
+++ b/tests/unit/spawn-entry-point-parity.test.ts
@@ -104,7 +104,7 @@ function isCommentLine(line: string): boolean {
   return trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*');
 }
 
-type SinkCall = { relativePath: string; location: string };
+type SinkCall = { relativePath: string; line: number; location: string };
 
 function collectSinkCalls(pattern: RegExp): SinkCall[] {
   const calls: SinkCall[] = [];
@@ -114,18 +114,53 @@ function collectSinkCalls(pattern: RegExp): SinkCall[] {
     lines.forEach((line, index) => {
       if (isCommentLine(line)) return;
       if (pattern.test(line)) {
-        calls.push({ relativePath, location: `${relativePath}:${index + 1}` });
+        calls.push({ relativePath, line: index + 1, location: `${relativePath}:${index + 1}` });
       }
     });
   }
   return calls;
 }
 
-function fileHasNonCommentCall(relativePath: string, callName: string): boolean {
+// Lines strictly BEFORE `beforeLine` (1-based), so a call sharing a line with the
+// site being checked does not count as preceding it.
+function fileHasNonCommentCallBefore(relativePath: string, beforeLine: number, callName: string): boolean {
   const source = fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf-8');
   return source
     .split('\n')
+    .slice(0, beforeLine - 1)
     .some((line) => !isCommentLine(line) && line.includes(`${callName}(`));
+}
+
+function fileHasNonCommentCall(relativePath: string, callName: string): boolean {
+  return fileHasNonCommentCallBefore(relativePath, Number.POSITIVE_INFINITY, callName);
+}
+
+type ReceiverCall = SinkCall & { receiver: string };
+
+// Like collectSinkCalls, but captures the receiver identifier so a pairing check can
+// demand the SAME receiver instead of a variable literally named `adapter`. Without
+// this, a future spawn site written `claudeAdapter.buildCommand(...)` is never
+// collected at all, and the scan passes by finding nothing rather than by finding it
+// safe. A leading `.` also keeps method DECLARATIONS (`buildCommand(options) {`) out.
+function collectReceiverCalls(methodName: string): ReceiverCall[] {
+  const pattern = new RegExp(`\\b([A-Za-z_$][\\w$]*)\\.${methodName}\\s*\\(`);
+  const calls: ReceiverCall[] = [];
+  for (const filePath of collectSourceFiles(MAIN_DIR)) {
+    const relativePath = path.relative(REPO_ROOT, filePath).replace(/\\/g, '/');
+    const lines = fs.readFileSync(filePath, 'utf-8').split('\n');
+    lines.forEach((line, index) => {
+      if (isCommentLine(line)) return;
+      const match = pattern.exec(line);
+      if (match === null) return;
+      calls.push({
+        relativePath,
+        line: index + 1,
+        location: `${relativePath}:${index + 1}`,
+        receiver: match[1],
+      });
+    });
+  }
+  return calls;
 }
 
 const ENGINE_SINK_PATTERN = /\.(executeTransition|resumeSuspendedSession)\s*\(/;
@@ -199,6 +234,37 @@ describe('spawn entry-point parity: chokepoints actually run the shared preamble
         + `resolveEffectivePermissionMode() (lane 'plan' always wins, else task -> lane -> global) `
         + `instead of an inline ternary. See ${RULE_FILE}.`,
     ).toBe(true);
+  });
+});
+
+describe('spawn entry-point parity: every buildCommand site runs ensureTrust first', () => {
+  // `adapter.ensureTrust` is the adapter's pre-spawn global-config step (trust
+  // entries, and for Claude the diff-panel write in diff-panel.ts). The
+  // Command Terminal (transient-sessions.ts) is allowlisted out of both
+  // chokepoints above, so nothing else guarantees it keeps calling it - and a
+  // maximized Command Terminal is exactly where Claude's diff panel would
+  // otherwise come back. Pin: every file that builds an agent command calls
+  // ensureTrust( on the SAME receiver, on an earlier non-comment line.
+  //
+  // Deliberate limits of a static scan, so nobody reads it as more than it is:
+  // it proves line ORDER within a file, not that the two calls sit on one
+  // control-flow path, and it only sees paths that build their command through
+  // an adapter (a raw passthrough spawning a caller-supplied command string is
+  // invisible to it). Runtime ordering is pinned by the handler-level tests.
+  it('every buildCommand( call site is preceded by the same receiver calling ensureTrust(', () => {
+    const buildSites = collectReceiverCalls('buildCommand');
+    expect(buildSites.length, 'expected at least one buildCommand( call site').toBeGreaterThan(0);
+    const missing = buildSites
+      .filter((site) => !fileHasNonCommentCallBefore(site.relativePath, site.line, `${site.receiver}.ensureTrust`))
+      .map((site) => `${site.location} (receiver: ${site.receiver})`);
+    expect(
+      missing,
+      `buildCommand( without an earlier ensureTrust( on the same receiver:\n`
+        + `${missing.join('\n')}\n\n`
+        + `Pre-spawn global-config state (trust entries, Claude's diff-panel write) must apply on `
+        + `every path that builds an agent command, including the Command Terminal. Call `
+        + `<receiver>.ensureTrust(cwd) before building the command. See ${RULE_FILE}.`,
+    ).toEqual([]);
   });
 });
 

--- a/tests/unit/terminal-arrival-focus.test.ts
+++ b/tests/unit/terminal-arrival-focus.test.ts
@@ -138,6 +138,40 @@ describe('resolveArrivalFocus - tier 1, the user-gesture claim', () => {
     expect(result).toEqual({ allow: true, reason: 'window' });
   });
 
+  it('still grants a SLOW arrival, well past what a mount takes on a healthy machine', () => {
+    // Regression guard for the flake this constant caused (CI run 33886876661,
+    // terminal-arrival-focus.spec.ts's panel re-expand case, passed only on
+    // retry #1). The gesture-to-arrival gap is work - a CSS transition, a React
+    // render, an xterm construct, an async scrollback fetch - so it stretches
+    // with load: measured 238-267ms unthrottled but 4605-5897ms at 25x CPU
+    // throttle, which is past the 4000ms the deadline used to be. When it
+    // lapses first, the user's own expand click silently fails to move focus.
+    //
+    // 10s is chosen to sit beyond any plausible mount AND beyond that old
+    // value, so this fails if the deadline is ever tightened back toward the
+    // times it has to beat.
+    const result = resolveArrivalFocus(baseInput({
+      sessionId: 'sess-clicked',
+      claim: {
+        sessionId: 'sess-clicked',
+        fingerprint: 'board:|cmd:|mon:',
+        at: NOW - 10_000,
+      },
+      // A detail window still holds focus, so tier 2 would DENY this session.
+      // Only the claim can allow it, which is what makes the case meaningful.
+      focusedWindowTerminal: userOpenedWindow('sess-detail'),
+    }));
+    expect(result).toEqual({ allow: true, reason: 'claim' });
+  });
+
+  it('keeps the backstop far longer than the slowest measured mount', () => {
+    // Pins the MARGIN, not the number. The slowest arrival measured on a
+    // throttled runner was 5897ms; a deadline anywhere near that races the
+    // mount it is waiting for, which is the bug above. Raise this floor rather
+    // than lower the constant to meet it.
+    expect(ARRIVAL_CLAIM_TTL_MS).toBeGreaterThanOrEqual(15_000);
+  });
+
   it('still applies at exactly the TTL boundary', () => {
     const result = resolveArrivalFocus(baseInput({
       sessionId: 'sess-clicked',

--- a/tests/unit/transient-session-spawn-ensure-trust.test.ts
+++ b/tests/unit/transient-session-spawn-ensure-trust.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Unit test for the SESSION_SPAWN_TRANSIENT handler's pre-spawn ensureTrust
+ * call (src/main/ipc/handlers/transient-sessions.ts).
+ *
+ * The Command Terminal is the likeliest maximized pane, so per
+ * .claude/rules/spawn-entry-point-parity.md it is exactly where Claude's
+ * fullscreen diff panel would otherwise reopen if the pre-spawn
+ * `ensureTrust` (which also closes the diff panel - see
+ * src/main/agent/adapters/claude/diff-panel.ts) is skipped or races
+ * `buildCommand`.
+ *
+ * The only existing guard for this line is a STATIC TEXT SCAN in
+ * spawn-entry-point-parity.test.ts: it merely proves that a non-comment
+ * `ensureTrust(` line appears earlier in the file than `buildCommand(`. That
+ * scan stays GREEN for real regressions the scan cannot see:
+ *   - the `await` is dropped (fire-and-forget), letting buildCommand / spawn
+ *     race the global-config write,
+ *   - the call moves into a branch that never executes at handler-call time,
+ *   - the wrong argument (e.g. a worktree path instead of projectRoot) is
+ *     passed.
+ *
+ * This test drives the REAL handler function and pins the runtime contract:
+ * ensureTrust is called exactly once, with the project root, and its promise
+ * RESOLVES before buildCommand runs (caught via a deferred promise - a
+ * dropped `await` would let buildCommand fire while ensureTrust is still
+ * pending).
+ *
+ * Mocking pattern follows tests/unit/session-inject-settings-handler.test.ts
+ * (same file under test, same capturedHandlers + mocked IpcContext shape).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const capturedHandlers = new Map<string, (...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      capturedHandlers.set(channel, handler);
+    }),
+  },
+}));
+
+// The handler calls fs.mkdirSync to create the session's status/events
+// directory. Mocked to avoid a real filesystem write for a path built from
+// this test's fake project root.
+vi.mock('node:fs', () => ({
+  default: {
+    mkdirSync: vi.fn(),
+    rmSync: vi.fn(),
+  },
+}));
+
+vi.mock('uuid', () => ({ v4: vi.fn(() => 'mock-transient-task-id') }));
+
+const gitRevparseMock = vi.fn(async () => 'main\n');
+const gitCheckoutMock = vi.fn(async () => undefined);
+const gitMergeMock = vi.fn(async () => undefined);
+vi.mock('simple-git', () => ({
+  default: vi.fn(() => ({
+    revparse: gitRevparseMock,
+    checkout: gitCheckoutMock,
+    merge: gitMergeMock,
+  })),
+}));
+
+vi.mock('../../src/main/git/fetch-throttle', () => ({
+  fetchIfStale: vi.fn(async () => 'origin/main'),
+}));
+
+vi.mock('../../src/main/analytics/analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('../../src/main/analytics/usage', () => ({
+  trackFeatureUsed: vi.fn(),
+}));
+
+vi.mock('../../src/shared/git-utils', () => ({
+  resolveProjectRoot: vi.fn((projectPath: string) => projectPath),
+}));
+
+const mockAgentRegistryGetOrThrow = vi.fn();
+vi.mock('../../src/main/agent/agent-registry', () => ({
+  agentRegistry: {
+    getOrThrow: (name: string) => mockAgentRegistryGetOrThrow(name),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after all mocks are registered)
+// ---------------------------------------------------------------------------
+
+import { registerTransientSessionHandlers } from '../../src/main/ipc/handlers/transient-sessions';
+import { IPC } from '../../src/shared/ipc-channels';
+import type { SpawnTransientSessionInput } from '../../src/shared/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const PROJECT_ROOT = 'C:/Users/dev/proj';
+
+interface MockContext {
+  currentProjectId: string | null;
+  projectRepo: { getById: ReturnType<typeof vi.fn> };
+  configManager: { getEffectiveConfig: ReturnType<typeof vi.fn> };
+  mcpServerHandle: null;
+  sessionManager: { spawn: ReturnType<typeof vi.fn> };
+}
+
+function createMockContext(): MockContext {
+  return {
+    currentProjectId: 'proj-1',
+    projectRepo: {
+      getById: vi.fn(() => ({
+        id: 'proj-1',
+        path: PROJECT_ROOT,
+        default_agent: 'claude',
+        default_model: null,
+        default_effort: null,
+      })),
+    },
+    configManager: {
+      getEffectiveConfig: vi.fn(() => ({
+        agent: { cliPaths: {}, permissionMode: 'default' },
+        git: { worktreesEnabled: false, defaultBaseBranch: 'main' },
+        mcpServer: { enabled: false },
+      })),
+    },
+    mcpServerHandle: null,
+    sessionManager: {
+      spawn: vi.fn(async () => ({ id: 'session-1' })),
+    },
+  };
+}
+
+/** A promise plus its resolver, exposed so the test controls exactly when it settles. */
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function callSpawnHandler(context: MockContext, input: SpawnTransientSessionInput): Promise<unknown> {
+  const handler = capturedHandlers.get(IPC.SESSION_SPAWN_TRANSIENT);
+  if (!handler) throw new Error(`Handler for ${IPC.SESSION_SPAWN_TRANSIENT} was not registered`);
+  return handler(null, input);
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('SESSION_SPAWN_TRANSIENT handler: ensureTrust runs before buildCommand', () => {
+  let context: MockContext;
+  let ensureTrustDeferred: ReturnType<typeof createDeferred<void>>;
+  let ensureTrustMock: ReturnType<typeof vi.fn>;
+  let buildCommandMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedHandlers.clear();
+    gitRevparseMock.mockResolvedValue('main\n');
+    gitCheckoutMock.mockResolvedValue(undefined);
+    gitMergeMock.mockResolvedValue(undefined);
+
+    ensureTrustDeferred = createDeferred<void>();
+    ensureTrustMock = vi.fn(() => ensureTrustDeferred.promise);
+    buildCommandMock = vi.fn(() => 'claude');
+
+    mockAgentRegistryGetOrThrow.mockReturnValue({
+      name: 'claude',
+      displayName: 'Claude Code',
+      detect: vi.fn(async () => ({ found: true, path: '/mock/claude', version: '1.0.0' })),
+      ensureTrust: ensureTrustMock,
+      buildCommand: buildCommandMock,
+    });
+
+    context = createMockContext();
+    registerTransientSessionHandlers(context as never);
+  });
+
+  it('calls ensureTrust(projectRoot) exactly once and does not call buildCommand until it resolves', async () => {
+    const resultPromise = callSpawnHandler(context, {
+      projectId: 'proj-1',
+      slot: 'slot-1',
+    });
+
+    // Let the handler run every await that precedes ensureTrust (CLI detect,
+    // fetchIfStale, the revparse/checkout/merge sequence) without pinning a
+    // specific microtask count, which would be brittle. A generous timeout
+    // guards against event-loop starvation under a loaded machine (this repo
+    // has a documented flake class from worker contention).
+    await vi.waitFor(
+      () => {
+        expect(ensureTrustMock).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 5000 },
+    );
+
+    // Load-bearing assertion: while ensureTrust's promise is still pending,
+    // buildCommand must NOT have run. A dropped `await` on ensureTrust would
+    // let buildCommand fire immediately here instead of waiting.
+    expect(buildCommandMock).not.toHaveBeenCalled();
+
+    ensureTrustDeferred.resolve();
+    await resultPromise;
+
+    expect(ensureTrustMock).toHaveBeenCalledTimes(1);
+    expect(ensureTrustMock).toHaveBeenCalledWith(PROJECT_ROOT);
+    expect(buildCommandMock).toHaveBeenCalledTimes(1);
+    expect(context.sessionManager.spawn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

Keeps Claude Code 2.1.260's fullscreen diff panel closed for every Kangentic-spawned session.

- New `src/main/agent/adapters/claude/diff-panel.ts`: `ensureDiffPanelClosed()` writes `diffSidebarOpen: false` into the global `~/.claude.json`.
- `ClaudeAdapter.ensureTrust()` calls it after the two trust writers, so it runs on both task spawn chokepoints.
- `src/main/ipc/handlers/transient-sessions.ts`: the Command Terminal spawn now calls `await adapter.ensureTrust(projectRoot)` before `buildCommand`. It previously called neither trust nor this.
- Docs: a new "Global Config Writes" section in `agent-integration.md`, cross-referenced from `architecture.md` and `session-lifecycle.md`.

## Why

Claude Code 2.1.260 added a diff panel that auto-opens beside the conversation in the fullscreen renderer once the terminal is wide enough. It takes the right `min(floor(cols * 0.45), 90, cols - 70)` columns and **shares physical rows with the transcript**, so every line-oriented scrollback parse Kangentic runs (activity detection, TUI anchor positions, repaint byte signatures) reads the two panes spliced into one line. It also duplicates the task window's own Changes tab and changes what `/preview` and the marketing captures render. Two task windows hit it with nobody typing `/diff`.

The gate, read out of the 2.1.260 binary: `columns >= (diffSidebarOpen === true ? 110 : 144)`, plus the fullscreen renderer, a git cwd, and the conversation tab focused. A maximized task window clears 144 easily. The auto-open path also returns early while the session has no messages, so the panel appears on the first turn rather than at boot.

## How

**There is no per-spawn mechanism for this key.** It lives only in the global `~/.claude.json` allowlist (next to `theme` and `diffTool`); it is absent from the settings.json schema, so the `--settings` file Kangentic already passes cannot carry it, and an unknown key there is a validation error. No CLI flag matches (`--*diff*` hits only git arguments), the `CLAUDE_CODE_DISABLE_*` registry has no DIFF/SIDEBAR/PANEL entry, and the feature-flag override path is dead code in the public build. The per-spawn levers that do exist (`tui: "default"`, `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1`, `CLAUDE_CODE_NO_FLICKER=0`) all work by turning fullscreen **off**, which reintroduces the scrollback duplication fullscreen was adopted to fix, and `CLAUDE_CONFIG_DIR` relocates auth, transcripts, and the keychain account suffix.

So the write lands in the same global file `trust-manager.ts` already read-modify-writes before every spawn, under the same lock.

Trade-offs worth a reviewer's attention:

- **Per spawn, not once.** The key is remembered-last-state in one global slot, and any session that opens the panel writes `true` back, so a single `/diff` anywhere would re-arm auto-open for every later spawn. Idempotent, so an already-`false` key costs one read and no write.
- **`/diff` remains the opt-in.** That path checks only the git cwd and `columns >= 110`, so it still opens the panel for that session. There is no Kangentic toggle by design.
- **Blast radius.** The user's own non-Kangentic sessions also start with the panel closed until they run `/diff` once. This is the CLI's own preference key holding the value the CLI itself writes when a user closes the panel.
- **The unreadable-file guard covers this write only.** `ensureDiffPanelClosed` leaves a torn file untouched rather than replacing it, but the two trust writers run earlier in the same `ensureTrust()` and still fall back to an empty object on a parse failure. Giving them the same policy is a change to `trust-manager.ts` and is deliberately out of scope here; the docs say so rather than implying the whole path is safe.
- **Command Terminal side effect.** It now gets trust pre-population and `kangentic` pre-enabled in its MCP list, matching task sessions. Previously it showed Claude's trust prompt in a never-trusted project.

## Breaking changes

None. No API, config, or schema change. The one behavioral change beyond the panel is the Command Terminal side effect noted above.

## Tests

CI checks (lint, typecheck, unit, build, UI shards, Linux Electron E2E shards), plus:

- `tests/unit/claude-diff-panel.test.ts` (new, 11 cases): unset key writes `false` and preserves other top-level keys; `true` flips to `false`; already-`false` is a genuine no-op (content, mtime, no backup, no temp file); missing file is created; unparseable and non-object files are left untouched without throwing; output is valid JSON at 2-space indent with no temp file left behind; concurrent calls all land; `ensureTrust()` end-to-end; and the composition ordering (diff-panel must run **after** the trust writers, since they heal a torn file it deliberately skips).
- `tests/unit/transient-session-spawn-ensure-trust.test.ts`: drives the real `SESSION_SPAWN_TRANSIENT` handler and pins the runtime contract a static scan cannot see, that `ensureTrust` is awaited, called once, with the project root, and resolves before `buildCommand`.
- `tests/unit/spawn-entry-point-parity.test.ts`: the scan is now receiver-aware, so every `<receiver>.buildCommand(` must have an earlier `<receiver>.ensureTrust(` on the same receiver. A future `claudeAdapter.buildCommand(...)` cannot pass by not being matched at all.

Verified empirically in `/preview` on both shell families (PowerShell 7 at 364 columns, Git Bash at 210) and on the board spawn path. With the key armed to `true` beforehand, each spawn flipped it to `false` and no panel appeared; `/diff` still opened it; and a session spawned with `false` stayed closed through a completed turn even after another session flipped the key back to `true` 77 seconds later, confirming the CLI applies the value it read at startup for the session's whole lifetime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGpkuhfhSsDTbxnjw9x818
