### PR TITLE
fix(azure-devops): gate the bearer token on a real host check

### DIFF
--- a/src/main/boards/adapters/azure-devops/adapter.ts
+++ b/src/main/boards/adapters/azure-devops/adapter.ts
@@ -17,18 +17,18 @@ import {
   extractInlineImageUrls,
 } from '../../shared';
 import { AzureDevOpsImporter } from './client';
-import { parseAzureDevOpsUrl, buildAzureDevOpsLabel } from './url-parser';
+import { parseAzureDevOpsUrl, buildAzureDevOpsLabel, isAzureDevOpsAuthedDownloadUrl } from './url-parser';
 
 registerSourceUrlParser('azure_devops', { parse: parseAzureDevOpsUrl, buildLabel: buildAzureDevOpsLabel });
-
-const AZURE_DEVOPS_HOST = 'dev.azure.com';
 
 /**
  * Board adapter for Azure DevOps work items.
  *
  * Downloads inline images with bearer token auth for Azure DevOps URLs
- * (comment screenshots are hosted on dev.azure.com and require authentication).
- * Adds authenticated file attachment downloading for Azure DevOps AttachedFile relations.
+ * (comment screenshots are hosted on the org's own host and require
+ * authentication). Adds authenticated file attachment downloading for Azure
+ * DevOps AttachedFile relations. Both download paths gate the token on
+ * `isAzureDevOpsAuthedDownloadUrl` so it never reaches a third-party host.
  */
 export class AzureDevOpsAdapter implements BoardAdapter {
   readonly id: ExternalSource = 'azure_devops';
@@ -96,7 +96,7 @@ export class AzureDevOpsAdapter implements BoardAdapter {
       return { attachments: [], skippedCount: 0 };
     }
 
-    const needsAuth = imageUrls.some((image) => image.url.includes(AZURE_DEVOPS_HOST));
+    const needsAuth = imageUrls.some((image) => isAzureDevOpsAuthedDownloadUrl(image.url));
     const authHeaders = needsAuth
       ? { Authorization: `Bearer ${await this.azure.getAccessToken()}` }
       : undefined;
@@ -108,9 +108,10 @@ export class AzureDevOpsAdapter implements BoardAdapter {
       const batch = imageUrls.slice(batchStart, batchStart + DOWNLOAD_CONCURRENCY);
       const results = await Promise.allSettled(
         batch.map((imageInfo) => {
-          // Only attach the bearer token to dev.azure.com URLs - sending it
-          // to external image hosts would leak credentials.
-          const headers = imageInfo.url.includes(AZURE_DEVOPS_HOST) ? authHeaders : undefined;
+          // Only attach the bearer token when the URL's host is an Azure DevOps
+          // host - image URLs come from user-authored work item bodies, so
+          // sending it to an external host would leak credentials.
+          const headers = isAzureDevOpsAuthedDownloadUrl(imageInfo.url) ? authHeaders : undefined;
           return downloadFile(imageInfo.url, imageInfo.filename, headers ? { headers } : undefined);
         }),
       );
@@ -134,8 +135,10 @@ export class AzureDevOpsAdapter implements BoardAdapter {
       return { attachments: [], skippedCount: 0 };
     }
 
-    const token = await this.azure.getAccessToken();
-    const authHeaders = { Authorization: `Bearer ${token}` };
+    const needsAuth = attachments.some((attachment) => isAzureDevOpsAuthedDownloadUrl(attachment.url));
+    const authHeaders = needsAuth
+      ? { Authorization: `Bearer ${await this.azure.getAccessToken()}` }
+      : undefined;
 
     const downloadedAttachments: DownloadedAttachment[] = [];
     let skippedCount = 0;
@@ -143,7 +146,13 @@ export class AzureDevOpsAdapter implements BoardAdapter {
     for (let batchStart = 0; batchStart < attachments.length; batchStart += DOWNLOAD_CONCURRENCY) {
       const batch = attachments.slice(batchStart, batchStart + DOWNLOAD_CONCURRENCY);
       const results = await Promise.allSettled(
-        batch.map((attachment) => downloadFile(attachment.url, attachment.filename, { headers: authHeaders })),
+        batch.map((attachment) => {
+          // Same host gate as the inline images. Relation URLs come back from the
+          // Azure REST API rather than from work item HTML, so this is a backstop
+          // rather than the primary defense, but it fails closed either way.
+          const headers = isAzureDevOpsAuthedDownloadUrl(attachment.url) ? authHeaders : undefined;
+          return downloadFile(attachment.url, attachment.filename, headers ? { headers } : undefined);
+        }),
       );
 
       for (const result of results) {

--- a/src/main/boards/adapters/azure-devops/url-parser.ts
+++ b/src/main/boards/adapters/azure-devops/url-parser.ts
@@ -25,6 +25,34 @@ export function parseAzureDevOpsUrl(url: string): { repository: string } {
   throw new Error('Invalid Azure DevOps URL. Expected format: https://dev.azure.com/org/project');
 }
 
+const LEGACY_HOST_SUFFIX = '.visualstudio.com';
+
+/**
+ * Decide whether a download URL's host should receive our Azure DevOps bearer
+ * token. Covers the modern `dev.azure.com` host and the legacy
+ * `{org}.visualstudio.com` spelling this adapter still imports from.
+ *
+ * A substring test is not enough. Inline image URLs come out of user-authored
+ * work item HTML, so `https://attacker.example/x.png?ref=dev.azure.com` and
+ * `https://dev.azure.com.attacker.example/x.png` would both pass one and send
+ * the token to a host the attacker controls. Never throws: a malformed or
+ * relative URL is simply not authed.
+ */
+export function isAzureDevOpsAuthedDownloadUrl(url: string): boolean {
+  let hostname: string;
+  try {
+    // hostname, not host: `host` carries the port, so a `dev.azure.com:443`
+    // URL would fail the comparison and silently lose its token.
+    hostname = new URL(url).hostname;
+  } catch {
+    return false;
+  }
+  if (hostname === 'dev.azure.com') return true;
+  // The leading dot rejects `evilvisualstudio.com`, the length check rejects a
+  // bare `.visualstudio.com` with no org label.
+  return hostname.endsWith(LEGACY_HOST_SUFFIX) && hostname.length > LEGACY_HOST_SUFFIX.length;
+}
+
 /** Build a human-readable label for an Azure DevOps source. */
 export function buildAzureDevOpsLabel(repository: string): string {
   if (repository.includes('::')) {

--- a/tests/ui/terminal-arrival-focus.spec.ts
+++ b/tests/ui/terminal-arrival-focus.spec.ts
@@ -235,6 +235,44 @@ async function settleFocusFrames(page: Page): Promise<void> {
   );
 }
 
+/**
+ * On a focus-assertion failure for an arriving terminal, print the arrival-focus
+ * arbiter's dev-only trace ring (exposed as `window.__kangenticTerminalTrace` by
+ * `DevtoolsBootstrap`, mounted unconditionally under Vite dev) plus the actual
+ * focused element's identity, via `console.log` so it lands directly in CI's
+ * `list`-reporter job log - the UI shard job uploads no report/trace artifact, so
+ * a `testInfo.attach()` would be invisible there.
+ *
+ * Diagnostic only: changes no wait and weakens no assertion. Added after the spec
+ * 3 CI failure below could not be reproduced locally (30/30 baseline runs; CDP
+ * CPU throttling broke the EARLIER veil-clear step instead of isolating this one,
+ * the wrong shape; 18/18 runs under real 30-core OS contention with 3 concurrent
+ * browsers) and static reading of the arbiter (`terminal-arrival-focus.ts`) found
+ * no invalidation path within this test's lifecycle - `ARRIVAL_CLAIM_TTL_MS` is
+ * already 30s specifically for this scenario class. Rather than guess at a fix
+ * for an unconfirmed cause, this captures the arbiter's own `{allow, reason}`
+ * decision (or its absence, which narrows to the rAF never running / the xterm
+ * ref being null at focus time) so the next occurrence resolves in one log line.
+ */
+async function logArrivalFocusFailure(page: Page, sessionId: string): Promise<void> {
+  const diagnostics = await page.evaluate((sid) => {
+    const traceReader = (window as unknown as { __kangenticTerminalTrace?: () => unknown[] }).__kangenticTerminalTrace;
+    const trace = (traceReader ? traceReader() : []) as Array<{ sessionId: string | null; event: string }>;
+    const relevant = trace.filter((entry) => entry.sessionId === sid || entry.event === 'arrival-focus');
+    const active = document.activeElement;
+    return {
+      relevantTrace: relevant,
+      activeElement: active && active !== document.body ? {
+        tag: active.tagName,
+        className: (active as HTMLElement).className ?? null,
+        paneSessionId: active.closest('[data-session-id]')?.getAttribute('data-session-id') ?? null,
+        testId: active.closest('[data-testid]')?.getAttribute('data-testid') ?? null,
+      } : null,
+    };
+  }, sessionId);
+  console.log(`[arrival-focus-diagnostics] session=${sessionId}`, JSON.stringify(diagnostics, null, 2));
+}
+
 test('a delayed background replay does not steal focus from a just-opened task detail', async () => {
   const { browser, page } = await launch();
   try {
@@ -384,7 +422,12 @@ test('re-expanding the bottom panel focuses its terminal while a detail window i
     await fallbackPane.waitFor({ state: 'visible', timeout: STEP_TIMEOUT_MS });
     await expect(fallbackPane.locator('[data-testid="terminal-replay-veil"]')).toHaveCount(0, { timeout: STEP_TIMEOUT_MS });
 
-    await expect(fallbackPane.locator('.xterm-helper-textarea').first()).toBeFocused({ timeout: STEP_TIMEOUT_MS });
+    try {
+      await expect(fallbackPane.locator('.xterm-helper-textarea').first()).toBeFocused({ timeout: STEP_TIMEOUT_MS });
+    } catch (error) {
+      await logArrivalFocusFailure(page, SESSION_FALLBACK);
+      throw error;
+    }
   } finally {
     await browser.close();
   }

--- a/tests/unit/azure-devops-download-auth.test.ts
+++ b/tests/unit/azure-devops-download-auth.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Azure DevOps download auth: which hosts receive the bearer token.
+ *
+ * Guards the fix for the CodeQL `js/incomplete-url-substring-sanitization`
+ * alerts on `azure-devops/adapter.ts`. The adapter used to gate the token on
+ * `url.includes('dev.azure.com')`, and inline image URLs are parsed straight
+ * out of a work item body, so anyone able to edit a work item could point the
+ * download at their own host and collect the user's Azure AD access token.
+ *
+ * The download helper is mocked at its leaf module (`shared/download-file`)
+ * rather than at the `shared/index.ts` barrel the adapter imports through;
+ * the barrel re-exports from the leaf, so the mock still intercepts.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const downloadFileSpy = vi.hoisted(() =>
+  vi.fn<(url: string, filename: string, options?: { headers?: Record<string, string> }) => Promise<unknown>>(),
+);
+
+vi.mock('../../src/main/boards/shared/download-file', async () => {
+  const actual = await vi.importActual<typeof import('../../src/main/boards/shared/download-file')>(
+    '../../src/main/boards/shared/download-file',
+  );
+  return { ...actual, downloadFile: downloadFileSpy };
+});
+
+const { AzureDevOpsAdapter } = await import('../../src/main/boards/adapters/azure-devops/adapter');
+const { AzureDevOpsImporter } = await import('../../src/main/boards/adapters/azure-devops/client');
+const { isAzureDevOpsAuthedDownloadUrl } = await import('../../src/main/boards/adapters/azure-devops/url-parser');
+
+const ACCESS_TOKEN = 'ado-access-token-1234567890';
+const EXPECTED_AUTHORIZATION = `Bearer ${ACCESS_TOKEN}`;
+
+const MODERN_IMAGE_URL = 'https://dev.azure.com/myorg/_apis/wit/attachments/abc.png';
+const LEGACY_IMAGE_URL = 'https://myorg.visualstudio.com/_apis/wit/attachments/abc.png';
+const SPOOFED_QUERY_URL = 'https://attacker.example/x.png?ref=dev.azure.com';
+const SPOOFED_PATH_URL = 'https://attacker.example/dev.azure.com/y.png';
+const SPOOFED_SUFFIX_URL = 'https://dev.azure.com.attacker.example/z.png';
+
+/** Build an adapter whose token minting is stubbed, so no `az` process is spawned. */
+function makeAdapter() {
+  const importer = new AzureDevOpsImporter();
+  const getAccessToken = vi.spyOn(importer, 'getAccessToken').mockResolvedValue(ACCESS_TOKEN);
+  return { adapter: new AzureDevOpsAdapter(importer), getAccessToken };
+}
+
+/** Find the mocked download call for a given URL, so assertions do not depend on batch ordering. */
+function optionsForUrl(url: string): { headers?: Record<string, string> } | undefined {
+  const call = downloadFileSpy.mock.calls.find(([calledUrl]) => calledUrl === url);
+  if (!call) throw new Error(`downloadFile was never called with ${url}`);
+  return call[2];
+}
+
+beforeEach(() => {
+  downloadFileSpy.mockReset();
+  downloadFileSpy.mockImplementation(async (url: string, filename: string) => ({
+    filename,
+    data: 'AAAA',
+    mediaType: 'application/octet-stream',
+    sizeBytes: 4,
+    sourceUrl: url,
+  }));
+});
+
+describe('isAzureDevOpsAuthedDownloadUrl', () => {
+  it('accepts the modern dev.azure.com host', () => {
+    expect(isAzureDevOpsAuthedDownloadUrl(MODERN_IMAGE_URL)).toBe(true);
+  });
+
+  it('accepts a legacy {org}.visualstudio.com host', () => {
+    expect(isAzureDevOpsAuthedDownloadUrl(LEGACY_IMAGE_URL)).toBe(true);
+  });
+
+  it('accepts a legacy host regardless of case, since URL lowercases the hostname', () => {
+    expect(isAzureDevOpsAuthedDownloadUrl('https://SOA-DCCED.visualstudio.com/x.png')).toBe(true);
+  });
+
+  it('accepts an explicit port, because the check reads hostname rather than host', () => {
+    expect(isAzureDevOpsAuthedDownloadUrl('https://dev.azure.com:8443/x.png')).toBe(true);
+  });
+
+  it('rejects a foreign host that only mentions dev.azure.com in the query string', () => {
+    expect(isAzureDevOpsAuthedDownloadUrl(SPOOFED_QUERY_URL)).toBe(false);
+  });
+
+  it('rejects a foreign host that only mentions dev.azure.com in the path', () => {
+    expect(isAzureDevOpsAuthedDownloadUrl(SPOOFED_PATH_URL)).toBe(false);
+  });
+
+  it('rejects a foreign host that uses dev.azure.com as a subdomain prefix', () => {
+    expect(isAzureDevOpsAuthedDownloadUrl(SPOOFED_SUFFIX_URL)).toBe(false);
+  });
+
+  it('rejects a host that merely ends in visualstudio.com without the dot separator', () => {
+    expect(isAzureDevOpsAuthedDownloadUrl('https://evilvisualstudio.com/x.png')).toBe(false);
+  });
+
+  it('rejects a bare .visualstudio.com with no org label', () => {
+    expect(isAzureDevOpsAuthedDownloadUrl('https://.visualstudio.com/x.png')).toBe(false);
+  });
+
+  it('returns false rather than throwing on a relative or malformed URL', () => {
+    expect(isAzureDevOpsAuthedDownloadUrl('/relative/x.png')).toBe(false);
+    expect(isAzureDevOpsAuthedDownloadUrl('not a url at all')).toBe(false);
+    expect(isAzureDevOpsAuthedDownloadUrl('')).toBe(false);
+  });
+});
+
+describe('AzureDevOpsAdapter.downloadImages - bearer token host gate', () => {
+  it('attaches the bearer token to a dev.azure.com image', async () => {
+    const { adapter } = makeAdapter();
+    await adapter.downloadImages(`![screenshot](${MODERN_IMAGE_URL})`);
+
+    expect(optionsForUrl(MODERN_IMAGE_URL)?.headers?.Authorization).toBe(EXPECTED_AUTHORIZATION);
+  });
+
+  it('attaches the bearer token to a legacy visualstudio.com image', async () => {
+    const { adapter } = makeAdapter();
+    await adapter.downloadImages(`![screenshot](${LEGACY_IMAGE_URL})`);
+
+    expect(optionsForUrl(LEGACY_IMAGE_URL)?.headers?.Authorization).toBe(EXPECTED_AUTHORIZATION);
+  });
+
+  it('never mints or sends a token when every image points at a spoofed host', async () => {
+    const { adapter, getAccessToken } = makeAdapter();
+    await adapter.downloadImages(
+      `![a](${SPOOFED_QUERY_URL}) ![b](${SPOOFED_PATH_URL}) ![c](${SPOOFED_SUFFIX_URL})`,
+    );
+
+    expect(downloadFileSpy).toHaveBeenCalledTimes(3);
+    expect(optionsForUrl(SPOOFED_QUERY_URL)).toBeUndefined();
+    expect(optionsForUrl(SPOOFED_PATH_URL)).toBeUndefined();
+    expect(optionsForUrl(SPOOFED_SUFFIX_URL)).toBeUndefined();
+    // The token is never even requested, which is what proves the needsAuth
+    // pre-check reads the host rather than a substring of the whole URL.
+    expect(getAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('authenticates only the real host when a body mixes real and spoofed images', async () => {
+    const { adapter, getAccessToken } = makeAdapter();
+    await adapter.downloadImages(`![real](${MODERN_IMAGE_URL}) ![fake](${SPOOFED_SUFFIX_URL})`);
+
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+    expect(optionsForUrl(MODERN_IMAGE_URL)?.headers?.Authorization).toBe(EXPECTED_AUTHORIZATION);
+    expect(optionsForUrl(SPOOFED_SUFFIX_URL)).toBeUndefined();
+  });
+
+  it('applies the same gate to an HTML img tag', async () => {
+    const { adapter } = makeAdapter();
+    await adapter.downloadImages(`<img src="${SPOOFED_QUERY_URL}" alt="a"><img src="${MODERN_IMAGE_URL}" alt="b">`);
+
+    expect(optionsForUrl(MODERN_IMAGE_URL)?.headers?.Authorization).toBe(EXPECTED_AUTHORIZATION);
+    expect(optionsForUrl(SPOOFED_QUERY_URL)).toBeUndefined();
+  });
+});
+
+describe('AzureDevOpsAdapter.downloadFileAttachments - bearer token host gate', () => {
+  it('attaches the bearer token to an Azure DevOps attachment relation URL', async () => {
+    const { adapter } = makeAdapter();
+    await adapter.downloadFileAttachments([
+      { url: 'https://dev.azure.com/myorg/_apis/wit/attachments/abc?api-version=7.0', filename: 'spec.pdf', sizeBytes: 0 },
+    ]);
+
+    const options = optionsForUrl('https://dev.azure.com/myorg/_apis/wit/attachments/abc?api-version=7.0');
+    expect(options?.headers?.Authorization).toBe(EXPECTED_AUTHORIZATION);
+  });
+
+  it('does not attach the bearer token to a relation URL on a foreign host', async () => {
+    const { adapter } = makeAdapter();
+    await adapter.downloadFileAttachments([
+      { url: 'https://attacker.example/dev.azure.com/spec.pdf', filename: 'spec.pdf', sizeBytes: 0 },
+    ]);
+
+    expect(optionsForUrl('https://attacker.example/dev.azure.com/spec.pdf')).toBeUndefined();
+  });
+
+  it('never mints a token when every attachment points at a foreign host', async () => {
+    const { adapter, getAccessToken } = makeAdapter();
+    await adapter.downloadFileAttachments([
+      { url: 'https://attacker.example/dev.azure.com/spec.pdf', filename: 'spec.pdf', sizeBytes: 0 },
+      { url: 'https://dev.azure.com.attacker.example/notes.pdf', filename: 'notes.pdf', sizeBytes: 0 },
+    ]);
+
+    expect(downloadFileSpy).toHaveBeenCalledTimes(2);
+    // Mirrors the downloadImages pre-check: an all-foreign batch must not spawn
+    // `az` at all, so a signed-out user still gets the unauthenticated downloads
+    // instead of a rejection from token minting.
+    expect(getAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('mints the token once when a batch mixes an Azure DevOps host with a foreign one', async () => {
+    const { adapter, getAccessToken } = makeAdapter();
+    const azureUrl = 'https://dev.azure.com/myorg/_apis/wit/attachments/abc?api-version=7.0';
+    const foreignUrl = 'https://attacker.example/dev.azure.com/spec.pdf';
+    await adapter.downloadFileAttachments([
+      { url: azureUrl, filename: 'real.pdf', sizeBytes: 0 },
+      { url: foreignUrl, filename: 'spec.pdf', sizeBytes: 0 },
+    ]);
+
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+    expect(optionsForUrl(azureUrl)?.headers?.Authorization).toBe(EXPECTED_AUTHORIZATION);
+    expect(optionsForUrl(foreignUrl)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Replaces the substring host test that gated the Azure DevOps bearer token with a real hostname
check, and applies that same check to the file-attachment download path, which had no host check
at all.

- `src/main/boards/adapters/azure-devops/url-parser.ts` gains one exported predicate,
  `isAzureDevOpsAuthedDownloadUrl`.
- `src/main/boards/adapters/azure-devops/adapter.ts` routes all four credential gates through it
  and drops the `AZURE_DEVOPS_HOST` const. Two are in `downloadImages` (the `needsAuth`
  token-minting pre-check, and the per-image header decision) and two are the same pair in
  `downloadFileAttachments`, which previously had no host check at all: it minted a token
  unconditionally and attached it to every URL it was handed.

Two things happen here, and the second is not a security fix. See Breaking changes.

## Why

CodeQL raised two `js/incomplete-url-substring-sanitization` alerts on `adapter.ts`, at the
`needsAuth` pre-check and at the per-image header decision. Both gated the token on
`url.includes('dev.azure.com')` against the whole URL.

Inline image URLs come from `extractInlineImageUrls(markdownBody)`, which pulls `![alt](url)` and
`<img src>` targets straight out of a work item body and validates only the `http://` / `https://`
prefix. Anyone able to edit a work item in the connected project therefore controlled that string,
and all of these passed:

- `https://attacker.example/x.png?ref=dev.azure.com`
- `https://attacker.example/dev.azure.com/x.png`
- `https://dev.azure.com.attacker.example/x.png`

A crafted image URL sent the user's Azure DevOps access token to a host the attacker controls.
`downloadFile` already strips the `authorization` header on a cross-host redirect, but that guard
covers hop two, and this leak is on hop one.

## How

The predicate parses the URL and compares `hostname` against `dev.azure.com` plus a real
`.visualstudio.com` subdomain. It is modeled on `isAsanaAuthedDownloadHost`
(`src/main/boards/adapters/asana/constants.ts`), which already does this correctly.

Four decisions worth a reviewer's attention:

1. **`hostname`, not `host`.** `host` carries the port, so `dev.azure.com:443` would fail equality
   and silently lose its token. This is a deliberate divergence from the Asana call site, which
   uses `.host`.
2. **It must never throw.** The check runs synchronously inside `batch.map()`, before
   `Promise.allSettled` exists, and the `needsAuth` `.some()` runs earlier still. A throw there
   escapes `map()` and rejects the entire import. `new URL()` throws on relative and malformed
   input, which `extractInlineImageUrls` does emit, so the parse is wrapped and returns false.
3. **The leading dot and the length guard.** `endsWith('.visualstudio.com')` rejects
   `evilvisualstudio.com`; the length check rejects a bare `.visualstudio.com`, which `new URL()`
   will happily produce.
4. **Any-depth subdomain, not a single label.** `url-parser.ts` and `pr/adapters/azure-devops/azure-remote.ts`
   both use `([^.]+)` for the legacy host. The whole `visualstudio.com` zone is Microsoft-controlled,
   so a loose match inside it leaks nothing to an attacker, while a too-tight match would be a
   silent broken-attachments regression for legacy orgs.

It was placed in `url-parser.ts` rather than a new `constants.ts` so it sits beside the existing
legacy-host regex and the two cannot drift apart.

Not done here, deliberately: no https-only enforcement (real regression tail in `http://` fixtures,
and not what CodeQL flagged), and no org scoping. `downloadImages(markdownBody)` has no
organization parameter, so the token still reaches any Azure DevOps org's host rather than only the
one being imported from. Tightening that needs a `BoardAdapter` signature change.

## Breaking changes

No API or config change. One behavioral change worth calling out, because it is easy to miss in a
PR framed as a security fix:

Legacy `{org}.visualstudio.com` image and attachment URLs previously received **no** token, because
the string `dev.azure.com` does not appear in them, so those downloads silently failed. They now
authenticate. For legacy-host orgs this repairs attachment downloads that were broken.

## Tests

New: `tests/unit/azure-devops-download-auth.test.ts`, 19 cases covering the predicate directly
(modern host, legacy host, uppercase host, explicit port, all three spoof shapes, missing-dot,
empty-label, and malformed input) and all four adapter gates through a mocked `downloadFile`.

Every gate was red-green verified, each in isolation, because the token-minting pre-checks are not
covered by the header assertions:

- All gates reverted to `.includes()`: 5 failures, exactly the spoof, legacy, and file-attachment
  cases.
- **Only** the `downloadImages` `needsAuth` line reverted: 1 failure,
  `expect(getAccessToken).not.toHaveBeenCalled()`.
- **Only** the `downloadFileAttachments` `needsAuth` line reverted to an unconditional mint: 1
  failure, the matching assertion on that path.

The isolation matters: every header-level assertion still passes with either pre-check broken, so
those two assertions are the only things guarding them.

Ran locally: `npm run typecheck`, `npm run lint`, the new suite, plus the adjacent
`azure-devops-url-parser`, `azure-devops-comments-attachments`, and `asana-attachments` suites, and
the repo hygiene guards. The full tiers are CI's job.

CodeQL cannot confirm this PR. `.github/workflows/codeql.yml` has no `pull_request` trigger on
purpose (the concurrency-budget note at the top of the file explains why), so the two alerts clear
on the push-to-`main` run after this merges, not here. Worth knowing before treating a green PR as
proof the alerts are gone. The shape of the fix, an equality plus suffix check on a parsed
`hostname`, is the form the rule treats as complete.

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] No em-dashes or `--` used as punctuation
- [x] Tests added or updated for this change
- [x] Docs updated if anchor source changed (no anchor source changed; audited anyway)
- [x] Ran `npm run lint`, `npm run typecheck`, and the relevant tests locally
- [ ] Screenshot or clip included (UI changes) - not a UI change
- [x] CLA signed (or will sign on first PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GksuSmCLJMpTPT6esV8ZQX
