### PR TITLE
fix(utility-process): stop mixing inherit with a piped handle in worker stdio

### DIFF
--- a/.claude/rules/cross-platform-parity.md
+++ b/.claude/rules/cross-platform-parity.md
@@ -5,6 +5,7 @@ paths:
   - "src/main/agent/**"
   - "src/main/git/**"
   - "src/main/utility-process/**"
+  - "src/main/retrieval/**"
   - "src/main/**/*path*"
 ---
 
@@ -39,9 +40,10 @@ breaks on the next platform.
 - **A packaged Windows GUI process has no console**, so `GetStdHandle` returns NULL there and a
   dev terminal will never show you the difference. Concretely, `utilityProcess.fork`'s `stdio`
   must not mix `inherit` with a real handle (`pipe` or `ignore`) across the stdout and stderr
-  slots: Electron leaves the `inherit` slot's handle null, Chromium still pushes it into the
-  child's inherit list, and `SetHandleInformation` fails a fatal `PCHECK` that kills the main
-  process (Sentry DESKTOP-S). All-`inherit` and all-real are both safe. `UTILITY_PROCESS_STDIO` in
+  slots: Electron leaves the `inherit` slot's handle null, Electron's own patch to
+  `child_process_launcher_helper_win.cc` still pushes it into the child's inherit list, and
+  `SetHandleInformation` fails a fatal `PCHECK` that kills the main process (Sentry DESKTOP-S).
+  All-`inherit` and all-real are both safe. `UTILITY_PROCESS_STDIO` in
   `src/main/utility-process/stderr-tail.ts` is the single place this is decided.
 
 ### Tests (unit, UI, E2E)
@@ -89,10 +91,13 @@ A test must pass on CI's headless Linux runner, not merely on local Windows. Con
   `/test` run. Because it is a static scan it flags the absolute-write subclass on any OS, without a
   Linux runner, closing the "green locally, red on CI" gap that let `main` go red by design.
 - **Test for utility-process stdio:** `tests/unit/stderr-tail.test.ts` pins `UTILITY_PROCESS_STDIO`
-  and fails when it mixes `inherit` with a real handle. This one needs a static guard rather than
-  CI, because no tier can catch it: CI never packages, and every tier (including E2E's
-  `_electron.launch()`) starts the app from a terminal, which hands it the valid stdout handle that
-  hides the bug.
+  and fails when it mixes `inherit` with a real handle. A companion scan in the same file walks
+  `src/main/**/*.ts` and fails on any `utilityProcess.fork` call that does not pass
+  `stdio: UTILITY_PROCESS_STDIO`, so a new call site cannot inline its own literal and drift. This
+  one has to be a static assertion rather than a running app, because no tier can reach the bug:
+  CI never packages, and every tier (including E2E's `_electron.launch()`) starts the app from a
+  terminal, which hands it the valid stdout handle that hides it. Both tests ride the unit tier, so
+  CI still runs them as a PR check.
 - **Review for code:** the `platform-guard` agent audits `src/main/pty`, `src/main/agent`,
   `src/main/git`, and any `path` / `fs.rm` / `child_process` usage for the code rules above
   (hardcoded `C:\\Users\\`, missing platform guards, missing `{ force: true }`, em-dashes and
@@ -113,5 +118,6 @@ time it runs on Linux.
 ## Scope
 
 Committed source under the platform-sensitive `src/main/` subsystems (pty, agent, git,
-utility-process, path handling) and all of `tests/`. Marketing capture fixtures (`tests/captures/`) that intentionally
-pin OS-specific rendering for screenshots are exempt from the geometry-tolerance conventions.
+utility-process, retrieval, path handling) and all of `tests/`. Marketing capture fixtures
+(`tests/captures/`) that intentionally pin OS-specific rendering for screenshots are exempt from
+the geometry-tolerance conventions.

--- a/.claude/rules/cross-platform-parity.md
+++ b/.claude/rules/cross-platform-parity.md
@@ -4,6 +4,7 @@ paths:
   - "src/main/pty/**"
   - "src/main/agent/**"
   - "src/main/git/**"
+  - "src/main/utility-process/**"
   - "src/main/**/*path*"
 ---
 
@@ -35,6 +36,13 @@ breaks on the next platform.
   succeeds while a handle is open.
 - **Line endings:** author with `\n`; never assert on or emit `\r\n` literally. Let git's
   normalization handle CRLF.
+- **A packaged Windows GUI process has no console**, so `GetStdHandle` returns NULL there and a
+  dev terminal will never show you the difference. Concretely, `utilityProcess.fork`'s `stdio`
+  must not mix `inherit` with a real handle (`pipe` or `ignore`) across the stdout and stderr
+  slots: Electron leaves the `inherit` slot's handle null, Chromium still pushes it into the
+  child's inherit list, and `SetHandleInformation` fails a fatal `PCHECK` that kills the main
+  process (Sentry DESKTOP-S). All-`inherit` and all-real are both safe. `UTILITY_PROCESS_STDIO` in
+  `src/main/utility-process/stderr-tail.ts` is the single place this is decided.
 
 ### Tests (unit, UI, E2E)
 
@@ -80,6 +88,11 @@ A test must pass on CI's headless Linux runner, not merely on local Windows. Con
   monitor-and-fix loop) and also locally in `/merge-back` Step 0 for a direct push and in a manual
   `/test` run. Because it is a static scan it flags the absolute-write subclass on any OS, without a
   Linux runner, closing the "green locally, red on CI" gap that let `main` go red by design.
