### PR TITLE
chore: add a code of conduct, Dependabot, and CodeQL scanning

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,9 +33,18 @@ body:
     id: kangentic-version
     attributes:
       label: Kangentic Version
-      placeholder: e.g. 0.6.0
+      placeholder: e.g. 0.39.0
     validations:
       required: true
+
+  - type: input
+    id: last-known-good-version
+    attributes:
+      label: Last Known Good Version
+      description: The most recent version where this worked. Leave blank if it never worked, or if you do not know.
+      placeholder: e.g. 0.38.0
+    validations:
+      required: false
 
   - type: input
     id: claude-cli-version

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# Dependabot is scoped to GitHub Actions only, deliberately.
+#
+# npm is NOT covered. Several dependencies are pinned exact because a floating
+# range has broken the app before (electron 41.1.1, recharts 3.9.2), so npm
+# bumps need a human deciding when to take them. Add the npm ecosystem here
+# later if that changes, with its own grouping.
+#
+# `groups` is load-bearing, not cosmetic. Every Dependabot PR fires the full CI
+# gate (21 concurrent jobs) and GitHub Free caps concurrent jobs at ~20
+# ACCOUNT-wide, so ungrouped bumps would queue against each other and against
+# any real PR running at the same time. One grouped weekly PR is at most one
+# gate run per week. See the concurrency-budget block in workflows/ci.yml.
+#
+# `commit-message` produces `chore(deps): bump ...`, matching the conventional
+# format the commit-msg hook enforces and the `deps` scope already in history.
+#
+# dependabot[bot] is allowlisted in workflows/cla.yml, so these PRs do not stall
+# on the CLA check.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      # Tuesday, not Monday: codeql.yml's weekly cron runs Monday 04:27 UTC, and
+      # a Dependabot PR fires the full 21-job gate. Overlapping them would put
+      # the account over the ~20-job concurrent cap on a day nobody is watching.
+      day: "tuesday"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,12 @@
 # `groups` is load-bearing, not cosmetic. Every Dependabot PR fires the full CI
 # gate (21 concurrent jobs) and GitHub Free caps concurrent jobs at ~20
 # ACCOUNT-wide, so ungrouped bumps would queue against each other and against
-# any real PR running at the same time. One grouped weekly PR is at most one
-# gate run per week. See the concurrency-budget block in workflows/ci.yml.
+# any real PR running at the same time. Grouping collapses that into one PR per
+# week instead of one per action. It is not a weekly CEILING on gate runs:
+# rebase-strategy defaults to `auto`, so an open grouped PR re-runs the gate
+# every time main moves under it, and open-pull-requests-limit lets a security
+# update sit alongside it. Merging the weekly PR promptly is what keeps the
+# count near one. See the concurrency-budget block in workflows/ci.yml.
 #
 # `commit-message` produces `chore(deps): bump ...`, matching the conventional
 # format the commit-msg hook enforces and the `deps` scope already in history.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,80 @@
+# CodeQL code scanning.
+#
+# THERE IS NO `pull_request:` TRIGGER, AND THAT IS DELIBERATE. Do not add one
+# without re-reading the concurrency-budget block at the top of ci.yml.
+#
+# The PR gate already runs 19 shards + `checks` + the CLA workflow = 21
+# concurrent jobs against GitHub Free's ~20-job ACCOUNT-wide cap. ci.yml
+# documents that 21 is a ceiling, not a target: at 22+ the earliest slot
+# releaser becomes a ~70s unit shard, so a queued UI shard starts that late and
+# blows past the ~226s pole that sets the whole run's wall clock. The two
+# Analyze jobs below would take every PR to 23.
+#
+# So scanning runs after the merge instead of before it. `main` is PR-gated, so
+# nothing reaches it unreviewed, and findings land within minutes of a merge
+# plus a weekly sweep that catches newly published queries against unchanged
+# code. The cost of the trade is real and worth naming: while there is no PR
+# trigger, CodeQL can never be a required status check.
+#
+# The push-to-main run overlaps ci.yml's own push run (21 + 2 = 23), so it
+# queues briefly. Nobody waits on that run - the PR check was the gate - so the
+# delay is accepted here and NOT on the PR path.
+#
+# This lives in its own workflow file rather than as jobs inside ci.yml on
+# purpose: tests/unit/ci-required-checks.test.ts asserts an exact job count for
+# ci.yml and cross-checks it against main's branch protection, so a job added
+# there would need both that snapshot and the protection rule updated.
+# tests/unit/repo-hygiene.test.ts pins the missing pull_request trigger.
+#
+# Default setup (the repo-settings toggle) is the other way to get scanning. It
+# was rejected for exactly one reason: it always adds its Analyze jobs to PRs
+# and offers no way to turn that off.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Mondays, 04:27 UTC. Off the hour so it does not land in the cron rush.
+    - cron: "27 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # security-events: write is what uploads the SARIF results. The other two
+      # are the documented minimum for the analyze step on a public repo.
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # `javascript-typescript` is one language covering both .js and .ts, not
+        # two. `actions` scans the workflow files in this directory.
+        language: [actions, javascript-typescript]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          # Both languages are interpreted, so there is nothing to compile.
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,14 +16,17 @@
 # code. The cost of the trade is real and worth naming: while there is no PR
 # trigger, CodeQL can never be a required status check.
 #
