### PR TITLE
fix(spawn): launch the sibling shim for a Windows .cmd agent head

### DIFF
--- a/.claude/rules/spawn-entry-point-parity.md
+++ b/.claude/rules/spawn-entry-point-parity.md
@@ -47,6 +47,14 @@ contract was kept in sync across three files by prose comments alone.
   otherwise allowlisted out of both chokepoints. A path that spawns a caller-supplied command
   string without going through `buildCommand` (`SESSION_SPAWN` in `handlers/sessions.ts`) is
   outside what the scan verifies; route a new one through a chokepoint instead.
+- Every file that calls `<receiver>.buildCommand(` also calls `resolveShimLaunch(`
+  (`src/main/agent/shared/shim-launch.ts`) first, after `ensureTrust`, and hands the builder the
+  resolved `agentPath` and `prompt`. On Windows an npm-installed CLI resolves to its `.cmd` shim,
+  which a PowerShell or Git Bash host launches through cmd.exe, and cmd.exe keeps only the first
+  line of a multi-line prompt (#353); the resolver swaps in the sibling shim the host can run, or
+  flattens the prompt. The runtime wiring per chokepoint is pinned by
+  `tests/unit/prepare-spawn-shim-launch-wiring.test.ts`, `tests/unit/transition-engine.test.ts`,
+  and `tests/unit/transient-session-spawn-shim-launch.test.ts`.
 - Adding a new spawn entry point means routing it through one of the two chokepoints, or adding
   a reasoned allowlist entry in the enforcement test AND updating this rule.
 
@@ -56,9 +64,10 @@ contract was kept in sync across three files by prose comments alone.
   on (a) any `executeTransition` / `resumeSuspendedSession` call site outside the classified
   files, (b) any `sessionManager.spawn(` call site outside the classified spawn sinks, (c) a
   chokepoint that stops calling `runSpawnPreamble` / `resolveEffectivePermissionMode`, (d)
-  any `lockAdvancedOverridesOnFirstSpawn` call outside `spawn-preamble.ts`, and (e) any
+  any `lockAdvancedOverridesOnFirstSpawn` call outside `spawn-preamble.ts`, (e) any
   `<receiver>.buildCommand(` call site with no earlier `<receiver>.ensureTrust(` on that same
-  receiver in the same file. That scan proves line order, not control flow; the runtime ordering
+  receiver in the same file, and (f) any `<receiver>.buildCommand(` call site with no earlier
+  `resolveShimLaunch(` in the same file. That scan proves line order, not control flow; the runtime ordering
   on the Command Terminal path is pinned separately by
   `tests/unit/transient-session-spawn-ensure-trust.test.ts`, which drives the handler and fails
   if the `await` is dropped or the call is removed. An

--- a/.claude/skills/cross-platform/SKILL.md
+++ b/.claude/skills/cross-platform/SKILL.md
@@ -35,7 +35,8 @@ When spawning a PTY session, the shell type determines command construction:
 `src/shared/paths.ts` provides platform-safe path utilities:
 
 - **`toForwardSlash(path)`** - Replace backslashes with forward slashes. Required for all paths written to `.claude.json` or config files, as Claude Code uses forward slashes on all platforms.
-- **`quoteArg(arg, shell?)`** - Shell-aware quoting, keyed on the TARGET shell, not the host platform: unix-like shells (bash, zsh, WSL) get single quotes with `'\''` escaping; PowerShell/cmd get double quotes with backtick/`$`/`"` escaping. When `shell` is omitted, falls back to platform detection (win32 = double quotes). Simple args (matching `/^[a-zA-Z0-9_.\/:-]+$/`) left unquoted; a backslashed Windows path is never simple, so it is always quoted.
+- **`quoteArg(arg, shell?, { multiline? })`** - Shell-aware quoting, keyed on the TARGET shell, not the host platform: unix-like shells (bash, zsh, WSL) get single quotes with `'\''` escaping; PowerShell/cmd get double quotes with backtick/`$`/`"` escaping. When `shell` is omitted, falls back to platform detection (win32 = double quotes). Simple args (matching `/^[a-zA-Z0-9_.\/:-]+$/`) left unquoted; a backslashed Windows path is never simple, so it is always quoted. `{ multiline: true }` keeps newlines in prompt-style content: literal inside `'...'` for unix-like shells, backtick-n escapes inside `"..."` for PowerShell, flattened for cmd. A bare `--` is emitted as `"--"` for PowerShell hosts (its binder eats an unquoted one before a `.ps1` sees `$args`).
+- **`isPowerShellShell(shell)`** - The PowerShell-family predicate (`powershell` / `pwsh` substring), the exact negation `isUnixLikeShell` applies. Use it instead of an inline `includes()` pair.
 - **`convertWindowsExePath(cmd, isWsl)`** - Converts the leading Windows exe path of a command string to POSIX form (`/c/...` or `/mnt/c/...`), recognizing bare, double-quoted, and single-quoted leading tokens (single quotes are what `quoteArg` emits for unix-like shells; a single-quoted token stays single-quoted so shell-active path characters remain inert). Called via `adaptCommandForShell` at the PTY spawn seam.
 - **`toGitBashPath(path)`** - `C:\Users\dev` -> `/c/Users/dev`
 - **`toWslPath(path)`** - `C:\Users\dev` -> `/mnt/c/Users/dev`
@@ -47,7 +48,11 @@ When spawning a PTY session, the shell type determines command construction:
 
 PowerShell interprets `\"` differently from bash. The command builder replaces double quotes with single quotes in prompts BEFORE `quoteArg()` wrapping. Without this, prompts containing quotes break PowerShell sessions.
 
-Additionally, `--` (end-of-options) is inserted before the prompt to prevent content like `->` or `--flag` from being parsed as CLI options.
+Additionally, `--` (end-of-options) is inserted before the prompt to prevent content like `->` or `--flag` from being parsed as CLI options. It goes through `quoteArg('--', shell)`, which emits `"--"` for PowerShell hosts; see the next section for why.
+
+## PowerShell, Git Bash, and npm `.cmd` shims
+
+An npm-installed agent CLI resolves on PATH to its `.cmd` shim (`which` walks PATHEXT). Running a `.cmd` routes through cmd.exe, whose command line ends at the first newline, so the multi-line `{{task_xml}}` prompt reached the agent as `<task>` alone (#353) under PowerShell and Git Bash alike; a cmd host is already flattened by `quoteArg`. `resolveShimLaunch` (`src/main/agent/shared/shim-launch.ts`) runs at every spawn chokepoint after `ensureTrust` and before `buildCommand`: on Windows with a `.cmd` / `.bat` head it launches the sibling shim npm writes beside it, the `.ps1` for PowerShell (gated on the host's `Get-ExecutionPolicy` allowing scripts, probed once per shell per run) or the extensionless `#!/bin/sh` script for Git Bash. With no usable sibling it keeps the `.cmd` and flattens the prompt with `sanitizeForPty`, warning once. PowerShell's binder consumes a bare `--` before a `.ps1` sees `$args`, which is why `quoteArg` quotes that marker. Full contract: `docs/cross-platform.md`.
 
 ## Windows File Operations
 
@@ -133,6 +138,7 @@ Sparse-checkout excludes `.claude/commands/` from worktrees (commands walk up th
 ## Key Source Files
 
 - `src/main/pty/spawn/shell-resolver.ts` - Shell discovery and default selection
+- `src/main/agent/shared/shim-launch.ts` - Sibling-shim selection for a `.cmd` / `.bat` head under PowerShell or Git Bash, with the prompt-flatten fallback
 - `src/main/agent/adapters/claude/command-builder.ts` - Claude CLI command assembly, prompt sanitization
 - `src/main/git/worktree-manager.ts` - Worktree CRUD with Windows retry logic
 - `src/renderer/hooks/useTerminal.ts` - xterm setup, WebGL fallback, resize debouncing

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -21,7 +21,7 @@ Each doc file and the source files that are its authority:
 | `transition-engine.md` | `src/main/transition-engine/transition-engine.ts`, `src/shared/types.ts` (ActionType, ActionConfig) |
 | `command-injection.md` | `src/main/transition-engine/injection-plan.ts`, `src/main/transition-engine/terminal-submit-scheduler.ts`, `src/main/pty/terminal-submit.ts`, `src/main/agent/adapters/claude/slash-command-verifier.ts` |
 | `database.md` | `src/main/db/migrations/**`, `src/main/db/database.ts`, `src/main/db/repositories/*.ts` |
-| `cross-platform.md` | `src/main/pty/spawn/shell-resolver.ts`, `src/shared/paths.ts` (adaptCommandForShell, convertWindowsExePath; called from `src/main/pty/lifecycle/session-spawn-flow.ts`), `electron-builder.yml`, `scripts/build.js` |
+| `cross-platform.md` | `src/main/pty/spawn/shell-resolver.ts`, `src/shared/paths.ts` (adaptCommandForShell, convertWindowsExePath, quoteArg, isPowerShellShell; called from `src/main/pty/lifecycle/session-spawn-flow.ts`), `src/main/agent/shared/shim-launch.ts`, `electron-builder.yml`, `scripts/build.js` |
 | `worktree-strategy.md` | `src/main/git/worktree-manager.ts`, `src/main/agent/adapters/claude/hook-manager.ts`, `src/main/agent/adapters/claude/trust-manager.ts` |
 | `activity-detection.md` | `src/main/agent/event-bridge.js`, `src/shared/types.ts` (EventType, EventTypeActivity, HookEvent), `src/main/activity-engine/engine/shapes.ts` (TransitionTrigger, default thresholds), `src/main/activity-engine/engine/watchdog.ts` (hold table) |
 | `mcp-server.md` | `src/main/agent/mcp-http-server.ts`, `src/main/agent/mcp-http/**`, `src/main/agent/commands/`, `src/main/ipc/handlers/sessions.ts`, `src/shared/types.ts` (MCP types) |

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -14,7 +14,7 @@ Every agent implements the `AgentAdapter` interface. Each adapter lives in `src/
 | `invalidateDetectionCache()` | Reset cached detection (e.g. after user changes CLI path) |
 | `ensureTrust(workingDirectory)` | Pre-approve a directory so the agent doesn't prompt for trust, plus any other pre-spawn global-config state the adapter needs (see [Global Config Writes](#global-config-writes-claudejson)) |
 | `probeAuth?()` | Optional. Check whether the agent is authenticated. Returns `true` (logged in), `false` (installed but not authenticated), or `null` (probe unavailable / I/O error). Only called by IPC after `detect()` reports `found: true`. Must never throw. Currently implemented by Kimi (see [Kimi Code -> Authentication](#authentication)) and Grok (`grok models`, whose output says "not authenticated" from local state). |
-| `buildCommand(options)` | Build the shell command string to spawn the agent |
+| `buildCommand(options)` | Build the shell command string to spawn the agent. `options.agentPath` is what `detect()` returned, except that on Windows a `.cmd` / `.bat` head is swapped by the spawn chokepoint for the sibling shim the PTY shell can run before the builder sees it (`resolveShimLaunch`, see [cross-platform.md](cross-platform.md#npm-cmd-shims-under-powershell-and-git-bash)); builders never inspect the extension |
 | `interpolateTemplate(template, variables)` | Replace `{{key}}` placeholders in prompt templates |
 | `runtime` | `AdapterRuntimeStrategy` declaring activity detection + session ID capture (see below) |
 | `removeHooks(directory, taskId?)` | Remove the per-directory config an adapter injected, on cleanup. `taskId` lets shared-file adapters (Codex, Gemini, Droid) reference-count so concurrent sessions in the same cwd do not clobber each other. The payload is not only hooks: Gemini also strips its `mcpServers.kangentic` entry (which carries the per-launch token), and Droid's refcount guards `<cwd>/.factory/mcp.json` rather than a hooks file. |
@@ -661,7 +661,7 @@ Caller-owned via `--session-id <uuid>`, mirroring Claude. `supportsCallerSession
 
 ### CLI Detection
 
-`config.agent.cliPaths.opencode` override, then `PATH` lookup for `opencode` (with the `.cmd` shim on Windows for `npm i -g opencode-ai` installs), then the standard Unix fallback paths. Distributed via Homebrew, Scoop, Chocolatey, Pacman, the curl|sh installer, and `npm i -g opencode-ai` - all install methods publish the same `opencode` binary name. The version probe runs `opencode --version` and strips an optional `opencode ` product prefix from the output.
+`config.agent.cliPaths.opencode` override, then `PATH` lookup for `opencode` (with the `.cmd` shim on Windows for `npm i -g opencode-ai` installs; under a PowerShell or Git Bash host the spawn chokepoint launches the sibling `.ps1` or sh shim instead, see [cross-platform.md](cross-platform.md#npm-cmd-shims-under-powershell-and-git-bash)), then the standard Unix fallback paths. Distributed via Homebrew, Scoop, Chocolatey, Pacman, the curl|sh installer, and `npm i -g opencode-ai` - all install methods publish the same `opencode` binary name. The version probe runs `opencode --version` and strips an optional `opencode ` product prefix from the output.
 
 ### Command Building
 

--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -55,6 +55,43 @@ shell/ConPTY updates reshaping their startup bytes (pwsh 7.6 started emitting `\
 those markers); see [session-lifecycle](session-lifecycle.md) for the detection layer it pairs
 with.
 
+### npm `.cmd` shims under PowerShell and Git Bash
+
+`quoteArg(..., { multiline: true })` keeps a multi-line prompt on one physical input line. For the
+PowerShell family it rewrites each newline as a backtick-n escape inside `"..."`, which PowerShell
+expands back into real newlines before the agent sees the argument; for unix-like shells the
+newlines stay literal inside `'...'`. Both hold only while the shell launches the agent binary
+itself. An npm-installed CLI resolves on PATH to its `.cmd` shim (`which` walks PATHEXT, which
+lists neither `.ps1` nor an empty extension), and running a `.cmd` routes through cmd.exe, whose
+command line ends at the first newline: the agent received `<task>` and nothing else (#353).
+Measured on Windows PowerShell 5.1, pwsh 7.6, and Git Bash; no encoding survives cmd.exe.
+
+`resolveShimLaunch` (`src/main/agent/shared/shim-launch.ts`) runs at every spawn chokepoint after
+`ensureTrust` and before `buildCommand` (see `.claude/rules/spawn-entry-point-parity.md`). On
+Windows with a `.cmd` or `.bat` head it launches the sibling shim native to the host shell
+instead, and npm writes both beside every `.cmd`:
+
+| Host shell | Sibling | Gate |
+|------------|---------|------|
+| PowerShell (pwsh/powershell) | `<name>.ps1` (`& node.exe <bin.js> $args`; a `$args` splat preserves multi-line arguments on 5.1 and 7) | The host's effective execution policy allows scripts: `Get-ExecutionPolicy` is `RemoteSigned`, `Unrestricted`, or `Bypass`, probed once per shell per app run through that same executable with a 5 s timeout; a failed probe counts as blocked. The probe runs without the app's `PSModulePath`: inherited from a pwsh 7 ancestor it makes 5.1 fail to autoload the module that owns `Get-ExecutionPolicy`. Windows PowerShell 5.1 defaults to `Restricted` on client editions, pwsh 7 to `RemoteSigned`, and the two keep separate policies. |
+| Git Bash | `<name>` (the extensionless `#!/bin/sh` shim, `exec node <bin.js> "$@"`) | The file exists and starts with `#!`. |
+| cmd | none | `quoteArg` already flattens for a cmd host. |
+| WSL | none | WSL cannot launch a `.cmd` at all (see [WSL interop](#wsl-runs-the-windows-binary-interop)), and the sh shim would run a Windows bundle under a Linux node. |
+
+With no usable sibling, or under `Restricted` / `AllSigned`, it keeps the `.cmd` head and flattens
+the prompt with `sanitizeForPty`, so the whole title and description still arrive on one line
+(the reporter's own workaround), and it logs the cause once per shell and path; for the policy
+case the fix is `Set-ExecutionPolicy RemoteSigned -Scope CurrentUser` in that host, then an app
+restart. Other platforms are untouched, the session row keeps the original prompt, and no adapter
+knows any of this: a `.cmd` shim is a Windows packaging fact.
+
+Two consequences. The Windows process tree becomes `pwsh -> node` rather than
+`pwsh -> cmd.exe -> node` (the background-shell watcher's immediate-parent rule counts both
+shapes). And PowerShell's parameter binder consumes a bare `--` before a `.ps1` sees `$args`, so
+`quoteArg('--', shell)` emits `"--"` for PowerShell hosts; the quoted form reaches native
+commands and cmd.exe as a plain `--` on every route, which is why the Claude, Grok, Ollama, and
+Warp builders route their end-of-options marker through `quoteArg`.
+
 ### Spawn-time cwd fixups (Windows)
 
 `resolveSpawnCwd()` (`src/main/pty/spawn/pty-spawn.ts`) passes the working directory to node-pty via its `cwd` option, but two Windows shells mishandle certain valid directories at startup. In those cases it returns a `cwdFixupCommand` that the spawn flow writes into the PTY (raw, before the agent command) so the session lands in the real project directory:
@@ -69,7 +106,8 @@ The PowerShell case fixes a Windows PowerShell 5.1 quirk: it treats `[` / `]` in
 ## Path Handling
 
 - `toForwardSlash()` - normalizes backslashes to forward slashes for cross-platform CLI commands
-- `quoteArg(arg, shell?)` - shell-aware quoting: single quotes for Unix-like shells (bash, zsh, WSL), double quotes for PowerShell/cmd. The shell parameter is explicitly passed in all spawn calls so quoting always matches the target shell. Falls back to platform detection when shell is omitted.
+- `quoteArg(arg, shell?, { multiline? })` - shell-aware quoting: single quotes for Unix-like shells (bash, zsh, WSL), double quotes for PowerShell/cmd. The shell parameter is explicitly passed in all spawn calls so quoting always matches the target shell. Falls back to platform detection when shell is omitted. `{ multiline: true }` keeps newlines in prompt-style content (literal inside `'...'` for unix-like shells, backtick-n escapes for PowerShell, flattened for cmd); a bare `--` is emitted as `"--"` for PowerShell hosts. See [npm `.cmd` shims under PowerShell and Git Bash](#npm-cmd-shims-under-powershell-and-git-bash) for the one place that contract does not reach on its own.
+- `isPowerShellShell(shell)` - the PowerShell-family predicate (`powershell` / `pwsh` substring, the exact negation `isUnixLikeShell` applies) shared by `adaptCommandForShell`, `buildSpawnClearPrelude`, `resolveShellArgs`, `resolveSpawnCwd`, `quoteArg`, and `resolveShimLaunch`.
 - Git Bash: paths like `C:\Users\...` become `/c/Users/...`
 - WSL: paths like `C:\Users\...` become `/mnt/c/Users/...`
 - `adaptCommandForShell()` - adds the `& ` prefix for PowerShell commands, and for unix-like shells (Git Bash, WSL) converts the leading Windows exe path to POSIX form via `convertWindowsExePath()`, which handles bare, double-quoted, and single-quoted leading tokens (a quoted token stays quoted with the same quote character even without spaces, so shell-active path characters like `&` remain inert in the target shell)

--- a/src/main/activity-engine/background-shell/process-tree.ts
+++ b/src/main/activity-engine/background-shell/process-tree.ts
@@ -682,7 +682,9 @@ export function hasNoNonConsoleDescendants(descendants: readonly ProcessInfo[]):
  * shell allowlist, but cmd is a wrapper inside bash, not a separate
  * logical bg shell. We use immediate-parent (not transitive ancestor)
  * because the agent CLI itself is sometimes launched through a shell
- * shim (pwsh -> npm-shim cmd.exe -> node[claude]). A transitive rule
+ * shim (pwsh -> npm-shim cmd.exe -> node[claude], the shape a `.cmd`
+ * head keeps when no sibling shim can run; see
+ * src/main/agent/shared/shim-launch.ts). A transitive rule
  * would treat that shim cmd as a "shell-like ancestor" of every bash
  * the agent spawns and skip them all, breaking the count.
  *

--- a/src/main/agent/adapters/claude/command-builder.ts
+++ b/src/main/agent/adapters/claude/command-builder.ts
@@ -210,9 +210,11 @@ export class CommandBuilder {
         ? options.prompt.replace(/"/g, "'")
         : options.prompt;
       // -- (end-of-options) prevents content like -> or --flag from being
-      // parsed as CLI options regardless of shell quoting behavior.
+      // parsed as CLI options regardless of shell quoting behavior. It goes
+      // through quoteArg because PowerShell's binder eats a bare -- before a
+      // .ps1 shim sees $args; the quoted form reaches every launcher intact.
       // multiline: true preserves newlines in the <task> XML envelope.
-      parts.push('--', quoteArg(safePrompt, shell, { multiline: true }));
+      parts.push(quoteArg('--', shell), quoteArg(safePrompt, shell, { multiline: true }));
     }
 
     return parts.join(' ');

--- a/src/main/agent/adapters/codex/command-builder.ts
+++ b/src/main/agent/adapters/codex/command-builder.ts
@@ -1,4 +1,4 @@
-import { toForwardSlash, quoteArg, isUnixLikeShell, sanitizeForPty } from '../../../../shared/paths';
+import { toForwardSlash, quoteArg, isUnixLikeShell } from '../../../../shared/paths';
 import { interpolateTemplate } from '../../shared/template-utils';
 import { buildHooks } from './hook-manager';
 import type { PermissionMode } from '../../../../shared/types';
@@ -141,19 +141,6 @@ function buildMcpConfigArgs(options: CodexCommandOptions): string[] {
   ];
 }
 
-/**
- * PowerShell expands `n before it hands an argument to an npm .CMD shim. The
- * shim then invokes cmd.exe, which treats the resulting physical newlines as
- * command boundaries instead of forwarding the full positional prompt.
- */
-function usesPowerShellCmdShim(codexPath: string, shell?: string): boolean {
-  const lowerShell = shell?.toLowerCase() ?? '';
-  return (
-    (lowerShell.includes('powershell') || lowerShell.includes('pwsh'))
-    && /\.cmd$/i.test(codexPath.trim())
-  );
-}
-
 export class CodexCommandBuilder {
   buildCodexCommand(options: CodexCommandOptions): string {
     const { shell } = options;
@@ -213,17 +200,19 @@ export class CodexCommandBuilder {
     // resumed conversation already contains it, and re-sending would re-ask
     // the task prompt on every resume.
     if (!isResume && options.prompt) {
-      const preservePromptNewlines = !usesPowerShellCmdShim(options.codexPath, shell);
-      const prompt = preservePromptNewlines
-        ? options.prompt
-        : sanitizeForPty(options.prompt);
       const needsDoubleQuoteReplacement = shell
         ? !isUnixLikeShell(shell)
         : process.platform === 'win32';
       const safePrompt = needsDoubleQuoteReplacement
-        ? prompt.replace(/"/g, "'")
-        : prompt;
-      parts.push(quoteArg(safePrompt, shell, { multiline: preservePromptNewlines }));
+        ? options.prompt.replace(/"/g, "'")
+        : options.prompt;
+      // Unconditionally multiline. A `.cmd` head would truncate this at the
+      // first newline (#353), but by here `codexPath` has already been through
+      // resolveShimLaunch at the spawn chokepoint, which either swapped in the
+      // sibling shim that carries newlines or flattened the prompt itself. The
+      // decision is shell and packaging knowledge, not Codex knowledge, so it
+      // stays out of this builder and out of the other thirteen.
+      parts.push(quoteArg(safePrompt, shell, { multiline: true }));
     }
 
     return parts.join(' ');

--- a/src/main/agent/adapters/grok/command-builder.ts
+++ b/src/main/agent/adapters/grok/command-builder.ts
@@ -151,7 +151,9 @@ export class GrokCommandBuilder {
     if (!isResume && options.prompt) {
       // `--` (end-of-options) prevents prompt content like `--flag` from
       // being parsed as a CLI option regardless of shell quoting behavior.
-      parts.push('--', this.quotePrompt(options.prompt, shell));
+      // quoteArg quotes it for PowerShell hosts, whose binder would otherwise
+      // consume it before a .ps1 shim sees $args.
+      parts.push(quoteArg('--', shell), this.quotePrompt(options.prompt, shell));
     }
 
     return parts.join(' ');

--- a/src/main/agent/adapters/ollama/ollama-adapter.ts
+++ b/src/main/agent/adapters/ollama/ollama-adapter.ts
@@ -106,8 +106,9 @@ export class OllamaAdapter implements AgentAdapter {
       // beginning with a dash (a markdown bullet, a dashed list item) would be
       // misread as a flag. Push the `--` end-of-options marker first so the
       // prompt is always taken as the positional argument (matches the Warp
-      // adapter).
-      parts.push('--', quoteArg(safePrompt, shell, { multiline: true }));
+      // adapter). quoteArg quotes the marker for PowerShell hosts, whose
+      // binder would otherwise consume it before a .ps1 shim sees $args.
+      parts.push(quoteArg('--', shell), quoteArg(safePrompt, shell, { multiline: true }));
     }
 
     return parts.join(' ');

--- a/src/main/agent/adapters/warp/warp-adapter.ts
+++ b/src/main/agent/adapters/warp/warp-adapter.ts
@@ -107,7 +107,9 @@ export class WarpAdapter implements AgentAdapter {
 
     // --prompt with shell-safe quoting (only when prompt is provided).
     // Placed after all flags with -- end-of-options guard so prompt
-    // content starting with "-" isn't misinterpreted as a CLI flag.
+    // content starting with "-" isn't misinterpreted as a CLI flag. The
+    // guard goes through quoteArg: PowerShell's binder eats a bare --
+    // before a .ps1 shim sees $args, and the quoted form survives.
     if (options.prompt) {
       const needsDoubleQuoteReplacement = shell
         ? !isUnixLikeShell(shell)
@@ -115,7 +117,7 @@ export class WarpAdapter implements AgentAdapter {
       const safePrompt = needsDoubleQuoteReplacement
         ? options.prompt.replace(/"/g, "'")
         : options.prompt;
-      parts.push('--', '--prompt', quoteArg(safePrompt, shell, { multiline: true }));
+      parts.push(quoteArg('--', shell), '--prompt', quoteArg(safePrompt, shell, { multiline: true }));
     }
 
     return parts.join(' ');

--- a/src/main/agent/agent-adapter.ts
+++ b/src/main/agent/agent-adapter.ts
@@ -84,7 +84,14 @@ export interface CommandOptions {
   nonInteractive?: boolean;
   statusOutputPath?: string; // path where the status bridge writes JSON
   eventsOutputPath?: string; // path where the event bridge appends JSONL
-  shell?: string; // target shell name - controls quoting style (single vs double quotes)
+  /**
+   * Target shell name. Controls quoting style (single vs double quotes). The
+   * spawn chokepoints also use it to swap a `.cmd` / `.bat` head for the
+   * sibling shim that shell can run before the builder sees `agentPath`
+   * (src/main/agent/shared/shim-launch.ts); builders never inspect the
+   * extension.
+   */
+  shell?: string;
   mcpServerEnabled?: boolean; // whether to enable Kangentic MCP server (delivery is adapter-specific: --mcp-config flag, settings file, or env var)
   /** In-process MCP HTTP server URL for this project. Required when mcpServerEnabled is true. */
   mcpServerUrl?: string;

--- a/src/main/agent/shared/shim-launch.ts
+++ b/src/main/agent/shared/shim-launch.ts
@@ -1,0 +1,283 @@
+import fs from 'node:fs';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { isPowerShellShell, isUnixLikeShell, sanitizeForPty } from '../../../shared/paths';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Pick the launcher for an agent CLI that resolved to a Windows `.cmd` /
+ * `.bat` shim, so a multi-line prompt survives the trip to the agent (#353).
+ *
+ * `AgentDetector` finds an npm-installed CLI through `which`, which walks
+ * PATHEXT and therefore lands on the `.cmd` shim (`codex.CMD`). Every builder
+ * emits that path as the command head and the task prompt as one quoted
+ * argument, and the spawn flow types the line into the live PTY shell.
+ * PowerShell expands the backtick-n escapes `quoteArg` wrote back into real
+ * newlines, Git Bash passes its single-quoted newlines through as they are,
+ * and then either host launches the `.cmd` through cmd.exe, whose command
+ * line ends at the first newline. The shim's `%*` forwards `"<task>` and the
+ * agent sees `<task>` and nothing else. Measured on Windows PowerShell 5.1,
+ * pwsh 7.6, and Git Bash: no encoding survives cmd.exe.
+ *
+ * npm writes two more shims beside every `.cmd`: a `.ps1` that forwards
+ * `$args` to node.exe, and an extensionless `#!/bin/sh` script that forwards
+ * `"$@"` (with explicit MINGW/MSYS handling). A `$args` splat preserves a
+ * multi-line argument on both PowerShell hosts, and bash to node.exe
+ * preserves it too, so each host gets the sibling native to it. `exit $ret`
+ * inside the `.ps1` ends the script, not the host shell, so the shell
+ * survives the agent exactly as it does with the `.cmd`. The process tree
+ * becomes `pwsh -> node` instead of `pwsh -> cmd.exe -> node`; the
+ * background-shell watcher's immediate-parent rule already counts both
+ * shapes (tests/unit/bg-shell-watcher.test.ts pins each).
+ *
+ * A `.ps1` cannot run when the host's effective execution policy is
+ * Restricted (Windows PowerShell 5.1's client default) or AllSigned, and the
+ * two hosts keep separate policies, so the policy is probed once per shell
+ * per run through the same host executable. With no usable sibling the
+ * `.cmd` stays and the prompt is flattened to one line instead, so the whole
+ * title and description still arrive; that is the reporter's own workaround
+ * and it never regresses a spawn that works today. Nothing here inspects the
+ * agent's name: a `.cmd` shim is a Windows packaging fact, not an agent fact.
+ *
+ * Runs at every spawn chokepoint after `ensureTrust` and before
+ * `buildCommand` (see .claude/rules/spawn-entry-point-parity.md). Import it
+ * by this file's path, never through the `agent/shared` barrel, which several
+ * suites replace with a factory.
+ */
+
+export interface ShimLaunchInput {
+  /** The path `detect()` resolved, possibly a `.cmd` / `.bat` shim. */
+  agentPath: string;
+  /** The shell the PTY types the command into. Undefined leaves the input untouched. */
+  shell: string | undefined;
+  /** The task prompt the builder will quote, if this spawn carries one. */
+  prompt: string | undefined;
+}
+
+export type ShimLaunchStrategy =
+  /** Not Windows, not a batch shim, or a shell that needs no swap. */
+  | 'unchanged'
+  /** PowerShell host: the sibling `.ps1` shim runs the agent. */
+  | 'ps1-sibling'
+  /** Git Bash host: the sibling `#!/bin/sh` shim runs the agent. */
+  | 'sh-sibling'
+  /** The batch shim stays and any prompt is flattened to one line. */
+  | 'flattened-prompt';
+
+export interface ShimLaunch {
+  agentPath: string;
+  prompt: string | undefined;
+  strategy: ShimLaunchStrategy;
+}
+
+/** Injection points for tests; production callers pass nothing. */
+export interface ShimLaunchDependencies {
+  platform?: NodeJS.Platform;
+  fileExists?: (candidatePath: string) => boolean;
+  /** The first bytes of a file, for the `#!` sniff; empty when unreadable. */
+  readFileHead?: (candidatePath: string) => string;
+  /** Trimmed `Get-ExecutionPolicy` output for the shell, or null when the probe failed. */
+  probeExecutionPolicy?: (shell: string) => Promise<string | null>;
+  warn?: (message: string) => void;
+}
+
+const EXECUTION_POLICY_PROBE_TIMEOUT_MS = 5000;
+
+/** Effective policies under which an unsigned local `.ps1` runs. */
+const SCRIPT_ALLOWING_POLICIES = new Set(['remotesigned', 'unrestricted', 'bypass']);
+
+/** One probe per shell string for the life of the process. */
+const executionPolicyProbes = new Map<string, Promise<string | null>>();
+
+/** One warning per shell and agent path, so a busy board does not repeat it per spawn. */
+const warnedLaunches = new Set<string>();
+
+/** `.cmd` / `.bat` by extension, case-insensitive (`which` returns `.CMD`). */
+export function isWindowsBatchShim(agentPath: string): boolean {
+  return /\.(cmd|bat)$/i.test(agentPath);
+}
+
+/**
+ * The sibling shim path: same directory and base name, the given extension.
+ * A string slice on the original path, never `path.join(path.dirname(...))`:
+ * on a posix host `path` would mangle a `C:\...` input, and the base name's
+ * case must survive (`codex.CMD` -> `codex.ps1`).
+ */
+export function shimSibling(agentPath: string, extension: '.ps1' | ''): string {
+  const match = /\.[^./\\]+$/.exec(agentPath);
+  const stem = match ? agentPath.slice(0, match.index) : agentPath;
+  return stem + extension;
+}
+
+/** True when `Get-ExecutionPolicy` output names a policy that runs unsigned local scripts. */
+export function executionPolicyAllowsScripts(policyOutput: string | null): boolean {
+  if (policyOutput === null) return false;
+  return SCRIPT_ALLOWING_POLICIES.has(policyOutput.trim().toLowerCase());
+}
+
+/**
+ * Ask the PowerShell host for its effective execution policy. Uncached; the
+ * resolver caches per shell. Any failure (missing host, timeout, non-zero
+ * exit, empty output) resolves null, which the resolver treats as blocked:
+ * a wrongly allowed `.ps1` fails the launch outright, while a wrongly blocked
+ * one only flattens the prompt.
+ */
+export async function probeExecutionPolicy(shell: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      shell,
+      ['-NoProfile', '-NonInteractive', '-Command', 'Get-ExecutionPolicy'],
+      {
+        env: environmentWithoutModulePath(),
+        timeout: EXECUTION_POLICY_PROBE_TIMEOUT_MS,
+        windowsHide: true,
+        encoding: 'utf-8',
+      },
+    );
+    const policy = stdout.trim();
+    return policy.length > 0 ? policy : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The probe's child environment: the app's own, minus `PSModulePath`.
+ *
+ * Windows PowerShell 5.1 autoloads `Get-ExecutionPolicy` from the
+ * Microsoft.PowerShell.Security module. A `PSModulePath` inherited from a
+ * pwsh 7 ancestor (the dogfood shape: `npm start` from a pwsh terminal, whose
+ * MSIX install lists its own Modules directory) makes 5.1 pick up the pwsh
+ * build of that module and fail with "the module could not be loaded", so the
+ * probe reported null on a machine whose policy was Bypass. Without the
+ * variable each host computes its own default module path; the policy itself
+ * is read from the registry and is unaffected. Matched case-insensitively,
+ * since Windows environment names are.
+ */
+function environmentWithoutModulePath(): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {};
+  for (const [name, value] of Object.entries(process.env)) {
+    if (name.toLowerCase() === 'psmodulepath') continue;
+    environment[name] = value;
+  }
+  return environment;
+}
+
+/** Test-only: forget every probed policy and every warning already issued. */
+export function resetShimLaunchCacheForTests(): void {
+  executionPolicyProbes.clear();
+  warnedLaunches.clear();
+}
+
+function readFileHeadFromDisk(candidatePath: string): string {
+  let descriptor: number | null = null;
+  try {
+    descriptor = fs.openSync(candidatePath, 'r');
+    const buffer = Buffer.alloc(2);
+    const bytesRead = fs.readSync(descriptor, buffer, 0, buffer.length, 0);
+    return buffer.toString('utf8', 0, bytesRead);
+  } catch {
+    return '';
+  } finally {
+    if (descriptor !== null) fs.closeSync(descriptor);
+  }
+}
+
+function cachedExecutionPolicy(
+  shell: string,
+  probe: (shell: string) => Promise<string | null>,
+): Promise<string | null> {
+  const pending = executionPolicyProbes.get(shell);
+  if (pending) return pending;
+  const started = probe(shell).catch(() => null);
+  executionPolicyProbes.set(shell, started);
+  return started;
+}
+
+function isWslShell(shell: string): boolean {
+  return shell.toLowerCase().startsWith('wsl');
+}
+
+function noSiblingMessage(agentPath: string, siblingPath: string): string {
+  return `[shim-launch] ${agentPath} is a cmd.exe batch shim with no ${siblingPath} beside it. `
+    + 'cmd.exe cuts the command line at the first newline, so the task prompt is flattened to one '
+    + 'line for this session. An npm install writes the sibling shims automatically; otherwise point '
+    + 'Settings > Agent at the CLI\'s native executable to keep multi-line prompts.';
+}
+
+function blockedPolicyMessage(
+  agentPath: string,
+  siblingPath: string,
+  shell: string,
+  policy: string | null,
+): string {
+  return `[shim-launch] ${siblingPath} exists but ${shell} reports execution policy `
+    + `"${policy ?? 'unknown'}", which blocks .ps1 scripts, so the agent launches through ${agentPath} `
+    + 'via cmd.exe and the task prompt is flattened to one line. Fix: run '
+    + '"Set-ExecutionPolicy RemoteSigned -Scope CurrentUser" in that PowerShell, then restart '
+    + 'Kangentic (the policy is probed once per shell per run).';
+}
+
+function keepBatchShim(input: ShimLaunchInput, warn: (message: string) => void, message: string): ShimLaunch {
+  // Only a prompt is degraded by the batch shim; a resume or a Command
+  // Terminal carries none, so there is nothing to warn about.
+  if (input.prompt !== undefined) {
+    const key = `${input.shell}\u0000${input.agentPath}`;
+    if (!warnedLaunches.has(key)) {
+      warnedLaunches.add(key);
+      warn(message);
+    }
+  }
+  return {
+    agentPath: input.agentPath,
+    prompt: input.prompt === undefined ? undefined : sanitizeForPty(input.prompt),
+    strategy: 'flattened-prompt',
+  };
+}
+
+/**
+ * Resolve how a spawn should launch `agentPath` under `shell`. The gate order
+ * is load-bearing: no filesystem or process access until the platform, shell,
+ * and extension checks all pass, so a unit test with a fake path never
+ * touches disk or spawns a shell.
+ */
+export async function resolveShimLaunch(
+  input: ShimLaunchInput,
+  dependencies: ShimLaunchDependencies = {},
+): Promise<ShimLaunch> {
+  const platform = dependencies.platform ?? process.platform;
+  const { agentPath, shell, prompt } = input;
+  if (platform !== 'win32' || shell === undefined || !isWindowsBatchShim(agentPath)) {
+    return { agentPath, prompt, strategy: 'unchanged' };
+  }
+  const fileExists = dependencies.fileExists ?? fs.existsSync;
+  const warn = dependencies.warn ?? console.warn;
+
+  if (isPowerShellShell(shell)) {
+    const siblingPath = shimSibling(agentPath, '.ps1');
+    if (!fileExists(siblingPath)) {
+      return keepBatchShim(input, warn, noSiblingMessage(agentPath, siblingPath));
+    }
+    const policy = await cachedExecutionPolicy(shell, dependencies.probeExecutionPolicy ?? probeExecutionPolicy);
+    if (!executionPolicyAllowsScripts(policy)) {
+      return keepBatchShim(input, warn, blockedPolicyMessage(agentPath, siblingPath, shell, policy));
+    }
+    return { agentPath: siblingPath, prompt, strategy: 'ps1-sibling' };
+  }
+
+  if (isUnixLikeShell(shell) && !isWslShell(shell)) {
+    // Git Bash. WSL is excluded: it cannot launch a `.cmd` at all (documented
+    // in docs/cross-platform.md), and the sh shim would run a Windows bundle
+    // under a Linux node, so that route stays as it is.
+    const siblingPath = shimSibling(agentPath, '');
+    const readFileHead = dependencies.readFileHead ?? readFileHeadFromDisk;
+    if (fileExists(siblingPath) && readFileHead(siblingPath).startsWith('#!')) {
+      return { agentPath: siblingPath, prompt, strategy: 'sh-sibling' };
+    }
+    return keepBatchShim(input, warn, noSiblingMessage(agentPath, siblingPath));
+  }
+
+  // cmd.exe host: quoteArg already flattens for it. WSL: see above.
+  return { agentPath, prompt, strategy: 'unchanged' };
+}

--- a/src/main/ipc/handlers/transient-sessions.ts
+++ b/src/main/ipc/handlers/transient-sessions.ts
@@ -10,6 +10,7 @@ import { trackEvent } from '../../analytics/analytics';
 import { trackFeatureUsed } from '../../analytics/usage';
 import { agentRegistry } from '../../agent/agent-registry';
 import { AgentCliNotFoundError } from '../../agent/shared/agent-cli-not-found';
+import { resolveShimLaunch } from '../../agent/shared/shim-launch';
 import { DEFAULT_AGENT } from '../../../shared/types';
 import type {
   SpawnTransientSessionInput,
@@ -41,6 +42,9 @@ export function registerTransientSessionHandlers(context: IpcContext): void {
 
     const detection = await adapter.detect(cliPathOverride);
     if (!detection.found || !detection.path) throw new AgentCliNotFoundError(agentName, adapter.displayName);
+    // The shell the PTY types the command into: it decides the quoting style
+    // and which shim variant a `.cmd` head is swapped for (shim-launch.ts).
+    const shell = await context.sessionManager.getShell();
     const permissionMode = config.agent.permissionMode as PermissionMode;
     const transientTaskId = uuidv4();
 
@@ -88,14 +92,28 @@ export function registerTransientSessionHandlers(context: IpcContext): void {
     const statusOutputPath = path.join(sessionDirectory, 'status.json');
     const eventsOutputPath = path.join(sessionDirectory, 'activity.json');
 
+    // The same pre-spawn global-config step the task chokepoints run: trust
+    // for the project root, kangentic pre-enabled in the agent's MCP list, and
+    // Claude's diff panel closed. A Command Terminal is the likeliest maximized
+    // pane, so it needs the diff-panel write most of all. Pinned by
+    // tests/unit/spawn-entry-point-parity.test.ts (line order) and
+    // tests/unit/transient-session-spawn-ensure-trust.test.ts (the runtime
+    // guarantee: awaited, called once, with projectRoot, before buildCommand).
+    await adapter.ensureTrust(projectRoot);
+    // A `.cmd` head under a PowerShell or Git Bash host launches through
+    // cmd.exe; hand the builder the sibling shim the shell can run instead
+    // (shim-launch.ts). No prompt here, but the head must match what task
+    // spawns use, so a Command Terminal never runs a different process shape.
+    const launch = await resolveShimLaunch({ agentPath: detection.path, shell, prompt: undefined });
     const commandOptions = {
-      agentPath: detection.path,
+      agentPath: launch.agentPath,
       taskId: transientTaskId,
       cwd: projectRoot,
       permissionMode,
       projectRoot,
       statusOutputPath,
       eventsOutputPath,
+      shell,
       mcpServerEnabled: config.mcpServer.enabled,
       mcpServerUrl: context.mcpServerHandle?.urlForProject(input.projectId),
       mcpServerToken: context.mcpServerHandle?.token,
@@ -105,14 +123,6 @@ export function registerTransientSessionHandlers(context: IpcContext): void {
       model: project.default_model ?? undefined,
       effort: project.default_effort ?? undefined,
     };
-    // The same pre-spawn global-config step the task chokepoints run: trust
-    // for the project root, kangentic pre-enabled in the agent's MCP list, and
-    // Claude's diff panel closed. A Command Terminal is the likeliest maximized
-    // pane, so it needs the diff-panel write most of all. Pinned by
-    // tests/unit/spawn-entry-point-parity.test.ts (line order) and
-    // tests/unit/transient-session-spawn-ensure-trust.test.ts (the runtime
-    // guarantee: awaited, called once, with projectRoot, before buildCommand).
-    await adapter.ensureTrust(projectRoot);
     const command = adapter.buildCommand(commandOptions);
     const extraEnv = adapter.buildEnv?.(commandOptions) ?? null;
 

--- a/src/main/pty/spawn/pty-spawn.ts
+++ b/src/main/pty/spawn/pty-spawn.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import os from 'node:os';
-import { isUncPath, isCmdShell } from '../../../shared/paths';
+import { isUncPath, isCmdShell, isPowerShellShell } from '../../../shared/paths';
 import { trackEvent, sanitizeErrorMessage } from '../../analytics/analytics';
 import { reportHandledError } from '../../analytics/error-reporting';
 
@@ -33,7 +33,7 @@ export function resolveShellArgs(shell: string): ShellInvocation {
     return { exe: executable, args: parts.slice(1) };
   }
   if (shellName.includes('cmd')) return { exe: shell, args: [] };
-  if (shellName.includes('powershell') || shellName.includes('pwsh')) {
+  if (isPowerShellShell(shellName)) {
     return { exe: shell, args: ['-NoLogo'] };
   }
   if (shellName.includes('fish') || shellName.includes('nu')) {
@@ -238,16 +238,12 @@ export function resolveSpawnCwd(input: {
     });
   }
 
-  const lowerShellName = input.shellName.toLowerCase();
   let cwdFixupCommand: string | null = null;
   if (input.platform === 'win32') {
     if (isUncPath(effectiveCwd) && isCmdShell(input.shellName)) {
       cwdFixupCommand = `pushd "${effectiveCwd}"`;
       effectiveCwd = os.homedir();
-    } else if (
-      (lowerShellName.includes('powershell') || lowerShellName.includes('pwsh'))
-      && /[[\]]/.test(effectiveCwd)
-    ) {
+    } else if (isPowerShellShell(input.shellName) && /[[\]]/.test(effectiveCwd)) {
       const escapedCwd = effectiveCwd.replace(/'/g, "''");
       cwdFixupCommand = `Set-Location -LiteralPath '${escapedCwd}'`;
     }

--- a/src/main/transition-engine/session-startup/prepare-spawn.ts
+++ b/src/main/transition-engine/session-startup/prepare-spawn.ts
@@ -16,6 +16,7 @@ import { isResumeConversationAbsent } from '../resume-conversation-guard';
 import type { SessionRepository } from '../../db/repositories/session-repository';
 import { resolveExecutionTarget } from '../../agent/shared/execution-target';
 import { resolveLaunchOptions } from '../../agent/shared/launch-options';
+import { resolveShimLaunch } from '../../agent/shared/shim-launch';
 
 /**
  * Fully-prepared agent spawn: the adapter has been resolved, the CLI
@@ -167,6 +168,16 @@ export async function prepareAgentSpawn(input: {
 
   await adapter.ensureTrust(cwd);
 
+  // Same shim resolution as the board path (shim-launch.ts): a `.cmd` head
+  // under a PowerShell or Git Bash host is swapped for the sibling shim that
+  // shell can run. This path never carries a prompt, but a crash-recovered
+  // session must launch through the same head the board spawn used.
+  const launch = await resolveShimLaunch({
+    agentPath: detection.path,
+    shell: input.resolvedShell,
+    prompt: undefined,
+  });
+
   // "Plan always wins, else task -> lane -> global" - the rule lives in
   // resolveEffectivePermissionMode (spawn-preamble.ts).
   const permissionMode = resolveEffectivePermissionMode(
@@ -219,7 +230,7 @@ export async function prepareAgentSpawn(input: {
   const { statusOutputPath, eventsOutputPath } = sessionOutputPaths(sessionDir);
 
   const commandOptions = {
-    agentPath: detection.path,
+    agentPath: launch.agentPath,
     taskId: task.id,
     prompt: undefined,
     cwd,

--- a/src/main/transition-engine/transition-engine.ts
+++ b/src/main/transition-engine/transition-engine.ts
@@ -9,6 +9,7 @@ import type { TerminalSubmit } from '../pty/terminal-submit';
 import { interpolateTemplate, resolveTaskTemplateVars } from '../agent/shared';
 import { resolveExecutionTarget } from '../agent/shared/execution-target';
 import { resolveLaunchOptions } from '../agent/shared/launch-options';
+import { resolveShimLaunch } from '../agent/shared/shim-launch';
 import { WorktreeManager, prepareWorktreeForRemoval, GitQueuePriority } from '../git/worktree-manager';
 import { prepareWorktreeFolder } from '../git/task-worktree-folder';
 import { agentRegistry } from '../agent/agent-registry';
@@ -338,12 +339,19 @@ export class TransitionEngine {
     const { statusOutputPath, eventsOutputPath } = sessionOutputPaths(sessionDir);
 
     const shell = await this.sessionManager.getShell();
+    // A `.cmd` head under a PowerShell or Git Bash host hands the multi-line
+    // prompt to cmd.exe, which keeps only its first line (#353). Swap in the
+    // sibling shim the host can run, else flatten the prompt. Sits after
+    // ensureTrust and before buildCommand (spawn-entry-point-parity). The
+    // session row below persists the ORIGINAL prompt: flattening is a
+    // delivery detail, not what the user wrote.
+    const launch = await resolveShimLaunch({ agentPath: detection.path, shell, prompt });
     const executionTarget = resolveExecutionTarget(agentName, appConfig.executionServers, appConfig.execution) ?? undefined;
     const launchOptions = resolveLaunchOptions(adapter, appConfig.launchOptions);
     const commandOptions = {
-      agentPath: detection.path,
+      agentPath: launch.agentPath,
       taskId: task.id,
-      prompt,
+      prompt: launch.prompt,
       cwd,
       permissionMode,
       projectRoot: appConfig.projectPath || undefined,

--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -107,11 +107,7 @@ export function toWslPath(windowsPath: string): string {
  */
 export function isUnixLikeShell(shellName: string): boolean {
   const lower = shellName.toLowerCase();
-  return (
-    !lower.includes('cmd') &&
-    !lower.includes('powershell') &&
-    !lower.includes('pwsh')
-  );
+  return !lower.includes('cmd') && !isPowerShellShell(lower);
 }
 
 /**
@@ -127,6 +123,21 @@ export function isUnixLikeShell(shellName: string): boolean {
 export function isCmdShell(shellName: string): boolean {
   const basename = shellName.toLowerCase().split(/[\\/]/).pop() ?? '';
   return basename.replace(/\.exe$/, '') === 'cmd';
+}
+
+/**
+ * True for the PowerShell family: Windows PowerShell 5.1 (`powershell.exe`)
+ * and PowerShell 7 (`pwsh.exe`), whether the shell spec is a bare picker
+ * name or a full path.
+ *
+ * A substring match on purpose, not the basename anchor `isCmdShell` uses:
+ * this is the exact test `isUnixLikeShell` negates, and the two must agree
+ * on every input or a spec could be neither unix-like nor PowerShell. Keep
+ * them in step if one ever tightens.
+ */
+export function isPowerShellShell(shellName: string): boolean {
+  const lower = shellName.toLowerCase();
+  return lower.includes('powershell') || lower.includes('pwsh');
 }
 
 /**
@@ -151,8 +162,7 @@ export function isCmdShell(shellName: string): boolean {
  * WSL all ship a `clear` builtin/binary), cmd chains with `&`.
  */
 export function buildSpawnClearPrelude(shellName: string): string {
-  const lower = shellName.toLowerCase();
-  if (lower.includes('powershell') || lower.includes('pwsh')) {
+  if (isPowerShellShell(shellName)) {
     return 'Clear-Host; ';
   }
   if (isCmdShell(shellName)) {
@@ -182,7 +192,7 @@ export function adaptCommandForShell(
 
   const lower = shellName.toLowerCase();
 
-  if (lower.includes('powershell') || lower.includes('pwsh')) {
+  if (isPowerShellShell(lower)) {
     return '& ' + cmd;
   }
 
@@ -242,12 +252,28 @@ export function sanitizeForPty(text: string): string {
  *    physical line and let PowerShell's escape parser produce the newlines.
  *  - cmd.exe: no escape syntax for embedded newlines; falls back to the
  *    sanitised single-line form.
+ *
+ * The PowerShell strategy holds only while PowerShell launches the target
+ * binary itself. When the command head is a `.cmd` / `.bat` shim (an npm
+ * global install on Windows), PowerShell expands the escapes and hands the
+ * result to cmd.exe, whose command line ends at the first newline, so the
+ * agent sees the first line only (#353). The spawn chokepoints route such
+ * heads through `resolveShimLaunch` (src/main/agent/shared/shim-launch.ts)
+ * before any builder runs, so builders may keep relying on this contract.
+ *
+ * A bare `--` is quoted for PowerShell hosts. PowerShell's parameter binder
+ * consumes an unquoted `--` before a `.ps1` script (the npm shim
+ * `resolveShimLaunch` prefers) sees `$args`, while the quoted form reaches
+ * native commands and cmd.exe as a plain `--` on every route.
  */
 export function quoteArg(
   arg: string,
   shell?: string,
   options?: { multiline?: boolean },
 ): string {
+  if (arg === '--' && shell !== undefined && isPowerShellShell(shell)) {
+    return '"--"';
+  }
   if (/^[a-zA-Z0-9_./:-]+$/.test(arg)) {
     return arg;
   }

--- a/tests/e2e/task-prompt.spec.ts
+++ b/tests/e2e/task-prompt.spec.ts
@@ -197,6 +197,15 @@ async function waitForTaskPromptScrollback(taskId: string, timeoutMs = 15000): P
   throw new Error(`Timed out waiting for task ${taskId} to print ${marker}`);
 }
 
+/**
+ * The mock's own prompt output: everything from its MOCK_CLAUDE_PROMPT:
+ * marker on. Asserting the title here rather than on the whole scrollback is
+ * what makes a truncated prompt fail (see the first test's comment).
+ */
+function promptPayload(scrollback: string): string {
+  return scrollback.slice(scrollback.indexOf('MOCK_CLAUDE_PROMPT:'));
+}
+
 test.describe('Claude Agent -- Task Prompt', () => {
   test.beforeEach(async () => {
     await ensureBoard();
@@ -215,8 +224,15 @@ test.describe('Claude Agent -- Task Prompt', () => {
     // marker (mock-owned, task-scoped - see waitForTaskPromptScrollback).
     const scrollback = await waitForTaskPromptScrollback(taskId);
 
-    // Verify both title and description are in the prompt
-    expect(scrollback).toContain(title);
+    // The title is asserted on the mock's own payload (everything from its
+    // marker on), never on the whole scrollback: the shell's echo of the typed
+    // command line precedes the marker and embeds the full <task> XML, so a
+    // whole-scrollback check passed even when the mock had received only
+    // "<task>" (#353: on Windows the npm .cmd shim hands the prompt to cmd.exe,
+    // which keeps its first line). The title line is about 45 chars, far under
+    // any column count, so no wrap can split it; the 78-char description line
+    // is borderline at 80 cols and stays on the whole scrollback.
+    expect(promptPayload(scrollback)).toContain(title);
     expect(scrollback).toContain(description);
   });
 
@@ -237,7 +253,7 @@ test.describe('Claude Agent -- Task Prompt', () => {
     // already earlier in that same ordered stream.
     const scrollback = await waitForTaskPromptScrollback(taskId);
 
-    expect(scrollback).toContain(title);
+    expect(promptPayload(scrollback)).toContain(title);
     expect(scrollback).toContain(description);
     // Planning column uses --permission-mode plan. Assert on the mock's own
     // labeled marker line (MOCK_CLAUDE_PERMISSION_MODE:plan), not on the raw
@@ -265,7 +281,7 @@ test.describe('Claude Agent -- Task Prompt', () => {
     const scrollback = await waitForTaskPromptScrollback(taskId);
 
     // The full description should be in the prompt
-    expect(scrollback).toContain(title);
+    expect(promptPayload(scrollback)).toContain(title);
     expect(scrollback).toContain(description);
   });
 });

--- a/tests/unit/adapter-multiline-prompt.test.ts
+++ b/tests/unit/adapter-multiline-prompt.test.ts
@@ -119,6 +119,29 @@ describe('Adapter multiline prompt - regression guard for { multiline: true }', 
     expect(command).not.toContain('\n');
   });
 
+  it('CodexCommandBuilder keeps the prompt multiline under PowerShell even when codexPath is still the .cmd head', () => {
+    // The deleted `usesPowerShellCmdShim` predicate flattened only when BOTH
+    // the shell was PowerShell AND codexPath ended in .cmd. The case above
+    // uses a .ps1 path, which never matched that predicate either, so it
+    // would pass whether or not the deleted branch came back. This is the
+    // one case a reverted flatten actually trips: a .cmd head under
+    // PowerShell. It runs on every CI OS, unlike the real-shim coverage in
+    // tests/unit/windows-cmd-shim-multiline-prompt.test.ts, which is
+    // describe.runIf(IS_WINDOWS) and skipped on Linux CI.
+    const builder = new CodexCommandBuilder();
+    const command = builder.buildCodexCommand({
+      codexPath: 'C:/Users/dev/AppData/Roaming/npm/codex.cmd',
+      taskId: 'task-1',
+      cwd: 'C:/project',
+      permissionMode: 'default',
+      shell: 'powershell',
+      prompt: MULTILINE_XML,
+    });
+
+    expect(command).toContain('`n');
+    expect(command).not.toContain('\n');
+  });
+
   it('AiderAdapter.buildCommand preserves newlines in prompt under bash', () => {
     const adapter = new AiderAdapter();
     const command = adapter.buildCommand({

--- a/tests/unit/adapter-multiline-prompt.test.ts
+++ b/tests/unit/adapter-multiline-prompt.test.ts
@@ -93,10 +93,19 @@ describe('Adapter multiline prompt - regression guard for { multiline: true }', 
     expect(command).toContain(EXPECTED_FRAGMENT);
   });
 
-  it('CodexCommandBuilder flattens multiline prompts for PowerShell CMD shims', () => {
+  it('CodexCommandBuilder keeps the prompt multiline under PowerShell, since the chokepoint owns the .cmd decision', () => {
+    // The narrow form of the #353 fix flattened here, in the builder, whenever
+    // the head was a .cmd and the shell was PowerShell. That moved to
+    // resolveShimLaunch (src/main/agent/shared/shim-launch.ts), which runs at
+    // every spawn chokepoint and either swaps in the sibling shim that carries
+    // newlines or flattens the prompt before any builder sees it. So the head
+    // a builder receives is already safe for the shell, and every adapter can
+    // keep one unconditional multiline contract instead of fourteen copies of
+    // a Windows packaging rule. Delivery through a REAL .cmd shim is pinned by
+    // tests/unit/windows-cmd-shim-multiline-prompt.test.ts.
     const builder = new CodexCommandBuilder();
     const command = builder.buildCodexCommand({
-      codexPath: 'C:/Users/dev/AppData/Roaming/npm/codex.CMD',
+      codexPath: 'C:/Users/dev/AppData/Roaming/npm/codex.ps1',
       taskId: 'task-1',
       cwd: 'C:/project',
       permissionMode: 'default',
@@ -104,9 +113,10 @@ describe('Adapter multiline prompt - regression guard for { multiline: true }', 
       prompt: MULTILINE_XML,
     });
 
+    // PowerShell's own escape for a newline, which its parser expands back
+    // before the child sees the argument.
+    expect(command).toContain('`n');
     expect(command).not.toContain('\n');
-    expect(command).not.toContain('`n');
-    expect(command).toContain('"<task> <title>Fix login</title> <description> Step 1. Step 2. </description> </task>"');
   });
 
   it('AiderAdapter.buildCommand preserves newlines in prompt under bash', () => {

--- a/tests/unit/command-builder.test.ts
+++ b/tests/unit/command-builder.test.ts
@@ -954,6 +954,29 @@ describe('adapter command composed through adaptCommandForShell', () => {
   });
 });
 
+// The real CommandBuilder.buildClaudeCommand's "--" end-of-options guard
+// (as opposed to the deliberately simplified inline buildClaudeCommand()
+// helper above, which never went through quoteArg for the marker) was never
+// exercised under a PowerShell-family shell, so a revert of the
+// `quoteArg('--', shell)` call back to a bare '--' literal passed every test
+// in this file until this one was added.
+describe('CommandBuilder buildClaudeCommand: quoted "--" end-of-options guard under PowerShell', () => {
+  it('quotes the -- marker before the prompt when the shell is PowerShell', () => {
+    const cmd = new CommandBuilder().buildClaudeCommand({
+      cliPath: '/usr/bin/claude',
+      taskId: 'task-1',
+      cwd: '/project',
+      permissionMode: 'default',
+      sessionId: 'sess-123',
+      shell: 'powershell',
+      prompt: 'Simple task description',
+    });
+
+    expect(cmd).toContain('"--"');
+    expect(cmd).toContain('Simple task description');
+  });
+});
+
 describe('Status Bridge Script', () => {
   const bridgePath = path.resolve(__dirname, '../../src/main/agent/status-bridge.js');
 

--- a/tests/unit/command-builder.test.ts
+++ b/tests/unit/command-builder.test.ts
@@ -12,6 +12,7 @@ import os from 'node:os';
 import {
   quoteArg,
   isCmdShell,
+  isPowerShellShell,
   adaptCommandForShell,
   convertWindowsExePath,
   sanitizeForPty,
@@ -252,6 +253,67 @@ describe('Command Builder Logic', () => {
     expect(isCmdShell('bash')).toBe(false);
     expect(isCmdShell('powershell')).toBe(false);
     expect(isCmdShell('pwsh')).toBe(false);
+  });
+
+  it('isPowerShellShell matches the PowerShell family as a bare name, an .exe, or a full path', () => {
+    expect(isPowerShellShell('powershell')).toBe(true);
+    expect(isPowerShellShell('pwsh')).toBe(true);
+    expect(isPowerShellShell('PowerShell')).toBe(true);
+    expect(isPowerShellShell('PWSH')).toBe(true);
+    expect(isPowerShellShell('powershell.exe')).toBe(true);
+    expect(isPowerShellShell('pwsh.exe')).toBe(true);
+    expect(isPowerShellShell('C:\\Program Files\\PowerShell\\7\\pwsh.exe')).toBe(true);
+    expect(isPowerShellShell('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe')).toBe(true);
+    expect(isPowerShellShell('C:/Program Files/PowerShell/7/pwsh.exe')).toBe(true);
+
+    expect(isPowerShellShell('cmd.exe')).toBe(false);
+    expect(isPowerShellShell('C:\\Windows\\System32\\cmd.exe')).toBe(false);
+    expect(isPowerShellShell('bash')).toBe(false);
+    expect(isPowerShellShell('C:\\Program Files\\Git\\bin\\bash.exe')).toBe(false);
+    expect(isPowerShellShell('zsh')).toBe(false);
+    expect(isPowerShellShell('fish')).toBe(false);
+    expect(isPowerShellShell('nu')).toBe(false);
+    expect(isPowerShellShell('/bin/sh')).toBe(false);
+    expect(isPowerShellShell('wsl -d Ubuntu')).toBe(false);
+  });
+
+  it('isPowerShellShell agrees with the inline substring test it replaced for every real shell form', () => {
+    // buildSpawnClearPrelude, adaptCommandForShell, resolveShellArgs, and
+    // resolveSpawnCwd each carried their own copy of this test. The predicate
+    // must stay behavior-identical for what the Windows picker stores, and it
+    // must be the exact negation isUnixLikeShell applies, so a spec can never
+    // be neither unix-like nor PowerShell.
+    const pickerForms = [
+      'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+      'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+      'C:\\Program Files\\Git\\bin\\bash.exe',
+      'C:\\Windows\\System32\\cmd.exe',
+      'wsl -d Ubuntu',
+      'powershell',
+      'pwsh',
+      '/bin/zsh',
+    ];
+    for (const form of pickerForms) {
+      const lower = form.toLowerCase();
+      expect(isPowerShellShell(form)).toBe(lower.includes('powershell') || lower.includes('pwsh'));
+    }
+  });
+
+  it('quoteArg quotes a bare -- for PowerShell hosts only', () => {
+    // PowerShell's parameter binder consumes an unquoted -- before a .ps1
+    // script (the npm shim resolveShimLaunch prefers) sees $args, so the
+    // end-of-options guard the Claude/Grok/Ollama/Warp builders emit would
+    // vanish on that route. The quoted form reaches every launcher as `--`.
+    expect(quoteArg('--', 'pwsh')).toBe('"--"');
+    expect(quoteArg('--', 'powershell')).toBe('"--"');
+    expect(quoteArg('--', 'C:\\Program Files\\PowerShell\\7\\pwsh.exe')).toBe('"--"');
+
+    expect(quoteArg('--', 'bash')).toBe('--');
+    expect(quoteArg('--', 'cmd')).toBe('--');
+    expect(quoteArg('--', 'wsl -d Ubuntu')).toBe('--');
+    expect(quoteArg('--')).toBe('--');
+    // Only the exact marker: a flag that starts with -- is an ordinary token.
+    expect(quoteArg('--prompt', 'pwsh')).toBe('--prompt');
   });
 
   it('PowerShell call operator prefix', () => {

--- a/tests/unit/event-activity-derivation-2.test.ts
+++ b/tests/unit/event-activity-derivation-2.test.ts
@@ -41,7 +41,8 @@ vi.mock('../../src/main/pty/spawn/shell-resolver', () => {
   return { ShellResolver: MockShellResolver };
 });
 
-vi.mock('../../src/shared/paths', () => ({
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
   adaptCommandForShell: (cmd: string) => cmd,
   buildSpawnClearPrelude: () => '',
   isUncPath: (p: string) => /^[\\/]{2}[^\\/]/.test(p),

--- a/tests/unit/event-activity-derivation.test.ts
+++ b/tests/unit/event-activity-derivation.test.ts
@@ -41,7 +41,8 @@ vi.mock('../../src/main/pty/spawn/shell-resolver', () => {
   return { ShellResolver: MockShellResolver };
 });
 
-vi.mock('../../src/shared/paths', () => ({
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
   adaptCommandForShell: (cmd: string) => cmd,
   buildSpawnClearPrelude: () => '',
   isUncPath: (p: string) => /^[\\/]{2}[^\\/]/.test(p),

--- a/tests/unit/grok-adapter.test.ts
+++ b/tests/unit/grok-adapter.test.ts
@@ -289,6 +289,17 @@ describe('GrokCommandBuilder', () => {
     expect(command).toContain("'hello'");
   });
 
+  it('quotes the "--" end-of-options guard for PowerShell hosts', () => {
+    // PowerShell's binder consumes a bare -- before a .ps1 shim sees $args,
+    // so the guard must reach the process through quoteArg's quoted form.
+    const command = builder.buildGrokCommand({
+      ...baseOptions,
+      shell: 'powershell',
+      prompt: 'fix the bug',
+    });
+    expect(command).toContain('"--"');
+  });
+
   it('routes per-session values through env, never argv', () => {
     const options = {
       ...baseOptions,

--- a/tests/unit/ollama-adapter.test.ts
+++ b/tests/unit/ollama-adapter.test.ts
@@ -245,6 +245,14 @@ describe('OllamaAdapter', () => {
         expect(command).toContain('"broken"');
       });
 
+      it('quotes the "--" end-of-options guard for PowerShell hosts', () => {
+        // PowerShell's binder consumes a bare -- before a .ps1 shim sees
+        // $args, so the guard must reach the process through quoteArg's
+        // quoted form.
+        const command = adapter.buildCommand(makeOptions({ prompt: 'fix the bug', shell: 'powershell' }));
+        expect(command).toContain('"--"');
+      });
+
       // ── process.platform fallback (no shell provided) ─────────────────
       // buildCommand falls back to `process.platform === 'win32'` when no
       // shell is supplied. The two tests below cover the unreached arm on CI

--- a/tests/unit/prepare-spawn-shim-launch-wiring.test.ts
+++ b/tests/unit/prepare-spawn-shim-launch-wiring.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Wiring test: prepareAgentSpawn (the STARTUP spawn chokepoint) resolves the
+ * shim launch before building the command (src/main/agent/shared/shim-launch.ts).
+ *
+ * On Windows an npm-installed CLI resolves to its `.cmd` shim, which a
+ * PowerShell or Git Bash host launches through cmd.exe, and cmd.exe keeps only
+ * the first line of a multi-line prompt (#353). resolveShimLaunch swaps in the
+ * sibling shim the host can run. This path never carries a prompt, but a
+ * crash-recovered session must launch through the same head the board spawn
+ * used, so the swap has to happen here too.
+ *
+ * The helper is mocked with a pass-through default so the REAL
+ * prepareAgentSpawn runs end to end on every OS; one test swaps the head to
+ * prove the builder sees the helper's result, not detect()'s. A separate file
+ * from prepare-spawn-first-spawn-lock.test.ts because vi.mock is file-global
+ * and the lock tests should keep exercising the unmocked import.
+ *
+ * Red-green: building from `detection.path` instead of `launch.agentPath`
+ * fails the swap test; dropping the `await` or moving the call above
+ * ensureTrust fails the ordering test; feeding buildEnv a second options
+ * object fails the shared-options test.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AppConfig, Swimlane, Task } from '../../src/shared/types';
+
+const CMD_HEAD = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.CMD';
+const PS1_SIBLING = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.ps1';
+const PWSH = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe';
+
+const resolveShimLaunchMock = vi.hoisted(() =>
+  vi.fn(async (input: { agentPath: string; shell: string | undefined; prompt: string | undefined }) => ({
+    agentPath: input.agentPath,
+    prompt: input.prompt,
+    strategy: 'unchanged' as const,
+  })),
+);
+
+vi.mock('../../src/main/agent/shared/shim-launch', () => ({
+  resolveShimLaunch: resolveShimLaunchMock,
+}));
+
+const buildCommandMock = vi.fn(() => 'codex --mock-run');
+const buildEnvMock = vi.fn(() => null);
+const ensureTrustMock = vi.fn(async () => {});
+
+const adapter = {
+  name: 'codex',
+  displayName: 'Codex',
+  sessionType: 'codex_agent',
+  supportsCallerSessionId: false,
+  detect: vi.fn(async () => ({ found: true, path: CMD_HEAD, version: '1.0.0' })),
+  ensureTrust: ensureTrustMock,
+  buildCommand: buildCommandMock,
+  buildEnv: buildEnvMock,
+};
+
+vi.mock('../../src/main/agent/agent-registry', () => ({
+  agentRegistry: {
+    get: vi.fn((agentName: string) => (agentName === 'codex' ? adapterRef : undefined)),
+  },
+}));
+
+// prepareAgentSpawn creates the on-disk session directory; keep it virtual.
+vi.mock('node:fs', () => ({
+  default: {
+    mkdirSync: vi.fn(),
+  },
+}));
+
+// Referenced from the vi.mock factory above (hoisted), so declared via
+// module scope after the mock declarations run.
+const adapterRef = adapter;
+
+import { prepareAgentSpawn } from '../../src/main/transition-engine/session-startup/prepare-spawn';
+
+const TASK_ID = 'task-startup-shim-001';
+const LANE_ID = 'lane-review';
+
+function makeTask(): Task {
+  return {
+    id: TASK_ID,
+    display_id: 1,
+    title: 'Startup task',
+    description: 'Recover me',
+    swimlane_id: LANE_ID,
+    position: 0,
+    agent: 'codex',
+    agent_override: null,
+    model_override: null,
+    effort_override: null,
+    permission_mode: null,
+    run_mode: 'column_settings',
+    session_id: null,
+    worktree_path: null,
+    branch_name: null,
+    pr_number: null,
+    pr_url: null,
+    base_branch: null,
+    use_worktree: null,
+    labels: [],
+    priority: 0,
+    attachment_count: 0,
+    archived_at: null,
+    created_at: '2025-01-01T00:00:00.000Z',
+    updated_at: '2025-01-01T00:00:00.000Z',
+  } as Task;
+}
+
+function makeSwimlane(): Swimlane {
+  return {
+    id: LANE_ID,
+    name: 'Review',
+    role: null,
+    position: 0,
+    color: '#888',
+    icon: null,
+    is_archived: false,
+    is_ghost: false,
+    permission_mode: null,
+    auto_spawn: true,
+    auto_command: null,
+    plan_exit_target_id: null,
+    agent_override: null,
+    model_override: null,
+    effort_override: null,
+    handoff_context: false,
+    session_target: 'main',
+    session_spawn_strategy: 'create_or_resume',
+    created_at: '2025-01-01T00:00:00.000Z',
+  } as Swimlane;
+}
+
+function makeEffectiveConfig(): AppConfig {
+  return {
+    agent: {
+      permissionMode: 'acceptEdits',
+      cliPaths: {},
+    },
+    mcpServer: { enabled: false },
+  } as unknown as AppConfig;
+}
+
+async function runPrepare() {
+  return prepareAgentSpawn({
+    task: makeTask(),
+    swimlane: makeSwimlane(),
+    cwd: '/mock/project',
+    projectId: 'proj-123',
+    projectPath: '/mock/project',
+    effectiveConfig: makeEffectiveConfig(),
+    projectDefaultAgent: 'codex',
+    projectDefaultModel: null,
+    projectDefaultEffort: null,
+    resolvedShell: PWSH,
+    mcpServerHandle: null,
+    resume: null,
+    hasSessionRecord: true,
+    tasks: { update: vi.fn() },
+  });
+}
+
+describe('prepareAgentSpawn: Windows .cmd shim launch resolution wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hands the detected path, the resolved shell, and an undefined prompt to resolveShimLaunch', async () => {
+    const result = await runPrepare();
+
+    expect(result.ok).toBe(true);
+    expect(resolveShimLaunchMock).toHaveBeenCalledTimes(1);
+    expect(resolveShimLaunchMock).toHaveBeenCalledWith({ agentPath: CMD_HEAD, shell: PWSH, prompt: undefined });
+  });
+
+  it('builds the command from the resolved head, not the detected one', async () => {
+    resolveShimLaunchMock.mockResolvedValueOnce({ agentPath: PS1_SIBLING, prompt: undefined, strategy: 'ps1-sibling' });
+
+    const result = await runPrepare();
+
+    expect(result.ok).toBe(true);
+    expect(buildCommandMock).toHaveBeenCalledTimes(1);
+    expect(buildCommandMock.mock.calls[0][0]).toMatchObject({ agentPath: PS1_SIBLING, shell: PWSH, prompt: undefined });
+  });
+
+  it('resolves after ensureTrust and before buildCommand', async () => {
+    await runPrepare();
+
+    const ensureTrustOrder = ensureTrustMock.mock.invocationCallOrder[0];
+    const resolveOrder = resolveShimLaunchMock.mock.invocationCallOrder[0];
+    const buildOrder = buildCommandMock.mock.invocationCallOrder[0];
+    expect(ensureTrustOrder).toBeLessThan(resolveOrder);
+    expect(resolveOrder).toBeLessThan(buildOrder);
+  });
+
+  it('passes the same resolved options object to buildEnv', async () => {
+    resolveShimLaunchMock.mockResolvedValueOnce({ agentPath: PS1_SIBLING, prompt: undefined, strategy: 'ps1-sibling' });
+
+    await runPrepare();
+
+    expect(buildEnvMock).toHaveBeenCalledTimes(1);
+    expect(buildEnvMock.mock.calls[0][0]).toBe(buildCommandMock.mock.calls[0][0]);
+  });
+});

--- a/tests/unit/session-exit-intentional.test.ts
+++ b/tests/unit/session-exit-intentional.test.ts
@@ -79,7 +79,8 @@ vi.mock('../../src/main/pr/pr-registry', () => ({
   detectPR: vi.fn(() => null),
 }));
 
-vi.mock('../../src/shared/paths', () => ({
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
   adaptCommandForShell: (cmd: string) => cmd,
   // performSpawn's deferred command write calls this ~100ms after every
   // spawn under this file's REAL timers; a factory without it throws

--- a/tests/unit/session-manager-activity-reasons-cache.test.ts
+++ b/tests/unit/session-manager-activity-reasons-cache.test.ts
@@ -22,7 +22,8 @@ vi.mock('../../src/main/pty/spawn/shell-resolver', () => {
   return { ShellResolver: MockShellResolver };
 });
 
-vi.mock('../../src/shared/paths', () => ({
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
   adaptCommandForShell: (command: string) => command,
   buildSpawnClearPrelude: () => '',
   isUncPath: (p: string) => /^[\\/]{2}[^\\/]/.test(p),

--- a/tests/unit/session-manager-agent-absence.test.ts
+++ b/tests/unit/session-manager-agent-absence.test.ts
@@ -38,7 +38,8 @@ vi.mock('../../src/main/pty/spawn/shell-resolver', () => {
   return { ShellResolver: MockShellResolver };
 });
 
-vi.mock('../../src/shared/paths', () => ({
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
   adaptCommandForShell: (command: string) => command,
   buildSpawnClearPrelude: () => '',
   isUncPath: (candidatePath: string) => /^[\\/]{2}[^\\/]/.test(candidatePath),

--- a/tests/unit/session-manager-data-tap.test.ts
+++ b/tests/unit/session-manager-data-tap.test.ts
@@ -28,7 +28,8 @@ vi.mock('../../src/main/pty/spawn/shell-resolver', () => {
   return { ShellResolver: MockShellResolver };
 });
 
-vi.mock('../../src/shared/paths', () => ({
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
   adaptCommandForShell: (cmd: string) => cmd,
   buildSpawnClearPrelude: () => '',
   isUncPath: (p: string) => /^[\\/]{2}[^\\/]/.test(p),

--- a/tests/unit/session-manager-placeholder-emit.test.ts
+++ b/tests/unit/session-manager-placeholder-emit.test.ts
@@ -26,7 +26,8 @@ vi.mock('../../src/main/pty/spawn/shell-resolver', () => {
   return { ShellResolver: MockShellResolver };
 });
 
-vi.mock('../../src/shared/paths', () => ({
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
   adaptCommandForShell: (command: string) => command,
   buildSpawnClearPrelude: () => '',
   isUncPath: (p: string) => /^[\\/]{2}[^\\/]/.test(p),

--- a/tests/unit/session-manager-prompt-draft-wiring.test.ts
+++ b/tests/unit/session-manager-prompt-draft-wiring.test.ts
@@ -32,7 +32,8 @@ vi.mock('../../src/main/pty/spawn/shell-resolver', () => {
   return { ShellResolver: MockShellResolver };
 });
 
-vi.mock('../../src/shared/paths', () => ({
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
   adaptCommandForShell: (command: string) => command,
   buildSpawnClearPrelude: () => '',
   isUncPath: (pathString: string) => /^[\\/]{2}[^\\/]/.test(pathString),

--- a/tests/unit/session-manager-report-terminated-shells.test.ts
+++ b/tests/unit/session-manager-report-terminated-shells.test.ts
@@ -46,7 +46,8 @@ vi.mock('../../src/main/pty/spawn/shell-resolver', () => {
   return { ShellResolver: MockShellResolver };
 });
 
-vi.mock('../../src/shared/paths', () => ({
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
   adaptCommandForShell: (command: string) => command,
   buildSpawnClearPrelude: () => '',
   isUncPath: (p: string) => /^[\\/]{2}[^\\/]/.test(p),

--- a/tests/unit/session-manager-write-queue.test.ts
+++ b/tests/unit/session-manager-write-queue.test.ts
@@ -51,7 +51,8 @@ vi.mock('../../src/main/pty/spawn/shell-resolver', () => {
   return { ShellResolver: MockShellResolver };
 });
 
-vi.mock('../../src/shared/paths', () => ({
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
   adaptCommandForShell: (cmd: string) => cmd,
   buildSpawnClearPrelude: () => '',
   isUncPath: (pathString: string) => /^[\\/]{2}[^\\/]/.test(pathString),

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -23,7 +23,8 @@ vi.mock('../../src/main/pty/spawn/shell-resolver', () => {
   return { ShellResolver: MockShellResolver };
 });
 
-vi.mock('../../src/shared/paths', () => ({
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
   adaptCommandForShell: (cmd: string) => cmd,
   buildSpawnClearPrelude: () => '',
   isUncPath: (p: string) => /^[\\/]{2}[^\\/]/.test(p),

--- a/tests/unit/session-queued-status.test.ts
+++ b/tests/unit/session-queued-status.test.ts
@@ -19,7 +19,8 @@ vi.mock('../../src/main/pty/spawn/shell-resolver', () => {
   return { ShellResolver: MockShellResolver };
 });
 
-vi.mock('../../src/shared/paths', () => ({
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
   adaptCommandForShell: (command: string) => command,
   buildSpawnClearPrelude: () => '',
   isUncPath: (p: string) => /^[\\/]{2}[^\\/]/.test(p),

--- a/tests/unit/session-respawn.test.ts
+++ b/tests/unit/session-respawn.test.ts
@@ -22,7 +22,8 @@ vi.mock('../../src/main/pty/spawn/shell-resolver', () => {
   return { ShellResolver: MockShellResolver };
 });
 
-vi.mock('../../src/shared/paths', () => ({
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
   adaptCommandForShell: (cmd: string) => cmd,
   buildSpawnClearPrelude: () => '',
   isUncPath: (p: string) => /^[\\/]{2}[^\\/]/.test(p),

--- a/tests/unit/session-spawn-flow.test.ts
+++ b/tests/unit/session-spawn-flow.test.ts
@@ -79,7 +79,8 @@ vi.mock('../../src/main/pr/pr-registry', () => ({
 // identity) so the cwd-fixup-order tests can override it per-call via
 // mockImplementationOnce to prove the fixup command bypasses it (see
 // "writes the fixup command RAW" below).
-vi.mock('../../src/shared/paths', () => ({
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
   adaptCommandForShell: vi.fn((cmd: string) => cmd),
   // Default to no prelude so the write-order assertions below stay
   // byte-exact; the dedicated prelude test overrides this with a marker.

--- a/tests/unit/session-suspend.test.ts
+++ b/tests/unit/session-suspend.test.ts
@@ -17,7 +17,8 @@ vi.mock('../../src/main/pty/spawn/shell-resolver', () => {
 });
 
 // Mock adaptCommandForShell
-vi.mock('../../src/shared/paths', () => ({
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
   adaptCommandForShell: (cmd: string) => cmd,
   buildSpawnClearPrelude: () => '',
   isUncPath: (p: string) => /^[\\/]{2}[^\\/]/.test(p),

--- a/tests/unit/shim-launch.test.ts
+++ b/tests/unit/shim-launch.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Unit tests for resolveShimLaunch (src/main/agent/shared/shim-launch.ts),
+ * the spawn-chokepoint step that keeps a multi-line prompt intact when an
+ * npm-installed agent CLI resolved to its Windows `.cmd` shim (#353).
+ *
+ * Every dependency is injected, so each case runs on Linux CI without a
+ * Windows host, a real shim, or a PowerShell process. The real chain (real
+ * PowerShell 5.1 / 7 and Git Bash driving real npm-format shims) is proven by
+ * tests/unit/windows-cmd-shim-multiline-prompt.test.ts on Windows.
+ *
+ * Red-green: dropping the extension gate fails the "never touches the
+ * filesystem" cases; keying the probe cache globally instead of per shell
+ * fails the two-host case; deriving the sibling with posix path.join fails the
+ * backslash case on Linux; forgetting to flatten on the fallback fails the
+ * no-sibling and blocked-policy cases.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  resolveShimLaunch,
+  resetShimLaunchCacheForTests,
+  isWindowsBatchShim,
+  shimSibling,
+  executionPolicyAllowsScripts,
+  probeExecutionPolicy,
+  type ShimLaunchDependencies,
+} from '../../src/main/agent/shared/shim-launch';
+import { buildTaskXml } from '../../src/main/agent/shared/prompt-xml';
+import { sanitizeForPty } from '../../src/shared/paths';
+
+// The probe is the module's only child-process access. execFile is replaced
+// through its promisify.custom hook because the module awaits
+// `promisify(execFile)`, which resolves `{ stdout, stderr }` only through that
+// hook (a plain callback mock would resolve the bare stdout string).
+const execFileProbe = vi.hoisted(() => ({
+  calls: [] as Array<{ file: string; args: readonly string[]; options: Record<string, unknown> }>,
+  result: { stdout: 'RemoteSigned\r\n', stderr: '' } as { stdout: string; stderr: string } | Error,
+}));
+
+vi.mock('node:child_process', () => {
+  const promisified = async (file: string, args: readonly string[], options: Record<string, unknown>) => {
+    execFileProbe.calls.push({ file, args, options });
+    if (execFileProbe.result instanceof Error) throw execFileProbe.result;
+    return execFileProbe.result;
+  };
+  const execFile = Object.assign(
+    () => {
+      throw new Error('shim-launch never uses the callback form of execFile');
+    },
+    { [Symbol.for('nodejs.util.promisify.custom')]: promisified },
+  );
+  return { execFile };
+});
+
+const CMD_HEAD = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.CMD';
+const PS1_SIBLING = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.ps1';
+const SH_SIBLING = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\codex';
+const SECOND_CMD_HEAD = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\gemini.cmd';
+const PWSH = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe';
+const POWERSHELL = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+const GIT_BASH = 'C:\\Program Files\\Git\\bin\\bash.exe';
+const CMD_EXE = 'C:\\Windows\\System32\\cmd.exe';
+const WSL = 'wsl -d Ubuntu';
+const NATIVE_EXE = 'C:\\Users\\dev\\.local\\bin\\claude.exe';
+const EXTENSIONLESS_HEAD = 'C:\\Users\\dev\\.local\\bin\\claude';
+
+// The real producer, so line 1 is exactly `<task>`: the line the bug left behind.
+const MULTILINE_PROMPT = buildTaskXml({ title: 'Fix login', description: 'Step 1.\n\nStep 2.' });
+
+function makeDependencies(overrides: Partial<ShimLaunchDependencies> = {}) {
+  return {
+    platform: 'win32' as NodeJS.Platform,
+    fileExists: vi.fn((candidatePath: string) => candidatePath === PS1_SIBLING || candidatePath === SH_SIBLING),
+    readFileHead: vi.fn(() => '#!/bin/sh'),
+    probeExecutionPolicy: vi.fn(async (): Promise<string | null> => 'RemoteSigned'),
+    warn: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resetShimLaunchCacheForTests();
+  execFileProbe.calls.length = 0;
+  execFileProbe.result = { stdout: 'RemoteSigned\r\n', stderr: '' };
+});
+
+describe('resolveShimLaunch: inputs that never rewrite', () => {
+  it.each([
+    ['linux', PWSH, CMD_HEAD, 'a .CMD head under pwsh on linux'],
+    ['darwin', PWSH, CMD_HEAD, 'a .CMD head under pwsh on darwin'],
+    ['win32', CMD_EXE, CMD_HEAD, 'a cmd.exe host (quoteArg already flattens for it)'],
+    ['win32', WSL, CMD_HEAD, 'a WSL host (cannot launch a .cmd at all; documented)'],
+    ['win32', PWSH, NATIVE_EXE, 'a native .exe head'],
+    ['win32', PWSH, EXTENSIONLESS_HEAD, 'an extensionless head'],
+    ['win32', undefined, CMD_HEAD, 'an undefined shell'],
+  ] as const)('leaves %s / %s / %s untouched (%s)', async (platform, shell, agentPath) => {
+    const dependencies = makeDependencies({ platform });
+
+    const result = await resolveShimLaunch({ agentPath, shell, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(result.agentPath).toBe(agentPath);
+    expect(result.prompt).toBe(MULTILINE_PROMPT);
+    expect(result.strategy).toBe('unchanged');
+    // The gates come first, so no filesystem or process access on this path.
+    expect(dependencies.fileExists).not.toHaveBeenCalled();
+    expect(dependencies.readFileHead).not.toHaveBeenCalled();
+    expect(dependencies.probeExecutionPolicy).not.toHaveBeenCalled();
+    expect(dependencies.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveShimLaunch: PowerShell host with a batch shim head', () => {
+  it('swaps a .CMD head for its .ps1 sibling under pwsh when the sibling exists and the policy allows scripts', async () => {
+    const dependencies = makeDependencies();
+
+    const result = await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(result.agentPath).toBe(PS1_SIBLING);
+    expect(result.prompt).toBe(MULTILINE_PROMPT);
+    expect(result.strategy).toBe('ps1-sibling');
+    expect(dependencies.warn).not.toHaveBeenCalled();
+  });
+
+  it.each(['RemoteSigned', 'Unrestricted', 'Bypass'])('treats the %s policy as permissive', async (policy) => {
+    const dependencies = makeDependencies({ probeExecutionPolicy: vi.fn(async () => policy) });
+
+    const result = await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(result.strategy).toBe('ps1-sibling');
+  });
+
+  it('normalises probe output (surrounding whitespace, mixed case) before comparing', async () => {
+    const dependencies = makeDependencies({ probeExecutionPolicy: vi.fn(async () => '  remotesigned\r\n') });
+
+    const result = await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(result.strategy).toBe('ps1-sibling');
+  });
+
+  it.each([
+    ['the pwsh 7 full path', PWSH],
+    ['the Windows PowerShell 5.1 full path', POWERSHELL],
+    ['a bare powershell name', 'powershell'],
+    ['a bare pwsh name', 'pwsh'],
+  ])('swaps under %s', async (_label, shell) => {
+    const result = await resolveShimLaunch({ agentPath: CMD_HEAD, shell, prompt: MULTILINE_PROMPT }, makeDependencies());
+
+    expect(result.agentPath).toBe(PS1_SIBLING);
+    expect(result.strategy).toBe('ps1-sibling');
+  });
+
+  it.each(['.cmd', '.Cmd', '.CMD', '.bat', '.BAT'])('matches the %s extension case-insensitively', async (extension) => {
+    const agentPath = `C:\\Users\\dev\\AppData\\Roaming\\npm\\codex${extension}`;
+    const dependencies = makeDependencies();
+
+    const result = await resolveShimLaunch({ agentPath, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(dependencies.fileExists).toHaveBeenCalledWith(PS1_SIBLING);
+    expect(result.agentPath).toBe(PS1_SIBLING);
+  });
+
+  it('derives the sibling with the original backslash separators intact', async () => {
+    // On Linux CI `path` is posix, so a path.join-based derivation would hand
+    // fileExists a mangled string. The exact expected string is the guard.
+    const dependencies = makeDependencies();
+
+    await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(dependencies.fileExists).toHaveBeenCalledTimes(1);
+    expect(dependencies.fileExists).toHaveBeenCalledWith(PS1_SIBLING);
+  });
+
+  it('keeps the .cmd head and flattens the prompt when no .ps1 sibling exists', async () => {
+    const dependencies = makeDependencies({ fileExists: vi.fn(() => false) });
+
+    const result = await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(result.agentPath).toBe(CMD_HEAD);
+    expect(result.prompt).toBe(sanitizeForPty(MULTILINE_PROMPT));
+    expect(result.prompt).not.toContain('\n');
+    expect(result.prompt).toContain('<title>Fix login</title>');
+    expect(result.strategy).toBe('flattened-prompt');
+    // Nothing to probe when there is no script to run.
+    expect(dependencies.probeExecutionPolicy).not.toHaveBeenCalled();
+    expect(dependencies.warn).toHaveBeenCalledTimes(1);
+    const message = dependencies.warn.mock.calls[0][0];
+    expect(message).toContain(CMD_HEAD);
+    expect(message).toContain(PS1_SIBLING);
+  });
+
+  it.each([
+    ['Restricted', 'Restricted'],
+    ['AllSigned', 'AllSigned'],
+    ['Undefined', 'Undefined'],
+    ['a null (failed) probe', null],
+  ])('keeps the .cmd head and flattens the prompt when the policy is %s', async (_label, policy) => {
+    const dependencies = makeDependencies({ probeExecutionPolicy: vi.fn(async () => policy) });
+
+    const result = await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(result.agentPath).toBe(CMD_HEAD);
+    expect(result.prompt).toBe(sanitizeForPty(MULTILINE_PROMPT));
+    expect(result.strategy).toBe('flattened-prompt');
+    expect(dependencies.warn).toHaveBeenCalledTimes(1);
+    const message = dependencies.warn.mock.calls[0][0];
+    expect(message).toContain(PS1_SIBLING);
+    expect(message).toContain('Set-ExecutionPolicy RemoteSigned -Scope CurrentUser');
+  });
+
+  it('keeps the .cmd head and flattens the prompt when the probe rejects', async () => {
+    const dependencies = makeDependencies({
+      probeExecutionPolicy: vi.fn(async () => {
+        throw new Error('spawn pwsh ENOENT');
+      }),
+    });
+
+    const result = await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(result.agentPath).toBe(CMD_HEAD);
+    expect(result.strategy).toBe('flattened-prompt');
+  });
+
+  it('leaves an undefined prompt undefined on the flatten path and does not warn about it', async () => {
+    // A resume or a Command Terminal carries no prompt, so nothing is degraded.
+    const dependencies = makeDependencies({ fileExists: vi.fn(() => false) });
+
+    const result = await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: undefined }, dependencies);
+
+    expect(result.agentPath).toBe(CMD_HEAD);
+    expect(result.prompt).toBeUndefined();
+    expect(result.strategy).toBe('flattened-prompt');
+    expect(dependencies.warn).not.toHaveBeenCalled();
+  });
+
+  it('leaves an undefined prompt undefined on the .ps1 path', async () => {
+    const result = await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: undefined }, makeDependencies());
+
+    expect(result.agentPath).toBe(PS1_SIBLING);
+    expect(result.prompt).toBeUndefined();
+  });
+
+  it('never sanitises on the .ps1 path: backticks, dollar signs and blank lines come back by reference', async () => {
+    const prompt = '<task>\n  <title>Use `code` and $HOME</title>\n\n\n</task>';
+
+    const result = await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt }, makeDependencies());
+
+    expect(result.prompt).toBe(prompt);
+  });
+});
+
+describe('resolveShimLaunch: Git Bash host with a batch shim head', () => {
+  it('swaps a .CMD head for its extensionless sh sibling when it exists and starts with a shebang', async () => {
+    const dependencies = makeDependencies();
+
+    const result = await resolveShimLaunch({ agentPath: CMD_HEAD, shell: GIT_BASH, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(result.agentPath).toBe(SH_SIBLING);
+    expect(result.prompt).toBe(MULTILINE_PROMPT);
+    expect(result.strategy).toBe('sh-sibling');
+    expect(dependencies.fileExists).toHaveBeenCalledWith(SH_SIBLING);
+    expect(dependencies.readFileHead).toHaveBeenCalledWith(SH_SIBLING);
+    // No execution policy on this route.
+    expect(dependencies.probeExecutionPolicy).not.toHaveBeenCalled();
+    expect(dependencies.warn).not.toHaveBeenCalled();
+  });
+
+  it('keeps the .cmd head and flattens the prompt when the extensionless sibling has no shebang', async () => {
+    const dependencies = makeDependencies({ readFileHead: vi.fn(() => 'MZ') });
+
+    const result = await resolveShimLaunch({ agentPath: CMD_HEAD, shell: GIT_BASH, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(result.agentPath).toBe(CMD_HEAD);
+    expect(result.prompt).toBe(sanitizeForPty(MULTILINE_PROMPT));
+    expect(result.strategy).toBe('flattened-prompt');
+    expect(dependencies.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the .cmd head and flattens the prompt when the extensionless sibling is missing', async () => {
+    const dependencies = makeDependencies({ fileExists: vi.fn(() => false) });
+
+    const result = await resolveShimLaunch({ agentPath: CMD_HEAD, shell: GIT_BASH, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(result.agentPath).toBe(CMD_HEAD);
+    expect(result.strategy).toBe('flattened-prompt');
+    expect(dependencies.readFileHead).not.toHaveBeenCalled();
+    expect(dependencies.warn.mock.calls[0][0]).toContain(SH_SIBLING);
+  });
+});
+
+describe('resolveShimLaunch: warn-once and per-shell policy cache', () => {
+  it('warns exactly once per agent path when falling back, across repeated spawns', async () => {
+    const dependencies = makeDependencies({ fileExists: vi.fn(() => false) });
+
+    for (let spawnIndex = 0; spawnIndex < 3; spawnIndex += 1) {
+      await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+    }
+
+    expect(dependencies.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns separately for a second agent path on the same shell', async () => {
+    const dependencies = makeDependencies({ fileExists: vi.fn(() => false) });
+
+    await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+    await resolveShimLaunch({ agentPath: SECOND_CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(dependencies.warn).toHaveBeenCalledTimes(2);
+    expect(dependencies.warn.mock.calls[1][0]).toContain(SECOND_CMD_HEAD);
+  });
+
+  it('probes the execution policy once per shell and serves later spawns from the cache', async () => {
+    const dependencies = makeDependencies({ fileExists: vi.fn((candidatePath: string) => candidatePath.endsWith('.ps1')) });
+
+    await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+    await resolveShimLaunch({ agentPath: SECOND_CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(dependencies.probeExecutionPolicy).toHaveBeenCalledTimes(1);
+  });
+
+  it('keys the cache by shell, so pwsh and powershell.exe each get their own probe', async () => {
+    // Windows PowerShell 5.1 and pwsh 7 keep separate execution policies
+    // (5.1 defaults to Restricted on client editions, pwsh to RemoteSigned).
+    const dependencies = makeDependencies();
+
+    await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+    await resolveShimLaunch({ agentPath: CMD_HEAD, shell: POWERSHELL, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(dependencies.probeExecutionPolicy).toHaveBeenCalledTimes(2);
+    expect(dependencies.probeExecutionPolicy).toHaveBeenCalledWith(PWSH);
+    expect(dependencies.probeExecutionPolicy).toHaveBeenCalledWith(POWERSHELL);
+  });
+
+  it('caches a failed probe for the process lifetime so a hung host does not delay every later spawn', async () => {
+    const failingProbe = vi.fn(async (): Promise<string | null> => null);
+    const permissiveProbe = vi.fn(async (): Promise<string | null> => 'RemoteSigned');
+
+    const first = await resolveShimLaunch(
+      { agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT },
+      makeDependencies({ probeExecutionPolicy: failingProbe }),
+    );
+    const second = await resolveShimLaunch(
+      { agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT },
+      makeDependencies({ probeExecutionPolicy: permissiveProbe }),
+    );
+
+    expect(first.strategy).toBe('flattened-prompt');
+    expect(second.strategy).toBe('flattened-prompt');
+    expect(failingProbe).toHaveBeenCalledTimes(1);
+    expect(permissiveProbe).not.toHaveBeenCalled();
+  });
+
+  it('resetShimLaunchCacheForTests clears both the policy cache and the warned set', async () => {
+    const dependencies = makeDependencies({ probeExecutionPolicy: vi.fn(async () => 'Restricted') });
+
+    await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+    resetShimLaunchCacheForTests();
+    await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(dependencies.probeExecutionPolicy).toHaveBeenCalledTimes(2);
+    expect(dependencies.warn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('shim-launch helpers', () => {
+  it('isWindowsBatchShim matches .cmd and .bat in any case and nothing else', () => {
+    expect(isWindowsBatchShim(CMD_HEAD)).toBe(true);
+    expect(isWindowsBatchShim('C:\\npm\\gemini.cmd')).toBe(true);
+    expect(isWindowsBatchShim('C:\\tools\\agent.bat')).toBe(true);
+    expect(isWindowsBatchShim('C:\\tools\\agent.BAT')).toBe(true);
+
+    expect(isWindowsBatchShim(NATIVE_EXE)).toBe(false);
+    expect(isWindowsBatchShim(PS1_SIBLING)).toBe(false);
+    expect(isWindowsBatchShim(EXTENSIONLESS_HEAD)).toBe(false);
+    // A directory named like a shim does not make its extensionless child one.
+    expect(isWindowsBatchShim('C:\\tools.cmd\\agent')).toBe(false);
+  });
+
+  it('shimSibling swaps only the final extension and keeps the base name, case, and separators', () => {
+    expect(shimSibling(CMD_HEAD, '.ps1')).toBe(PS1_SIBLING);
+    expect(shimSibling(CMD_HEAD, '')).toBe(SH_SIBLING);
+    expect(shimSibling('C:/Users/dev/AppData/Roaming/npm/gemini.cmd', '.ps1')).toBe('C:/Users/dev/AppData/Roaming/npm/gemini.ps1');
+    expect(shimSibling('C:\\tools.v2\\agent.bat', '')).toBe('C:\\tools.v2\\agent');
+    expect(shimSibling('C:\\tools\\Cursor-Agent.CMD', '.ps1')).toBe('C:\\tools\\Cursor-Agent.ps1');
+  });
+
+  it('executionPolicyAllowsScripts accepts only the policies that run an unsigned local script', () => {
+    expect(executionPolicyAllowsScripts('RemoteSigned')).toBe(true);
+    expect(executionPolicyAllowsScripts('Unrestricted')).toBe(true);
+    expect(executionPolicyAllowsScripts('Bypass')).toBe(true);
+    expect(executionPolicyAllowsScripts('  bypass\r\n')).toBe(true);
+
+    expect(executionPolicyAllowsScripts('Restricted')).toBe(false);
+    expect(executionPolicyAllowsScripts('AllSigned')).toBe(false);
+    expect(executionPolicyAllowsScripts('Undefined')).toBe(false);
+    expect(executionPolicyAllowsScripts('')).toBe(false);
+    expect(executionPolicyAllowsScripts(null)).toBe(false);
+  });
+});
+
+describe('probeExecutionPolicy', () => {
+  it('asks the host itself, hidden and with a timeout, and returns the trimmed policy name', async () => {
+    const policy = await probeExecutionPolicy(PWSH);
+
+    expect(policy).toBe('RemoteSigned');
+    expect(execFileProbe.calls).toHaveLength(1);
+    const call = execFileProbe.calls[0];
+    // The same executable the PTY runs: 5.1 and 7 keep separate policies.
+    expect(call.file).toBe(PWSH);
+    expect(call.args).toEqual(['-NoProfile', '-NonInteractive', '-Command', 'Get-ExecutionPolicy']);
+    expect(call.options).toMatchObject({ windowsHide: true, timeout: 5000 });
+  });
+
+  it('strips PSModulePath from the probe environment so a pwsh 7 ancestor cannot break 5.1 module autoload', async () => {
+    // Measured: Windows PowerShell 5.1 launched under a PSModulePath that
+    // lists pwsh 7's Modules directory fails to autoload the Security module
+    // that owns Get-ExecutionPolicy, and the probe reported null on a Bypass
+    // machine. Everything else in the environment must still pass through.
+    const previous = process.env.PSModulePath;
+    process.env.PSModulePath = 'C:\\Program Files\\PowerShell\\7\\Modules';
+    process.env.KANGENTIC_PROBE_CANARY = 'kept';
+    try {
+      await probeExecutionPolicy(POWERSHELL);
+    } finally {
+      if (previous === undefined) delete process.env.PSModulePath;
+      else process.env.PSModulePath = previous;
+      delete process.env.KANGENTIC_PROBE_CANARY;
+    }
+
+    const environment = execFileProbe.calls[0].options.env as Record<string, string | undefined>;
+    expect(environment).toBeDefined();
+    expect(Object.keys(environment).map((name) => name.toLowerCase())).not.toContain('psmodulepath');
+    expect(environment.KANGENTIC_PROBE_CANARY).toBe('kept');
+  });
+
+  it('resolves null when the host cannot be run', async () => {
+    execFileProbe.result = new Error('spawn pwsh ENOENT');
+
+    await expect(probeExecutionPolicy(PWSH)).resolves.toBeNull();
+  });
+
+  it('resolves null when the host prints nothing', async () => {
+    execFileProbe.result = { stdout: '  \n', stderr: '' };
+
+    await expect(probeExecutionPolicy(PWSH)).resolves.toBeNull();
+  });
+});

--- a/tests/unit/shim-launch.test.ts
+++ b/tests/unit/shim-launch.test.ts
@@ -307,6 +307,20 @@ describe('resolveShimLaunch: warn-once and per-shell policy cache', () => {
     expect(dependencies.warn.mock.calls[1][0]).toContain(SECOND_CMD_HEAD);
   });
 
+  it('warns separately for the same agent path under two different PowerShell-family shells', async () => {
+    // The warn-once key joins the shell and the agent path (keepBatchShim). pwsh
+    // 7 and Windows PowerShell 5.1 keep separate execution policies, so a
+    // fallback flattened under one host must still warn again under the
+    // other. Narrowing the key to agentPath alone would collapse this to one
+    // warning and fail the assertion below.
+    const dependencies = makeDependencies({ fileExists: vi.fn(() => false) });
+
+    await resolveShimLaunch({ agentPath: CMD_HEAD, shell: PWSH, prompt: MULTILINE_PROMPT }, dependencies);
+    await resolveShimLaunch({ agentPath: CMD_HEAD, shell: POWERSHELL, prompt: MULTILINE_PROMPT }, dependencies);
+
+    expect(dependencies.warn).toHaveBeenCalledTimes(2);
+  });
+
   it('probes the execution policy once per shell and serves later spawns from the cache', async () => {
     const dependencies = makeDependencies({ fileExists: vi.fn((candidatePath: string) => candidatePath.endsWith('.ps1')) });
 

--- a/tests/unit/spawn-entry-point-parity.test.ts
+++ b/tests/unit/spawn-entry-point-parity.test.ts
@@ -268,6 +268,35 @@ describe('spawn entry-point parity: every buildCommand site runs ensureTrust fir
   });
 });
 
+describe('spawn entry-point parity: every buildCommand site resolves the shim launch first', () => {
+  // On Windows an npm-installed CLI resolves to its `.cmd` shim, which a
+  // PowerShell or Git Bash host launches through cmd.exe, and cmd.exe keeps
+  // only the first line of a multi-line prompt (#353). resolveShimLaunch
+  // (src/main/agent/shared/shim-launch.ts) swaps in the sibling shim the host
+  // can run, or flattens the prompt, and it has to run on every path that
+  // builds an agent command or one launcher silently truncates while the
+  // others work. Same static-scan limits as the ensureTrust check above; the
+  // runtime wiring per chokepoint is pinned by
+  // prepare-spawn-shim-launch-wiring.test.ts, transition-engine.test.ts, and
+  // transient-session-spawn-shim-launch.test.ts.
+  it('every buildCommand( call site is preceded by a resolveShimLaunch( call in the same file', () => {
+    const buildSites = collectReceiverCalls('buildCommand');
+    expect(buildSites.length, 'expected at least one buildCommand( call site').toBeGreaterThan(0);
+    const missing = buildSites
+      .filter((site) => !fileHasNonCommentCallBefore(site.relativePath, site.line, 'resolveShimLaunch'))
+      .map((site) => site.location);
+    expect(
+      missing,
+      `buildCommand( without an earlier resolveShimLaunch( in the same file:\n`
+        + `${missing.join('\n')}\n\n`
+        + `A .cmd / .bat head must be resolved for the PTY shell before any builder sees it, or a `
+        + `multi-line prompt reaches the agent as its first line only on Windows (#353). Call `
+        + `resolveShimLaunch({ agentPath, shell, prompt }) after ensureTrust and hand the builder its `
+        + `agentPath and prompt. See ${RULE_FILE}.`,
+    ).toEqual([]);
+  });
+});
+
 describe('spawn entry-point parity: single lock call site', () => {
   it('lockAdvancedOverridesOnFirstSpawn is only referenced inside spawn-preamble.ts', () => {
     const outsideCalls = collectSinkCalls(/\blockAdvancedOverridesOnFirstSpawn\s*\(/)

--- a/tests/unit/transient-session-spawn-shim-launch.test.ts
+++ b/tests/unit/transient-session-spawn-shim-launch.test.ts
@@ -1,41 +1,48 @@
 /**
- * Unit test for the SESSION_SPAWN_TRANSIENT handler's pre-spawn ensureTrust
- * call (src/main/ipc/handlers/transient-sessions.ts).
+ * Wiring test: the SESSION_SPAWN_TRANSIENT handler
+ * (src/main/ipc/handlers/transient-sessions.ts) resolves the shim launch for
+ * the PTY shell before building the Command Terminal's command.
  *
- * The Command Terminal is the likeliest maximized pane, so per
- * .claude/rules/spawn-entry-point-parity.md it is exactly where Claude's
- * fullscreen diff panel would otherwise reopen if the pre-spawn
- * `ensureTrust` (which also closes the diff panel - see
- * src/main/agent/adapters/claude/diff-panel.ts) is skipped or races
- * `buildCommand`.
+ * On Windows an npm-installed CLI resolves to its `.cmd` shim, which a
+ * PowerShell or Git Bash host launches through cmd.exe (#353). The Command
+ * Terminal carries no prompt, so nothing is truncated here, but its head must
+ * match what task spawns use: resolveShimLaunch
+ * (src/main/agent/shared/shim-launch.ts) swaps in the sibling shim the host
+ * can run, and the handler now also passes that shell to the builder so
+ * quoting matches the shell the PTY types into.
  *
- * The only existing guard for this line is a STATIC TEXT SCAN in
- * spawn-entry-point-parity.test.ts: it merely proves that a non-comment
- * `ensureTrust(` line appears earlier in the file than `buildCommand(`. That
- * scan stays GREEN for real regressions the scan cannot see:
- *   - the `await` is dropped (fire-and-forget), letting buildCommand / spawn
- *     race the global-config write,
- *   - the call moves into a branch that never executes at handler-call time,
- *   - the wrong argument (e.g. a worktree path instead of projectRoot) is
- *     passed.
+ * Mocking pattern follows transient-session-spawn-ensure-trust.test.ts (same
+ * handler, same capturedHandlers + mocked IpcContext shape), with the helper
+ * mocked at its leaf path and a pass-through default.
  *
- * This test drives the REAL handler function and pins the runtime contract:
- * ensureTrust is called exactly once, with the project root, and its promise
- * RESOLVES before buildCommand runs (caught via a deferred promise - a
- * dropped `await` would let buildCommand fire while ensureTrust is still
- * pending).
- *
- * Mocking pattern follows tests/unit/session-inject-settings-handler.test.ts
- * (same file under test, same capturedHandlers + mocked IpcContext shape).
+ * Red-green: building from `detection.path` instead of `launch.agentPath`
+ * fails the swap test; dropping `shell` from commandOptions fails the shell
+ * test; moving the resolve call above ensureTrust fails the ordering test.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const CMD_HEAD = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\claude.CMD';
+const PS1_SIBLING = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\claude.ps1';
+const PWSH = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
 // ---------------------------------------------------------------------------
 
 const capturedHandlers = new Map<string, (...args: unknown[]) => unknown>();
+
+const resolveShimLaunchMock = vi.hoisted(() =>
+  vi.fn(async (input: { agentPath: string; shell: string | undefined; prompt: string | undefined }) => ({
+    agentPath: input.agentPath,
+    prompt: input.prompt,
+    strategy: 'unchanged' as const,
+  })),
+);
+
+vi.mock('../../src/main/agent/shared/shim-launch', () => ({
+  resolveShimLaunch: resolveShimLaunchMock,
+}));
 
 vi.mock('electron', () => ({
   ipcMain: {
@@ -57,14 +64,11 @@ vi.mock('node:fs', () => ({
 
 vi.mock('uuid', () => ({ v4: vi.fn(() => 'mock-transient-task-id') }));
 
-const gitRevparseMock = vi.fn(async () => 'main\n');
-const gitCheckoutMock = vi.fn(async () => undefined);
-const gitMergeMock = vi.fn(async () => undefined);
 vi.mock('simple-git', () => ({
   default: vi.fn(() => ({
-    revparse: gitRevparseMock,
-    checkout: gitCheckoutMock,
-    merge: gitMergeMock,
+    revparse: vi.fn(async () => 'main\n'),
+    checkout: vi.fn(async () => undefined),
+    merge: vi.fn(async () => undefined),
   })),
 }));
 
@@ -135,20 +139,9 @@ function createMockContext(): MockContext {
     mcpServerHandle: null,
     sessionManager: {
       spawn: vi.fn(async () => ({ id: 'session-1' })),
-      // The handler reads the PTY shell for quoting and shim resolution
-      // (see transient-session-spawn-shim-launch.test.ts for that wiring).
-      getShell: vi.fn(async () => 'bash'),
+      getShell: vi.fn(async () => PWSH),
     },
   };
-}
-
-/** A promise plus its resolver, exposed so the test controls exactly when it settles. */
-function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((res) => {
-    resolve = res;
-  });
-  return { promise, resolve };
 }
 
 async function callSpawnHandler(context: MockContext, input: SpawnTransientSessionInput): Promise<unknown> {
@@ -161,27 +154,22 @@ async function callSpawnHandler(context: MockContext, input: SpawnTransientSessi
 // Test suite
 // ---------------------------------------------------------------------------
 
-describe('SESSION_SPAWN_TRANSIENT handler: ensureTrust runs before buildCommand', () => {
+describe('SESSION_SPAWN_TRANSIENT handler: Windows .cmd shim launch resolution wiring', () => {
   let context: MockContext;
-  let ensureTrustDeferred: ReturnType<typeof createDeferred<void>>;
   let ensureTrustMock: ReturnType<typeof vi.fn>;
   let buildCommandMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     capturedHandlers.clear();
-    gitRevparseMock.mockResolvedValue('main\n');
-    gitCheckoutMock.mockResolvedValue(undefined);
-    gitMergeMock.mockResolvedValue(undefined);
 
-    ensureTrustDeferred = createDeferred<void>();
-    ensureTrustMock = vi.fn(() => ensureTrustDeferred.promise);
+    ensureTrustMock = vi.fn(async () => {});
     buildCommandMock = vi.fn(() => 'claude');
 
     mockAgentRegistryGetOrThrow.mockReturnValue({
       name: 'claude',
       displayName: 'Claude Code',
-      detect: vi.fn(async () => ({ found: true, path: '/mock/claude', version: '1.0.0' })),
+      detect: vi.fn(async () => ({ found: true, path: CMD_HEAD, version: '1.0.0' })),
       ensureTrust: ensureTrustMock,
       buildCommand: buildCommandMock,
     });
@@ -190,35 +178,31 @@ describe('SESSION_SPAWN_TRANSIENT handler: ensureTrust runs before buildCommand'
     registerTransientSessionHandlers(context as never);
   });
 
-  it('calls ensureTrust(projectRoot) exactly once and does not call buildCommand until it resolves', async () => {
-    const resultPromise = callSpawnHandler(context, {
-      projectId: 'proj-1',
-      slot: 'slot-1',
-    });
+  it('fetches the session shell and hands it to resolveShimLaunch with the detected path and no prompt', async () => {
+    await callSpawnHandler(context, { projectId: 'proj-1', slot: 'slot-1' });
 
-    // Let the handler run every await that precedes ensureTrust (CLI detect,
-    // fetchIfStale, the revparse/checkout/merge sequence) without pinning a
-    // specific microtask count, which would be brittle. A generous timeout
-    // guards against event-loop starvation under a loaded machine (this repo
-    // has a documented flake class from worker contention).
-    await vi.waitFor(
-      () => {
-        expect(ensureTrustMock).toHaveBeenCalledTimes(1);
-      },
-      { timeout: 5000 },
-    );
+    expect(context.sessionManager.getShell).toHaveBeenCalledTimes(1);
+    expect(resolveShimLaunchMock).toHaveBeenCalledTimes(1);
+    expect(resolveShimLaunchMock).toHaveBeenCalledWith({ agentPath: CMD_HEAD, shell: PWSH, prompt: undefined });
+  });
 
-    // Load-bearing assertion: while ensureTrust's promise is still pending,
-    // buildCommand must NOT have run. A dropped `await` on ensureTrust would
-    // let buildCommand fire immediately here instead of waiting.
-    expect(buildCommandMock).not.toHaveBeenCalled();
+  it('builds the command from the resolved head and passes the shell to the builder', async () => {
+    resolveShimLaunchMock.mockResolvedValueOnce({ agentPath: PS1_SIBLING, prompt: undefined, strategy: 'ps1-sibling' });
 
-    ensureTrustDeferred.resolve();
-    await resultPromise;
+    await callSpawnHandler(context, { projectId: 'proj-1', slot: 'slot-1' });
 
-    expect(ensureTrustMock).toHaveBeenCalledTimes(1);
-    expect(ensureTrustMock).toHaveBeenCalledWith(PROJECT_ROOT);
     expect(buildCommandMock).toHaveBeenCalledTimes(1);
+    expect(buildCommandMock.mock.calls[0][0]).toMatchObject({ agentPath: PS1_SIBLING, shell: PWSH });
     expect(context.sessionManager.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves after ensureTrust and before buildCommand', async () => {
+    await callSpawnHandler(context, { projectId: 'proj-1', slot: 'slot-1' });
+
+    const ensureTrustOrder = ensureTrustMock.mock.invocationCallOrder[0];
+    const resolveOrder = resolveShimLaunchMock.mock.invocationCallOrder[0];
+    const buildOrder = buildCommandMock.mock.invocationCallOrder[0];
+    expect(ensureTrustOrder).toBeLessThan(resolveOrder);
+    expect(resolveOrder).toBeLessThan(buildOrder);
   });
 });

--- a/tests/unit/transition-engine.test.ts
+++ b/tests/unit/transition-engine.test.ts
@@ -210,6 +210,22 @@ vi.mock('../../src/main/transition-engine/resume-cwd-migration', () => ({
   migrateResumeCwdIfRenamed: vi.fn(async () => {}),
 }));
 
+// Pass-through by default so every describe in this file runs the engine
+// unchanged (their stub adapter detects '/usr/bin/claude' under 'bash', which
+// the real helper leaves alone on any OS anyway); the shim-launch wiring
+// describe at the end of the file swaps in a result per test.
+const resolveShimLaunchMock = vi.hoisted(() =>
+  vi.fn(async (input: { agentPath: string; shell: string | undefined; prompt: string | undefined }) => ({
+    agentPath: input.agentPath,
+    prompt: input.prompt,
+    strategy: 'unchanged' as const,
+  })),
+);
+
+vi.mock('../../src/main/agent/shared/shim-launch', () => ({
+  resolveShimLaunch: resolveShimLaunchMock,
+}));
+
 vi.mock('node:fs', async (importOriginal) => {
   const original = await importOriginal<typeof import('node:fs')>();
   // The source under test uses `import fs from 'node:fs'` (default import).
@@ -1462,5 +1478,103 @@ describe('TransitionEngine - executeSpawnAgent throws a typed error when the age
     await expect(
       engine.executeTransition(task as Parameters<typeof engine.executeTransition>[0], 'todo', 'doing'),
     ).rejects.toThrow(agentCliNotFoundMessage(mockAdapter.displayName));
+  });
+});
+
+describe('TransitionEngine - Windows .cmd shim launch resolution wiring (executeSpawnAgent chokepoint)', () => {
+  // resolveShimLaunch (src/main/agent/shared/shim-launch.ts) must run at this
+  // chokepoint after ensureTrust, receive the detected path, the PTY shell,
+  // and the interpolated prompt, and its result (BOTH fields) must be what
+  // buildCommand sees. A chokepoint that took only agentPath from it and kept
+  // the intent's prompt would still truncate through a .cmd on the flatten
+  // fallback (#353). The session row, on the other hand, keeps the ORIGINAL
+  // prompt: flattening is a delivery detail, not what the user wrote.
+  const CMD_HEAD = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.CMD';
+  const PS1_SIBLING = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.ps1';
+  const PWSH = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAdapter.detect.mockImplementation(async () => ({ found: true, path: CMD_HEAD, version: '1.0.0' }));
+    mockAdapter.buildCommand.mockImplementation((options: { prompt?: string }) => {
+      return `claude ${options.prompt ?? ''}`;
+    });
+  });
+
+  afterEach(() => {
+    // mockAdapter is shared module state; restore the path every other
+    // describe in this file assumes.
+    mockAdapter.detect.mockImplementation(async () => ({ found: true, path: '/usr/bin/claude', version: '1.0.0' }));
+  });
+
+  it('hands the detected path, the session shell, and the interpolated prompt to resolveShimLaunch, after ensureTrust and before buildCommand', async () => {
+    const task = makeTask();
+    const sessionManager = makeSessionManager();
+    sessionManager.getShell.mockResolvedValue(PWSH);
+    const { engine } = makeEngine({ sessionManager });
+
+    await engine.executeTransition(task as Parameters<typeof engine.executeTransition>[0], 'todo', 'doing');
+
+    expect(resolveShimLaunchMock).toHaveBeenCalledTimes(1);
+    expect(resolveShimLaunchMock).toHaveBeenCalledWith({
+      agentPath: CMD_HEAD,
+      shell: PWSH,
+      prompt: expect.stringContaining('<task>'),
+    });
+    const ensureTrustOrder = mockAdapter.ensureTrust.mock.invocationCallOrder[0];
+    const resolveOrder = resolveShimLaunchMock.mock.invocationCallOrder[0];
+    const buildOrder = mockAdapter.buildCommand.mock.invocationCallOrder[0];
+    expect(ensureTrustOrder).toBeLessThan(resolveOrder);
+    expect(resolveOrder).toBeLessThan(buildOrder);
+  });
+
+  it('builds the command from the resolved head AND the resolved prompt, while the session row keeps the original prompt', async () => {
+    resolveShimLaunchMock.mockResolvedValueOnce({
+      agentPath: PS1_SIBLING,
+      prompt: 'RESOLVED-PROMPT',
+      strategy: 'flattened-prompt',
+    });
+    const task = makeTask();
+    const sessionManager = makeSessionManager();
+    const sessionRepo = makeSessionRepo();
+    const { engine } = makeEngine({ sessionManager, sessionRepo });
+
+    await engine.executeTransition(task as Parameters<typeof engine.executeTransition>[0], 'todo', 'doing');
+
+    // Red: a chokepoint keeping `agentPath: detection.path` or `prompt` (the
+    // intent's) instead of the helper's fields fails one of these.
+    expect(mockAdapter.buildCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ agentPath: PS1_SIBLING, prompt: 'RESOLVED-PROMPT' }),
+    );
+    expect(sessionRepo.insertedRecords).toHaveLength(1);
+    const inserted = sessionRepo.insertedRecords[0] as { prompt: string | null };
+    expect(inserted.prompt).toContain('<task>');
+    expect(inserted.prompt).not.toBe('RESOLVED-PROMPT');
+  });
+
+  it('produces a real Codex command whose head is the .ps1 sibling', async () => {
+    const task = makeTask();
+    resolveShimLaunchMock.mockResolvedValueOnce({
+      agentPath: PS1_SIBLING,
+      prompt: buildTaskXml({ title: task.title, description: task.description }),
+      strategy: 'ps1-sibling',
+    });
+    const codexCommandBuilder = new CodexCommandBuilder();
+    mockAdapter.buildCommand.mockImplementation((options: { agentPath: string; prompt?: string }) => {
+      const { agentPath, ...rest } = options;
+      return codexCommandBuilder.buildCodexCommand({ codexPath: agentPath, ...rest } as CodexCommandOptions);
+    });
+    const sessionManager = makeSessionManager();
+    sessionManager.getShell.mockResolvedValue(PWSH);
+    const { engine } = makeEngine({ sessionManager });
+
+    await engine.executeTransition(task as Parameters<typeof engine.executeTransition>[0], 'todo', 'doing');
+
+    expect(sessionManager.spawnedSessions).toHaveLength(1);
+    const command = sessionManager.spawnedSessions[0].command;
+    expect(command.startsWith(`"${PS1_SIBLING}"`)).toBe(true);
+    expect(command).not.toContain('codex.CMD');
+    // The multi-line prompt still rides the PowerShell backtick-n contract.
+    expect(command).toContain('`n');
   });
 });

--- a/tests/unit/warp-adapter.test.ts
+++ b/tests/unit/warp-adapter.test.ts
@@ -230,6 +230,15 @@ describe('WarpAdapter', () => {
         }));
         expect(command).toContain('"broken"');
       });
+
+      it('quotes the "--" end-of-options marker ahead of --prompt for PowerShell hosts', () => {
+        // The -- --prompt ordering itself is pinned separately above ("includes
+        // -- --prompt when prompt is provided") and stays out of scope here.
+        // This only pins that the marker is quoted under PowerShell: its binder
+        // consumes a bare -- before a .ps1 shim sees $args.
+        const command = adapter.buildCommand(makeOptions({ prompt: 'Fix the bug', shell: 'powershell' }));
+        expect(command).toContain('"--" --prompt');
+      });
     });
 
     // ── Ignored options ──────────────────────────────────────────────────

--- a/tests/unit/windows-cmd-shim-multiline-prompt.test.ts
+++ b/tests/unit/windows-cmd-shim-multiline-prompt.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Windows-only integration test for #353: the multi-line `{{task_xml}}` prompt
+ * through a real npm-format `.cmd` shim under real Windows PowerShell 5.1,
+ * pwsh 7, and Git Bash, and through the sibling shims resolveShimLaunch
+ * (src/main/agent/shared/shim-launch.ts) launches instead.
+ *
+ * The reporter's own harness (command builder -> PowerShell -> ConPTY -> a
+ * receiver) passed because it stopped short of the `.cmd`; the cut happens in
+ * cmd.exe's parse of the child command line, so this test keeps the shim in
+ * the chain and records what the receiver's argv actually held.
+ *
+ * Reports as skipped on Linux CI (no Windows runner) and runs under `/test` on
+ * the dogfood machine. The decision logic itself is guarded on CI by
+ * tests/unit/shim-launch.test.ts with injected dependencies.
+ *
+ * No node-pty variant: PowerShell builds the child command line identically
+ * whether the statement arrived through PSReadLine or -EncodedCommand (same
+ * parser, same backtick-n expansion, same CreateProcess), the reporter already
+ * verified ConPTY passes the newline, and an interactive shell would only add
+ * this repo's documented flake class. -EncodedCommand and a bash `-s` stdin
+ * read are the faithful stand-ins for the spawn flow typing the line.
+ *
+ * Red-green: the "red pin" cases document the hazard itself (they fail the day
+ * a Windows build stops cutting the line, which would be news); the green
+ * cases fail if resolveShimLaunch stops finding a sibling, quoteArg stops
+ * emitting backtick-n or the quoted `--`, or the flatten fallback regresses.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile, execFileSync } from 'node:child_process';
+import { promisify } from 'node:util';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import which from 'which';
+import { CodexCommandBuilder } from '../../src/main/agent/adapters/codex';
+import { buildTaskXml } from '../../src/main/agent/shared/prompt-xml';
+import {
+  resolveShimLaunch,
+  probeExecutionPolicy,
+  executionPolicyAllowsScripts,
+  resetShimLaunchCacheForTests,
+} from '../../src/main/agent/shared/shim-launch';
+import { adaptCommandForShell, isPowerShellShell, quoteArg, sanitizeForPty } from '../../src/shared/paths';
+
+const execFileAsync = promisify(execFile);
+const IS_WINDOWS = process.platform === 'win32';
+
+interface HostSpec {
+  name: string;
+  path: string;
+  family: 'powershell' | 'bash';
+}
+
+/**
+ * Hosts present on this machine, discovered at collection time so
+ * describe.each can enumerate them. powershell.exe ships with Windows; pwsh
+ * and Git Bash are optional. Git Bash is looked up at its install path only:
+ * a bare `which('bash')` can return the WSL launcher in System32.
+ */
+function discoverHosts(): HostSpec[] {
+  if (!IS_WINDOWS) return [];
+  const hosts: HostSpec[] = [];
+  const powershell = which.sync('powershell', { nothrow: true });
+  if (powershell) hosts.push({ name: 'Windows PowerShell 5.1', path: powershell, family: 'powershell' });
+  const pwsh = which.sync('pwsh', { nothrow: true });
+  if (pwsh) hosts.push({ name: 'pwsh 7', path: pwsh, family: 'powershell' });
+  const gitBash = path.join(process.env.ProgramFiles ?? 'C:\\Program Files', 'Git', 'bin', 'bash.exe');
+  if (fs.existsSync(gitBash)) hosts.push({ name: 'Git Bash', path: gitBash, family: 'bash' });
+  return hosts;
+}
+
+const HOSTS = discoverHosts();
+
+// npm's cmd-shim writes CRLF, and cmd.exe's GOTO label scan is line-ending
+// sensitive, so the batch fixture is joined with CRLF. This is on-disk data
+// for cmd.exe, not authored text: the cross-platform rule's CRLF ban covers
+// assertions and prose.
+const CMD_LINE_ENDING = '\r\n';
+
+/** The npm `cmd-shim` batch file, verbatim except for the script path. */
+const NPM_CMD_SHIM = [
+  '@ECHO off',
+  'GOTO start',
+  ':find_dp0',
+  'SET dp0=%~dp0',
+  'EXIT /b',
+  ':start',
+  'SETLOCAL',
+  'CALL :find_dp0',
+  '',
+  'IF EXIST "%dp0%\\node.exe" (',
+  '  SET "_prog=%dp0%\\node.exe"',
+  ') ELSE (',
+  '  SET "_prog=node"',
+  ')',
+  '',
+  'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & set PATHEXT=%PATHEXT:;.JS;=;% & "%_prog%"  "%dp0%\\receiver.js" %*',
+  '',
+].join(CMD_LINE_ENDING);
+
+/** The two-line shape every tests/fixtures/mock-*.cmd uses. */
+const MINIMAL_CMD_SHIM = ['@echo off', 'node "%~dp0receiver.js" %*', ''].join(CMD_LINE_ENDING);
+
+/** The npm `.ps1` shim, verbatim except for the script path. */
+const NPM_PS1_SHIM = `#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & "$basedir/node$exe"  "$basedir/receiver.js" $args
+  } else {
+    & "$basedir/node$exe"  "$basedir/receiver.js" $args
+  }
+  $ret=$LASTEXITCODE
+} else {
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & "node$exe"  "$basedir/receiver.js" $args
+  } else {
+    & "node$exe"  "$basedir/receiver.js" $args
+  }
+  $ret=$LASTEXITCODE
+}
+exit $ret
+`;
+
+/** The npm extensionless sh shim, verbatim except for the script path. */
+const NPM_SH_SHIM = `#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
+
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir_win=\`cygpath -w "$basedir"\`
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        echo "Error: wslpath failed to convert path. WSL environment may be misconfigured." >&2
+        exit 1
+      fi
+    fi
+  ;;
+esac
+
+PROG_EXE="$basedir/node.exe"
+if ! [ -x "$PROG_EXE" ]; then
+  PROG_EXE="$basedir/node"
+  if ! [ -x "$PROG_EXE" ]; then
+    PROG_EXE=node
+    if ! [ -x "$PROG_EXE" ]; then
+      PROG_EXE=node.exe
+    fi
+  fi
+fi
+
+exec "$PROG_EXE"  "$basedir_win/receiver.js" "$@"
+`;
+
+/** Records the argv it was launched with; the out path rides an env var so the argv shape stays production's. */
+const RECEIVER_JS = `const fs = require('node:fs');
+fs.writeFileSync(process.env.KANGENTIC_RECEIVER_OUT, JSON.stringify(process.argv.slice(2)), 'utf8');
+`;
+
+const XML = buildTaskXml({ title: 'Fix login for issue 353', description: 'Step 1.\n\nStep 2.' });
+
+describe.runIf(IS_WINDOWS)('Windows npm .cmd shim vs multiline prompt (#353)', () => {
+  let tempDir: string;
+  let cmdShim: string;
+  let minimalCmdShim: string;
+  let ps1Shim: string;
+  let shShim: string;
+  let runCounter = 0;
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kangentic-cmd-shim-'));
+    cmdShim = path.join(tempDir, 'receiver.cmd');
+    minimalCmdShim = path.join(tempDir, 'receiver-minimal.cmd');
+    ps1Shim = path.join(tempDir, 'receiver.ps1');
+    shShim = path.join(tempDir, 'receiver');
+    fs.writeFileSync(path.join(tempDir, 'receiver.js'), RECEIVER_JS, 'utf8');
+    fs.writeFileSync(cmdShim, NPM_CMD_SHIM, 'utf8');
+    fs.writeFileSync(minimalCmdShim, MINIMAL_CMD_SHIM, 'utf8');
+    fs.writeFileSync(ps1Shim, NPM_PS1_SHIM, 'utf8');
+    fs.writeFileSync(shShim, NPM_SH_SHIM, 'utf8');
+  });
+
+  afterAll(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Run the typed command line through the host exactly as the spawn flow
+   * would hand it over, then return the receiver's recorded argv. A fresh out
+   * file per run, asserted absent first, so a stale file from an earlier case
+   * can never satisfy a later one. Non-zero exits are expected on the red
+   * pins (cmd.exe tries to run the cut-off lines as commands), so the exit
+   * status is not asserted; the argv file is the evidence.
+   */
+  async function runThroughHost(
+    host: HostSpec,
+    commandLine: string,
+    options: { bypassPolicy?: boolean } = {},
+  ): Promise<string[]> {
+    runCounter += 1;
+    const outPath = path.join(tempDir, `argv-${runCounter}.json`);
+    expect(fs.existsSync(outPath)).toBe(false);
+    const env = {
+      ...process.env,
+      KANGENTIC_RECEIVER_OUT: outPath,
+      // The shim's `node` fallback must resolve under any launcher.
+      PATH: `${path.dirname(process.execPath)}${path.delimiter}${process.env.PATH ?? ''}`,
+    };
+    let diagnostics = '';
+    try {
+      if (host.family === 'powershell') {
+        const hostArguments = ['-NoProfile', '-NonInteractive'];
+        if (options.bypassPolicy !== false) hostArguments.push('-ExecutionPolicy', 'Bypass');
+        hostArguments.push('-EncodedCommand', Buffer.from(commandLine, 'utf16le').toString('base64'));
+        const result = await execFileAsync(host.path, hostArguments, {
+          env, timeout: 30_000, windowsHide: true, encoding: 'utf-8',
+        });
+        diagnostics = result.stderr;
+      } else {
+        // `-s` reads the command from stdin, the way the PTY types it.
+        execFileSync(host.path, ['--noprofile', '--norc', '-s'], {
+          input: `${commandLine}\n`, env, timeout: 30_000, windowsHide: true, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
+        });
+      }
+    } catch (error) {
+      diagnostics = error instanceof Error ? error.message : String(error);
+    }
+    if (!fs.existsSync(outPath)) {
+      throw new Error(`${host.name} never ran the receiver for: ${commandLine}\n${diagnostics}`);
+    }
+    return JSON.parse(fs.readFileSync(outPath, 'utf8')) as string[];
+  }
+
+  /** The command line the spawn flow types: builder output plus the host's own head adaptation. */
+  function typedLine(built: string, host: HostSpec): string {
+    return adaptCommandForShell(built, host.path, 'win32');
+  }
+
+  function buildCodexCommand(host: HostSpec, codexPath: string, prompt: string | undefined): string {
+    // No eventsOutputPath, so buildHooks never runs and there is no hook file
+    // I/O; MCP off so no -c payload. What remains is the head, -C, the
+    // approval flags, and the positional prompt: the reporter's exact shape.
+    return new CodexCommandBuilder().buildCodexCommand({
+      codexPath,
+      taskId: 'task-353',
+      cwd: tempDir,
+      permissionMode: 'default',
+      shell: host.path,
+      prompt,
+      mcpServerEnabled: false,
+    });
+  }
+
+  describe.each(HOSTS)('$name', (host) => {
+    it('is recognised by the shell predicates the resolver keys on', () => {
+      expect(isPowerShellShell(host.path)).toBe(host.family === 'powershell');
+    });
+
+    it.each([
+      ['the npm cmd-shim', () => cmdShim],
+      ['the tests/fixtures mock-*.cmd shape', () => minimalCmdShim],
+    ])('red pin: a quoteArg multiline prompt through %s reaches the receiver as <task> alone', async (_label, shim) => {
+      const built = `${quoteArg(shim(), host.path)} ${quoteArg(XML, host.path, { multiline: true })}`;
+
+      const argv = await runThroughHost(host, typedLine(built, host));
+
+      // Strict equality also proves the newline ended the whole command line:
+      // nothing after it reached the receiver either.
+      expect(argv).toEqual(['<task>']);
+    }, 60_000);
+
+    it('red pin: the real CodexCommandBuilder command through the .cmd shim loses everything after the first line', async () => {
+      const built = buildCodexCommand(host, cmdShim, XML);
+
+      const argv = await runThroughHost(host, typedLine(built, host));
+
+      expect(argv).toContain('-C');
+      expect(argv.at(-1)).toBe('<task>');
+    }, 60_000);
+
+    it('green: resolveShimLaunch picks the sibling shim and the receiver gets the XML byte for byte', async () => {
+      resetShimLaunchCacheForTests();
+      // The policy is injected so this case is deterministic whatever the
+      // machine's setting; the runner's -ExecutionPolicy Bypass covers the
+      // script itself. The Git Bash route has no policy to inject.
+      const launch = await resolveShimLaunch(
+        { agentPath: cmdShim, shell: host.path, prompt: XML },
+        { probeExecutionPolicy: async () => 'RemoteSigned' },
+      );
+      expect(launch.agentPath).toBe(host.family === 'powershell' ? ps1Shim : shShim);
+      expect(launch.strategy).toBe(host.family === 'powershell' ? 'ps1-sibling' : 'sh-sibling');
+      expect(launch.prompt).toBe(XML);
+      const built = buildCodexCommand(host, launch.agentPath, launch.prompt);
+
+      const argv = await runThroughHost(host, typedLine(built, host));
+
+      expect(argv).toContain('-C');
+      expect(argv.at(-1)).toBe(XML);
+    }, 60_000);
+
+    it('green: a quoted -- end-of-options marker survives the sibling shim ahead of the prompt', async () => {
+      // The Claude, Grok, Ollama, and Warp builders emit the marker before the
+      // prompt. PowerShell's binder eats a bare -- before a .ps1 sees $args;
+      // quoteArg's quoted form is what reaches the receiver as a plain --.
+      const shim = host.family === 'powershell' ? ps1Shim : shShim;
+      const built = `${quoteArg(shim, host.path)} ${quoteArg('--', host.path)} ${quoteArg(XML, host.path, { multiline: true })}`;
+
+      const argv = await runThroughHost(host, typedLine(built, host));
+
+      expect(argv).toEqual(['--', XML]);
+    }, 60_000);
+
+    it('green: the flatten fallback through the .cmd shim delivers the whole prompt on one line', async () => {
+      resetShimLaunchCacheForTests();
+      // PowerShell: the probe says Restricted. Git Bash: no sh sibling. Both
+      // keep the .cmd head and flatten; this is also the path the Windows E2E
+      // suite takes, since the mock fixtures have no sibling shims.
+      const siblingless = path.join(tempDir, 'lonely.cmd');
+      fs.writeFileSync(siblingless, NPM_CMD_SHIM, 'utf8');
+      const launch = await resolveShimLaunch(
+        { agentPath: siblingless, shell: host.path, prompt: XML },
+        { probeExecutionPolicy: async () => 'Restricted', warn: () => {} },
+      );
+      expect(launch.agentPath).toBe(siblingless);
+      expect(launch.strategy).toBe('flattened-prompt');
+      const built = buildCodexCommand(host, launch.agentPath, launch.prompt);
+
+      const argv = await runThroughHost(host, typedLine(built, host));
+
+      expect(argv.at(-1)).toBe(sanitizeForPty(XML));
+      expect(argv.at(-1)).toContain('<title>Fix login for issue 353</title>');
+    }, 60_000);
+
+    if (host.family === 'powershell') {
+      it('the production execution-policy probe returns a known policy name from this host', async () => {
+        const policy = await probeExecutionPolicy(host.path);
+
+        expect(policy).toMatch(/^(Restricted|AllSigned|RemoteSigned|Unrestricted|Bypass|Undefined)$/);
+      }, 60_000);
+
+      it('under the host\'s own policy, a permissive machine runs the .ps1 sibling (skips when blocked)', async (context) => {
+        // The one case that ties the probe's verdict to what a live PTY,
+        // spawned with only -NoLogo, would actually do.
+        const policy = await probeExecutionPolicy(host.path);
+        if (!executionPolicyAllowsScripts(policy)) {
+          context.skip();
+          return;
+        }
+        const built = buildCodexCommand(host, ps1Shim, XML);
+
+        const argv = await runThroughHost(host, typedLine(built, host), { bypassPolicy: false });
+
+        expect(argv.at(-1)).toBe(XML);
+      }, 60_000);
+    }
+  });
+});


### PR DESCRIPTION
## What

Fixes a Windows prompt-truncation bug at the agent-spawn boundary, in the shell/path layer so every adapter gets it rather than one.

- New `src/main/agent/shared/shim-launch.ts` (`resolveShimLaunch`), applied at all three `buildCommand` chokepoints: `transition-engine.ts` (board spawns), `session-startup/prepare-spawn.ts` (startup recovery), and `ipc/handlers/transient-sessions.ts` (Command Terminal).
- `src/shared/paths.ts`: adds an `isPowerShellShell` predicate, replacing five inline copies of the same substring test, and makes `quoteArg` quote a bare `--` for PowerShell hosts.
- The Claude, Grok, Ollama, and Warp builders route their end-of-options marker through `quoteArg`.
- Removes the Codex-only form of this fix that landed in #354, now that the chokepoint owns the decision.

## Why

Closes #353.

On Windows an npm-installed agent CLI resolves through PATHEXT to its `.cmd` shim (`codex.CMD`). Both PowerShell and Git Bash run that shim through cmd.exe, whose command line ends at the first newline, so the multi-line `{{task_xml}}` prompt reached the agent as `<task>` alone and the agent opened by asking what it was supposed to do.

Two things measured while confirming it. Git Bash hits the same cmd.exe truncation, so this was never PowerShell-only. And npm writes a `.ps1` and an extensionless sh shim beside every `.cmd`, both of which carry a multi-line argument intact.

A `.cmd` shim is a Windows packaging fact, not a Codex fact, and all 14 adapters hand off the prompt the same way, so the branch belongs in the shell/path layer per `.claude/rules/agent-adapters-boundary.md`.

## How

At each chokepoint, after `ensureTrust` and before `buildCommand`, `resolveShimLaunch` inspects the resolved head:

| Host shell | `.cmd` / `.bat` head becomes | Gate |
|---|---|---|
| PowerShell (pwsh/powershell) | the sibling `.ps1` | `Get-ExecutionPolicy` is RemoteSigned, Unrestricted, or Bypass, probed once per shell per run |
| Git Bash | the extensionless sh shim | the file exists and starts with `#!` |
| cmd | unchanged | `quoteArg` already flattens for a cmd host |
| WSL | unchanged | WSL cannot launch a `.cmd` at all |

With no usable sibling, or under Restricted / AllSigned, the `.cmd` head stays and the prompt is flattened with `sanitizeForPty`, so the whole title and description still arrive on one line. That is the workaround the reporter found, now automatic, with the cause logged once per shell and path. The session DB row keeps the original prompt; flattening is a delivery detail.

Two smaller findings ride along, both measured rather than assumed:

- PowerShell's parameter binder consumes an unquoted `--` before a `.ps1` script sees `$args`, so the end-of-options guard would silently vanish on the new route. `quoteArg('--', shell)` now emits `"--"` for PowerShell hosts, which reaches native commands and cmd.exe as a plain `--`.
- A `PSModulePath` inherited from a pwsh 7 ancestor makes Windows PowerShell 5.1 fail to autoload `Get-ExecutionPolicy`, which made the probe report null on a machine whose policy was Bypass. The probe now runs without that variable.

Trade-off worth a reviewer's attention: the Windows process tree becomes `pwsh -> node` instead of `pwsh -> cmd.exe -> node`. The background-shell watcher's immediate-parent rule already counts both shapes, and `tests/unit/bg-shell-watcher.test.ts` pins each.

## Breaking changes

None. Other platforms and non-PowerShell, non-Git-Bash shells are untouched, and a user with no usable sibling shim keeps the current launch path with a better prompt than before.

## Tests

- `tests/unit/shim-launch.test.ts` covers the decision matrix with injected `platform`, `fileExists`, `readFileHead`, `probeExecutionPolicy`, and `warn`, so it runs on CI's headless Linux without a Windows host: every unchanged path, both sibling swaps, both flatten fallbacks, warn-once, and the per-shell probe cache.
- `tests/unit/windows-cmd-shim-multiline-prompt.test.ts` is the regression test the original bug needed. It is Windows-only (`describe.runIf`) and drives real Windows PowerShell 5.1, pwsh 7, and Git Bash through real npm-format `.cmd`, `.ps1`, and sh shims in a temp dir. Red pins assert the `.cmd` truncation to `<task>`; green cases assert byte-for-byte XML delivery. The earlier local test passed precisely because it stopped short of the `.cmd`, which is how this shipped.
- Chokepoint wiring is pinned per site (`prepare-spawn-shim-launch-wiring`, `transient-session-spawn-shim-launch`, and a describe in `transition-engine.test.ts`), and `spawn-entry-point-parity.test.ts` now statically fails any `buildCommand(` site not preceded by `resolveShimLaunch(`.
- `tests/e2e/task-prompt.spec.ts` now asserts the title against the mock's own marker payload rather than the whole scrollback. The old assertion was satisfied by the shell's echo of the command line, which is why the Windows E2E passed vacuously through this bug.
- Verified end to end in the running app on both PowerShell hosts, with a real npm-format shim pair, before this PR.

CI runs lint, typecheck, build, unit, UI, and the Linux Electron E2E shards.

Generated with [Claude Code](https://claude.com/claude-code)
