### PR TITLE
fix(codex): flatten prompts for PowerShell CMD shims

### DIFF
--- a/src/main/agent/adapters/codex/command-builder.ts
+++ b/src/main/agent/adapters/codex/command-builder.ts
@@ -1,4 +1,4 @@
-import { toForwardSlash, quoteArg, isUnixLikeShell } from '../../../../shared/paths';
+import { toForwardSlash, quoteArg, isUnixLikeShell, sanitizeForPty } from '../../../../shared/paths';
 import { interpolateTemplate } from '../../shared/template-utils';
 import { buildHooks } from './hook-manager';
 import type { PermissionMode } from '../../../../shared/types';
@@ -141,6 +141,19 @@ function buildMcpConfigArgs(options: CodexCommandOptions): string[] {
   ];
 }
 
+/**
+ * PowerShell expands `n before it hands an argument to an npm .CMD shim. The
+ * shim then invokes cmd.exe, which treats the resulting physical newlines as
+ * command boundaries instead of forwarding the full positional prompt.
+ */
+function usesPowerShellCmdShim(codexPath: string, shell?: string): boolean {
+  const lowerShell = shell?.toLowerCase() ?? '';
+  return (
+    (lowerShell.includes('powershell') || lowerShell.includes('pwsh'))
+    && /\.cmd$/i.test(codexPath.trim())
+  );
+}
+
 export class CodexCommandBuilder {
   buildCodexCommand(options: CodexCommandOptions): string {
     const { shell } = options;
@@ -200,13 +213,17 @@ export class CodexCommandBuilder {
     // resumed conversation already contains it, and re-sending would re-ask
     // the task prompt on every resume.
     if (!isResume && options.prompt) {
+      const preservePromptNewlines = !usesPowerShellCmdShim(options.codexPath, shell);
+      const prompt = preservePromptNewlines
+        ? options.prompt
+        : sanitizeForPty(options.prompt);
       const needsDoubleQuoteReplacement = shell
         ? !isUnixLikeShell(shell)
         : process.platform === 'win32';
       const safePrompt = needsDoubleQuoteReplacement
-        ? options.prompt.replace(/"/g, "'")
-        : options.prompt;
-      parts.push(quoteArg(safePrompt, shell, { multiline: true }));
+        ? prompt.replace(/"/g, "'")
+        : prompt;
+      parts.push(quoteArg(safePrompt, shell, { multiline: preservePromptNewlines }));
     }
 
     return parts.join(' ');

--- a/tests/unit/adapter-multiline-prompt.test.ts
+++ b/tests/unit/adapter-multiline-prompt.test.ts
@@ -93,6 +93,22 @@ describe('Adapter multiline prompt - regression guard for { multiline: true }', 
     expect(command).toContain(EXPECTED_FRAGMENT);
   });
 
+  it('CodexCommandBuilder flattens multiline prompts for PowerShell CMD shims', () => {
+    const builder = new CodexCommandBuilder();
+    const command = builder.buildCodexCommand({
+      codexPath: 'C:/Users/dev/AppData/Roaming/npm/codex.CMD',
+      taskId: 'task-1',
+      cwd: 'C:/project',
+      permissionMode: 'default',
+      shell: 'powershell',
+      prompt: MULTILINE_XML,
+    });
+
+    expect(command).not.toContain('\n');
+    expect(command).not.toContain('`n');
+    expect(command).toContain('"<task> <title>Fix login</title> <description> Step 1. Step 2. </description> </task>"');
+  });
+
   it('AiderAdapter.buildCommand preserves newlines in prompt under bash', () => {
     const adapter = new AiderAdapter();
     const command = adapter.buildCommand({


### PR DESCRIPTION
## What

Flatten multiline Codex task prompts when PowerShell invokes the npm `codex.CMD` shim.

## Why

Fixes #353. PowerShell expands newline escapes before the CMD shim forwards arguments, so Codex receives only `<task>`.

## How

Detect the PowerShell plus `.CMD` path and sanitize the positional prompt before quoting it. Unix-like shells and non-CMD launchers keep multiline XML.

## Breaking changes

None.

## Tests

- [x] Added a regression test for `powershell` plus `codex.CMD`.
- [x] Ran the ESLint command directly because the local npm bin shim is unavailable.
- [x] Ran the TypeScript compiler directly because the local npm bin shim is unavailable.
- [x] Ran targeted unit tests: 152 passed.
- [x] Verified the generated `.CMD` command is one physical line.
- [ ] Full unit suite: blocked locally because node-pty cannot attach a console in this automation environment. CI remains the full gate.

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] No em dashes or double-hyphen punctuation used
- [x] Tests added or updated for this change
- [x] Docs update not required because no documented anchor changed
- [x] Ran lint, typecheck, and relevant tests locally
- [x] Screenshot or clip included (UI changes not applicable)
- [x] CLA signed (or will sign on first PR)