### PR TITLE
fix(terminal): discharge the arrival-focus decision a pre-empted replay cancels

### DIFF
--- a/.claude/rules/terminal-arrival-focus.md
+++ b/.claude/rules/terminal-arrival-focus.md
@@ -21,7 +21,7 @@ tell a programmatic focus from a user one.
 ## The rule
 
 **Arrival focus is decided by user-intent state, never by replay order or rAF order.** Route every
-programmatic focus on an arriving terminal through `mayTakeArrivalFocus(sessionId)`
+programmatic focus on an arriving terminal through `mayTakeArrivalFocus(sessionId, site)`
 (`src/renderer/utils/terminal-arrival-focus.ts`). Hosts own the policy and pass it to `useTerminal`
 as the `mayTakeArrivalFocus` option, so the hook stays surface-agnostic.
 
@@ -45,6 +45,37 @@ as the `mayTakeArrivalFocus` option, so the hook stays surface-agnostic.
   retried CI test and, off CI, as an expand click that silently does not move focus. Do not
   tighten it toward observed mount times; if a tighter bound is ever wanted, anchor it to the
   claimed terminal's own mount instead of to the gesture.
+- **An arrival is an OBLIGATION owed by a replay, discharged exactly once.** It is not an instant
+  that either happens or does not. A replay arms the obligation where it STARTS
+  (`arrivalFocusOwedRef` in `useTerminal`), and every path that ends that replay discharges it
+  through `focusOnArrival`: the two that complete normally, and the three that pre-empt one (the
+  watchdog and the two IPC rejections). A path that ends a replay without discharging cancels the
+  decision permanently, because nothing asks again.
+
+  This is not hypothetical. `armScrollbackWatchdog` bumps the replay generation, which makes that
+  replay's own `afterWrite` return ABOVE the frame that asks the arbiter, and it clears
+  `scrollbackPendingRef`, which lifts the replay veil. So the terminal looks like one that
+  finished arriving and simply refused focus, while in fact the arbiter was never consulted at
+  all. It shipped as an intermittently retried CI test (the panel re-expand case) whose arbiter
+  trace was EMPTY, which is why two rounds of reading the tier ladder found nothing.
+
+  Arm at replay START, never at completion: a replay that never completes is the entire case this
+  exists for, so arming in `afterWrite` leaves the pre-emption paths with nothing to discharge.
+  And a DENIED decision discharges exactly like a granted one - a deny is a real answer, and
+  re-asking after one reopens the race the exclusivity rule above closes.
+
+  A `skipFocus` reload does NOT discharge when it COMPLETES, deliberately. It is a repair, and
+  letting it answer an outstanding arrival would let a reveal or refocus catch-up focus a terminal
+  on a park/reveal edge, which is not an arrival at all.
+
+  Two gaps stay open, and neither is closed. A `skipFocus` reload that supersedes a live mount
+  replay strands that obligation, which is the behaviour that already shipped. And the repair's
+  own watchdog discharges unconditionally, so a repair that stalls past `SCROLLBACK_WATCHDOG_MS`
+  spends the stranded obligation and focuses on the very edge the completion path refuses.
+  `onTerminalReveal` is the only route in, being the one `skipFocus` caller with no
+  `scrollbackPendingRef` guard and so the only one that can supersede a live mount replay. Closing
+  either needs a signal for "is this arrival still the user's intent" that does not exist yet, and
+  guessing would trade a terminal that does not focus for one that focuses at the wrong moment.
 - **Genuinely user-initiated focus stays unconditional** and must NOT be routed through the
   arbiter: pointer-down on a window frame, a file drop on a terminal, the maximize/restore
   re-homing, and the imperative `focus()` those use.
@@ -65,7 +96,20 @@ as the `mayTakeArrivalFocus` option, so the hook stays surface-agnostic.
   Every mismatch case is constructed so the next tier down would have allowed it.
 - **Test (behavior):** `tests/ui/terminal-arrival-focus.spec.ts` drives the real race with a
   per-session replay delay and asserts focus stays in the just-opened detail, plus that a panel tab
-  click still focuses its own terminal.
+  click still focuses its own terminal. Its fourth case is the obligation: it delays a
+  focus-bearing reload past `SCROLLBACK_WATCHDOG_MS` so the watchdog pre-empts the decision, and
+  asserts the terminal is focused anyway. That case drives the RELOAD path deliberately - on a
+  fresh mount `TerminalTab`'s own `tab-init` frame focuses the terminal a frame after
+  construction, long before the watchdog, so a mount-based version passes with the fix reverted.
+- **Test (discharge sites):** `tests/unit/terminal-arrival-focus-sites.test.ts` pins all five
+  discharge calls in `useTerminal.ts`, and pins each replay's arm ahead of that replay's own
+  completion. It slices the source into the watchdog, mount and reload regions and checks each
+  region separately, because `focusOnArrival('replay-error')` appears in two of them and a
+  whole-file substring search would let either one be deleted. It checks position, not a count of
+  occurrences: a count would fail on an `armArrival()` helper extraction, which reintroduces
+  nothing, and a pin that fires on safe refactors gets deleted rather than understood.
+  `useTerminal` has no unit tier, so this is a static pin: it makes deleting a discharge fail
+  instantly rather than only in the 6-second UI case.
 - **Review:** `/code-review` flags a new arrival path that focuses unconditionally.
 
 **Mechanical coverage is deliberately incomplete on the CLAIM side, and this is the gap:** the

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -514,9 +514,11 @@ Sessions are resumable on next launch via `--resume <agent_session_id>` from the
   main delays 150-400ms for the repaint settle, and every arrival path used to end in an
   unconditional `xterm.focus()` - so whichever replay resolved LAST won, and a user who opened a
   task and started typing could have the keystrokes land in whatever agent the panel fell back to.
