### PR TITLE
ci(codeql): stop scanning tests, scripts, and dev tooling

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,10 @@
 # Default setup (the repo-settings toggle) is the other way to get scanning. It
 # was rejected for exactly one reason: it always adds its Analyze jobs to PRs
 # and offers no way to turn that off.
+#
+# Scan SCOPE is narrowed by the inline `config:` on the Initialize CodeQL step
+# below, which excludes tests, scripts, and src/devtools. The reasoning for each
+# exclusion lives next to it.
 name: CodeQL
 
 on:
@@ -76,6 +80,31 @@ jobs:
           languages: ${{ matrix.language }}
           # Both languages are interpreted, so there is nothing to compile.
           build-mode: none
+          # Scope. These three trees produced 13 of the 21 open alerts in
+          # September 2026, outnumbering the real findings 13 to 4, which is how
+          # a genuine alert gets missed. None of them ships or is
+          # attacker-reachable. Dismissing the alerts one by one is not durable:
+          # the next Math.random() in a new spec opens a new one.
+          #
+          # paths-ignore only applies to the interpreted analysis, so this is
+          # inert for the `actions` leg, which scans this directory. The entries
+          # are bare directory names because the pattern syntax forbids mixing
+          # `**` with other characters.
+          config: |
+            paths-ignore:
+              # Test code. Mock session ids and per-run suffixes from
+              # Math.random(), and MD5 in tests/e2e/helpers.ts, which has to
+              # reproduce the real Kimi CLI's session-directory naming.
+              - tests
+              # Local dev and build scripts. Never packaged, and a flag like
+              # measure-injection-flush.mjs's --pattern regex is
+              # developer-supplied by definition.
+              - scripts
+              # Dev tooling, including the localhost-only inspection server. It
+              # is build-excluded behind __KANGENTIC_DEV__ and dead-code
+              # eliminated, so it never reaches a packaged app. See
+              # .claude/rules/dev-tooling-build-exclusion.md.
+              - src/devtools
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4

--- a/tests/unit/repo-hygiene.test.ts
+++ b/tests/unit/repo-hygiene.test.ts
@@ -185,4 +185,53 @@ describe('.github/workflows/codeql.yml', () => {
       'Keep the weekly schedule: it catches newly published queries against unchanged code.',
     ).toBe(true);
   });
