### PR TITLE
fix(e2e): retry the first-window wait, and guard the openPath timeout forwarding

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -261,16 +261,46 @@ export async function launchApp(options?: {
     args.push('--no-sandbox');
   }
 
-  // Retry electron.launch() with backoff - Windows can transiently fail
-  // to attach the debugger pipe under resource pressure or AV scans.
+  // Retry the whole launch-AND-first-window sequence with backoff. Two distinct
+  // transients land here and they need the same handling:
+  //
+  //  - electron.launch() THROWS. Windows fails to attach the debugger pipe
+  //    under resource pressure or AV scans. Fast, so retrying is cheap.
+  //  - launch() RESOLVES but the window never arrives. On a loaded CI runner
+  //    (8 electron workers per shard) the app can take longer to open its first
+  //    window than firstWindow() will wait.
+  //
+  // firstWindow() used to sit outside this loop on its Playwright default of
+  // 30s, so the second case got no retry at all: one slow window failed the
+  // whole hook, which is the observed flake (grok-activity-detection, CI run
+  // 34301585231, "Timeout 30000ms exceeded while waiting for event window",
+  // alongside a cluster of 25s close force-kills on the same shard).
+  //
+  // The killAppProcess() on the failure path is belt-and-braces, not the fix:
+  // Playwright does dispose the app at worker teardown, so a launched-but-
+  // windowless process is not orphaned for the whole run (measured - the
+  // janitor reports zero leaks either way). Killing it here just releases the
+  // process now instead of at worker teardown, which is worth doing when the
+  // reason we are retrying at all is that the runner is short on capacity.
+  //
+  // Budget: this runs in beforeAll, which gets the electron project's 45s test
+  // timeout, and the rest of this function can spend ~15s of it on
+  // waitForSelector. So cap each window wait well under the old 30s and stop
+  // retrying once the launch phase has eaten launchPhaseBudgetMs, rather than
+  // letting three long attempts blow the hook's budget by themselves.
   const maxLaunchAttempts = 3;
-  const baseRetryDelayMs = 2000;
+  const baseRetryDelayMs = 1500;
+  const firstWindowTimeoutMs = 12_000;
+  const launchPhaseBudgetMs = 26_000;
+  const launchStartedAt = Date.now();
   let app: ElectronApplication | undefined;
+  let page: Page | undefined;
   let lastLaunchError: Error | undefined;
 
   for (let attempt = 1; attempt <= maxLaunchAttempts; attempt++) {
+    let pendingApp: ElectronApplication | undefined;
     try {
-      app = await electron.launch({
+      pendingApp = await electron.launch({
         args,
         env: {
           ...process.env,
@@ -283,22 +313,34 @@ export async function launchApp(options?: {
         },
         colorScheme: 'dark',
       });
+      page = await pendingApp.firstWindow({ timeout: firstWindowTimeoutMs });
+      app = pendingApp;
       break;
     } catch (error) {
       lastLaunchError = error as Error;
-      if (attempt < maxLaunchAttempts) {
+      // If launch() resolved and firstWindow() was what failed, that process is
+      // still running. Release it now rather than at worker teardown. Skip the
+      // graceful close: an app with no window is the case whose close() hangs.
+      if (pendingApp) await killAppProcess(pendingApp);
+
+      const elapsedMs = Date.now() - launchStartedAt;
+      const budgetLeft = elapsedMs < launchPhaseBudgetMs;
+      if (attempt < maxLaunchAttempts && budgetLeft) {
         const retryDelayMs = baseRetryDelayMs * attempt;
-        console.error(`electron.launch() attempt ${attempt} failed, retrying in ${retryDelayMs}ms: ${lastLaunchError.message}`);
+        console.error(`electron launch attempt ${attempt} failed after ${elapsedMs}ms, retrying in ${retryDelayMs}ms: ${lastLaunchError.message}`);
         await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+        continue;
       }
+      if (!budgetLeft) {
+        console.error(`electron launch attempt ${attempt} failed after ${elapsedMs}ms, out of launch-phase budget: ${lastLaunchError.message}`);
+      }
+      break;
     }
   }
 
-  if (!app) {
+  if (!app || !page) {
     throw new Error(`electron.launch() failed after ${maxLaunchAttempts} attempts: ${lastLaunchError?.message}`);
   }
-
-  const page = await app.firstWindow();
 
   // When HEADED=1 (user-invoked), maximize so the user can watch.
   // Otherwise (CI/automated), just let it run at default size.
@@ -386,6 +428,20 @@ export async function closeApp(app: ElectronApplication | undefined): Promise<vo
       `${CLOSE_TIMEOUT_MS}ms - force-killing Electron process`,
   );
 
+  await killAppProcess(app);
+}
+
+/**
+ * Kill the Electron process behind `app` immediately, skipping the graceful
+ * `app.close()` race.
+ *
+ * closeApp() waits CLOSE_TIMEOUT_MS before reaching for this, which is right at
+ * teardown but far too slow inside launchApp's retry loop: an app that never
+ * produced a window is exactly the app whose close() hangs, so waiting the full
+ * race there would spend the hook's whole timeout budget on a process we have
+ * already given up on.
+ */
+async function killAppProcess(app: ElectronApplication): Promise<void> {
   // `process()` THROWS rather than returning undefined once Playwright has torn
   // down its handle, which is exactly what happens when the app died on its own
   // while `app.close()` was still hanging - the case this force-kill path exists

--- a/tests/unit/attachment-open-helper.test.ts
+++ b/tests/unit/attachment-open-helper.test.ts
@@ -79,6 +79,36 @@ describe('openAttachmentFile', () => {
     expect(result).toBe('');
   });
 
+  // The deliberate guard on this helper FORWARDING its caller's timeoutMs to
+  // openPathBounded rather than letting the shared default apply. The tests
+  // above pass a timeoutMs too, but they await on real timers, so dropping the
+  // forward makes them fail by 5000ms runner timeout rather than by assertion:
+  // slow, silent about the actual cause, and lost entirely if anyone ever
+  // raises testTimeout (which is exactly what that timeout's own error message
+  // advises). Asserting the tick keeps the guard independent of the runner's
+  // deadline, and of OPEN_PATH_TIMEOUT_MS happening to equal it.
+  it('honors an explicit timeoutMs rather than the shared default', async () => {
+    vi.useFakeTimers();
+    mockShell.openPath.mockReturnValue(new Promise<string>(() => { /* never settles */ }));
+
+    const resultPromise = openAttachmentFile(makeAttachment(), {
+      platform: 'linux',
+      tempDirRoot: tmpRoot,
+      timeoutMs: 20,
+    });
+    let settled = false;
+    void resultPromise.then(() => { settled = true; });
+
+    // One tick short of the override: still pending. A dropped forward would
+    // arm the 5000ms default here instead, and fail the next assertion at once.
+    await vi.advanceTimersByTimeAsync(19);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(settled).toBe(true);
+    expect(await resultPromise).toBe('');
+  });
+
   it('still reveals the file if openPath eventually reports an error after the timeout', async () => {
     let resolveOpen: (value: string) => void = () => {};
     mockShell.openPath.mockReturnValue(new Promise<string>((resolve) => { resolveOpen = resolve; }));


### PR DESCRIPTION
## What

Two test-only changes. No production code.

1. `tests/e2e/helpers.ts` - `launchApp` now retries the first-window wait instead of failing the launch outright, and `killAppProcess` is extracted from `closeApp`.
2. `tests/unit/attachment-open-helper.test.ts` - one test that deterministically pins `openAttachmentFile` forwarding its caller's `timeoutMs` to `openPathBounded`.

## Why

**The E2E flake.** `launchApp` retried `electron.launch()` three times with backoff but awaited `app.firstWindow()` outside that loop, on Playwright's 30s default. Two different transients reach this code and only one was covered:

- `launch()` throws. Windows debug-pipe under resource pressure. Already retried.
- `launch()` resolves but the window never arrives. A loaded CI runner at 8 electron workers per shard. Not retried at all, so one slow window failed the whole `beforeAll`.

That is the observed flake: `grok-activity-detection.spec.ts:101` in run 34301585231 failed with `electronApplication.firstWindow: Timeout 30000ms exceeded`, surrounded by a cluster of 25s `app.close()` force-kills on the same shard. It passed on Playwright's retry, so the check still reported green. The same teardown signature is present on `main`, so this is pre-existing and not introduced by this branch.

**The unit guard.** `openAttachmentFile` lets `openPathBounded` own the 5000ms default. Three existing tests did catch a dropped forward, but only by accident: they await on real timers, so the fallback collided with vitest's default `testTimeout`, which is also 5000ms and left unset in `vitest.config.ts`. Measured with the forward removed, all three failed by runner timeout at about 5018ms and the file went from 0.3s to 15.3s, reporting only `Test timed out in 5000ms`. That message advises raising `testTimeout`, and doing so would make all three pass with the forward still broken.

## How

**E2E.** Move `firstWindow()` inside the retry loop with an explicit 12s per-attempt timeout, and stop retrying once the launch phase has spent its budget. `beforeAll` gets the electron project's 45s and `waitForSelector` can want 15s of it, so three unbounded 30s waits could never have fit. `killAppProcess()` is split out of `closeApp()` so the retry path can drop a launched-but-windowless app without the 25s graceful race, which is the race that hangs when there is no window.

One correction worth recording, since the first draft of this change asserted otherwise: the kill is belt-and-braces, not the fix. I assumed the old code orphaned the process and then measured it. The janitor reports zero leaks either way, because Playwright disposes the app at worker teardown. Killing here only releases the process sooner, which is still worth doing when the reason for retrying is that the runner is short on capacity. The retry is what actually addresses the flake.

**Unit.** One fake-timer test using the same settled-flag pattern as the neighbouring default-timeout test: pending at tick 19, settled at tick 20.

| | Before | After |
|---|---|---|
| Failure mode | Runner timeout | Assertion |
| Time to red | 5018ms | 7ms |
| Survives raising `testTimeout` | No | Yes |

The three original tests keep their real-timer shape. Their `timeoutMs` is setup for the late-outcome reveal behavior they actually assert, not a forwarding guard.

## Breaking changes

None. Test-only.

## Tests

CI runs lint, typecheck, unit, build, and the UI and Linux Electron E2E shards.

- **E2E fix, verified by forcing the failure**: with the window wait set to fail every time, attempts now retry with backoff (observed at 844ms and 3171ms) where before there was one attempt and no recovery. The affected spec passes locally, and the janitor reports zero leaked instances.
- **Unit guard, red-green**: removing `timeoutMs: options?.timeoutMs` from `attachment-open.ts` fails the new test on its assertion in 7ms; restoring it passes.

Honest limit on the E2E claim: the flake is intermittent and did not reproduce on every run, so one green CI run is consistent with the fix but is not proof of it. What is proven is the mechanism, that a slow first window now retries where it previously had no recovery path at all.

Generated with [Claude Code](https://claude.com/claude-code)