-# The push-to-main run overlaps ci.yml's own push run (21 + 2 = 23), so it
-# queues briefly. Nobody waits on that run - the PR check was the gate - so the
-# delay is accepted here and NOT on the PR path.
+# The push-to-main run overlaps ci.yml's own push run. That run is 20 jobs, not
+# the PR path's 21: cla.yml is a pull_request_target workflow and never fires on
+# a push. So the overlap is 20 + 2 = 22, still past the ceiling, and it queues
+# briefly. Nobody waits on that run - the PR check was the gate - so the delay
+# is accepted here and NOT on the PR path.
 #
 # This lives in its own workflow file rather than as jobs inside ci.yml on
 # purpose: tests/unit/ci-required-checks.test.ts asserts an exact job count for
-# ci.yml and cross-checks it against main's branch protection, so a job added
-# there would need both that snapshot and the protection rule updated.
+# ci.yml and checks it against a captured snapshot of main's branch protection
+# (it does not re-read the API), so a job added there would need both that
+# snapshot and the protection rule updated.
 # tests/unit/repo-hygiene.test.ts pins the missing pull_request trigger.
 #
 # Default setup (the repo-settings toggle) is the other way to get scanning. It

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+support@kangentic.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,17 @@ type(scope): subject
 ```
 
 Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`,
-`revert`. The scope is optional. Keep the subject short and in the imperative mood. Examples:
+`revert`. Keep the subject short and in the imperative mood.
+
+The scope is optional and is not checked by the hook. When you use one, prefer a scope already in use
+over a new spelling of one (`agent` not `agents`, `session` not `sessions`, `db` not `database`).
+These are the ones in most active use:
+
+`agent` `session` `pty` `terminal` `command-terminal` `board` `backlog` `ui` `renderer` `ipc` `db`
+`git` `worktree` `browser` `mcp` `activity` `mobile-bridge` `protocol` `settings` `changes` `pr`
+`ci` `test` `e2e` `deps` `release`
+
+The list is illustrative, not exhaustive. A new subsystem gets a new scope. Examples:
 
 - `fix(session): resume when worktree branch is deleted`
 - `feat(board): add keyboard shortcut for moving tasks between columns`
@@ -222,7 +232,8 @@ Look for issues labeled **good first issue** for approachable tasks. If you want
 
 ## Code of Conduct
 
-Be respectful, constructive, and collaborative. We're all here to build something useful.
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). Report unacceptable behavior to
+support@kangentic.com.
 
 ## Questions?
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,9 @@
 
 ## Reporting a vulnerability
 
-Email **support@kangentic.com**. Please do not open a public GitHub issue for a security problem,
-so we can ship a fix before the details are public.
+Use GitHub's [private vulnerability reporting](https://github.com/Kangentic/kangentic/security/advisories/new),
+or email **support@kangentic.com** if you would rather not go through GitHub. Please do not open a
+public GitHub issue for a security problem, so we can ship a fix before the details are public.
 
 Include whatever you have:
 

