### PR TITLE
fix(db): degrade gracefully when the global database cannot be read

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -23,11 +23,16 @@ Overridable via the `KANGENTIC_DATA_DIR` environment variable. When set, all dat
 
 ## Configuration
 
-All database connections are opened with three pragmas:
+All database connections are opened with three pragmas, in this order:
 
-- `journal_mode = WAL` -- concurrent reads without blocking writers
 - `busy_timeout = 5000` -- wait up to 5 seconds on locked databases before returning SQLITE_BUSY
+- `journal_mode = WAL` -- concurrent reads without blocking writers
 - `foreign_keys = ON` -- enforce referential integrity on all foreign key constraints
+
+The order matters. `busy_timeout` is a connection setting that covers only the statements after
+it, and `journal_mode = WAL` takes a lock: it creates the `-wal` and `-shm` sidecars. Setting the
+timeout second would leave the WAL switch, the one statement most likely to collide, with no retry
+window at all.
 
 All queries are synchronous via **better-sqlite3** -- they block the Node.js event loop briefly but avoid callback complexity.
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -59,11 +59,13 @@ which is correct rather than `app.quit()` because `registerAllIpc` has not run y
 `NODE_ENV=test` the dialog is skipped so the E2E tier never hangs on a modal nobody can click.
 
 **While running.** Global-database reads go through `softly()` (`src/main/db/soft-db.ts`), which
-returns a fallback instead of throwing and logs once per operation. Four reads are softened:
+returns a fallback instead of throwing and logs once per operation. Four operations are softened:
 `project:list`, `projectGroup:list` and `project:getCurrent` in
-`src/main/ipc/handlers/projects.ts`, plus the `lastOpenedProject` lookup inside `createWindow()`.
-That last one is not an IPC handler and is the first global-database touch on the whole boot path,
-which is exactly where DESKTOP-9 threw.
+`src/main/ipc/handlers/projects.ts`, plus `lastOpenedProject`, which is read at two call sites
+inside `createWindow()`: once to resolve the boot project path, and again inside the
+`preloadPromise` catch block when that path turns out to be missing. Neither is an IPC handler,
+and the first is the first global-database touch on the whole boot path, which is exactly where
+DESKTOP-9 threw. Both share the one operation name, so a failure at either logs once for the pair.
 
 Only the two list reads raise the dialog, once per incident: a successful Retry re-arms it, so a
 later outage can still speak. `project:getCurrent` does not, because `project:list` already speaks

--- a/docs/database.md
+++ b/docs/database.md
@@ -31,6 +31,53 @@ All database connections are opened with three pragmas:
 
 All queries are synchronous via **better-sqlite3** -- they block the Node.js event loop briefly but avoid callback complexity.
 
+A connection is published to its module cache only after the pragmas and migrations have both
+succeeded. On failure the half-built handle is closed and the error is rethrown, so a retry
+reopens rather than reusing a connection that never ran migrations. `resetGlobalDb()` drops the
+cached global connection deliberately, which is what the Retry button below reopens through.
+
+## When the global database cannot be read
+
+`SQLITE_IOERR`, `SQLITE_READONLY`, and `SQLITE_BUSY` on `index.db` are environmental: an antivirus
+scan, a OneDrive or Dropbox sync lock, a read-only or full volume, or failing storage. There is
+nothing to fix in the query, so the policy is to say so rather than to retry silently or fail
+opaquely.
+
+**At startup.** `ensureGlobalDbReadable()` (`src/main/db/global-db-dialog.ts`) opens the database
+early in the `app.whenReady()` body, before the MCP server starts and before any window exists. A
+failure shows a modal naming the resolved file path, the SQLite code (or the plain error message
+when the failure carries no `SQLITE_*` code, such as a `NODE_MODULE_VERSION` mismatch), and the
+likely causes, with Retry and Quit. Retry drops the cached connection and reopens; a lock is usually over within
+seconds, so this recovers without a relaunch. Quit counts an `app_error` and calls `app.exit(0)`,
+which is correct rather than `app.quit()` because `registerAllIpc` has not run yet and
+`performShutdown` would throw reaching for a board config manager that does not exist. Under
+`NODE_ENV=test` the dialog is skipped so the E2E tier never hangs on a modal nobody can click.
+
+**While running.** Global-database reads go through `softly()` (`src/main/db/soft-db.ts`), which
+returns a fallback instead of throwing and logs once per operation. Four reads are softened:
+`project:list`, `projectGroup:list` and `project:getCurrent` in
+`src/main/ipc/handlers/projects.ts`, plus the `lastOpenedProject` lookup inside `createWindow()`.
+That last one is not an IPC handler and is the first global-database touch on the whole boot path,
+which is exactly where DESKTOP-9 threw.
+
+Only the two list reads raise the dialog, once per incident: a successful Retry re-arms it, so a
+later outage can still speak. `project:getCurrent` does not, because `project:list` already speaks
+for the pair and it answers null on the cold-boot path anyway.
+
+`createWindow()` is additionally wrapped in `try`/`finally`, because the `lastOpenedProject` read
+sits below its own `loadURL` call. A throw there used to skip `initUpdater`, `initAnnouncements`
+and `markStartupComplete`, leaving a live renderer invoking `announcements:get` with nobody
+listening (Sentry DESKTOP-3/4, the Windows event). Softening the read and making the block
+throw-proof are two layers against the same failure, not separate concerns.
+
+Writes are never softened: a mutation that swallows its failure reports a success that did not
+happen (see `.claude/rules/project-scoped-ipc.md`).
+
+Advisory tables opt out of the notification. The dev-port lease ledger degrades on every unit-tier
+CI run by design, so it passes `level: 'warn'` and no `notify`; wiring the dialog into the
+combinator itself would show it to production users and consume the one notification the project
+list needs.
+
 ## Global DB Schema
 
 ### projects table

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -17,16 +17,76 @@ export function setProjectDbInitializer(initializer: (db: Database.Database) => 
   projectDbInitializer = initializer;
 }
 