+
+  /**
+   * The scope narrowing on the Initialize CodeQL step, pinned for the same
+   * reason as the triggers above: it fails green.
+   *
+   * Two edits break it silently. Deleting the `config:` block is valid YAML and
+   * a passing workflow, so the test, script, and devtools trees go back to
+   * outnumbering the real findings in the alert list. Or an entry gets a typo
+   * (`script` for `scripts`) or names a tree that has since moved, and CodeQL
+   * treats a pattern matching nothing as a pattern excluding nothing. It does
+   * not warn, so the step stays green and the noise quietly returns.
+   *
+   * The entry list is asserted exactly, not as a subset. Growth is the half
+   * worth catching: adding a tree here removes it from a security scanner's
+   * view, which should never ride along inside an unrelated change.
+   */
+  it('keeps its paths-ignore scope, and every entry names a real directory', () => {
+    const lines = stripComments(readFileSync(codeqlPath, 'utf8'));
+    const pathsIgnoreIndex = lines.findIndex((line) => /^\s*paths-ignore:\s*$/.test(line));
+
+    expect(
+      pathsIgnoreIndex,
+      'The `paths-ignore` block on the Initialize CodeQL step is gone. Without it the test, script, and devtools trees are scanned again, and their alerts bury the real findings.',
+    ).toBeGreaterThan(-1);
+
+    // A line scan, matching the rest of this file: no YAML parser is a direct
+    // dependency, and these are `- value` entries at a fixed indent under the
+    // key. Collect them until the indent falls back to the key's own level.
+    const keyIndent = lines[pathsIgnoreIndex].search(/\S/);
+    const ignoredPaths: string[] = [];
+    for (const line of lines.slice(pathsIgnoreIndex + 1)) {
+      if (line.trim() === '') continue;
+      if (line.search(/\S/) <= keyIndent) break;
+      const entry = /^\s*-\s*(\S+)\s*$/.exec(line);
+      if (entry) ignoredPaths.push(entry[1]);
+    }
+
+    expect(
+      ignoredPaths,
+      'Keep the paths-ignore list exact. Dropping a tree puts its alerts back in front of the real findings, and adding one hides a tree from CodeQL, which is a decision that belongs in its own change.',
+    ).toEqual(['tests', 'scripts', 'src/devtools']);
+
+    for (const ignoredPath of ignoredPaths) {
+      expect(
+        existsSync(join(REPO_ROOT, ignoredPath)),
+        `paths-ignore names \`${ignoredPath}\`, which is not a directory in this repo. A pattern that matches nothing excludes nothing, and CodeQL does not warn about it.`,
+      ).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
## What

Narrows the CodeQL scan scope. The `Initialize CodeQL` step in
`.github/workflows/codeql.yml` gains an inline `config:` carrying
`paths-ignore: [tests, scripts, src/devtools]`, each entry with its own reason
next to it. Nothing else changes: the `on:` block, the language matrix, and the
analyze step are untouched.

A companion test from the Code Review pass pins the list exactly and checks that
every entry names a real directory.

## Why

13 of the 21 open code-scanning alerts sat in code that never ships and is never
attacker-reachable, outnumbering the real findings 13 to 4. That ratio is how a
genuine alert gets missed.

- `tests`: mock session ids and per-run suffixes from `Math.random()`, plus MD5 in
  `tests/e2e/helpers.ts`, which has to reproduce the real Kimi CLI's
  session-directory naming and so cannot change.
- `scripts`: local dev and build scripts, never packaged. A flag like
  `measure-injection-flush.mjs`'s `--pattern` regex is developer-supplied by
  definition.
- `src/devtools`: the localhost-only inspection server, build-excluded behind
  `__KANGENTIC_DEV__` and dead-code eliminated, so it never reaches a packaged
  app. See `.claude/rules/dev-tooling-build-exclusion.md`.

Dismissing those alerts one at a time is not durable: the next `Math.random()` in
a new spec opens a new one. The path exclusion is the self-maintaining fix.

## How

An addition to the existing hand-owned advanced-setup workflow, not a migration
off it. Three things worth a reviewer's eye:

- **`init@v4` accepts `config`** as a YAML string in the same format as
  `config-file`, and it takes precedence over `config-file`. `analyze@v4` declares
  no config input at all, so the scope resolves once at init and carries through
  with nothing to add there. Verified against both actions' `action.yml` on the v4
  tag.
- **Inline over a separate config file.** This workflow is already the single
  self-documenting home for every scanning decision, including the deliberate
  absence of a `pull_request:` trigger, and the repo has no `.github/codeql/`
  precedent. Keeping the exclusions here puts each reason beside the decision it
  explains.
- **Bare directory names, not globs.** The pattern syntax forbids mixing `**` with
  other characters, so `src/devtools/**/*` would be a trap. `paths-ignore` applies
  to the interpreted analysis only, which makes it inert for the `actions` matrix
  leg that scans this directory.

Three alerts in `src/main/agent/event-bridge.js` stay in scope deliberately. That
is shipped code, and `js/regex-injection` fires on the pattern reaching
`new RegExp` through argv, so bounding the match subject would not touch the sink
and excluding the file would stop scanning production code. The patterns are
compile-time constants from `directive-builders.ts` and nobody outside the repo
supplies them, so those three get dismissed as used-as-intended after the merge.

## Breaking changes

None. CI-configuration only, with no effect on the app, the build, or any other
workflow.

## Tests

- `tests/unit/repo-hygiene.test.ts` gains a case pinning the `paths-ignore` entry
  list exactly and asserting each entry names a directory that exists. The exact
  list is the point: dropping a tree puts its alerts back in front of the real
  findings, and adding one hides a tree from a security scanner, which should not
  ride along inside an unrelated change. A typo'd entry would otherwise fail
  green, since CodeQL treats a pattern matching nothing as excluding nothing and
  does not warn. Red-green verified against both a reverted workflow and a typo'd
  entry. 12 tests pass in that file.
- Ran locally: `npm run typecheck`, `npm run lint`, and
  `npx vitest run tests/unit/repo-hygiene.test.ts`.
- Also checked by hand that the block scalar nests correctly. Parsing
  `codeql.yml` alone proves nothing about a `config:` block, since the string is
  opaque text to that parse, so the real check is a nested parse of the string
  itself resolving to exactly `{paths-ignore: [tests, scripts, src/devtools]}`.

**This PR cannot verify the outcome, by design.** `codeql.yml` has no
`pull_request:` trigger, for the concurrency-budget reason its header comment
explains, so no Analyze job runs here and no alert moves. The check is the open
alert list after the merge:
`gh api repos/Kangentic/kangentic/code-scanning/alerts?state=open`. Alert 12 is
the discriminator worth watching: it points at `session-store.ts`, which has no
`Math.random()` in it, and its taint originates in `tests/ui/mock-electron-api.js`,
so it closes only if `paths-ignore` suppresses extraction rather than just
reporting.

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] No em-dashes or `--` used as punctuation
- [x] Tests added or updated for this change
- [x] Docs updated if anchor source changed (types, IPC channels, migrations, adapters, settings)
- [x] Ran `npm run lint`, `npm run typecheck`, and the relevant tests locally
- [x] Screenshot or clip included (UI changes)
- [x] CLA signed (or will sign on first PR)

Anchor note: no anchor source changed. `.github/workflows/**` is not on the
canonical list in `.claude/skills/sync-docs/SKILL.md`, and the only CodeQL
reference anywhere in `docs/` or the root markdown is a `CHANGELOG.md` line from
when scanning was first added. No UI change, so no screenshot applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TU4mVQpKF5ZyYTGij9RmU
