### PR TITLE
fix(command-terminal): re-pair surviving PTYs from main's own slot record

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,7 +182,7 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 | `transition:set` | invoke | Set action chain for lane A→B |
 | `transition:getFor` | invoke | Get transitions for lane pair (exact match, then wildcard) |
 
-### Sessions (37 channels)
+### Sessions (38 channels)
 | Channel | Pattern | Purpose |
 |---------|---------|---------|
 | `session:spawn` | invoke | Spawn PTY session (may queue) |
@@ -221,6 +221,7 @@ Build-excluded from production via `__KANGENTIC_DEV__` (esbuild dead-code elimin
 | `session:getToolBreakdown` | invoke | Fetch live per-tool call breakdown for an active session (from the in-memory accumulator, not the DB) |
 | `session:spawnTransient` | invoke | Spawn ephemeral command terminal session (no task, no DB) |
 | `session:killTransient` | invoke | Kill a transient session and clean up session directory |
+| `session:setTransientLabel` | invoke | Record a Command Terminal's auto-derived name on its live registry row (first write wins). The renderer derives the name and has already applied it locally; main retains it purely so it survives a renderer reload, alongside the slot and branch that `toSession` carries. |
 | `session:injectSettings` | invoke | Inject a model/effort change into a live transient session's PTY via slash commands. Session-keyed (no task row, no DB persistence); backs the command-terminal context bar picker. |
 
 ### Usage Stats (1 channel)

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -1049,6 +1049,32 @@ Transient sessions are ephemeral Claude Code terminals spawned from the command 
 - **No resume capability** - killed on close, not suspendable
 - **No queue** - spawned immediately regardless of concurrency limits
 
+### Identity survives a renderer reload
+
+Which Command Terminal window owns which PTY is a `(projectId, slot)` pairing held in the
+renderer's `transientSessions` map. That map is renderer-only memory: HMR preserves it via
+`import.meta.hot.data`, a full page reload does not. Main keeps every transient PTY running
+regardless, so without recovery a reload left a live conversation with nothing pointing at it,
+and the window came back as an empty fresh boot.
+
+Main is the authority for the pairing. `ManagedSession` retains `commandTerminalSlot`,
+`commandTerminalBranch`, and `commandTerminalLabel` (in memory, not a DB row, so this does not
+make a transient session persistent), and `toSession` carries all three to the renderer on every
+session row. `planTransientRecovery`
+(`src/renderer/stores/session-store/transient-recovery.ts`) rebuilds the map from that on every
+`syncSessions`, for every project:
+
+1. An entry already pointing at a running session is kept verbatim, which preserves the
+   first-prompt-wins label.
+2. Every other survivor claims the slot main recorded for it.
+3. A survivor whose slot is taken, or that carries none, takes the lowest free slot, so no live
+   PTY is left unreachable.
+
+Step 3 is the one case where a terminal is renumbered; see
+`src/shared/command-terminal-name.ts` for why that is preferred to orphaning it. A window that
+mounts before recovery runs adopts an unpaired live PTY for its slot rather than spawning
+(`findAdoptableTransientSession`), so the duplicate cannot be recreated by a race.
+
 ### Spawn Flow (`SESSION_SPAWN_TRANSIENT`)
 
 1. Optionally checkout a target branch (falls back to current branch on failure)

--- a/src/main/ipc/handlers/transient-sessions.ts
+++ b/src/main/ipc/handlers/transient-sessions.ts
@@ -152,6 +152,14 @@ export function registerTransientSessionHandlers(context: IpcContext): void {
     return { session, branch, checkoutError };
   });
 