-  `mayTakeArrivalFocus(sessionId)` decides from user-intent STATE instead, in three tiers:
+  `mayTakeArrivalFocus(sessionId, site)` decides from user-intent STATE instead, in four tiers:
   a claim recorded by a gesture that named a terminal before it existed (a panel tab click, a panel
-  expand - the panel is not a window, so neither moves any layer's `focusedWindowId`); else the
+  expand - the panel is not a window, so neither moves any layer's `focusedWindowId`); else a
+  window an AGENT opened or raised, which denies EVERYONE including its own terminal while it
+  holds focus (`openedByAgent`, see `.claude/rules/agent-driven-focus.md`); else the
   terminal-hosting window holding window-layer focus, resolved by ANCHOR across all three layers
   via `resolveFocusedWindowTerminal` in `dictation-target.ts`; else, when nothing owns the user's
   attention, allow unless focus is in a typing surface. A claim is NOT consumed on grant, because
@@ -531,6 +533,17 @@ Sessions are resumable on next launch via `--resume <agent_session_id>` from the
   surface-agnostic. Genuinely user-initiated focus (frame pointer-down, file drop, maximize
   re-homing) is unconditional and marked `// arrival-focus-ok:`. See
   `.claude/rules/terminal-arrival-focus.md`.
+- **The arrival is an obligation the replay owes, not a moment it passes through.** A replay arms
+  it at START and discharges it via `focusOnArrival`: the two normal completions, plus the three
+  that PRE-EMPT one - the stuck-replay watchdog (`SCROLLBACK_WATCHDOG_MS`) and the two IPC
+  rejections. The one deliberate exception is a `skipFocus` reload, which does not discharge, since
+  letting a reveal or refocus catch-up answer an arrival would move focus on a park/reveal edge
+  that is not an arrival at all. Without that, a pre-empted replay took its
+  focus decision down with it: the watchdog bumps the replay generation, so the replay's own
+  `afterWrite` returns above the frame that asks the arbiter, and it clears the pending flag, which
+  lifts the replay veil. The terminal then looks fully arrived and merely unfocusable, while the
+  arbiter was in fact never consulted - and nothing asks again, so it stays that way for the life
+  of the terminal.
 - The converse also holds: anything with NO mounted xterm must be OUT of that set. A collapsed panel renders no `TerminalTab`, so `derivePanelSessionId` returns null for it (`panelShowsTerminal`, threaded from `useTerminalResize`'s `showContent`). Otherwise main streams bytes nothing can acknowledge, and a chatty agent eventually trips backpressure (`BACKPRESSURE_HIGH_WATER`) and has its PTY paused. Output produced while collapsed accumulates in main's scrollback ring and is replayed when the panel expands and the terminal remounts. A remount is not the only way back: a session that stays MOUNTED and merely leaves the focused union (a detail window a detached monitor owns, a hidden panel, a closed command bar over a transient) is repaired on the focus edge alone, without remounting. See the focus-edge catch-up bullet under Output Streaming.
 
 ## Project-Scoped Session State
@@ -1009,11 +1022,18 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   `focused-terminals.ts`), and `repaint-repaired` / `repaint-verified` (renderer,
   `repaint-nudge.ts`, the latter meaning the frame was already correct and the nudge cost one
   render). `arrival-focus` (renderer, `terminal-arrival-focus.ts`) joins them, carrying the
-  allow/deny plus the tier that decided it (`claim` / `claim-mismatch` / `window` /
-  `window-mismatch` / `occupied` / `burst-taken` / `unclaimed`) - the only record of WHY a terminal
+  allow/deny plus the tier that decided it (`claim` / `claim-mismatch` / `agent-window` /
+  `window` / `window-mismatch` / `occupied` / `burst-taken` / `unclaimed`), the `site` that asked
+  (one arrival decides more than once, and they were otherwise indistinguishable), and the
+  arbiter's own INPUTS: the claimed session, both fingerprints, the claim's age, and the focused
+  window's session. The reason alone was not enough to diagnose with - it could not separate "no
+  claim was live" from "a claim was live and its fingerprint had moved". `claimArrivalFocus` emits
+  `arrival-claim` / `arrival-claim-clear` beside it, so a claim that was never made reads as a
+  positive fact rather than as a missing entry. Together they are the only record of WHY a terminal
   did or did not take focus, which a "typed into the wrong terminal" report otherwise leaves to
-  guesswork. All seven merge into `kangentic_devtools_terminal_state`'s timeline alongside the
-  resize and replay events above. `kangentic_devtools_terminal_forensics` is the session-scoped
+  guesswork - and an ABSENT `arrival-focus` entry is itself a diagnosis, meaning nothing ever asked
+  (see the arrival-obligation bullet above). All nine merge into
+  `kangentic_devtools_terminal_state`'s timeline alongside the resize and replay events above. `kangentic_devtools_terminal_forensics` is the session-scoped
   companion: renderer viewport rows, main's re-parsed grid, and the raw byte ring side by side,
   which is what separates "the agent never sent these rows" from "we lost them".
 - **Replay veil for a warm mount.** For an already-running session, `TerminalTab`'s launch overlay

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -1026,8 +1026,8 @@ The handoff is transparent to the user - the task card shows spawn progress phas
   `window` / `window-mismatch` / `occupied` / `burst-taken` / `unclaimed`), the `site` that asked
   (one arrival decides more than once, and they were otherwise indistinguishable), and the
   arbiter's own INPUTS: the claimed session, both fingerprints, the claim's age, and the focused
-  window's session. The reason alone was not enough to diagnose with - it could not separate "no
-  claim was live" from "a claim was live and its fingerprint had moved". `claimArrivalFocus` emits
+  window's session and `openedByAgent` stamp. The reason alone was not enough to diagnose with - it
+  could not separate "no claim was live" from "a claim was live and its fingerprint had moved". `claimArrivalFocus` emits
   `arrival-claim` / `arrival-claim-clear` beside it, so a claim that was never made reads as a
   positive fact rather than as a missing entry. Together they are the only record of WHY a terminal
   did or did not take focus, which a "typed into the wrong terminal" report otherwise leaves to

--- a/src/renderer/components/command-bar/CommandTerminalPane.tsx
+++ b/src/renderer/components/command-bar/CommandTerminalPane.tsx
@@ -18,7 +18,7 @@
  */
 import { useCallback, useEffect, useRef, type RefObject } from 'react';
 import { useTerminal } from '../../hooks/useTerminal';
-import { mayTakeArrivalFocus } from '../../utils/terminal-arrival-focus';
+import { mayTakeArrivalFocus, type ArrivalFocusSite } from '../../utils/terminal-arrival-focus';
 import { useTerminalRefit } from '../../hooks/useTerminalRefit';
 import { useDeferredTerminalInit } from '../../hooks/useDeferredTerminalInit';
 import { useTerminalFileDrop } from '../../hooks/useTerminalFileDrop';