--- a/tests/unit/repo-hygiene.test.ts
+++ b/tests/unit/repo-hygiene.test.ts
@@ -145,8 +145,10 @@ describe('.github/workflows/codeql.yml', () => {
    * push, and this repo pushes topic branches that already have an open PR as a
    * matter of course. Such a push runs ci.yml's 21-job PR gate and these two
    * Analyze jobs at the same time, so deleting one line here costs exactly what
-   * adding a `pull_request:` trigger costs. The guard above stays green through
-   * it, and so does the one below: `push:` is still present either way.
+   * adding a `pull_request:` trigger costs. Both of the other guards stay green
+   * through that deletion: no `pull_request:` trigger appears, and `push:`
+   * itself is still there. Deleting the whole trigger is a different edit, and
+   * the guard below is the one that catches that.
    */
   it('scopes the push trigger to main', () => {
     const lines = stripComments(readFileSync(codeqlPath, 'utf8'));

--- a/tests/unit/repo-hygiene.test.ts
+++ b/tests/unit/repo-hygiene.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Open-source repo hygiene artifacts that nothing else validates. They live
+ * outside `src/`, so no typecheck, lint rule, or existing test touches them, and
+ * each one fails silently: a Code of Conduct with the Contributor Covenant's
+ * `[INSERT CONTACT METHOD]` placeholder still renders fine on GitHub, and a
+ * Dependabot config with a typo'd ecosystem name is simply ignored.
+ *
+ * The CodeQL assertion is the one that carries real weight. See its own comment.
+ *
+ * Deliberately a line scan rather than a YAML parse, matching
+ * ci-required-checks.test.ts: no YAML parser is a direct dependency of this
+ * repo, and the shapes asserted here are single keys at a fixed indent.
+ */
+
+const REPO_ROOT = join(__dirname, '..', '..');
+
+/**
+ * The role address. A personal address here would be a `no-personal-info.md`
+ * violation in a public repo, and the Covenant ships with a placeholder that has
+ * to be replaced by hand, so this pins the one correct value rather than merely
+ * asserting that some email is present.
+ */
+const CONTACT_ADDRESS = 'support@kangentic.com';
+
+/** Drop full-line comments so a file's own prose cannot satisfy a key scan. */
+function stripComments(source: string): string[] {
+  return source.split('\n').filter((line) => !/^\s*#/.test(line));
+}
+
+describe('CODE_OF_CONDUCT.md', () => {
+  const codeOfConductPath = join(REPO_ROOT, 'CODE_OF_CONDUCT.md');
+
+  it('exists at the repo root', () => {
+    // GitHub's community profile only detects the root, .github/ and docs/.
+    // Root is the choice here: docs/ is mirrored to the marketing website.
+    expect(
+      existsSync(codeOfConductPath),
+      'CODE_OF_CONDUCT.md must stay at the repo root so GitHub detects it.',
+    ).toBe(true);
+  });
+
+  it('names the reporting address instead of the Covenant placeholder', () => {
+    const source = readFileSync(codeOfConductPath, 'utf8');
+
+    expect(
+      source,
+      `The Code of Conduct must route reports to ${CONTACT_ADDRESS}.`,
+    ).toContain(CONTACT_ADDRESS);
+
+    expect(
+      source,
+      'The Contributor Covenant placeholder was never filled in.',
+    ).not.toContain('INSERT CONTACT METHOD');
+  });
+});
+
+describe('.github/dependabot.yml', () => {
+  const dependabotPath = join(REPO_ROOT, '.github', 'dependabot.yml');
+
+  it('exists and declares the github-actions ecosystem', () => {
+    expect(existsSync(dependabotPath), '.github/dependabot.yml is missing.').toBe(true);
+
+    const lines = stripComments(readFileSync(dependabotPath, 'utf8'));
+    const declaresActions = lines.some((line) =>
+      /^\s*-?\s*package-ecosystem:\s*["']?github-actions["']?\s*$/.test(line),
+    );
+
+    // A misspelled ecosystem is accepted by the file and then silently does
+    // nothing, so the value is what gets pinned, not just the key.
+    expect(
+      declaresActions,
+      'Dependabot must declare the `github-actions` ecosystem. npm is deliberately excluded; see the file header.',
+    ).toBe(true);
+  });
+
+  it('groups its updates into a single PR', () => {
+    const lines = stripComments(readFileSync(dependabotPath, 'utf8'));
+
+    // Ungrouped bumps open one PR each, and every Dependabot PR fires the full
+    // 21-job gate against a ~20-job account-wide cap.
+    expect(
+      lines.some((line) => /^\s*groups:\s*$/.test(line)),
+      'Keep the `groups:` block: ungrouped action bumps open a PR each, and each one runs the whole CI gate.',
+    ).toBe(true);
+  });
+});
+
+describe('.github/workflows/codeql.yml', () => {
+  const codeqlPath = join(REPO_ROOT, '.github', 'workflows', 'codeql.yml');
+
+  it('exists', () => {
+    expect(existsSync(codeqlPath), 'CodeQL scanning workflow is missing.').toBe(true);
+  });
+
+  /**
+   * THE LOAD-BEARING ONE.
+   *
+   * ci.yml's concurrency-budget block documents that the PR gate already runs 21
+   * concurrent jobs against GitHub Free's ~20-job account-wide cap, and that 21
+   * is a ceiling: at 22+ the earliest slot releaser becomes a ~70s unit shard,
+   * so a queued UI shard starts that late and pushes the run past its ~226s
+   * pole. CodeQL's two Analyze jobs on a PR would take it to 23.
+   *
+   * Adding a `pull_request:` trigger here is therefore a CI wall-clock
+   * regression on every PR, forever, and it is a completely reasonable-looking
+   * one-line edit. Nothing else would catch it: the workflow would go green.
+   */
+  it('has no pull_request trigger', () => {
+    const lines = stripComments(readFileSync(codeqlPath, 'utf8'));
+    const prTrigger = lines.find((line) => /^\s*pull_request(_target)?:/.test(line));
+
+    expect(
+      prTrigger,
+      'CodeQL must not run on pull requests. It would add 2 jobs to a PR gate already at the documented 21-job ceiling (see the concurrency-budget block in ci.yml). Scanning runs on push to main and weekly instead.',
+    ).toBeUndefined();
+  });
+
+  it('still runs on push to main and on a schedule', () => {
+    // The guard above is satisfied by a workflow with no triggers at all, which
+    // would disable scanning entirely while staying green.
+    const lines = stripComments(readFileSync(codeqlPath, 'utf8'));
+
+    expect(
+      lines.some((line) => /^\s*push:/.test(line)),
+      'CodeQL must still run on push to main, otherwise nothing is scanned after a merge.',
+    ).toBe(true);
+
+    expect(
+      lines.some((line) => /^\s*schedule:/.test(line)),
+      'Keep the weekly schedule: it catches newly published queries against unchanged code.',
+    ).toBe(true);
+  });
+});

--- a/tests/unit/repo-hygiene.test.ts
+++ b/tests/unit/repo-hygiene.test.ts
@@ -43,19 +43,29 @@ describe('CODE_OF_CONDUCT.md', () => {
     ).toBe(true);
   });
 
-  it('names the reporting address instead of the Covenant placeholder', () => {
-    const source = readFileSync(codeOfConductPath, 'utf8');
-
+  it('does not ship the Covenant placeholder', () => {
     expect(
-      source,
-      `The Code of Conduct must route reports to ${CONTACT_ADDRESS}.`,
-    ).toContain(CONTACT_ADDRESS);
-
-    expect(
-      source,
+      readFileSync(codeOfConductPath, 'utf8'),
       'The Contributor Covenant placeholder was never filled in.',
     ).not.toContain('INSERT CONTACT METHOD');
   });
+});
+
+/**
+ * Three files route reports to the same role address, and this diff put it in
+ * two of them. A stale address in any one sends a report nowhere, and none of
+ * the three is read often enough for that to surface on its own.
+ */
+describe('report routing', () => {
+  it.each(['CODE_OF_CONDUCT.md', 'CONTRIBUTING.md', 'SECURITY.md'])(
+    '%s routes reports to the role address',
+    (fileName) => {
+      expect(
+        readFileSync(join(REPO_ROOT, fileName), 'utf8'),
+        `${fileName} must route reports to ${CONTACT_ADDRESS}.`,
+      ).toContain(CONTACT_ADDRESS);
+    },
+  );
 });
 
 describe('.github/dependabot.yml', () => {
@@ -85,6 +95,15 @@ describe('.github/dependabot.yml', () => {
     expect(
       lines.some((line) => /^\s*groups:\s*$/.test(line)),
       'Keep the `groups:` block: ungrouped action bumps open a PR each, and each one runs the whole CI gate.',
+    ).toBe(true);
+
+    // `groups:` on its own is satisfied by a group that matches nothing. The
+    // catch-all pattern is what actually collapses every bump into one PR, so
+    // narrowing it puts the unmatched remainder back on the gate one PR at a
+    // time while the assertion above stays green.
+    expect(
+      lines.some((line) => /^\s*-\s*["']?\*["']?\s*$/.test(line)),
+      'Keep the catch-all `- "*"` pattern under `groups:`. A narrowed pattern list leaves every action it does not match opening its own PR.',
     ).toBe(true);
   });
 });
@@ -117,6 +136,36 @@ describe('.github/workflows/codeql.yml', () => {
       prTrigger,
       'CodeQL must not run on pull requests. It would add 2 jobs to a PR gate already at the documented 21-job ceiling (see the concurrency-budget block in ci.yml). Scanning runs on push to main and weekly instead.',
     ).toBeUndefined();
+  });
+
+  /**
+   * The same 23-job breach as the guard above, through a different door.
+   *
+   * A `push:` trigger with no `branches:` filter fires on every topic-branch
+   * push, and this repo pushes topic branches that already have an open PR as a
+   * matter of course. Such a push runs ci.yml's 21-job PR gate and these two
+   * Analyze jobs at the same time, so deleting one line here costs exactly what
+   * adding a `pull_request:` trigger costs. The guard above stays green through
+   * it, and so does the one below: `push:` is still present either way.
+   */
+  it('scopes the push trigger to main', () => {
+    const lines = stripComments(readFileSync(codeqlPath, 'utf8'));
+    const branchFilter = lines.find((line) => /^\s*branches:/.test(line));
+
+    expect(
+      branchFilter,
+      'The push trigger must keep its `branches:` filter. Without it CodeQL runs on every topic-branch push, stacking 2 Analyze jobs on top of the 21-job PR gate in ci.yml.',
+    ).toBeDefined();
+
+    expect(
+      branchFilter ?? '',
+      'Keep the push trigger scoped to main. A wildcard branch pattern fires CodeQL on every topic-branch push.',
+    ).toMatch(/\bmain\b/);
+
+    expect(
+      branchFilter ?? '',
+      'Keep the push trigger scoped to main. A wildcard branch pattern fires CodeQL on every topic-branch push.',
+    ).not.toMatch(/\*/);
   });
 
   it('still runs on push to main and on a schedule', () => {


### PR DESCRIPTION
## What

Open-source repo hygiene, from a comparison against `nestjs/nest` filtered on what pays off at one maintainer and three open issues.

- `CODE_OF_CONDUCT.md` (new): Contributor Covenant 2.1, reports to support@kangentic.com. The community profile reported `code_of_conduct: null` at 75% health.
- `.github/dependabot.yml` (new): `github-actions` only, weekly on Tuesday, grouped into one PR.
- `.github/workflows/codeql.yml` (new): `actions` and `javascript-typescript` at `github/codeql-action@v4`.
- `.github/ISSUE_TEMPLATE/bug_report.yml`: a Last Known Good Version input. Its sibling version placeholder was stale at `0.6.0`.
- `CONTRIBUTING.md`: the Code of Conduct section points at the new file, and the Commit Messages section now documents the scopes actually in use.
- `SECURITY.md`: names GitHub private vulnerability reporting, now enabled.
- `tests/unit/repo-hygiene.test.ts` (new): 11 assertions pinning all of the above.

Settings-only, no file change: 12 topics, the homepage, and four security features that were all off (secret scanning, push protection, Dependabot security updates, private vulnerability reporting).

## Why

`topics: []`, `homepage: null`, no Code of Conduct, no dependency updates, and a `SECURITY.md` with no scanning behind it. All of it is free on a public repo and none of it was on.

## How

Two items landed differently from the way the task specified them, both on measurement rather than preference.

**CodeQL is a committed workflow with no `pull_request` trigger, not GitHub's default setup.** `ci.yml` documents a 21-job ceiling against GitHub Free's ~20-job account-wide cap, and states that at 22+ the earliest slot releaser becomes a ~70s unit shard, so a queued UI shard starts that late and pushes the run past its ~226s pole. Default setup adds one Analyze job per language to every PR with no way to disable that, which would put the gate at 23. Scanning runs on push to main plus a weekly cron instead. The cost of the trade is that CodeQL can never become a required check while it has no PR trigger. It is not one today.

**No `scope-enum` was added to commitlint,** so `package.json` is untouched. The proposed 14-scope list covers 18.7% of history: 216 distinct scopes across 1559 scoped commits of the last 2000, and the five most used (`ui` 87, `board` 82, `review` 78, `release` 66, `terminal` 65) are all absent from it. The justification does not transfer either, since `/release` groups the changelog by type and strips the prefix, so scope feeds nothing downstream. An error-level enum would have rejected most agent-written commits at the husky hook. `CONTRIBUTING.md` documents the real list instead, as illustrative rather than enforced.

Dependabot is scoped to `github-actions` only. npm version bumps stay out because several dependencies are pinned exact for known reasons, but Dependabot *security* updates are now enabled at the repo level, so a real advisory still opens a PR.

## Breaking changes

None.

## Tests

`tests/unit/repo-hygiene.test.ts` covers the Code of Conduct placeholder and contact address, report routing across all three policy files, the Dependabot ecosystem and its catch-all group pattern, and the CodeQL triggers.

Its load-bearing assertion is that `codeql.yml` carries no `pull_request` trigger, red-greened by temporarily adding one: it fails with a message explaining the job-count cost. A sibling guard pins the `branches: [main]` filter on the push trigger, which is the same 23-job breach through a different door.

Verified locally: typecheck, lint, and the scoped test file. `commitlint` still accepts a free-form scope, confirming the enum decision did not regress the hook. CI covers the rest.

Not verifiable before merge: the CodeQL workflow has never executed. Pass condition on its first run is both matrix legs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sqee4ELodyE78RChns2Bhw
