### PR TITLE
fix(ipc): bound shell:openPath so the invoke is always answered

### DIFF
--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -19,6 +19,7 @@ import { broadcast } from '../../pop-out/window-broadcast';
 import { resolveRelayUrl } from '../../../shared/relay';
 import { EXTERNAL_OPEN_SCHEMES, isAllowedExternalUrl } from '../../../shared/external-url';
 import { capClipboardImage, pruneClipboardTempDir } from '../helpers/clipboard-image';
+import { openPathBounded } from '../helpers/open-path';
 import type {
   NotificationInput,
   AgentCommand,
@@ -532,8 +533,10 @@ export function registerSystemHandlers(context: IpcContext): void {
 
   // Normalize so a path the renderer joined with forward slashes (git paths use
   // '/') opens correctly on Windows, which needs native backslash separators -
-  // matching the SHELL_SHOW_ITEM_IN_FOLDER handler below.
-  ipcMain.handle(IPC.SHELL_OPEN_PATH, (_, dirPath: string) => shell.openPath(path.normalize(dirPath)));
+  // matching the SHELL_SHOW_ITEM_IN_FOLDER handler below. Bounded because a
+  // raw shell.openPath can outlive this invoke on Linux, where it waits on
+  // xdg-open, and Electron then raises "reply was never sent" in the renderer.
+  ipcMain.handle(IPC.SHELL_OPEN_PATH, (_, dirPath: string) => openPathBounded(path.normalize(dirPath)));
   // shell.openExternal is ShellExecute on Windows and will launch any
   // registered protocol handler, so this is a process trust boundary -
   // reject anything outside the allowlist instead of passing it straight to

--- a/src/main/ipc/helpers/attachment-open.ts
+++ b/src/main/ipc/helpers/attachment-open.ts
@@ -3,8 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { shell } from 'electron';
 import { attachmentDiskName } from '../../../shared/attachment-filename';
-
-export const OPEN_PATH_TIMEOUT_MS = 5000;
+import { openPathBounded } from './open-path';
 
 export interface OpenableAttachment {
   id: string;
@@ -15,7 +14,7 @@ export interface OpenableAttachment {
 export interface OpenAttachmentOptions {
   /** Defaults to process.platform. Injectable so the Windows-only temp-copy branch is testable on Linux CI. */
   platform?: NodeJS.Platform;
-  /** Defaults to OPEN_PATH_TIMEOUT_MS. */
+  /** Passed through to openPathBounded, which defaults it to OPEN_PATH_TIMEOUT_MS. */
   timeoutMs?: number;
   /** Defaults to os.tmpdir(). Injectable so tests never write to a hardcoded absolute path. */
   tempDirRoot?: string;
@@ -25,51 +24,36 @@ export interface OpenAttachmentOptions {
  * Open an attachment with the OS default app, and guarantee the IPC invoke
  * that called this always gets a reply.
  *
- * shell.openPath() never rejects - it always resolves, with '' on success or
- * a non-empty error string on failure (Electron's
- * shell/common/api/electron_api_shell.cc). Nothing bounds how long that can
- * take: on Linux, OpenPath shells out to xdg-open, which can wait on
- * whatever viewer it launches. If that promise never settles, it can outlive
- * the renderer's ipcRenderer.invoke() call, and the reply channel gets torn
- * down without ever sending a reply - surfacing as "reply was never sent"
- * (Electron's ReplyChannel::EnsureReplySent pre-finalizer). Racing openPath
- * against a timeout does not un-stick that hang; it only guarantees this
- * handler's own promise settles, so the invoke is always answered.
+ * openPathBounded owns the bounded wait and the reason for it (an xdg-open
+ * hang outliving the renderer's invoke); this function adds only the
+ * attachment-specific parts: the win32 temp copy and the reveal-in-file-manager
+ * fallback.
  */
 export async function openAttachmentFile(
   attachment: OpenableAttachment,
   options?: OpenAttachmentOptions,
 ): Promise<string> {
   const platform = options?.platform ?? process.platform;
-  const timeoutMs = options?.timeoutMs ?? OPEN_PATH_TIMEOUT_MS;
   const tempDirRoot = options?.tempDirRoot ?? os.tmpdir();
 
   const targetPath = resolveOpenTarget(attachment, platform, tempDirRoot);
 
-  const openPromise = shell.openPath(targetPath);
-  const result = await raceWithTimeout(openPromise, timeoutMs);
+  const errorMessage = await openPathBounded(targetPath, {
+    timeoutMs: options?.timeoutMs,
+    // The invoke was already answered '' at the timeout. If openPath
+    // eventually does report an error, still reveal the file - the renderer
+    // has been told this succeeded, so there is no toast for this outcome.
+    onLateOutcome: (lateError) => {
+      if (lateError) shell.showItemInFolder(targetPath);
+    },
+  });
 
-  if (result.timedOut) {
-    // The invoke is answered now. If openPath eventually does report an
-    // error, still reveal the file - the renderer has already been told
-    // this succeeded, so there is no toast for this late outcome.
-    void openPromise.then(
-      (lateError) => {
-        if (lateError) shell.showItemInFolder(targetPath);
-      },
-      () => {
-        // Nothing left to report: the invoke was answered at the timeout.
-      },
-    );
-    return '';
-  }
-
-  if (result.value) {
+  if (errorMessage) {
     // Unsupported format or no default app - fall back to showing the file
     // in the file manager so the user can act on it manually.
     shell.showItemInFolder(targetPath);
   }
-  return result.value;
+  return errorMessage;
 }
 
 /**
@@ -117,28 +101,4 @@ function copyIsCurrent(sourcePath: string, copyPath: string): boolean {
   } catch {
     return false;
   }
-}
-
-type RaceResult = { timedOut: true } | { timedOut: false; value: string };
-
-function raceWithTimeout(promise: Promise<string>, timeoutMs: number): Promise<RaceResult> {
-  return new Promise((resolve) => {
-    const timer = setTimeout(() => resolve({ timedOut: true }), timeoutMs);
-    void promise.then(
-      (value) => {
-        clearTimeout(timer);
-        resolve({ timedOut: false, value });
-      },
-      (error: unknown) => {
-        // openPath is documented never to reject, but this function exists to
-        // guarantee the invoke is answered - so it cannot depend on an
-        // upstream contract holding. Report a rejection as the failure it is
-        // instead of stalling until the timer and then claiming success.
-        clearTimeout(timer);
-        const message = error instanceof Error ? error.message : String(error);
-        // Never resolve '' here: '' is this function's success value.
-        resolve({ timedOut: false, value: message || 'The file could not be opened.' });
-      },
-    );
-  });
 }

--- a/src/main/ipc/helpers/index.ts
+++ b/src/main/ipc/helpers/index.ts
@@ -22,5 +22,7 @@ export {
   deleteTaskWorktree,
   reapSessionLeftovers,
 } from './task-cleanup';
-export { openAttachmentFile, OPEN_PATH_TIMEOUT_MS } from './attachment-open';
+export { openAttachmentFile } from './attachment-open';
 export type { OpenableAttachment, OpenAttachmentOptions } from './attachment-open';
+export { openPathBounded, OPEN_PATH_TIMEOUT_MS } from './open-path';
+export type { OpenPathBoundedOptions } from './open-path';

--- a/src/main/ipc/helpers/open-path.ts
+++ b/src/main/ipc/helpers/open-path.ts
@@ -1,0 +1,75 @@
+import { shell } from 'electron';
+
+export const OPEN_PATH_TIMEOUT_MS = 5000;
+
+export interface OpenPathBoundedOptions {
+  /** Defaults to OPEN_PATH_TIMEOUT_MS. */
+  timeoutMs?: number;
+  /**
+   * Called with openPath's real outcome when the timer won the race. The
+   * invoke has already been answered '' by then, so this is a
+   * main-process-side fallback only, never a report back to the renderer.
+   */
+  onLateOutcome?: (errorMessage: string) => void;
+}
+
+/**
+ * Open a path with the OS default handler, and guarantee this promise settles
+ * so an IPC invoke awaiting it is always answered.
+ *
+ * shell.openPath() never rejects - it always resolves, with '' on success or
+ * a non-empty error string on failure (Electron's
+ * shell/common/api/electron_api_shell.cc). Nothing bounds how long that can
+ * take: on Linux, OpenPath shells out to xdg-open, which can wait on
+ * whatever viewer it launches. If that promise never settles, it can outlive
+ * the renderer's ipcRenderer.invoke() call, and the reply channel gets torn
+ * down without ever sending a reply - surfacing as "reply was never sent"
+ * (Electron's ReplyChannel::EnsureReplySent pre-finalizer). Racing openPath
+ * against a timeout does not un-stick that hang; it only guarantees this
+ * function's own promise settles, so the invoke is always answered.
+ *
+ * Resolves the string the renderer contract expects: '' on success AND on
+ * timeout, otherwise Electron's error string.
+ *
+ * This is the only place in the main process that may call shell.openPath.
+ * tests/unit/open-path-bounded-boundary.test.ts fails CI on any other call
+ * site, because an unbounded one re-opens the bug above.
+ */
+export function openPathBounded(targetPath: string, options?: OpenPathBoundedOptions): Promise<string> {
+  const timeoutMs = options?.timeoutMs ?? OPEN_PATH_TIMEOUT_MS;
+  const openPromise = shell.openPath(targetPath);
+
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      // The invoke is answered now. Hand the eventual real outcome to the
+      // caller's fallback, which can still act in the main process.
+      void openPromise.then(
+        (lateError) => options?.onLateOutcome?.(lateError),
+        () => {
+          // Nothing left to report: the invoke was answered at the timeout.
+        },
+      );
+      resolve('');
+    }, timeoutMs);
+
+    // The race proper. If the timer already fired, both branches below are
+    // late: clearTimeout is a no-op and resolve() cannot change a promise the
+    // timer already settled, so the timeout path's answer stands.
+    void openPromise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        // openPath is documented never to reject, but this function exists to
+        // guarantee the invoke is answered - so it cannot depend on an
+        // upstream contract holding. Report a rejection as the failure it is
+        // instead of stalling until the timer and then claiming success.
+        clearTimeout(timer);
+        const message = error instanceof Error ? error.message : String(error);
+        // Never resolve '' here: '' is this function's success value.
+        resolve(message || 'The file could not be opened.');
+      },
+    );
+  });
+}

--- a/tests/unit/attachment-open-helper.test.ts
+++ b/tests/unit/attachment-open-helper.test.ts
@@ -24,7 +24,8 @@ const { mockShell } = vi.hoisted(() => {
 
 vi.mock('electron', () => ({ shell: mockShell }));
 
-import { openAttachmentFile, OPEN_PATH_TIMEOUT_MS } from '../../src/main/ipc/helpers/attachment-open';
+import { openAttachmentFile } from '../../src/main/ipc/helpers/attachment-open';
+import { OPEN_PATH_TIMEOUT_MS } from '../../src/main/ipc/helpers/open-path';
 import { attachmentDiskName } from '../../src/shared/attachment-filename';
 
 let tmpRoot: string;

--- a/tests/unit/open-path-bounded-boundary.test.ts
+++ b/tests/unit/open-path-bounded-boundary.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// shell.openPath() never rejects and nothing bounds how long it takes: on Linux
+// it shells out to xdg-open, which can wait on whatever viewer it launches. A
+// handler that returns that promise straight to ipcMain.handle can therefore
+// outlive the renderer's ipcRenderer.invoke(), and Electron's
+// ReplyChannel::EnsureReplySent then raises "reply was never sent" as an
+// unhandled rejection in the renderer.
+//
+// That shipped twice: once for attachments (task #487) and again for every
+// "open folder" control (Sentry DESKTOP-P), because the first fix was a
+// private race inside the attachment helper rather than a shared one. The race
+// now lives in openPathBounded, and this scan is what stops a third unbounded
+// call site from re-opening the bug.
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+// Both main-process trees. src/devtools/main is dev-only (build-excluded via
+// __KANGENTIC_DEV__) so it cannot produce a production Sentry event, but the
+// team dogfoods from npm start and would hit the same hang there. Its renderer
+// and preload siblings are deliberately NOT scanned: they reach openPath
+// through window.electronAPI, which is the bridge, not Electron's shell.
+const SCAN_DIRS = ['src/main', 'src/devtools/main'];
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);
+const OPEN_PATH_CALL = /\bshell\s*\.\s*openPath\s*\(/;
+// The one module allowed to call it: it owns the timeout race that guarantees
+// the caller's promise settles.
+const CHOKEPOINT = 'src/main/ipc/helpers/open-path.ts';
+
+function collectSourceFiles(directory: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath));
+    } else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function isCommentLine(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*');
+}
+
+function toPosixRelative(filePath: string): string {
+  return path.relative(REPO_ROOT, filePath).replace(/\\/g, '/');
+}
+
+describe('shell.openPath is only called through the bounded helper', () => {
+  it(`main-process code calls shell.openPath only in ${CHOKEPOINT}`, () => {
+    const offenders: string[] = [];
+    for (const scanDir of SCAN_DIRS) {
+      for (const filePath of collectSourceFiles(path.join(REPO_ROOT, scanDir))) {
+        const relativePath = toPosixRelative(filePath);
+        if (relativePath === CHOKEPOINT) continue;
+        fs.readFileSync(filePath, 'utf-8').split('\n').forEach((line, index) => {
+          if (isCommentLine(line)) return;
+          if (!OPEN_PATH_CALL.test(line)) return;
+          offenders.push(`${relativePath}:${index + 1}`);
+        });
+      }
+    }
+
+    expect(
+      offenders,
+      `shell.openPath must be called only from ${CHOKEPOINT}. An unbounded call can outlive the renderer's ipcRenderer.invoke() and surface as "reply was never sent" (Sentry DESKTOP-P). Call openPathBounded() instead.\nOffenders:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it(`${CHOKEPOINT} exists and is the module that calls shell.openPath`, () => {
+    // Guards the scan itself: if the helper is renamed or its call inlined
+    // away, the test above would silently pass with nothing left to protect.
+    const chokepoint = fs.readFileSync(path.join(REPO_ROOT, CHOKEPOINT), 'utf-8');
+
+    expect(OPEN_PATH_CALL.test(chokepoint)).toBe(true);
+    expect(chokepoint).toContain('export function openPathBounded');
+  });
+});

--- a/tests/unit/shell-open-path-handler.test.ts
+++ b/tests/unit/shell-open-path-handler.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Unit tests for the SHELL_OPEN_PATH IPC handler in
+ * src/main/ipc/handlers/system.ts.
+ *
+ * Every "open folder" control in the app calls this channel (the sidebar's
+ * Open in Explorer, both task-detail header entries, both Command Terminal
+ * entries, the Changes file tree). It used to hand shell.openPath() straight
+ * back to ipcMain.handle with nothing bounding it, so on Linux - where
+ * openPath waits on xdg-open, which can wait on whatever viewer it launches -
+ * the promise could outlive the renderer's ipcRenderer.invoke(). Electron then
+ * tears down the reply channel and its ReplyChannel::EnsureReplySent
+ * pre-finalizer raises "reply was never sent" as an unhandled rejection in the
+ * renderer (Sentry DESKTOP-P). The handler now routes through openPathBounded,
+ * which guarantees the invoke is answered.
+ *
+ * Strategy mirrors shell-open-external-handler.test.ts: mock electron's
+ * ipcMain to capture registered handlers, then invoke the SHELL_OPEN_PATH
+ * handler directly and assert against a mocked `shell.openPath`.
+ *
+ * Tier: Unit (vitest, no browser, no Electron).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import { IPC } from '../../src/shared/ipc-channels';
+import { OPEN_PATH_TIMEOUT_MS } from '../../src/main/ipc/helpers/open-path';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks - must be declared before any imports that trigger them.
+// ---------------------------------------------------------------------------
+
+const { capturedHandlers, mockShell } = vi.hoisted(() => {
+  const capturedHandlers = new Map<string, (...args: unknown[]) => unknown>();
+  const mockShell = { openPath: vi.fn(), openExternal: vi.fn(), showItemInFolder: vi.fn() };
+  return { capturedHandlers, mockShell };
+});
+
+vi.mock('electron', () => ({
+  app: { getVersion: vi.fn(() => '0.0.0'), getPath: vi.fn(() => '/tmp') },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      capturedHandlers.set(channel, handler);
+    }),
+    on: vi.fn(),
+  },
+  Notification: { isSupported: vi.fn(() => false) },
+  dialog: { showOpenDialog: vi.fn() },
+  shell: mockShell,
+  globalShortcut: { isRegistered: vi.fn(() => false), register: vi.fn(() => true), unregister: vi.fn() },
+  clipboard: { writeText: vi.fn(), readImage: vi.fn() },
+}));
+
+vi.mock('../../src/main/agent/agent-registry', () => ({
+  agentRegistry: {
+    list: vi.fn(() => []),
+    get: vi.fn(() => null),
+    getOrThrow: vi.fn(),
+    has: vi.fn(() => false),
+  },
+}));
+
+vi.mock('../../src/main/git/worktree-manager', () => ({ WorktreeManager: class {} }));
+vi.mock('../../src/main/git/git-checks', () => ({ isGitRepo: vi.fn(() => false) }));
+vi.mock('../../src/main/db/database', () => ({ getProjectDb: vi.fn() }));
+vi.mock('../../src/main/db/repositories/handoff-repository', () => ({
+  HandoffRepository: class { listByTaskId = vi.fn(() => []); },
+}));
+vi.mock('../../src/shared/object-utils', () => ({
+  deepMergeConfig: vi.fn((base: unknown, overrides: unknown) => ({ ...(base as object), ...(overrides as object) })),
+}));
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => ({ pid: 1234, unref: vi.fn() })),
+  exec: vi.fn(),
+  execFile: vi.fn(),
+}));
+vi.mock('../../src/main/config/apply-runtime-config', () => ({
+  applyRuntimeConfig: vi.fn(),
+}));
+vi.mock('../../src/main/ipc/handlers/projects', () => ({
+  syncProjectMcpConfig: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after all mocks are registered).
+// ---------------------------------------------------------------------------
+
+import { registerSystemHandlers } from '../../src/main/ipc/handlers/system';
+
+// ---------------------------------------------------------------------------
+// Test context factory (minimal - the shell handler needs no project state).
+// ---------------------------------------------------------------------------
+
+function makeContext() {
+  return {
+    configManager: {
+      load: vi.fn(() => ({
+        agent: { cliPaths: {}, maxConcurrentSessions: 5, idleTimeoutMinutes: 30 },
+        terminal: { shell: null },
+        mcpServer: { enabled: false },
+        autoNameRateLimitPerHour: 60,
+      })),
+      getEffectiveConfig: vi.fn(() => ({
+        agent: { maxConcurrentSessions: 5, idleTimeoutMinutes: 30 },
+        terminal: { shell: null },
+      })),
+      save: vi.fn(),
+      saveProjectOverrides: vi.fn(),
+      loadProjectOverrides: vi.fn(() => null),
+    },
+    sessionManager: {
+      setMaxConcurrent: vi.fn(),
+      setShell: vi.fn(),
+      setIdleTimeout: vi.fn(),
+    },
+    boardConfigManager: { getDefaultBaseBranch: vi.fn(() => null) },
+    projectRepo: { list: vi.fn(() => []) },
+    shellResolver: { getAvailableShells: vi.fn(() => []), getDefaultShell: vi.fn(() => 'bash') },
+    gitDetector: { detect: vi.fn(() => ({ found: false })) },
+    mainWindow: {
+      minimize: vi.fn(), maximize: vi.fn(), unmaximize: vi.fn(),
+      isMaximized: vi.fn(() => false), close: vi.fn(), isFocused: vi.fn(() => true),
+      flashFrame: vi.fn(), isDestroyed: vi.fn(() => false),
+      isMinimized: vi.fn(() => false), restore: vi.fn(), show: vi.fn(),
+      focus: vi.fn(), once: vi.fn(), webContents: { send: vi.fn() },
+    },
+    currentProjectPath: null,
+    currentProjectId: null,
+    mcpServerHandle: null,
+  };
+}
+
+function invokeShellOpenPathHandler(dirPath: string): Promise<string> {
+  const handler = capturedHandlers.get(IPC.SHELL_OPEN_PATH);
+  if (!handler) throw new Error(`Handler not registered for ${IPC.SHELL_OPEN_PATH}`);
+  return handler(undefined, dirPath) as Promise<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SHELL_OPEN_PATH IPC handler', () => {
+  beforeEach(() => {
+    capturedHandlers.clear();
+    // A bare vi.fn() returns undefined, and openPathBounded calls .then() on
+    // whatever openPath hands back - so an unset mock throws a TypeError
+    // instead of exercising the handler.
+    mockShell.openPath.mockReset();
+    mockShell.openPath.mockResolvedValue('');
+    mockShell.showItemInFolder.mockReset();
+    registerSystemHandlers(makeContext() as Parameters<typeof registerSystemHandlers>[0]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves "" when openPath never settles, at OPEN_PATH_TIMEOUT_MS (the DESKTOP-P regression case)', async () => {
+    vi.useFakeTimers();
+    mockShell.openPath.mockReturnValue(new Promise<string>(() => { /* never settles */ }));
+
+    const resultPromise = invokeShellOpenPathHandler('/some/dir');
+    let settled = false;
+    void resultPromise.then(() => { settled = true; });
+
+    // One tick short of the timeout: still pending.
+    await vi.advanceTimersByTimeAsync(OPEN_PATH_TIMEOUT_MS - 1);
+    expect(settled).toBe(false);
+
+    // The final tick: the bounded race answers the invoke.
+    await vi.advanceTimersByTimeAsync(1);
+    expect(settled).toBe(true);
+    expect(await resultPromise).toBe('');
+  });
+
+  it('stays quiet when a timed-out openPath rejects late, with no onLateOutcome to receive it', async () => {
+    // This handler passes no onLateOutcome, so the timer's late .then() has an
+    // undefined success handler and only its rejection handler to lean on. If
+    // either were missing, the late rejection would surface as an unhandled
+    // rejection in the main process - the failure class this whole change is
+    // about, moved one layer down.
+    vi.useFakeTimers();
+    let rejectOpen: (reason: Error) => void = () => {};
+    mockShell.openPath.mockReturnValue(new Promise<string>((_resolve, reject) => { rejectOpen = reject; }));
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => { unhandled.push(reason); };
+    process.on('unhandledRejection', onUnhandled);
+
+    try {
+      const resultPromise = invokeShellOpenPathHandler('/some/dir');
+      await vi.advanceTimersByTimeAsync(OPEN_PATH_TIMEOUT_MS);
+      expect(await resultPromise).toBe('');
+
+      rejectOpen(new Error('xdg-open died long after the timeout'));
+      // Real timers: an unhandled rejection is reported on a later macrotask.
+      vi.useRealTimers();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
+  it('resolves "" when openPath succeeds', async () => {
+    mockShell.openPath.mockResolvedValue('');
+
+    expect(await invokeShellOpenPathHandler('/some/dir')).toBe('');
+  });
+
+  it("resolves Electron's error string when openPath reports a failure", async () => {
+    mockShell.openPath.mockResolvedValue('Failed to open path');
+
+    expect(await invokeShellOpenPathHandler('/missing/dir')).toBe('Failed to open path');
+  });
+
+  it('resolves a non-empty string when openPath rejects, since "" is the success value', async () => {
+    mockShell.openPath.mockRejectedValue(new Error('spawn xdg-open ENOENT'));
+
+    expect(await invokeShellOpenPathHandler('/some/dir')).toBe('spawn xdg-open ENOENT');
+  });
+
+  it.each([
+    ['a resolved success', ''],
+    ['a resolved failure', 'Failed to open path'],
+  ])('never reveals in the file manager on %s (the target is a directory)', async (_label, openResult) => {
+    mockShell.openPath.mockResolvedValue(openResult);
+
+    await invokeShellOpenPathHandler('/some/dir');
+
+    expect(mockShell.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it('normalizes a forward-slash path before opening it', async () => {
+    const inputPath = 'project/sub/dir';
+
+    await invokeShellOpenPathHandler(inputPath);
+
+    // Computed, never a hardcoded separator: a literal would be green on
+    // Windows and red on CI's Linux runner.
+    expect(mockShell.openPath).toHaveBeenCalledWith(path.normalize(inputPath));
+  });
+});


### PR DESCRIPTION
## What

Bounds the `shell:openPath` IPC handler so its invoke is always answered.

- New `src/main/ipc/helpers/open-path.ts` owns `openPathBounded()` and `OPEN_PATH_TIMEOUT_MS`.
- `src/main/ipc/handlers/system.ts` routes `SHELL_OPEN_PATH` through it.
- `src/main/ipc/helpers/attachment-open.ts` drops its private `raceWithTimeout` and its own copy of the 5000ms default, and calls the shared helper.

The channel, its `invoke` kind, and its `Promise<string>` renderer signature are unchanged. No new IPC channel.

## Why

Sentry **DESKTOP-P**: `Error invoking remote method 'shell:openPath': reply was never sent` (Kangentic 0.39.0, Electron 41.1.1, Ubuntu 26.04, caught by the renderer's `onunhandledrejection`).

The handler returned `shell.openPath()` straight to `ipcMain.handle` with nothing bounding it. `shell.openPath` never rejects, and on Linux it shells out to `xdg-open`, which can wait on whatever viewer it launches. When that promise outlived the renderer's `ipcRenderer.invoke()`, Electron tore down the reply channel and its `ReplyChannel::EnsureReplySent` pre-finalizer raised the unhandled rejection.

The breadcrumbs rule out a window close: the last click is `[aria-label="Open project folder"]` at 16:26:04 and the rejection lands at 16:26:11, so the handler hung about 7 seconds with no close in between.

Task #487 fixed the identical shape for attachments, but as a private race inside `openAttachmentFile`. The plain handler behind every "open folder" control never got the guard: the sidebar's Open in Explorer, both task-detail header entries, both Command Terminal entries, and the Changes file tree.

## How

One shared helper instead of a second copy of the race, so the two call paths cannot drift apart again. `openPathBounded` resolves `''` on success and on timeout, otherwise Electron's error string, which is what the renderer contract already expected. The attachment path keeps its extra behavior through an `onLateOutcome` callback, so its reveal-in-file-manager fallback is unchanged.

`tests/unit/open-path-bounded-boundary.test.ts` is the durable part. It scans `src/main` and `src/devtools/main` and fails on any `shell.openPath` outside the chokepoint. This bug shipped twice because the first fix was private to one helper; the scan is what stops a third unbounded call site.

Worth stating plainly: the timeout does not un-stick the hang. When `xdg-open` hangs the folder still does not open, and only the unhandled rejection goes away. Every renderer call site is a bare `void` that ignores the returned string, so surfacing an error would be a separate change.

## Breaking changes

None.

## Tests

CI runs lint, typecheck, unit, build, and the UI and Linux Electron E2E shards.

Added:

- `tests/unit/shell-open-path-handler.test.ts` pins the timeout at `OPEN_PATH_TIMEOUT_MS`, the resolved error string, the rejection path, the absence of a reveal fallback, and the existing normalize behavior. It also pins that a timed-out open which later rejects emits no unhandled rejection.
- `tests/unit/open-path-bounded-boundary.test.ts` is the static chokepoint scan described above.

`tests/unit/attachment-open-helper.test.ts` changes only its import of the moved constant. Every assertion is kept, and they are the proof the extraction preserved attachment behavior.

Both new files were verified red-green by reverting the fix: the never-settles case fails on its assertion in under half a second rather than on a runner timeout, and the scan names the offending line.

Verified in a running app on Windows through the real preload-to-main path: success resolves `""` in 21ms and the folder opens, a bad path resolves `"Failed to open path"`, and clicking Open in Explorer produces no unhandled rejection, no console error, and no toast. The hang itself only reproduces on Linux, so this is a no-regression check rather than a repro.

Generated with [Claude Code](https://claude.com/claude-code)