@@ -57,7 +57,10 @@ export function CommandTerminalPane({ sessionId, isMaximized, gridGetterRef }: C
   // be remounted by the project-switch reconcile rather than by a user gesture,
   // so its arrivals are arbitrated like any other. A real Ctrl+Shift+P still
   // focuses: opening the layer focuses its window, which the arbiter resolves.
-  const mayFocusOnArrival = useCallback(() => mayTakeArrivalFocus(sessionId), [sessionId]);
+  const mayFocusOnArrival = useCallback(
+    (site: ArrivalFocusSite) => mayTakeArrivalFocus(sessionId, site),
+    [sessionId],
+  );
 
   const { terminalRef, initTerminal, fit, flushResize, focus, getDimensions } = useTerminal({
     sessionId,
@@ -95,7 +98,7 @@ export function CommandTerminalPane({ sessionId, isMaximized, gridGetterRef }: C
     initTerminal,
     onInit: () => {
       fit();
-      if (mayFocusOnArrival()) focus();
+      if (mayFocusOnArrival('deferred-init')) focus();
     },
   });
 

--- a/src/renderer/components/terminal/TerminalTab.tsx
+++ b/src/renderer/components/terminal/TerminalTab.tsx
@@ -9,7 +9,7 @@ import { LaunchOverlay } from '../LaunchOverlay';
 import { useTerminalOverlay } from '../../utils/task-progress';
 import { useTerminalRefit } from '../../hooks/useTerminalRefit';
 import { useDeferredTerminalInit } from '../../hooks/useDeferredTerminalInit';
-import { mayTakeArrivalFocus } from '../../utils/terminal-arrival-focus';
+import { mayTakeArrivalFocus, type ArrivalFocusSite } from '../../utils/terminal-arrival-focus';
 
 const FIT_DELAY_MS = 100;
 
@@ -101,7 +101,10 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
   // pass `active` hardcoded true, so `active` carries no information about which
   // surface the user is actually on - the arbiter answers that from user-intent
   // state instead. See terminal-arrival-focus.ts.
-  const mayFocusOnArrival = useCallback(() => mayTakeArrivalFocus(sessionId), [sessionId]);
+  const mayFocusOnArrival = useCallback(
+    (site: ArrivalFocusSite) => mayTakeArrivalFocus(sessionId, site),
+    [sessionId],
+  );
 
   const { terminalRef, initTerminal, fit, flushResize, focus, reloadScrollback, scrollbackPending, suppressDataRef } = useTerminal({
     sessionId,
@@ -220,7 +223,7 @@ export function TerminalTab({ sessionId, taskId, active, releaseEscapeWhenPointe
       // `initialized` already true, so it focuses about one frame after mount -
       // well before any replay settles. Gating only the replay would therefore
       // leave the race intact, just decided earlier.
-      if (initialized.current && mayFocusOnArrival()) {
+      if (initialized.current && mayFocusOnArrival('tab-init')) {
         focus();
       }
     });

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -277,8 +277,13 @@ interface UseTerminalOptions {
    *  firing to lift its replay veil so only the settled frame is ever shown.
    *  Read live via a ref, so the callback never goes stale. */
   onScrollbackSettled?: () => void;
-  /** Host policy: may this terminal take keyboard focus on ARRIVAL (the mount
-   *  replay, or a reload the caller did not opt out of with `skipFocus`)?
+  /** Host policy: may this terminal take keyboard focus on ARRIVAL?
+   *
+   *  An arrival is armed by a replay START (a mount, or a reload the caller did
+   *  not opt out of with `skipFocus`) and answered exactly once, by whichever
+   *  path ends that replay: either completion, the stuck-replay watchdog, or
+   *  either IPC rejection. So this is consulted from five sites, all of them
+   *  through `focusOnArrival`.
    *
    *  Arrival focus is arbitrated because two terminals can mount together and
    *  each finish its replay at an unpredictable moment, so an unconditional
@@ -639,8 +644,9 @@ export function useTerminal(options: UseTerminalOptions) {
    *  current callback. */
   const onScrollbackSettledRef = useRef(options.onScrollbackSettled);
   onScrollbackSettledRef.current = options.onScrollbackSettled;
-  /** Updated every render (same pattern as onScrollbackSettledRef) so the two
-   *  arrival-focus frames below ask the host's CURRENT policy. */
+  /** Updated every render (same pattern as onScrollbackSettledRef) so the single
+   *  arrival-focus frame below (`focusOnArrival`, reached from all five discharge
+   *  sites) asks the host's CURRENT policy. */
   const mayTakeArrivalFocusRef = useRef(options.mayTakeArrivalFocus);
   mayTakeArrivalFocusRef.current = options.mayTakeArrivalFocus;
 

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -21,6 +21,9 @@ import { createRepaintNudge, isUserInputData, isMouseReport, mouseReportLane, ty
 import { registerMountedTerminal } from '../utils/terminal-mount-registry';
 import { registerTerminalAnchor } from '../utils/terminal-anchor-registry';
 import type { PtyResizeOrigin, TerminalColorOverrides } from '../../shared/types';
+// Type only, so this creates no runtime edge to the arbiter (the hook stays
+// surface-agnostic and never reads the policy - it only labels its own paths).
+import type { ArrivalFocusSite } from '../utils/terminal-arrival-focus';
 import { activateUnicode11 } from '../../shared/xterm-unicode11';
 import '@xterm/xterm/css/xterm.css';
 
@@ -285,8 +288,14 @@ interface UseTerminalOptions {
    *
    *  Read live via a ref (same pattern as onScrollbackSettled) and evaluated
    *  INSIDE the focus frame, so the answer is the one at focus time rather than
-   *  at render time. Absent means allow; both live hosts pass it. */
-  mayTakeArrivalFocus?: () => boolean;
+   *  at render time. Absent means allow; both live hosts pass it.
+   *
+   *  `site` names which arrival path is asking, purely so the decision is
+   *  identifiable in the dev trace ring. The hook stays surface-agnostic: it is
+   *  labelling its OWN paths, not reading the policy. `ArrivalFocusSite` is a
+   *  type-only import, erased at build, so this adds no runtime edge to the
+   *  arbiter. */
+  mayTakeArrivalFocus?: (site: ArrivalFocusSite) => boolean;
 }
 
 /** Restore a saved scroll position (from HMR) or pin to the bottom.
@@ -536,6 +545,23 @@ export function useTerminal(options: UseTerminalOptions) {
   /** Monotonic counter to abandon stale scrollback operations when a newer
    *  one starts (e.g. initTerminal and reloadScrollback racing). */
   const scrollbackGenerationRef = useRef(0);
+  /** Whether this terminal still owes an arrival-focus DECISION.
+   *
+   *  An arrival is an obligation a REPLAY takes on (a mount, or a reload the
+   *  caller did not opt out of), not an instant that happens to pass. The
+   *  decision used to live only inside that replay's own completion frame, so any
+   *  path that PRE-EMPTED the replay cancelled the decision along with it and
+   *  nothing ever asked again - leaving the terminal unfocusable for the rest of
+   *  its life.
+   *
+   *  The watchdog below does exactly that, which is what made this so hard to
+   *  read: it bumps the generation (so `afterWrite` returns above its focus
+   *  frame) AND clears the veil, so the terminal looks like one that finished
+   *  arriving and simply refused focus. It shipped as an intermittently retried
+   *  CI test (`terminal-arrival-focus.spec.ts`, the panel re-expand case) whose
+   *  arbiter trace was empty, because the arbiter was never consulted at all.
+   *  See `focusOnArrival`. */
+  const arrivalFocusOwedRef = useRef(false);
   /** Backstop timer for a stuck replay (see SCROLLBACK_WATCHDOG_MS). Arming a
    *  new one clears any prior timer, so at most one is ever live - the one
    *  for the most recently started replay. */
@@ -631,6 +657,38 @@ export function useTerminal(options: UseTerminalOptions) {
     onScrollbackSettledRef.current?.();
   }, []);
 
+  /** Discharge this terminal's arrival-focus obligation, at most once per arrival.
+   *
+   *  Every path that ends a replay WITHOUT a newer replay having started routes
+   *  here: the two that complete normally, and the three that pre-empt one (the
+   *  watchdog and the two IPC rejections). A pre-empted replay therefore hands its
+   *  obligation on rather than dropping it, which is the whole fix - see
+   *  `arrivalFocusOwedRef`. A generation-aborted exit deliberately does not route
+   *  here, because the newer replay that bumped the generation owns the obligation
+   *  instead; the one exception is a `skipFocus` repair, which supersedes without
+   *  taking ownership (see the `!skipFocus` gate in `reloadScrollback`).
+   *
+   *  The ref is cleared BEFORE the frame, not inside it, so two paths racing the
+   *  same replay cannot both focus. A DENIED decision discharges exactly like a
+   *  granted one: a deny is a real answer from the arbiter, and re-asking after
+   *  one would reopen the race the arbiter exists to close
+   *  (.claude/rules/terminal-arrival-focus.md - tiers are EXCLUSIVE).
+   *
+   *  Terminal before policy, for the reason the two original call sites gave: the
+   *  policy is not a pure query (it records the grant that suppresses a competing
+   *  tier-3 arrival), so asking it for a host that unmounted between the settle
+   *  and this frame would deny a live terminal on behalf of a disposed one. */
+  const focusOnArrival = useCallback((site: ArrivalFocusSite) => {
+    if (!arrivalFocusOwedRef.current) return;
+    arrivalFocusOwedRef.current = false;
+    requestAnimationFrame(() => {
+      const terminal = xtermRef.current;
+      if (!terminal) return;
+      if (mayTakeArrivalFocusRef.current?.(site) === false) return;
+      terminal.focus();
+    });
+  }, []);
+
   /** Trace one step of a replay's lifecycle. Every entry carries its generation,
    *  because an abort is always "a newer generation started" and the two numbers
    *  are the whole story - without them a replay that died is visible only as the
@@ -663,6 +721,14 @@ export function useTerminal(options: UseTerminalOptions) {
       // fit / scroll / focus after we already force-recovered.
       scrollbackGenerationRef.current += 1;
       settleScrollback(true);
+      // The generation bump above just cancelled this replay's own arrival-focus
+      // decision (`afterWrite` now returns above its focus frame), and the settle
+      // cleared the veil, so to everything downstream this terminal has finished
+      // arriving. Discharge the obligation here rather than leaving it to the
+      // recovery below: the recovery is a repair that passes `skipFocus`, and it
+      // does not run at all once the budget is spent, so neither is a reliable
+      // owner. See `focusOnArrival`.
+      focusOnArrival('replay-watchdog');
       const canRecover = stuckReplayRecoveriesRef.current < MAX_STUCK_REPLAY_RECOVERIES;
       traceReplay('replay-watchdog', { trigger, generation, recovering: canRecover });
       if (!canRecover) return;
@@ -671,7 +737,7 @@ export function useTerminal(options: UseTerminalOptions) {
       // send another SIGWINCH and start a fresh repaint round of its own.
       reloadScrollbackRef.current?.({ skipResize: true, skipFocus: true });
     }, SCROLLBACK_WATCHDOG_MS);
-  }, [settleScrollback, traceReplay]);
+  }, [settleScrollback, traceReplay, focusOnArrival]);
 
   /**
    * Discard the bytes the incoming queue is HOLDING, because the sample that
@@ -985,6 +1051,10 @@ export function useTerminal(options: UseTerminalOptions) {
       // are ordered on the main process, not here - see the parallel-IPC note
       // below.
       scrollbackPendingRef.current = true;
+      // The mount is what takes the arrival on. Armed here, alongside the pending
+      // flag, so every exit from the replay below - completion, watchdog, or IPC
+      // rejection - finds the obligation and discharges it.
+      arrivalFocusOwedRef.current = true;
       const scrollbackGeneration = ++scrollbackGenerationRef.current;
       const suppressScrollback = suppressDataRef.current;
       traceReplay('replay-start', { trigger: 'mount', generation: scrollbackGeneration, suppressed: suppressScrollback });
@@ -1083,16 +1153,7 @@ export function useTerminal(options: UseTerminalOptions) {
             // corrective resize: main already sampled the settled frame at the
             // fitted width, and a same-dims resize is a documented no-op (POSIX
             // sends SIGWINCH only on a real size change; ConPTY likewise).
-            requestAnimationFrame(() => {
-              // Terminal first: the policy is not a pure query (it records the
-              // grant that suppresses a competing tier-3 arrival), so asking it
-              // for a host that unmounted between the settle and this frame
-              // would deny a live terminal on behalf of a disposed one.
-              const terminal = xtermRef.current;
-              if (!terminal) return;
-              if (mayTakeArrivalFocusRef.current?.() === false) return;
-              terminal.focus();
-            });
+            focusOnArrival('mount-replay');
           };
           if (scrollback && xtermRef.current) {
             // Chunked so a 512KB replay doesn't parse in one synchronous write.
@@ -1129,6 +1190,12 @@ export function useTerminal(options: UseTerminalOptions) {
             scrollbackWatchdogRef.current = null;
           }
           settleScrollback(false);
+          // Same obligation, same reason as the watchdog: this exit ends the
+          // replay without reaching its focus frame. Usually inert - a rejected
+          // read means the session is gone, so the frame's null-check bails - but
+          // discharging unconditionally is what keeps "every exit answers" true
+          // by inspection rather than by case analysis.
+          focusOnArrival('replay-error');
         });
       // Last statement of the synchronous body: the promise chain above is only
       // REGISTERED here, so this is where the beat the long frame measures ends.
@@ -1140,7 +1207,7 @@ export function useTerminal(options: UseTerminalOptions) {
       fitElapsedMs = readClock() - fitStartedAt;
       traceInitTiming('session-less');
     }
-  }, [options.sessionId, options.fontFamily, options.fontSize, options.cursorStyle, customBackground, customForeground, customCursor, options.shellName, options.releaseEscapeWhenPointerOutside, settleScrollback, armScrollbackWatchdog, traceReplay, dropHeldBytesSupersededBySample]);
+  }, [options.sessionId, options.fontFamily, options.fontSize, options.cursorStyle, customBackground, customForeground, customCursor, options.shellName, options.releaseEscapeWhenPointerOutside, settleScrollback, armScrollbackWatchdog, traceReplay, dropHeldBytesSupersededBySample, focusOnArrival]);
 
   // Set up data listener. Inbound PTY data flows through a bounded queue that
   // writes capped slices paced by xterm.write's completion callback, yielding
@@ -1619,6 +1686,11 @@ export function useTerminal(options: UseTerminalOptions) {
     // re-issue this mechanism exists to give it.
     if (!reloadOptions?.reissue) replayWidthAttemptsRef.current = 0;
     scrollbackPendingRef.current = true;
+    // Armed at replay START, exactly like the mount does, and NOT at completion.
+    // A reload that never completes is precisely the case this exists for, so
+    // arming in `afterWrite` would leave the watchdog with nothing to discharge -
+    // which is the original bug wearing a different hat.
+    if (!skipFocus) arrivalFocusOwedRef.current = true;
     const scrollbackGeneration = ++scrollbackGenerationRef.current;
     traceReplay('replay-start', { trigger: 'reload', generation: scrollbackGeneration, skipResize });
     armScrollbackWatchdog('reload', scrollbackGeneration);
@@ -1753,23 +1825,31 @@ export function useTerminal(options: UseTerminalOptions) {
             return;
           }
           if (widthDecision.refundBudget) replayWidthAttemptsRef.current = 0;
-          // Focus after the reload completes, unless the caller opted out or the
-          // host's arrival policy declines. The two gates are separate on
+          // Focus after the reload completes, if an arrival is outstanding and the
+          // host's arrival policy allows it. The two gates stay separate on
           // purpose: `skipFocus` is a CALLER saying "this reload is a repair, not
           // an arrival", while the policy is the HOST arbitrating between
           // terminals that all believe they are arriving.
+          //
+          // A repair does NOT discharge on COMPLETION, even when an arrival is
+          // still owed from a mount replay something pre-empted. Letting it would
+          // mean a reveal or refocus catch-up (both `skipFocus`) could focus a
+          // terminal on a park/reveal edge, which is not an arrival and which no
+          // spec covers.
+          //
+          // That leaves two gaps, and this line closes neither. A `skipFocus`
+          // reload that supersedes a live mount replay strands the obligation,
+          // which is the behaviour that already shipped. And `armScrollbackWatchdog`
+          // discharges UNCONDITIONALLY, so a repair that stalls past
+          // SCROLLBACK_WATCHDOG_MS spends that stranded obligation and focuses on
+          // the very edge this line refuses. `onTerminalReveal` is the only route
+          // in, being the one `skipFocus` caller with no `scrollbackPendingRef`
+          // guard and so the only one that can supersede a live mount replay.
+          // See the obligation bullet in .claude/rules/terminal-arrival-focus.md.
+          //
           // No corrective resize: when a resize was sent above, main sampled
           // the settled frame; a same-dims resize is a no-op either way.
-          if (!skipFocus) {
-            requestAnimationFrame(() => {
-              // Terminal first, for the same reason as the mount-replay frame:
-              // the policy records a grant, so a disposed host must not consult it.
-              const terminal = xtermRef.current;
-              if (!terminal) return;
-              if (mayTakeArrivalFocusRef.current?.() === false) return;
-              terminal.focus();
-            });
-          }
+          if (!skipFocus) focusOnArrival('reload');
         };
         if (scrollback && xtermRef.current) {
           // Clear the old frame HERE, not before the fetch: the reset and the
@@ -1822,8 +1902,11 @@ export function useTerminal(options: UseTerminalOptions) {
           scrollbackWatchdogRef.current = null;
         }
         settleScrollback(false);
+        // See the matching call in initTerminal's catch: this exit ends the
+        // replay short of its focus frame, so it answers any outstanding arrival.
+        focusOnArrival('replay-error');
       });
-  }, [options.sessionId, settleScrollback, armScrollbackWatchdog, traceReplay, dropHeldBytesSupersededBySample]);
+  }, [options.sessionId, settleScrollback, armScrollbackWatchdog, traceReplay, dropHeldBytesSupersededBySample, focusOnArrival]);
 
   // Let the watchdog (armed from initTerminal, declared above this callback)
   // re-issue a stuck replay without a circular declaration.

--- a/src/renderer/utils/terminal-arrival-focus.ts
+++ b/src/renderer/utils/terminal-arrival-focus.ts
@@ -123,6 +123,23 @@ export interface ArrivalFocusDecision {
 }
 
 /**
+ * Which arrival path is asking. One mount produces several decisions, and in the
+ * trace ring they were otherwise indistinguishable - `{allow, reason}` alone
+ * cannot say whether the host's mount frame asked and was denied or never ran.
+ *
+ * `replay-watchdog` and `replay-error` are the PRE-EMPTION paths: they ask on
+ * behalf of an arrival whose own decision was cancelled before it could run. See
+ * `useTerminal`'s `focusOnArrival`.
+ */
+export type ArrivalFocusSite =
+  | 'tab-init'
+  | 'deferred-init'
+  | 'mount-replay'
+  | 'reload'
+  | 'replay-watchdog'
+  | 'replay-error';
+
+/**
  * PURE. The whole decision, with no store or DOM reads, so every tier and every
  * exclusivity edge is testable directly.
  */
@@ -244,9 +261,14 @@ export function windowFocusFingerprint(): string {
 export function claimArrivalFocus(sessionId: string | null): void {
   if (!sessionId) {
     arrivalClaim = null;
+    // Traced so "no claim was standing" reads as a POSITIVE fact in the ring.
+    // Inferring it from a missing entry cannot separate a gesture that cleared
+    // the claim from a gesture that never ran at all.
+    traceTerminalRenderer(null, 'arrival-claim-clear', {});
     return;
   }
   arrivalClaim = { sessionId, fingerprint: windowFocusFingerprint(), at: Date.now() };
+  traceTerminalRenderer(sessionId, 'arrival-claim', { fingerprint: arrivalClaim.fingerprint });
 }
 
 /**
@@ -265,29 +287,48 @@ export function focusIsInTypingSurface(): boolean {
 
 /**
  * The live gate. Hosts pass this down to `useTerminal` as a predicate, so the hook
- * itself stays surface-agnostic and never imports this module.
+ * itself stays surface-agnostic and holds no VALUE import of this module. It does
+ * import `ArrivalFocusSite` as a type, which is erased at build and creates no
+ * runtime edge - the hook only names which of its own arrival paths is asking, it
+ * never reads the policy.
  *
  * A null `sessionId` cannot arrive (both hosts require one before they mount a
  * terminal), so it is permitted rather than given a policy of its own.
  */
-export function mayTakeArrivalFocus(sessionId: string | null): boolean {
+export function mayTakeArrivalFocus(sessionId: string | null, site: ArrivalFocusSite): boolean {
   if (!sessionId) return true;
   const now = Date.now();
+  const claim = arrivalClaim;
+  const liveFingerprint = windowFocusFingerprint();
+  const focusedWindowTerminal = resolveFocusedWindowTerminal();
   const decision = resolveArrivalFocus({
     sessionId,
-    claim: arrivalClaim,
+    claim,
     now,
-    windowFocusFingerprint: windowFocusFingerprint(),
-    focusedWindowTerminal: resolveFocusedWindowTerminal(),
+    windowFocusFingerprint: liveFingerprint,
+    focusedWindowTerminal,
     focusIsInTypingSurface: focusIsInTypingSurface(),
     lastGrant: lastArrivalGrant,
   });
   // Dev-only ring (see traceTerminalRenderer), so this costs nothing shipped. The
   // decision is the only record of WHY a terminal did or did not take focus, and
   // the next "typed into the wrong terminal" report needs it.
+  //
+  // The INPUTS ride along because the reason alone is not diagnostic enough. A
+  // `claim-mismatch` never said WHICH session was claimed, and a tier-1 miss
+  // could not be separated into "no claim was live" and "a claim was live and its
+  // fingerprint had moved" - which is exactly the branch a real occurrence has to
+  // answer. `site` names the asking path, since one mount decides several times.
   traceTerminalRenderer(sessionId, 'arrival-focus', () => ({
     allow: decision.allow,
     reason: decision.reason,
+    site,
+    claimSessionId: claim?.sessionId ?? null,
+    claimFingerprint: claim?.fingerprint ?? null,
+    claimAgeMs: claim ? now - claim.at : null,
+    liveFingerprint,
+    focusedWindowSessionId: focusedWindowTerminal?.sessionId ?? null,
+    focusedWindowOpenedByAgent: focusedWindowTerminal?.openedByAgent ?? null,
   }));
   // Only a TIER-3 grant is recorded, because only tier 3 reads it. Tiers 1 and 2
   // are already exclusive - they deny a mismatch outright - so a burst hold adds

--- a/tests/ui/terminal-arrival-focus.spec.ts
+++ b/tests/ui/terminal-arrival-focus.spec.ts
@@ -243,24 +243,48 @@ async function settleFocusFrames(page: Page): Promise<void> {
  * `list`-reporter job log - the UI shard job uploads no report/trace artifact, so
  * a `testInfo.attach()` would be invisible there.
  *
- * Diagnostic only: changes no wait and weakens no assertion. Added after the spec
- * 3 CI failure below could not be reproduced locally (30/30 baseline runs; CDP
- * CPU throttling broke the EARLIER veil-clear step instead of isolating this one,
- * the wrong shape; 18/18 runs under real 30-core OS contention with 3 concurrent
- * browsers) and static reading of the arbiter (`terminal-arrival-focus.ts`) found
- * no invalidation path within this test's lifecycle - `ARRIVAL_CLAIM_TTL_MS` is
- * already 30s specifically for this scenario class. Rather than guess at a fix
- * for an unconfirmed cause, this captures the arbiter's own `{allow, reason}`
- * decision (or its absence, which narrows to the rAF never running / the xterm
- * ref being null at focus time) so the next occurrence resolves in one log line.
+ * Diagnostic only: changes no wait and weakens no assertion.
+ *
+ * It earned its keep. The failure it was added for turned out to be an arrival
+ * whose decision was never made at all: the scrollback watchdog pre-empted the
+ * replay, which cancelled the decision (a generation bump) and lifted the veil (a
+ * settle) in the same breath, so the terminal read as fully arrived and merely
+ * unfocusable. Two rounds of reading the tier ladder found nothing because the
+ * arbiter was never consulted - the ABSENCE of an `arrival-focus` entry was the
+ * whole signal, and nothing was printing it. Spec 4 now covers that path.
+ *
+ * So what to read here, in order: no `arrival-focus` entry for the session means
+ * nothing asked (look for `replay-watchdog` / `replay-abort` just before it); an
+ * `{allow: false, reason}` entry is a product-side denial, and the claim and
+ * fingerprint fields on it separate "no claim was live" from "a claim was live
+ * and its fingerprint had moved"; `{allow: true}` with focus elsewhere means it
+ * was granted and then stolen, which is a different bug.
  */
 async function logArrivalFocusFailure(page: Page, sessionId: string): Promise<void> {
   const diagnostics = await page.evaluate((sid) => {
     const traceReader = (window as unknown as { __kangenticTerminalTrace?: () => unknown[] }).__kangenticTerminalTrace;
+    // An absent bridge and an empty ring both used to read as `[]`, which are very
+    // different diagnoses - one means the dev tooling did not mount, the other
+    // means the app genuinely decided nothing.
+    const traceInstalled = typeof traceReader === 'function';
     const trace = (traceReader ? traceReader() : []) as Array<{ sessionId: string | null; event: string }>;
-    const relevant = trace.filter((entry) => entry.sessionId === sid || entry.event === 'arrival-focus');
+    // Every `arrival-` event, not just `arrival-focus`: a CLAIM for a different
+    // session is exactly what a `claim-mismatch` needs explaining, and filtering
+    // on this session alone would drop it.
+    const matching = trace.filter((entry) => entry.sessionId === sid || entry.event.startsWith('arrival-'));
+    // The TAIL, because the diagnosis is always the last few events before the
+    // failure and the CI job log truncates a long dump - which is what happened to
+    // the first version of this helper, mid-entry at ~1.8KB.
+    const TAIL = 24;
+    const relevant = matching.slice(-TAIL);
     const active = document.activeElement;
     return {
+      traceInstalled,
+      // TRACE_RING_SIZE is 300, shared across every session and event kind, so a
+      // busy spec can evict the early entries. Report occupancy rather than
+      // letting a truncated ring read as "it never happened".
+      ringEntries: trace.length,
+      matchingEntries: matching.length,
       relevantTrace: relevant,
       activeElement: active && active !== document.body ? {
         tag: active.tagName,
@@ -271,6 +295,30 @@ async function logArrivalFocusFailure(page: Page, sessionId: string): Promise<vo
     };
   }, sessionId);
   console.log(`[arrival-focus-diagnostics] session=${sessionId}`, JSON.stringify(diagnostics, null, 2));
+}
+
+/**
+ * Read the dev-only trace ring (`window.__kangenticTerminalTrace`, installed by
+ * `DevtoolsBootstrap` under Vite dev), filtered to one session and one event kind.
+ * Returns each entry's `detail`, so a spec can assert on WHICH path produced a
+ * decision rather than only that some decision happened.
+ */
+async function readTraceDetails(
+  page: Page,
+  sessionId: string,
+  event: string,
+): Promise<Array<Record<string, unknown>>> {
+  return page.evaluate(([targetSessionId, targetEvent]) => {
+    const traceReader = (window as unknown as { __kangenticTerminalTrace?: () => unknown[] }).__kangenticTerminalTrace;
+    const trace = (traceReader ? traceReader() : []) as Array<{
+      sessionId: string | null;
+      event: string;
+      detail?: Record<string, unknown>;
+    }>;
+    return trace
+      .filter((entry) => entry.sessionId === targetSessionId && entry.event === targetEvent)
+      .map((entry) => entry.detail ?? {});
+  }, [sessionId, event]);
 }
 
 test('a delayed background replay does not steal focus from a just-opened task detail', async () => {
@@ -428,6 +476,113 @@ test('re-expanding the bottom panel focuses its terminal while a detail window i
       await logArrivalFocusFailure(page, SESSION_FALLBACK);
       throw error;
     }
+  } finally {
+    await browser.close();
+  }
+});
+
+/**
+ * Spec 4: an arrival whose replay is PRE-EMPTED still gets its focus decision.
+ *
+ * `useTerminal`'s scrollback watchdog (SCROLLBACK_WATCHDOG_MS, 5s) is a backstop
+ * for a replay that never completes. When it fires it bumps the replay
+ * generation, which makes that replay's own `afterWrite` return ABOVE the frame
+ * which asks the arbiter - so the arrival-focus decision is cancelled - and it
+ * clears `scrollbackPendingRef`, which lifts the replay veil. To everything
+ * downstream the terminal has finished arriving. In fact nothing ever asked
+ * whether it may take focus, and nothing asks again, so that terminal is
+ * unfocusable for the rest of its life.
+ *
+ * Why this drives the RELOAD path rather than a fresh mount. On a solo mount
+ * `TerminalTab`'s own init frame (the `mayFocusOnArrival('tab-init')` call in its
+ * `active` effect) runs one frame after the init queue constructs the terminal,
+ * and focuses it long before the watchdog - so a mount-based version of this spec
+ * would pass with the fix reverted, i.e. vacuously. Lifting the launch overlay on
+ * an ALREADY-INITIALIZED terminal produces an arrival with no `tab-init` frame at
+ * all (`TerminalTab`'s `terminalReady` false -> true effect calls
+ * `reloadScrollback()` with no `skipFocus`), so the pre-empted decision is the
+ * only one there is. That is what makes this red-green.
+ *
+ * The tab click before the delay is what puts a live claim in place. Without it
+ * the still-focused detail window wins tier 2 and the terminal is denied for a
+ * legitimate reason, which would also pass vacuously.
+ *
+ * How to verify RED / GREEN: drop the `focusOnArrival('replay-watchdog')` call
+ * from `armScrollbackWatchdog` in `useTerminal.ts` and this fails with the
+ * production symptom - pane mounted, veil gone, textarea never focused.
+ */
+test('a terminal whose replay the watchdog pre-empts still takes arrival focus', async () => {
+  // The watchdog is a real 5s wall-clock timer and the replay behind it is
+  // delayed past that deliberately, so this one case needs more than the tier's
+  // default per-test budget. 90s rather than 60s because the four STEP_TIMEOUT_MS
+  // waits ahead of the delay sum to 32s on their own, and 32 + 5.5 + the 20s
+  // watchdog poll + a final 8s focus wait already reaches 60 before anything has
+  // gone wrong. A loaded CI shard would then fail this on the budget rather than
+  // on the behaviour under test.
+  test.setTimeout(90_000);
+  const { browser, page } = await launch({ delayFallbackReplay: false });
+  try {
+    await page.locator('[data-testid="terminal-session-pane"]').waitFor({ state: 'visible', timeout: STEP_TIMEOUT_MS });
+    // DETAIL only. The fallback session keeps its launch overlay, so lifting that
+    // overlay later is what produces the arrival under test.
+    await markFirstOutput(page, [SESSION_DETAIL]);
+
+    await page.locator(`text=Arrival Detail ${RUN_ID}`).first().click();
+    const dialog = page.locator('[data-testid="task-detail-dialog"]');
+    await dialog.waitFor({ state: 'visible', timeout: STEP_TIMEOUT_MS });
+
+    const fallbackPane = page.locator(
+      `[data-testid="terminal-session-pane"][data-session-id="${SESSION_FALLBACK}"]`,
+    );
+    await fallbackPane.waitFor({ state: 'visible', timeout: STEP_TIMEOUT_MS });
+
+    // A tab click claims arrival focus for this session (selectActiveSession ->
+    // claimArrivalFocus). The session is already the panel's selection, so this
+    // moves no tab and remounts nothing - it only puts the claim in place, which
+    // is what lets tier 1 grant while the detail window still holds window focus.
+    await page.locator(`[data-testid="terminal-session-tab"][data-session-id="${SESSION_FALLBACK}"]`)
+      .click({ timeout: STEP_TIMEOUT_MS });
+
+    // Past SCROLLBACK_WATCHDOG_MS (5000), so the reload below is guaranteed to be
+    // pre-empted rather than completing. Armed here rather than at launch so the
+    // earlier mounts stay fast and keep their own recovery budget intact.
+    await page.evaluate((sessionId) => {
+      (window as unknown as { __mockScrollbackDelayMs?: Record<string, number> })
+        .__mockScrollbackDelayMs = { [sessionId]: 5500 };
+    }, SESSION_FALLBACK);
+
+    // Lift the launch overlay: terminalReady false -> true makes TerminalTab call
+    // reloadScrollback() with no skipFocus, i.e. an arrival.
+    await markFirstOutput(page, [SESSION_FALLBACK]);
+
+    // Wait for the watchdog's own trace event rather than for the veil. The
+    // watchdog clears the veil and then its recovery replay (delayed again by the
+    // same mock entry) raises it, so the veil is not a stable marker here - and
+    // asserting the watchdog actually fired is what stops this spec passing
+    // vacuously if the delay ever stops applying, the same argument the mock's
+    // getScrollback makes for __mockScrollbackCalls.
+    await expect.poll(
+      async () => (await readTraceDetails(page, SESSION_FALLBACK, 'replay-watchdog')).length,
+      { timeout: 20_000 },
+    ).toBeGreaterThan(0);
+
+    // The production symptom first, so a regression reports as "the terminal was
+    // never focused" rather than as a trace-shape mismatch.
+    try {
+      await expect(fallbackPane.locator('.xterm-helper-textarea').first()).toBeFocused({ timeout: STEP_TIMEOUT_MS });
+    } catch (error) {
+      await logArrivalFocusFailure(page, SESSION_FALLBACK);
+      throw error;
+    }
+
+    // Then the non-vacuity guard: the decision has to have come from the
+    // watchdog's discharge. A green produced by some other focus path would not
+    // be the thing under test, and this spec is built so no other path can run -
+    // if one appears, this is what says so instead of quietly passing.
+    expect(
+      (await readTraceDetails(page, SESSION_FALLBACK, 'arrival-focus'))
+        .filter((detail) => detail.site === 'replay-watchdog' && detail.allow === true),
+    ).toHaveLength(1);
   } finally {
     await browser.close();
   }

--- a/tests/unit/terminal-arrival-focus-sites.test.ts
+++ b/tests/unit/terminal-arrival-focus-sites.test.ts
@@ -139,6 +139,114 @@ describe('every arrival focus in a terminal host is arbitrated', () => {
     ).toEqual([]);
   });
 
+  it('every path that ends a replay discharges the arrival obligation', () => {
+    // An arrival is an obligation a replay takes on, discharged exactly once by
+    // `focusOnArrival`. A path that ENDS a replay without discharging cancels the
+    // decision permanently: the terminal is never asked again and can never take
+    // focus. That is not hypothetical - the watchdog did exactly this, and it
+    // shipped as an intermittently retried CI test whose arbiter trace was empty,
+    // because the arbiter had never been consulted at all.
+    //
+    // `useTerminal` has no unit tier (it needs a real DOM and a live xterm), so
+    // this is a static pin rather than a behavioural test. The behavioural guard
+    // is `tests/ui/terminal-arrival-focus.spec.ts`'s watchdog case; this exists so
+    // that DELETING the discharge fails here too, loudly and instantly, instead of
+    // only in a 6-second UI spec someone might not run.
+    const source = fs.readFileSync(
+      path.join(REPO_ROOT, 'src/renderer/hooks/useTerminal.ts'),
+      'utf8',
+    );
+
+    // Sliced into the three regions that own a replay, and checked region by
+    // region. A whole-file `includes` cannot do this job: two of the five
+    // discharge calls are BOTH spelled `focusOnArrival('replay-error')` (the
+    // mount catch and the reload catch), so one occurrence satisfies a global
+    // search and either site could be deleted with the pin still green.
+    //
+    // The boundaries are the three callback declarations, in file order. Pin them
+    // first: a renamed or reordered declaration would otherwise slice the source
+    // into garbage and every check below would pass vacuously, which is the same
+    // failure the sibling host-scan test guards against.
+    const regionAnchors = [
+      ['the watchdog', 'const armScrollbackWatchdog = useCallback('],
+      ['the mount replay', 'const initTerminal = useCallback('],
+      ['the reload replay', 'const reloadScrollback = useCallback('],
+    ] as const;
+    const anchorIndexes = regionAnchors.map(([, declaration]) => source.indexOf(declaration));
+    const missingAnchors = regionAnchors
+      .filter((_, position) => anchorIndexes[position] === -1)
+      .map(([label, declaration]) => `${label} (expected ${declaration})`);
+    expect(
+      missingAnchors,
+      'This scan slices useTerminal.ts by callback declaration, and one is no '
+      + 'longer spelled the way it was. Re-anchor it, or every check below '
+      + `silently stops testing anything.\nMissing:\n${missingAnchors.join('\n')}`,
+    ).toEqual([]);
+    expect(
+      anchorIndexes,
+      'The three replay-owning callbacks are no longer in watchdog -> mount -> '
+      + 'reload file order, so the slices below overlap or invert.',
+    ).toEqual([...anchorIndexes].sort((first, second) => first - second));
+
+    const [watchdogRegion, mountRegion, reloadRegion] = [
+      source.slice(anchorIndexes[0], anchorIndexes[1]),
+      source.slice(anchorIndexes[1], anchorIndexes[2]),
+      source.slice(anchorIndexes[2]),
+    ];
+
+    // Each entry: the region, the path inside it, and the call that must appear.
+    const requiredDischarges = [
+      [watchdogRegion, "the watchdog's force-clear", "focusOnArrival('replay-watchdog')"],
+      [mountRegion, 'the mount replay completing', "focusOnArrival('mount-replay')"],
+      [mountRegion, "the mount replay's IPC rejection", "focusOnArrival('replay-error')"],
+      [reloadRegion, 'the reload replay completing', "focusOnArrival('reload')"],
+      [reloadRegion, "the reload replay's IPC rejection", "focusOnArrival('replay-error')"],
+    ] as const;
+
+    const missing = requiredDischarges
+      .filter(([region, , call]) => !region.includes(call))
+      .map(([, label, call]) => `${label} (expected ${call})`);
+
+    expect(
+      missing,
+      'A replay path in useTerminal.ts no longer discharges the arrival-focus '
+      + 'obligation, so a terminal arriving down that path can never take focus '
+      + `(see .claude/rules/terminal-arrival-focus.md).\nMissing:\n${missing.join('\n')}`,
+    ).toEqual([]);
+
+    // The obligation has to be ARMED where a replay STARTS, not where it
+    // completes: a replay that never completes is the whole point, so arming in
+    // `afterWrite` would leave the pre-emption paths with nothing to discharge.
+    //
+    // Checked positionally rather than by counting occurrences. A count pin reads
+    // as precision it does not have - it would fail on an `armArrival()` helper
+    // extraction, which reintroduces nothing - and a pin that fires on safe
+    // refactors gets deleted rather than understood.
+    //
+    // Both replays are checked, each against its OWN `afterWrite`. Checking the
+    // whole file instead would only ever see the mount's arm and the mount's
+    // `afterWrite`, since `indexOf` stops at the first of each - and the reload is
+    // the path the behaviour spec had to be built on, because a mount-based
+    // version of it passes with the fix reverted.
+    const armingRegions = [
+      ['the mount replay', mountRegion],
+      ['the reload replay', reloadRegion],
+    ] as const;
+    for (const [label, region] of armingRegions) {
+      const armIndex = region.indexOf('arrivalFocusOwedRef.current = true');
+      const afterWriteIndex = region.indexOf('const afterWrite =');
+      expect(armIndex, `${label} never arms the arrival obligation at all.`).toBeGreaterThan(-1);
+      expect(afterWriteIndex, `${label} has no \`afterWrite\` to arm ahead of.`).toBeGreaterThan(-1);
+      expect(
+        armIndex,
+        `${label} arms the arrival obligation at or after its own \`afterWrite\`, `
+        + 'i.e. at replay COMPLETION. It must be armed where the replay STARTS, or '
+        + 'a replay that is pre-empted before completing leaves nothing to '
+        + 'discharge - which is the original bug.',
+      ).toBeLessThan(afterWriteIndex);
+    }
+  });
+
   it('scans the terminal hosts it is meant to cover', () => {
     // The scan is a no-op if `isTerminalHost` stops matching (a renamed hook, a moved file), and a
     // no-op scan passes silently. Pin the hosts so that failure is loud.

--- a/tests/unit/terminal-arrival-focus-sites.test.ts
+++ b/tests/unit/terminal-arrival-focus-sites.test.ts
@@ -247,6 +247,103 @@ describe('every arrival focus in a terminal host is arbitrated', () => {
     }
   });
 
+  it('the reload path only arms and discharges the arrival obligation when the caller did not pass skipFocus', () => {
+    // A `skipFocus` reload is a REPAIR (a park/reveal catch-up, a width-drift heal),
+    // not an arrival, so it must neither promise an obligation nor pay one off. Two
+    // independent gates hold that, one at arm time and one at discharge time (see
+    // the obligation bullet in .claude/rules/terminal-arrival-focus.md):
+    //
+    //   if (!skipFocus) arrivalFocusOwedRef.current = true;   // arm
+    //   ...
+    //   if (!skipFocus) focusOnArrival('reload');              // discharge
+    //
+    // Deleting the ARM gate alone still looks harmless in isolation - the repair's
+    // own discharge stays gated off - but it leaves an obligation standing that the
+    // watchdog (which discharges UNCONDITIONALLY on force-recovery) can later spend,
+    // focusing the terminal on the very park/reveal edge the discharge gate exists to
+    // refuse. Deleting the DISCHARGE gate alone widens the already-documented
+    // "stranded obligation" gap from watchdog-only to every skipFocus completion. A
+    // single assertion covering only one gate would leave the other free to regress,
+    // exactly the trap the sibling test's own comment names for the two identically
+    // spelled `focusOnArrival('replay-error')` calls.
+    const source = fs.readFileSync(
+      path.join(REPO_ROOT, 'src/renderer/hooks/useTerminal.ts'),
+      'utf8',
+    );
+    const reloadDeclarationIndex = source.indexOf('const reloadScrollback = useCallback(');
+    expect(
+      reloadDeclarationIndex,
+      'reloadScrollback moved or was renamed; re-anchor this scan.',
+    ).toBeGreaterThan(-1);
+    const reloadRegion = source.slice(reloadDeclarationIndex);
+
+    // Tolerant of whitespace and an optional brace body, not a literal single-line
+    // substring: a harmless reformat (wrapping the guarded statement, or adding
+    // braces to the `if`) must not break this pin.
+    const armGate = /if\s*\(\s*!skipFocus\s*\)\s*\{?\s*arrivalFocusOwedRef\.current\s*=\s*true/;
+    const dischargeGate = /if\s*\(\s*!skipFocus\s*\)\s*\{?\s*focusOnArrival\(\s*'reload'\s*\)/;
+
+    expect(
+      armGate.test(reloadRegion),
+      'reloadScrollback must only ARM the arrival obligation when the caller did not '
+      + 'pass skipFocus. Without the `if (!skipFocus)` gate, a repair reload (park/reveal '
+      + "catch-up, width-drift heal) arms an obligation its own completion won't pay, "
+      + 'leaving it standing for the watchdog to discharge unconditionally later - '
+      + 'focusing the terminal on a park/reveal edge that is not an arrival at all.',
+    ).toBe(true);
+
+    expect(
+      dischargeGate.test(reloadRegion),
+      'reloadScrollback must only DISCHARGE the arrival obligation on completion when the '
+      + 'caller did not pass skipFocus. Without the `if (!skipFocus)` gate, every repair '
+      + 'reload focuses on completion, not just the ones that outlive the watchdog - '
+      + 'widening the documented "stranded obligation" gap (terminal-arrival-focus.md) '
+      + 'from a rare edge to the common case.',
+    ).toBe(true);
+  });
+
+  it('focusOnArrival clears the obligation before, not inside, its focus frame', () => {
+    // "Discharged exactly once" (the fix's headline property) depends on WHEN the ref
+    // is cleared, not just that it is cleared. Clearing before the requestAnimationFrame
+    // means a second path that discharges the same replay (there cannot be one - each
+    // arm is per-replay - but a future call site addition could get this wrong) finds
+    // the obligation already gone. Clearing inside the frame, after the
+    // `if (!terminal) return` bail in particular, would let two discharges for the same
+    // arming both pass the outer `if (!arrivalFocusOwedRef.current) return` guard before
+    // either clears it, consulting the arbiter twice for one arrival - the exact race
+    // the comment above `focusOnArrival` in useTerminal.ts says this ordering prevents.
+    const source = fs.readFileSync(
+      path.join(REPO_ROOT, 'src/renderer/hooks/useTerminal.ts'),
+      'utf8',
+    );
+    const declarationIndex = source.indexOf(
+      'const focusOnArrival = useCallback((site: ArrivalFocusSite) => {',
+    );
+    const nextDeclarationIndex = source.indexOf('const traceReplay = useCallback(');
+    expect(
+      declarationIndex,
+      'focusOnArrival moved or was renamed; re-anchor this scan.',
+    ).toBeGreaterThan(-1);
+    expect(
+      nextDeclarationIndex,
+      'traceReplay moved or was renamed; re-anchor this scan.',
+    ).toBeGreaterThan(declarationIndex);
+
+    const focusOnArrivalRegion = source.slice(declarationIndex, nextDeclarationIndex);
+    const clearIndex = focusOnArrivalRegion.indexOf('arrivalFocusOwedRef.current = false');
+    const rafIndex = focusOnArrivalRegion.indexOf('requestAnimationFrame(');
+
+    expect(clearIndex, 'focusOnArrival no longer clears the obligation at all.').toBeGreaterThan(-1);
+    expect(rafIndex, 'focusOnArrival no longer schedules its focus frame via requestAnimationFrame.').toBeGreaterThan(-1);
+    expect(
+      clearIndex,
+      'The obligation must clear BEFORE requestAnimationFrame is scheduled, not inside its '
+      + 'callback. Clearing inside the frame would let a second discharge for the same '
+      + 'arming reach the arbiter before the first one clears the ref, consulting it twice '
+      + 'for one arrival.',
+    ).toBeLessThan(rafIndex);
+  });
+
   it('scans the terminal hosts it is meant to cover', () => {
     // The scan is a no-op if `isTerminalHost` stops matching (a renamed hook, a moved file), and a
     // no-op scan passes silently. Pin the hosts so that failure is loud.

--- a/tests/unit/terminal-arrival-focus.test.ts
+++ b/tests/unit/terminal-arrival-focus.test.ts
@@ -453,12 +453,12 @@ describe('mayTakeArrivalFocus / claimArrivalFocus (the real, impure wrapper)', (
     // denied as a claim-mismatch against the session cleared above. If the
     // null branch became a no-op, the stale claim on 'sess-a' would still be
     // live and would deny 'sess-b'.
-    expect(mayTakeArrivalFocus('sess-b')).toBe(true);
+    expect(mayTakeArrivalFocus('sess-b', 'mount-replay')).toBe(true);
   });
 
   it('claims tier-1 exclusivity through the real wrapper: the claimed session is allowed, any other is denied', () => {
     claimArrivalFocus('sess-a');
-    expect(mayTakeArrivalFocus('sess-a')).toBe(true);
+    expect(mayTakeArrivalFocus('sess-a', 'mount-replay')).toBe(true);
 
     // Step past the tier-3 burst window (well inside the tier-1 claim's own
     // TTL) before the second check. Without this, a wrapper that silently
@@ -469,7 +469,7 @@ describe('mayTakeArrivalFocus / claimArrivalFocus (the real, impure wrapper)', (
     // Stepping past the burst window removes that false-pass path.
     vi.advanceTimersByTime(ARRIVAL_BURST_MS + 1);
 
-    expect(mayTakeArrivalFocus('sess-b')).toBe(false);
+    expect(mayTakeArrivalFocus('sess-b', 'mount-replay')).toBe(false);
   });
 
   it('records lastArrivalGrant only for a tier-3 (unclaimed) grant, never for a tier-1 (claim) grant', () => {
@@ -478,10 +478,10 @@ describe('mayTakeArrivalFocus / claimArrivalFocus (the real, impure wrapper)', (
     // check below (an unrelated session, checked at the SAME instant, well
     // inside ARRIVAL_BURST_MS) would be denied as burst-taken instead of
     // reaching tier 3 on its own.
-    expect(mayTakeArrivalFocus('sess-claimed')).toBe(true);
+    expect(mayTakeArrivalFocus('sess-claimed', 'mount-replay')).toBe(true);
     claimArrivalFocus(null);
 
-    expect(mayTakeArrivalFocus('sess-unrelated')).toBe(true);
+    expect(mayTakeArrivalFocus('sess-unrelated', 'mount-replay')).toBe(true);
   });
 });
 
@@ -524,7 +524,7 @@ describe('focusIsInTypingSurface (through mayTakeArrivalFocus, its only entry po
     const matchesSpy = vi.fn(() => false);
     vi.stubGlobal('document', { body: {}, activeElement: { matches: matchesSpy } });
 
-    expect(mayTakeArrivalFocus('sess-button-focus')).toBe(true);
+    expect(mayTakeArrivalFocus('sess-button-focus', 'mount-replay')).toBe(true);
     // The load-bearing assertion: this is what fails if `button` (or anything
     // else) is ever added to the selector list. The return-value assertion
     // above cannot see that change, because the stub returns whatever this
@@ -537,7 +537,7 @@ describe('focusIsInTypingSurface (through mayTakeArrivalFocus, its only entry po
     const matchesSpy = vi.fn(() => true);
     vi.stubGlobal('document', { body: {}, activeElement: { matches: matchesSpy } });
 
-    expect(mayTakeArrivalFocus('sess-textarea-focus')).toBe(false);
+    expect(mayTakeArrivalFocus('sess-textarea-focus', 'mount-replay')).toBe(false);
   });
 
   it('short-circuits on activeElement === document.body without calling matches', () => {
@@ -545,7 +545,7 @@ describe('focusIsInTypingSurface (through mayTakeArrivalFocus, its only entry po
     const bodySentinel = { matches: matchesSpy };
     vi.stubGlobal('document', { body: bodySentinel, activeElement: bodySentinel });
 
-    expect(mayTakeArrivalFocus('sess-body-focus')).toBe(true);
+    expect(mayTakeArrivalFocus('sess-body-focus', 'mount-replay')).toBe(true);
     // The load-bearing assertion for the second red condition: dropping the
     // `active === document.body` guard would route this call into
     // `active.matches(...)` instead of short-circuiting. A real


### PR DESCRIPTION
## What

An arrival-focus decision is now an obligation a replay arms at its START and discharges exactly once, through a shared `focusOnArrival` helper in `src/renderer/hooks/useTerminal.ts`. Every path that ends a replay discharges it: the two normal completions, plus the three that pre-empt one (the stuck-replay watchdog and the two IPC rejections).

Also enriches the arrival-focus dev trace, and fixes pre-existing drift in `docs/session-lifecycle.md` (it described the arbiter as three tiers and omitted `agent-window`).

## Why

`tests/ui/terminal-arrival-focus.spec.ts` was failing intermittently on CI's UI shard 11 and passing on retry. The final `toBeFocused` burned its full 8s with the textarea resolving 17 times, so the element was present and simply never took focus.

The arbiter was never consulted at all, which is why two previous rounds of reading the tier ladder found nothing. `armScrollbackWatchdog` (5s) bumps the replay generation, which makes that replay's `afterWrite` return above the frame that asks the arbiter, and it calls `settleScrollback`, which lifts the replay veil. The terminal then reads as fully arrived and merely refusing focus, and nothing asks again, so it stays unfocusable for the rest of its life.

The supporting measurement was already on record and misread. The 30s TTL raise (a928f100) timed this same panel re-expand at 4605-5897ms under 25x CPU throttle and attributed all of it to the 4000ms claim deadline. Those numbers straddle the 5000ms watchdog, which is why the flake outlived that fix.

## How

The arbiter, the tier ladder, the claim, the fingerprint and `ARRIVAL_CLAIM_TTL_MS` are untouched, so the tier-exclusivity rule holds by construction. A denied decision discharges like a granted one, since a deny is a real answer and re-asking after one would reopen the race the arbiter exists to close.

Two deliberate trade-offs:

- A `skipFocus` reload does NOT discharge. Letting it would allow a reveal or refocus catch-up to focus a terminal on a park/reveal edge, which is not an arrival. The narrow corner that leaves open (a `skipFocus` reload superseding a live mount replay strands that obligation) is exactly the behavior that already shipped, so nothing regresses. Recorded in `.claude/rules/terminal-arrival-focus.md` rather than half-fixed.
- `mayTakeArrivalFocus` gained a `site` argument and the trace now carries the arbiter's inputs. `{allow, reason}` alone could not separate "no claim was live" from "a claim was live and its fingerprint had moved", and an absent entry, which turned out to be the whole signal here, was invisible.

## Breaking changes

None.

## Tests

Reproduced deterministically, with no CPU throttling and no timing luck: delaying a focus-bearing reload past the watchdog makes the textarea resolve 19 times and never take focus, against the CI failure's 17.

- `tests/ui/terminal-arrival-focus.spec.ts` gains a fourth spec for the pre-empted arrival. It drives the RELOAD path on purpose: on a fresh mount `TerminalTab`'s own init frame focuses the terminal long before the watchdog, so a mount-based version would pass with the fix reverted. Verified red-green twice.
- `tests/unit/terminal-arrival-focus-sites.test.ts` gains static pins that each replay-ending path discharges, that the obligation is armed at replay start rather than completion, that both `skipFocus` gates are present, and that the ref clears before the focus frame. `useTerminal` has no unit tier, so these are structural rather than behavioural.
- Locally: typecheck, lint, and the arrival-focus, park/reveal, hold, replay-veil and command-terminal UI specs. The full tiers are CI's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pWNM4d9xmiTorMrqtEW2w