+- **Test for utility-process stdio:** `tests/unit/stderr-tail.test.ts` pins `UTILITY_PROCESS_STDIO`
+  and fails when it mixes `inherit` with a real handle. This one needs a static guard rather than
+  CI, because no tier can catch it: CI never packages, and every tier (including E2E's
+  `_electron.launch()`) starts the app from a terminal, which hands it the valid stdout handle that
+  hides the bug.
 - **Review for code:** the `platform-guard` agent audits `src/main/pty`, `src/main/agent`,
   `src/main/git`, and any `path` / `fs.rm` / `child_process` usage for the code rules above
   (hardcoded `C:\\Users\\`, missing platform guards, missing `{ force: true }`, em-dashes and
@@ -99,6 +112,6 @@ time it runs on Linux.
 
 ## Scope
 
-Committed source under the platform-sensitive `src/main/` subsystems (pty, agent, git, path
-handling) and all of `tests/`. Marketing capture fixtures (`tests/captures/`) that intentionally
+Committed source under the platform-sensitive `src/main/` subsystems (pty, agent, git,
+utility-process, path handling) and all of `tests/`. Marketing capture fixtures (`tests/captures/`) that intentionally
 pin OS-specific rendering for screenshots are exempt from the geometry-tolerance conventions.

--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -144,18 +144,19 @@ The `files` array in `electron-builder.yml` explicitly whitelists `.vite/build/*
 The embed worker's closure is the one that bites: the worker is forked from `app.asar.unpacked`, and Node resolution from a real directory never looks inside the asar, so a package the worker reaches only transitively (transformers.js requires `onnxruntime-common` and `sharp` at module scope) must be unpacked too, or the worker exits 1 at module load on every fork. 0.38.0 and 0.39.0 shipped that way (Sentry DESKTOP-6, DESKTOP-H). `build/afterPack.js` now runs `build/verify-unpacked-worker.js` after packing: it loads `@huggingface/transformers` from the unpacked tree in a child `node` whose module resolution is fenced to that tree (an unfenced probe would find the repo's own `node_modules` above `out/` and pass), and fails the package with the child's stderr when anything is missing. `npm run package` runs it too, so the gate holds locally, not only on the release matrix.
 
 Separately, how the embed and line-count workers are forked bites on Windows too.
-`UTILITY_PROCESS_STDIO` in
-`src/main/utility-process/stderr-tail.ts` must never mix `inherit` with a real handle (`pipe` or
-`ignore`) across the stdout and stderr slots. Electron gives an `inherit` slot no Windows branch,
-so its handle stays null, and it passes both handles to `ServiceProcessHost` anyway. Electron's
-patch to `child_process_launcher_helper_win.cc` arms the child's inherit list when either handle
-is valid, then fills the null slot from `GetStdHandle(STD_OUTPUT_HANDLE)`, which is NULL in a
-packaged GUI build because there is no console. `SetHandleInformation` on that null handle fails a
-`PCHECK` in `launch_win.cc` and kills the main process outright. 0.39.1 shipped
-`['ignore', 'inherit', 'pipe']` and crashed that way (Sentry DESKTOP-S); the array is now
-`['ignore', 'ignore', 'pipe']`. All-`inherit` (what passing no `stdio` gives you) and all-real are
-both safe. `npm start` cannot catch this, because a dev terminal hands the process a valid stdout
-handle. `tests/unit/stderr-tail.test.ts` guards the mixing rule.
+`UTILITY_PROCESS_STDIO` in `src/main/utility-process/stderr-tail.ts` must never mix `inherit` with
+a real handle (`pipe` or `ignore`) across the stdout and stderr slots. Electron gives an `inherit`
+slot no Windows branch, so its handle stays null, and it passes both handles to
+`ServiceProcessHost` anyway. Electron's patch to `child_process_launcher_helper_win.cc` arms the
+child's inherit list when either handle is valid, then fills the null slot from
+`GetStdHandle(STD_OUTPUT_HANDLE)`, which is NULL in a packaged GUI build because there is no
+console. `SetHandleInformation` on that null handle fails a `PCHECK` in `launch_win.cc` and kills
+the main process outright. 0.39.1 shipped `['ignore', 'inherit', 'pipe']` and crashed that way
+(Sentry DESKTOP-S); the array is now `['ignore', 'ignore', 'pipe']`. All-`inherit` (what passing no
+`stdio` gives you) and all-real are both safe, but omitting `stdio` also drops the piped stderr the
+crash reports need, so both workers pass the constant. `npm start` cannot catch this, because a dev
+terminal hands the process a valid stdout handle. `tests/unit/stderr-tail.test.ts` guards the
+mixing rule and also scans every `utilityProcess.fork` call site for the shared constant.
 
 ### Bridge Script Unpacking
 

--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -143,6 +143,20 @@ The `files` array in `electron-builder.yml` explicitly whitelists `.vite/build/*
 
 The embed worker's closure is the one that bites: the worker is forked from `app.asar.unpacked`, and Node resolution from a real directory never looks inside the asar, so a package the worker reaches only transitively (transformers.js requires `onnxruntime-common` and `sharp` at module scope) must be unpacked too, or the worker exits 1 at module load on every fork. 0.38.0 and 0.39.0 shipped that way (Sentry DESKTOP-6, DESKTOP-H). `build/afterPack.js` now runs `build/verify-unpacked-worker.js` after packing: it loads `@huggingface/transformers` from the unpacked tree in a child `node` whose module resolution is fenced to that tree (an unfenced probe would find the repo's own `node_modules` above `out/` and pass), and fails the package with the child's stderr when anything is missing. `npm run package` runs it too, so the gate holds locally, not only on the release matrix.
 
+Separately, how the embed and line-count workers are forked bites on Windows too.
+`UTILITY_PROCESS_STDIO` in
+`src/main/utility-process/stderr-tail.ts` must never mix `inherit` with a real handle (`pipe` or
+`ignore`) across the stdout and stderr slots. Electron gives an `inherit` slot no Windows branch,
+so its handle stays null, and it passes both handles to `ServiceProcessHost` anyway. Electron's
+patch to `child_process_launcher_helper_win.cc` arms the child's inherit list when either handle
+is valid, then fills the null slot from `GetStdHandle(STD_OUTPUT_HANDLE)`, which is NULL in a
+packaged GUI build because there is no console. `SetHandleInformation` on that null handle fails a
+`PCHECK` in `launch_win.cc` and kills the main process outright. 0.39.1 shipped
+`['ignore', 'inherit', 'pipe']` and crashed that way (Sentry DESKTOP-S); the array is now
+`['ignore', 'ignore', 'pipe']`. All-`inherit` (what passing no `stdio` gives you) and all-real are
+both safe. `npm start` cannot catch this, because a dev terminal hands the process a valid stdout
+handle. `tests/unit/stderr-tail.test.ts` guards the mixing rule.
+
 ### Bridge Script Unpacking
 
 Bridge scripts (`event-bridge.js`, `status-bridge.js`) are executed by Claude Code hooks in a separate `node` process outside Electron. Plain Node.js cannot read files inside asar archives, so `asarUnpack` names them individually, alongside `embed-worker.js`, `line-count-worker.js`, and `plugins/**` (unpacked for the retrieval and embedding subsystem rather than for the hook bridges). Only those five entries under `.vite/build/` are extracted to `app.asar.unpacked/`; the rest of the directory stays inside the archive. The `resolveBridgeScript()` function in `src/main/agent/shared/bridge-utils.ts` rewrites `app.asar` to `app.asar.unpacked` in resolved paths when running in a packaged build.

--- a/src/main/utility-process/stderr-tail.ts
+++ b/src/main/utility-process/stderr-tail.ts
@@ -26,9 +26,26 @@ import { StringDecoder } from 'node:string_decoder';
  */
 
 /** stdio for both Kangentic utility processes: stdin must be `ignore`
- *  (Electron supports nothing else there), stdout keeps the `inherit`
- *  default, stderr is piped so `captureWorkerStderr` can drain it. */
-export const UTILITY_PROCESS_STDIO: Array<'pipe' | 'ignore' | 'inherit'> = ['ignore', 'inherit', 'pipe'];
+ *  (Electron supports nothing else there), stderr is piped so
+ *  `captureWorkerStderr` can drain it, and stdout must NOT be `inherit`.
+ *
+ *  Never mix `inherit` with a real handle across the stdout/stderr slots. On
+ *  Windows, Electron gives `inherit` no branch at all, so that slot's handle
+ *  stays null, and it hands both to `ServiceProcessHost` regardless. Electron's
+ *  patch to `child_process_launcher_helper_win.cc` arms the child's inherit
+ *  list when EITHER handle is valid, then fills the null slot from
+ *  `GetStdHandle(STD_OUTPUT_HANDLE)`, which is NULL in a packaged GUI build
+ *  with no console. `SetHandleInformation(NULL, ...)` then fails a PCHECK in
+ *  `launch_win.cc` and takes the whole main process down (DESKTOP-S, 0.39.1).
+ *
+ *  All-`inherit` is safe (the list is never built) and all-real is safe; only
+ *  the mix is fatal. Passing no `stdio` at all is the all-`inherit` case, which
+ *  is why `['ignore', 'inherit', 'pipe']` looked like it was keeping a default
+ *  it was in fact replacing. Since stderr has to be piped, stdout goes to
+ *  `ignore` (a real `NUL` handle on Windows, `/dev/null` elsewhere). Nothing is
+ *  lost: a packaged build had no console for `inherit` to reach anyway, and
+ *  neither worker writes to stdout. */
+export const UTILITY_PROCESS_STDIO: Array<'pipe' | 'ignore' | 'inherit'> = ['ignore', 'ignore', 'pipe'];
 
 export const DEFAULT_STDERR_TAIL_BYTES = 8 * 1024;
 

--- a/src/main/utility-process/stderr-tail.ts
+++ b/src/main/utility-process/stderr-tail.ts
@@ -41,10 +41,17 @@ import { StringDecoder } from 'node:string_decoder';
  *  All-`inherit` is safe (the list is never built) and all-real is safe; only
  *  the mix is fatal. Passing no `stdio` at all is the all-`inherit` case, which
  *  is why `['ignore', 'inherit', 'pipe']` looked like it was keeping a default
- *  it was in fact replacing. Since stderr has to be piped, stdout goes to
- *  `ignore` (a real `NUL` handle on Windows, `/dev/null` elsewhere). Nothing is
- *  lost: a packaged build had no console for `inherit` to reach anyway, and
- *  neither worker writes to stdout. */
+ *  it was in fact replacing. That default survives DESKTOP-S but drops the
+ *  piped stderr DESKTOP-H needs, so both workers still have to pass this
+ *  constant rather than omit `stdio`. Since stderr has to be piped, stdout goes
+ *  to `ignore` (a real `NUL` handle on Windows, `/dev/null` elsewhere).
+ *
+ *  Almost nothing is lost by that: a packaged build had no console for
+ *  `inherit` to reach anyway, and neither worker writes to stdout itself. A
+ *  dependency loaded at module scope (transformers.js and onnxruntime, in the
+ *  embed worker) could still print there, and that output reached the dev
+ *  terminal under `inherit` and now goes to `NUL`. No crash report is affected:
+ *  stderr is captured either way. */
 export const UTILITY_PROCESS_STDIO: Array<'pipe' | 'ignore' | 'inherit'> = ['ignore', 'ignore', 'pipe'];
 
 export const DEFAULT_STDERR_TAIL_BYTES = 8 * 1024;

--- a/tests/unit/embed-client.test.ts
+++ b/tests/unit/embed-client.test.ts
@@ -611,10 +611,12 @@ describe('EmbedClient', () => {
     client.dispose();
   });
 
-  it('forks the worker with stderr piped (stdin ignored, stdout inherited) so a crash can be explained', async () => {
+  it('forks the worker with stderr piped and stdin/stdout ignored so a crash can be explained', async () => {
     // DESKTOP-H: with Electron's default `inherit`, a packaged GUI build sent
     // the worker's uncaught-exception dump nowhere, and every report could
     // only say "exit code 1". Dropping `pipe` silently kills the diagnostic.
+    // DESKTOP-S: putting `inherit` back in the stdout slot alongside that pipe
+    // kills the main process outright on packaged Windows (see stderr-tail.ts).
     const client = new EmbedClient(TEST_MODEL);
     await embedAfterReady(client, ['x']);
 
@@ -623,7 +625,7 @@ describe('EmbedClient', () => {
       [],
       expect.objectContaining({
         serviceName: 'kangentic-embeddings',
-        stdio: ['ignore', 'inherit', 'pipe'],
+        stdio: ['ignore', 'ignore', 'pipe'],
       }),
     );
     client.dispose();

--- a/tests/unit/line-count-client.test.ts
+++ b/tests/unit/line-count-client.test.ts
@@ -297,7 +297,7 @@ describe('LineCountClient', () => {
     }
   });
 
-  it('forks the worker with stderr piped (stdin ignored, stdout inherited), the same shape as the embed worker', async () => {
+  it('forks the worker with stderr piped and stdin/stdout ignored, the same shape as the embed worker', async () => {
     const client = new LineCountClient();
     const promise = client.countFiles(['/mock/a.txt']);
     lastChild().emit('message', { type: 'result', id: 1, entries: [] });
@@ -308,7 +308,7 @@ describe('LineCountClient', () => {
       [],
       expect.objectContaining({
         serviceName: 'kangentic-line-count',
-        stdio: ['ignore', 'inherit', 'pipe'],
+        stdio: ['ignore', 'ignore', 'pipe'],
       }),
     );
     client.dispose();

--- a/tests/unit/stderr-tail.test.ts
+++ b/tests/unit/stderr-tail.test.ts
@@ -220,6 +220,105 @@ describe('UTILITY_PROCESS_STDIO', () => {
   });
 });
 
+/** How far past a `utilityProcess.fork(` call to look for its `stdio:` option.
+ *  Generous enough for an options object that wraps over several lines, since a
+ *  window that ends too early fails a call site that is in fact correct. */
+const FORK_OPTIONS_WINDOW_LINES = 12;
+
+/** 1-based line numbers of the `utilityProcess.fork(` calls in `source` that do
+ *  not pass `stdio: UTILITY_PROCESS_STDIO`.
+ *
+ *  Split out from the tree scan below so the detection logic itself can be run
+ *  against known-bad input. Scanning the real tree only ever proves the
+ *  compliant case: both call sites today already pass the constant, so the
+ *  assertion holds no matter what this function does, and a regex that silently
+ *  stopped matching would keep the guard green forever. */
+function findForkCallsMissingSharedStdio(source: string): number[] {
+  const lines = source.split('\n');
+  // `utilityProcess` and `.fork(` land on separate lines when a formatter
+  // breaks the chain, so the call is matched against the whole source rather
+  // than line by line.
+  const forkCallPattern = /utilityProcess\s*\.\s*fork\s*\(/g;
+  const callLineIndexes: number[] = [];
+  let callMatch = forkCallPattern.exec(source);
+  while (callMatch !== null) {
+    callLineIndexes.push(source.slice(0, callMatch.index).split('\n').length - 1);
+    callMatch = forkCallPattern.exec(source);
+  }
+
+  const offendingLineNumbers: number[] = [];
+  callLineIndexes.forEach((lineIndex, callIndex) => {
+    const nextCallLineIndex = callLineIndexes[callIndex + 1] ?? lines.length;
+    // Never read past the next call: a shared window lets a compliant call a
+    // few lines below mask a non-compliant one, which is the exact regression
+    // this guard exists to catch.
+    const windowEnd = Math.min(lineIndex + FORK_OPTIONS_WINDOW_LINES, Math.max(nextCallLineIndex, lineIndex + 1));
+    const optionsWindow = lines.slice(lineIndex, windowEnd).join('\n');
+    if (!/stdio:\s*UTILITY_PROCESS_STDIO\b/.test(optionsWindow)) {
+      offendingLineNumbers.push(lineIndex + 1);
+    }
+  });
+  return offendingLineNumbers;
+}
+
+describe('findForkCallsMissingSharedStdio', () => {
+  // Red cases for the tree scan below, which can only ever go green against the
+  // current tree. Each fixture is the shape of a real call site.
+
+  it('accepts a single-line call that passes the shared constant', () => {
+    const source = [
+      `const child = utilityProcess.fork(workerPath, [], { serviceName: SERVICE_NAME, stdio: UTILITY_PROCESS_STDIO });`,
+    ].join('\n');
+    expect(findForkCallsMissingSharedStdio(source)).toEqual([]);
+  });
+
+  it('accepts an options object that wraps over more lines than a short window would cover', () => {
+    const source = [
+      `const child = utilityProcess.fork(workerPath, [], {`,
+      `  serviceName: SERVICE_NAME,`,
+      `  cwd: workerDirectory,`,
+      `  env: workerEnvironment,`,
+      `  stdio: UTILITY_PROCESS_STDIO,`,
+      `});`,
+    ].join('\n');
+    expect(findForkCallsMissingSharedStdio(source)).toEqual([]);
+  });
+
+  it('flags a call that inlines its own stdio literal', () => {
+    const source = [
+      `const child = utilityProcess.fork(workerPath, [], {`,
+      `  serviceName: SERVICE_NAME,`,
+      `  stdio: ['ignore', 'inherit', 'pipe'],`,
+      `});`,
+    ].join('\n');
+    expect(findForkCallsMissingSharedStdio(source)).toEqual([1]);
+  });
+
+  it('flags a call that passes no stdio at all', () => {
+    // Omitting `stdio` is the all-`inherit` default, so it survives DESKTOP-S,
+    // but it drops the piped stderr that DESKTOP-H added. Both workers need the
+    // constant, so the absent case is an offender too.
+    const source = [`const child = utilityProcess.fork(workerPath, [], { serviceName: SERVICE_NAME });`].join('\n');
+    expect(findForkCallsMissingSharedStdio(source)).toEqual([1]);
+  });
+
+  it('flags a call whose method chain is split across lines', () => {
+    const source = [
+      `const child = utilityProcess`,
+      `  .fork(workerPath, [], { serviceName: SERVICE_NAME, stdio: ['ignore', 'inherit', 'pipe'] });`,
+    ].join('\n');
+    expect(findForkCallsMissingSharedStdio(source)).toEqual([1]);
+  });
+
+  it('does not let a compliant call mask a non-compliant one a few lines above it', () => {
+    const source = [
+      `const first = utilityProcess.fork(firstWorker, [], { serviceName: 'a', stdio: ['ignore', 'inherit', 'pipe'] });`,
+      `const second = utilityProcess.fork(secondWorker, [], { serviceName: 'b', stdio: UTILITY_PROCESS_STDIO });`,
+    ].join('\n');
+    expect(findForkCallsMissingSharedStdio(source)).toEqual([1]);
+  });
+});
+
 describe('utilityProcess.fork call sites', () => {
   it('every utilityProcess.fork call passes the shared UTILITY_PROCESS_STDIO constant, never an inline literal', () => {
     // The value-level tests above (and the ones in embed-client.test.ts /
@@ -230,6 +329,10 @@ describe('utilityProcess.fork call sites', () => {
     // NEXT time it changes for a good reason, a duplicated literal is exactly
     // how DESKTOP-S (or its next variant) comes back at a call site nobody
     // remembered to update. This scans source text for the identifier itself.
+    //
+    // The scan root stays the whole of `src/main` rather than the directories
+    // that fork today, because the call site this needs to catch is the one
+    // nobody anticipated.
     const repoRoot = path.resolve(__dirname, '../..');
     const scanRoot = path.join(repoRoot, 'src/main');
     const offenders: string[] = [];
@@ -248,18 +351,11 @@ describe('utilityProcess.fork call sites', () => {
     }
 
     for (const filePath of collectSourceFiles(scanRoot)) {
-      const relPath = path.relative(repoRoot, filePath).replace(/\\/g, '/');
-      const lines = fs.readFileSync(filePath, 'utf-8').split('\n');
-      lines.forEach((line, index) => {
-        if (!/utilityProcess\.fork\s*\(/.test(line)) return;
-        // A small window past the call line covers a fork() options object
-        // that wraps onto following lines, not just the single-line form both
-        // current call sites use.
-        const window = lines.slice(index, index + 4).join('\n');
-        if (!/stdio:\s*UTILITY_PROCESS_STDIO\b/.test(window)) {
-          offenders.push(`${relPath}:${index + 1}`);
-        }
-      });
+      const relativePath = path.relative(repoRoot, filePath).replace(/\\/g, '/');
+      const source = fs.readFileSync(filePath, 'utf-8');
+      for (const lineNumber of findForkCallsMissingSharedStdio(source)) {
+        offenders.push(`${relativePath}:${lineNumber}`);
+      }
     }
 
     expect(

--- a/tests/unit/stderr-tail.test.ts
+++ b/tests/unit/stderr-tail.test.ts
@@ -197,7 +197,23 @@ describe('captureWorkerStderr', () => {
 });
 
 describe('UTILITY_PROCESS_STDIO', () => {
-  it('pipes stderr only, with stdin ignored as Electron requires and stdout left inherited', () => {
-    expect(UTILITY_PROCESS_STDIO).toEqual(['ignore', 'inherit', 'pipe']);
+  it('pipes stderr only, with stdin and stdout ignored', () => {
+    expect(UTILITY_PROCESS_STDIO).toEqual(['ignore', 'ignore', 'pipe']);
+  });
+
+  it('never mixes inherit with a real handle in the stdout/stderr slots (DESKTOP-S)', () => {
+    // Electron leaves an `inherit` slot's Windows handle null and passes both
+    // to ServiceProcessHost anyway. Electron's own patch to
+    // child_process_launcher_helper_win.cc (not stock Chromium) arms the
+    // child's inherit list when EITHER handle is valid, then fills the null
+    // slot from GetStdHandle(), which is NULL in a packaged GUI process with no
+    // console. SetHandleInformation on that null handle then fails a PCHECK in
+    // launch_win.cc and kills the main process. All-inherit is safe (the list
+    // is never built) and all-real is safe, so this checks the mix rather than
+    // banning `inherit` outright.
+    const [stdin, ...outputs] = UTILITY_PROCESS_STDIO;
+    expect(stdin).toBe('ignore'); // Electron supports nothing else here.
+    const inheritCount = outputs.filter((mode) => mode === 'inherit').length;
+    expect(inheritCount === 0 || inheritCount === outputs.length).toBe(true);
   });
 });

--- a/tests/unit/stderr-tail.test.ts
+++ b/tests/unit/stderr-tail.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import path from 'node:path';
 import {
   StderrTail,
   DEFAULT_STDERR_TAIL_BYTES,
@@ -215,5 +217,54 @@ describe('UTILITY_PROCESS_STDIO', () => {
     expect(stdin).toBe('ignore'); // Electron supports nothing else here.
     const inheritCount = outputs.filter((mode) => mode === 'inherit').length;
     expect(inheritCount === 0 || inheritCount === outputs.length).toBe(true);
+  });
+});
+
+describe('utilityProcess.fork call sites', () => {
+  it('every utilityProcess.fork call passes the shared UTILITY_PROCESS_STDIO constant, never an inline literal', () => {
+    // The value-level tests above (and the ones in embed-client.test.ts /
+    // line-count-client.test.ts) only pin what UTILITY_PROCESS_STDIO equals -
+    // they use deep equality, so a call site that inlines its own literal
+    // array matching today's value would pass them silently. That defeats the
+    // "one place this is decided" invariant this constant exists for: the
+    // NEXT time it changes for a good reason, a duplicated literal is exactly
+    // how DESKTOP-S (or its next variant) comes back at a call site nobody
+    // remembered to update. This scans source text for the identifier itself.
+    const repoRoot = path.resolve(__dirname, '../..');
+    const scanRoot = path.join(repoRoot, 'src/main');
+    const offenders: string[] = [];
+
+    function collectSourceFiles(directory: string): string[] {
+      const files: string[] = [];
+      for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        const fullPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+          files.push(...collectSourceFiles(fullPath));
+        } else if (fullPath.endsWith('.ts') && !fullPath.endsWith('.d.ts')) {
+          files.push(fullPath);
+        }
+      }
+      return files;
+    }
+
+    for (const filePath of collectSourceFiles(scanRoot)) {
+      const relPath = path.relative(repoRoot, filePath).replace(/\\/g, '/');
+      const lines = fs.readFileSync(filePath, 'utf-8').split('\n');
+      lines.forEach((line, index) => {
+        if (!/utilityProcess\.fork\s*\(/.test(line)) return;
+        // A small window past the call line covers a fork() options object
+        // that wraps onto following lines, not just the single-line form both
+        // current call sites use.
+        const window = lines.slice(index, index + 4).join('\n');
+        if (!/stdio:\s*UTILITY_PROCESS_STDIO\b/.test(window)) {
+          offenders.push(`${relPath}:${index + 1}`);
+        }
+      });
+    }
+
+    expect(
+      offenders,
+      `Every utilityProcess.fork call must pass stdio: UTILITY_PROCESS_STDIO, never an inline array - see stderr-tail.ts for why the stdout/stderr slots must never mix inherit with a real handle (DESKTOP-S). Offenders:\n${offenders.join('\n')}`,
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

`UTILITY_PROCESS_STDIO` in `src/main/utility-process/stderr-tail.ts` changes from
`['ignore', 'inherit', 'pipe']` to `['ignore', 'ignore', 'pipe']`. That constant is the `stdio`
array both Kangentic utility workers pass to `utilityProcess.fork`, so it covers
`src/main/retrieval/embedder/embed-client.ts` and `src/main/git/line-count/line-count-client.ts`.
Also: two guard tests, a note in `docs/cross-platform.md`, and a bullet plus two path entries in
`.claude/rules/cross-platform-parity.md`.

## Why

Sentry DESKTOP-S: `logging::LogMessage::HandleFatal`, level fatal, crashed process `browser`.
The main process dies outright with no recovery path, on packaged Windows only. 0.39.1 is the
only release carrying it, and it is the current release.

The crash key is `launch_win.cc:339: Check failed: . : The handle is invalid. (0x6)`. The
mechanism, read end to end:

1. Electron gives an `inherit` stdio slot no Windows branch, so that slot's `ScopedHandle` stays
   null, and it calls `WithStdoutHandle` / `WithStderrHandle` unconditionally anyway.
2. Electron's own patch to `child_process_launcher_helper_win.cc` arms the child's inherit list
   when EITHER handle is valid, then fills the null slot from `GetStdHandle(STD_OUTPUT_HANDLE)` and
   pushes it with no validity check. A packaged GUI build has no console, so that is NULL.
3. `SetHandleInformation` on the null handle fails a `PCHECK` in `launch_win.cc`, which is fatal
   by construction.

So the hazard is narrower than "never use `inherit`": it is MIXING `inherit` in one of the
stdout/stderr slots with a real handle in the other. All-`inherit` never builds the inherit list
at all, which is why the pre-0.39.1 `utilityProcess.fork` default never crashed. All-real is safe
too. stderr must stay piped for the stderr tail, so stdout moves to `ignore`.

This is also wider than it looks. `captureGitChurn` runs on every task move, suspend, idle
timeout, and settings restart, and it reaches `countUntrackedEntries`, which forks the line-count
worker once a worktree carries more than 2 MiB of untracked files. No panel needs to be open.

## How

One array, no `process.platform` branch: the value is safe everywhere, and on POSIX `ignore` just
maps stdout to `/dev/null`.

Almost nothing is lost. A packaged build had no console for `inherit` to reach, and neither worker
writes to stdout itself. The honest caveat is that a dependency loaded at module scope
(transformers.js and onnxruntime, in the embed worker) could print there, and that output reached a
dev terminal under `inherit` and now goes to NUL. No crash report is affected, because stderr is
captured either way.

Rejected the alternative of piping stdout and draining it: it buys back only that dev-terminal
chatter, and adds a second pipe that deadlocks the worker at 64KB if a drain is ever missed.

The docblock on the constant is rewritten. Its old "stdout keeps the `inherit` default" line is
the exact misreading that caused this, because an explicit array is not the same as passing no
array.

## Breaking changes

None.

## Tests

CI checks (lint, typecheck, unit, build, UI shards, Linux Electron E2E shards), plus two guards in
`tests/unit/stderr-tail.test.ts`:

- The exact-value assertion is updated, and a new guard encodes the MIXING rule rather than banning
  `inherit` outright, so a future all-`inherit` value is not failed for the wrong reason.
- A call-site scan walks `src/main/**/*.ts` and fails any `utilityProcess.fork` call whose `stdio`
  does not name the shared constant. The existing assertions all compare the array by deep
  equality, so an inlined literal matching today's value would have passed them silently.

`tests/unit/embed-client.test.ts` and `tests/unit/line-count-client.test.ts` have their fork-option
assertions updated.

The code-review pass found that the call-site scan as first written could only ever go green:
both call sites already pass the constant, so the assertion held no matter what the regex did, and
confirming the scan found those call sites did not prove the predicate discriminated. Its detection
is now split into `findForkCallsMissingSharedStdio` and pinned against six fixtures, which exposed
three real defects: a 4-line lookahead that would have failed a correct call site whose options
object carries more keys, a window that ran past the next call so a compliant call could mask a
non-compliant one above it, and a per-line match blind to a wrapped `utilityProcess` / `.fork(`
chain. Each was confirmed red in isolation.

No tier can reproduce the crash itself: CI never packages, and every tier (including E2E's
`_electron.launch()`) starts the app from a terminal, which supplies the valid stdout handle that
hides the bug. That is why these are static assertions, though both still ride the unit tier and so
run as a PR check.

Verified by hand instead, against Electron 41.1.1 launched with no console. Only
`explorer.exe <shortcut>` strips the std handles; `npx electron` and `Start-Process` both inherit
them and fail to reproduce, which is why `npm start` never caught this. Four variants on that one
launch path:

| stdio | result |
|---|---|
| `['ignore','inherit','pipe']` (0.39.1) | dies after fork |
| `['ignore','pipe','inherit']` (mirror mix) | dies after fork |
| `['ignore','inherit','inherit']` (old default) | survives |
| `['ignore','ignore','pipe']` (this PR) | survives |

The dying runs log `[FATAL:base\process\launch_win.cc:339] Check failed: . : The handle is
invalid. (0x6)`, a literal match for the Sentry crash key, line number included. On the fixed
value the real bundled line-count worker spawns, returns correct line counts, and `child.stderr`
is still a readable stream, so the stderr tail is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWq9AoWjCZjmHgbWb2PFfJ
