### PR TITLE
fix(shutdown): drain node-pty exit callbacks before Electron tears Node down

### DIFF
--- a/.claude/rules/synchronous-shutdown.md
+++ b/.claude/rules/synchronous-shutdown.md
@@ -19,7 +19,8 @@ synchronous.
 
 1. Do all cleanup synchronously: mark DB session records `suspended`, kill PTYs, close DBs
    (better-sqlite3 is synchronous).
-2. Do NOT call `event.preventDefault()`. Let Electron's normal quit proceed.
+2. Do NOT call `event.preventDefault()`, with exactly one sanctioned exception: the bounded PTY
+   exit-callback drain described below. Nothing else may hold the quit.
 3. Fire-and-forget analytics. Never `await` a network call during shutdown.
 4. Set a hard failsafe timer (`taskkill /T /F` on Windows, `SIGKILL` of the process group
    elsewhere) as a backstop.
@@ -28,11 +29,45 @@ This forfeits the 2-second graceful CLI exit window (`suspendAll`). Sessions sta
 because DB records are marked `suspended` before PTYs are killed, and `--resume <id>` works from
 the saved session id.
 
+## The one exception: the PTY exit-callback drain
+
+`src/main/pty/shutdown/exit-callback-drain.ts`, wired by `createBeforeQuitHandler`
+(`src/main/pty/shutdown/before-quit-handler.ts`). After the synchronous cleanup has killed the
+PTYs, the handler calls `event.preventDefault()`, polls the killed children's pids every 25ms
+until every one is gone plus 100ms of further loop turns (deadline 1500ms), then calls
+`app.quit()` again. The second `before-quit` pass is a no-op and Electron proceeds. With no PTY
+killed, the quit is the plain synchronous one.
+
+Why it exists (Sentry DESKTOP-C, symbolicated against node-pty's shipped `conpty.pdb`): node-pty
+delivers a PTY's exit through a native `Napi::ThreadSafeFunction`. When that callback is first
+dispatched after `node::Stop()` (Electron's `PostMainMessageLoopRun` stops Node, then
+`FreeEnvironment` runs the libuv loop once more to close handles), `napi_call_function` is
+refused, node-addon-api throws a C++ `Napi::Error`, its catch block's `ThrowAsJavaScriptException`
+is refused too, and a second C++ exception escapes from inside a catch block: the process dies
+with an unhandled C++ exception. No JS frame is below that dispatch, so no try/catch can reach
+it, and Kangentic ships node-pty's prebuilt binary, which lacks
+`NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS`. VS Code has the same open crash on macOS
+(microsoft/vscode#243952). Not killing the PTYs is not an option either: the same function's
+finalizer joins the waiting thread, so an un-killed child hangs teardown until the hard failsafe.
+
+Why it does not reintroduce the zombie problem: it is timer-only (`setTimeout` plus
+`process.kill(pid, 0)`), never awaits network, PTY output, IPC, or DB work, is deadline-bounded,
+re-enters through `app.quit()` (never `process.exit()`, so Electron's own teardown runs), runs
+only when the cleanup actually killed a PTY, never runs after an OS-initiated shutdown (Windows
+`session-end`, powerMonitor `shutdown`), and the hard failsafe is armed inside `performShutdown()`
+before the drain starts.
+
 ## Enforcement (self-maintaining)
 
 - **Tests:** `tests/unit/task-move-shutdown.test.ts`, `shutdown-history-wiring.test.ts`, and
   `shutdown-leak-fixes.test.ts` cover early-exit guards, IPC error swallowing during shutdown,
-  and closing connections before close to plug leaks. Run in CI via `npm run test:unit`.
+  and closing connections before close to plug leaks. `tests/unit/pty-exit-callback-drain.test.ts`
+  pins the drain's settle, deadline, and never-rejects contract;
+  `tests/unit/before-quit-drain-wiring.test.ts` pins the handler state machine (hold once, re-quit
+  once, pass the second time) and scans `src/main/index.ts` for the `createBeforeQuitHandler`
+  registration, the `app.quit()` re-entry, the absence of `process.exit` there, and the
+  OS-shutdown disarm; `tests/unit/session-shutdown-flow.test.ts` pins that `killAllSessions`
+  returns the killed pids. All run in CI via `npm run test:unit`.
 - **Contract:** the JSDoc in `src/main/shutdown.ts` and
   `src/main/pty/shutdown/session-shutdown.ts` restate the synchronous requirement at the call
   sites.

--- a/.claude/skills/sentry/SKILL.md
+++ b/.claude/skills/sentry/SKILL.md
@@ -69,7 +69,8 @@ issue = affected installs).
   / `onerror` (renderer globals), `generic` via `captureException` (a boundary or
   `reportHandledError` - check the `source` tag: `updater`, `pty_spawn`, `spawn`).
 - **Symbolication caveat:** packaged-release events resolve to real file/line only once a
-  release build uploaded sourcemaps (`SENTRY_AUTH_TOKEN` set during `npm run build`). A dev
+  release build uploaded sourcemaps (`KANGENTIC_SENTRY_TOKEN` set during `npm run build`;
+  `SENTRY_AUTH_TOKEN` is accepted as the fallback). A dev
   event's renderer frames are unminified module URLs (readable); a packaged event without
   uploaded maps shows minified positions - lean on message, mechanism, tags, and breadcrumbs.
 - **Environment tag** separates `development` (forced-on dev/preview runs) from `production`
@@ -78,6 +79,35 @@ issue = affected installs).
 - **Cross-reference locally:** the same failure usually has a local trail - `.kangentic/logs/`
   (crash JSONs, main console), `kangentic_tail_logs`, and the Aptabase `app_error` /
   `spawn_failed` counts are the volume view of the same signal.
+
+## Native minidumps (`platform: native`, mechanism `minidump`)
+
+A native crash's frames arrive as raw addresses with `function: null` for any module Sentry has
+no debug file for (node-pty's `conpty.node` / `pty.node`, `better_sqlite3.node`). They can still
+be resolved offline on a Windows machine, because node-pty ships the matching PDB in its npm
+tarball (`node_modules/node-pty/prebuilds/win32-x64/conpty.pdb`):
+
+1. Read the `debugmeta` entry: for the module, take `image_addr` (the load base) and `debug_id`.
+2. Confirm the shipped PDB is the same build: `dumpbin /HEADERS <path to conpty.node>` prints the
+   RSDS record (`{GUID}, age, pdb path`); it must equal `debug_id` (`<guid>-<age>`).
+3. RVA = `instructionAddr - image_addr` for every frame in that module, `trust: scan` ones
+   included (scanned frames are stale, but they name what ran on this stack recently).
+4. Resolve the RVAs with dbghelp from PowerShell, no debugger install needed: P/Invoke
+   `SymSetOptions` (undname, deferred loads, load lines), `SymInitializeW`,
+   `SymLoadModuleExW(hProcess, 0, <path to conpty.node>, null, 0x180000000, <size of image>, 0, 0)`
+   (the PDB is found next to the image), then `SymFromAddrW` and `SymGetLineFromAddrW64` at
+   `0x180000000 + RVA`. Function plus source line come back; this is how DESKTOP-C resolved to
+   `Napi::Error::ThrowAsJavaScriptException` inside `ThreadSafeFunction::CallJS`'s catch block.
+5. Read the frames as a C++ story: `_CxxThrowException` is the throw site,
+   `__FrameHandler4::CxxCallCatchBlock` above it means the throw happened inside a catch block,
+   and `RtlDispatchException` / `RtlUnwindEx` further out mean an exception was already being
+   handled when this one was raised.
+
+The Windows release build uploads those PDBs as Sentry debug files when the token is present
+(`scripts/build.js`), so a future event should symbolicate without this. Two caveats when reading
+a native event: the SDK persists scope to disk with a 500 ms write throttle, so the last
+half-second of breadcrumbs before the crash is usually missing (an entire quit sequence fits in
+that gap), and `Kangentic.exe` frames carry names only because Electron publishes its symbols.
 
 ## Typical requests
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,10 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=4096
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEBUG: electron-builder
+          # Sentry release symbolication: sourcemaps (scripts/build.js,
+          # vite.config.mts) and node-pty's Windows PDBs (scripts/build.js).
+          # Both uploads are no-ops while the secret is unset.
+          KANGENTIC_SENTRY_TOKEN: ${{ secrets.KANGENTIC_SENTRY_TOKEN }}
           # macOS notarization
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,7 +386,8 @@ session; rules with one load when you touch matching files. Each rule names its 
 - `ui-conventions.md` - shared UI primitives, selectors, font floor, no hover-only controls, brief accurate copy (`src/renderer/`).
 - `popover-escapes-clipping.md` - a menu popover portals to `document.body` with `strategy: 'fixed'`; `z-index` never escapes an ancestor's overflow clip (`src/renderer/`).
 - `light-dismiss-denylist.md` - clicking outside a task window closes it unless excluded; overlays mount outside the `data-dismiss-layer` shell subtree, action cursors need `data-no-dismiss`, and hover must not promise what the click will not do (`src/renderer/`).
-- `synchronous-shutdown.md` - the `before-quit` path must be synchronous (`src/main/` shutdown).
+- `synchronous-shutdown.md` - the `before-quit` path must be synchronous; the only sanctioned
+  `preventDefault` is the bounded PTY exit-callback drain (`src/main/` shutdown).
 - `utc-timestamps.md` - DB writes use `new Date().toISOString()` (`src/main/db/`).
 - `ipc-7-layer-parity.md` - wire an IPC endpoint through all 7 layers.
 - `project-scoped-ipc.md` - renderer-driven task/session mutations forward an explicit interaction-time `projectId` (`src/preload/`, `src/main/ipc/`, `src/renderer/stores/`).

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -177,6 +177,11 @@ in one Sentry org, one triage surface.
   artifact; resolution is entirely server-side. The DSN in source is a public routing
   identifier by design, not a secret. `KANGENTIC_SENTRY_TOKEN` is also what the `/sentry`
   skill reads for issue retrieval, so one scoped variable serves both.
+- **Native debug files** ride the same gate: the Windows release build (`scripts/build.js`) also
+  uploads node-pty's shipped Windows PDBs (`node_modules/node-pty/prebuilds/win32-*/`) as Sentry
+  debug files, so a native crash inside `conpty.node` symbolicates server-side to function and
+  line instead of arriving as raw addresses (the DESKTOP-C investigation had to resolve those
+  offline). Only the Windows leg uploads, so the release matrix sends them once.
 
 ## What We Don't Collect
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -663,6 +663,7 @@ Shell-specific adaptations:
 | Status debounce | 100 ms | Usage file watch |
 | Event debounce | 50 ms | Event log + activity state watch |
 | Graceful shutdown | 2000 ms | `suspendAll()` timeout (exists in code but NOT used during app quit; synchronous shutdown kills PTYs immediately) |
+| PTY exit-callback drain | 25 ms poll, 100 ms settle, 1500 ms deadline | `before-quit` holds the quit until the killed PTY children are gone, so node-pty's native exit callback is dispatched while JS is still callable (Sentry DESKTOP-C; `src/main/pty/shutdown/exit-callback-drain.ts`) |
 | Idle timeout check | 60000 ms | Polling interval for `checkIdleTimeouts()` |
 
 Stale-thinking detection is no longer a `SessionManager` constant. It now lives in the activity engine watchdog (`src/main/activity-engine/engine/`), which emits a synthetic idle transition after `DEFAULT_STALE_THINKING_TIMEOUT_MS` (180000 ms) of no activity signal while in the "thinking" state. The engine is event-driven, so there is no separate polling timer. See [Activity Detection](activity-detection.md).

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -190,6 +190,9 @@ Flags:
 2. Vite builds renderer → `.vite/build/renderer/main_window/`
 3. esbuild bundles main + preload (minified)
 4. Copies bridge scripts (`status-bridge.js`, `event-bridge.js`) to `.vite/build/`
+5. Uploads node-pty's shipped Windows PDBs to Sentry as debug files (`uploadNativeDebugFiles`):
+   Windows leg only, gated on a `KANGENTIC_SENTRY_TOKEN` / `SENTRY_AUTH_TOKEN` upload token, and
+   non-fatal on failure (a missing token is a no-op)
 
 ### Worktree Dev
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -462,9 +462,9 @@ Lifecycle on task move (`task-move.ts`, the session switch branch inside Priorit
 
 ## Shutdown
 
-On app close, the `before-quit` handler calls `syncShutdownCleanup()`, which is fully synchronous. The `suspendAll()` method exists in `SessionManager` but is **never called during shutdown** -- it is async and would break the synchronous requirement.
+On app close, the `before-quit` handler (`createBeforeQuitHandler` in `src/main/pty/shutdown/before-quit-handler.ts`, wired in `src/main/index.ts`) calls `syncShutdownCleanup()` (`src/main/shutdown.ts`), which is fully synchronous. The `suspendAll()` method exists in `SessionManager` but is **never called during shutdown**: it is async and would break the synchronous requirement.
 
-The actual shutdown sequence (`syncShutdownCleanup()` in `src/main/index.ts`):
+The actual shutdown sequence (`syncShutdownCleanup()` in `src/main/shutdown.ts`):
 
 1. Cancel all pending command injections
 2. List all in-memory sessions with `running` or `queued` status
@@ -474,7 +474,9 @@ The actual shutdown sequence (`syncShutdownCleanup()` in `src/main/index.ts`):
 6. Clean up session files and clear in-memory session maps
 7. Delete ephemeral project from index (if applicable)
 8. Close all database connections via `closeAll()`
-9. Let Electron's normal quit proceed (tears down Chromium child processes)
+9. Return the child pids of the PTYs `killAll()` killed
+
+Then, only when at least one PTY was killed, the handler calls `event.preventDefault()` and runs the bounded PTY exit-callback drain (`drainPtyExitCallbacks` in `src/main/pty/shutdown/exit-callback-drain.ts`): it polls the killed pids every 25 ms until every one is gone, allows 100 ms of further loop turns, gives up at 1500 ms, and then calls `app.quit()` again. The second `before-quit` pass is a no-op and Electron's normal quit proceeds (tearing down Chromium child processes). The drain logs `[SHUTDOWN] pty-drain:start n=<count>` and `pty-drain:done <ms>` (or `pty-drain:timeout <ms> lingering=<pids>`). It exists because node-pty delivers a PTY's exit through a native ThreadSafeFunction, and an exit callback first dispatched after Electron has stopped Node kills the process with an unhandled C++ exception (Sentry DESKTOP-C); the drain makes sure those callbacks land while JS is still callable. OS-initiated shutdowns (Windows `session-end`, powerMonitor `shutdown`) skip the drain, and with no PTY killed the quit is the plain synchronous one. The rule and its rationale: `.claude/rules/synchronous-shutdown.md`.
 
 A hard failsafe timer (`taskkill /T /F` on Windows, 6 seconds) runs as a backstop in case Electron's shutdown hangs.
 
@@ -748,8 +750,10 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   exactly then). Every renderer resize sender now traces `resize-request` with an origin
   tag (`mount`/`flush`/`reload`/`echo-reassert`/`debounced-onResize`) and main traces every
   resize outcome (`resize-applied`/`resize-noop`/`resize-refused`/`resize-stash`/
-  `resize-ignored`/`resize-invalid`, plus `resize-reassert`/`resize-reassert-failed` from the
-  post-boot re-assert below), so `kangentic_devtools_terminal_state`'s merged trace
+  `resize-ignored`/`resize-invalid`/`resize-failed` (node-pty threw on a just-died child; main
+  records the failure and returns `{ colsChanged }` rather than rejecting the renderer's invoke),
+  plus `resize-reassert`/`resize-reassert-failed` from the post-boot re-assert below), so
+  `kangentic_devtools_terminal_state`'s merged trace
   names the trigger if a divergence ever recurs. A resize for a queued or suspended session
   stashes (including suspend's marked-but-alive teardown window, where the PTY is still
   non-null but must not be reshaped or re-echoed); one for a missing or exited session is

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -1019,6 +1019,7 @@ The handoff is transparent to the user - the task card shows spawn progress phas
 | Status debounce | 100 ms | Usage file watch |
 | Event debounce | 50 ms | Event log + activity state watch |
 | Hard shutdown deadline | 6000 ms | Failsafe timer before force-killing process tree |
+| PTY exit-callback drain | 25 ms poll, 100 ms settle, 1500 ms deadline | `before-quit` holds the quit until the killed PTY children are gone, so node-pty's native exit callback lands while JS is still callable (see Shutdown above) |
 | Command inject delay | 100 ms | Wait after PTY spawn before writing command |
 | Idle timeout check | 60000 ms | Polling interval for `checkIdleTimeouts()` (every 60s) |
 | Stale thinking threshold | 180000 ms | If no activity signal for 180s while in "thinking" state, emit synthetic idle event (v2 engine is event-driven, no polling timer) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "@kangentic/branding": "^2.8.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@playwright/test": "^1.60.0",
+        "@sentry/cli": "^2.58.6",
         "@sentry/esbuild-plugin": "^5.4.0",
         "@sentry/vite-plugin": "^5.4.0",
         "@tailwindcss/postcss": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@kangentic/branding": "^2.8.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/test": "^1.60.0",
+    "@sentry/cli": "^2.58.6",
     "@sentry/esbuild-plugin": "^5.4.0",
     "@sentry/vite-plugin": "^5.4.0",
     "@tailwindcss/postcss": "^4.3.0",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -22,6 +22,9 @@ const keepDevtools = process.env.KANGENTIC_BUILD_DEV === '1';
 // IDs, then deleted, so nothing ships.
 const sentryAuthToken = process.env.KANGENTIC_SENTRY_TOKEN ?? process.env.SENTRY_AUTH_TOKEN;
 const uploadSourcemaps = Boolean(sentryAuthToken);
+// One Sentry project receives both the sourcemaps and the native debug files.
+const SENTRY_ORG = 'kangentic';
+const SENTRY_PROJECT = 'desktop';
 
 // The uploadSourcemaps guard gates the require below (the function itself runs
 // eagerly at module load), so unit tests that require this module for
@@ -31,8 +34,8 @@ function resolveSentryEsbuildPlugins() {
   const { sentryEsbuildPlugin } = require('@sentry/esbuild-plugin');
   return [
     sentryEsbuildPlugin({
-      org: 'kangentic',
-      project: 'desktop',
+      org: SENTRY_ORG,
+      project: SENTRY_PROJECT,
       authToken: sentryAuthToken,
       telemetry: false,
       sourcemaps: {
@@ -40,6 +43,49 @@ function resolveSentryEsbuildPlugins() {
       },
     }),
   ];
+}
+
+/**
+ * Upload node-pty's shipped Windows PDBs to Sentry as debug files, under the
+ * same token gate as the sourcemaps above. Kangentic ships node-pty's npm
+ * prebuilds (conpty.node, pty.node, conpty_console_list.node) unchanged, and
+ * the tarball carries their PDBs next to them, so the debug ids in a native
+ * crash's module list match these files exactly. Without the upload a crash
+ * inside conpty.node arrives as raw addresses (DESKTOP-C had to be resolved
+ * offline with dbghelp); with it, Sentry symbolicates to function and line.
+ *
+ * Windows leg only: the release matrix builds on three platforms and the
+ * files are identical on each, so one upload is enough. The `require` sits
+ * behind the gate for the same reason as resolveSentryEsbuildPlugins.
+ *
+ * A failed upload warns and lets the build finish: the files only make a
+ * FUTURE crash report readable, so they are not worth failing a release over.
+ * `execute` must be asked to reject on a non-zero exit (`'rejectOnError'`);
+ * its plain live mode resolves whatever sentry-cli exits with, which would
+ * turn every failure into a false "uploaded" line below.
+ */
+async function uploadNativeDebugFiles() {
+  if (!uploadSourcemaps || process.platform !== 'win32') return;
+  const prebuildsDir = path.join(projectDir, 'node_modules', 'node-pty', 'prebuilds');
+  const debugFileDirs = ['win32-x64', 'win32-arm64']
+    .map((arch) => path.join(prebuildsDir, arch))
+    .filter((dir) => fs.existsSync(dir));
+  if (debugFileDirs.length === 0) {
+    console.warn('[build] No node-pty Windows prebuilds found; skipping the debug-file upload');
+    return;
+  }
+  const SentryCli = require('@sentry/cli');
+  const sentryCli = new SentryCli(null, { authToken: sentryAuthToken, silent: false });
+  try {
+    await sentryCli.execute(
+      ['debug-files', 'upload', '--org', SENTRY_ORG, '--project', SENTRY_PROJECT, ...debugFileDirs],
+      'rejectOnError',
+    );
+  } catch (error) {
+    console.warn('[build] node-pty debug-file upload failed; native frames from this release will not symbolicate on Sentry:', error);
+    return;
+  }
+  console.log(`[build] Uploaded node-pty debug files to Sentry from ${debugFileDirs.length} prebuild dir(s)`);
 }
 
 /**
@@ -237,6 +283,9 @@ async function build() {
   // (see src/main/agent/mcp-http-server.ts), so we no longer bundle a
   // standalone mcp-server.js for Claude Code to spawn as a child.
 
+  // Release-only (token-gated) and Windows-only: see uploadNativeDebugFiles.
+  await uploadNativeDebugFiles();
+
   console.log('[build] Done! Output in .vite/build/');
 }
 
@@ -252,4 +301,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { assertVendorChunksLazy };
+module.exports = { assertVendorChunksLazy, uploadNativeDebugFiles };

--- a/src/main/activity-engine/background-shell/process-tree.ts
+++ b/src/main/activity-engine/background-shell/process-tree.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcessByStdio } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import type { Readable, Writable } from 'node:stream';
+import { isProcessAlive } from '../../shared/process-liveness';
 
 /**
  * Shape of the long-lived PowerShell child. `stdio: ['pipe', 'pipe', 'ignore']`
@@ -113,14 +114,7 @@ class WindowsProbe implements ProcessTreeProbe {
   private disposed = false;
 
   isAlive(pid: number): boolean {
-    if (!Number.isInteger(pid) || pid <= 0) return false;
-    try {
-      process.kill(pid, 0);
-      return true;
-    } catch (err: unknown) {
-      const code = (err as NodeJS.ErrnoException).code;
-      return code === 'EPERM';
-    }
+    return isProcessAlive(pid);
   }
 
   async listDescendants(rootPid: number): Promise<ProcessInfo[]> {
@@ -393,14 +387,7 @@ class PosixProbe implements ProcessTreeProbe {
   dispose(): void { /* no-op */ }
 
   isAlive(pid: number): boolean {
-    if (!Number.isInteger(pid) || pid <= 0) return false;
-    try {
-      process.kill(pid, 0);
-      return true;
-    } catch (err: unknown) {
-      const code = (err as NodeJS.ErrnoException).code;
-      return code === 'EPERM';
-    }
+    return isProcessAlive(pid);
   }
 
   async listDescendants(rootPid: number): Promise<ProcessInfo[]> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -57,6 +57,9 @@ import { destroyAllLanes } from './browser/browser-lane-manager';
 import { sweepOrphanedBrowserPartitions } from './browser/browser-partition-cleanup';
 import { loadReactDevTools } from './devtools';
 import { syncShutdownCleanup, startHardShutdownFailsafe } from './shutdown';
+import { createBeforeQuitHandler } from './pty/shutdown/before-quit-handler';
+import { drainPtyExitCallbacks } from './pty/shutdown/exit-callback-drain';
+import { isProcessAlive } from './shared/process-liveness';
 import { prRefreshScheduler } from './pr/pr-refresh-scheduler';
 import { retrievalService } from './retrieval/retrieval-service';
 import { lineCountClient } from './git/line-count/line-count-client';
@@ -1331,6 +1334,7 @@ app.whenReady().then(async () => {
   // closing event instead of a stale one.
   if (process.platform === 'win32') {
     mainWindow!.on('session-end', () => {
+      osInitiatedShutdown = true;
       performShutdown();
     });
   }
@@ -1351,6 +1355,7 @@ app.whenReady().then(async () => {
   // closing event instead of leaving a stale last event.
   if (process.platform !== 'win32') {
     powerMonitor.on('shutdown', () => {
+      osInitiatedShutdown = true;
       performShutdown();
     });
   }
@@ -1593,6 +1598,19 @@ function getShutdownDependencies() {
 }
 
 /**
+ * Child pids of the PTYs the synchronous cleanup killed, consumed once by the
+ * before-quit handler's exit-callback drain.
+ */
+let killedPtyPids: number[] = [];
+/**
+ * Set by the OS-initiated shutdown paths (Windows session-end, powerMonitor
+ * 'shutdown'). A before-quit that follows one of those never holds the quit:
+ * the OS is tearing the process down, and a prevented quit during logout is
+ * not something worth risking for a drain the OS will cut short anyway.
+ */
+let osInitiatedShutdown = false;
+
+/**
  * Shared synchronous shutdown flush: app quit (before-quit), SIGINT/SIGTERM,
  * and OS-initiated shutdown/reboot/log-off (powerMonitor 'shutdown' on
  * Linux/macOS, BrowserWindow 'session-end' on Windows) all route through
@@ -1610,13 +1628,28 @@ function performShutdown(): boolean {
 
   // Synchronous cleanup - then let the quit proceed normally so Electron
   // tears down all Chromium child processes (GPU, utility, crashpad, etc.)
-  syncShutdownCleanup(getShutdownDependencies());
+  killedPtyPids = syncShutdownCleanup(getShutdownDependencies());
   return true;
 }
 
-app.on('before-quit', () => {
-  performShutdown();
-});
+// The synchronous cleanup, then the one sanctioned event.preventDefault() in
+// the quit path: a timer-bounded drain that lets node-pty dispatch the killed
+// children's exit callbacks while JS is still callable, then app.quit() again.
+// See pty/shutdown/exit-callback-drain.ts and
+// .claude/rules/synchronous-shutdown.md.
+app.on('before-quit', createBeforeQuitHandler({
+  performShutdown: () => {
+    performShutdown();
+  },
+  getKilledPtyPids: () => (osInitiatedShutdown ? [] : killedPtyPids),
+  drainPtyExitCallbacks: (pids) => drainPtyExitCallbacks({ pids, isProcessAlive }),
+  hideAllWindows: () => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      if (!window.isDestroyed()) window.hide();
+    }
+  },
+  requestQuit: () => app.quit(),
+}));
 
 // Handle force-close (Ctrl+C / SIGINT / SIGTERM) which may not fire before-quit
 for (const signal of ['SIGINT', 'SIGTERM'] as const) {

--- a/src/main/pty/lifecycle/session-spawn-flow.ts
+++ b/src/main/pty/lifecycle/session-spawn-flow.ts
@@ -20,6 +20,7 @@ import { safeKillPty } from './pty-kill';
 import { resolveShellArgs, buildSpawnEnv, resolveSpawnCwd } from '../spawn/pty-spawn';
 import { handleSpawnFailure } from '../spawn/spawn-failure-handler';
 import { isShuttingDown } from '../../shutdown-state';
+import { traceTerminal } from '../terminal-trace';
 import { adaptCommandForShell, buildSpawnClearPrelude } from '../../../shared/paths';
 
 /**
@@ -569,10 +570,28 @@ export async function performSpawn(
   // would add a spurious `& ` prefix): cmd.exe `pushd "<unc>"` maps the UNC
   // path to a temporary drive letter, PowerShell `Set-Location -LiteralPath`
   // corrects its wildcard-mangled provider location for bracketed paths.
+  //
+  // These timers hold the raw ptyProcess, not session.pty, so they would
+  // outlive the kill / respawn / exit paths that null session.pty (each in
+  // its own tick before the 100ms fires). Every write therefore re-checks
+  // that the session still owns THIS pty and tolerates node-pty throwing on
+  // a just-died child; the exit path owns the cleanup either way.
+  const writeIfStillOwned = (text: string): void => {
+    if (session.pty !== ptyProcess) {
+      traceTerminal(id, 'deferred-write-skipped', { bytes: text.length });
+      return;
+    }
+    try {
+      ptyProcess.write(text);
+    } catch (error) {
+      // PTY died between the timer arming and firing; nothing to deliver to.
+      traceTerminal(id, 'deferred-write-failed', { bytes: text.length, message: String(error) });
+    }
+  };
   if (input.command || cwdFixupCommand) {
     setTimeout(() => {
       if (cwdFixupCommand) {
-        ptyProcess.write(cwdFixupCommand + '\r');
+        writeIfStillOwned(cwdFixupCommand + '\r');
       }
       if (input.command) {
         // Non-transient (agent) spawns get the shell's own clear prefixed
@@ -583,9 +602,9 @@ export async function performSpawn(
         const prelude = input.transient ? '' : buildSpawnClearPrelude(shellName);
         const cmd = prelude + adaptCommandForShell(input.command, shellName);
         if (cwdFixupCommand) {
-          setTimeout(() => ptyProcess.write(cmd + '\r'), 200);
+          setTimeout(() => writeIfStillOwned(cmd + '\r'), 200);
         } else {
-          ptyProcess.write(cmd + '\r');
+          writeIfStillOwned(cmd + '\r');
         }
       }
     }, 100);

--- a/src/main/pty/session-manager.ts
+++ b/src/main/pty/session-manager.ts
@@ -1253,7 +1253,23 @@ export class SessionManager extends EventEmitter {
       traceTerminal(sessionId, 'resize-noop', { origin, cols: clampedCols, rows: clampedRows });
       return { colsChanged };
     }
-    session.pty.resize(clampedCols, clampedRows);
+    try {
+      session.pty.resize(clampedCols, clampedRows);
+    } catch (error) {
+      // node-pty throws a plain Error once the child has exited but before
+      // onExit has nulled session.pty (up to ~1s on Windows, where the exit
+      // event waits on the conout flush). Same hazard the jiggle ladder in
+      // reassertGeometryForBootingChild guards; the exit path owns the
+      // cleanup, so record it and return instead of rejecting the renderer's
+      // resize invoke.
+      traceTerminal(sessionId, 'resize-failed', {
+        origin,
+        cols: clampedCols,
+        rows: clampedRows,
+        message: String(error),
+      });
+      return { colsChanged };
+    }
     // A resize applied while the agent is still booting can be lost: ConPTY
     // only delivers a resize to a connected client, and in the spawn window
     // the child is still starting behind the shell (and, under WSL, two
@@ -2081,10 +2097,11 @@ export class SessionManager extends EventEmitter {
    * Synchronously kill every PTY and clean up. Runs from Electron's
    * `before-quit` handler. Must NOT become async - see
    * session-shutdown.killAllSessions and
-   * .claude/rules/synchronous-shutdown.md.
+   * .claude/rules/synchronous-shutdown.md. Returns the killed children's
+   * pids for the before-quit exit-callback drain.
    */
-  killAll(): void {
-    killAllSessions(this.shutdownContext());
+  killAll(): number[] {
+    return killAllSessions(this.shutdownContext());
   }
 
   private shutdownContext() {

--- a/src/main/pty/shutdown/before-quit-handler.ts
+++ b/src/main/pty/shutdown/before-quit-handler.ts
@@ -1,0 +1,77 @@
+import type { PtyExitDrainResult } from './exit-callback-drain';
+
+/**
+ * The `before-quit` handler: the synchronous shutdown cleanup, then the one
+ * sanctioned `event.preventDefault()` in the quit path, held only for the
+ * bounded PTY exit-callback drain (see exit-callback-drain.ts for why), then
+ * `app.quit()` again so Electron's normal teardown runs. Pure so the state
+ * machine is unit-testable; src/main/index.ts supplies the Electron pieces.
+ * See .claude/rules/synchronous-shutdown.md.
+ */
+
+export interface BeforeQuitEvent {
+  preventDefault: () => void;
+}
+
+export interface BeforeQuitHandlerDependencies {
+  /** Idempotent: does the real work on the first call, nothing afterwards. */
+  performShutdown: () => void;
+  /** Child pids the cleanup killed; empty means no drain and no preventDefault. */
+  getKilledPtyPids: () => number[];
+  drainPtyExitCallbacks: (pids: number[]) => Promise<PtyExitDrainResult>;
+  /** Best-effort: the app should look quit while the drain runs. */
+  hideAllWindows: () => void;
+  /** Always app.quit(), never process.exit(): Electron must run its own teardown. */
+  requestQuit: () => void;
+}
+
+type DrainState = 'idle' | 'draining' | 'complete';
+
+export function createBeforeQuitHandler(
+  dependencies: BeforeQuitHandlerDependencies,
+): (event: BeforeQuitEvent) => void {
+  let drainState: DrainState = 'idle';
+
+  return (event: BeforeQuitEvent): void => {
+    dependencies.performShutdown();
+
+    // Second pass after the drain: let Electron proceed.
+    if (drainState === 'complete') return;
+
+    // A repeated quit request while the drain is running keeps waiting; the
+    // drain's own deadline bounds how long.
+    if (drainState === 'draining') {
+      event.preventDefault();
+      return;
+    }
+
+    const killedPtyPids = dependencies.getKilledPtyPids();
+    if (killedPtyPids.length === 0) {
+      // Nothing to drain: byte-for-byte the plain synchronous quit.
+      drainState = 'complete';
+      return;
+    }
+
+    drainState = 'draining';
+    event.preventDefault();
+    try {
+      dependencies.hideAllWindows();
+    } catch {
+      // Cosmetic only; a window that refuses to hide must not block the quit.
+    }
+
+    const completeAndQuit = (): void => {
+      drainState = 'complete';
+      dependencies.requestQuit();
+    };
+
+    let drain: Promise<PtyExitDrainResult>;
+    try {
+      drain = dependencies.drainPtyExitCallbacks(killedPtyPids);
+    } catch {
+      completeAndQuit();
+      return;
+    }
+    drain.then(completeAndQuit, completeAndQuit);
+  };
+}

--- a/src/main/pty/shutdown/exit-callback-drain.ts
+++ b/src/main/pty/shutdown/exit-callback-drain.ts
@@ -1,0 +1,130 @@
+/**
+ * Bounded drain of node-pty exit callbacks, run between the synchronous
+ * shutdown cleanup and the moment Electron is allowed to tear Node down.
+ *
+ * Why it exists (Sentry DESKTOP-C, symbolicated against node-pty's shipped
+ * conpty.pdb): node-pty delivers a PTY's exit through a native
+ * `Napi::ThreadSafeFunction`. A thread waits for the child process to die,
+ * then queues a main-thread call of node-pty's JS exit handler. If that call
+ * is first dispatched after `node::Stop()` (Electron's
+ * `PostMainMessageLoopRun` stops Node, then `FreeEnvironment` runs the libuv
+ * loop once more to close handles), `napi_call_function` is refused, node-addon-api
+ * throws a C++ `Napi::Error`, and its catch block's `ThrowAsJavaScriptException`
+ * is refused too, so a second C++ exception escapes from inside a catch block
+ * and the process dies with an unhandled C++ exception. No JS frame is below
+ * that dispatch, so nothing in this codebase can catch it, and Kangentic ships
+ * node-pty's prebuilt binary, which lacks NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS.
+ * VS Code carries the same open crash on macOS (microsoft/vscode#243952).
+ *
+ * The synchronous cleanup kills every PTY, so every quit with a live session
+ * races that dispatch against the message loop quitting. This drain removes
+ * the race from the app side: it keeps the loop alive, timer-only, until each
+ * killed child's pid is gone plus a few more loop turns for the queued
+ * callback to be dispatched while JS is still callable. Deadline-bounded, no
+ * network, no PTY output, no IPC; the caller then re-issues `app.quit()`.
+ * Not killing the PTYs is not an option: the same ThreadSafeFunction's
+ * finalizer joins the waiting thread, so an un-killed child would hang
+ * Electron's teardown until the hard failsafe fires.
+ *
+ * The pid probe is the right signal on both platforms. On Windows
+ * `process.kill(pid, 0)` throws ESRCH the instant the process object is
+ * signalled, which is when node-pty's thread wakes from WaitForSingleObject.
+ * On POSIX it throws ESRCH only once the zombie has been reaped, which
+ * node-pty's thread does with waitpid right before queuing the callback.
+ */
+
+export const PTY_EXIT_DRAIN_POLL_MS = 25;
+/** Loop turns to allow after the last child is gone: the exit thread's
+ *  BlockingCall lands on the libuv async handle, which the next loop
+ *  iteration dispatches. Four ticks (100ms) leaves margin for a busy box. */
+export const PTY_EXIT_DRAIN_SETTLE_TICKS = 4;
+export const PTY_EXIT_DRAIN_DEADLINE_MS = 1500;
+
+export interface PtyExitDrainOptions {
+  /** Child pids of the PTYs the synchronous cleanup just killed. */
+  pids: number[];
+  isProcessAlive: (pid: number) => boolean;
+  pollIntervalMs?: number;
+  settleTicks?: number;
+  deadlineMs?: number;
+  /** Defaults to console.log; the lines become Sentry console breadcrumbs. */
+  log?: (line: string) => void;
+}
+
+export interface PtyExitDrainResult {
+  timedOut: boolean;
+  elapsedMs: number;
+  /** Pids still alive at the deadline (empty on a clean drain). */
+  lingeringPids: number[];
+}
+
+/**
+ * Resolve once every pid is gone and `settleTicks` further polls have run,
+ * or at `deadlineMs`, whichever comes first. Never rejects: a probe that
+ * throws counts as dead so the quit can never be held open by the drain.
+ * The timers are deliberately not unref'd; keeping the loop alive is the point.
+ */
+export function drainPtyExitCallbacks(options: PtyExitDrainOptions): Promise<PtyExitDrainResult> {
+  const pending = new Set(options.pids.filter((pid) => Number.isInteger(pid) && pid > 0));
+  if (pending.size === 0) {
+    return Promise.resolve({ timedOut: false, elapsedMs: 0, lingeringPids: [] });
+  }
+
+  const pollIntervalMs = options.pollIntervalMs ?? PTY_EXIT_DRAIN_POLL_MS;
+  const settleTicks = options.settleTicks ?? PTY_EXIT_DRAIN_SETTLE_TICKS;
+  const deadlineMs = options.deadlineMs ?? PTY_EXIT_DRAIN_DEADLINE_MS;
+  const log = options.log ?? ((line: string) => console.log(line));
+  const startedAt = Date.now();
+  log(`[SHUTDOWN] pty-drain:start n=${pending.size}`);
+
+  return new Promise((resolve) => {
+    let settled = false;
+    // -1 while pids are still being polled; counts down once the set is empty.
+    let settleTicksRemaining = -1;
+    let pollTimer: NodeJS.Timeout | null = null;
+    let deadlineTimer: NodeJS.Timeout | null = null;
+
+    const finish = (timedOut: boolean): void => {
+      if (settled) return;
+      settled = true;
+      if (pollTimer) clearTimeout(pollTimer);
+      if (deadlineTimer) clearTimeout(deadlineTimer);
+      const elapsedMs = Date.now() - startedAt;
+      const lingeringPids = [...pending];
+      if (timedOut) {
+        log(`[SHUTDOWN] pty-drain:timeout ${elapsedMs}ms lingering=${lingeringPids.join(',')}`);
+      } else {
+        log(`[SHUTDOWN] pty-drain:done ${elapsedMs}ms`);
+      }
+      resolve({ timedOut, elapsedMs, lingeringPids });
+    };
+
+    const probe = (pid: number): boolean => {
+      try {
+        return options.isProcessAlive(pid);
+      } catch {
+        return false;
+      }
+    };
+
+    const tick = (): void => {
+      if (settled) return;
+      if (settleTicksRemaining < 0) {
+        for (const pid of pending) {
+          if (!probe(pid)) pending.delete(pid);
+        }
+        if (pending.size === 0) settleTicksRemaining = settleTicks;
+      } else {
+        settleTicksRemaining -= 1;
+      }
+      if (settleTicksRemaining === 0) {
+        finish(false);
+        return;
+      }
+      pollTimer = setTimeout(tick, pollIntervalMs);
+    };
+
+    deadlineTimer = setTimeout(() => finish(true), deadlineMs);
+    pollTimer = setTimeout(tick, pollIntervalMs);
+  });
+}

--- a/src/main/pty/shutdown/session-shutdown.ts
+++ b/src/main/pty/shutdown/session-shutdown.ts
@@ -131,16 +131,28 @@ export async function suspendAllSessions<S extends ShutdownSession>(
  * in time (we do NOT wait); the agent might get a few ms to start
  * flushing conversation state. For a true graceful suspend, call
  * suspendAllSessions first.
+ *
+ * Returns the child pid of every PTY it killed. The before-quit handler
+ * feeds them to the exit-callback drain (exit-callback-drain.ts), which
+ * holds the quit until those children are gone and node-pty's exit
+ * callbacks have been dispatched while JS is still callable. A pid is
+ * returned even when killPty reports the child was already dead: it
+ * polls dead on the first tick, and the drain's settle ticks still cover
+ * an exit callback that is queued but not yet dispatched.
  */
 export function killAllSessions<S extends ShutdownSession>(
   context: ShutdownContext<S>,
-): void {
+): number[] {
+  const killedPtyPids: number[] = [];
   for (const session of context.sessions.values()) {
     if (session.pty) {
       writeExitSequence(session.pty, session.exitSequence);
       const ptyRef = session.pty;
+      // Read before nulling: the drain needs the child pid, not the wrapper.
+      const childPid = ptyRef.pid;
       session.pty = null; // prevent double-kill (conpty heap corruption on Windows)
       context.killPty(ptyRef);
+      if (Number.isInteger(childPid) && childPid > 0) killedPtyPids.push(childPid);
     }
     // Detach our onData / onExit listeners so node-pty stops invoking the
     // callbacks on a later tick. Without this a final ConPTY chunk fires
@@ -163,4 +175,5 @@ export function killAllSessions<S extends ShutdownSession>(
   context.sessions.clear();
   context.sessionQueue.clear();
   context.firstOutputTracker.clear();
+  return killedPtyPids;
 }

--- a/src/main/shared/process-liveness.ts
+++ b/src/main/shared/process-liveness.ts
@@ -1,0 +1,22 @@
+/**
+ * Liveness probe for a child process id, shared by the shutdown drain
+ * (src/main/pty/shutdown/exit-callback-drain.ts) and the background-shell
+ * process-tree probes.
+ *
+ * POSIX signal-0 semantics, which Node implements on Windows too (OpenProcess
+ * plus GetExitCodeProcess, so a terminated process reads as dead even while
+ * another handle keeps its pid reserved). EPERM means the process exists but
+ * cannot be signalled, which counts as alive. On POSIX a zombie stays alive
+ * until it is reaped, which is exactly what the shutdown drain wants: node-pty's
+ * exit thread reaps the child a moment before it queues the exit callback.
+ */
+export function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === 'EPERM';
+  }
+}

--- a/src/main/shutdown.ts
+++ b/src/main/shutdown.ts
@@ -38,9 +38,15 @@ const HARD_SHUTDOWN_DEADLINE_MS = 6000;
  * Chromium child processes (GPU, utility, crashpad) stayed alive because
  * Electron never reached its own cleanup. By doing only sync work and letting
  * the quit proceed, Electron's normal shutdown tears down all child processes.
+ *
+ * The one sanctioned exception lives OUTSIDE this function: after it returns,
+ * the before-quit handler (pty/shutdown/before-quit-handler.ts) holds the
+ * quit for the timer-bounded PTY exit-callback drain and then re-issues
+ * app.quit(). That is why this returns the killed children's pids.
  */
-export function syncShutdownCleanup(dependencies: ShutdownDependencies): void {
+export function syncShutdownCleanup(dependencies: ShutdownDependencies): number[] {
   console.log('[SHUTDOWN] cleanup:start');
+  let killedPtyPids: number[] = [];
   // Clear pending timers that could fire during shutdown
   dependencies.clearPendingTimers();
   dependencies.stopUpdaterTimers();
@@ -139,7 +145,7 @@ export function syncShutdownCleanup(dependencies: ShutdownDependencies): void {
     // Kill all PTY sessions immediately (with best-effort exit signals).
     // Stays synchronous - no await. Sessions are resumable via --resume
     // <agent_session_id> from the DB record marked 'suspended' above.
-    sessionManager.killAll();
+    killedPtyPids = sessionManager.killAll();
     sessionManager.dispose();
 
     // Ephemeral cleanup: delete project from index so it doesn't show on next launch.
@@ -159,6 +165,7 @@ export function syncShutdownCleanup(dependencies: ShutdownDependencies): void {
   console.log('[SHUTDOWN] cleanup:done');
   // Dev-only diagnostic; a no-op in production (dead-code-eliminated via __KANGENTIC_DEV__).
   logActiveHandlesAtShutdown();
+  return killedPtyPids;
 }
 
 /**

--- a/tests/unit/before-quit-drain-wiring.test.ts
+++ b/tests/unit/before-quit-drain-wiring.test.ts
@@ -1,0 +1,225 @@
+/**
+ * The before-quit handler state machine
+ * (src/main/pty/shutdown/before-quit-handler.ts) and its wiring into
+ * src/main/index.ts.
+ *
+ * The handler is the one sanctioned event.preventDefault() in the quit path:
+ * it holds the quit only for the bounded PTY exit-callback drain (Sentry
+ * DESKTOP-C) and then re-issues app.quit(). The behavioural half drives the
+ * pure handler with stubbed dependencies. The static half scans index.ts,
+ * which makes top-level electron calls and cannot be imported by a unit test
+ * (the same constraint and approach as tests/unit/startup-gate.test.ts).
+ *
+ * Tier: Unit.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { createBeforeQuitHandler } from '../../src/main/pty/shutdown/before-quit-handler';
+import type { PtyExitDrainResult } from '../../src/main/pty/shutdown/exit-callback-drain';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const INDEX_SOURCE = fs.readFileSync(path.join(REPO_ROOT, 'src/main/index.ts'), 'utf-8');
+
+function makeDeferredDrain() {
+  let resolveDrain: (result: PtyExitDrainResult) => void = () => undefined;
+  let rejectDrain: (error: Error) => void = () => undefined;
+  const promise = new Promise<PtyExitDrainResult>((resolve, reject) => {
+    resolveDrain = resolve;
+    rejectDrain = reject;
+  });
+  return { promise, resolveDrain, rejectDrain };
+}
+
+function makeHarness(killedPtyPids: number[]) {
+  const deferred = makeDeferredDrain();
+  const dependencies = {
+    performShutdown: vi.fn(),
+    getKilledPtyPids: vi.fn(() => killedPtyPids),
+    drainPtyExitCallbacks: vi.fn(() => deferred.promise),
+    hideAllWindows: vi.fn(),
+    requestQuit: vi.fn(),
+  };
+  const handler = createBeforeQuitHandler(dependencies);
+  const event = { preventDefault: vi.fn() };
+  return { dependencies, handler, event, deferred };
+}
+
+/** Let the drain's then-callbacks run. */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('createBeforeQuitHandler', () => {
+  it('holds the first quit for the drain, then re-quits once and lets the second pass through', async () => {
+    const { dependencies, handler, event, deferred } = makeHarness([4242, 4343]);
+
+    handler(event);
+
+    expect(dependencies.performShutdown).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(dependencies.hideAllWindows).toHaveBeenCalledTimes(1);
+    expect(dependencies.drainPtyExitCallbacks).toHaveBeenCalledWith([4242, 4343]);
+    // Nothing re-quits until the drain settles.
+    expect(dependencies.requestQuit).not.toHaveBeenCalled();
+
+    deferred.resolveDrain({ timedOut: false, elapsedMs: 80, lingeringPids: [] });
+    await flushMicrotasks();
+    expect(dependencies.requestQuit).toHaveBeenCalledTimes(1);
+
+    // The re-quit's before-quit pass: cleanup is re-entered (its own guard
+    // makes it a no-op) and Electron must NOT be held again.
+    const secondEvent = { preventDefault: vi.fn() };
+    handler(secondEvent);
+    expect(dependencies.performShutdown).toHaveBeenCalledTimes(2);
+    expect(secondEvent.preventDefault).not.toHaveBeenCalled();
+    expect(dependencies.requestQuit).toHaveBeenCalledTimes(1);
+  });
+
+  it('is byte-for-byte the plain synchronous quit when no PTY was killed', () => {
+    const { dependencies, handler, event } = makeHarness([]);
+
+    handler(event);
+    expect(dependencies.performShutdown).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(dependencies.drainPtyExitCallbacks).not.toHaveBeenCalled();
+    expect(dependencies.hideAllWindows).not.toHaveBeenCalled();
+    expect(dependencies.requestQuit).not.toHaveBeenCalled();
+
+    // A later pass (an OS retry, a second Cmd+Q) proceeds too.
+    const secondEvent = { preventDefault: vi.fn() };
+    handler(secondEvent);
+    expect(secondEvent.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('keeps holding a repeated quit while the drain is running, without restarting the drain', async () => {
+    const { dependencies, handler, event, deferred } = makeHarness([4242]);
+
+    handler(event);
+    const impatientEvent = { preventDefault: vi.fn() };
+    handler(impatientEvent);
+
+    expect(impatientEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(dependencies.drainPtyExitCallbacks).toHaveBeenCalledTimes(1);
+
+    deferred.resolveDrain({ timedOut: true, elapsedMs: 1500, lingeringPids: [4242] });
+    await flushMicrotasks();
+    expect(dependencies.requestQuit).toHaveBeenCalledTimes(1);
+  });
+
+  it('still re-quits exactly once when the drain rejects', async () => {
+    const { dependencies, handler, event, deferred } = makeHarness([4242]);
+
+    handler(event);
+    deferred.rejectDrain(new Error('drain failed'));
+    await flushMicrotasks();
+
+    expect(dependencies.requestQuit).toHaveBeenCalledTimes(1);
+    const afterEvent = { preventDefault: vi.fn() };
+    handler(afterEvent);
+    expect(afterEvent.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('still re-quits exactly once when the drain throws synchronously', () => {
+    const { dependencies, handler, event } = makeHarness([4242]);
+    dependencies.drainPtyExitCallbacks.mockImplementation(() => {
+      throw new Error('drain constructor exploded');
+    });
+
+    expect(() => handler(event)).not.toThrow();
+    expect(dependencies.requestQuit).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let a window that refuses to hide block the drain', () => {
+    const { dependencies, handler, event } = makeHarness([4242]);
+    dependencies.hideAllWindows.mockImplementation(() => {
+      throw new Error('window already destroyed');
+    });
+
+    expect(() => handler(event)).not.toThrow();
+    expect(dependencies.drainPtyExitCallbacks).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * Pins the read order: performShutdown() must run BEFORE getKilledPtyPids()
+   * is read, because in the real wiring (src/main/index.ts) performShutdown is
+   * what assigns the module-level killedPtyPids as a side effect - reading it
+   * first would always see the empty pre-shutdown array. makeHarness's other
+   * tests stub getKilledPtyPids over a CONSTANT array, so they cannot tell
+   * "read after performShutdown" apart from "read before"; this test makes the
+   * stub order-sensitive so it can. Red-green: swapping the two statements at
+   * the top of the handler in before-quit-handler.ts (reading
+   * dependencies.getKilledPtyPids() before calling
+   * dependencies.performShutdown()) turns this red, because
+   * drainPtyExitCallbacks would then be called with the stale empty array
+   * instead of [4242].
+   */
+  it('reads getKilledPtyPids AFTER performShutdown, mirroring the real wiring where performShutdown assigns killedPtyPids as a side effect', () => {
+    let pids: number[] = [];
+    const dependencies = {
+      performShutdown: vi.fn(() => {
+        pids = [4242];
+      }),
+      getKilledPtyPids: vi.fn(() => pids),
+      drainPtyExitCallbacks: vi.fn(() => new Promise<PtyExitDrainResult>(() => undefined)),
+      hideAllWindows: vi.fn(),
+      requestQuit: vi.fn(),
+    };
+    const handler = createBeforeQuitHandler(dependencies);
+    const event = { preventDefault: vi.fn() };
+
+    handler(event);
+
+    expect(dependencies.drainPtyExitCallbacks).toHaveBeenCalledWith([4242]);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('the before-quit drain is wired into src/main/index.ts', () => {
+  it('registers the handler for before-quit and re-quits through app.quit, never process.exit', () => {
+    const start = INDEX_SOURCE.indexOf("app.on('before-quit', createBeforeQuitHandler(");
+    expect(
+      start,
+      "src/main/index.ts must register app.on('before-quit') through createBeforeQuitHandler; a bare performShutdown() handler reintroduces the DESKTOP-C crash-on-quit race",
+    ).toBeGreaterThan(-1);
+
+    // The registration ends at its own `}));`; slicing to a fixed length would
+    // run into the SIGINT/SIGTERM block that follows, which legitimately
+    // calls process.exit (no loop turn is needed there).
+    const end = INDEX_SOURCE.indexOf('}));', start);
+    expect(end, 'the createBeforeQuitHandler registration must close with `}));`').toBeGreaterThan(start);
+    const handlerRegion = INDEX_SOURCE.slice(start, end);
+    expect(
+      handlerRegion,
+      'the drain must re-enter the quit with app.quit() so Electron runs its own teardown (process.exit skips it and is the zombie-child failure mode the synchronous-shutdown rule exists for)',
+    ).toContain('requestQuit: () => app.quit()');
+    expect(handlerRegion).not.toContain('process.exit');
+  });
+
+  it('feeds the pids the synchronous cleanup actually killed into the drain', () => {
+    expect(
+      INDEX_SOURCE,
+      'performShutdown must capture syncShutdownCleanup() return value; dropping it leaves the drain with nothing to wait on and the quit unprotected',
+    ).toContain('killedPtyPids = syncShutdownCleanup(');
+    expect(INDEX_SOURCE).toContain('getKilledPtyPids: () => (osInitiatedShutdown ? [] : killedPtyPids)');
+  });
+
+  it('never holds an OS-initiated shutdown', () => {
+    // Windows session-end and the powerMonitor shutdown event both route
+    // through performShutdown; each must disarm the drain first so a logout
+    // is never answered with a prevented quit.
+    const flagSets = INDEX_SOURCE.match(/osInitiatedShutdown = true;/g) ?? [];
+    expect(
+      flagSets.length,
+      'both OS-initiated shutdown paths (Windows session-end, powerMonitor shutdown) must set osInitiatedShutdown = true before performShutdown(), or a logout is answered with a held quit; a third OS path needs the same disarm and this count bumped',
+    ).toBe(2);
+  });
+
+  it('keeps the signal path synchronous (SIGINT/SIGTERM exit without running the loop)', () => {
+    const signalBlock = INDEX_SOURCE.slice(INDEX_SOURCE.indexOf("for (const signal of ['SIGINT', 'SIGTERM'] as const)"), INDEX_SOURCE.length);
+    expect(signalBlock).toContain('if (performShutdown()) process.exit(0);');
+  });
+});

--- a/tests/unit/process-liveness.test.ts
+++ b/tests/unit/process-liveness.test.ts
@@ -1,0 +1,45 @@
+/**
+ * isProcessAlive (src/main/shared/process-liveness.ts): the pid probe shared
+ * by the shutdown exit-callback drain and the background-shell process-tree
+ * probes. Tier: Unit.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { isProcessAlive } from '../../src/main/shared/process-liveness';
+
+function makeErrnoError(code: string): NodeJS.ErrnoException {
+  const error = new Error(code) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
+
+describe('isProcessAlive', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reports the current process as alive', () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  it('rejects pids that cannot name a child process', () => {
+    expect(isProcessAlive(0)).toBe(false);
+    expect(isProcessAlive(-1)).toBe(false);
+    expect(isProcessAlive(Number.NaN)).toBe(false);
+    expect(isProcessAlive(12.5)).toBe(false);
+  });
+
+  it('treats EPERM as alive (the process exists but cannot be signalled)', () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw makeErrnoError('EPERM');
+    });
+    expect(isProcessAlive(4242)).toBe(true);
+  });
+
+  it('treats ESRCH as dead (terminated on Windows, reaped on POSIX)', () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw makeErrnoError('ESRCH');
+    });
+    expect(isProcessAlive(4242)).toBe(false);
+  });
+});

--- a/tests/unit/pty-exit-callback-drain.test.ts
+++ b/tests/unit/pty-exit-callback-drain.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for the bounded PTY exit-callback drain
+ * (src/main/pty/shutdown/exit-callback-drain.ts).
+ *
+ * The drain is what stands between the synchronous shutdown cleanup and
+ * Electron tearing Node down. Sentry DESKTOP-C: node-pty's exit callback is a
+ * native ThreadSafeFunction; dispatched after node::Stop(), node-addon-api
+ * throws a C++ exception from inside its own catch block and the process
+ * dies. The drain keeps the loop alive, timer-only, until each killed child is
+ * gone plus a few loop turns, so the callback lands while JS is callable.
+ *
+ * Everything here runs on fake timers with an injected pid probe. Tier: Unit.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  drainPtyExitCallbacks,
+  PTY_EXIT_DRAIN_DEADLINE_MS,
+  PTY_EXIT_DRAIN_POLL_MS,
+  PTY_EXIT_DRAIN_SETTLE_TICKS,
+} from '../../src/main/pty/shutdown/exit-callback-drain';
+import type { PtyExitDrainResult } from '../../src/main/pty/shutdown/exit-callback-drain';
+
+/** Start a drain and expose whether / how it settled without awaiting it. */
+function startDrain(options: Parameters<typeof drainPtyExitCallbacks>[0]) {
+  const state: { result: PtyExitDrainResult | null } = { result: null };
+  void drainPtyExitCallbacks(options).then((result) => {
+    state.result = result;
+  });
+  return state;
+}
+
+describe('drainPtyExitCallbacks', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves at once, without polling or logging, when there is nothing to drain', async () => {
+    const isProcessAlive = vi.fn(() => true);
+    const log = vi.fn();
+
+    const result = await drainPtyExitCallbacks({ pids: [], isProcessAlive, log });
+
+    expect(result).toEqual({ timedOut: false, elapsedMs: 0, lingeringPids: [] });
+    expect(isProcessAlive).not.toHaveBeenCalled();
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('treats non-positive and non-integer pids as nothing to drain', async () => {
+    const isProcessAlive = vi.fn(() => true);
+
+    const result = await drainPtyExitCallbacks({ pids: [0, -7, Number.NaN, 12.5], isProcessAlive });
+
+    expect(result.timedOut).toBe(false);
+    expect(isProcessAlive).not.toHaveBeenCalled();
+  });
+
+  it('resolves only after the settle ticks that follow the last pid disappearing', async () => {
+    const log = vi.fn();
+    const state = startDrain({
+      pids: [11, 22],
+      isProcessAlive: () => false,
+      pollIntervalMs: 10,
+      settleTicks: 2,
+      deadlineMs: 1000,
+      log,
+    });
+
+    // Tick 1 (10ms) sees both pids gone and arms the settle; ticks 2 and 3
+    // are the settle. Resolving at tick 1 would quit before libuv has run
+    // the loop turn that dispatches the queued exit callback.
+    await vi.advanceTimersByTimeAsync(20);
+    expect(state.result).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(state.result).toEqual({ timedOut: false, elapsedMs: 30, lingeringPids: [] });
+    expect(log.mock.calls.map((call) => call[0])).toEqual([
+      '[SHUTDOWN] pty-drain:start n=2',
+      '[SHUTDOWN] pty-drain:done 30ms',
+    ]);
+  });
+
+  it('keeps polling a lingering pid and stops re-polling the ones already gone', async () => {
+    let pollsOfLingering = 0;
+    const isProcessAlive = vi.fn((pid: number) => {
+      if (pid !== 22) return false;
+      pollsOfLingering += 1;
+      // Alive for the first three polls, gone from the fourth.
+      return pollsOfLingering <= 3;
+    });
+    const state = startDrain({
+      pids: [11, 22],
+      isProcessAlive,
+      pollIntervalMs: 10,
+      settleTicks: 2,
+      deadlineMs: 1000,
+    });
+
+    // Polls at 10/20/30 see pid 22 alive, 40 sees it gone, 50 and 60 settle.
+    await vi.advanceTimersByTimeAsync(50);
+    expect(state.result).toBeNull();
+    await vi.advanceTimersByTimeAsync(10);
+    expect(state.result).toEqual({ timedOut: false, elapsedMs: 60, lingeringPids: [] });
+
+    // Pid 11 was gone on the first poll and never probed again.
+    const probesOfDeadPid = isProcessAlive.mock.calls.filter((call) => call[0] === 11);
+    expect(probesOfDeadPid).toHaveLength(1);
+  });
+
+  it('gives up at the deadline, reports the lingering pids, and stops polling', async () => {
+    const isProcessAlive = vi.fn(() => true);
+    const log = vi.fn();
+    const state = startDrain({
+      pids: [11],
+      isProcessAlive,
+      pollIntervalMs: 10,
+      settleTicks: 2,
+      deadlineMs: 100,
+      log,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(state.result).toEqual({ timedOut: true, elapsedMs: 100, lingeringPids: [11] });
+    expect(log).toHaveBeenLastCalledWith('[SHUTDOWN] pty-drain:timeout 100ms lingering=11');
+
+    // The poll timer was cleared with the deadline: no probes after it.
+    const probesAtDeadline = isProcessAlive.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(200);
+    expect(isProcessAlive.mock.calls.length).toBe(probesAtDeadline);
+  });
+
+  it('treats a probe that throws as a dead process, so a broken probe can never hold the quit', async () => {
+    const state = startDrain({
+      pids: [11],
+      isProcessAlive: () => {
+        throw new Error('probe exploded');
+      },
+      pollIntervalMs: 10,
+      settleTicks: 1,
+      deadlineMs: 1000,
+    });
+
+    await vi.advanceTimersByTimeAsync(20);
+    expect(state.result).toEqual({ timedOut: false, elapsedMs: 20, lingeringPids: [] });
+  });
+
+  it('ships defaults that finish a clean drain well inside the 6s hard-shutdown failsafe', () => {
+    // A clean drain costs settle ticks x poll interval after the last pid is
+    // gone; the deadline bounds a child that ignores the kill. Both must leave
+    // Electron's own teardown room under startHardShutdownFailsafe's 6000ms.
+    expect(PTY_EXIT_DRAIN_POLL_MS * PTY_EXIT_DRAIN_SETTLE_TICKS).toBeLessThanOrEqual(200);
+    expect(PTY_EXIT_DRAIN_DEADLINE_MS).toBeLessThanOrEqual(2000);
+  });
+});

--- a/tests/unit/session-auto-resume-on-restart.test.ts
+++ b/tests/unit/session-auto-resume-on-restart.test.ts
@@ -62,7 +62,7 @@ function makeDeps(options: { sessionStatus?: 'running' | 'queued' } = {}) {
     listSessions: vi.fn(() => [
       { taskId: 'task-A', projectId: 'proj-1', status: sessionStatus },
     ]),
-    killAll: vi.fn(),
+    killAll: vi.fn(() => [] as number[]),
     dispose: vi.fn(),
   };
   return {

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -697,6 +697,23 @@ describe('KillAll', () => {
     expect(manager.listSessions()).toHaveLength(0);
   });
 
+  it('returns the killed PTYs child pids, wired through killAllSessions for the before-quit exit-callback drain', async () => {
+    // Nothing else exercises this through the real SessionManager: session-shutdown-flow.test.ts
+    // pins killAllSessions's own pid-collection logic against a synthetic
+    // ShutdownContext, and shutdown-history-wiring.test.ts pins that
+    // syncShutdownCleanup passes a mocked killAll's return value through -
+    // neither calls the real SessionManager.killAll(), so a regression that
+    // drops the `return` in session-manager.ts (leaving killAll() run
+    // killAllSessions but resolve to undefined) would not be caught anywhere
+    // else.
+    const { mockPty: pty1 } = await spawnSession('task-ka-pid1');
+    const { mockPty: pty2 } = await spawnSession('task-ka-pid2');
+
+    const killedPids = manager.killAll();
+
+    expect(killedPids).toEqual([pty1.pid, pty2.pid]);
+  });
+
   it('kills all PTY processes', async () => {
     const { mockPty: pty1 } = await spawnSession('task-ka-k1');
     const { mockPty: pty2 } = await spawnSession('task-ka-k2');

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -253,6 +253,40 @@ describe('Scrollback clearing on resize', () => {
     expect(scrollback).toContain('hello world');
   });
 
+  it('reports a resize the just-died PTY rejected instead of throwing it at the renderer', async () => {
+    const { session, mockPty } = await spawnSession();
+    // node-pty's WindowsPtyAgent.resize throws this once the child has exited
+    // but before the 'exit' event (which nulls session.pty) lands, up to ~1s
+    // later on Windows. Every guard before the native call still passes in
+    // that window, so the throw used to escape as an unhandled IPC rejection.
+    mockPty.resize.mockImplementationOnce(() => {
+      throw new Error('Cannot resize a pty that has already exited');
+    });
+    vi.mocked(traceTerminal).mockClear();
+    // The catch block must return early: a regression that lets control fall
+    // through to the success path (deleting the `return { colsChanged };`
+    // inside the catch in session-manager.ts) would still trace
+    // 'resize-applied' and emit 'pty-resize' for a resize whose native call
+    // never actually took effect. Observing both proves the early return, not
+    // just the trace call.
+    const resizes: Array<[string, number, number]> = [];
+    manager.on('pty-resize', (sessionId: string, cols: number, rows: number) => resizes.push([sessionId, cols, rows]));
+
+    const result = manager.resize(session.id, 200, 40);
+
+    expect(result).toEqual({ colsChanged: true });
+    const failed = vi.mocked(traceTerminal).mock.calls.find((call) => call[1] === 'resize-failed');
+    expect(failed?.[0]).toBe(session.id);
+    expect(failed?.[2]).toMatchObject({
+      cols: 200,
+      rows: 40,
+      message: expect.stringContaining('already exited'),
+    });
+    expect(resizes).toEqual([]);
+    const applied = vi.mocked(traceTerminal).mock.calls.find((call) => call[1] === 'resize-applied');
+    expect(applied).toBeUndefined();
+  });
+
   it('a rows-only resize arms the repaint settle (arming widens; the report stays colsChanged)', async () => {
     const { session, feedData } = await spawnSession();
 

--- a/tests/unit/session-shutdown-flow.test.ts
+++ b/tests/unit/session-shutdown-flow.test.ts
@@ -115,4 +115,53 @@ describe('killAllSessions', () => {
     expect(sessionQueueClear).toHaveBeenCalledTimes(1);
     expect(firstOutputClear).toHaveBeenCalledTimes(1);
   });
+
+  // The returned pids feed the before-quit exit-callback drain (Sentry
+  // DESKTOP-C): the quit is held until these children are gone so node-pty's
+  // exit callback is dispatched while JS is still callable.
+  describe('returned child pids', () => {
+    function makePty(pid: number | undefined): pty.IPty {
+      return { write: vi.fn(), kill: vi.fn(), pid } as unknown as pty.IPty;
+    }
+
+    it('returns the child pid of every PTY it killed, read before the reference is nulled', () => {
+      const first = makeSession({ id: 'sess-1', pty: makePty(4242) });
+      const second = makeSession({ id: 'sess-2', pty: makePty(4343) });
+      const { context, killPty } = makeContext([first, second]);
+      // The kill lands on a session whose pty is already nulled (the
+      // double-kill guard), so the pid must have been captured beforehand.
+      killPty.mockImplementation(() => {
+        expect(first.pty).toBeNull();
+        return true;
+      });
+
+      expect(killAllSessions(context)).toEqual([4242, 4343]);
+    });
+
+    it('returns nothing for a session with no PTY', () => {
+      const session = makeSession({ pty: null });
+      const { context, killPty } = makeContext([session]);
+
+      expect(killAllSessions(context)).toEqual([]);
+      expect(killPty).not.toHaveBeenCalled();
+    });
+
+    it('still returns the pid when killPty reports the child was already dead', () => {
+      // An exit callback can be queued but not yet dispatched; the drain's
+      // settle ticks cover it, so the pid must not be dropped here.
+      const session = makeSession({ pty: makePty(4242) });
+      const { context, killPty } = makeContext([session]);
+      killPty.mockReturnValue(false);
+
+      expect(killAllSessions(context)).toEqual([4242]);
+    });
+
+    it('skips a PTY whose pid is missing or not a positive integer', () => {
+      const missing = makeSession({ id: 'sess-1', pty: makePty(undefined) });
+      const zero = makeSession({ id: 'sess-2', pty: makePty(0) });
+      const { context } = makeContext([missing, zero]);
+
+      expect(killAllSessions(context)).toEqual([]);
+    });
+  });
 });

--- a/tests/unit/session-spawn-flow.test.ts
+++ b/tests/unit/session-spawn-flow.test.ts
@@ -901,6 +901,45 @@ describe('performSpawn - Windows cwd fixup write order', () => {
     expect(writeMock).toHaveBeenCalledTimes(2);
     expect(writeMock.mock.calls[1][0]).toBe('CLEARPRE; claude --resume abc\r');
   });
+
+  it('skips the deferred writes once the session no longer owns the PTY', async () => {
+    // The timers hold the raw ptyProcess, not session.pty. Every kill /
+    // respawn / exit path nulls session.pty in its own tick, before the 100ms
+    // write fires; the write must notice rather than type into a dead ConPTY
+    // handle (node-pty throws) or into a successor session's shell.
+    vi.mocked(resolveSpawnCwd).mockReturnValueOnce({
+      effectiveCwd: 'C:\\Users\\dev\\[foo]\\bar',
+      cwdFixupCommand: "Set-Location -LiteralPath 'C:\\Users\\dev\\[foo]\\bar'",
+    });
+
+    const context = makeContext();
+    const input = makeInput({ command: 'claude --resume abc' });
+
+    await performSpawn(input, context);
+
+    const writeMock = ptySpawnMock.mock.results[0]?.value.write as ReturnType<typeof vi.fn>;
+    const session = context.registry.get(input.id!);
+    expect(session?.pty).not.toBeNull();
+    session!.pty = null;
+
+    vi.advanceTimersByTime(300);
+    expect(writeMock).not.toHaveBeenCalled();
+  });
+
+  it('tolerates node-pty throwing on a write to a PTY that died between the timer arming and firing', async () => {
+    const context = makeContext();
+    const input = makeInput({ command: 'echo hi' });
+
+    await performSpawn(input, context);
+
+    const writeMock = ptySpawnMock.mock.results[0]?.value.write as ReturnType<typeof vi.fn>;
+    writeMock.mockImplementationOnce(() => {
+      throw new Error('EPIPE');
+    });
+
+    expect(() => vi.advanceTimersByTime(100)).not.toThrow();
+    expect(writeMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('performSpawn - activity engine initialTurnActive seed (thinking vs idle)', () => {

--- a/tests/unit/shutdown-history-wiring.test.ts
+++ b/tests/unit/shutdown-history-wiring.test.ts
@@ -111,13 +111,13 @@ function buildRunningSession(overrides: Partial<Session> = {}): Session {
   } as Session;
 }
 
-function buildMockDependencies(sessions: Session[]) {
+function buildMockDependencies(sessions: Session[], killedPtyPids: number[] = []) {
   // Stable diffWatcher stub so a test can assert closeAll() ran during cleanup.
   const diffWatcher = { closeAll: vi.fn() };
   return {
     getSessionManager: vi.fn(() => ({
       listSessions: vi.fn(() => sessions),
-      killAll: vi.fn(),
+      killAll: vi.fn(() => killedPtyPids),
       dispose: vi.fn(),
       cancelAll: vi.fn(),
       getUsageCache: vi.fn(() => ({})),
@@ -193,6 +193,20 @@ describe('syncShutdownCleanup history wire-up', () => {
     const dependencies = buildMockDependencies([]);
     syncShutdownCleanup(dependencies);
     expect(dependencies.stopAnnouncementTimers).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the child pids killAll reported, so the before-quit drain has something to wait on', () => {
+    // Sentry DESKTOP-C: the drain that follows this cleanup holds the quit
+    // until these children are gone. Swallowing killAll's return value here
+    // would silently disarm it and leave every quit racing node-pty's exit
+    // callback against Node teardown again.
+    const dependencies = buildMockDependencies([], [4242, 4343]);
+    expect(syncShutdownCleanup(dependencies)).toEqual([4242, 4343]);
+  });
+
+  it('returns an empty pid list when there was nothing to kill', () => {
+    const dependencies = buildMockDependencies([]);
+    expect(syncShutdownCleanup(dependencies)).toEqual([]);
   });
 
   it('does NOT call captureSessionMetrics for queued sessions (never spawned - nothing to capture)', () => {

--- a/tests/unit/upload-native-debug-files.test.ts
+++ b/tests/unit/upload-native-debug-files.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit coverage for `uploadNativeDebugFiles` in scripts/build.js - the
+ * release-only, Windows-only, token-gated upload of node-pty's shipped
+ * Windows PDBs to Sentry as debug files (see the function's own doc comment
+ * in build.js: DESKTOP-C had to be symbolicated offline with dbghelp because
+ * this path had never run in a release).
+ *
+ * `uploadSourcemaps` is computed once at module load from
+ * `KANGENTIC_SENTRY_TOKEN ?? SENTRY_AUTH_TOKEN`, so each scenario that needs
+ * a different token/platform combination resets the module registry
+ * (`vi.resetModules()`) and re-imports the script after stubbing env and
+ * `process.platform` - mirroring how
+ * tests/unit/assert-vendor-chunks-lazy.test.ts imports this same CJS script
+ * via vite-node's require/import interop.
+ *
+ * `@sentry/cli` interception: `vi.mock('@sentry/cli', ...)` does NOT
+ * intercept build.js's `require('@sentry/cli')` call - build.js is loaded
+ * via vite-node's require/import interop as a plain CJS module, and its
+ * function-scoped `require` resolves through Node's own module cache, not
+ * vitest's mock registry (empirically confirmed: a probing `vi.mock` that
+ * threw on load was never reached, and the real @sentry/cli constructor ran,
+ * attempting an actual network call to Sentry's API - it failed only because
+ * no valid token was supplied, not because anything here stopped it). The
+ * working technique instead pre-seeds Node's OWN `require.cache` at
+ * `@sentry/cli`'s resolved absolute path with a fake module before importing
+ * build.js, so build.js's `require('@sentry/cli')` finds the cache hit and
+ * returns the fake export without ever touching the real package. EVERY
+ * scenario below installs the fake, including the three that expect the
+ * require to never be reached at all: this worktree's real
+ * node_modules/node-pty/prebuilds/win32-x64 and win32-arm64 exist (as empty
+ * directories), so relying on the real filesystem state to keep those
+ * scenarios away from `require('@sentry/cli')` is not safe - only asserting
+ * `constructorCalls` stays empty, behind a fake that can never reach the
+ * network, is. Every test that installs the fake restores the original
+ * cache entry (or deletes the key) in a `finally`, so no test leaks state
+ * into a sibling.
+ *
+ * Tier: Unit.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const SENTRY_CLI_RESOLVED_PATH = require.resolve('@sentry/cli');
+
+const ORIGINAL_PLATFORM = process.platform;
+
+function setPlatform(platform: string): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+interface FakeSentryCliConstructorCall {
+  configFile: unknown;
+  options: unknown;
+}
+
+interface FakeSentryCliExecuteCall {
+  args: string[];
+  mode: string;
+}
+
+/**
+ * Installs a fake `@sentry/cli` export at its real resolved path in Node's
+ * require cache, so build.js's `require('@sentry/cli')` returns it instead
+ * of the real package - the real package's `execute()` spawns an actual
+ * sentry-cli process / network call, which no test here may ever trigger.
+ * `restore()` must be called (a `finally` in every caller) to avoid leaking
+ * the fake into a sibling test. Defaults `executeImplementation` to a
+ * resolved no-op so scenarios that only care about the constructor (or that
+ * expect the require to never happen at all) do not have to supply one.
+ */
+function installFakeSentryCli(
+  executeImplementation: (args: string[], mode: string) => Promise<void> = async () => undefined,
+): {
+  constructorCalls: FakeSentryCliConstructorCall[];
+  executeCalls: FakeSentryCliExecuteCall[];
+  restore: () => void;
+} {
+  const constructorCalls: FakeSentryCliConstructorCall[] = [];
+  const executeCalls: FakeSentryCliExecuteCall[] = [];
+
+  class FakeSentryCli {
+    constructor(configFile: unknown, options: unknown) {
+      constructorCalls.push({ configFile, options });
+    }
+    execute(args: string[], mode: string): Promise<void> {
+      executeCalls.push({ args, mode });
+      return executeImplementation(args, mode);
+    }
+  }
+
+  const originalCacheEntry = require.cache[SENTRY_CLI_RESOLVED_PATH];
+  require.cache[SENTRY_CLI_RESOLVED_PATH] = {
+    id: SENTRY_CLI_RESOLVED_PATH,
+    filename: SENTRY_CLI_RESOLVED_PATH,
+    loaded: true,
+    exports: FakeSentryCli,
+  } as unknown as NodeJS.Module;
+
+  return {
+    constructorCalls,
+    executeCalls,
+    restore: () => {
+      if (originalCacheEntry) {
+        require.cache[SENTRY_CLI_RESOLVED_PATH] = originalCacheEntry;
+      } else {
+        delete require.cache[SENTRY_CLI_RESOLVED_PATH];
+      }
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.unstubAllEnvs();
+  // Clear both token env vars so each test starts from the ungated state;
+  // scenarios that need a token stub it explicitly.
+  vi.stubEnv('KANGENTIC_SENTRY_TOKEN', '');
+  vi.stubEnv('SENTRY_AUTH_TOKEN', '');
+  vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  setPlatform(ORIGINAL_PLATFORM);
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe('uploadNativeDebugFiles', () => {
+  it('(1) no-ops without touching fs.existsSync or requiring @sentry/cli when no token is set, even on win32', async () => {
+    setPlatform('win32');
+    // Mocked (not pass-through): this worktree's real
+    // node_modules/node-pty/prebuilds/win32-x64 happens to exist (an empty
+    // dir), so a pass-through spy would make this test's "not called" proof
+    // depend on incidental local disk state instead of on the token gate
+    // actually short-circuiting before this call.
+    const existsSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const fakeSentryCli = installFakeSentryCli();
+
+    try {
+      const buildModule = await import('../../scripts/build.js');
+
+      await expect(buildModule.uploadNativeDebugFiles()).resolves.toBeUndefined();
+
+      expect(existsSyncSpy).not.toHaveBeenCalled();
+      expect(fakeSentryCli.constructorCalls).toEqual([]);
+      expect(console.warn).not.toHaveBeenCalled();
+      expect(console.log).not.toHaveBeenCalled();
+    } finally {
+      fakeSentryCli.restore();
+    }
+  });
+
+  it('(2) no-ops on a non-win32 platform even with a token set', async () => {
+    setPlatform('linux');
+    vi.stubEnv('KANGENTIC_SENTRY_TOKEN', 'fake-token');
+    // See the same note in scenario (1): mocked, not pass-through.
+    const existsSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const fakeSentryCli = installFakeSentryCli();
+
+    try {
+      const buildModule = await import('../../scripts/build.js');
+
+      await expect(buildModule.uploadNativeDebugFiles()).resolves.toBeUndefined();
+
+      expect(existsSyncSpy).not.toHaveBeenCalled();
+      expect(fakeSentryCli.constructorCalls).toEqual([]);
+      expect(console.warn).not.toHaveBeenCalled();
+    } finally {
+      fakeSentryCli.restore();
+    }
+  });
+
+  it('(3) warns and no-ops when token + win32 but no node-pty Windows prebuilds exist', async () => {
+    setPlatform('win32');
+    vi.stubEnv('KANGENTIC_SENTRY_TOKEN', 'fake-token');
+    const existsSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const fakeSentryCli = installFakeSentryCli();
+
+    try {
+      const buildModule = await import('../../scripts/build.js');
+
+      await expect(buildModule.uploadNativeDebugFiles()).resolves.toBeUndefined();
+
+      // Proves the mock actually intercepted the call the function makes
+      // (rather than this passing by coincidence because the real
+      // node_modules/node-pty/prebuilds dir happens to be absent locally).
+      expect(existsSyncSpy).toHaveBeenCalled();
+      expect(existsSyncSpy.mock.calls.some((call) => String(call[0]).includes('win32-x64'))).toBe(true);
+      expect(fakeSentryCli.constructorCalls).toEqual([]);
+      expect(console.warn).toHaveBeenCalledWith(
+        '[build] No node-pty Windows prebuilds found; skipping the debug-file upload',
+      );
+    } finally {
+      fakeSentryCli.restore();
+    }
+  });
+
+  it('(4) uploads with the org/project/prebuild-dir args and logs success once execute resolves', async () => {
+    setPlatform('win32');
+    vi.stubEnv('KANGENTIC_SENTRY_TOKEN', 'fake-token');
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const fakeSentryCli = installFakeSentryCli(async () => undefined);
+
+    try {
+      const buildModule = await import('../../scripts/build.js');
+
+      await expect(buildModule.uploadNativeDebugFiles()).resolves.toBeUndefined();
+
+      expect(fakeSentryCli.constructorCalls).toEqual([
+        { configFile: null, options: { authToken: 'fake-token', silent: false } },
+      ]);
+      expect(fakeSentryCli.executeCalls).toEqual([
+        {
+          args: [
+            'debug-files',
+            'upload',
+            '--org',
+            'kangentic',
+            '--project',
+            'desktop',
+            expect.stringContaining(path.join('node-pty', 'prebuilds', 'win32-x64')),
+            expect.stringContaining(path.join('node-pty', 'prebuilds', 'win32-arm64')),
+          ],
+          mode: 'rejectOnError',
+        },
+      ]);
+      expect(console.log).toHaveBeenCalledWith(
+        '[build] Uploaded node-pty debug files to Sentry from 2 prebuild dir(s)',
+      );
+      expect(console.warn).not.toHaveBeenCalled();
+    } finally {
+      fakeSentryCli.restore();
+    }
+  });
+
+  it('(5) warns and lets the build finish (does not throw) when execute rejects', async () => {
+    setPlatform('win32');
+    vi.stubEnv('KANGENTIC_SENTRY_TOKEN', 'fake-token');
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const uploadError = new Error('sentry-cli exited with code 1');
+    const fakeSentryCli = installFakeSentryCli(async () => {
+      throw uploadError;
+    });
+
+    try {
+      const buildModule = await import('../../scripts/build.js');
+
+      await expect(buildModule.uploadNativeDebugFiles()).resolves.toBeUndefined();
+
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('node-pty debug-file upload failed; native frames from this release will not symbolicate on Sentry'),
+        uploadError,
+      );
+      // A failed upload must not block the build: no success log, no throw.
+      expect(console.log).not.toHaveBeenCalled();
+    } finally {
+      fakeSentryCli.restore();
+    }
+  });
+});


### PR DESCRIPTION
## What

Fixes Sentry DESKTOP-C, a fatal native crash (`Unhandled C++ Exception` inside `conpty.node`) on the Electron main thread, by draining node-pty's PTY exit callbacks before Electron is allowed to tear Node down at quit.

- New `src/main/pty/shutdown/exit-callback-drain.ts` (the bounded drain) and `before-quit-handler.ts` (the before-quit state machine), wired in `src/main/index.ts`.
- `killAllSessions` / `SessionManager.killAll` / `syncShutdownCleanup` now return the killed children's pids.
- `SessionManager.resize` catches node-pty's just-died throw (`resize-failed` trace) instead of rejecting the renderer's invoke; the deferred spawn-command writes in `session-spawn-flow.ts` re-check PTY ownership and tolerate a dead PTY.
- `scripts/build.js` uploads node-pty's shipped Windows PDBs to Sentry as debug files under the existing token gate (Windows leg only, non-fatal). `release.yml` now passes `KANGENTIC_SENTRY_TOKEN`; it passed no Sentry token before, so the sourcemap upload was a CI no-op too.
- `.claude/rules/synchronous-shutdown.md` documents the one sanctioned `preventDefault`; the sentry skill gains an offline native-minidump symbolication recipe; docs updated.

## Why

The task's suspects (a resize or write after a task-detail close) were wrong. Symbolicating the minidump against the `conpty.pdb` that node-pty ships (same debug id as the crashed binary) resolves the frames to node-addon-api's `ThreadSafeFunction::CallJS` catch block calling `ThrowAsJavaScriptException`, which threw a second time from inside the catch. The only ThreadSafeFunction in node-pty is the PTY exit callback. It was dispatched after `node::Stop()`, during `FreeEnvironment`'s final `uv_run`, so both the JS call and the re-throw were refused. The synchronous before-quit cleanup kills every PTY, so every quit with a live session races that dispatch against the message loop quitting. VS Code has the identical open crash on macOS (`pty.node`, microsoft/vscode#243952). No JS frame is below the dispatch, so no try/catch can reach it, and we ship node-pty's prebuild, which lacks `NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS`.

The missing quit breadcrumbs were the SDK's 500ms scope-write throttle, not a missing quit.

## How

The cleanup stays synchronous and unchanged in what it does. Afterwards, only when at least one PTY was killed, the handler calls `event.preventDefault()`, hides the windows, and polls the killed pids every 25ms until every one is gone, then allows 100ms of further loop turns so libuv dispatches the queued exit callbacks while JS is still callable, then calls `app.quit()` again. Deadline 1500ms. The second before-quit pass is a no-op. OS-initiated shutdowns (Windows `session-end`, powerMonitor `shutdown`) never hold the quit; SIGINT/SIGTERM keep their `process.exit` path (no loop turn, no dispatch). The 6s hard failsafe is armed before the drain starts.

Trade-offs a reviewer should weigh: this is a deliberate, documented exception to the synchronous-shutdown rule (the old zombie failure was an unbounded async chain plus `process.exit`; this is timer-only and re-enters through `app.quit()`), and the settle is a heuristic (100ms of loop turns after the last pid dies). Rebuilding `conpty.node` with the swallow define was considered and left out: winpty target, Spectre libs, and the release whitelist make a postinstall rebuild brittle; the binary fix belongs upstream.

## Breaking changes

None. Quit latency grows by roughly 100 to 300ms when sessions are live (up to 1.5s if a child ignores the kill); a quit with no sessions is byte-for-byte unchanged.

## Tests

New: `tests/unit/pty-exit-callback-drain.test.ts`, `before-quit-drain-wiring.test.ts` (state machine plus a static scan of index.ts), `process-liveness.test.ts`, `upload-native-debug-files.test.ts`. Extended: `session-shutdown-flow`, `shutdown-history-wiring`, `session-auto-resume-on-restart`, `session-manager` (resize on a just-died PTY), `session-spawn-flow` (deferred writes skipped once ownership is lost).

Verified on a Windows dev build with error reporting forced on: three real quits through the title-bar Close. With three Command Terminal PTYs, `pty-drain:start n=3` then `pty-drain:done 220ms` (203ms when killed mid-boot); with zero sessions, no drain lines. Every run exited 0 with no timeout, no failsafe, no surviving process, and zero new crash events in the Application log. Typecheck, lint, and the scoped unit runs are green locally; CI runs the full tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018T6pSyUnMBLAHYYgTJW4Wo