+/**
+ * Close a connection we are abandoning, swallowing a close that itself fails.
+ *
+ * Closing a connection whose file is already unreachable can throw again, and
+ * the original open attempt's error is the one worth surfacing. Used by every
+ * path that gives a half-built or superseded handle back to the OS, which on
+ * Windows is what stops a retry from fighting our own file lock.
+ */
+function closeQuietly(db: Database.Database): void {
+  try {
+    db.close();
+  } catch {
+    // Best effort. The handle is being abandoned either way.
+  }
+}
+
+/**
+ * The global index database, opened lazily and cached for the process.
+ *
+ * The connection is built into a LOCAL and only published to `globalDb` once the
+ * pragmas and migrations have succeeded. Publishing first (which is what this
+ * did until Sentry DESKTOP-9) means a throw from `journal_mode = WAL` leaves a
+ * cached handle that never ran migrations: the first caller sees the real
+ * `SqliteError`, and every later caller gets `no such table: projects` instead,
+ * so the symptom mutates away from its cause. WAL is the likely throw site
+ * precisely because it has to create the `-wal` and `-shm` sidecars, which is
+ * what an antivirus scan or a cloud-sync lock blocks.
+ *
+ * On failure the half-built handle is closed (releasing the file, so a retry is
+ * not fighting our own lock) and the error is rethrown for the caller to
+ * degrade on. `getProjectDb` below already had this shape; global was the
+ * outlier.
+ */
 export function getGlobalDb(): Database.Database {
   if (!globalDb) {
     ensureDirs();
-    globalDb = new Database(PATHS.globalDb);
-    globalDb.pragma('journal_mode = WAL');
-    globalDb.pragma('busy_timeout = 5000');
-    globalDb.pragma('foreign_keys = ON');
-    runGlobalMigrations(globalDb);
+    const db = new Database(PATHS.globalDb);
+    try {
+      // busy_timeout FIRST. It is a connection setting, so it only covers
+      // statements that run after it, and `journal_mode = WAL` is a
+      // lock-taking statement: it creates the -wal and -shm sidecars. Two
+      // Kangentic instances sharing a config dir (the main checkout plus a
+      // non-ephemeral worktree dev run) now both open this file eagerly at
+      // boot, so the WAL switch is exactly where they can collide.
+      db.pragma('busy_timeout = 5000');
+      db.pragma('journal_mode = WAL');
+      db.pragma('foreign_keys = ON');
+      runGlobalMigrations(db);
+    } catch (error) {
+      closeQuietly(db);
+      throw error;
+    }
+    globalDb = db;
   }
   return globalDb;
+}
+
+/**
+ * Drop the cached global connection so the next `getGlobalDb()` is a real
+ * reopen. This is what makes the unreadable-database dialog's Retry button
+ * mean something: without it, a retry after a transient lock would re-read a
+ * cache that is either stale or absent for the wrong reason.
+ *
+ * Distinct from `closeAll()`, which also tears down every project database as
+ * part of shutdown.
+ */
+export function resetGlobalDb(): void {
+  if (!globalDb) return;
+  closeQuietly(globalDb);
+  globalDb = null;
 }
 
 export function getProjectDb(projectId: string): Database.Database {
@@ -34,14 +94,25 @@ export function getProjectDb(projectId: string): Database.Database {
   if (!db) {
     ensureDirs();
     db = new Database(PATHS.projectDb(projectId));
-    db.pragma('journal_mode = WAL');
-    db.pragma('busy_timeout = 5000');
-    db.pragma('foreign_keys = ON');
-    runProjectMigrations(db);
-    // Load optional extensions (sqlite-vec) after migrations. Never throws:
-    // the initializer swallows a load failure and the engine falls back to
-    // lexical-only search.
-    projectDbInitializer?.(db);
+    try {
+      // busy_timeout before the WAL switch, for the same reason as the global
+      // database above.
+      db.pragma('busy_timeout = 5000');
+      db.pragma('journal_mode = WAL');
+      db.pragma('foreign_keys = ON');
+      runProjectMigrations(db);
+      // Load optional extensions (sqlite-vec) after migrations. Never throws:
+      // the initializer swallows a load failure and the engine falls back to
+      // lexical-only search.
+      projectDbInitializer?.(db);
+    } catch (error) {
+      // This path never had the global cache bug (the map is written below,
+      // after migrations), but it did leak the handle: on Windows an unclosed
+      // connection keeps the file locked by US, so the retry fights our own
+      // lock on top of whatever caused the failure.
+      closeQuietly(db);
+      throw error;
+    }
     projectDbs.set(projectId, db);
   }
   return db;

--- a/src/main/db/global-db-dialog.ts
+++ b/src/main/db/global-db-dialog.ts
@@ -1,0 +1,156 @@
+import { app, BrowserWindow, dialog } from 'electron';
+
+import { PATHS } from '../config/paths';
+import { getGlobalDb, resetGlobalDb } from './database';
+import { describeSqliteFailure } from './sqlite-error';
+
+/**
+ * The user-facing policy for an unreadable global database.
+ *
+ * Sentry DESKTOP-9/A/B: one install hit `SQLITE_IOERR` on `index.db` at launch.
+ * `SQLITE_IOERR` is environmental - an antivirus scan, a OneDrive or Dropbox
+ * sync lock, or failing storage - so there is nothing to fix in the query. What
+ * was worth fixing is that the app said nothing: the raw `SqliteError` crossed
+ * IPC as `Error invoking remote method 'project:list'` and startup carried on
+ * into a half-initialized state. Low frequency, wide blast radius. This is the
+ * failure mode where the app looks broken with no explanation.
+ *
+ * One dialog, two entry points, so the copy cannot drift:
+ *
+ *   - `ensureGlobalDbReadable()` at startup, before any window exists.
+ *   - `notifyGlobalDbUnavailable()` for a read that degraded mid-session.
+ *
+ * Always the async `dialog.showMessageBox`, never `showMessageBoxSync`: a sync
+ * dialog blocks the main process, which would freeze every live PTY.
+ */
+
+const RETRY_BUTTON = 0;
+
+/** E2E launches with NODE_ENV=test, where a modal would hang the tier with nobody to click it. */
+function dialogsSuppressed(): boolean {
+  return process.env.NODE_ENV === 'test';
+}
+
+async function askRetryOrQuit(error: unknown, parent: BrowserWindow | null): Promise<boolean> {
+  const detail = [
+    PATHS.globalDb,
+    '',
+    describeSqliteFailure(error),
+    '',
+    'This usually means another program is holding the file: an antivirus scan, '
+    + 'a OneDrive or Dropbox sync, or a failing drive.',
+  ].join('\n');
+
+  const options: Electron.MessageBoxOptions = {
+    type: 'error',
+    title: 'Kangentic',
+    message: "Kangentic can't read its database",
+    detail,
+    buttons: ['Retry', 'Quit'],
+    defaultId: RETRY_BUTTON,
+    cancelId: 1,
+    noLink: true,
+  };
+
+  const result = parent && !parent.isDestroyed()
+    ? await dialog.showMessageBox(parent, options)
+    : await dialog.showMessageBox(options);
+
+  return result.response === RETRY_BUTTON;
+}
+
+export type GlobalDbReadyResult = { ok: true } | { ok: false; error: unknown };
+
+/**
+ * Prove the global database is readable before startup builds anything on it.
+ *
+ * Resolves `{ ok: false }` when the user chose Quit, in which case the caller
+ * must abandon startup. Retry drops the cached connection and reopens for real,
+ * which is what makes it worth offering: an antivirus scan or a sync lock is
+ * usually over within seconds, so the recoverable case does not need a
+ * relaunch.
+ *
+ * The give-up error comes back rather than being swallowed, so the caller can
+ * still count the failure. This whole cluster was only ever noticed because it
+ * arrived in Sentry as an unhandled rejection; handling it must not also make
+ * it invisible.
+ *
+ * Called EARLY in the whenReady body rather than next to `createWindow()`, so
+ * a user with a locked database sees the message before the MCP server's
+ * several-second startup instead of after it. This also means the database is
+ * proven readable before any window exists, which is the ordering that stops
+ * the renderer from ever racing a startup that died half way through.
+ */
+export async function ensureGlobalDbReadable(): Promise<GlobalDbReadyResult> {
+  for (;;) {
+    try {
+      getGlobalDb();
+      return { ok: true };
+    } catch (error) {
+      console.error('[db] Global database is unreadable at startup:', error);
+      if (dialogsSuppressed()) return { ok: false, error };
+      if (!await askRetryOrQuit(error, null)) return { ok: false, error };
+      resetGlobalDb();
+    }
+  }
+}
+
+let notified = false;
+
+/**
+ * Report a global-database read that degraded while the app was already
+ * running, and offer the same Retry / Quit choice.
+ *
+ * Fire-and-forget and once per incident: the failure is a standing condition,
+ * and a second dialog for the same one teaches nothing. A successful Retry
+ * re-arms the flag below, so a later failure can still speak.
+ *
+ * Retry reopens the connection and stops there. It deliberately does NOT
+ * reload the renderer: that would destroy every `<webview>` guest, which is the
+ * whole point of `.claude/rules/retained-pane-never-remounts.md`, and the
+ * hard-reload recovery that does exist only re-pairs Command Terminal PTYs. So
+ * a successful retry restores writes and every future read, while a list that
+ * already degraded to empty stays empty until something refetches it. That
+ * limit is deliberately NOT in the dialog copy, which is shared with the
+ * startup path where it would be wrong: the copy stays on the cause, naming the
+ * file, the SQLite code, and what is likely holding it.
+ */
+export function notifyGlobalDbUnavailable(
+  error: unknown,
+  operation: string,
+  parentWindow?: BrowserWindow | null,
+): void {
+  if (notified) return;
+  notified = true;
+
+  console.error(`[db] Global database unavailable (${operation}); notifying the user.`, error);
+  if (dialogsSuppressed()) return;
+
+  void (async () => {
+    // The caller names the parent, because `getAllWindows()` is not just the
+    // main window: `browser-lane-manager.ts` creates offscreen lanes with
+    // `show: false`, and pop-outs are separate windows too. Owning a modal to
+    // an invisible lane would hide the very message this exists to deliver.
+    // The fallback still has to skip those, since it runs when the caller had
+    // no window to offer.
+    const parent = parentWindow && !parentWindow.isDestroyed()
+      ? parentWindow
+      : BrowserWindow.getAllWindows().find((window) => !window.isDestroyed() && window.isVisible()) ?? null;
+    const retry = await askRetryOrQuit(error, parent);
+    if (!retry) {
+      app.quit();
+      return;
+    }
+    resetGlobalDb();
+    try {
+      getGlobalDb();
+      // Re-arm, so a database that fails again later can still say so once more.
+      notified = false;
+    } catch (retryError) {
+      console.error('[db] Retry failed; the global database is still unreadable.', retryError);
+    }
+  })().catch((dialogError) => {
+    // A dialog that cannot open must not become the crash it was reporting.
+    console.error('[db] Failed to show the unreadable-database dialog:', dialogError);
+  });
+}

--- a/src/main/db/repositories/dev-port-repository.ts
+++ b/src/main/db/repositories/dev-port-repository.ts
@@ -1,4 +1,5 @@
 import { getGlobalDb } from '../database';
+import { softly as softDbAccess } from '../soft-db';
 import type { DevPortLease } from '../../../shared/types';
 
 /**
@@ -30,24 +31,23 @@ import type { DevPortLease } from '../../../shared/types';
 
 /**
  * Run a ledger query, degrading to `fallback` if the global database cannot be
- * reached. Logged ONCE per process: the failure is a standing condition, not a
- * per-call event, and a line per task serialization would bury everything else.
+ * reached. The combinator now lives in `../soft-db` so this file and the
+ * project-list IPC handlers share one implementation of the log-once
+ * discipline; the shared version bounds the log per OPERATION rather than per
+ * process, which still avoids the line-per-task-serialization flood this
+ * comment originally objected to.
+ *
+ * Never `notify`. This ledger degrading is EXPECTED - it is what every
+ * unit-tier CI run does - so a dialog here would be wrong, and would burn the
+ * once-per-process notification that the project list genuinely needs.
  */
-let ledgerUnavailableLogged = false;
 function softly<T>(operation: string, fallback: T, run: () => T): T {
-  try {
-    return run();
-  } catch (error) {
-    if (!ledgerUnavailableLogged) {
-      ledgerUnavailableLogged = true;
-      console.warn(
-        `[dev-ports] Reservation ledger unavailable (${operation}); treating every task as holding `
-        + 'no ports. Reservations will not persist until the global database is reachable.',
-        error,
-      );
-    }
-    return fallback;
-  }
+  return softDbAccess(operation, fallback, run, {
+    tag: '[dev-ports]',
+    level: 'warn',
+    note: 'Treating every task as holding no ports. Reservations will not persist '
+      + 'until the global database is reachable.',
+  });
 }
 
 interface DevPortRow {

--- a/src/main/db/soft-db.ts
+++ b/src/main/db/soft-db.ts
@@ -1,0 +1,121 @@
+import { isShuttingDown } from '../shutdown-state';
+
+/**
+ * Run a database access that must not take its caller down with it.
+ *
+ * Promoted from the private `softly()` in `repositories/dev-port-repository.ts`,
+ * which argued the case first: a lookup that degrades to a sensible empty
+ * answer is often the correct behaviour, while a throw that propagates is not.
+ * Sentry DESKTOP-A/B is the second consumer, and what earned the extraction:
+ * `project:list` and `projectGroup:list` were bare one-liners, so a
+ * `SQLITE_IOERR` on the global database reached the user as
+ * `Error invoking remote method 'project:list'` with a stack trace attached.
+ *
+ * ## What may be softened
+ *
+ * Reads, and writes that are ADVISORY - nothing reports their success and
+ * nothing downstream depends on it. The dev-port lease table is the whole of
+ * the second category today, and its own docblock explains why an advisory
+ * ledger must never be load bearing.
+ *
+ * NOT a write whose success is reported back to the renderer.
+ * `.claude/rules/project-scoped-ipc.md` is explicit that a failed mutation must
+ * not report success, and swallowing one here would do exactly that.
+ *
+ * ## Why the dialog is opt-in and not baked in
+ *
+ * Not every soft failure means the app is broken. The dev-port ledger degrades
+ * on every unit-tier CI run by design (`better-sqlite3` is an Electron ABI
+ * build, so `getGlobalDb()` throws NODE_MODULE_VERSION under plain Node - see
+ * tests/unit/dev-port-ledger-unavailable.test.ts). Wiring the user-facing
+ * notification into this combinator would mean a dev-only feature's expected
+ * ledger miss pops "Kangentic can't read its database" at a production user,
+ * and would burn the once-per-process notification on it, so the later
+ * `project:list` failure surfaces nothing at all. That is precisely the "app
+ * looks broken with no explanation" case this module exists to close.
+ *
+ * So `notify` is passed only by call sites whose failure genuinely leaves the
+ * app non-functional.
+ */
+
+export interface SoftlyOptions {
+  /**
+   * Appended to the one-time log line to say what the fallback MEANS, since
+   * "returned an empty array" reads very differently for an advisory ledger
+   * than for the project list.
+   */
+  note?: string;
+  /** Log prefix. Defaults to `[db]`; the dev-port ledger keeps its own. */
+  tag?: string;
+  /**
+   * Console level. Defaults to `error`. The advisory dev-port ledger passes
+   * `warn`, because its degradation is expected rather than a fault. The log
+   * mirror persists both unconditionally, so this is about how the line reads,
+   * not whether it survives.
+   */
+  level?: 'warn' | 'error';
+  /**
+   * Surface the unreadable-database dialog. Only for access whose failure makes
+   * the app non-functional. The notifier debounces to once per process.
+   */
+  notify?: boolean;
+}
+
+/**
+ * Called on every notifying failure. Injected rather than imported so this
+ * module's static graph stays free of `electron` and `@sentry/electron`, which
+ * is the same reason `setProjectDbInitializer` exists in `database.ts`: the
+ * unit tier traverses this graph and cannot load either.
+ *
+ * Left unset, a notifying access still degrades and still logs. It just has no
+ * way to tell anyone, which is the right behaviour outside a running app.
+ */
+export type GlobalDbFailureNotifier = (error: unknown, operation: string) => void;
+
+let notifier: GlobalDbFailureNotifier | null = null;
+
+export function setGlobalDbFailureNotifier(notify: GlobalDbFailureNotifier): void {
+  notifier = notify;
+}
+
+/**
+ * Logged once per OPERATION, not once per call. The dev-port docblock's
+ * objection was to a line per task serialization, which this still avoids; the
+ * operation set is small and static, so the bound holds while each distinct
+ * failure still gets said out loud exactly once.
+ */
+const loggedOperations = new Set<string>();
+
+export function softly<T>(
+  operation: string,
+  fallback: T,
+  run: () => T,
+  options: SoftlyOptions = {},
+): T {
+  try {
+    return run();
+  } catch (error) {
+    // Shutdown closes every connection synchronously, so anything that resumes
+    // afterwards throws "The database connection is not open". That is teardown
+    // working correctly, not a disk problem: stay silent. Same guard, same
+    // reason as handlers/task-move.ts.
+    if (isShuttingDown()) return fallback;
+
+    if (!loggedOperations.has(operation)) {
+      loggedOperations.add(operation);
+      const tag = options.tag ?? '[db]';
+      const note = options.note ? ` ${options.note}` : '';
+      const line = `${tag} Database access failed (${operation}); degrading.${note}`;
+      if (options.level === 'warn') console.warn(line, error);
+      else console.error(line, error);
+    }
+
+    // No once-guard here on purpose. The notifier owns those semantics, because
+    // it is the half that knows a successful Retry has re-armed it. Duplicating
+    // the flag here would leave this one latched true after a recovery and
+    // silence the next real failure.
+    if (options.notify) notifier?.(error, operation);
+
+    return fallback;
+  }
+}

--- a/src/main/db/sqlite-error.ts
+++ b/src/main/db/sqlite-error.ts
@@ -1,0 +1,49 @@
+/**
+ * Classification for `better-sqlite3` failures, so the degradation paths can
+ * tell a user what happened instead of showing them a stack trace.
+ *
+ * Nothing in `src/` inspected a `SQLITE_*` code before this module. It exists
+ * because of Sentry DESKTOP-9/A/B: one install hit `SQLITE_IOERR` on the global
+ * `index.db` and the raw `SqliteError` crossed IPC as
+ * `Error invoking remote method 'project:list'`. That message names the channel
+ * and says nothing about the file, the cause, or what the user can do.
+ *
+ * The codes here are the ones a healthy install can still hit for reasons
+ * outside the app: an antivirus scan or a cloud-sync client holding the file,
+ * a read-only or full volume, failing storage. They are environmental, so the
+ * copy points at the environment rather than at Kangentic.
+ */
+
+/** The shape `better-sqlite3` throws. It is not exported as a value by the package. */
+interface SqliteErrorLike extends Error {
+  code: string;
+}
+
+/**
+ * True for a `better-sqlite3` error carrying a `SQLITE_*` code.
+ *
+ * Deliberately duck-typed rather than an `instanceof` check: `SqliteError` is
+ * not exported from `better-sqlite3`'s type surface, and the native binding is
+ * mocked wholesale in the unit tier (see tests/unit/dev-port-ledger-unavailable.test.ts
+ * for why the real one cannot load under plain Node).
+ */
+export function isSqliteError(error: unknown): error is SqliteErrorLike {
+  if (!(error instanceof Error)) return false;
+  const code = (error as Partial<SqliteErrorLike>).code;
+  return typeof code === 'string' && code.startsWith('SQLITE_');
+}
+
+/**
+ * The one-line technical cause shown under the file path in the unreadable-database
+ * dialog, e.g. `disk I/O error (SQLITE_IOERR)`.
+ *
+ * A non-SQLite failure still reaches here. Opening the database can fail with a
+ * plain `Error` (a `NODE_MODULE_VERSION` ABI mismatch is the documented one), and
+ * the user needs a line either way, so this falls back to the message rather than
+ * returning nothing.
+ */
+export function describeSqliteFailure(error: unknown): string {
+  if (isSqliteError(error)) return `${error.message} (${error.code})`;
+  if (error instanceof Error && error.message) return error.message;
+  return String(error);
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,7 +27,7 @@ import { isStartupComplete, markStartupComplete, shouldCreateWindowOnActivate } 
 import { isBenignStreamWriteError } from './diagnostics/benign-stream-error';
 const windowConfigManager = new ConfigManager();
 import { initAnalytics, trackEvent, sanitizeErrorMessage, shouldEmitHeartbeat, setAnalyticsClientId } from './analytics/analytics';
-import { initErrorReporting, isErrorReportingActive, setErrorReportingUser } from './analytics/error-reporting';
+import { initErrorReporting, isErrorReportingActive, reportHandledError, setErrorReportingUser } from './analytics/error-reporting';
 import { initUsageAnalytics, trackUpdateOutcome } from './analytics/usage';
 import { resolveClientId } from './analytics/client-id';
 import { PATHS } from './config/paths';
@@ -64,6 +64,8 @@ import { prRefreshScheduler } from './pr/pr-refresh-scheduler';
 import { retrievalService } from './retrieval/retrieval-service';
 import { lineCountClient } from './git/line-count/line-count-client';
 import { setProjectDbInitializer } from './db/database';
+import { softly, setGlobalDbFailureNotifier } from './db/soft-db';
+import { ensureGlobalDbReadable, notifyGlobalDbUnavailable } from './db/global-db-dialog';
 import { setWorktreeRemovedListener, setWorktreeRemovingListener } from './git/worktree-manager';
 import { notifyAdaptersWorktreeRemoved } from './ipc/helpers/task-cleanup';
 import { loadVecExtension } from './retrieval/vec-extension';
@@ -1005,7 +1007,16 @@ const createWindow = () => {
   // IPC handlers were registered earlier in this function (registerAllIpc),
   // and Electron queues any webContents.send() calls until the renderer is ready.
   const cwd = getCwdArg();
-  const projectPath = cwd || getLastOpenedProject()?.path || null;
+  // Softened because this line is where DESKTOP-9 threw. It is the first
+  // global-database touch on the whole boot path, it sits BELOW loadURL, and a
+  // synchronous throw here took initUpdater and initAnnouncements down with it.
+  // The startup gate above should mean the database is already proven readable,
+  // but an antivirus scan or a sync lock is intermittent by nature and can
+  // arrive in between. Degrading to "no last project" opens the app on the
+  // project picker, which is a far better answer than a dead startup.
+  const projectPath = cwd
+    || softly('lastOpenedProject', null, () => getLastOpenedProject()?.path ?? null)
+    || null;
   const preloadPromise = (async () => {
     // Dev-only ephemeral: open isolated CLONES of the worktree, never the worktree
     // itself, so nothing the preview does (agents, edits, commits) can reach the
@@ -1092,7 +1103,10 @@ const createWindow = () => {
       // Found" dialog offers "Locate Folder..." instead of a dead board.
       // Electron queues the send until the renderer is ready.
       if (err instanceof Error && err.message.includes(PROJECT_PATH_MISSING_PREFIX) && mainWindow && !mainWindow.isDestroyed()) {
-        const lastOpened = getLastOpenedProject();
+        // Softened for the same reason as the read above: this one sits inside
+        // a catch, so a database throw here would replace a recoverable
+        // "Locate Folder..." prompt with an unhandled rejection.
+        const lastOpened = softly('lastOpenedProject', undefined, () => getLastOpenedProject());
         if (lastOpened && path.resolve(lastOpened.path) === path.resolve(projectPath)) {
           mainWindow.webContents.send(IPC.PROJECT_PATH_MISSING, lastOpened);
         }
@@ -1215,6 +1229,70 @@ app.whenReady().then(async () => {
     endPhase('restoreShellEnv');
   }
 
+  // Prove the global index database is readable before startup builds anything
+  // on top of it (Sentry DESKTOP-9/A/B). SQLITE_IOERR there is environmental -
+  // an antivirus scan, a OneDrive or Dropbox sync lock, failing storage - and
+  // it used to surface as an unhandled rejection plus a renderer that got a
+  // stack trace where a message belonged.
+  //
+  // Placed EARLY, not next to createWindow(), for two reasons: the user sees
+  // the dialog before the MCP server's multi-second startup rather than after
+  // it, and proving the database readable before any window exists removes the
+  // whole "renderer races a startup that died half way through" scenario for
+  // this cause.
+  //
+  // Note this makes the global database open eagerly on every boot. It used to
+  // be opened lazily at the first getLastOpenedProject() call, which
+  // short-circuits whenever --cwd is passed, so preview and worktree dev runs
+  // never touched it at all.
+
+  // The notifier is what softly() reaches for when a global read degrades while
+  // the app is already running. The Sentry report is debounced, because softly()
+  // calls this on EVERY notifying failure and the renderer re-reads project:list
+  // on each project switch and HMR re-sync. An unreadable database is one
+  // condition, not one event per read, so an undebounced report would send a
+  // burst of identical events for a fault Sentry already has.
+  let globalDbFailureReported = false;
+  setGlobalDbFailureNotifier((error, operation) => {
+    if (!globalDbFailureReported) {
+      globalDbFailureReported = true;
+      reportHandledError(error, { source: 'global_db_read', operation });
+    }
+    // mainWindow is read at CALL time, not registration time: this runs before
+    // createWindow, so it is still null here and holds the real window by the
+    // time a read can degrade.
+    notifyGlobalDbUnavailable(error, operation, mainWindow);
+  });
+  phase('ensureGlobalDbReadable');
+  const globalDbReady = await ensureGlobalDbReadable();
+  endPhase('ensureGlobalDbReadable');
+  if (!globalDbReady.ok) {
+    // Count it. Handling this failure must not also make it invisible: the
+    // whole cluster was noticed only because it reached Sentry as an unhandled
+    // rejection. Aptabase rather than Sentry, matching the app_error sources
+    // around it, because the cause is environmental and the user has already
+    // been shown a dialog naming it.
+    trackEvent('app_error', {
+      source: 'globalDbUnreadable',
+      message: sanitizeErrorMessage(
+        globalDbReady.error instanceof Error
+          ? globalDbReady.error.message
+          : String(globalDbReady.error),
+      ),
+    });
+    // exit, not quit. The user chose Quit before registerAllIpc ran, so there
+    // is no IPC context, no window, no PTY and no open database to tear down -
+    // and performShutdown's first act is to reach for the board config manager,
+    // which throws "IPC not initialized" and aborts the rest of the teardown.
+    // app.exit(0) is what the single-instance-lock bail above already uses for
+    // the same "give up before startup built anything" case.
+    //
+    // The gate stays shut deliberately: no window, and no dock-click recovery
+    // into a state that cannot work.
+    app.exit(0);
+    return;
+  }
+
   // Fix node-pty spawn-helper permissions on macOS before any PTY spawns.
   // Must run before createWindow() which triggers session recovery.
   ensureSpawnHelperPermissions();
@@ -1312,20 +1390,36 @@ app.whenReady().then(async () => {
   initUsageAnalytics(path.join(PATHS.configDir, 'analytics-usage.json'));
   trackUpdateOutcome(app.getVersion());
 
-  // These four lines MUST stay one unbroken synchronous block. createWindow()
-  // calls mainWindow.loadURL() internally, so the renderer starts loading
-  // before initUpdater/initAnnouncements have registered their channels; only
-  // the absence of an await here guarantees the renderer cannot reach its first
+  // This span MUST stay one unbroken synchronous block. createWindow() calls
+  // mainWindow.loadURL() internally, so the renderer starts loading before
+  // initUpdater/initAnnouncements have registered their channels; only the
+  // absence of an await here guarantees the renderer cannot reach its first
   // invoke until they have. Adding an await in this span re-opens DESKTOP-3/4
   // from the whenReady path itself, which the static scan in
   // tests/unit/startup-gate.test.ts exists to catch.
-  createWindow();
-  initUpdater(mainWindow!);
-  initAnnouncements(mainWindow!);
-  // Open the gate: from here an activate event may rebuild the window. Before
-  // this point the module-scope activate handler is a no-op, so a macOS
-  // launch-time activate can no longer race ahead of the registrations above.
-  markStartupComplete();
+  //
+  // The finally covers the OTHER way to break the same block: a THROW. That is
+  // what the Windows DESKTOP-3/4 event was. createWindow() reached
+  // getLastOpenedProject() below loadURL, the global database threw
+  // SQLITE_IOERR, and the two registrations plus the gate open never ran - so
+  // a live renderer invoked announcements:get with nobody listening. An await
+  // scan cannot see that; the finally makes it structurally impossible.
+  // Neither init is idempotent, and a finally runs exactly once, so this is
+  // safe. With mainWindow still null the throw landed before the window
+  // existed, there is no renderer to confuse, and the whenReady .catch below
+  // handles it as before.
+  try {
+    createWindow();
+  } finally {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      initUpdater(mainWindow);
+      initAnnouncements(mainWindow);
+    }
+    // Open the gate: from here an activate event may rebuild the window. Before
+    // this point the module-scope activate handler is a no-op, so a macOS
+    // launch-time activate can no longer race ahead of the registrations above.
+    markStartupComplete();
+  }
 
   // Windows has no powerMonitor 'shutdown' event (Linux/macOS only). An OS
   // shutdown/restart/log-off there is signaled via this BrowserWindow event

--- a/src/main/ipc/handlers/projects.ts
+++ b/src/main/ipc/handlers/projects.ts
@@ -14,6 +14,7 @@ import { isGitRepo, isInsideWorktree, isKangenticWorktree, ensureGitRepo, hasCom
 import { readWorktreeHeadUnqueued } from '../../git/worktree-head';
 import { agentRegistry } from '../../agent/agent-registry';
 import { getProjectDb, closeProjectDb } from '../../db/database';
+import { softly } from '../../db/soft-db';
 import { PATHS } from '../../config/paths';
 import { applyRuntimeConfig } from '../../config/apply-runtime-config';
 import { ensureGitignore } from '../helpers';
@@ -26,7 +27,7 @@ import { runWithProjectLogContext } from '../../diagnostics/project-log-context'
 import { prRefreshScheduler } from '../../pr/pr-refresh-scheduler';
 import { retrievalService } from '../../retrieval/retrieval-service';
 import { DEFAULT_AGENT } from '../../../shared/types';
-import type { Project, Task, AppConfig, ProjectSearchEntriesInput, ProjectRelocateOptions, ProjectPathProbe, ProjectEnsureGitResult, ProjectOpenByPathOverrides } from '../../../shared/types';
+import type { Project, ProjectGroup, Task, AppConfig, ProjectSearchEntriesInput, ProjectRelocateOptions, ProjectPathProbe, ProjectEnsureGitResult, ProjectOpenByPathOverrides } from '../../../shared/types';
 import type { IpcContext } from '../ipc-context';
 import type { ProjectRepository } from '../../db/repositories/project-repository';
 import type { ConfigManager } from '../../config/config-manager';
@@ -596,7 +597,22 @@ export function getLastOpenedProject(context: IpcContext): Project | undefined {
 }
 
 export function registerProjectHandlers(context: IpcContext): void {
-  ipcMain.handle(IPC.PROJECT_LIST, () => context.projectRepo.list());
+  // The three global-database READS below are softened; every write in this
+  // file still throws. Sentry DESKTOP-A/B: these were bare one-liners, so a
+  // SQLITE_IOERR on index.db crossed IPC as
+  // "Error invoking remote method 'project:list'" and the renderer got a stack
+  // trace where a message belonged. `notify` is set on the two list reads
+  // because an app with no project list is not usable and the user has earned
+  // an explanation. See src/main/db/soft-db.ts for why it is opt-in.
+  //
+  // Writes deliberately keep throwing: .claude/rules/project-scoped-ipc.md
+  // says a failed mutation must not report success.
+  ipcMain.handle(IPC.PROJECT_LIST, () => softly(
+    'project:list',
+    [] as Project[],
+    () => context.projectRepo.list(),
+    { notify: true },
+  ));
 
   ipcMain.handle(IPC.PROJECT_CREATE, (_, input) => {
     // Explicit input wins; the inherited defaults only fill what it left unset.
@@ -722,8 +738,15 @@ export function registerProjectHandlers(context: IpcContext): void {
   });
 
   ipcMain.handle(IPC.PROJECT_GET_CURRENT, () => {
-    if (!context.currentProjectId) return null;
-    return context.projectRepo.getById(context.currentProjectId) || null;
+    const currentProjectId = context.currentProjectId;
+    if (!currentProjectId) return null;
+    // No `notify`: project:list speaks for the pair, and this one already
+    // answers null on the cold-boot path, so a second dialog would add nothing.
+    return softly<Project | null>(
+      'project:getCurrent',
+      null,
+      () => context.projectRepo.getById(currentProjectId) || null,
+    );
   });
 
   ipcMain.handle(IPC.PROJECT_REORDER, (_, ids: string[]) => {
@@ -803,7 +826,12 @@ export function registerProjectHandlers(context: IpcContext): void {
   });
 
   // Project Groups
-  ipcMain.handle(IPC.PROJECT_GROUP_LIST, () => context.projectGroupRepo.list());
+  ipcMain.handle(IPC.PROJECT_GROUP_LIST, () => softly(
+    'projectGroup:list',
+    [] as ProjectGroup[],
+    () => context.projectGroupRepo.list(),
+    { notify: true },
+  ));
 
   ipcMain.handle(IPC.PROJECT_GROUP_CREATE, (_, input: { name: string }) => {
     return context.projectGroupRepo.create(input);

--- a/src/renderer/stores/project-store.ts
+++ b/src/renderer/stores/project-store.ts
@@ -1,6 +1,7 @@
 import { create, type StateCreator } from 'zustand';
 import type { Project, ProjectCreateInput, ProjectGroup, ProjectGroupCreateInput, ProjectRelocateOptions, ProjectRelocateResult, ProjectOpenByPathOverrides, ProjectPathProbe, ProjectEnsureGitResult } from '../../shared/types';
 import { PROJECT_PATH_MISSING_PREFIX } from '../../shared/ipc-channels';
+import { describeIpcError } from '../lib/ipc-error';
 // Not `./session-store` directly: that would close an import cycle whose
 // circular-import invalidate full-reloads the dev page. See the module docblock.
 import { killTransientSessionForProject, markIdleSessionsSeen } from './session-lifecycle-hooks';
@@ -58,7 +59,17 @@ const projectStoreInitializer: StateCreator<ProjectStore> = (set, get) => ({
 
   loadProjects: async () => {
     set({ loading: true });
-    const projects = await window.electronAPI.projects.list();
+    // The catch is what stops a rejection from stranding the whole app on its
+    // loading spinner: without it `loading` stays true and `hydrated` never
+    // flips, so App.tsx never runs hydrateView either. The main process now
+    // degrades this read rather than rejecting (see src/main/db/soft-db.ts),
+    // but a permanent spinner is the wrong answer to ANY failure here.
+    let projects: Project[] = [];
+    try {
+      projects = await window.electronAPI.projects.list();
+    } catch (error) {
+      console.error('[project-store] Failed to load projects:', describeIpcError(error));
+    }
     projectsReady = true;
     set({ projects, loading: false, hydrated: projectsReady && currentReady });
   },
@@ -212,15 +223,32 @@ const projectStoreInitializer: StateCreator<ProjectStore> = (set, get) => ({
   },
 
   loadCurrent: async () => {
-    const project = await window.electronAPI.projects.getCurrent();
+    // The third hydration gate, and the same reasoning as loadProjects above:
+    // `currentReady` is half of what flips `hydrated`, so a rejection here
+    // strands the app on its loading spinner just as completely. App.tsx calls
+    // this as a floating promise as well, so the rejection would also have no
+    // owner. Degrading to "no current project" opens the project picker.
+    let project: Project | null = null;
+    try {
+      project = await window.electronAPI.projects.getCurrent();
+    } catch (error) {
+      console.error('[project-store] Failed to load the current project:', describeIpcError(error));
+    }
     currentReady = true;
     set({ currentProject: project, hydrated: projectsReady && currentReady });
   },
 
   // Group actions
   loadGroups: async () => {
-    const groups = await window.electronAPI.projectGroups.list();
-    set({ groups });
+    // Called as a floating promise from App.tsx, so a rejection here is an
+    // unhandled one. Groups are presentational: no groups renders a flat
+    // project list, which is a working app.
+    try {
+      const groups = await window.electronAPI.projectGroups.list();
+      set({ groups });
+    } catch (error) {
+      console.error('[project-store] Failed to load project groups:', describeIpcError(error));
+    }
   },
 
   createGroup: async (input) => {

--- a/tests/unit/dev-port-ledger-unavailable.test.ts
+++ b/tests/unit/dev-port-ledger-unavailable.test.ts
@@ -77,13 +77,19 @@ describe('DevPortRepository with an unreachable global database', () => {
     expect(() => devPortRepository.releaseByTaskId('task-1')).not.toThrow();
   });
 
-  it('warns ONCE, not once per call', () => {
+  it('warns once per operation, not once per call', () => {
     // A standing condition, not a per-call event. One line per task
     // serialization would bury every other diagnostic in the log.
+    //
+    // The bound is per OPERATION since the combinator moved to
+    // src/main/db/soft-db.ts, shared with the project-list IPC handlers. Two
+    // distinct operations are exercised below, so two lines is the ceiling and
+    // 50 calls still produce no more than that. The flood this guards against
+    // is unchanged.
     for (let index = 0; index < 25; index += 1) {
       devPortRepository.listForTask(`task-${index}`);
       devPortRepository.getByPort(7300 + index);
     }
-    expect(warn.mock.calls.length).toBeLessThanOrEqual(1);
+    expect(warn.mock.calls.length).toBeLessThanOrEqual(2);
   });
 });

--- a/tests/unit/dev-port-ledger-unavailable.test.ts
+++ b/tests/unit/dev-port-ledger-unavailable.test.ts
@@ -35,6 +35,9 @@ vi.mock('../../src/main/db/database', () => ({
 }));
 
 const { devPortRepository } = await import('../../src/main/db/repositories/dev-port-repository');
+// `../database` is mocked above, but soft-db (the shared combinator the
+// repository now routes through) is not - this is the real module.
+const { setGlobalDbFailureNotifier } = await import('../../src/main/db/soft-db');
 
 let warn: ReturnType<typeof vi.spyOn>;
 
@@ -45,6 +48,10 @@ beforeEach(() => {
 
 afterEach(() => {
   warn.mockRestore();
+  // soft-db's notifier is process-global module state, not reset per test. A
+  // notifier registered here would otherwise leak into whichever test runs
+  // next in this file.
+  setGlobalDbFailureNotifier(() => {});
 });
 
 describe('DevPortRepository with an unreachable global database', () => {
@@ -91,5 +98,33 @@ describe('DevPortRepository with an unreachable global database', () => {
       devPortRepository.getByPort(7300 + index);
     }
     expect(warn.mock.calls.length).toBeLessThanOrEqual(2);
+  });
+
+  it('never notifies the global-db-failure listener: this ledger degrading is expected, not a fault', () => {
+    // src/main/db/soft-db.ts's own docblock is explicit: `notify` is opt-in,
+    // reserved for a read whose failure genuinely leaves the app
+    // non-functional. The dev-port ledger degrades on every unit-tier CI run
+    // by design (that is the whole reason this file exists), so wiring a
+    // notification in here would pop "Kangentic can't read its database" at a
+    // production user for a condition that is completely normal in dev, and
+    // would burn the once-per-process notification that an unreadable
+    // project:list genuinely needs.
+    //
+    // tests/unit/global-db-degradation.test.ts already pins "options with no
+    // `notify` never call the notifier" at the combinator level, but that test
+    // builds its own options object - it cannot catch a future edit that adds
+    // `notify: true` to THIS file's private softly() wrapper. This exercises
+    // the real production module instead, so that edit would actually fail a
+    // test.
+    const notifier = vi.fn();
+    setGlobalDbFailureNotifier(notifier);
+
+    devPortRepository.listForTask('task-1');
+    devPortRepository.getByTaskId('task-1');
+    devPortRepository.getByPort(7300);
+    devPortRepository.claim(7300, 'proj-1', 'task-1');
+    devPortRepository.releaseByTaskId('task-1');
+
+    expect(notifier).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/global-db-degradation.test.ts
+++ b/tests/unit/global-db-degradation.test.ts
@@ -219,6 +219,49 @@ describe('getGlobalDb caching', () => {
     expect(runGlobalMigrationsMock).toHaveBeenCalledTimes(1);
   });
 
+  it('sets busy_timeout before switching to WAL, on both the global and project databases', async () => {
+    // busy_timeout is a connection setting: it only covers statements that run
+    // AFTER it. journal_mode = WAL is a lock-taking statement (it creates the
+    // -wal and -shm sidecars), and two Kangentic instances sharing a config dir
+    // (the main checkout plus a non-ephemeral worktree dev run) both open this
+    // file eagerly at boot now, so the WAL switch is exactly where they can
+    // collide. Swapping the two pragma lines back would silently drop the
+    // busy-wait coverage for that collision while every existing assertion
+    // (which only checked WAL was called, not when) kept passing.
+    const globalHealthy = healthyConnection();
+    const projectHealthy = healthyConnection();
+    openDatabase.mockReturnValueOnce(globalHealthy).mockReturnValueOnce(projectHealthy);
+
+    const { getGlobalDb, getProjectDb } = await freshModules();
+    getGlobalDb();
+    getProjectDb('project-1');
+
+    const expectedOrder = ['busy_timeout = 5000', 'journal_mode = WAL', 'foreign_keys = ON'];
+    expect(globalHealthy.pragma.mock.calls.map(([sql]) => sql)).toEqual(expectedOrder);
+    expect(projectHealthy.pragma.mock.calls.map(([sql]) => sql)).toEqual(expectedOrder);
+  });
+
+  it('does not let a close() that itself throws mask the original open failure', async () => {
+    // "the original open attempt's error is the one worth surfacing" is
+    // closeQuietly's whole stated purpose (see its docblock in database.ts). A
+    // connection whose file is already unreachable can easily fail its own
+    // close() too, and if that propagated it would replace the real
+    // SQLITE_IOERR with a generic close failure - which is exactly the wrong
+    // cause for the unreadable-database dialog to name.
+    const broken = ioErrorOnPragma();
+    broken.close = vi.fn(() => { throw new Error('close failed'); });
+    const healthy = healthyConnection();
+    openDatabase.mockReturnValueOnce(broken).mockReturnValueOnce(healthy);
+
+    const { getGlobalDb } = await freshModules();
+
+    expect(() => getGlobalDb()).toThrow('disk I/O error');
+    expect(broken.close).toHaveBeenCalled();
+    // The abandoned handle's own close failure must not have wedged the
+    // module: a second call still reopens normally.
+    expect(getGlobalDb()).toBe(healthy);
+  });
+
   it('closes a project connection whose pragma threw, too', async () => {
     // getProjectDb never had the cache bug (it writes the map only after
     // migrations), but it did leak the handle: on Windows an unclosed
@@ -247,6 +290,23 @@ describe('getGlobalDb caching', () => {
     expect(getGlobalDb()).toBe(first);
     resetGlobalDb();
     expect(first.close).toHaveBeenCalled();
+    expect(getGlobalDb()).toBe(second);
+  });
+
+  it('resetGlobalDb still reopens even when the old handle fails to close', async () => {
+    // A propagating close() here would throw straight out of the Retry button's
+    // click handler (askRetryOrQuit -> resetGlobalDb -> getGlobalDb), which is
+    // the one path that exists specifically to recover from a locked file - the
+    // exact case where the old handle's close() is likeliest to fail too.
+    const first = healthyConnection();
+    first.close = vi.fn(() => { throw new Error('close failed'); });
+    const second = healthyConnection();
+    openDatabase.mockReturnValueOnce(first).mockReturnValueOnce(second);
+
+    const { getGlobalDb, resetGlobalDb } = await freshModules();
+
+    expect(getGlobalDb()).toBe(first);
+    expect(() => resetGlobalDb()).not.toThrow();
     expect(getGlobalDb()).toBe(second);
   });
 });
@@ -454,6 +514,41 @@ describe('notifyGlobalDbUnavailable', () => {
 
     notifyGlobalDbUnavailable(new Error('boom again'), 'project:list');
     await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not re-arm after a retry that fails again, so a later failure stays silent', async () => {
+    // The mirror of the re-arm test above. A Retry click that STILL fails must
+    // not flip `notified` back to false, or a second call site failing on the
+    // same still-broken database would pop a second identical dialog for a
+    // condition that has not actually changed.
+    //
+    // The naive version of this test (fire twice, assert one dialog) would
+    // pass whether or not the catch branch below ever ran, because `notified`
+    // never got reset either way. So this first waits for proof that the retry
+    // was actually attempted and actually failed, THEN fires the second call.
+    openDatabase.mockReturnValue(ioErrorOnPragma());
+    showMessageBoxMock.mockResolvedValue({ response: RETRY });
+    const { notifyGlobalDbUnavailable } = await freshModules();
+
+    notifyGlobalDbUnavailable(new Error('boom'), 'project:list');
+    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
+      '[db] Retry failed; the global database is still unreadable.',
+      expect.anything(),
+    ));
+
+    // `notifyGlobalDbUnavailable` bails at `if (notified) return;` before it
+    // does anything else, and that early return is synchronous - so whether
+    // this second call did anything can be read back immediately, with no
+    // further wait needed.
+    notifyGlobalDbUnavailable(new Error('boom again'), 'projectGroup:list');
+    expect(
+      errorSpy,
+      'a second call for a different operation must bail at the top-of-function `notified` guard rather than logging its own "unavailable; notifying" line, which is the earliest observable proof it never re-entered the dialog flow',
+    ).not.toHaveBeenCalledWith(
+      expect.stringContaining('projectGroup:list'),
+      expect.anything(),
+    );
+    expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
   });
 
   it('owns the modal to the window the caller named', async () => {

--- a/tests/unit/global-db-degradation.test.ts
+++ b/tests/unit/global-db-degradation.test.ts
@@ -1,0 +1,512 @@
+/**
+ * Unit tests for the unreadable-global-database path: src/main/db/database.ts,
+ * src/main/db/soft-db.ts, and src/main/db/global-db-dialog.ts.
+ *
+ * Regression cover for Sentry DESKTOP-9 / DESKTOP-A / DESKTOP-B. One install hit
+ * `SqliteError: disk I/O error` on the global index.db at launch. Three things
+ * went wrong at once, and each has tests below:
+ *
+ *   1. `getGlobalDb()` published the connection to its module cache BEFORE the
+ *      pragmas and migrations ran, so a throw from `journal_mode = WAL` left a
+ *      cached handle that had never been migrated. The first caller saw the real
+ *      SqliteError; every later caller got `no such table: projects` instead, so
+ *      the symptom mutated away from its cause.
+ *   2. `project:list` and `projectGroup:list` were bare one-liners, so the
+ *      SqliteError crossed IPC raw. (Covered in project-list-degradation.test.ts,
+ *      which needs the opposite mock universe: this file runs the REAL database
+ *      module, that one mocks it.)
+ *   3. Nothing told the user anything.
+ *
+ * Every module here is the real one. `better-sqlite3` is mocked instead, because
+ * it is an Electron ABI build that cannot load under plain Node at all (see
+ * dev-port-ledger-unavailable.test.ts for the CI failure that documents this).
+ * Driving the failure from the driver rather than from a mocked `getGlobalDb`
+ * is what makes assertion 1 meaningful: a mocked database module would have no
+ * cache to get this wrong.
+ *
+ * Module-level state (the connection cache, the log-once set, the notify-once
+ * flag) is cleared with vi.resetModules() plus a fresh import rather than a
+ * test-only reset export, which is this repo's idiom - see the comment in
+ * tests/unit/startup-gate.test.ts and importFreshModule() in
+ * tests/unit/announcements-init-guard.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+interface FakeWindow {
+  name: string;
+  isDestroyed: () => boolean;
+  isVisible: () => boolean;
+}
+
+const {
+  openDatabase,
+  runGlobalMigrationsMock,
+  showMessageBoxMock,
+  appQuitMock,
+  isShuttingDownMock,
+  allWindows,
+} = vi.hoisted(() => ({
+  openDatabase: vi.fn(),
+  runGlobalMigrationsMock: vi.fn(),
+  showMessageBoxMock: vi.fn(),
+  appQuitMock: vi.fn(),
+  isShuttingDownMock: vi.fn(() => false),
+  // Mutable so a test can stand up the window set it needs. BrowserWindow.getAllWindows()
+  // is NOT just the main window: browser-lane-manager.ts creates offscreen lanes
+  // with `show: false`, and pop-outs are windows of their own.
+  allWindows: [] as FakeWindow[],
+}));
+
+vi.mock('better-sqlite3', () => ({
+  // Returning an object from a constructor overrides `this`, so this stands in
+  // for `new Database(file)` without needing a real native binding.
+  default: function MockDatabase(file: string) {
+    return openDatabase(file);
+  },
+}));
+
+vi.mock('../../src/main/db/migrations', () => ({
+  runGlobalMigrations: (...args: unknown[]) => runGlobalMigrationsMock(...args),
+  runProjectMigrations: vi.fn(),
+}));
+
+vi.mock('../../src/main/config/paths', () => ({
+  PATHS: {
+    globalDb: '/mock/config/index.db',
+    projectDb: (id: string) => `/mock/config/projects/${id}.db`,
+  },
+  ensureDirs: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  app: { quit: (...args: unknown[]) => appQuitMock(...args) },
+  BrowserWindow: { getAllWindows: () => allWindows },
+  dialog: { showMessageBox: (...args: unknown[]) => showMessageBoxMock(...args) },
+}));
+
+vi.mock('../../src/main/shutdown-state', () => ({
+  isShuttingDown: () => isShuttingDownMock(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface MockConnection {
+  pragma: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+}
+
+/** A connection that answers every pragma happily. */
+function healthyConnection(): MockConnection {
+  return { pragma: vi.fn(), close: vi.fn() };
+}
+
+/**
+ * A connection that opens fine and then fails on its first pragma, which is the
+ * DESKTOP-9 shape exactly: `new Database()` succeeded and
+ * `pragma('journal_mode = WAL')` threw, because WAL has to create the -wal and
+ * -shm sidecars and that is what a scan or sync lock blocks.
+ */
+function ioErrorOnPragma(): MockConnection {
+  const error = Object.assign(new Error('disk I/O error'), { code: 'SQLITE_IOERR' });
+  return {
+    pragma: vi.fn(() => { throw error; }),
+    close: vi.fn(),
+  };
+}
+
+const RETRY = 0;
+const QUIT = 1;
+
+async function freshModules() {
+  vi.resetModules();
+  const database = await import('../../src/main/db/database');
+  const softDb = await import('../../src/main/db/soft-db');
+  const dialogModule = await import('../../src/main/db/global-db-dialog');
+  return { ...database, ...softDb, ...dialogModule };
+}
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+const originalNodeEnv = process.env.NODE_ENV;
+
+beforeEach(() => {
+  openDatabase.mockReset();
+  runGlobalMigrationsMock.mockReset();
+  showMessageBoxMock.mockReset();
+  appQuitMock.mockReset();
+  isShuttingDownMock.mockReturnValue(false);
+  allWindows.length = 0;
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  // The dialog suppresses itself under NODE_ENV=test so E2E never hangs on a
+  // modal. Most tests here are ABOUT the dialog, so it is cleared by default
+  // and the suppression gets its own test.
+  delete process.env.NODE_ENV;
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+  warnSpy.mockRestore();
+  if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = originalNodeEnv;
+});
+
+// ---------------------------------------------------------------------------
+
+describe('getGlobalDb caching', () => {
+  it('does not cache a connection whose pragma threw', async () => {
+    // THE red-green test for DESKTOP-9's second-order bug. Before the fix,
+    // `globalDb` was assigned on the line above the pragmas, so the broken
+    // handle stayed cached for the life of the process and every later read
+    // failed as `no such table: projects` instead of as the disk error.
+    const broken = ioErrorOnPragma();
+    const healthy = healthyConnection();
+    openDatabase.mockReturnValueOnce(broken).mockReturnValueOnce(healthy);
+
+    const { getGlobalDb } = await freshModules();
+
+    expect(() => getGlobalDb()).toThrow('disk I/O error');
+    expect(
+      broken.close,
+      'the half-built connection must be closed on failure: leaving the file handle open means a retry is fighting our own lock, not just the antivirus scan',
+    ).toHaveBeenCalled();
+
+    expect(
+      getGlobalDb(),
+      'a second call must REOPEN. Returning the cached, never-migrated connection is what turned a disk error into `no such table: projects` and hid the real cause.',
+    ).toBe(healthy);
+    expect(openDatabase).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache a connection whose migrations threw', async () => {
+    // Same hazard, one step later in the same function. Migrations run on the
+    // connection after the pragmas, so an I/O error there is just as able to
+    // leave a handle that answers queries against a schema that was never built.
+    const broken = healthyConnection();
+    const healthy = healthyConnection();
+    openDatabase.mockReturnValueOnce(broken).mockReturnValueOnce(healthy);
+    runGlobalMigrationsMock
+      .mockImplementationOnce(() => { throw new Error('migration failed'); })
+      .mockImplementation(() => {});
+
+    const { getGlobalDb } = await freshModules();
+
+    expect(() => getGlobalDb()).toThrow('migration failed');
+    expect(broken.close).toHaveBeenCalled();
+    expect(getGlobalDb()).toBe(healthy);
+  });
+
+  it('caches a healthy connection, so the happy path still opens once', async () => {
+    const healthy = healthyConnection();
+    openDatabase.mockReturnValue(healthy);
+
+    const { getGlobalDb } = await freshModules();
+
+    expect(getGlobalDb()).toBe(healthy);
+    expect(getGlobalDb()).toBe(healthy);
+    expect(
+      openDatabase,
+      'the fix must not turn the cache off: reopening index.db on every read would be a real regression',
+    ).toHaveBeenCalledTimes(1);
+    expect(healthy.pragma).toHaveBeenCalledWith('journal_mode = WAL');
+    expect(runGlobalMigrationsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes a project connection whose pragma threw, too', async () => {
+    // getProjectDb never had the cache bug (it writes the map only after
+    // migrations), but it did leak the handle: on Windows an unclosed
+    // connection keeps the file locked by US, so the retry fights our own lock
+    // on top of whatever caused the failure. The code now claims the same
+    // guarantee as getGlobalDb, so it gets the same assertion.
+    const broken = ioErrorOnPragma();
+    const healthy = healthyConnection();
+    openDatabase.mockReturnValueOnce(broken).mockReturnValueOnce(healthy);
+
+    const { getProjectDb } = await freshModules();
+
+    expect(() => getProjectDb('project-1')).toThrow('disk I/O error');
+    expect(broken.close).toHaveBeenCalled();
+    expect(getProjectDb('project-1')).toBe(healthy);
+  });
+
+  it('resetGlobalDb closes the handle and forces a genuine reopen', async () => {
+    // This is what makes the dialog's Retry button mean something.
+    const first = healthyConnection();
+    const second = healthyConnection();
+    openDatabase.mockReturnValueOnce(first).mockReturnValueOnce(second);
+
+    const { getGlobalDb, resetGlobalDb } = await freshModules();
+
+    expect(getGlobalDb()).toBe(first);
+    resetGlobalDb();
+    expect(first.close).toHaveBeenCalled();
+    expect(getGlobalDb()).toBe(second);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('softly', () => {
+  it('returns the value when the read succeeds', async () => {
+    const { softly } = await freshModules();
+    expect(softly('op', [], () => [1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it('returns the fallback instead of throwing', async () => {
+    const { softly } = await freshModules();
+    expect(softly('op', ['fallback'], () => { throw new Error('boom'); })).toEqual(['fallback']);
+  });
+
+  it('logs once per operation, not once per call', async () => {
+    // The dev-port ledger's objection, preserved through the extraction: one
+    // line per task serialization would bury every other diagnostic.
+    const { softly } = await freshModules();
+    const boom = () => { throw new Error('boom'); };
+
+    for (let index = 0; index < 20; index += 1) {
+      softly('project:list', [], boom);
+      softly('projectGroup:list', [], boom);
+    }
+
+    expect(errorSpy.mock.calls.length).toBe(2);
+  });
+
+  it('routes an advisory failure to warn rather than error', async () => {
+    // The dev-port ledger degrades on every unit-tier CI run by design, so it
+    // reads as a warning. An unreadable project list does not.
+    const { softly } = await freshModules();
+    softly('listForTask', [], () => { throw new Error('boom'); }, { level: 'warn' });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('stays completely silent during shutdown', async () => {
+    // Shutdown closes every connection synchronously, so anything resuming
+    // afterwards throws "The database connection is not open". That is teardown
+    // working, not a disk fault, and it must not log or raise a dialog.
+    isShuttingDownMock.mockReturnValue(true);
+    const { softly, setGlobalDbFailureNotifier } = await freshModules();
+    const notifier = vi.fn();
+    setGlobalDbFailureNotifier(notifier);
+
+    expect(softly('project:list', [], () => { throw new Error('closed'); }, { notify: true })).toEqual([]);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(notifier).not.toHaveBeenCalled();
+  });
+
+  it('notifies only when the call site asked for it', async () => {
+    // THE design assertion. If the notification hung off the combinator itself,
+    // the dev-port ledger's expected degradation would pop "Kangentic can't read
+    // its database" at a production user AND burn the once-per-process
+    // notification, so the project:list failure right after it would surface
+    // nothing at all - which is the exact "looks broken with no explanation"
+    // case this whole change exists to close.
+    const { softly, setGlobalDbFailureNotifier } = await freshModules();
+    const notifier = vi.fn();
+    setGlobalDbFailureNotifier(notifier);
+    const boom = () => { throw new Error('boom'); };
+
+    softly('listForTask', [], boom, { level: 'warn' });
+    expect(
+      notifier,
+      'an advisory read must not notify: it is expected to fail on every unit-tier CI run',
+    ).not.toHaveBeenCalled();
+
+    softly('project:list', [], boom, { notify: true });
+    expect(notifier).toHaveBeenCalledTimes(1);
+    expect(notifier).toHaveBeenCalledWith(expect.any(Error), 'project:list');
+  });
+
+  it('still degrades when no notifier was ever registered', async () => {
+    // The unit tier never registers one. A read must not become a TypeError
+    // because nobody was listening.
+    const { softly } = await freshModules();
+    expect(softly('project:list', [], () => { throw new Error('boom'); }, { notify: true })).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('ensureGlobalDbReadable', () => {
+  it('passes silently when the database opens', async () => {
+    openDatabase.mockReturnValue(healthyConnection());
+    const { ensureGlobalDbReadable } = await freshModules();
+
+    expect((await ensureGlobalDbReadable()).ok).toBe(true);
+    expect(showMessageBoxMock).not.toHaveBeenCalled();
+  });
+
+  it('names the file and the SQLite code in the dialog', async () => {
+    openDatabase.mockReturnValue(ioErrorOnPragma());
+    showMessageBoxMock.mockResolvedValue({ response: QUIT });
+    const { ensureGlobalDbReadable } = await freshModules();
+
+    await ensureGlobalDbReadable();
+
+    const [options] = showMessageBoxMock.mock.calls[0];
+    expect(options.detail).toContain('/mock/config/index.db');
+    expect(options.detail).toContain('disk I/O error (SQLITE_IOERR)');
+    expect(
+      options.detail,
+      'the copy has to name the likely causes: the whole point is that SQLITE_IOERR is environmental and the user, not the app, is the one who can act on it',
+    ).toContain('antivirus');
+    expect(options.buttons).toEqual(['Retry', 'Quit']);
+  });
+
+  it('reopens for real on Retry and succeeds once the lock clears', async () => {
+    openDatabase
+      .mockReturnValueOnce(ioErrorOnPragma())
+      .mockReturnValueOnce(healthyConnection());
+    showMessageBoxMock.mockResolvedValue({ response: RETRY });
+    const { ensureGlobalDbReadable } = await freshModules();
+
+    expect((await ensureGlobalDbReadable()).ok).toBe(true);
+    expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
+    expect(
+      openDatabase,
+      'Retry must reopen. An antivirus scan or a sync lock is usually over within seconds, which is the only reason offering Retry beats telling the user to relaunch.',
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps asking while the database stays unreadable', async () => {
+    openDatabase.mockReturnValue(ioErrorOnPragma());
+    showMessageBoxMock
+      .mockResolvedValueOnce({ response: RETRY })
+      .mockResolvedValueOnce({ response: RETRY })
+      .mockResolvedValue({ response: QUIT });
+    const { ensureGlobalDbReadable } = await freshModules();
+
+    expect((await ensureGlobalDbReadable()).ok).toBe(false);
+    expect(showMessageBoxMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('reports failure without a dialog under NODE_ENV=test', async () => {
+    // E2E launches with NODE_ENV=test. A modal there hangs the whole tier with
+    // nobody to click it.
+    process.env.NODE_ENV = 'test';
+    openDatabase.mockReturnValue(ioErrorOnPragma());
+    const { ensureGlobalDbReadable } = await freshModules();
+
+    expect((await ensureGlobalDbReadable()).ok).toBe(false);
+    expect(showMessageBoxMock).not.toHaveBeenCalled();
+  });
+
+  it('hands the give-up error back so the caller can still count it', async () => {
+    // Handling this failure must not also make it invisible. The whole cluster
+    // was noticed only because it reached Sentry as an unhandled rejection; a
+    // silent gate would trade one blind spot for another.
+    openDatabase.mockReturnValue(ioErrorOnPragma());
+    showMessageBoxMock.mockResolvedValue({ response: QUIT });
+    const { ensureGlobalDbReadable } = await freshModules();
+
+    const result = await ensureGlobalDbReadable();
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toMatchObject({ code: 'SQLITE_IOERR' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('notifyGlobalDbUnavailable', () => {
+  it('shows the dialog once per process', async () => {
+    openDatabase.mockReturnValue(ioErrorOnPragma());
+    showMessageBoxMock.mockResolvedValue({ response: QUIT });
+    const { notifyGlobalDbUnavailable } = await freshModules();
+
+    notifyGlobalDbUnavailable(new Error('boom'), 'project:list');
+    notifyGlobalDbUnavailable(new Error('boom'), 'projectGroup:list');
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalled());
+
+    expect(
+      showMessageBoxMock,
+      'a standing condition deserves one dialog. project:list and projectGroup:list both fail on the same boot, and two identical modals teach nothing.',
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('quits when the user chooses Quit', async () => {
+    showMessageBoxMock.mockResolvedValue({ response: QUIT });
+    const { notifyGlobalDbUnavailable } = await freshModules();
+
+    notifyGlobalDbUnavailable(new Error('boom'), 'project:list');
+    await vi.waitFor(() => expect(appQuitMock).toHaveBeenCalled());
+  });
+
+  it('re-arms after a successful retry, so a later failure can speak again', async () => {
+    // The reason the once-guard lives here and not in softly(): this is the
+    // half that knows recovery happened. A duplicate flag in the combinator
+    // would stay latched true and silence the next real failure.
+    openDatabase.mockReturnValue(healthyConnection());
+    showMessageBoxMock.mockResolvedValue({ response: RETRY });
+    const { notifyGlobalDbUnavailable } = await freshModules();
+
+    notifyGlobalDbUnavailable(new Error('boom'), 'project:list');
+    // Wait for the REOPEN, not for the dialog. The dialog resolves first and
+    // the re-arm happens after the reopen succeeds, so waiting on the dialog
+    // would fire the second notify into a flag that is still latched.
+    await vi.waitFor(() => expect(openDatabase).toHaveBeenCalled());
+
+    notifyGlobalDbUnavailable(new Error('boom again'), 'project:list');
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('owns the modal to the window the caller named', async () => {
+    const lane: FakeWindow = { name: 'lane', isDestroyed: () => false, isVisible: () => false };
+    const main: FakeWindow = { name: 'main', isDestroyed: () => false, isVisible: () => true };
+    allWindows.push(lane, main);
+    showMessageBoxMock.mockResolvedValue({ response: QUIT });
+    const { notifyGlobalDbUnavailable } = await freshModules();
+
+    notifyGlobalDbUnavailable(new Error('boom'), 'project:list', main as never);
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalled());
+
+    expect(showMessageBoxMock.mock.calls[0][0]).toBe(main);
+  });
+
+  it('never owns the modal to an offscreen lane when it has to guess', async () => {
+    // browser-lane-manager.ts creates lanes with `show: false` and
+    // `offscreen: true`, and getAllWindows() returns them. Parenting the
+    // "your database is unreadable" modal to one would hide the very message
+    // this code exists to deliver. The lane is FIRST in the list on purpose:
+    // an unfiltered `.find(w => !w.isDestroyed())` picks it.
+    const lane: FakeWindow = { name: 'lane', isDestroyed: () => false, isVisible: () => false };
+    const popOut: FakeWindow = { name: 'pop-out', isDestroyed: () => false, isVisible: () => true };
+    allWindows.push(lane, popOut);
+    showMessageBoxMock.mockResolvedValue({ response: QUIT });
+    const { notifyGlobalDbUnavailable } = await freshModules();
+
+    notifyGlobalDbUnavailable(new Error('boom'), 'project:list', null);
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalled());
+
+    expect(showMessageBoxMock.mock.calls[0][0]).toBe(popOut);
+  });
+
+  it('falls back to a parentless dialog when every window is hidden', async () => {
+    allWindows.push({ name: 'lane', isDestroyed: () => false, isVisible: () => false });
+    showMessageBoxMock.mockResolvedValue({ response: QUIT });
+    const { notifyGlobalDbUnavailable } = await freshModules();
+
+    notifyGlobalDbUnavailable(new Error('boom'), 'project:list', null);
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalled());
+
+    // One argument means the parentless overload: a top-level dialog, which is
+    // visible, rather than one owned by a window nobody can see.
+    expect(showMessageBoxMock.mock.calls[0].length).toBe(1);
+  });
+
+  it('does not quit or reopen under NODE_ENV=test', async () => {
+    process.env.NODE_ENV = 'test';
+    const { notifyGlobalDbUnavailable } = await freshModules();
+
+    notifyGlobalDbUnavailable(new Error('boom'), 'project:list');
+
+    expect(showMessageBoxMock).not.toHaveBeenCalled();
+    expect(appQuitMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/project-list-degradation.test.ts
+++ b/tests/unit/project-list-degradation.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Unit tests for the degraded project-list read path in
+ * src/main/ipc/handlers/projects.ts.
+ *
+ * Regression cover for Sentry DESKTOP-A / DESKTOP-B. Both handlers were bare
+ * one-liners:
+ *
+ *   ipcMain.handle(IPC.PROJECT_LIST, () => context.projectRepo.list());
+ *
+ * so a SqliteError on the global index.db crossed IPC untouched and the
+ * renderer got `Error invoking remote method 'project:list': SqliteError: disk
+ * I/O error`. That message names the channel and says nothing about the file,
+ * the cause, or what the user can do about it. Worse, the rejection stranded
+ * project-store's `loading` flag at true, so the app sat on its spinner
+ * forever.
+ *
+ * Split from global-db-degradation.test.ts because the two need opposite mock
+ * universes: that file runs the REAL database module against a mocked
+ * better-sqlite3, this one mocks the database module wholesale so a repository
+ * can be made to throw on demand.
+ *
+ * The mock set below is carried over from project-probe-path-handler.test.ts,
+ * which is the established way to import this module under test.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const capturedHandlers = new Map<string, (...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => ({
+  app: { getVersion: vi.fn(() => '0.0.0'), getPath: vi.fn(() => '/tmp') },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      capturedHandlers.set(channel, handler);
+    }),
+    on: vi.fn(),
+  },
+  Notification: { isSupported: vi.fn(() => false) },
+  dialog: { showOpenDialog: vi.fn() },
+  shell: { openPath: vi.fn(), openExternal: vi.fn() },
+}));
+
+vi.mock('../../src/main/git/git-checks', () => ({
+  isGitRepo: vi.fn(() => false),
+  isInsideWorktree: vi.fn(() => false),
+  isKangenticWorktree: vi.fn(() => false),
+  ensureGitRepo: vi.fn(),
+}));
+vi.mock('../../src/main/git/worktree-head', () => ({
+  readWorktreeHeadUnqueued: vi.fn(async () => ({ branch: null, sha: null })),
+}));
+vi.mock('../../src/main/git/original-fs', () => ({
+  default: {
+    existsSync: vi.fn(() => true),
+    statSync: vi.fn(() => ({ isDirectory: () => true })),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
+    readdirSync: vi.fn(() => []),
+    rmSync: vi.fn(),
+    promises: { stat: vi.fn(async () => ({ isDirectory: () => true })) },
+  },
+}));
+vi.mock('../../src/main/agent/agent-registry', () => ({
+  agentRegistry: {
+    list: vi.fn(() => ['claude']),
+    get: vi.fn(() => null),
+    getOrThrow: vi.fn(),
+    has: vi.fn(() => false),
+  },
+}));
+vi.mock('../../src/main/git/worktree-manager', () => ({
+  WorktreeManager: class { static clearQueue = vi.fn(); },
+}));
+vi.mock('../../src/main/db/database', () => ({
+  getProjectDb: vi.fn(() => ({})),
+  closeProjectDb: vi.fn(),
+}));
+vi.mock('../../src/main/db/repositories/task-repository', () => ({
+  TaskRepository: class { list = vi.fn(() => []); },
+}));
+vi.mock('../../src/main/db/repositories/session-repository', () => ({
+  SessionRepository: class {},
+}));
+vi.mock('../../src/main/db/repositories/swimlane-repository', () => ({
+  SwimlaneRepository: class {},
+}));
+vi.mock('../../src/main/db/repositories/transcript-repository', () => ({
+  TranscriptRepository: class {},
+}));
+vi.mock('../../src/main/transition-engine/session-startup', () => ({
+  resumeSuspendedSessions: vi.fn(async () => {}),
+  autoSpawnTasks: vi.fn(async () => {}),
+}));
+vi.mock('../../src/main/transition-engine/resource-cleanup', () => ({
+  cleanupStaleResourcesAsync: vi.fn(async () => {}),
+  pruneOrphanedWorktreeTasks: vi.fn(),
+}));
+vi.mock('../../src/main/config/paths', () => ({
+  PATHS: { projectDb: vi.fn((id: string) => `/tmp/${id}.db`) },
+}));
+vi.mock('../../src/main/config/apply-runtime-config', () => ({
+  applyRuntimeConfig: vi.fn(),
+}));
+vi.mock('../../src/main/ipc/helpers', () => ({ ensureGitignore: vi.fn() }));
+vi.mock('../../src/main/ipc/helpers/project-entry-search', () => ({
+  searchProjectEntries: vi.fn(async () => ({ entries: [], truncated: false })),
+}));
+vi.mock('../../src/main/analytics/analytics', () => ({ trackEvent: vi.fn() }));
+vi.mock('../../src/main/shutdown-state', () => ({ isShuttingDown: vi.fn(() => false) }));
+
+import { registerProjectHandlers } from '../../src/main/ipc/handlers/projects';
+import { setGlobalDbFailureNotifier } from '../../src/main/db/soft-db';
+import { IPC } from '../../src/shared/ipc-channels';
+
+const DISK_IO_ERROR = Object.assign(new Error('disk I/O error'), { code: 'SQLITE_IOERR' });
+
+function throwingRepo() {
+  return {
+    list: () => { throw DISK_IO_ERROR; },
+    getById: () => { throw DISK_IO_ERROR; },
+  };
+}
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  capturedHandlers.clear();
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+  // This file imports soft-db once at module scope, so a notifier registered by
+  // one test stays registered for every test after it. Vitest's per-file
+  // isolation stops that crossing into another file; it does not stop it
+  // crossing into the next test here.
+  setGlobalDbFailureNotifier(() => {});
+});
+
+describe('the project-list handlers with an unreadable global database', () => {
+  it('resolves an empty list instead of rejecting', async () => {
+    registerProjectHandlers({
+      projectRepo: throwingRepo(),
+      projectGroupRepo: throwingRepo(),
+    } as never);
+
+    const listProjects = capturedHandlers.get(IPC.PROJECT_LIST);
+    const listGroups = capturedHandlers.get(IPC.PROJECT_GROUP_LIST);
+    expect(listProjects, 'project:list was never registered').toBeDefined();
+    expect(listGroups, 'projectGroup:list was never registered').toBeDefined();
+
+    await expect(
+      Promise.resolve(listProjects!()),
+      "a raw rejection reaches the renderer as \"Error invoking remote method 'project:list'\" with a stack trace attached, and strands project-store's loading flag at true",
+    ).resolves.toEqual([]);
+    await expect(Promise.resolve(listGroups!())).resolves.toEqual([]);
+  });
+
+  it('answers null for the current project instead of rejecting', async () => {
+    registerProjectHandlers({
+      projectRepo: throwingRepo(),
+      projectGroupRepo: throwingRepo(),
+      currentProjectId: 'project-1',
+    } as never);
+
+    const getCurrent = capturedHandlers.get(IPC.PROJECT_GET_CURRENT);
+    await expect(Promise.resolve(getCurrent!())).resolves.toBeNull();
+  });
+
+  it('tells the user, once, that the database is unreadable', async () => {
+    const notifier = vi.fn();
+    setGlobalDbFailureNotifier(notifier);
+    registerProjectHandlers({
+      projectRepo: throwingRepo(),
+      projectGroupRepo: throwingRepo(),
+      currentProjectId: 'project-1',
+    } as never);
+
+    capturedHandlers.get(IPC.PROJECT_LIST)!();
+    capturedHandlers.get(IPC.PROJECT_GROUP_LIST)!();
+
+    expect(
+      notifier.mock.calls.map(([, operation]) => operation),
+      'both list reads must notify. Degrading to an empty list without saying anything is the "app looks broken with no explanation" failure this change exists to close; the notifier itself debounces to one dialog.',
+    ).toEqual(['project:list', 'projectGroup:list']);
+
+    // getCurrent deliberately does NOT notify: project:list already speaks for
+    // the pair, and it answers null on the cold-boot path anyway.
+    capturedHandlers.get(IPC.PROJECT_GET_CURRENT)!();
+    expect(notifier).toHaveBeenCalledTimes(2);
+  });
+
+  it('still returns real data when the database is healthy', async () => {
+    // The guard must not swallow the happy path.
+    const projects = [{ id: 'project-1', path: '/mock/one' }];
+    registerProjectHandlers({
+      projectRepo: { list: () => projects },
+      projectGroupRepo: { list: () => [] },
+    } as never);
+
+    await expect(Promise.resolve(capturedHandlers.get(IPC.PROJECT_LIST)!())).resolves.toBe(projects);
+  });
+});
+
+/**
+ * The self-maintaining half. The bug shipped as a one-liner, and the next
+ * one-line global read added to this file would reintroduce it silently. This
+ * scan makes that fail CI instead.
+ *
+ * Scoped to READ methods on the two GLOBAL repositories. A handler that also
+ * calls a write method is excluded: those are larger flows (PROJECT_OPEN reads
+ * getById then writes updateLastOpened) where the read is not the thing being
+ * answered and the write has to keep throwing anyway.
+ *
+ * Matching `.list()` alone was not enough - it would have waved through a
+ * one-liner like `(_, id) => context.projectRepo.getById(id)`, which is exactly
+ * the shape PROJECT_GET_CURRENT has.
+ *
+ * Per-project repositories are out of scope; they degrade through their own
+ * paths.
+ */
+describe('projects.ts keeps its global-database list reads soft', () => {
+  const SOURCE = fs.readFileSync(
+    path.resolve(__dirname, '../../src/main/ipc/handlers/projects.ts'),
+    'utf-8',
+  );
+
+  /**
+   * Handler bodies, sliced from each `ipcMain.handle(` to the file's 2-space
+   * close. Brace-balancing would have to understand string literals; this
+   * anchor matches the other static scans in tests/unit, and the sanity check
+   * below fails loudly if the formatting ever moves out from under it.
+   *
+   * Both close forms are accepted. A handler whose body is a block ends `});`,
+   * one whose body is a single expression ends `));` - the softened list reads
+   * are the second kind, and matching only the first walked straight past them
+   * into the NEXT handler, which quietly made this scan assert the wrong thing.
+   */
+  function handlerBodies(): { channel: string; body: string }[] {
+    const bodies: { channel: string; body: string }[] = [];
+    const pattern = /ipcMain\.handle\((IPC\.\w+)/g;
+    for (const match of SOURCE.matchAll(pattern)) {
+      const start = match.index;
+      const closes = ['\n  });', '\n  ));']
+        .map((marker) => SOURCE.indexOf(marker, start))
+        .filter((index) => index !== -1);
+      const closeIndex = closes.length > 0 ? Math.min(...closes) : SOURCE.length;
+      bodies.push({ channel: match[1], body: SOURCE.slice(start, closeIndex) });
+    }
+    return bodies;
+  }
+
+  it('finds the handlers it means to scan, and slices them apart', () => {
+    // An anchor that silently matches nothing - or that runs two handlers
+    // together - is a scan that passes forever.
+    const bodies = handlerBodies();
+    const channels = bodies.map((entry) => entry.channel);
+    expect(channels.length).toBeGreaterThan(15);
+    expect(channels).toContain('IPC.PROJECT_LIST');
+    expect(channels).toContain('IPC.PROJECT_GROUP_LIST');
+
+    // No body may contain a second handler registration. That is exactly the
+    // over-capture that made the write scan below read PROJECT_CREATE's body as
+    // part of PROJECT_LIST's.
+    for (const entry of bodies) {
+      expect(
+        entry.body.match(/ipcMain\.handle\(/g)?.length ?? 0,
+        `the slice for ${entry.channel} ran past its own close and swallowed the next handler`,
+      ).toBe(1);
+    }
+  });
+
+  // `softly<Project | null>(` is as softened as `softly(`. Matching the bare
+  // literal missed the explicitly-typed call and reported it as an offender.
+  const SOFTENED = /\bsoftly\s*[<(]/;
+  const GLOBAL_REPO = String.raw`context\.(projectRepo|projectGroupRepo)`;
+  const READ = new RegExp(`${GLOBAL_REPO}\\.(list|getById|getLastOpened)\\(`);
+  const WRITE = new RegExp(
+    `${GLOBAL_REPO}\\.(create|delete|update|rename|reorder|setGroup|setCollapsed|setDefault\\w*|updateLastOpened)\\(`,
+  );
+
+  it('routes every read-only global-repo handler through softly()', () => {
+    const offenders = handlerBodies()
+      .filter((entry) => READ.test(entry.body) && !WRITE.test(entry.body))
+      .filter((entry) => !SOFTENED.test(entry.body))
+      .map((entry) => entry.channel);
+
+    expect(
+      offenders,
+      'a global-database read that is not wrapped in softly() rejects across IPC on a SQLITE_IOERR, which is Sentry DESKTOP-A/B. Wrap it (see src/main/db/soft-db.ts) or move the read out of the handler body.',
+    ).toEqual([]);
+  });
+
+  it('does not soften writes', () => {
+    // The other half of the rule. .claude/rules/project-scoped-ipc.md: a failed
+    // mutation must not report success. A create/delete/rename that swallowed
+    // its error would tell the renderer it worked.
+    const softenedWrites = handlerBodies()
+      .filter((entry) => SOFTENED.test(entry.body) && WRITE.test(entry.body))
+      .map((entry) => entry.channel);
+
+    expect(
+      softenedWrites,
+      'a write must keep throwing: swallowing it reports a success that never happened',
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/project-store-load-degradation.test.ts
+++ b/tests/unit/project-store-load-degradation.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for project-store's load path when the IPC read fails.
+ *
+ * `loadProjects` sets `loading: true` and then awaited the invoke with no catch,
+ * so a rejection left `loading` stuck at true and `hydrated` at false forever.
+ * App.tsx's `Promise.all([configLoaded, projectsLoaded]).then(...)` has no catch
+ * either, so `hydrateView` never ran. The user's evidence of a disk I/O error on
+ * index.db was a permanent loading spinner (Sentry DESKTOP-A/B).
+ *
+ * `loadGroups` is worse in one respect: App.tsx calls it as a fully floating
+ * promise, so a rejection there was an unhandled rejection with no owner at all.
+ *
+ * The main process now degrades both reads rather than rejecting (see
+ * src/main/db/soft-db.ts and project-list-degradation.test.ts), so these are
+ * defence in depth. They are still worth pinning: the store must reach a
+ * rendered state on ANY failure, not only on the one class the main side
+ * happens to soften today.
+ *
+ * The stub cannot be written against a real app: contextBridge exposes
+ * `window.electronAPI` non-configurable and non-writable, and freezes each
+ * sub-object, so this behaviour is unreachable from a devtools eval and belongs
+ * here. Stub shape follows archived-tasks-slice.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
+
+vi.mock('../../src/renderer/stores/session-lifecycle-hooks', () => ({
+  killTransientSessionForProject: vi.fn(),
+  markIdleSessionsSeen: vi.fn(),
+}));
+vi.mock('../../src/renderer/stores/config-store', () => ({
+  useConfigStore: { getState: () => ({ loadConfig: vi.fn() }) },
+}));
+vi.mock('../../src/renderer/stores/project-cache', () => ({
+  dropProject: vi.fn(),
+}));
+
+const projectsApi = { list: vi.fn(), getCurrent: vi.fn() };
+const projectGroupsApi = { list: vi.fn() };
+
+(globalThis as Record<string, unknown>).window = {
+  electronAPI: { projects: projectsApi, projectGroups: projectGroupsApi },
+};
+
+import { useProjectStore } from '../../src/renderer/stores/project-store';
+
+const DISK_IO = new Error("Error invoking remote method 'project:list': SqliteError: disk I/O error");
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  projectsApi.list.mockReset();
+  projectsApi.getCurrent.mockReset();
+  projectGroupsApi.list.mockReset();
+  useProjectStore.setState({ projects: [], groups: [], currentProject: null, loading: false, hydrated: false });
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  // Without the restore the spies stack and the outer one keeps the previous
+  // test's calls, which turns "did not log" into a false failure.
+  errorSpy.mockRestore();
+});
+
+afterAll(() => {
+  // Symmetric with the module-scope assignment above. Vitest's per-file
+  // isolation contains the leak today, but a `window` global left standing is
+  // the kind of setup that only bites once someone changes the pool config.
+  delete (globalThis as Record<string, unknown>).window;
+});
+
+describe('loadProjects when the read fails', () => {
+  it('does not strand the app on its loading spinner', async () => {
+    projectsApi.list.mockRejectedValue(DISK_IO);
+
+    await expect(
+      useProjectStore.getState().loadProjects(),
+      'a rejection must not escape: App.tsx calls this inside an uncatched Promise.all, so a throw also skips hydrateView',
+    ).resolves.toBeUndefined();
+
+    const state = useProjectStore.getState();
+    expect(
+      state.loading,
+      'loading stuck at true is what the user actually saw: a spinner that never resolves, with no hint that the database was the problem',
+    ).toBe(false);
+    expect(state.projects).toEqual([]);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('still flips hydrated so the view can render', async () => {
+    projectsApi.list.mockRejectedValue(DISK_IO);
+    projectsApi.getCurrent.mockResolvedValue(null);
+
+    await useProjectStore.getState().loadProjects();
+    await useProjectStore.getState().loadCurrent();
+
+    expect(
+      useProjectStore.getState().hydrated,
+      'both gates have to close for hydrated to flip; a failed projects read must still count as settled or the app never leaves its boot state',
+    ).toBe(true);
+  });
+
+  it('keeps working normally when the read succeeds', async () => {
+    const projects = [{ id: 'project-1', name: 'One' }];
+    projectsApi.list.mockResolvedValue(projects);
+
+    await useProjectStore.getState().loadProjects();
+
+    expect(useProjectStore.getState().projects).toBe(projects);
+    expect(useProjectStore.getState().loading).toBe(false);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('loadGroups when the read fails', () => {
+  it('swallows the rejection it has no owner for', async () => {
+    // App.tsx calls loadGroups() as a floating promise, so a rejection here is
+    // an unhandled rejection rather than a failure anyone reports.
+    projectGroupsApi.list.mockRejectedValue(DISK_IO);
+
+    await expect(useProjectStore.getState().loadGroups()).resolves.toBeUndefined();
+    expect(
+      useProjectStore.getState().groups,
+      'no groups renders a flat project list, which is a working app',
+    ).toEqual([]);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('keeps working normally when the read succeeds', async () => {
+    const groups = [{ id: 'group-1', name: 'Group' }];
+    projectGroupsApi.list.mockResolvedValue(groups);
+
+    await useProjectStore.getState().loadGroups();
+
+    expect(useProjectStore.getState().groups).toBe(groups);
+  });
+});
+
+describe('loadCurrent when the read fails', () => {
+  it('does not strand the app on its loading spinner', async () => {
+    projectsApi.getCurrent.mockRejectedValue(DISK_IO);
+
+    await expect(
+      useProjectStore.getState().loadCurrent(),
+      'a rejection must not escape: App.tsx calls this as a floating promise too, so a throw would be an unhandled rejection with no owner',
+    ).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('clears currentProject to null after the failure', async () => {
+    // Seed a stale selection first so the assertion below pins the DEGRADE,
+    // not just an initial value that was already null.
+    useProjectStore.setState({ currentProject: { id: 'stale-project', name: 'Stale' } });
+    projectsApi.getCurrent.mockRejectedValue(DISK_IO);
+
+    await useProjectStore.getState().loadCurrent();
+
+    expect(
+      useProjectStore.getState().currentProject,
+      'degrading to no current project is what opens the project picker instead of leaving a stale one selected',
+    ).toBe(null);
+  });
+
+  it('still flips hydrated once both reads have settled, even when both reject', async () => {
+    projectsApi.list.mockRejectedValue(DISK_IO);
+    projectsApi.getCurrent.mockRejectedValue(DISK_IO);
+
+    await useProjectStore.getState().loadProjects();
+    await useProjectStore.getState().loadCurrent();
+
+    expect(
+      useProjectStore.getState().hydrated,
+      'both gates have to close for hydrated to flip; a failed current-project read must still count as settled or the app never leaves its boot state',
+    ).toBe(true);
+  });
+
+  it('keeps working normally when the read succeeds', async () => {
+    const project = { id: 'project-1', name: 'One' };
+    projectsApi.getCurrent.mockResolvedValue(project);
+
+    await useProjectStore.getState().loadCurrent();
+
+    expect(useProjectStore.getState().currentProject).toBe(project);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/sqlite-error.test.ts
+++ b/tests/unit/sqlite-error.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for src/main/db/sqlite-error.ts.
+ *
+ * The only existing coverage was indirect: global-db-degradation.test.ts asserts
+ * the dialog copy contains "disk I/O error (SQLITE_IOERR)", which reaches only
+ * the isSqliteError-true branch and the first return of describeSqliteFailure.
+ * This file pins every branch directly, including the duck-typing decision
+ * itself: isSqliteError checks `instanceof Error` before it looks at `code`, so
+ * a plain object carrying a SQLITE_* code is deliberately rejected.
+ *
+ * The module imports nothing, so no mocks are needed here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isSqliteError, describeSqliteFailure } from '../../src/main/db/sqlite-error';
+
+describe('isSqliteError', () => {
+  it('is true for an Error carrying a SQLITE_* code', () => {
+    const error = Object.assign(new Error('disk I/O error'), { code: 'SQLITE_IOERR' });
+    expect(isSqliteError(error)).toBe(true);
+  });
+
+  it('is false for a plain Error with no code', () => {
+    expect(isSqliteError(new Error('boom'))).toBe(false);
+  });
+
+  it('is false when code is not a string', () => {
+    const error = Object.assign(new Error('boom'), { code: 14 });
+    expect(isSqliteError(error)).toBe(false);
+  });
+
+  it('is false when code is a string that does not start with SQLITE_', () => {
+    const error = Object.assign(new Error('no such file'), { code: 'ENOENT' });
+    expect(isSqliteError(error)).toBe(false);
+  });
+
+  it('is false for a non-Error object that merely has a SQLITE_* code', () => {
+    // The load-bearing half of the duck-typing decision: this object has the
+    // exact shape better-sqlite3 throws, but it is rejected on the
+    // `instanceof Error` guard alone, before `code` is even read.
+    const notAnError = { message: 'disk I/O error', code: 'SQLITE_IOERR' };
+    expect(isSqliteError(notAnError)).toBe(false);
+  });
+
+  it('is false for null', () => {
+    expect(isSqliteError(null)).toBe(false);
+  });
+
+  it('is false for a plain string', () => {
+    expect(isSqliteError('disk I/O error')).toBe(false);
+  });
+});
+
+describe('describeSqliteFailure', () => {
+  it('returns "<message> (<code>)" for a SQLite error', () => {
+    const error = Object.assign(new Error('disk I/O error'), { code: 'SQLITE_IOERR' });
+    expect(describeSqliteFailure(error)).toBe('disk I/O error (SQLITE_IOERR)');
+  });
+
+  it('falls back to the message for a plain Error', () => {
+    // The documented real case: a NODE_MODULE_VERSION ABI mismatch throws a
+    // plain Error, not a SqliteError, and the user still needs a line.
+    const error = new Error(
+      "The module 'better_sqlite3.node' was compiled against a different Node.js version",
+    );
+    expect(describeSqliteFailure(error)).toBe(error.message);
+  });
+
+  it('falls back to String(error) for a non-Error value', () => {
+    expect(describeSqliteFailure('disk I/O error')).toBe('disk I/O error');
+  });
+
+  it('falls back to String(error) for an Error with an empty message', () => {
+    // `error instanceof Error && error.message` requires a truthy message, so
+    // an empty string falls through to the String(error) branch rather than
+    // returning ''.
+    const error = new Error('');
+    expect(describeSqliteFailure(error)).toBe(String(error));
+  });
+});

--- a/tests/unit/startup-gate.test.ts
+++ b/tests/unit/startup-gate.test.ts
@@ -218,6 +218,80 @@ describe('the startup gate is wired into src/main/index.ts', () => {
     ).toBe(false);
   });
 
+  it('registers updater and announcements from a finally, so a THROW cannot skip them', () => {
+    // The sibling of the await scan above, and the gap the Windows DESKTOP-3/4
+    // event fell through on 2026-09-03. An await is not the only way to break
+    // the "unbroken synchronous block": a THROW breaks it just as completely.
+    //
+    // What happened: createWindow() reaches getLastOpenedProject() BELOW its own
+    // loadURL call, the global database threw SQLITE_IOERR (DESKTOP-9), and
+    // initUpdater / initAnnouncements / markStartupComplete never ran. The
+    // renderer was already loading, so its first invoke found no handler. The
+    // await scan cannot see that, because no await was ever added.
+    //
+    // Anchored on `} finally {` rather than on brace-balancing, consistent with
+    // this file's other exact-text anchors.
+    const windowIndex = INDEX_SOURCE.indexOf('createWindow();');
+    const gateIndex = INDEX_SOURCE.indexOf('markStartupComplete();', windowIndex);
+    const span = INDEX_SOURCE.slice(windowIndex, gateIndex);
+
+    expect(
+      span,
+      'the in-body createWindow() call must be followed by a `} finally {`: without it, any throw inside createWindow after loadURL leaves a live renderer invoking announcements/updater channels that were never registered (the Windows DESKTOP-3/4 event)',
+    ).toContain('} finally {');
+
+    // The finally has to be the thing that CONTAINS the registrations, not
+    // merely sit somewhere in the span. Slice from the finally to the gate open
+    // and prove both calls are inside it.
+    const finallyIndex = span.indexOf('} finally {');
+    const finallyBody = span.slice(finallyIndex);
+    expect(
+      finallyBody,
+      'initUpdater must sit INSIDE the finally. Leaving it before the try, or between the try and the finally, is the starvable ordering this test exists to reject.',
+    ).toContain('initUpdater(');
+    expect(
+      finallyBody,
+      'initAnnouncements must sit INSIDE the finally, for the same reason as initUpdater: it is the channel pair the renderer actually invoked with nobody listening.',
+    ).toContain('initAnnouncements(');
+  });
+
+  it('opens the global database before it builds the window', () => {
+    // Sentry DESKTOP-9/A/B. The first global-database touch used to be
+    // getLastOpenedProject() inside createWindow, BELOW loadURL, with no guard
+    // at all: a SQLITE_IOERR there produced an unhandled rejection, a renderer
+    // holding a raw "Error invoking remote method" stack trace, and a startup
+    // that carried on half-initialized. Proving the database readable first is
+    // what turns that into a dialog naming the file.
+    const gateIndex = INDEX_SOURCE.indexOf('await ensureGlobalDbReadable()');
+    expect(
+      gateIndex,
+      'src/main/index.ts must await ensureGlobalDbReadable() during startup: without it a locked or failing index.db reaches the user as an unhandled rejection instead of a message naming the file (DESKTOP-9/A/B)',
+    ).toBeGreaterThan(-1);
+
+    const windowIndex = INDEX_SOURCE.indexOf('createWindow();');
+    expect(
+      gateIndex,
+      'the database check must run BEFORE createWindow(): once loadURL has fired, the renderer is already invoking channels, which is the whole failure this ordering prevents',
+    ).toBeLessThan(windowIndex);
+
+    // Calling it and ignoring the answer would leave startup walking into the
+    // state the dialog just told the user is broken.
+    //
+    // app.exit, not app.quit: the user chose Quit before registerAllIpc ran, so
+    // performShutdown's first act (reaching for the board config manager)
+    // throws "IPC not initialized" and aborts the rest of the teardown. Verified
+    // against a read-only index.db, which logged exactly that.
+    const bail = sliceAfter('await ensureGlobalDbReadable()', 1400);
+    expect(
+      bail,
+      'startup must ACT on ensureGlobalDbReadable(): a false answer is the user choosing Quit, and it has to stop the startup body rather than fall through into createWindow',
+    ).toContain('app.exit(0);');
+    expect(
+      bail,
+      'the give-up must still be counted. This whole cluster was noticed only because it reached Sentry as an unhandled rejection, so a gate that handles it silently trades one blind spot for another.',
+    ).toContain("source: 'globalDbUnreadable'");
+  });
+
   it('keeps the degraded-startup escape hatch that also opens the gate', () => {
     // A count scan, not a proximity regex: the whenReady body already contains
     // unrelated .catch( calls (pruneStaleWorktreeProjects,

--- a/tests/unit/startup-gate.test.ts
+++ b/tests/unit/startup-gate.test.ts
@@ -292,6 +292,80 @@ describe('the startup gate is wired into src/main/index.ts', () => {
     ).toContain("source: 'globalDbUnreadable'");
   });
 
+  it('wraps every getLastOpenedProject() call site in softly(\'lastOpenedProject\', ...)', () => {
+    // getLastOpenedProject() reads the global database, and this is the exact
+    // line DESKTOP-9 threw from: a bare call, below loadURL, with nothing
+    // between it and a SQLITE_IOERR. Comment-only mentions of the function name
+    // (this file narrates it in two docblocks) are excluded first, so only real
+    // call expressions are counted - otherwise the comments alone would inflate
+    // the count and hide a missing wrapper.
+    //
+    // Counted rather than anchored on the two known call sites by exact text: a
+    // THIRD call site added later that skips the wrapper must fail this test
+    // even though the two existing sites keep passing.
+    const codeSource = INDEX_SOURCE
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('//'))
+      .join('\n');
+
+    const callSites = codeSource.match(/getLastOpenedProject\(\)/g) ?? [];
+    const softenedCallSites = codeSource.match(/softly\('lastOpenedProject'/g) ?? [];
+
+    expect(
+      callSites.length,
+      'no getLastOpenedProject() call sites found in src/main/index.ts - has the function been renamed, or this scan\'s anchor gone stale?',
+    ).toBeGreaterThan(0);
+    expect(
+      softenedCallSites.length,
+      "every getLastOpenedProject() call in index.ts must be wrapped in softly('lastOpenedProject', ...): a bare call is what threw SQLITE_IOERR as an unhandled rejection in DESKTOP-9, and reintroducing even one unwrapped call site reopens it",
+    ).toBe(callSites.length);
+  });
+
+  it('debounces the Sentry report but calls the user notification unconditionally, inside the global-db-failure notifier', () => {
+    // This closure is registered via setGlobalDbFailureNotifier() entirely
+    // inside app.whenReady().then(...), which makes top-level electron calls and
+    // cannot be imported by a unit test - the same constraint the rest of this
+    // file works around with a static scan.
+    //
+    // softly() invokes this notifier on EVERY notifying failure (the renderer
+    // re-reads project:list on each project switch and HMR re-sync), but an
+    // unreadable database is one standing condition, not one event per read.
+    // reportHandledError must debounce to once per process behind
+    // globalDbFailureReported, or a burst of duplicate Sentry events would fire
+    // for a fault Sentry already has. notifyGlobalDbUnavailable owns its own
+    // once-per-incident + re-arm-on-retry semantics (see
+    // global-db-degradation.test.ts), so it must be called unconditionally:
+    // gating it on the same one-shot flag would silence the user-facing dialog
+    // after the very first failure even once a later Retry re-armed it.
+    const guardMarker = 'if (!globalDbFailureReported) {';
+    const guardStart = INDEX_SOURCE.indexOf(guardMarker);
+    expect(guardStart, 'the debounce guard `if (!globalDbFailureReported)` was not found in src/main/index.ts').toBeGreaterThan(-1);
+
+    // The guard's own closing brace is a newline followed by 4-space indent,
+    // which is unambiguous here: the only other `}` between the guard opening
+    // and its close belongs to reportHandledError's inline options object,
+    // which closes on the SAME line it opens on and never starts a line of its
+    // own at this indent.
+    const guardCloseIndex = INDEX_SOURCE.indexOf('\n    }\n', guardStart);
+    expect(guardCloseIndex, 'could not find the debounce guard\'s closing brace').toBeGreaterThan(guardStart);
+    const guardBody = INDEX_SOURCE.slice(guardStart, guardCloseIndex);
+
+    expect(
+      guardBody,
+      'reportHandledError must sit INSIDE the once-per-process guard: an unguarded call would send a burst of duplicate Sentry events for one standing condition every time softly() notifies',
+    ).toContain('reportHandledError(');
+    expect(
+      guardBody,
+      'notifyGlobalDbUnavailable must NOT be called inside the report guard: it has its own once-per-incident debounce with a re-arm on a successful Retry, and calling it here would double that semantics onto the wrong flag and silence the dialog after the very first failure',
+    ).not.toContain('notifyGlobalDbUnavailable(');
+
+    const afterGuard = INDEX_SOURCE.slice(guardCloseIndex, guardCloseIndex + 400);
+    expect(
+      afterGuard,
+      'notifyGlobalDbUnavailable must still be called, unconditionally, after the report guard closes - otherwise a degraded read after the first Sentry report never reaches the user at all',
+    ).toContain('notifyGlobalDbUnavailable(');
+  });
+
   it('keeps the degraded-startup escape hatch that also opens the gate', () => {
     // A count scan, not a proximity regex: the whenReady body already contains
     // unrelated .catch( calls (pruneStaleWorktreeProjects,


### PR DESCRIPTION
## What

Makes the app degrade gracefully when the global database (`<configDir>/index.db`) cannot be read.

- `src/main/db/database.ts` publishes a connection to its module cache only after the pragmas and migrations succeed, closes the half-built handle on failure, and gains `resetGlobalDb()`.
- `src/main/db/soft-db.ts` (new) holds `softly()`, promoted from `dev-port-repository`'s private combinator so there is one implementation.
- `src/main/db/sqlite-error.ts` and `src/main/db/global-db-dialog.ts` (new) classify the failure and present it: a modal naming the file, the SQLite code and the likely causes, with Retry and Quit.
- `src/main/index.ts` gates startup on the database being readable, and wraps `createWindow()` in `try`/`finally`.
- `src/main/ipc/handlers/projects.ts` softens `project:list`, `projectGroup:list` and `project:getCurrent`.
- `src/renderer/stores/project-store.ts` no longer strands its loading flag on a rejection.

No IPC channels added, removed, or renamed.

## Why

Sentry DESKTOP-9 / DESKTOP-A / DESKTOP-B, one install, one instant. A `SQLITE_IOERR` on `index.db` reached the user as an unhandled rejection in main and a raw `Error invoking remote method 'project:list'` in the renderer, and startup then carried on into a half-initialized state. The cause is environmental (an antivirus scan, a cloud-sync lock, failing storage), so there is nothing to fix in the query. What was worth fixing is that nothing degraded and nobody was told.

The Windows DESKTOP-3/4 event at the same timestamp is the same cause, not a separate race. Reading the events rather than the titles is what settled it: `project:list` failed as a `SqliteError` (so `registerAllIpc` completed), the renderer issued invokes at all (so `loadURL` ran), and `announcements:get` failed as "No handler registered" (so `initAnnouncements` did not). That brackets the throw to `getLastOpenedProject()` inside `createWindow()`, below its own `loadURL`. It is #582's "unbroken synchronous block" invariant broken by a throw rather than an await, and `startup-gate.test.ts` only ever scanned for the await.

Closes #596.

## How

Two bugs and one policy.

`getGlobalDb` published its connection before running the pragmas and migrations, so a throw left a cached handle that had never been migrated: the first caller saw the real `SqliteError`, every later one got `no such table: projects`, and the symptom mutated away from its cause. `getProjectDb` never had the cache bug but did leak the handle, which on Windows keeps the file locked by us. Both now close through a shared `closeQuietly`, and both set `busy_timeout` before `journal_mode = WAL` rather than after: the timeout covers only the statements that follow it, and the WAL switch is the lock-taking one, so the old order left the most collision-prone statement with no retry window.

The policy is that reads degrade and writes do not. A swallowed mutation reports a success that did not happen, which `.claude/rules/project-scoped-ipc.md` forbids. The notification is opt-in per call site rather than baked into `softly()`: the dev-port ledger degrades on every unit-tier CI run by design, so wiring the dialog into the combinator would show it to production users and burn the one notification the project list needs.

Two things are deliberately out of scope. The 21 unguarded `register*Handlers` calls in `register-all.ts` can starve each other, but a throw there precedes `loadURL`, so no renderer exists to race. And the global migration run is not transactional, so Retry recovers only because those steps are idempotent. Both are written down in `docs/database.md` rather than fixed here.

## Breaking changes

None. The startup gate does open the global database eagerly on every boot, where it was previously opened lazily at the first `getLastOpenedProject()` call, which short-circuits whenever `--cwd` is passed. Measured at 19ms cold and 9ms warm.

## Tests

CI (lint, typecheck, build, unit, UI, E2E) plus 82 unit tests across six files. Every one was verified red-green by mutating the production line it covers, not just by passing.

- `global-db-degradation.test.ts` (29): the cache bug for both a pragma and a migration throw, `getProjectDb` close-on-failure, `closeQuietly` swallowing a throwing `close()`, pragma ordering, `softly()`'s fallback / log-once / shutdown-silence / notify-opt-in, the retry loop, a failed Retry not re-arming the dialog, and the modal refusing to parent itself to an offscreen lane window.
- `project-list-degradation.test.ts` (7): the softened handlers resolve fallbacks, plus a static scan asserting every read-only global-repo handler in `projects.ts` goes through `softly()` and no write does, so the next one-line read handler cannot silently reintroduce this.
- `project-store-load-degradation.test.ts` (5): a rejected read no longer strands `loading: true`. This lives in the unit tier because `contextBridge` exposes `window.electronAPI` non-writable and freezes each sub-object, so it is unreachable from a running app.
- `startup-gate.test.ts` (+5): the `try`/`finally`, the startup gate ordering and its `app.exit(0)` bail, every `getLastOpenedProject()` call site being wrapped, and the notifier's debounce boundary.
- `sqlite-error.test.ts` (11) and `dev-port-ledger-unavailable.test.ts` (+1) cover the classifier's branches and prove the advisory ledger never reaches the notifier.

Verified in a real build against a read-only `index.db`: the dialog names the resolved path, Retry after clearing the lock boots normally (`ensureGlobalDbReadable (13868ms)` then `createWindow (34ms)`), and Quit exits 0. That rig caught `app.quit()` throwing "IPC not initialized" because it runs before `registerAllIpc`; the bail is `app.exit(0)` now. A preview run confirmed `announcements:get` and `getHistory` still answer after the `try`/`finally` restructure, which is the pair that failed in DESKTOP-3/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XgTAkvz7cn5qpxWFHGYBy