+  // Retain the renderer-derived terminal name on the live session. Purely so it
+  // survives a renderer reload: the pairing map that normally holds it is
+  // renderer-only memory, and `planTransientRecovery` reads this back off the
+  // session row to restore the name with the slot and branch.
+  ipcMain.handle(IPC.SESSION_SET_TRANSIENT_LABEL, (_, sessionId: string, label: string) => {
+    context.sessionManager.setCommandTerminalLabel(sessionId, label);
+  });
+
   ipcMain.handle(IPC.SESSION_KILL_TRANSIENT, (_, sessionId: string) => {
     // Capture session info before removal for cleanup
     const session = context.sessionManager.getSession(sessionId);

--- a/src/main/pty/session-manager.ts
+++ b/src/main/pty/session-manager.ts
@@ -1900,6 +1900,24 @@ export class SessionManager extends EventEmitter {
     this.telemetry.setSessionUsage(sessionId, partial);
   }
 
+  /**
+   * Record a Command Terminal's auto-derived name so it outlives the renderer.
+   *
+   * Main is a passive holder here: the renderer derives the name and has already
+   * applied it locally, and nothing in main reads it back except `toSession`,
+   * which hands it to the next renderer that has to rebuild the pairing map.
+   * First write wins, matching the renderer's own first-prompt-wins rule, so a
+   * later re-derivation cannot silently rename a terminal the user already knows
+   * by name. Unknown or non-transient sessions are ignored.
+   */
+  setCommandTerminalLabel(sessionId: string, label: string): void {
+    const session = this.registry.get(sessionId);
+    if (!session?.transient || session.commandTerminalLabel) return;
+    const trimmed = label.trim();
+    if (!trimmed) return;
+    session.commandTerminalLabel = trimmed;
+  }
+
   /** Return cached activity state for all sessions (survives renderer reloads). */
   getActivityCache(): Record<string, ActivityState> {
     return this.telemetry.getActivityCache();

--- a/src/main/pty/session-registry.ts
+++ b/src/main/pty/session-registry.ts
@@ -58,6 +58,17 @@ export interface ManagedSession {
    * not a live read of HEAD.
    */
   commandTerminalBranch?: string | null;
+  /**
+   * For a transient session, the name auto-derived from its first prompt.
+   * Undefined for task agents and until one is derived.
+   *
+   * Main does not compute this and does not use it: the renderer derives it (via
+   * the adapter's `summarize`) and pushes it here so it OUTLIVES the renderer.
+   * The pairing map that holds it is renderer-only memory, so without this a
+   * reload loses every terminal's name, and the auto-namer then re-derives from
+   * whatever prompt comes next. Same reason the slot and branch live here.
+   */
+  commandTerminalLabel?: string | null;
   /** Swimlane this session is isolated to (null = main session). Drives the Main/Isolated badge. */
   isolatedSwimlaneId?: string | null;
   /** Agent-reported session ID (the value passed to `--resume`). Known at
@@ -181,6 +192,14 @@ export function toSession(session: ManagedSession): Session {
     exitCode: session.exitCode,
     resuming: session.resuming,
     transient: session.transient || undefined,
+    // The renderer pairs a Command Terminal window to its PTY by (project, slot)
+    // in renderer-only memory, which a full page reload destroys. These two are
+    // main's authoritative copy of that pairing, so `syncSessions` can re-pair a
+    // survivor exactly instead of guessing. Dropping them here is what used to
+    // orphan a live terminal on every reload.
+    commandTerminalSlot: session.commandTerminalSlot ?? null,
+    commandTerminalBranch: session.commandTerminalBranch ?? null,
+    commandTerminalLabel: session.commandTerminalLabel ?? null,
     isolatedSwimlaneId: session.isolatedSwimlaneId,
     agentSessionId: session.agentSessionId ?? null,
   };
@@ -385,6 +404,11 @@ export class SessionRegistry {
    * widening the DTO would ripple through every existing consumer). Returns a
    * narrow projection rather than `ManagedSession` so callers still cannot
    * reach the pty handle, parsers, or adapter attachment.
+   *
+   * `commandTerminalSlot` / `commandTerminalBranch` used to be in that same
+   * monitor-only category and no longer are: `toSession` carries them too, because
+   * the renderer needs the slot to re-pair a surviving Command Terminal PTY to its
+   * window after a page reload. `agentName` remains the narrow-DTO example.
    */
   listManagedSummaries(): ManagedSessionSummary[] {
     return Array.from(this.sessions.values(), (session) => ({

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -276,6 +276,7 @@ const api: ElectronAPI = {
     getToolBreakdown: (sessionId: string) => ipcRenderer.invoke(IPC.SESSION_GET_TOOL_BREAKDOWN, sessionId),
     spawnTransient: (input) => ipcRenderer.invoke(IPC.SESSION_SPAWN_TRANSIENT, input),
     killTransient: (id) => ipcRenderer.invoke(IPC.SESSION_KILL_TRANSIENT, id),
+    setTransientLabel: (sessionId: string, label: string) => ipcRenderer.invoke(IPC.SESSION_SET_TRANSIENT_LABEL, sessionId, label),
     setFocused: (sessionIds: string[]) => ipcRenderer.invoke(IPC.SESSION_SET_FOCUSED, sessionIds),
     setMounted: (sessionIds: string[]) => ipcRenderer.invoke(IPC.SESSION_SET_MOUNTED, sessionIds),
     notifyUserInterrupt: (sessionId: string) => ipcRenderer.invoke(IPC.SESSION_NOTIFY_USER_INTERRUPT, sessionId),

--- a/src/renderer/components/command-bar/CommandTerminalWindow.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalWindow.tsx
@@ -34,6 +34,7 @@ import { ContextBar } from '../terminal/ContextBar';
 import { CommandTerminalPane, type TerminalGridGetter } from './CommandTerminalPane';
 import { useSessionStore } from '../../stores/session-store';
 import { transientKey, type TransientKillOutcome } from '../../stores/session-store/transient-session-slice';
+import { findAdoptableTransientSession } from '../../stores/session-store/transient-recovery';
 import { commandTerminalChangesEntityId } from '../../stores/session-store/task-changes-panel-slice';
 import { useBoardStore } from '../../stores/board-store';
 import { useConfigStore } from '../../stores/config-store';
@@ -244,6 +245,23 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
       }
     }
 
+    // No map entry, but main may still be running a PTY stamped with this slot: a
+    // renderer reload destroys the map while every transient PTY survives.
+    // Spawning here would manufacture a duplicate AND leave that survivor
+    // unreachable, which is the bug this guard closes. `syncSessions` normally
+    // re-pairs first, so this covers a window that mounts ahead of it - not a
+    // theoretical case: strip this branch and
+    // `command-terminal.spec.ts`'s "adopts the live PTY for its slot" test spawns
+    // a second PTY and strands the first.
+    const adoptable = findAdoptableTransientSession(state.sessions, state.transientSessions, currentProjectId, slot);
+    if (adoptable) {
+      state.adoptTransientSession(currentProjectId, slot, adoptable);
+      setSessionId(adoptable.id);
+      setBranch(adoptable.commandTerminalBranch ?? null);
+      setTerminalReady(true);
+      return;
+    }
+
     state.spawnTransientSession(slot)
       .then((result) => {
         setSessionId(result.session.id);
@@ -271,16 +289,33 @@ export function CommandTerminalWindow({ managedWindow, isMaximized, titleBarPoin
   // On an HMR remount, skip the shimmer when reattaching to a live transient
   // session (otherwise useState(false) would flash the launch overlay).
   const [terminalReady, setTerminalReady] = useState(() => {
-    if (!getIsHmrReload()) return false;
     const currentProjectId = useProjectStore.getState().currentProject?.id ?? null;
     if (!currentProjectId) return false;
+    const state = useSessionStore.getState();
+    // An adoptable survivor attaches without spawning, so it must skip the
+    // shimmer - otherwise a reload-recovered terminal flashes the launch overlay
+    // over a conversation that is already running.
+    //
+    // Checked BEFORE the HMR gate below, not after, because a genuine page reload
+    // is the case it exists for and `getIsHmrReload()` is FALSE there: the flag is
+    // "false on cold start, true after any HMR cycle" (utils/hmr-flag.ts), and a
+    // full reload is a cold start. Behind the gate this branch could only ever run
+    // under Fast Refresh, which is the one path that does not need it - the map
+    // survives HMR via import.meta.hot.data, so the entry check below already
+    // covers it. Being adoptable is a strictly stronger condition than "this is
+    // HMR" anyway: it means main is running a live PTY for this exact slot, which
+    // is reason enough to skip the launch overlay however the renderer got here.
+    if (findAdoptableTransientSession(state.sessions, state.transientSessions, currentProjectId, slot)) return true;
+    if (!getIsHmrReload()) return false;
     // Reattach shimmer-free only if the slot's session is still alive; a stale
     // entry (session died while the layer was hidden, exit event not yet applied)
     // must fall through to the spawn path WITH the shimmer, mirroring the mount
     // effect's alive check below.
-    const state = useSessionStore.getState();
     const existing = state.transientSessions[transientKey(currentProjectId, slot)];
-    return !!existing && state.sessions.some((session) => session.id === existing.sessionId && session.status === 'running');
+    if (existing) {
+      return state.sessions.some((session) => session.id === existing.sessionId && session.status === 'running');
+    }
+    return false;
   });
 
   useEffect(() => {

--- a/src/renderer/components/command-bar/command-window-reconcile.ts
+++ b/src/renderer/components/command-bar/command-window-reconcile.ts
@@ -37,10 +37,17 @@ export interface CommandWindowTransientEntry {
 /** A minimal session row: only the fields liveness needs. `status` uses the real
  *  `SessionStatus` union (a type-only import, erased at build, so the module stays
  *  runtime-pure) to keep the `'running'` liveness check typo-proof and tracking
- *  the source enum. A real `Session` still assigns structurally. */
+ *  the source enum. A real `Session` still assigns structurally.
+ *
+ *  The three optional fields carry main's own record of which Command Terminal
+ *  slot a PTY belongs to. They are optional so a fixture can still pass a bare
+ *  `{ id, status }` where the pairing is irrelevant. */
 export interface CommandWindowSessionRef {
   id: string;
   status: SessionStatus;
+  projectId?: string;
+  transient?: boolean;
+  commandTerminalSlot?: string | null;
 }
 
 export interface CommandWindowReconcilePlan {
@@ -74,16 +81,34 @@ export function planCommandWindowReconciliation(input: {
   const runningSessionIds = new Set(
     sessions.filter((session) => session.status === 'running').map((session) => session.id),
   );
-  const liveSlots = new Set(
-    Object.values(transientSessions)
+  // Two sources, unioned. The map is the renderer's own pairing; the session rows
+  // are main's, and they are what keeps this correct when the map is behind. A
+  // renderer reload destroys the map while every transient PTY survives, so a
+  // map-only read reports "no live sessions" for a project that has several, takes
+  // the branch below, and lets the kept window fresh-spawn over a live terminal.
+  const liveSlots = new Set([
+    ...Object.values(transientSessions)
       .filter((entry) => entry.projectId === projectId && runningSessionIds.has(entry.sessionId))
       .map((entry) => entry.slot),
-  );
+    // flatMap rather than filter-then-map: a boolean predicate cannot narrow
+    // `commandTerminalSlot` for the map that follows it, so that shape needs a
+    // cast to compile and the non-null-ness rests on the reader. Returning the
+    // slot from inside the guard lets the compiler prove it instead.
+    ...sessions.flatMap((session) => (
+      session.transient
+      && session.status === 'running'
+      && session.projectId === projectId
+      && session.commandTerminalSlot
+        ? [session.commandTerminalSlot]
+        : []
+    )),
+  ]);
 
   // No live session for this project: keep exactly one window (lowest slot, so
   // the layer always opens with a terminal) and close the rest. That kept window
-  // fresh-spawns for the current project via its own mount effect. Fills from the
-  // lowest slot to match `syncSessions` re-pairing (slot-1 up).
+  // fresh-spawns for the current project via its own mount effect. Reached on a
+  // genuine project switch to a project with no terminals - never merely because
+  // the pairing map was lost, which the union above rules out.
   if (liveSlots.size === 0 && windows.length > 0) {
     const bySlotAscending = [...windows].sort((first, second) => slotNumber(first.slot) - slotNumber(second.slot));
     const [, ...surplus] = bySlotAscending;

--- a/src/renderer/lib/auto-name-scheduler.ts
+++ b/src/renderer/lib/auto-name-scheduler.ts
@@ -142,6 +142,15 @@ export function maybeLabelTransientSession(sessionId: string, event: SessionEven
   const transientSessions = useSessionStore.getState().transientSessions;
   const owningEntry = Object.values(transientSessions).find((entry) => entry.sessionId === sessionId);
   if (!owningEntry) return;
+  // Already named, so this prompt is not the first one - the in-memory guard
+  // above only covers this renderer, and a reload clears it while recovery
+  // restores the label from main. Without this check the reloaded renderer pays
+  // a summarize call on the next prompt and `setTransientSessionLabel` discards
+  // the answer, since first-prompt-wins.
+  if (owningEntry.label) {
+    autoNameLabeledTransient.add(sessionId);
+    return;
+  }
 
   const promptText = (event.detail ?? '').trim();
   if (!promptText) return;

--- a/src/renderer/stores/session-store.ts
+++ b/src/renderer/stores/session-store.ts
@@ -7,7 +7,8 @@ import type { SessionStore, PendingTuiAnchor } from './session-store/types';
 import { buildSessionByTaskId, withSessionUpserted } from './session-store/session-index';
 import { isLiveSessionStatus } from '../../shared/session-liveness';
 import { createTaskChangesPanelSlice } from './session-store/task-changes-panel-slice';
-import { createTransientSessionSlice, transientKey, type TransientSessionEntry } from './session-store/transient-session-slice';
+import { createTransientSessionSlice, type TransientSessionEntry } from './session-store/transient-session-slice';
+import { planTransientRecovery } from './session-store/transient-recovery';
 import { registerSessionLifecycleHooks } from './session-lifecycle-hooks';
 import { mergeRateLimitSnapshot } from '../utils/rate-limit-window';
 import { claimArrivalFocus } from '../utils/terminal-arrival-focus';
@@ -443,38 +444,26 @@ const sessionStoreInitializer: StateCreator<SessionStore> = (set, get, api) => (
       pendingCommandLabel: nextPendingCommandLabel,
     });
 
-    // Recover transient session entries after a full page reload. The main
-    // process keeps transient PTYs alive, but the renderer's in-memory map is
-    // lost on a hard reload (HMR preserves it via import.meta.hot.data, so this
-    // only fires on a true reload, not Fast Refresh). Rebuild best-effort: pair
-    // the project's surviving transient PTYs to slot ids in a stable order. The
-    // command windows reattach by (project, slot) on next open. Skip if the
-    // project already has tracked entries (the HMR-preserved path).
-    if (currentProjectId) {
-      const alreadyTracked = Object.values(get().transientSessions).some(
-        (entry) => entry.projectId === currentProjectId,
-      );
-      if (!alreadyTracked) {
-        const survivors = mergedSessions
-          .filter((session) => session.transient && session.projectId === currentProjectId && session.status === 'running')
-          .sort((sessionA, sessionB) => sessionA.id.localeCompare(sessionB.id));
-        if (survivors.length > 0) {
-          set((state) => {
-            const transientSessions: Record<string, TransientSessionEntry> = { ...state.transientSessions };
-            survivors.forEach((session, index) => {
-              const slot = `slot-${index + 1}`;
-              transientSessions[transientKey(currentProjectId, slot)] = {
-                projectId: currentProjectId,
-                slot,
-                sessionId: session.id,
-                branch: null,
-              };
-            });
-            return { transientSessions };
-          });
-        }
-      }
-    }
+    // Re-pair surviving Command Terminal PTYs to their windows. Main keeps
+    // transient PTYs alive across a renderer reload, but the (project, slot) map
+    // is renderer-only memory - HMR preserves it via import.meta.hot.data, a full
+    // reload does not - so without this a live conversation is left with nothing
+    // pointing at it, and the project's terminal count exceeds its window count.
+    //
+    // Unconditional, per-slot, and cross-project by design. It used to be gated on
+    // "this project has no tracked entries", so one freshly spawned terminal
+    // permanently blocked re-pairing of that project's other survivors, and
+    // wrapped in `if (currentProjectId)`, so a background project's terminals were
+    // never recovered at all. It also dealt out `slot-1, slot-2, ...` over a
+    // uuid-sorted list, which could put someone else's conversation under
+    // "Command Terminal 1". The slot now arrives on the session row, so pairing is
+    // exact; the planner keeps already-paired entries verbatim, which is what
+    // makes running on every sync (Fast Refresh included) safe for their labels.
+    const recoveredTransientSessions = planTransientRecovery({
+      sessions: mergedSessions,
+      transientSessions: get().transientSessions,
+    });
+    if (recoveredTransientSessions) set({ transientSessions: recoveredTransientSessions });
 
     return true;
   },

--- a/src/renderer/stores/session-store/transient-recovery.ts
+++ b/src/renderer/stores/session-store/transient-recovery.ts
@@ -1,0 +1,197 @@
+/**
+ * Pure planner that re-pairs surviving Command Terminal PTYs to their windows.
+ *
+ * `transientSessions` is renderer-only memory keyed by `(projectId, slot)`. It
+ * survives Fast Refresh via `import.meta.hot.data` but NOT a full page reload,
+ * while main keeps every transient PTY running. Without recovery the reload
+ * leaves a live conversation with nothing pointing at it: the window comes back
+ * as a fresh empty boot and the project's terminal count exceeds its window
+ * count.
+ *
+ * Main stamps the slot at spawn (`ipc/handlers/transient-sessions.ts`) and it now
+ * reaches the renderer on every `Session` row, so pairing is EXACT rather than
+ * guessed. The previous implementation sorted survivors by uuid and dealt them
+ * `slot-1`, `slot-2`, ... which had no relationship to the slot a PTY actually
+ * ran under: closing slot 1 of 2, or ids sorting the other way, silently put
+ * someone else's conversation under "Command Terminal 1" with no error.
+ *
+ * Kept pure and store-free so it is unit-testable without jsdom, Zustand, or
+ * React, mirroring `command-window-reconcile.ts` and the `workspace-saver.ts`
+ * precedent. The caller applies the result (see `syncSessions`).
+ */
+
+import type { Session } from '../../../shared/types';
+import { buildTransientSessionEntry, type TransientSessionEntry, transientKey } from './transient-session-slice';
+
+/** A running Command Terminal PTY for some project. */
+function isLiveTransient(session: Session): boolean {
+  return !!session.transient && session.status === 'running';
+}
+
+/**
+ * Oldest first, so that when two survivors claim the same slot the one that has
+ * held it longest keeps it. `startedAt` is a UTC ISO 8601 string, so a lexical
+ * compare IS the chronological one. Ids break a tie, purely so the result is
+ * deterministic when two sessions share a timestamp (which fixtures do).
+ */
+function byStartedAtThenId(first: Session, second: Session): number {
+  return first.startedAt.localeCompare(second.startedAt) || first.id.localeCompare(second.id);
+}
+
+/** Lowest `slot-N` (from 1 up) not already claimed for this project.
+ *
+ *  No `MAX_COMMAND_TERMINALS` cap: live transients are already bounded by the
+ *  window allocator (`nextFreeSlot`), and `planCommandWindowReconciliation`
+ *  applies its own `openBudget`. A second cap here could only disagree with
+ *  those, and the way it would fail is by leaving a live PTY unpaired, which is
+ *  the bug this module exists to prevent.
+ *
+ *  The loop is bounded anyway. `claimedSlots.size + 1` candidates cannot all be
+ *  claimed by a set of that size, so a free slot is always found before the
+ *  bound - it is a termination proof, not a policy. An unbounded `for(;;)` in a
+ *  path that runs on every session sync is not worth the (however small) risk of
+ *  a hang if an invariant above it ever changes. */
+function lowestFreeSlot(claimedSlots: ReadonlySet<string>): string {
+  for (let slotNumber = 1; slotNumber <= claimedSlots.size + 1; slotNumber++) {
+    const slot = `slot-${slotNumber}`;
+    if (!claimedSlots.has(slot)) return slot;
+  }
+  /* c8 ignore next 2 -- unreachable by the pigeonhole argument above. */
+  throw new Error('lowestFreeSlot: no free slot below the pigeonhole bound');
+}
+
+/**
+ * A live transient PTY that main says belongs to `(projectId, slot)` but which no
+ * map entry points at, or null.
+ *
+ * This is the orphan shape a renderer reload produces, seen from one window's
+ * point of view. `planTransientRecovery` normally re-pairs before any window
+ * mounts, so this is the mount effect's guard for the case where it does not:
+ * spawning on an empty map manufactures a duplicate AND strands the survivor,
+ * which is strictly worse than either alone.
+ *
+ * Deliberately does NOT fall back to "any unpaired live transient for this
+ * project". Attaching a window to a terminal that main says belongs to a
+ * different slot is the mis-pairing this whole module exists to prevent: the user
+ * would get someone else's conversation under this window's title, with no error.
+ */
+export function findAdoptableTransientSession(
+  sessions: readonly Session[],
+  transientSessions: Readonly<Record<string, TransientSessionEntry>>,
+  projectId: string,
+  slot: string,
+): Session | null {
+  const pairedSessionIds = new Set(Object.values(transientSessions).map((entry) => entry.sessionId));
+  return sessions.find((session) => (
+    isLiveTransient(session)
+    && session.projectId === projectId
+    && session.commandTerminalSlot === slot
+    && !pairedSessionIds.has(session.id)
+  )) ?? null;
+}
+
+/**
+ * Rebuild the (project, slot) pairing map from the authoritative session list.
+ *
+ * Runs on every `syncSessions`, for EVERY project, with no "already tracked"
+ * short-circuit. The old gates were the bug: one freshly spawned entry made the
+ * whole project look recovered and permanently blocked re-pairing of its other
+ * survivors, and the current-project wrapper meant a background project's
+ * terminals were never recovered at all.
+ *
+ * Returns the SAME object reference when nothing needs to change, so the common
+ * no-op sync does not touch the store.
+ */
+export function planTransientRecovery(input: {
+  sessions: readonly Session[];
+  transientSessions: Readonly<Record<string, TransientSessionEntry>>;
+}): Record<string, TransientSessionEntry> | null {
+  const { sessions, transientSessions } = input;
+
+  // One pass over each input, grouped by project. Doing the `transientSessions`
+  // scan per project instead would be O(projects x entries) on a function that
+  // runs on every session sync.
+  const liveByProject = new Map<string, Session[]>();
+  for (const session of sessions) {
+    if (!isLiveTransient(session)) continue;
+    const forProject = liveByProject.get(session.projectId);
+    if (forProject) forProject.push(session);
+    else liveByProject.set(session.projectId, [session]);
+  }
+  if (liveByProject.size === 0) return null;
+
+  const entriesByProject = new Map<string, TransientSessionEntry[]>();
+  for (const entry of Object.values(transientSessions)) {
+    if (!liveByProject.has(entry.projectId)) continue;
+    const forProject = entriesByProject.get(entry.projectId);
+    if (forProject) forProject.push(entry);
+    else entriesByProject.set(entry.projectId, [entry]);
+  }
+
+  // Allocated on the first write, not up front: the overwhelmingly common call
+  // is a no-op sync where every survivor is already paired, and that case should
+  // cost no copy of the map at all.
+  let next: Record<string, TransientSessionEntry> | null = null;
+  const pair = (projectId: string, slot: string, session: Session): void => {
+    next ??= { ...transientSessions };
+    // Shared with `adoptTransientSession`, the other path that re-pairs a
+    // survivor, so the two cannot disagree about which fields an entry carries.
+    // The label is the one that matters: main retains the derived name for
+    // exactly this moment, and without it a recovered terminal falls back to
+    // "Command Terminal N" and the auto-namer renames it from a LATER prompt,
+    // since it fires per prompt event.
+    next[transientKey(projectId, slot)] = buildTransientSessionEntry(projectId, slot, session);
+  };
+
+  for (const [projectId, liveSessions] of liveByProject) {
+    const liveSessionIds = new Set(liveSessions.map((session) => session.id));
+
+    // Pass 1: keep what is already paired, VERBATIM. An entry pointing at a
+    // still-running session owns its slot, and rewriting it would drop the
+    // `label` that `setTransientSessionLabel` derived from the first prompt -
+    // first-prompt-wins, so a clobbered label never comes back. This matters
+    // because syncSessions is Pattern B (re-run on every Fast Refresh), not just
+    // on the hard reload this module is named for.
+    const claimedSlots = new Set<string>();
+    const pairedSessionIds = new Set<string>();
+    for (const entry of entriesByProject.get(projectId) ?? []) {
+      // An entry whose session is gone or dead is stale: its slot goes back in
+      // the pool rather than blocking a survivor.
+      if (!liveSessionIds.has(entry.sessionId)) continue;
+      claimedSlots.add(entry.slot);
+      pairedSessionIds.add(entry.sessionId);
+    }
+    if (pairedSessionIds.size === liveSessions.length) continue;
+
+    const unpaired = liveSessions
+      .filter((session) => !pairedSessionIds.has(session.id))
+      .sort(byStartedAtThenId);
+
+    // Pass 2: exact re-pair. Each survivor claims the slot main recorded for it.
+    const rehome: Session[] = [];
+    for (const session of unpaired) {
+      const slot = session.commandTerminalSlot;
+      // No slot is a real case, not defensive padding (see
+      // `commandTerminalSlotNumber`): a session spawned before this plumbing
+      // existed, or by a path that sends none. A collision is real too - a slot
+      // is reused as soon as its window is closed, so a post-reload spawn can
+      // take the same slot a survivor still holds.
+      if (!slot || claimedSlots.has(slot)) {
+        rehome.push(session);
+        continue;
+      }
+      claimedSlots.add(slot);
+      pair(projectId, slot, session);
+    }
+
+    // Pass 3: everything left (unslotted, or its slot taken) gets the lowest free
+    // slot, so no live PTY is ever left unreachable.
+    for (const session of rehome) {
+      const slot = lowestFreeSlot(claimedSlots);
+      claimedSlots.add(slot);
+      pair(projectId, slot, session);
+    }
+  }
+
+  return next;
+}

--- a/src/renderer/stores/session-store/transient-session-slice.ts
+++ b/src/renderer/stores/session-store/transient-session-slice.ts
@@ -43,6 +43,35 @@ export function transientKey(projectId: string, slot: string): string {
   return `${projectId}::${slot}`;
 }
 
+/**
+ * Build the pairing entry for a SURVIVING PTY that main says owns `(projectId,
+ * slot)`.
+ *
+ * Shared by the only two paths that re-pair a survivor - `adoptTransientSession`
+ * below and `planTransientRecovery`'s pairing pass - because they have to agree on
+ * which fields an entry carries, and they did not. The adopt path built the entry
+ * by hand and omitted `label`, so a terminal recovered through it came back as
+ * "Command Terminal N"; recovery's pass 1 then kept that label-less entry verbatim,
+ * the auto-namer re-derived a name from a LATER prompt, and main refused the mirror
+ * because first-write-wins. One builder is what stops that drifting again.
+ *
+ * `spawnTransientSession` deliberately does NOT use this: a fresh spawn takes its
+ * branch from the spawn RESULT rather than the session row, and has no label yet.
+ */
+export function buildTransientSessionEntry(
+  projectId: string,
+  slot: string,
+  session: Session,
+): TransientSessionEntry {
+  return {
+    projectId,
+    slot,
+    sessionId: session.id,
+    branch: session.commandTerminalBranch ?? null,
+    ...(session.commandTerminalLabel ? { label: session.commandTerminalLabel } : {}),
+  };
+}
+
 /** Every transient session id for a project, in map order. Drives the focused-set
  *  push (each visible terminal must be focused). Activity aggregates do NOT use
  *  this: they go through `selectCommandTerminalSummary` below, which reads the
@@ -77,11 +106,11 @@ const EMPTY_COMMAND_TERMINAL_SUMMARY: CommandTerminalSummary = { count: 0, tone:
  * tone. Drives the title-bar glyph and the per-project sidebar indicator.
  *
  * Reads the SESSIONS list rather than the `transientSessions` map on purpose. That
- * map is renderer-owned window pairing, and its hard-reload recovery only re-pairs
- * the CURRENT project's survivors (see `syncSessions`), so a map-based count would
- * read zero for every background project after a reload. `session:list` is unscoped
- * and every row carries `projectId` + `transient` stamped by main, so this stays
- * correct cross-project and across reloads.
+ * map is renderer-owned window pairing, reconstructed after a reload by
+ * `planTransientRecovery`; reading main's own rows keeps this count independent of
+ * whether that reconstruction has run yet. `session:list` is unscoped and every row
+ * carries `projectId` + `transient` stamped by main, so it is correct cross-project
+ * and across reloads by construction.
  *
  * WORKING wins: any active terminal makes the whole project read active, else
  * attention if any needs you, else rest. Bucketed only through the shared
@@ -165,6 +194,14 @@ export interface TransientSessionSlice {
     branch?: string,
     grid?: { cols: number; rows: number },
   ) => Promise<{ session: Session; branch: string; checkoutError?: string }>;
+  /** Pair an ALREADY-RUNNING transient PTY to `(projectId, slot)` without spawning.
+   *
+   *  The window mount effect's last resort before it spawns: main's session row
+   *  says this PTY belongs to this slot, but nothing in the map points at it. That
+   *  is the reload-orphan shape, and spawning instead would manufacture a duplicate
+   *  and strand the survivor. Recovery normally re-pairs first, so this only fires
+   *  when a window mounts ahead of it. */
+  adoptTransientSession: (projectId: string, slot: string, session: Session) => void;
   /** Kill one slot's transient PTY (IPC) and scrub its renderer state.
    *
    *  Reports which of the three things actually happened, because they are not
@@ -247,6 +284,15 @@ export function createTransientSessionSlice(preserved: {
       return result;
     },
 
+    adoptTransientSession: (projectId, slot, session) => {
+      set((state) => ({
+        transientSessions: {
+          ...state.transientSessions,
+          [transientKey(projectId, slot)]: buildTransientSessionEntry(projectId, slot, session),
+        },
+      }));
+    },
+
     killTransientSessionBySlot: async (projectId, slot) => {
       const entry = get().transientSessions[transientKey(projectId, slot)];
       // No entry means no PTY to address. Nothing was killed, and saying so is the
@@ -308,6 +354,7 @@ export function createTransientSessionSlice(preserved: {
     setTransientSessionLabel: (sessionId, label) => {
       const trimmed = label.trim();
       if (!trimmed) return;
+      let applied = false;
       set((state) => {
         const next = { ...state.transientSessions };
         for (const [key, entry] of Object.entries(next)) {
@@ -316,10 +363,19 @@ export function createTransientSessionSlice(preserved: {
             // user-set or earlier-derived label on subsequent prompts.
             if (entry.label) return state;
             next[key] = { ...entry, label: trimmed };
+            applied = true;
             return { transientSessions: next };
           }
         }
         return state;
+      });
+      // Mirror to main so the name outlives this renderer. Only on a real apply,
+      // so a no-op (already labelled, or no owning entry) issues no IPC. Main
+      // holds it passively; nothing here waits on it, and a rejection costs only
+      // the name after a future reload.
+      if (!applied) return;
+      void window.electronAPI.sessions.setTransientLabel(sessionId, trimmed).catch(() => {
+        // Best-effort - the label is already applied locally.
       });
     },
 

--- a/src/shared/command-terminal-name.ts
+++ b/src/shared/command-terminal-name.ts
@@ -16,6 +16,17 @@
  * Numbering is unconditional rather than "only once a second terminal exists",
  * again for stability: a conditional number changes the title of a window that
  * did not change.
+ *
+ * ONE case renumbers, deliberately. A renderer reload destroys the (project,
+ * slot) pairing map while main keeps every PTY alive, so recovery re-pairs
+ * survivors from the slot main recorded (`planTransientRecovery`). If a terminal
+ * spawned after the reload has already taken that slot, the survivor cannot have
+ * it back and moves to the lowest free one, so a conversation that was "Command
+ * Terminal 1" returns as "Command Terminal 2". That breaks the stability rule
+ * above, and it is still the right trade: the alternative is one of the two PTYs
+ * being left with no window at all, unreachable with its question pending. The
+ * rule holds everywhere else - nothing renumbers because a sibling opened or
+ * closed.
  */
 
 export const COMMAND_TERMINAL_BASE_TITLE = 'Command Terminal';

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -128,6 +128,7 @@ export const IPC = {
   SESSION_GET_TOOL_BREAKDOWN: 'session:getToolBreakdown',
   SESSION_SPAWN_TRANSIENT: 'session:spawnTransient',
   SESSION_KILL_TRANSIENT: 'session:killTransient',
+  SESSION_SET_TRANSIENT_LABEL: 'session:setTransientLabel',
   SESSION_SET_FOCUSED: 'session:setFocused',
   SESSION_SET_MOUNTED: 'session:setMounted',
   SESSION_NOTIFY_USER_INTERRUPT: 'session:notifyUserInterrupt',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -718,6 +718,34 @@ export interface Session {
   /** True for ephemeral command terminal sessions (no task association, no DB persistence). */
   transient?: boolean;
   /**
+   * For a transient session, the durable Command Terminal window SLOT id
+   * (`slot-1`, ...) the renderer allocated at spawn. Null for task agents and for
+   * a transient spawned by a path that sends none.
+   *
+   * On this DTO for CORRECTNESS, which is what separates it from `agentName`
+   * (deliberately kept off, as a diagnostic - see `listManagedSummaries` in
+   * src/main/pty/session-registry.ts). The renderer's (project, slot) pairing map
+   * is renderer-only memory that a full page reload destroys, leaving live PTYs
+   * with nothing pointing at them. This is main's authoritative copy of the
+   * pairing, so recovery re-pairs a survivor to the slot it actually ran under
+   * instead of guessing a position. See planTransientRecovery.
+   */
+  commandTerminalSlot?: string | null;
+  /** For a transient session, the branch it was spawned on (the RESOLVED branch,
+   *  after any checkout fallback). Null for task agents. Carried for the same
+   *  reason as the slot: recovery restores it, so a recovered terminal's header
+   *  branch pill is not blank. */
+  commandTerminalBranch?: string | null;
+  /** For a transient session, the name auto-derived from its first prompt. Null
+   *  until one is derived, and for task agents.
+   *
+   *  Derived in the renderer (`auto-name-scheduler.ts`) and pushed to main purely
+   *  so it survives a reload, alongside the slot and branch. Without that, a
+   *  recovered terminal drops back to "Command Terminal N" AND the auto-namer
+   *  re-fires on the next prompt, renaming it after whatever the user happened to
+   *  type second. */
+  commandTerminalLabel?: string | null;
+  /**
    * Parallel-session discriminator for the terminal badge. Null/undefined (main
    * session, or legacy/transient sessions) shows as "Main"; a swimlane id (the
    * column this session is isolated to) shows as "Isolated". See
@@ -4830,6 +4858,10 @@ export interface ElectronAPI {
     getToolBreakdown: (sessionId: string) => Promise<PerToolStat[]>;
     spawnTransient: (input: SpawnTransientSessionInput) => Promise<{ session: Session; branch: string; checkoutError?: string }>;
     killTransient: (sessionId: string) => Promise<void>;
+    /** Record a transient session's auto-derived name on main, so it survives a
+     *  renderer reload. Fire-and-forget: the renderer has already applied it
+     *  locally, and main only retains it for recovery. */
+    setTransientLabel: (sessionId: string, label: string) => Promise<void>;
     setFocused: (sessionIds: string[]) => Promise<void>;
     /**
      * Which sessions this renderer has an xterm MOUNTED for - a superset of

--- a/tests/e2e/command-terminal-reload-recovery.spec.ts
+++ b/tests/e2e/command-terminal-reload-recovery.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * E2E: a renderer reload must not orphan a live Command Terminal PTY.
+ *
+ * The (project, slot) pairing that ties a Command Terminal window to its PTY is
+ * renderer-only memory. A full reload destroys it while main keeps every
+ * transient PTY running, so the terminal used to come back as a fresh, empty
+ * boot with the original conversation still alive and unreachable.
+ *
+ * This lives at the E2E tier because it is the only one that can do the thing
+ * the bug needs: a REAL `page.reload()` against a REAL PTY. The UI tier fakes
+ * the reload structurally (it seeds surviving sessions into a mock while the
+ * renderer's map starts empty) because its mock reinstalls through
+ * `addInitScript` and its state resets on navigation, so a genuine reload there
+ * would take the "surviving" PTYs with it.
+ *
+ * Deliberately store-free. `__zustandStores` is not reliably present in the E2E
+ * context (see the note on `dismissOnboardingChecklist`), and main's own session
+ * list is the stronger assertion anyway: the regression is a SECOND PTY being
+ * spawned while the first is stranded, and that is visible as a count.
+ */
+import { test, expect } from '@playwright/test';
+import {
+  launchApp,
+  waitForBoard,
+  createProject,
+  createTempProject,
+  cleanupTempProject,
+  getTestDataDir,
+  cleanupTestDataDir,
+  dismissOnboardingChecklist,
+  closeApp,
+} from './helpers';
+import type { ElectronApplication, Page } from '@playwright/test';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const TEST_NAME = 'command-terminal-reload-recovery';
+const runId = Date.now();
+const PROJECT_NAME = `Reload Recovery ${runId}`;
+
+/** Resolve the platform-appropriate mock Claude path. */
+function mockClaudePath(): string {
+  const fixturesDir = path.join(__dirname, '..', 'fixtures');
+  if (process.platform === 'win32') {
+    return path.join(fixturesDir, 'mock-claude.cmd');
+  }
+  const jsPath = path.join(fixturesDir, 'mock-claude.js');
+  fs.chmodSync(jsPath, 0o755);
+  return jsPath;
+}
+
+/** Pre-write config with the mock CLI under the key the transient spawn reads
+ *  (`agent.cliPaths`, not the legacy `claude.cliPath`) and worktrees off. */
+function writeTestConfig(dataDir: string): void {
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dataDir, 'config.json'),
+    JSON.stringify({
+      hasCompletedFirstRun: true,
+      agent: { cliPaths: { claude: mockClaudePath() } },
+      git: { worktreesEnabled: false },
+    }),
+  );
+}
+
+interface TransientRow {
+  id: string;
+  startedAt: string;
+}
+
+/** Every running Command Terminal PTY main currently owns, as main reports it. */
+async function liveTerminals(page: Page): Promise<TransientRow[]> {
+  return page.evaluate(async () => {
+    const sessions = await window.electronAPI.sessions.list();
+    return sessions
+      .filter((session) => session.transient && session.status === 'running')
+      .map((session) => ({ id: session.id, startedAt: session.startedAt }));
+  });
+}
+
+/** The live terminals in spawn order, which is also slot order. */
+async function orderedByStart(page: Page): Promise<TransientRow[]> {
+  const rows = await liveTerminals(page);
+  return rows.sort(
+    (first, second) => first.startedAt.localeCompare(second.startedAt) || first.id.localeCompare(second.id),
+  );
+}
+
+/** Open the Command Terminal layer and wait for a window to be on screen. */
+async function openCommandTerminalLayer(page: Page): Promise<void> {
+  await page.keyboard.press('Control+Shift+P');
+  await page.locator('[data-testid="command-terminal-window"]').first()
+    .waitFor({ state: 'visible', timeout: 20000 });
+}
+
+test.describe('Command Terminal reload recovery', () => {
+  let app: ElectronApplication | undefined;
+  let page: Page;
+  let projectPath: string;
+
+  test.beforeAll(async () => {
+    cleanupTestDataDir(TEST_NAME);
+    const dataDir = getTestDataDir(TEST_NAME);
+    writeTestConfig(dataDir);
+    projectPath = createTempProject(TEST_NAME);
+
+    const launched = await launchApp({ dataDir });
+    app = launched.app;
+    page = launched.page;
+    // No waitForBoard first: a fresh dataDir opens on the welcome screen, which
+    // has no swimlanes. createProject reloads and waits for the board itself.
+    await createProject(page, PROJECT_NAME, projectPath);
+  });
+
+  test.afterAll(async () => {
+    await closeApp(app);
+    cleanupTempProject(TEST_NAME);
+    cleanupTestDataDir(TEST_NAME);
+  });
+
+  test('a real page reload reattaches the survivor under its own terminal number', async () => {
+    // Two terminals, then stop the FIRST. That leaves exactly one survivor, and
+    // it is the one on slot-2 - which is what makes this deterministic rather
+    // than a coin flip. Recovery used to deal survivors `slot-1, slot-2, ...`
+    // over an id-sorted list, so a lone survivor always landed on slot-1 no
+    // matter which terminal it actually was. With one terminal that guess is
+    // accidentally right, which is why the test needs two.
+    await openCommandTerminalLayer(page);
+    await expect
+      .poll(async () => (await liveTerminals(page)).length, { timeout: 30000, intervals: [250, 500, 1000] })
+      .toBe(1);
+
+    await page.locator('[data-testid="quick-session-new-terminal"]').click();
+    await expect
+      .poll(async () => (await liveTerminals(page)).length, { timeout: 30000, intervals: [250, 500, 1000] })
+      .toBe(2);
+
+    // Spawn order is slot order, so the older row is the slot-1 terminal. Derived
+    // from startedAt rather than from `commandTerminalSlot`, deliberately: this
+    // test asserts observable behavior, so it must not identify its subject using
+    // the very field the fix added.
+    const [firstTerminal, secondTerminal] = await orderedByStart(page);
+
+    await page.evaluate((id) => window.electronAPI.sessions.killTransient(id), firstTerminal.id);
+    await expect
+      .poll(async () => (await liveTerminals(page)).map((row) => row.id), { timeout: 15000, intervals: [250, 500] })
+      .toEqual([secondTerminal.id]);
+
+    await page.reload();
+    await dismissOnboardingChecklist(page);
+    await waitForBoard(page);
+
+    // The survivor outlived the renderer, which is the premise: main never killed it.
+    await expect
+      .poll(async () => (await liveTerminals(page)).map((row) => row.id), { timeout: 15000, intervals: [250, 500] })
+      .toEqual([secondTerminal.id]);
+
+    await openCommandTerminalLayer(page);
+
+    // It comes back as Command Terminal 2, the number it has always had. Under
+    // the positional guess it returned as "Command Terminal 1", so the window
+    // named a terminal that was not the one it was showing.
+    await expect(page.getByText('Command Terminal 2', { exact: true }).first())
+      .toBeVisible({ timeout: 15000 });
+
+    // Still exactly one PTY, still the same one, and the window is bound to it
+    // rather than merely coexisting with it. A fresh spawn would satisfy the
+    // window count just as well.
+    const after = await liveTerminals(page);
+    expect(after).toHaveLength(1);
+    expect(after[0].id).toBe(secondTerminal.id);
+    await expect(page.locator(`[data-session-id="${secondTerminal.id}"]`).first())
+      .toBeVisible({ timeout: 15000 });
+    await expect(page.locator('[data-testid="command-terminal-window"]')).toHaveCount(1);
+  });
+});

--- a/tests/ui/command-terminal.spec.ts
+++ b/tests/ui/command-terminal.spec.ts
@@ -278,6 +278,11 @@ function multiTerminalPreConfig(): string {
 
 const RECONCILE_PROJECT_ID = 'proj-cmd-restart';
 const HARD_RELOAD_PROJECT_ID = 'proj-cmd-hard-reload';
+const SLOT_MISMATCH_PROJECT_ID = 'proj-cmd-slot-mismatch';
+const ORPHAN_RACE_PROJECT_ID = 'proj-cmd-orphan-race';
+const BACKGROUND_FOREGROUND_PROJECT_ID = 'proj-cmd-bg-foreground';
+const BACKGROUND_PROJECT_ID = 'proj-cmd-bg-background';
+const ADOPT_PROJECT_ID = 'proj-cmd-adopt';
 
 /**
  * Init-script fragment that decorates the DEFAULT mock spawnTransient (which
@@ -349,8 +354,9 @@ function restartBlobPreConfig(): string {
 }
 
 /** One project with the same 2-window blob PLUS two surviving running transient
- *  PTYs: the hard-reload path. syncSessions re-pairs the survivors to slot-1 /
- *  slot-2 at boot, so on first open both windows restore and reattach. */
+ *  PTYs: the hard-reload path. Each survivor carries the slot main recorded for
+ *  it, so syncSessions re-pairs them EXACTLY and on first open both windows
+ *  restore and reattach. */
 function hardReloadPreConfig(): string {
   return `
     window.__mockPreConfigure(function (state) {
@@ -371,11 +377,13 @@ function hardReloadPreConfig(): string {
         id: 'hr-sess-1', taskId: 'hr-sess-1', projectId: '${HARD_RELOAD_PROJECT_ID}', pid: 3001,
         status: 'running', shell: 'bash', cwd: '/mock/hard-reload-project', startedAt: ts,
         exitCode: null, resuming: false, transient: true,
+        commandTerminalSlot: 'slot-1', commandTerminalBranch: 'main',
       });
       state.sessions.push({
         id: 'hr-sess-2', taskId: 'hr-sess-2', projectId: '${HARD_RELOAD_PROJECT_ID}', pid: 3002,
         status: 'running', shell: 'bash', cwd: '/mock/hard-reload-project', startedAt: ts,
         exitCode: null, resuming: false, transient: true,
+        commandTerminalSlot: 'slot-2', commandTerminalBranch: 'feature/two',
       });
       return { currentProjectId: '${HARD_RELOAD_PROJECT_ID}' };
     });
@@ -384,17 +392,220 @@ function hardReloadPreConfig(): string {
   `;
 }
 
-/** Transient-session entries (slot + sessionId) tracked for a project. */
-async function transientEntriesFor(page: Page, projectId: string): Promise<Array<{ slot: string; sessionId: string }>> {
+/** Survivors on NON-CONSECUTIVE slots whose ids sort the OPPOSITE way to those
+ *  slots. This is the fixture shape `hardReloadPreConfig` cannot express: there,
+ *  `hr-sess-1` / `hr-sess-2` happen to sort into slot order, so a positional
+ *  `slot-${index + 1}` guess over an id-sorted list lands correctly by accident.
+ *  Here it pairs `slot-1`->`sm-zzz` and `slot-2`->`sm-aaa`, i.e. each window shows
+ *  the other terminal's conversation under a title that says otherwise. */
+function slotMismatchPreConfig(): string {
+  return `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+      state.projects.push({
+        id: '${SLOT_MISMATCH_PROJECT_ID}',
+        name: 'Slot Mismatch Project',
+        path: '/mock/slot-mismatch-project',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        state.swimlanes.push(Object.assign({}, s, { id: 'lane-sm-' + i, position: i, created_at: ts }));
+      });
+      state.sessions.push({
+        id: 'sm-zzz', taskId: 'sm-zzz', projectId: '${SLOT_MISMATCH_PROJECT_ID}', pid: 3101,
+        status: 'running', shell: 'bash', cwd: '/mock/slot-mismatch-project', startedAt: ts,
+        exitCode: null, resuming: false, transient: true,
+        commandTerminalSlot: 'slot-2', commandTerminalBranch: 'main',
+      });
+      state.sessions.push({
+        id: 'sm-aaa', taskId: 'sm-aaa', projectId: '${SLOT_MISMATCH_PROJECT_ID}', pid: 3102,
+        status: 'running', shell: 'bash', cwd: '/mock/slot-mismatch-project', startedAt: ts,
+        exitCode: null, resuming: false, transient: true,
+        commandTerminalSlot: 'slot-3', commandTerminalBranch: 'main',
+      });
+      return { currentProjectId: '${SLOT_MISMATCH_PROJECT_ID}' };
+    });
+    ${spawnCounterSource()}
+  `;
+}
+
+/** One project with no seeded sessions. The test spawns a terminal itself and then
+ *  injects a survivor, which is how it reproduces the "a fresh spawn won the race"
+ *  shape that a pre-seeded fixture cannot: the map must already hold an entry for
+ *  the project when recovery runs. */
+function orphanRacePreConfig(): string {
+  return `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+      state.projects.push({
+        id: '${ORPHAN_RACE_PROJECT_ID}',
+        name: 'Orphan Race Project',
+        path: '/mock/orphan-race-project',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        state.swimlanes.push(Object.assign({}, s, { id: 'lane-or-' + i, position: i, created_at: ts }));
+      });
+      return { currentProjectId: '${ORPHAN_RACE_PROJECT_ID}' };
+    });
+    ${spawnCounterSource()}
+  `;
+}
+
+/** Two projects, the FIRST current, with a surviving PTY belonging to the second.
+ *  The background project's terminal must still be re-paired: recovery used to be
+ *  wrapped in `if (currentProjectId)` and scoped to it, so switching to that
+ *  project found nothing and spawned over the live terminal. */
+function backgroundProjectPreConfig(): string {
+  return `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+      ['${BACKGROUND_FOREGROUND_PROJECT_ID}', '${BACKGROUND_PROJECT_ID}'].forEach(function (id, index) {
+        state.projects.push({
+          id: id,
+          name: index === 0 ? 'Foreground Project' : 'Background Project',
+          path: '/mock/bg-project-' + index,
+          github_url: null,
+          default_agent: 'claude',
+          last_opened: ts,
+          created_at: ts,
+        });
+      });
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        state.swimlanes.push(Object.assign({}, s, { id: 'lane-bg-' + i, position: i, created_at: ts }));
+      });
+      state.sessions.push({
+        id: 'bg-sess-1', taskId: 'bg-sess-1', projectId: '${BACKGROUND_PROJECT_ID}', pid: 3201,
+        status: 'running', shell: 'bash', cwd: '/mock/bg-project-1', startedAt: ts,
+        exitCode: null, resuming: false, transient: true,
+        commandTerminalSlot: 'slot-2', commandTerminalBranch: 'main',
+      });
+      return { currentProjectId: '${BACKGROUND_FOREGROUND_PROJECT_ID}' };
+    });
+    ${spawnCounterSource()}
+  `;
+}
+
+/** One project with a single surviving PTY on slot-1. The test drops the pairing
+ *  map by hand afterwards, which is the one state recovery cannot produce for
+ *  itself: `sessions` holding a live terminal while the map holds nothing. */
+function adoptPreConfig(): string {
+  return `
+    window.__mockPreConfigure(function (state) {
+      var ts = new Date().toISOString();
+      state.projects.push({
+        id: '${ADOPT_PROJECT_ID}',
+        name: 'Adopt Project',
+        path: '/mock/adopt-project',
+        github_url: null,
+        default_agent: 'claude',
+        last_opened: ts,
+        created_at: ts,
+      });
+      state.DEFAULT_SWIMLANES.forEach(function (s, i) {
+        state.swimlanes.push(Object.assign({}, s, { id: 'lane-ad-' + i, position: i, created_at: ts }));
+      });
+      state.sessions.push({
+        id: 'ad-sess-1', taskId: 'ad-sess-1', projectId: '${ADOPT_PROJECT_ID}', pid: 3301,
+        status: 'running', shell: 'bash', cwd: '/mock/adopt-project', startedAt: ts,
+        exitCode: null, resuming: false, transient: true,
+        commandTerminalSlot: 'slot-1', commandTerminalBranch: 'main',
+      });
+      return { currentProjectId: '${ADOPT_PROJECT_ID}' };
+    });
+    ${spawnCounterSource()}
+  `;
+}
+
+/** Drop every transient pairing entry, leaving the sessions list untouched. */
+async function clearTransientPairings(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const stores = (window as unknown as {
+      __zustandStores?: { session?: { setState: (partial: { transientSessions: Record<string, unknown> }) => void } };
+    }).__zustandStores;
+    stores?.session?.setState({ transientSessions: {} });
+  });
+}
+
+/** Transient-session entries (slot + sessionId + branch) tracked for a project. */
+async function transientEntriesFor(
+  page: Page,
+  projectId: string,
+): Promise<Array<{ slot: string; sessionId: string; branch: string | null }>> {
   return page.evaluate((projectId) => {
     const stores = (window as unknown as {
-      __zustandStores?: { session?: { getState: () => { transientSessions: Record<string, { projectId: string; slot: string; sessionId: string }> } } };
+      __zustandStores?: { session?: { getState: () => { transientSessions: Record<string, { projectId: string; slot: string; sessionId: string; branch: string | null }> } } };
     }).__zustandStores;
     const map = stores?.session?.getState().transientSessions ?? {};
     return Object.values(map)
       .filter((entry) => entry.projectId === projectId)
-      .map((entry) => ({ slot: entry.slot, sessionId: entry.sessionId }));
+      .map((entry) => ({ slot: entry.slot, sessionId: entry.sessionId, branch: entry.branch }));
   }, projectId);
+}
+
+/** A project's slot-to-sessionId pairing, as a plain sorted object. The pairing is
+ *  what the recovery has to get RIGHT: a count-only assertion passes just as
+ *  happily when a window is showing another terminal's conversation. */
+async function transientPairingFor(page: Page, projectId: string): Promise<Record<string, string>> {
+  const entries = await transientEntriesFor(page, projectId);
+  const pairing: Record<string, string> = {};
+  for (const entry of entries) pairing[entry.slot] = entry.sessionId;
+  return pairing;
+}
+
+/** Push a running Command Terminal PTY into the mock AFTER boot, then re-run the
+ *  renderer's session sync, modelling main having kept a terminal alive that the
+ *  renderer does not yet know about.
+ *
+ *  `__mockPreConfigure` hands out the mock's own `sessions` array by reference, so
+ *  a post-boot push lands in `sessions.list()`. The caller asserts the row arrived
+ *  before relying on it. */
+async function injectRunningTerminal(
+  page: Page,
+  session: { id: string; projectId: string; slot: string; branch?: string },
+): Promise<void> {
+  await page.evaluate((session) => {
+    const configure = (window as unknown as {
+      __mockPreConfigure?: (fn: (state: { sessions: unknown[] }) => void) => void;
+    }).__mockPreConfigure;
+    configure?.((state) => {
+      state.sessions.push({
+        id: session.id,
+        taskId: session.id,
+        projectId: session.projectId,
+        pid: 4242,
+        status: 'running',
+        shell: 'bash',
+        cwd: '/mock/project',
+        startedAt: new Date().toISOString(),
+        exitCode: null,
+        resuming: false,
+        transient: true,
+        commandTerminalSlot: session.slot,
+        commandTerminalBranch: session.branch ?? 'main',
+      });
+    });
+  }, session);
+  await page.evaluate(() => {
+    const stores = (window as unknown as {
+      __zustandStores?: { session?: { getState: () => { syncSessions: () => Promise<boolean> } } };
+    }).__zustandStores;
+    return stores?.session?.getState().syncSessions();
+  });
+}
+
+/** The count the sidebar's per-project Command Terminal indicator is printing, or
+ *  0 when it is absent (the indicator hides itself at zero). */
+async function sidebarTerminalCount(page: Page, projectId: string): Promise<number> {
+  const indicator = page.getByTestId(`project-terminals-${projectId}`);
+  if (await indicator.count() === 0) return 0;
+  return Number(await indicator.first().getAttribute('data-count'));
 }
 
 /** Count of fresh spawnTransient calls recorded for a project. */
@@ -1383,6 +1594,19 @@ test.describe('Command Terminal', () => {
           .poll(async () => (await transientEntriesFor(page, HARD_RELOAD_PROJECT_ID)).length, { timeout: 8000, intervals: [100, 200, 500] })
           .toBe(2);
 
+        // Each survivor is paired to the slot MAIN recorded for it. A length check
+        // alone cannot tell a correct pairing from a window quietly showing the
+        // other terminal's conversation, which is the failure this guards.
+        expect(await transientPairingFor(page, HARD_RELOAD_PROJECT_ID)).toEqual({
+          'slot-1': 'hr-sess-1',
+          'slot-2': 'hr-sess-2',
+        });
+        // The branch survives recovery too, so the header pill is not blank.
+        const recoveredBranches = (await transientEntriesFor(page, HARD_RELOAD_PROJECT_ID))
+          .sort((first, second) => first.slot.localeCompare(second.slot))
+          .map((entry) => entry.branch);
+        expect(recoveredBranches).toEqual(['main', 'feature/two']);
+
         await page.keyboard.press('Control+Shift+P');
         await expect(page.getByTestId('command-terminal-window')).toHaveCount(2, { timeout: 5000 });
         // Both reattached: no fresh spawns for the project.
@@ -1404,6 +1628,131 @@ test.describe('Command Terminal', () => {
         const geometryBySlot = await commandWindowGeometryBySlot(page);
         expectGeometryNear(geometryBySlot['slot-1'], HARD_RELOAD_BLOB_GEOMETRY['slot-1']);
         expectGeometryNear(geometryBySlot['slot-2'], HARD_RELOAD_BLOB_GEOMETRY['slot-2']);
+      } finally {
+        await browser.close();
+      }
+    });
+
+    test('survivors are paired to their own slots, not to a position in a sorted list', async () => {
+      const { browser, page } = await launchWithState(slotMismatchPreConfig());
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+        await expect
+          .poll(() => transientPairingFor(page, SLOT_MISMATCH_PROJECT_ID), { timeout: 8000, intervals: [100, 200, 500] })
+          .toEqual({ 'slot-2': 'sm-zzz', 'slot-3': 'sm-aaa' });
+
+        // Slots 2 and 3 with nothing on slot 1: the numbering is the terminal's own
+        // durable identity, not a rank, so a window keeps its name when a sibling
+        // is closed. Renumbering here would rename a window the user is looking at.
+        await page.keyboard.press('Control+Shift+P');
+        await expect(page.getByTestId('command-terminal-window')).toHaveCount(2, { timeout: 5000 });
+        await expect
+          .poll(() => commandWindowAnchors(page), { timeout: 5000, intervals: [100, 200, 500] })
+          .toEqual(['slot-2', 'slot-3']);
+        expect(await spawnCountFor(page, SLOT_MISMATCH_PROJECT_ID)).toBe(0);
+      } finally {
+        await browser.close();
+      }
+    });
+
+    test('a survivor is still recovered when a fresh spawn already tracked the project', async () => {
+      // The reported production failure. Recovery used to bail the moment the
+      // project had ANY tracked entry, so the terminal that won the post-reload
+      // race permanently hid every other survivor: the PTY kept running with its
+      // pending question and nothing could reach it.
+      const { browser, page } = await launchWithState(orphanRacePreConfig());
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+        // A real spawn puts slot-1 in the map, so the project is "already tracked".
+        await page.keyboard.press('Control+Shift+P');
+        await expect(page.getByTestId('command-terminal-window')).toHaveCount(1, { timeout: 5000 });
+        await expect
+          .poll(async () => (await transientEntriesFor(page, ORPHAN_RACE_PROJECT_ID)).length, { timeout: 5000, intervals: [100, 200, 500] })
+          .toBe(1);
+        await page.keyboard.press('Control+Shift+P');
+        await expect(page.getByTestId('command-terminal-window')).not.toBeVisible({ timeout: 5000 });
+
+        // Main was keeping a second terminal alive all along, stamped with the same
+        // slot the fresh spawn took (a slot is reused as soon as its window closes).
+        await injectRunningTerminal(page, {
+          id: 'orphaned-pty', projectId: ORPHAN_RACE_PROJECT_ID, slot: 'slot-1', branch: 'main',
+        });
+        await expect
+          .poll(async () => (await runningSessionIds(page, ['orphaned-pty'])).length, { timeout: 5000, intervals: [100, 200, 500] })
+          .toBe(1);
+
+        // The live window keeps slot-1; the survivor re-homes rather than being
+        // dropped, so both PTYs stay reachable.
+        await expect
+          .poll(async () => (await transientEntriesFor(page, ORPHAN_RACE_PROJECT_ID)).length, { timeout: 5000, intervals: [100, 200, 500] })
+          .toBe(2);
+        const pairing = await transientPairingFor(page, ORPHAN_RACE_PROJECT_ID);
+        expect(Object.values(pairing)).toContain('orphaned-pty');
+
+        // The symptom the bug report opens with: the sidebar counted both PTYs
+        // (it reads main's rows) while only one window existed. A pairing-only
+        // assertion can pass while the layer still shows one window for two PTYs.
+        await page.keyboard.press('Control+Shift+P');
+        await expect(page.getByTestId('command-terminal-window')).toHaveCount(2, { timeout: 5000 });
+        expect(await sidebarTerminalCount(page, ORPHAN_RACE_PROJECT_ID)).toBe(2);
+        // Adopted, not respawned: still the one spawn from the top of the test.
+        expect(await spawnCountFor(page, ORPHAN_RACE_PROJECT_ID)).toBe(1);
+      } finally {
+        await browser.close();
+      }
+    });
+
+    test('a window mounting with no pairing adopts the live PTY for its slot instead of spawning', async () => {
+      // The mount effect's own guard, isolated. Recovery normally re-pairs before
+      // any window mounts, so the only way to reach this is to hand the renderer
+      // the state it protects against: main still running a terminal for slot-1
+      // while the pairing map holds nothing. Spawning here would BOTH manufacture
+      // a duplicate PTY and strand the live one.
+      const { browser, page } = await launchWithState(adoptPreConfig());
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+        await expect
+          .poll(async () => (await transientEntriesFor(page, ADOPT_PROJECT_ID)).length, { timeout: 8000, intervals: [100, 200, 500] })
+          .toBe(1);
+
+        await clearTransientPairings(page);
+        await page.keyboard.press('Control+Shift+P');
+        await expect(page.getByTestId('command-terminal-window')).toHaveCount(1, { timeout: 5000 });
+
+        // Bound to the SURVIVOR, and the map re-points at it. A fresh spawn would
+        // satisfy the window count just as well, which is why neither assertion
+        // alone is enough.
+        await expect
+          .poll(() => transientPairingFor(page, ADOPT_PROJECT_ID), { timeout: 5000, intervals: [100, 200, 500] })
+          .toEqual({ 'slot-1': 'ad-sess-1' });
+        expect(await spawnCountFor(page, ADOPT_PROJECT_ID)).toBe(0);
+      } finally {
+        await browser.close();
+      }
+    });
+
+    test('a background project keeps its surviving terminal', async () => {
+      const { browser, page } = await launchWithState(backgroundProjectPreConfig());
+      try {
+        await page.locator('[data-swimlane-name="To Do"]').waitFor({ state: 'visible', timeout: 15000 });
+
+        // Recovered while the OTHER project is open. Scoping recovery to the current
+        // project left this PTY unpaired until the user switched, by which point the
+        // layer had already spawned a fresh terminal over the top of it.
+        await expect
+          .poll(() => transientPairingFor(page, BACKGROUND_PROJECT_ID), { timeout: 8000, intervals: [100, 200, 500] })
+          .toEqual({ 'slot-2': 'bg-sess-1' });
+
+        await page.locator('[role="button"]:has-text("Background Project")').click();
+        await expect.poll(() => activeProjectId(page), { timeout: 5000, intervals: [100, 200, 500] }).toBe(BACKGROUND_PROJECT_ID);
+        await page.keyboard.press('Control+Shift+P');
+        await expect(page.getByTestId('command-terminal-window')).toHaveCount(1, { timeout: 5000 });
+        await expect
+          .poll(() => commandWindowAnchors(page), { timeout: 5000, intervals: [100, 200, 500] })
+          .toEqual(['slot-2']);
+        expect(await spawnCountFor(page, BACKGROUND_PROJECT_ID)).toBe(0);
       } finally {
         await browser.close();
       }

--- a/tests/ui/mock-electron-api.js
+++ b/tests/ui/mock-electron-api.js
@@ -1913,6 +1913,7 @@
       },
       spawnTransient: async function (input) {
         var id = crypto.randomUUID();
+        var branch = input.branch || 'main';
         var session = {
           id: id,
           taskId: id,
@@ -1925,11 +1926,30 @@
           exitCode: null,
           resuming: false,
           transient: true,
+          // Main stamps the slot and the RESOLVED branch onto the session row, and
+          // the renderer re-pairs a surviving PTY to its window by that slot after
+          // a reload. Omitting them here would let a UI test pass against a row
+          // shape production never produces.
+          commandTerminalSlot: input.slot || null,
+          commandTerminalBranch: branch,
+          commandTerminalLabel: null,
           isolatedSwimlaneId: null,
           agentSessionId: null,
         };
         sessions.push(session);
-        return { session: session, branch: input.branch || 'main' };
+        return { session: session, branch: branch };
+      },
+      setTransientLabel: async function (sessionId, label) {
+        // Mirrors main: retained on the session row (first write wins) so a
+        // recovered terminal keeps its derived name. Trims and rejects a blank
+        // for the same reason main does - the store already trims before it
+        // calls, so a mock without this guard only diverges for a test that
+        // drives the API directly, which is exactly when the divergence lies.
+        var session = sessions.find(function (session) { return session.id === sessionId; });
+        var trimmed = (label || '').trim();
+        if (trimmed && session && session.transient && !session.commandTerminalLabel) {
+          session.commandTerminalLabel = trimmed;
+        }
       },
       killTransient: async function (sessionId) {
         var index = sessions.findIndex(function (s) { return s.id === sessionId; });

--- a/tests/unit/auto-name-scheduler.test.ts
+++ b/tests/unit/auto-name-scheduler.test.ts
@@ -173,16 +173,16 @@ function setupStores(options: {
   });
 }
 
-function setupSummarizeApi(impl: (input: { prompt: string }) => Promise<unknown> | unknown): void {
+function setupSummarizeApi(impl: (input: { prompt: string }) => Promise<unknown> | unknown): ReturnType<typeof vi.fn> {
   // The scheduler reads `window.electronAPI.agent.summarize` directly. In the
   // node test env vitest provides no `window`, so we attach to globalThis (which
   // is the same object the production code's `window` resolves to under jsdom).
   (globalThis as unknown as { window: Record<string, unknown> }).window = (globalThis as unknown as { window?: Record<string, unknown> }).window ?? {};
+  const summarize = vi.fn(async (input: { prompt: string }) => impl(input));
   (globalThis as unknown as { window: { electronAPI: unknown } }).window.electronAPI = {
-    agent: {
-      summarize: vi.fn(async (input: { prompt: string }) => impl(input)),
-    },
+    agent: { summarize },
   };
+  return summarize;
 }
 
 // ---------------------------------------------------------------------------
@@ -465,6 +465,32 @@ describe('maybeLabelTransientSession', () => {
     maybeLabelTransientSession('transient-1', makePromptEvent('hello'));
     await vi.runAllTimersAsync();
 
+    expect(setTransientSessionLabel).not.toHaveBeenCalled();
+  });
+
+  it('marks an already-labelled entry as done without deriving a new name', () => {
+    // The reload-recovery shape: recovery restored the label from main onto the
+    // entry, but the in-memory `autoNameLabeledTransient` guard was cleared by the
+    // reload itself, so the entry's `label` is the only signal left that this
+    // session is already named. Falling through here would pay a summarize call
+    // on this later prompt and then discard the result, since setTransientSessionLabel
+    // is first-prompt-wins - leaving the renderer's derivation attempt and main's
+    // retained name permanently disagreeing about which prompt "won".
+    const setTransientSessionLabel = vi.fn();
+    setupStores({
+      transientSessions: {
+        'project-1::slot-1': {
+          projectId: 'project-1', slot: 'slot-1', sessionId: 'transient-1', branch: null, label: 'Already Named',
+        },
+      },
+      setTransientSessionLabel,
+    });
+    const summarize = setupSummarizeApi(() => ({ ok: true, title: 'should not fire' }));
+
+    maybeLabelTransientSession('transient-1', makePromptEvent('a later prompt'));
+
+    expect(autoNameLabeledTransient.has('transient-1')).toBe(true);
+    expect(summarize).not.toHaveBeenCalled();
     expect(setTransientSessionLabel).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/command-window-reconcile.test.ts
+++ b/tests/unit/command-window-reconcile.test.ts
@@ -24,6 +24,13 @@ function runningSession(id: string): CommandWindowSessionRef {
   return { id, status: 'running' };
 }
 
+/** A running Command Terminal PTY as main reports it, carrying the slot it was
+ *  spawned under. This is what lets the planner see a live terminal the renderer's
+ *  pairing map has lost track of. */
+function runningTerminal(id: string, slot: string, projectId = PROJECT_A): CommandWindowSessionRef {
+  return { id, status: 'running', transient: true, projectId, commandTerminalSlot: slot };
+}
+
 describe('planCommandWindowReconciliation', () => {
   it('keeps only the lowest-slot window when the project has no live sessions', () => {
     const plan = planCommandWindowReconciliation({
@@ -156,6 +163,52 @@ describe('planCommandWindowReconciliation', () => {
       maxWindows: MAX_WINDOWS,
     });
     expect(plan.closeWindowIds).toEqual([]);
+    expect(plan.openSlots).toEqual([]);
+  });
+
+  it('counts a live PTY the pairing map has lost as a live slot', () => {
+    // A renderer reload destroys the map while every transient PTY survives. Read
+    // from the map alone this looks like "no live sessions", which takes the
+    // keep-one-window branch and lets that window fresh-spawn over a live
+    // terminal. Main's own session rows are what close that hole.
+    const plan = planCommandWindowReconciliation({
+      windows: [windowRef('slot-1'), windowRef('slot-2')],
+      transientSessions: {},
+      sessions: [runningTerminal('sess-1', 'slot-1'), runningTerminal('sess-2', 'slot-2')],
+      projectId: PROJECT_A,
+      maxWindows: MAX_WINDOWS,
+    });
+    expect(plan.closeWindowIds).toEqual([]);
+    expect(plan.openSlots).toEqual([]);
+  });
+
+  it('opens a window for an unpaired live PTY that has none', () => {
+    const plan = planCommandWindowReconciliation({
+      windows: [windowRef('slot-1')],
+      transientSessions: transientMap([{ projectId: PROJECT_A, slot: 'slot-1', sessionId: 'sess-1' }]),
+      sessions: [runningSession('sess-1'), runningTerminal('sess-2', 'slot-2')],
+      projectId: PROJECT_A,
+      maxWindows: MAX_WINDOWS,
+    });
+    expect(plan.closeWindowIds).toEqual([]);
+    expect(plan.openSlots).toEqual(['slot-2']);
+  });
+
+  it('ignores session rows from another project, task agents, and dead PTYs', () => {
+    const plan = planCommandWindowReconciliation({
+      windows: [windowRef('slot-1'), windowRef('slot-2')],
+      transientSessions: {},
+      sessions: [
+        runningTerminal('other-project', 'slot-1', PROJECT_B),
+        // A task agent: running, but not a Command Terminal and carries no slot.
+        { id: 'task-agent', status: 'running', projectId: PROJECT_A },
+        { ...runningTerminal('dead', 'slot-2'), status: 'exited' },
+      ],
+      projectId: PROJECT_A,
+      maxWindows: MAX_WINDOWS,
+    });
+    // Nothing live for project A, so the keep-one-window branch still applies.
+    expect(plan.closeWindowIds).toEqual(['win-slot-2']);
     expect(plan.openSlots).toEqual([]);
   });
 

--- a/tests/unit/project-scoped-ipc.test.ts
+++ b/tests/unit/project-scoped-ipc.test.ts
@@ -74,6 +74,10 @@ const ALLOWLIST_CHANNELS = new Set([
   'SESSION_INJECT_SETTINGS',
   'SESSION_SPAWN_TRANSIENT',
   'SESSION_KILL_TRANSIENT',
+  // By-session-id, and it touches no DB at all: the transient session's derived
+  // name is retained on the in-memory registry row so it survives a renderer
+  // reload. A Command Terminal has no task and no project-scoped record.
+  'SESSION_SET_TRANSIENT_LABEL',
 ]);
 
 interface InvokeCall {

--- a/tests/unit/session-manager-command-terminal-label.test.ts
+++ b/tests/unit/session-manager-command-terminal-label.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for SessionManager.setCommandTerminalLabel.
+ *
+ * Main is a passive holder for the Command Terminal's auto-derived name: the
+ * renderer computes it and has already applied it locally, and nothing in main
+ * reads it back except `toSession`, which hands it to the next renderer that has
+ * to rebuild the pairing map after a reload.
+ *
+ * The guards matter because the caller is a fire-and-forget IPC that no one
+ * awaits: a bad sessionId, a task agent, or a second derivation must not corrupt
+ * or overwrite a name the user already knows the terminal by.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock('../../src/main/pty/spawn/shell-resolver', () => {
+  class MockShellResolver {
+    async getDefaultShell() { return '/bin/bash'; }
+  }
+  return { ShellResolver: MockShellResolver };
+});
+
+vi.mock('../../src/shared/paths', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/paths')>()),
+  adaptCommandForShell: (command: string) => command,
+  buildSpawnClearPrelude: () => '',
+  isUncPath: (p: string) => /^[\\/]{2}[^\\/]/.test(p),
+}));
+
+vi.mock('../../src/main/analytics/analytics', () => ({
+  trackEvent: vi.fn(),
+  sanitizeErrorMessage: (message: string) => message,
+}));
+
+import { SessionManager } from '../../src/main/pty/session-manager';
+import type { ManagedSession, SessionRegistry } from '../../src/main/pty/session-registry';
+
+/** Reach the private registry the same way the sibling suites reach telemetry. */
+function getRegistry(manager: SessionManager): SessionRegistry {
+  return (manager as unknown as { registry: SessionRegistry }).registry;
+}
+
+function register(manager: SessionManager, overrides: Partial<ManagedSession> & { id: string }): void {
+  getRegistry(manager).set(overrides.id, {
+    taskId: 'task-1',
+    projectId: 'project-1',
+    pty: null,
+    status: 'running',
+    shell: '/bin/bash',
+    cwd: '/mock/project',
+    startedAt: new Date().toISOString(),
+    exitCode: null,
+    resuming: false,
+    transient: true,
+    exitSequence: ['\x03'],
+    ...overrides,
+  });
+}
+
+function labelOf(manager: SessionManager, sessionId: string): string | null | undefined {
+  return getRegistry(manager).get(sessionId)?.commandTerminalLabel;
+}
+
+describe('SessionManager.setCommandTerminalLabel', () => {
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new SessionManager();
+  });
+
+  it('records the name on a transient session', () => {
+    register(manager, { id: 'term-1' });
+    manager.setCommandTerminalLabel('term-1', 'Fix the parser');
+    expect(labelOf(manager, 'term-1')).toBe('Fix the parser');
+  });
+
+  it('keeps the first name, so a later derivation cannot rename a known terminal', () => {
+    register(manager, { id: 'term-1' });
+    manager.setCommandTerminalLabel('term-1', 'Fix the parser');
+    manager.setCommandTerminalLabel('term-1', 'Something else entirely');
+    expect(labelOf(manager, 'term-1')).toBe('Fix the parser');
+  });
+
+  it('trims, and ignores a blank name rather than storing one', () => {
+    register(manager, { id: 'term-1' });
+    manager.setCommandTerminalLabel('term-1', '   ');
+    expect(labelOf(manager, 'term-1')).toBeUndefined();
+
+    manager.setCommandTerminalLabel('term-1', '  Fix the parser  ');
+    expect(labelOf(manager, 'term-1')).toBe('Fix the parser');
+  });
+
+  it('ignores a task agent, which has no Command Terminal name', () => {
+    register(manager, { id: 'agent-1', transient: false });
+    manager.setCommandTerminalLabel('agent-1', 'Fix the parser');
+    expect(labelOf(manager, 'agent-1')).toBeUndefined();
+  });
+
+  it('ignores an unknown session instead of throwing', () => {
+    // The caller is a fire-and-forget IPC, so a session that exited during the
+    // round trip is routine rather than exceptional.
+    expect(() => manager.setCommandTerminalLabel('gone', 'Fix the parser')).not.toThrow();
+  });
+});

--- a/tests/unit/session-registry.test.ts
+++ b/tests/unit/session-registry.test.ts
@@ -12,10 +12,11 @@
  *     spawn flow drains with, so a second stale row cannot survive a spawn).
  *   - registerSuspendedPlaceholder: idempotent per task. A live or suspended
  *     row blocks the insert; an exited row is replaced.
+ *   - toSession: the Command Terminal pairing fields reach the renderer.
  */
 
 import { describe, it, expect } from 'vitest';
-import { SessionRegistry } from '../../src/main/pty/session-registry';
+import { SessionRegistry, toSession } from '../../src/main/pty/session-registry';
 import type { ManagedSession } from '../../src/main/pty/session-registry';
 
 /** Build a minimal ManagedSession with only the fields relevant to this test. */
@@ -36,6 +37,41 @@ function makeManagedSession(overrides: Partial<ManagedSession> = {}): ManagedSes
     ...overrides,
   };
 }
+
+// ---------------------------------------------------------------------------
+// toSession
+// ---------------------------------------------------------------------------
+
+/**
+ * `listSessions()` is `Array.from(this.sessions.values(), toSession)`, so this
+ * mapper is the only thing every session row the renderer ever sees passes
+ * through. It used to drop the Command Terminal slot, which forced the renderer's
+ * reload recovery to GUESS which window each surviving PTY belonged to: a live
+ * conversation could come back under another terminal's title, or not come back
+ * at all.
+ */
+describe('toSession', () => {
+  it('carries the Command Terminal slot, branch and derived name to the renderer', () => {
+    const session = toSession(makeManagedSession({
+      transient: true,
+      commandTerminalSlot: 'slot-2',
+      commandTerminalBranch: 'feature/x',
+      commandTerminalLabel: 'Fix the parser',
+    }));
+
+    expect(session.commandTerminalSlot).toBe('slot-2');
+    expect(session.commandTerminalBranch).toBe('feature/x');
+    expect(session.commandTerminalLabel).toBe('Fix the parser');
+  });
+
+  it('reports null for a task agent, which has none of them', () => {
+    const session = toSession(makeManagedSession());
+
+    expect(session.commandTerminalSlot).toBeNull();
+    expect(session.commandTerminalBranch).toBeNull();
+    expect(session.commandTerminalLabel).toBeNull();
+  });
+});
 
 // ---------------------------------------------------------------------------
 // hasLiveSessionForTask

--- a/tests/unit/transient-recovery.test.ts
+++ b/tests/unit/transient-recovery.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect } from 'vitest';
+import {
+  planTransientRecovery,
+  findAdoptableTransientSession,
+} from '../../src/renderer/stores/session-store/transient-recovery';
+import type { TransientSessionEntry } from '../../src/renderer/stores/session-store/transient-session-slice';
+import type { Session } from '../../src/shared/types';
+
+const PROJECT_A = 'project-a';
+const PROJECT_B = 'project-b';
+
+/** A live Command Terminal PTY row as `sessions.list()` delivers it. */
+function transientSession(overrides: Partial<Session> & { id: string }): Session {
+  return {
+    taskId: overrides.id,
+    projectId: PROJECT_A,
+    pid: 1000,
+    status: 'running',
+    shell: 'bash',
+    cwd: '/mock/project',
+    startedAt: '2026-09-08T12:00:00.000Z',
+    exitCode: null,
+    resuming: false,
+    transient: true,
+    commandTerminalSlot: null,
+    commandTerminalBranch: null,
+    commandTerminalLabel: null,
+    isolatedSwimlaneId: null,
+    agentSessionId: null,
+    ...overrides,
+  };
+}
+
+/** A task agent's session row: never transient, never paired to a slot. */
+function taskSession(id: string): Session {
+  return transientSession({ id, transient: false });
+}
+
+function transientMap(entries: TransientSessionEntry[]): Record<string, TransientSessionEntry> {
+  const map: Record<string, TransientSessionEntry> = {};
+  for (const entry of entries) map[`${entry.projectId}::${entry.slot}`] = entry;
+  return map;
+}
+
+describe('planTransientRecovery', () => {
+  it('re-pairs each survivor to the slot main recorded, not to a dense position', () => {
+    // The whole point of carrying commandTerminalSlot. The old `slot-${index + 1}`
+    // guess would have produced slot-1 / slot-2 here, so a window titled "Command
+    // Terminal 2" would show the terminal that actually ran as number 5.
+    const recovered = planTransientRecovery({
+      sessions: [
+        transientSession({ id: 'sess-2', commandTerminalSlot: 'slot-2', commandTerminalBranch: 'main' }),
+        transientSession({ id: 'sess-5', commandTerminalSlot: 'slot-5', commandTerminalBranch: 'feature/x' }),
+      ],
+      transientSessions: {},
+    });
+
+    expect(recovered).not.toBeNull();
+    expect(recovered![`${PROJECT_A}::slot-2`]).toEqual({
+      projectId: PROJECT_A, slot: 'slot-2', sessionId: 'sess-2', branch: 'main',
+    });
+    expect(recovered![`${PROJECT_A}::slot-5`]).toEqual({
+      projectId: PROJECT_A, slot: 'slot-5', sessionId: 'sess-5', branch: 'feature/x',
+    });
+    expect(Object.keys(recovered!)).toHaveLength(2);
+  });
+
+  it('pairs survivors whose ids sort the opposite way to their slots', () => {
+    // The existing hard-reload fixture is green only because its ids happen to
+    // sort into slot order. Reverse that and the old uuid sort mis-pairs both.
+    const recovered = planTransientRecovery({
+      sessions: [
+        transientSession({ id: 'zzz', commandTerminalSlot: 'slot-1' }),
+        transientSession({ id: 'aaa', commandTerminalSlot: 'slot-2' }),
+      ],
+      transientSessions: {},
+    });
+
+    expect(recovered![`${PROJECT_A}::slot-1`].sessionId).toBe('zzz');
+    expect(recovered![`${PROJECT_A}::slot-2`].sessionId).toBe('aaa');
+  });
+
+  it('keeps a live paired entry and re-homes a survivor that claims the same slot', () => {
+    // The reported production failure. A post-reload spawn took slot-1 while the
+    // survivor stamped slot-1 was still running. Last-wins would orphan one of
+    // them; the live window keeps its slot and the survivor moves to slot-2.
+    const recovered = planTransientRecovery({
+      sessions: [
+        transientSession({ id: 'survivor', commandTerminalSlot: 'slot-1', startedAt: '2026-09-08T19:45:39.000Z' }),
+        transientSession({ id: 'fresh-spawn', commandTerminalSlot: 'slot-1', startedAt: '2026-09-08T19:53:54.000Z' }),
+      ],
+      transientSessions: transientMap([
+        { projectId: PROJECT_A, slot: 'slot-1', sessionId: 'fresh-spawn', branch: 'main' },
+      ]),
+    });
+
+    expect(recovered![`${PROJECT_A}::slot-1`].sessionId).toBe('fresh-spawn');
+    expect(recovered![`${PROJECT_A}::slot-2`].sessionId).toBe('survivor');
+    // Neither PTY is left unreachable, which is the actual bug.
+    const pairedIds = Object.values(recovered!).map((entry) => entry.sessionId).sort();
+    expect(pairedIds).toEqual(['fresh-spawn', 'survivor']);
+  });
+
+  it('recovers a project that is not the current one', () => {
+    // The old block was wrapped in `if (currentProjectId)`, so a background
+    // project's terminals were never re-paired. The planner has no such concept.
+    const recovered = planTransientRecovery({
+      sessions: [
+        transientSession({ id: 'a-1', projectId: PROJECT_A, commandTerminalSlot: 'slot-1' }),
+        transientSession({ id: 'b-1', projectId: PROJECT_B, commandTerminalSlot: 'slot-1' }),
+      ],
+      transientSessions: {},
+    });
+
+    expect(recovered![`${PROJECT_A}::slot-1`].sessionId).toBe('a-1');
+    expect(recovered![`${PROJECT_B}::slot-1`].sessionId).toBe('b-1');
+  });
+
+  it('is not blocked by a project that already has one tracked entry', () => {
+    // The `alreadyTracked` gate: one entry made the whole project look recovered,
+    // so a second survivor stayed orphaned forever.
+    const recovered = planTransientRecovery({
+      sessions: [
+        transientSession({ id: 'tracked', commandTerminalSlot: 'slot-1' }),
+        transientSession({ id: 'orphan', commandTerminalSlot: 'slot-2' }),
+      ],
+      transientSessions: transientMap([
+        { projectId: PROJECT_A, slot: 'slot-1', sessionId: 'tracked', branch: 'main' },
+      ]),
+    });
+
+    expect(recovered![`${PROJECT_A}::slot-2`].sessionId).toBe('orphan');
+  });
+
+  it('gives unslotted survivors the lowest free slots, oldest first', () => {
+    // A null slot is a real case (a session spawned before the slot plumbing, or
+    // by a path that sends none), so it must still be paired rather than dropped.
+    const recovered = planTransientRecovery({
+      sessions: [
+        transientSession({ id: 'newer', startedAt: '2026-09-08T12:00:02.000Z' }),
+        transientSession({ id: 'older', startedAt: '2026-09-08T12:00:01.000Z' }),
+      ],
+      transientSessions: {},
+    });
+
+    expect(recovered![`${PROJECT_A}::slot-1`].sessionId).toBe('older');
+    expect(recovered![`${PROJECT_A}::slot-2`].sessionId).toBe('newer');
+  });
+
+  it('breaks a startedAt tie by id so the pairing is deterministic', () => {
+    const recovered = planTransientRecovery({
+      sessions: [transientSession({ id: 'hr-sess-2' }), transientSession({ id: 'hr-sess-1' })],
+      transientSessions: {},
+    });
+
+    expect(recovered![`${PROJECT_A}::slot-1`].sessionId).toBe('hr-sess-1');
+    expect(recovered![`${PROJECT_A}::slot-2`].sessionId).toBe('hr-sess-2');
+  });
+
+  it('lets a slotted survivor keep its slot while an unslotted one fills around it', () => {
+    const recovered = planTransientRecovery({
+      sessions: [
+        transientSession({ id: 'slotted', commandTerminalSlot: 'slot-1', startedAt: '2026-09-08T12:00:02.000Z' }),
+        transientSession({ id: 'unslotted', startedAt: '2026-09-08T12:00:01.000Z' }),
+      ],
+      transientSessions: {},
+    });
+
+    // Exact re-pairs are assigned before any lowest-free fill, so the unslotted
+    // row cannot take slot-1 out from under the row that actually ran there.
+    expect(recovered![`${PROJECT_A}::slot-1`].sessionId).toBe('slotted');
+    expect(recovered![`${PROJECT_A}::slot-2`].sessionId).toBe('unslotted');
+  });
+
+  it('restores the derived label main retained for a survivor', () => {
+    // Without this the terminal comes back as "Command Terminal N" and the
+    // auto-namer, whose in-renderer guard the reload also cleared, renames it
+    // from whatever prompt the user types next.
+    const recovered = planTransientRecovery({
+      sessions: [
+        transientSession({ id: 'named', commandTerminalSlot: 'slot-1', commandTerminalLabel: 'Fix the parser' }),
+      ],
+      transientSessions: {},
+    });
+
+    expect(recovered![`${PROJECT_A}::slot-1`].label).toBe('Fix the parser');
+  });
+
+  it('leaves an unnamed survivor without a label key', () => {
+    const recovered = planTransientRecovery({
+      sessions: [transientSession({ id: 'unnamed', commandTerminalSlot: 'slot-1' })],
+      transientSessions: {},
+    });
+
+    expect(recovered![`${PROJECT_A}::slot-1`]).not.toHaveProperty('label');
+  });
+
+  it('preserves the derived label on an already-paired entry', () => {
+    // syncSessions is Pattern B, so this now runs on every Fast Refresh.
+    // setTransientSessionLabel is first-prompt-wins, so a clobbered label is gone
+    // for good.
+    const recovered = planTransientRecovery({
+      sessions: [
+        transientSession({ id: 'labelled', commandTerminalSlot: 'slot-1' }),
+        transientSession({ id: 'orphan', commandTerminalSlot: 'slot-2' }),
+      ],
+      transientSessions: transientMap([
+        { projectId: PROJECT_A, slot: 'slot-1', sessionId: 'labelled', branch: 'main', label: 'Fix the parser' },
+      ]),
+    });
+
+    expect(recovered![`${PROJECT_A}::slot-1`].label).toBe('Fix the parser');
+  });
+
+  it('frees a stale entry slot for a survivor that claims it', () => {
+    const recovered = planTransientRecovery({
+      sessions: [
+        { ...transientSession({ id: 'dead' }), status: 'exited' },
+        transientSession({ id: 'survivor', commandTerminalSlot: 'slot-1' }),
+      ],
+      transientSessions: transientMap([
+        { projectId: PROJECT_A, slot: 'slot-1', sessionId: 'dead', branch: 'main' },
+      ]),
+    });
+
+    expect(recovered![`${PROJECT_A}::slot-1`].sessionId).toBe('survivor');
+  });
+
+  it('returns null when every survivor is already paired', () => {
+    // Reference identity matters: this is the common case on every sync, and a
+    // fresh object would re-render every transient consumer for nothing.
+    const recovered = planTransientRecovery({
+      sessions: [transientSession({ id: 'sess-1', commandTerminalSlot: 'slot-1' })],
+      transientSessions: transientMap([
+        { projectId: PROJECT_A, slot: 'slot-1', sessionId: 'sess-1', branch: 'main' },
+      ]),
+    });
+
+    expect(recovered).toBeNull();
+  });
+
+  it('returns null when there are no live transient sessions', () => {
+    const recovered = planTransientRecovery({
+      sessions: [taskSession('task-1'), { ...transientSession({ id: 'gone' }), status: 'exited' }],
+      transientSessions: {},
+    });
+
+    expect(recovered).toBeNull();
+  });
+
+  it('never pairs a task agent session', () => {
+    const recovered = planTransientRecovery({
+      sessions: [taskSession('task-1'), transientSession({ id: 'terminal', commandTerminalSlot: 'slot-1' })],
+      transientSessions: {},
+    });
+
+    expect(Object.keys(recovered!)).toEqual([`${PROJECT_A}::slot-1`]);
+  });
+
+  it('leaves other projects\' entries untouched', () => {
+    const existing = transientMap([
+      { projectId: PROJECT_B, slot: 'slot-1', sessionId: 'b-1', branch: 'main', label: 'B work' },
+    ]);
+    const recovered = planTransientRecovery({
+      sessions: [
+        transientSession({ id: 'a-1', projectId: PROJECT_A, commandTerminalSlot: 'slot-1' }),
+        transientSession({ id: 'b-1', projectId: PROJECT_B, commandTerminalSlot: 'slot-1' }),
+      ],
+      transientSessions: existing,
+    });
+
+    expect(recovered![`${PROJECT_B}::slot-1`]).toEqual(existing[`${PROJECT_B}::slot-1`]);
+  });
+});
+
+describe('findAdoptableTransientSession', () => {
+  it('finds a live unpaired PTY stamped with this slot', () => {
+    const adoptable = findAdoptableTransientSession(
+      [transientSession({ id: 'orphan', commandTerminalSlot: 'slot-2', commandTerminalBranch: 'main' })],
+      {},
+      PROJECT_A,
+      'slot-2',
+    );
+
+    expect(adoptable?.id).toBe('orphan');
+  });
+
+  it('ignores a PTY that is already paired to some window', () => {
+    const adoptable = findAdoptableTransientSession(
+      [transientSession({ id: 'paired', commandTerminalSlot: 'slot-1' })],
+      transientMap([{ projectId: PROJECT_A, slot: 'slot-1', sessionId: 'paired', branch: 'main' }]),
+      PROJECT_A,
+      'slot-1',
+    );
+
+    expect(adoptable).toBeNull();
+  });
+
+  it('never adopts a PTY belonging to a different slot', () => {
+    // Attaching to the wrong slot puts someone else's conversation under this
+    // window's title, silently. Spawning is the correct outcome here.
+    const adoptable = findAdoptableTransientSession(
+      [transientSession({ id: 'other', commandTerminalSlot: 'slot-3' })],
+      {},
+      PROJECT_A,
+      'slot-1',
+    );
+
+    expect(adoptable).toBeNull();
+  });
+
+  it('never adopts across projects, or a dead or unslotted PTY', () => {
+    const sessions = [
+      transientSession({ id: 'other-project', projectId: PROJECT_B, commandTerminalSlot: 'slot-1' }),
+      { ...transientSession({ id: 'dead', commandTerminalSlot: 'slot-1' }), status: 'exited' as const },
+      transientSession({ id: 'unslotted' }),
+      taskSession('task-1'),
+    ];
+
+    expect(findAdoptableTransientSession(sessions, {}, PROJECT_A, 'slot-1')).toBeNull();
+  });
+});

--- a/tests/unit/transient-session-adopt.test.ts
+++ b/tests/unit/transient-session-adopt.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for `buildTransientSessionEntry` and `adoptTransientSession` on
+ * TransientSessionSlice.
+ *
+ * `buildTransientSessionEntry` is the single builder shared by `adoptTransientSession`
+ * (here) and `planTransientRecovery`'s pairing pass (tests/unit/transient-recovery.test.ts).
+ * Before the extraction, `adoptTransientSession` built its pairing entry by hand and
+ * omitted `label`, so a terminal recovered through the adopt path lost its derived
+ * name. These tests pin that both fields - `branch` and `label` - survive the trip
+ * from a live `Session` row into the pairing entry, at both the pure-builder level
+ * and through the slice's observable store behavior.
+ *
+ * We instantiate the slice directly via `createTransientSessionSlice`, following the
+ * same set/get harness as tests/unit/transient-session-label.test.ts, so no Zustand
+ * store instance or `useProjectStore` import is needed.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the project-store so importing the slice doesn't pull in
+// useProjectStore's browser/IPC dependencies.
+vi.mock('../../src/renderer/stores/project-store', () => ({
+  useProjectStore: {
+    getState: vi.fn(() => ({ currentProject: null })),
+  },
+}));
+
+import {
+  buildTransientSessionEntry,
+  createTransientSessionSlice,
+  transientKey,
+  type TransientSessionEntry,
+} from '../../src/renderer/stores/session-store/transient-session-slice';
+import type { SessionStore } from '../../src/renderer/stores/session-store/types';
+import type { Session } from '../../src/shared/types';
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal in-memory store that runs the slice
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a minimal Zustand-style set/get pair for the transient slice.
+ * We only need the transientSessions map from the wider SessionStore shape;
+ * the other fields are never touched by adoptTransientSession.
+ */
+function makeSliceStore(initial?: {
+  transientSessions?: Record<string, TransientSessionEntry>;
+}) {
+  let state: Pick<SessionStore, 'transientSessions'> & Record<string, unknown> = {
+    transientSessions: initial?.transientSessions ?? {},
+    sessions: [],
+    _sessionByTaskId: new Map(),
+    sessionUsage: {},
+    sessionFirstOutput: {},
+    sessionActivity: {},
+    sessionEvents: {},
+    seenIdleSessions: {},
+    commandBarVisible: false,
+  };
+
+  const get = () => state as unknown as SessionStore;
+
+  const set = (updater: Partial<SessionStore> | ((prev: SessionStore) => Partial<SessionStore>)) => {
+    if (typeof updater === 'function') {
+      const partial = updater(state as unknown as SessionStore);
+      if (partial !== (state as unknown)) {
+        state = { ...state, ...partial };
+      }
+    } else {
+      state = { ...state, ...updater };
+    }
+  };
+
+  const sliceCreator = createTransientSessionSlice(undefined);
+  const slice = sliceCreator(set as unknown as Parameters<typeof sliceCreator>[0], get, {} as unknown as Parameters<typeof sliceCreator>[2]);
+
+  return {
+    slice,
+    getState: () => state,
+  };
+}
+
+/** A live Command Terminal PTY row as `sessions.list()` delivers it. */
+function makeSession(overrides: Partial<Session> & { id: string }): Session {
+  return {
+    taskId: overrides.id,
+    projectId: 'proj-abc',
+    pid: 1000,
+    status: 'running',
+    shell: 'bash',
+    cwd: '/mock/project',
+    startedAt: '2026-09-08T12:00:00.000Z',
+    exitCode: null,
+    resuming: false,
+    transient: true,
+    commandTerminalSlot: null,
+    commandTerminalBranch: null,
+    commandTerminalLabel: null,
+    isolatedSwimlaneId: null,
+    agentSessionId: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildTransientSessionEntry - the shared pure builder
+// ---------------------------------------------------------------------------
+
+describe('buildTransientSessionEntry', () => {
+  it('carries both branch and label from the session row', () => {
+    const entry = buildTransientSessionEntry(
+      'proj-abc',
+      'slot-1',
+      makeSession({ id: 'sess-1', commandTerminalBranch: 'feature/x', commandTerminalLabel: 'Fix the parser' }),
+    );
+
+    expect(entry).toEqual({
+      projectId: 'proj-abc', slot: 'slot-1', sessionId: 'sess-1', branch: 'feature/x', label: 'Fix the parser',
+    });
+  });
+
+  it('defaults branch to null and omits label when the session carries neither', () => {
+    const entry = buildTransientSessionEntry('proj-abc', 'slot-1', makeSession({ id: 'sess-1' }));
+
+    expect(entry.branch).toBeNull();
+    expect(entry).not.toHaveProperty('label');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// adoptTransientSession - the observable store behavior
+// ---------------------------------------------------------------------------
+
+describe('adoptTransientSession', () => {
+  it('writes a pairing entry carrying both branch and label from the survivor session', () => {
+    const { slice, getState } = makeSliceStore();
+
+    slice.adoptTransientSession(
+      'proj-abc',
+      'slot-1',
+      makeSession({ id: 'sess-1', commandTerminalBranch: 'feature/x', commandTerminalLabel: 'Fix the parser' }),
+    );
+
+    expect(getState().transientSessions[transientKey('proj-abc', 'slot-1')]).toEqual({
+      projectId: 'proj-abc', slot: 'slot-1', sessionId: 'sess-1', branch: 'feature/x', label: 'Fix the parser',
+    });
+  });
+
+  it('defaults branch to null and leaves label absent for an unnamed survivor', () => {
+    const { slice, getState } = makeSliceStore();
+
+    slice.adoptTransientSession('proj-abc', 'slot-1', makeSession({ id: 'sess-1' }));
+
+    const entry = getState().transientSessions[transientKey('proj-abc', 'slot-1')];
+    expect(entry?.branch).toBeNull();
+    expect(entry).not.toHaveProperty('label');
+  });
+
+  it('overwrites any existing entry at the same slot with the adopted session', () => {
+    const { slice, getState } = makeSliceStore({
+      transientSessions: {
+        [transientKey('proj-abc', 'slot-1')]: {
+          projectId: 'proj-abc', slot: 'slot-1', sessionId: 'stale-session', branch: 'main', label: 'Stale',
+        },
+      },
+    });
+
+    slice.adoptTransientSession(
+      'proj-abc',
+      'slot-1',
+      makeSession({ id: 'sess-1', commandTerminalBranch: 'feature/y', commandTerminalLabel: 'New Name' }),
+    );
+
+    expect(getState().transientSessions[transientKey('proj-abc', 'slot-1')]).toEqual({
+      projectId: 'proj-abc', slot: 'slot-1', sessionId: 'sess-1', branch: 'feature/y', label: 'New Name',
+    });
+  });
+});

--- a/tests/unit/transient-session-label.test.ts
+++ b/tests/unit/transient-session-label.test.ts
@@ -12,9 +12,14 @@
  *   - unknown sessionId leaves state unchanged
  *   - the map is keyed by (project, slot), so the label targets the matched
  *     session regardless of which slot owns it
+ *
+ * Also covers the `applied`-gated mirror to main (`window.electronAPI.sessions
+ * .setTransientLabel`): exactly one IPC call when the label genuinely applies,
+ * zero calls on any no-op path, and a rejected mirror call swallowed rather than
+ * thrown or left as an unhandled rejection.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the project-store so importing the slice doesn't pull in
 // useProjectStore's browser/IPC dependencies.
@@ -84,9 +89,34 @@ function entry(overrides: Partial<TransientSessionEntry> & Pick<TransientSession
   return { branch: null, ...overrides };
 }
 
+/**
+ * Stub `window.electronAPI.sessions.setTransientLabel`. In the node test env
+ * vitest provides no `window`, so we attach to globalThis (the same object the
+ * production code's `window` resolves to under jsdom); see the identical
+ * pattern in `tests/unit/auto-name-scheduler.test.ts`.
+ */
+function setupSetTransientLabelApi(
+  impl: (sessionId: string, label: string) => Promise<void>,
+): ReturnType<typeof vi.fn> {
+  const setTransientLabel = vi.fn((sessionId: string, label: string) => impl(sessionId, label));
+  (globalThis as unknown as { window: Record<string, unknown> }).window =
+    (globalThis as unknown as { window?: Record<string, unknown> }).window ?? {};
+  (globalThis as unknown as { window: { electronAPI: unknown } }).window.electronAPI = {
+    sessions: { setTransientLabel },
+  };
+  return setTransientLabel;
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  // Default resolving stub so every test below can call setTransientSessionLabel
+  // without crashing on a real apply; tests that care about the mirror call
+  // shape install their own via setupSetTransientLabelApi.
+  setupSetTransientLabelApi(async () => {});
+});
 
 describe('setTransientSessionLabel', () => {
   it('sets the label on the matching transient session entry', () => {
@@ -175,5 +205,115 @@ describe('setTransientSessionLabel', () => {
     expect(getState().transientSessions[transientKey('proj-1', 'slot-1')]?.label).toBeUndefined();
     expect(getState().transientSessions[transientKey('proj-1', 'slot-2')]?.label).toBe('Second Slot Label');
     expect(getState().transientSessions[transientKey('proj-2', 'slot-1')]?.label).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setTransientSessionLabel - mirror to main, gated on `applied`
+// ---------------------------------------------------------------------------
+
+describe('setTransientSessionLabel - IPC mirror to main', () => {
+  it('mirrors to main exactly once, with the trimmed label, when the label newly applies', () => {
+    const setTransientLabel = setupSetTransientLabelApi(async () => {});
+    const { slice } = makeSliceStore({
+      transientSessions: {
+        [transientKey('proj-abc', 'slot-1')]: entry({ projectId: 'proj-abc', slot: 'slot-1', sessionId: 'sess-1' }),
+      },
+    });
+
+    slice.setTransientSessionLabel('sess-1', '  Fix Login Flow  ');
+
+    expect(setTransientLabel).toHaveBeenCalledTimes(1);
+    expect(setTransientLabel).toHaveBeenCalledWith('sess-1', 'Fix Login Flow');
+  });
+
+  it('issues no IPC call when the entry already has a label (no-op apply)', () => {
+    const setTransientLabel = setupSetTransientLabelApi(async () => {});
+    const { slice } = makeSliceStore({
+      transientSessions: {
+        [transientKey('proj-abc', 'slot-1')]: entry({
+          projectId: 'proj-abc', slot: 'slot-1', sessionId: 'sess-1', label: 'Existing',
+        }),
+      },
+    });
+
+    slice.setTransientSessionLabel('sess-1', 'Second Label Should Be Ignored');
+
+    expect(setTransientLabel).not.toHaveBeenCalled();
+  });
+
+  it('issues no IPC call for an unknown sessionId (no owning entry)', () => {
+    const setTransientLabel = setupSetTransientLabelApi(async () => {});
+    const { slice } = makeSliceStore({
+      transientSessions: {
+        [transientKey('proj-abc', 'slot-1')]: entry({ projectId: 'proj-abc', slot: 'slot-1', sessionId: 'sess-1' }),
+      },
+    });
+
+    slice.setTransientSessionLabel('sess-nonexistent', 'Should Not Mirror');
+
+    expect(setTransientLabel).not.toHaveBeenCalled();
+  });
+
+  it('issues no IPC call for an empty or whitespace-only label (trimmed no-op)', () => {
+    const setTransientLabel = setupSetTransientLabelApi(async () => {});
+    const { slice } = makeSliceStore({
+      transientSessions: {
+        [transientKey('proj-abc', 'slot-1')]: entry({ projectId: 'proj-abc', slot: 'slot-1', sessionId: 'sess-1' }),
+      },
+    });
+
+    slice.setTransientSessionLabel('sess-1', '   ');
+
+    expect(setTransientLabel).not.toHaveBeenCalled();
+  });
+
+  it('swallows a rejected mirror call without throwing or producing an unhandled rejection', async () => {
+    // Listen for Node's own unhandledRejection event directly rather than
+    // relying on the test runner to surface one: it is the only reliable way
+    // to prove the production `.catch` is doing its job, since a missing catch
+    // otherwise fails nothing observable inside this test body.
+    //
+    // Deliberately NOT a vi.fn() here (unlike every other test in this file):
+    // vi.fn's own call-tracking attaches a settle handler to the promise it
+    // returns, which itself counts as "handling" the rejection from Node's
+    // point of view - a repro confirmed a vi.fn-wrapped rejecting mock never
+    // reaches this listener even with the production `.catch` removed. A raw
+    // function is the only way this assertion can actually go red.
+    const capturedRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown): void => {
+      capturedRejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    const calls: Array<[string, string]> = [];
+    (globalThis as unknown as { window: Record<string, unknown> }).window =
+      (globalThis as unknown as { window?: Record<string, unknown> }).window ?? {};
+    (globalThis as unknown as { window: { electronAPI: unknown } }).window.electronAPI = {
+      sessions: {
+        setTransientLabel: (sessionId: string, label: string) => {
+          calls.push([sessionId, label]);
+          return Promise.reject(new Error('network down'));
+        },
+      },
+    };
+
+    try {
+      const { slice } = makeSliceStore({
+        transientSessions: {
+          [transientKey('proj-abc', 'slot-1')]: entry({ projectId: 'proj-abc', slot: 'slot-1', sessionId: 'sess-1' }),
+        },
+      });
+
+      expect(() => slice.setTransientSessionLabel('sess-1', 'Fix Login Flow')).not.toThrow();
+      // Flush enough event-loop turns for Node to report the rejection as
+      // unhandled if nothing caught it.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(calls).toEqual([['sess-1', 'Fix Login Flow']]);
+      expect(capturedRejections).toHaveLength(0);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
   });
 });

--- a/tests/unit/transient-session-set-label-handler.test.ts
+++ b/tests/unit/transient-session-set-label-handler.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit test for the SESSION_SET_TRANSIENT_LABEL handler wiring
+ * (src/main/ipc/handlers/transient-sessions.ts).
+ *
+ * Every other test touching this feature exercises one side of the IPC boundary
+ * in isolation: tests/unit/session-manager-command-terminal-label.test.ts drives
+ * `SessionManager.setCommandTerminalLabel` directly (no IPC involved), and
+ * tests/unit/transient-session-label.test.ts drives the renderer's mirror call
+ * against a hand-rolled `window.electronAPI.sessions.setTransientLabel` stub (no
+ * real preload or handler involved). Neither proves the actual `ipcMain.handle`
+ * registration exists or that it forwards its two arguments in the right order.
+ *
+ * That gap matters because the renderer's call site is fire-and-forget
+ * (`void window.electronAPI.sessions.setTransientLabel(...).catch(() => {})` in
+ * transient-session-slice.ts): an unregistered channel or a swapped argument
+ * order would silently lose every derived Command Terminal name after a reload,
+ * with no throw, no toast, and no failing test anywhere else in the suite.
+ *
+ * Mocking pattern follows tests/unit/transient-session-spawn-ensure-trust.test.ts
+ * (same file under test, same capturedHandlers + mocked IpcContext shape).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const capturedHandlers = new Map<string, (...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      capturedHandlers.set(channel, handler);
+    }),
+  },
+}));
+
+vi.mock('node:fs', () => ({
+  default: {
+    mkdirSync: vi.fn(),
+    rmSync: vi.fn(),
+  },
+}));
+
+vi.mock('uuid', () => ({ v4: vi.fn(() => 'mock-transient-task-id') }));
+
+vi.mock('simple-git', () => ({
+  default: vi.fn(() => ({
+    revparse: vi.fn(async () => 'main\n'),
+    checkout: vi.fn(async () => undefined),
+    merge: vi.fn(async () => undefined),
+  })),
+}));
+
+vi.mock('../../src/main/git/fetch-throttle', () => ({
+  fetchIfStale: vi.fn(async () => 'origin/main'),
+}));
+
+vi.mock('../../src/main/analytics/analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('../../src/main/analytics/usage', () => ({
+  trackFeatureUsed: vi.fn(),
+}));
+
+vi.mock('../../src/shared/git-utils', () => ({
+  resolveProjectRoot: vi.fn((projectPath: string) => projectPath),
+}));
+
+vi.mock('../../src/main/agent/agent-registry', () => ({
+  agentRegistry: {
+    getOrThrow: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after all mocks are registered)
+// ---------------------------------------------------------------------------
+
+import { registerTransientSessionHandlers } from '../../src/main/ipc/handlers/transient-sessions';
+import { IPC } from '../../src/shared/ipc-channels';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface MockContext {
+  currentProjectId: string | null;
+  projectRepo: { getById: ReturnType<typeof vi.fn> };
+  configManager: { getEffectiveConfig: ReturnType<typeof vi.fn> };
+  mcpServerHandle: null;
+  sessionManager: { setCommandTerminalLabel: ReturnType<typeof vi.fn> };
+}
+
+function createMockContext(): MockContext {
+  return {
+    currentProjectId: 'proj-1',
+    projectRepo: { getById: vi.fn() },
+    configManager: { getEffectiveConfig: vi.fn() },
+    mcpServerHandle: null,
+    sessionManager: {
+      setCommandTerminalLabel: vi.fn(),
+    },
+  };
+}
+
+function getCapturedHandler(): (...args: unknown[]) => unknown {
+  const handler = capturedHandlers.get(IPC.SESSION_SET_TRANSIENT_LABEL);
+  if (!handler) throw new Error(`Handler for ${IPC.SESSION_SET_TRANSIENT_LABEL} was not registered`);
+  return handler;
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('SESSION_SET_TRANSIENT_LABEL handler', () => {
+  let context: MockContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedHandlers.clear();
+    context = createMockContext();
+    registerTransientSessionHandlers(context as never);
+  });
+
+  it('registers a handler for the channel', () => {
+    // Red without this: registerTransientSessionHandlers running at all (every
+    // other test in the describe block below) does not prove THIS channel was
+    // among the handles it registered.
+    expect(capturedHandlers.has(IPC.SESSION_SET_TRANSIENT_LABEL)).toBe(true);
+  });
+
+  it('forwards (sessionId, label) to sessionManager.setCommandTerminalLabel in that order', () => {
+    const handler = getCapturedHandler();
+
+    handler(null, 'sess-1', 'Fix the parser');
+
+    // Positional, not toHaveBeenCalledWith on a swapped pair: this is exactly
+    // the mistake this test exists to catch, since the two arguments are both
+    // plain strings and a swap would compile and pass any type check.
+    expect(context.sessionManager.setCommandTerminalLabel).toHaveBeenCalledTimes(1);
+    expect(context.sessionManager.setCommandTerminalLabel).toHaveBeenCalledWith('sess-1', 'Fix the parser');
+  });
+
+  it('does not throw when the manager call itself has no return value', () => {
+    // ipcMain.handle callbacks may return void; the renderer's call site awaits
+    // the invoke promise but discards the resolved value, so nothing depends on
+    // this handler returning anything - only on it not throwing.
+    const handler = getCapturedHandler();
+    expect(() => handler(null, 'sess-2', 'Another name')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

A renderer reload no longer orphans a live Command Terminal PTY.

Main now owns the window-to-PTY pairing. `ManagedSession` retains
`commandTerminalSlot`, `commandTerminalBranch`, and `commandTerminalLabel`, `toSession` carries
all three to the renderer, and a new pure planner (`planTransientRecovery`) rebuilds the
renderer's pairing map from that on every `syncSessions`.

Touches the session registry and manager, the transient-session IPC handler and its new
`session:setTransientLabel` channel, the Command Terminal window and reconcile planner, and the
session store's transient slice.

## Why

The `(project, slot)` pairing lives in `transientSessions`, which is renderer-only memory: HMR
preserves it via `import.meta.hot.data`, a full page reload does not. Main keeps every transient
PTY running regardless, so a reload left a live conversation with nothing pointing at it. The
terminal came back as an empty fresh boot, and the sidebar counted more terminals than there were
windows. HMR is the frequent trigger, but a production reload orphans them identically.

Main already recorded the slot at spawn and threw it away. `toSession` is the one mapper every
session row the renderer sees passes through, and it dropped the field, so recovery had to guess.
Three defects followed from that:

- It dealt survivors `slot-1, slot-2, ...` over a uuid-sorted list, so a window could show a
  different terminal than its title named, with no error.
- It bailed if the project had any tracked entry, so one terminal that won the post-reload race
  hid every other survivor permanently.
- It was scoped to the current project, so a background project never recovered at all.

Recovery also wrote `branch: null` and dropped the derived name, so a recovered terminal lost its
branch pill and its title.

## How

`planTransientRecovery` is unconditional, per-slot, and cross-project:

1. An entry already pointing at a running session is kept verbatim, which preserves the
   first-prompt-wins label. This matters because `syncSessions` is Pattern B, so recovery now runs
   on every Fast Refresh, not only on a hard reload.
2. Every other survivor claims the slot main recorded for it.
3. A survivor whose slot is taken, or that carries none, takes the lowest free slot, so no live
   PTY is left unreachable.

Trade-offs worth a reviewer's attention:

- **Step 3 renumbers a terminal**, which `command-terminal-name.ts` says never happens. It is now
  documented there: losing a PTY entirely is the worse outcome, and this is the only case.
- **The label needed a new IPC channel.** It is derived in the renderer, so main cannot compute
  it; it is mirrored over `session:setTransientLabel` and held passively, first write wins. Without
  it the auto-namer re-fires after a reload (its in-memory guard is cleared too) and renames the
  terminal from a later prompt.
- **`Session` gained three optional fields.** `listManagedSummaries` documents the opposite policy
  for `agentName`; the distinction is that these are needed for correctness, not diagnostics, and
  that comment was updated rather than left contradicting the change.
- **The `liveSlots.size === 0` branch was kept**, not removed. It is correct for switching to a
  project with no terminals. Unioning main's session rows into the live-slot set is what stops it
  firing when survivors exist.
- **`selectCommandTerminalSummary` still reads the sessions list.** Unifying it with the pairing
  map would be a refactor with no correctness gain; its now-false comment was corrected instead.

## Breaking changes

None. All three `Session` fields are optional, so no existing consumer changes.

## Tests

Every case below was verified red on unmodified source before being taken as passing.

- `tests/unit/transient-recovery.test.ts` (new): the planner matrix, including exact re-pair of
  non-dense slots, the collision re-home, cross-project recovery, the removed already-tracked
  gate, unslotted fill order, label restore, and the same-reference no-op.
- `tests/unit/session-manager-command-terminal-label.test.ts` (new) and
  `tests/unit/transient-session-set-label-handler.test.ts` (new): the manager's first-write-wins
  guards, and the handler's registration plus argument order. The renderer's mirror call is
  fire-and-forget, so a swapped argument pair would otherwise lose every name silently.
- `tests/unit/session-registry.test.ts`, `command-window-reconcile.test.ts`: `toSession` carrying
  the three fields, and the session-row union in `liveSlots`.
- `tests/ui/command-terminal.spec.ts`: five cases, including the mis-pairing that put another
  terminal's conversation under the wrong title, and the reported symptom of the sidebar count
  exceeding the window count.
- `tests/e2e/command-terminal-reload-recovery.spec.ts` (new): a real `page.reload()` against two
  real PTYs. Two terminals is what makes it discriminating, since with one the old positional
  guess lands correctly by accident.

Also checked by hand in a live instance: two Command Terminals came back reattached to their
original slots with their original uptimes, and no duplicate PTY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ToatoefgHBTJe5R1aUBsGH
